### PR TITLE
XamlTileRenderer:Render Image elements

### DIFF
--- a/UWP/Renderer/XamlCardRenderer.vcxproj
+++ b/UWP/Renderer/XamlCardRenderer.vcxproj
@@ -109,6 +109,7 @@
     <ClInclude Include="lib\AdaptiveImage.h" />
     <ClInclude Include="lib\AdaptiveTextBlock.h" />
     <ClInclude Include="lib\ErrorHandling.h" />
+    <ClInclude Include="lib\ImageLoadTracker.h" />
     <ClInclude Include="lib\pch.h" />
     <ClInclude Include="lib\Util.h" />
     <ClInclude Include="lib\Vector.h" />
@@ -117,6 +118,7 @@
     <ClCompile Include="lib\AdaptiveCard.cpp" />
     <ClCompile Include="lib\AdaptiveImage.cpp" />
     <ClCompile Include="lib\AdaptiveTextBlock.cpp" />
+    <ClCompile Include="lib\ImageLoadTracker.cpp" />
     <ClCompile Include="lib\Util.cpp" />
     <ClCompile Include="lib\XamlBuilder.cpp" />
     <ClCompile Include="lib\XamlCardRendererComponent.cpp" />

--- a/UWP/Renderer/XamlCardRenderer.vcxproj.filters
+++ b/UWP/Renderer/XamlCardRenderer.vcxproj.filters
@@ -8,6 +8,7 @@
     <ClCompile Include="dll\dll.cpp" />
     <ClCompile Include="lib\XamlBuilder.cpp" />
     <ClCompile Include="lib\AdaptiveImage.cpp" />
+    <ClCompile Include="lib\ImageLoadTracker.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="lib\pch.h" />
@@ -19,6 +20,7 @@
     <ClInclude Include="lib\XamlBuilder.h" />
     <ClInclude Include="lib\Vector.h" />
     <ClInclude Include="lib\AdaptiveImage.h" />
+    <ClInclude Include="lib\ImageLoadTracker.h" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="idl\AdaptiveCards.XamlCardRenderer.idl" />

--- a/UWP/Renderer/dll/AdaptiveCards.XamlCardRenderer.man
+++ b/UWP/Renderer/dll/AdaptiveCards.XamlCardRenderer.man
@@ -47,6 +47,11 @@
               threading="Both"
               trustLevel="Base"
               />
+          <class
+              activatableClassId="AdaptiveCards.XamlCardRenderer.AdaptiveImage"
+              threading="Both"
+              trustLevel="Base"
+              />
         </classes>
       </winRTInProcServer>
     </servers>

--- a/UWP/Renderer/idl/AdaptiveCards.XamlCardRenderer.idl
+++ b/UWP/Renderer/idl/AdaptiveCards.XamlCardRenderer.idl
@@ -8,6 +8,9 @@ namespace AdaptiveCards
 {
     namespace XamlCardRenderer
     {
+        runtimeclass XamlCardRenderer;
+        runtimeclass ImageRenderResult;
+
         runtimeclass AdaptiveTextBlock;
         runtimeclass AdaptiveCard;
         runtimeclass AdaptiveImage;
@@ -81,6 +84,8 @@ namespace AdaptiveCards
         {
             interface Windows.Foundation.Collections.IVector<IAdaptiveCardElement*>;
             interface Windows.Foundation.Collections.IObservableVector<IAdaptiveCardElement*>;
+            interface Windows.Foundation.IAsyncOperation<Windows.UI.Xaml.UIElement*>;
+            interface Windows.Foundation.IAsyncOperation<ImageRenderResult*>;
         }
 
         [
@@ -92,7 +97,8 @@ namespace AdaptiveCards
             [propget] HRESULT ElementType([out, retval] ElementType* value);
             [propput] HRESULT ElementType([in] ElementType value);
 
-            HRESULT Render([out, retval] Windows.UI.Xaml.UIElement** uiElement);
+            [propget] HRESULT Size([out, retval] CardElementSize* value);
+            [propput] HRESULT Size([in] CardElementSize value);
         };
 
         [
@@ -172,9 +178,6 @@ namespace AdaptiveCards
             interface IAdaptiveCardElement;
         };
 
-        runtimeclass XamlCardRenderer;
-        runtimeclass ImageRenderResult;
-
         [flags]
         [version(NTDDI_WIN10_RS1)]
         typedef [v1_enum] enum RenderOptions
@@ -207,7 +210,7 @@ namespace AdaptiveCards
         {
             HRESULT SetRenderOptions([in] RenderOptions options);
             HRESULT SetOverrideStyles([in] Windows.UI.Xaml.ResourceDictionary* overrideDictionary);
-            HRESULT RenderCardAsXaml([in] AdaptiveCard* adaptiveCard,[out, retval] Windows.UI.Xaml.UIElement** root);
+            HRESULT RenderCardAsXaml([in] AdaptiveCard* adaptiveCard,[out, retval] Windows.UI.Xaml.UIElement** result);
             HRESULT RenderCardAsImage([in] AdaptiveCard* adaptiveCard,[out, retval] Windows.Foundation.IAsyncOperation<ImageRenderResult>** result);
         }
 

--- a/UWP/Renderer/lib/AdaptiveCard.cpp
+++ b/UWP/Renderer/lib/AdaptiveCard.cpp
@@ -12,6 +12,8 @@ namespace AdaptiveCards { namespace XamlCardRenderer
 {
     HRESULT AdaptiveCard::RuntimeClassInitialize()
     {
+        m_size = CardElementSize::Auto;
+
         m_items = Microsoft::WRL::Make<Vector<IAdaptiveCardElement*>>();
         if (m_items == nullptr)
         {
@@ -39,9 +41,16 @@ namespace AdaptiveCards { namespace XamlCardRenderer
     }
 
     _Use_decl_annotations_
-    IFACEMETHODIMP AdaptiveCard::Render(IUIElement** element)
+    HRESULT AdaptiveCard::get_Size(ABI::AdaptiveCards::XamlCardRenderer::CardElementSize* size)
     {
-        *element = nullptr;
+        *size = m_size;
+        return S_OK;
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveCard::put_Size(ABI::AdaptiveCards::XamlCardRenderer::CardElementSize size)
+    {
+        m_size = size;
         return S_OK;
     }
 }}

--- a/UWP/Renderer/lib/AdaptiveCard.h
+++ b/UWP/Renderer/lib/AdaptiveCard.h
@@ -23,10 +23,12 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveCards::XamlCardRenderer::ElementType* elementType);
         IFACEMETHODIMP put_ElementType(_In_ ABI::AdaptiveCards::XamlCardRenderer::ElementType elementType);
 
-        IFACEMETHODIMP Render(_COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** element);
+        IFACEMETHODIMP get_Size(_Out_ ABI::AdaptiveCards::XamlCardRenderer::CardElementSize* size);
+        IFACEMETHODIMP put_Size(_In_ ABI::AdaptiveCards::XamlCardRenderer::CardElementSize size);
 
     private:
         Microsoft::WRL::ComPtr<ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCardElement*>> m_items;
+        ABI::AdaptiveCards::XamlCardRenderer::CardElementSize m_size;
     };
 
     ActivatableClass(AdaptiveCard);

--- a/UWP/Renderer/lib/AdaptiveImage.cpp
+++ b/UWP/Renderer/lib/AdaptiveImage.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "AdaptiveImage.h"
+
 #include "Util.h"
 #include "XamlCardRendererComponent.h"
 
@@ -12,7 +13,8 @@ using namespace ABI::Windows::UI::Xaml::Controls;
 
 namespace AdaptiveCards { namespace XamlCardRenderer
 {
-    AdaptiveImage::AdaptiveImage() : m_image(std::make_unique<Image>())
+    AdaptiveImage::AdaptiveImage() : m_image(std::make_unique<Image>()),
+                                     m_size(ABI::AdaptiveCards::XamlCardRenderer::CardElementSize::Auto)
     {
     }
 
@@ -79,8 +81,17 @@ namespace AdaptiveCards { namespace XamlCardRenderer
     }
 
     _Use_decl_annotations_
-        HRESULT AdaptiveImage::Render(IUIElement** /*image*/)
+    HRESULT AdaptiveImage::get_Size(ABI::AdaptiveCards::XamlCardRenderer::CardElementSize* size)
     {
+        *size = m_size;
         return S_OK;
     }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveImage::put_Size(ABI::AdaptiveCards::XamlCardRenderer::CardElementSize size)
+    {
+        m_size = size;
+        return S_OK;
+    }
+
 }}

--- a/UWP/Renderer/lib/AdaptiveImage.h
+++ b/UWP/Renderer/lib/AdaptiveImage.h
@@ -29,11 +29,12 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveCards::XamlCardRenderer::ElementType* elementType);
         IFACEMETHODIMP put_ElementType(_In_ ABI::AdaptiveCards::XamlCardRenderer::ElementType elementType);
 
-        IFACEMETHODIMP Render(_COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** Image);
+        IFACEMETHODIMP get_Size(_Out_ ABI::AdaptiveCards::XamlCardRenderer::CardElementSize* size);
+        IFACEMETHODIMP put_Size(_In_ ABI::AdaptiveCards::XamlCardRenderer::CardElementSize size);
 
     private:
         std::unique_ptr<AdaptiveCards::Image> m_image;
-
+        ABI::AdaptiveCards::XamlCardRenderer::CardElementSize m_size;
     };
 
     ActivatableClass(AdaptiveImage);

--- a/UWP/Renderer/lib/AdaptiveTextBlock.cpp
+++ b/UWP/Renderer/lib/AdaptiveTextBlock.cpp
@@ -13,7 +13,7 @@ using namespace ABI::Windows::UI::Xaml::Controls;
 
 namespace AdaptiveCards { namespace XamlCardRenderer
 {
-    AdaptiveTextBlock::AdaptiveTextBlock() : m_TextBlock(std::make_unique<TextBlock>()) 
+    AdaptiveTextBlock::AdaptiveTextBlock() : m_TextBlock(std::make_unique<TextBlock>())
     {
     }
 
@@ -116,26 +116,17 @@ namespace AdaptiveCards { namespace XamlCardRenderer
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveTextBlock::Render(IUIElement** TextBlock)
+    HRESULT AdaptiveTextBlock::get_Size(ABI::AdaptiveCards::XamlCardRenderer::CardElementSize* size)
     {
-        *TextBlock = nullptr;
-
-        ComPtr<IInspectable> inspectableTextBlock;
-        ComPtr<ITextBlock> textBlock;
-        RETURN_IF_FAILED(RoActivateInstance(HStringReference(RuntimeClass_Windows_UI_Xaml_Controls_TextBlock).Get(), inspectableTextBlock.ReleaseAndGetAddressOf()));
-        RETURN_IF_FAILED(inspectableTextBlock.As(&textBlock));
-
-        HSTRING text;
-        RETURN_IF_FAILED(this->get_Text(&text));
-        RETURN_IF_FAILED(textBlock->put_Text(text));
-
-        boolean wrap;
-        RETURN_IF_FAILED(this->get_Wrap(&wrap));
-        RETURN_IF_FAILED(textBlock->put_TextWrapping(wrap ? TextWrapping::TextWrapping_WrapWholeWords : TextWrapping::TextWrapping_NoWrap));
-
-        // Fill other properties.
-
-        return textBlock->QueryInterface(TextBlock);
-
+        *size = static_cast<ABI::AdaptiveCards::XamlCardRenderer::CardElementSize>(m_TextBlock->GetSize());
+        return S_OK;
     }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveTextBlock::put_Size(ABI::AdaptiveCards::XamlCardRenderer::CardElementSize size)
+    {
+        m_TextBlock->SetSize(static_cast<AdaptiveCards::CardElementSize>(size));
+        return S_OK;
+    }
+
 }}

--- a/UWP/Renderer/lib/AdaptiveTextBlock.h
+++ b/UWP/Renderer/lib/AdaptiveTextBlock.h
@@ -40,7 +40,8 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveCards::XamlCardRenderer::ElementType* elementType);
         IFACEMETHODIMP put_ElementType(_In_ ABI::AdaptiveCards::XamlCardRenderer::ElementType elementType);
 
-        IFACEMETHODIMP Render(_COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** TextBlock);
+        IFACEMETHODIMP get_Size(_Out_ ABI::AdaptiveCards::XamlCardRenderer::CardElementSize* size);
+        IFACEMETHODIMP put_Size(_In_ ABI::AdaptiveCards::XamlCardRenderer::CardElementSize size);
 
     private:
         std::unique_ptr<AdaptiveCards::TextBlock> m_TextBlock;

--- a/UWP/Renderer/lib/ImageLoadTracker.cpp
+++ b/UWP/Renderer/lib/ImageLoadTracker.cpp
@@ -1,0 +1,84 @@
+#include "pch.h"
+#include "ImageLoadTracker.h"
+
+#include <wrl\event.h>
+
+using namespace Microsoft::WRL;
+using namespace Microsoft::WRL::Wrappers;
+using namespace ABI::AdaptiveCards::XamlCardRenderer;
+using namespace ABI::Windows::UI::Xaml;
+using namespace ABI::Windows::UI::Xaml::Media::Imaging;
+
+namespace AdaptiveCards { namespace XamlCardRenderer
+{
+    ImageLoadTracker::~ImageLoadTracker()
+    {
+        for (auto& eventRegistration : m_eventRegistrations)
+        {
+            UnsubscribeFromEvents(eventRegistration.first, eventRegistration.second);
+        }
+    }
+
+    _Use_decl_annotations_
+    void ImageLoadTracker::TrackBitmapImage(IBitmapImage* bitmapImage)
+    {
+        ComPtr<IBitmapImage> localBitmapImage(bitmapImage);
+        TrackedImageDetails trackedImageDetails;
+
+        ComPtr<IRoutedEventHandler> imageOpenedEventHandler = Microsoft::WRL::Callback<IRoutedEventHandler, ImageLoadTracker>(this, &ImageLoadTracker::trackedImage_ImageLoaded);
+        THROW_IF_FAILED(bitmapImage->add_ImageOpened(imageOpenedEventHandler.Get(), &trackedImageDetails.imageOpenedRegistration));
+        ComPtr<IExceptionRoutedEventHandler> imageFailedEventHandler = Microsoft::WRL::Callback<IExceptionRoutedEventHandler, ImageLoadTracker>(this, &ImageLoadTracker::trackedImage_ImageFailed);
+        THROW_IF_FAILED(bitmapImage->add_ImageFailed(imageFailedEventHandler.Get(), &trackedImageDetails.imageFailedRegistration));
+
+        // Ensure we donn't try and write the private data from multiple threads
+        auto exclusiveLock = m_lock.LockExclusive();
+
+        ComPtr<IInspectable> inspectableBitmapImage;
+        THROW_IF_FAILED(localBitmapImage.As(&inspectableBitmapImage));
+        if (m_eventRegistrations.find(inspectableBitmapImage.Get()) == m_eventRegistrations.end())
+        {
+            // If we haven't registered for this image events yet, do so
+            m_eventRegistrations[inspectableBitmapImage.Get()] = trackedImageDetails;
+            m_trackedImageCount++;
+        }
+    }
+
+    _Use_decl_annotations_
+    HRESULT ImageLoadTracker::trackedImage_ImageLoaded(IInspectable* sender, IRoutedEventArgs* /*eventArgs*/)
+    {
+        ImageLoadResultReceived(sender);
+        return S_OK;
+    }
+    
+    _Use_decl_annotations_
+    HRESULT ImageLoadTracker::trackedImage_ImageFailed(IInspectable* sender, IExceptionRoutedEventArgs* /*eventArgs*/)
+    {
+        ImageLoadResultReceived(sender);
+        return S_OK;
+    }
+
+    _Use_decl_annotations_
+    void ImageLoadTracker::ImageLoadResultReceived(IInspectable* sender)
+    {
+        auto exclusiveLock = m_lock.LockExclusive();
+        m_trackedImageCount--;
+        if (m_eventRegistrations.find(sender) != m_eventRegistrations.end())
+        {
+            UnsubscribeFromEvents(sender, m_eventRegistrations[sender]);
+        }
+    }
+
+    _Use_decl_annotations_
+    void ImageLoadTracker::UnsubscribeFromEvents(IInspectable* bitmapImage, TrackedImageDetails& trackedImageDetails)
+    {
+        auto exclusiveLock = m_lock.LockExclusive();
+        ComPtr<IInspectable> inspectableBitmapImage(bitmapImage);
+        ComPtr<IBitmapImage> localBitmapImage;
+        inspectableBitmapImage.As(&localBitmapImage);
+
+        // Best effort, ignore returns
+        localBitmapImage->remove_ImageOpened(trackedImageDetails.imageOpenedRegistration);
+        localBitmapImage->remove_ImageFailed(trackedImageDetails.imageFailedRegistration);
+    }
+
+}}

--- a/UWP/Renderer/lib/ImageLoadTracker.h
+++ b/UWP/Renderer/lib/ImageLoadTracker.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "AdaptiveCards.XamlCardRenderer.h"
+
+namespace AdaptiveCards { namespace XamlCardRenderer
+{
+    struct TrackedImageDetails
+    {
+        EventRegistrationToken imageOpenedRegistration;
+        EventRegistrationToken imageFailedRegistration;
+    };
+
+    class ImageLoadTracker
+    {
+    public:
+        ~ImageLoadTracker();
+        void TrackBitmapImage(_In_ ABI::Windows::UI::Xaml::Media::Imaging::IBitmapImage* bitmapImage);
+
+    private:
+        Microsoft::WRL::Wrappers::SRWLock m_lock;
+        int m_trackedImageCount = 0;
+        std::unordered_map<IInspectable*, TrackedImageDetails> m_eventRegistrations;
+
+        HRESULT trackedImage_ImageLoaded(_In_ IInspectable* sender, _In_ ABI::Windows::UI::Xaml::IRoutedEventArgs* eventArgs);
+        HRESULT trackedImage_ImageFailed(_In_ IInspectable* sender, _In_ ABI::Windows::UI::Xaml::IExceptionRoutedEventArgs* eventArgs);
+        void ImageLoadResultReceived(_In_ IInspectable* sender);
+        void UnsubscribeFromEvents(_In_ IInspectable* bitmapImage, _In_ TrackedImageDetails& trackedImageDetails);
+    };
+}}

--- a/UWP/Renderer/lib/XamlBuilder.h
+++ b/UWP/Renderer/lib/XamlBuilder.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "AdaptiveCards.XamlCardRenderer.h"
+#include "ImageLoadTracker.h"
 
 namespace AdaptiveCards { namespace XamlCardRenderer
 {
@@ -17,13 +18,19 @@ namespace AdaptiveCards { namespace XamlCardRenderer
                 ABI::Windows::UI::Xaml::Controls::IPanel*)>> m_adaptiveElementBuilder;
         Microsoft::WRL::ComPtr<ABI::Windows::Foundation::IPropertyValueStatics> m_propertyValueStatics;
         std::vector<Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IResourceDictionary>> m_resourceDictionaries;
+        ImageLoadTracker m_imageLoadTracker;
 
         void EnsurePropertyValueStatics();
         bool TryGetStyleFromResourceDictionaries(
             _In_ std::wstring styleName,
             _COM_Outptr_result_maybenull_ ABI::Windows::UI::Xaml::IStyle** style);
         Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::Controls::IPanel> CreateRootPanelFromAdaptiveCard(_In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCard* adaptiveCard);
+        Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::Media::IImageSource> LoadImageFromUrl(_In_ ABI::Windows::Foundation::IUriRuntimeClass* imageUrl);
+
         void BuildTextBlock(
+            _In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCardElement* adaptiveCardElement,
+            _In_ ABI::Windows::UI::Xaml::Controls::IPanel* parentPanel);
+        void BuildImage(
             _In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCardElement* adaptiveCardElement,
             _In_ ABI::Windows::UI::Xaml::Controls::IPanel* parentPanel);
     };

--- a/UWP/Renderer/lib/XamlStyleKeyGenerators.h
+++ b/UWP/Renderer/lib/XamlStyleKeyGenerators.h
@@ -1,6 +1,10 @@
 #pragma once
 
 #include "AdaptiveCards.XamlCardRenderer.h"
+#include "Enums.h"
+#include "ErrorHandling.h"
+
+const PCWSTR c_StyleSeparator = L".";
 
 namespace AdaptiveCards { namespace XamlCardRenderer
 {
@@ -9,12 +13,44 @@ namespace AdaptiveCards { namespace XamlCardRenderer
     public:
         static std::wstring GenerateKeyForTextBlock(ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveTextBlock* /*textBlock*/)
         {
-            std::wstring styleKey(L"TextBlock");
+            std::wstring styleKey = GetElementTypeAsString(CardElementType::TextBlock);
+
             // TODO: MSFT:10826544 - Programmatic xaml style generation
 
             return styleKey;
         }
 
+        static std::wstring GenerateKeyForImage(ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveImage* image)
+        {
+            Microsoft::WRL::ComPtr<ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveImage> adaptiveImage(image);
+            Microsoft::WRL::ComPtr<ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCardElement> adaptiveCardElement;
+            THROW_IF_FAILED(adaptiveImage.As(&adaptiveCardElement));
+
+            std::wstring styleKey = GetElementTypeAsString(CardElementType::Image);
+            styleKey.append(c_StyleSeparator);
+            styleKey.append(GetSizeFromCard(adaptiveCardElement.Get()).c_str());
+
+            // TODO: MSFT:10826544 - Programmatic xaml style generation
+
+            return styleKey;
+        }
+
+    private:
+        static std::wstring GetElementTypeAsString(_In_ AdaptiveCards::CardElementType elementType)
+        {
+            std::string elementTypeString = AdaptiveCards::CardElementTypeToString(elementType);
+            std::wstring elementTypeWideString(elementTypeString.begin(), elementTypeString.end());
+            return elementTypeWideString;
+        }
+
+        static std::wstring GetSizeFromCard(_In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCardElement* adaptiveCardElement)
+        {
+            ABI::AdaptiveCards::XamlCardRenderer::CardElementSize size;
+            THROW_IF_FAILED(adaptiveCardElement->get_Size(&size));
+            std::string sizeString = AdaptiveCards::SizeToString(static_cast<AdaptiveCards::CardElementSize>(size));
+            std::wstring sizeWideString(sizeString.begin(), sizeString.end());
+            return sizeWideString;
+        }
     };
 
 }}

--- a/UWP/Visualizer/MainPage.xaml
+++ b/UWP/Visualizer/MainPage.xaml
@@ -33,7 +33,7 @@
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
             <TextBlock Text="Rendered As Xaml Output:" Grid.Row="0"/>
-            <ContentPresenter x:Name="renderedXamlPresenter" Height="100" Width="100" Grid.Row="1"/>
+            <ContentPresenter x:Name="renderedXamlPresenter" Grid.Row="1"/>
             <TextBlock Text="Rendered As Image Output:" Grid.Row="2"/>
             <Image x:Name="renderedXamlImage" Grid.Row="3"/>
         </Grid>

--- a/UWP/Visualizer/MainPage.xaml.cs
+++ b/UWP/Visualizer/MainPage.xaml.cs
@@ -33,12 +33,24 @@ namespace XamlCardVisualizer
             AdaptiveTextBlock textBlock1 = new AdaptiveTextBlock();
             textBlock1.Text = "Hello";
             card.Items.Add(textBlock1);
+            AdaptiveImage image = new AdaptiveImage();
+            image.Uri = new Uri("https://docs.microsoft.com/en-us/_themes/images/microsoft-header.png");
+            card.Items.Add(image);
             AdaptiveTextBlock textBlock2 = new AdaptiveTextBlock();
             textBlock2.Text = "World";
             card.Items.Add(textBlock2);
 
             AdaptiveCards.XamlCardRenderer.XamlCardRenderer renderer = new AdaptiveCards.XamlCardRenderer.XamlCardRenderer();
             this.renderedXamlPresenter.Content = renderer.RenderCardAsXaml(card);
+
+            /* TODO MSFT:10826542 - XamlTileRenderer:Delay rendering completion until images are fully available
+            var renderAsyncOperation = renderer.RenderCardAsXamlAsync(card);
+            renderAsyncOperation.Completed = new AsyncOperationCompletedHandler<UIElement>(
+                (op, status) =>
+                {
+                    this.renderedXamlPresenter.Content = op.GetResults();
+                });
+            */
         }
     }
 }

--- a/shared/ObjectModel/Enums.cpp
+++ b/shared/ObjectModel/Enums.cpp
@@ -48,7 +48,7 @@ static std::unordered_map<std::string, CardElementType, CaseInsensitiveHash, Cas
 {
     {"AdaptiveCard", CardElementType::AdaptiveCard},
     {"TextBlock", CardElementType::TextBlock},
-    //{ "Image", CardElementType::Image },
+    { "Image", CardElementType::Image },
     //{ "FactGroup", CardElementType::FactGroup },
     //{ "ColumnGroup", CardElementType::ColumnGroup },
     //{ "ImageGallery", CardElementType::ImageGallery },
@@ -60,7 +60,7 @@ static std::unordered_map<CardElementType, std::string> CardElementTypeEnumToNam
 {
     { CardElementType::AdaptiveCard, "AdaptiveCard" },
     { CardElementType::TextBlock, "TextBlock" },
-    //{ CardElementType::Image, "Image" },
+    { CardElementType::Image, "Image" },
     //{ CardElementType::FactGroup, "FactGroup" },
     //{ CardElementType::ColumnGroup, "ColumnGroup" },
     //{ CardElementType::ImageGallery, "ImageGallery" },

--- a/shared/ObjectModel/Image.cpp
+++ b/shared/ObjectModel/Image.cpp
@@ -20,7 +20,7 @@ Image::Image(
 {
 }
 
-std::shared_ptr<Image> Image::Deserialize(const Json::Value& json)
+std::shared_ptr<Image> Image::Deserialize(const Json::Value& /*json*/)
 {
     return std::make_shared<Image>();
 }


### PR DESCRIPTION
This change adds the basic rendering of image element to the xaml card
renderer.  While the element creation follows the same pattern as the
existing text blocks, there's a chunk of extra logic dedicated to
tracking the actual loading of the image pixels.  While not currently
used, this will be used by task 10826542 to ensure all images are loaded
before rendering the xaml tree to a single image.