### PR TITLE
XamlTileRenderer:Delay rendering completion until images are fully available

### DIFF
--- a/UWP/Renderer/XamlCardRenderer.vcxproj
+++ b/UWP/Renderer/XamlCardRenderer.vcxproj
@@ -81,6 +81,10 @@
       <SubSystem>Console</SubSystem>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <ModuleDefinitionFile>.\dll\AdaptiveCards.XamlCardRenderer.def</ModuleDefinitionFile>
+      <AdditionalDependencies>
+        user32.lib;
+        %(AdditionalDependencies);
+      </AdditionalDependencies>
     </Link>
     <CustomBuildStep>
       <Command>mdmerge -partial -i "$(OutDir)$(TargetName).winmd" -o "$(OutDir)Output" -metadata_dir "$(FrameworkSdkDir)UnionMetadata" &amp;&amp; copy /y "$(OutDir)Output\*" "$(OutDir)"</Command>
@@ -101,7 +105,10 @@
     <ClCompile>
       <PreprocessorDefinitions Condition="'$(Configuration)'=='Debug'">_WINRT_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Configuration)'=='Release'">_WINRT_DLL;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\shared\ObjectModel;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>
+	..\..\shared\ObjectModel;
+	%(AdditionalIncludeDirectories)
+</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -109,9 +116,17 @@
     <ClInclude Include="lib\AdaptiveContainer.h" />
     <ClInclude Include="lib\AdaptiveImage.h" />
     <ClInclude Include="lib\AdaptiveTextBlock.h" />
+    <ClInclude Include="lib\AsyncOperations.h" />
+    <ClInclude Include="lib\DefaultResourceDictionary.h" />
     <ClInclude Include="lib\ErrorHandling.h" />
+    <ClInclude Include="lib\IImageLoadTrackerListener.h" />
     <ClInclude Include="lib\ImageLoadTracker.h" />
+    <ClInclude Include="lib\ImageRenderResult.h" />
+    <ClInclude Include="lib\IRenderXamlToImageExecutionInstance.h" />
+    <ClInclude Include="lib\IXamlBuilderListener.h" />
     <ClInclude Include="lib\pch.h" />
+    <ClInclude Include="lib\RenderXamlToImageExecutionInstance.h" />
+    <ClInclude Include="lib\RenderXamlToImageTask.h" />
     <ClInclude Include="lib\Util.h" />
     <ClInclude Include="lib\Vector.h" />
     <ClInclude Include="lib\XamlBuilder.h" />
@@ -121,10 +136,15 @@
     <ClCompile Include="lib\AdaptiveImage.cpp" />
     <ClCompile Include="lib\AdaptiveTextBlock.cpp" />
     <ClCompile Include="lib\ImageLoadTracker.cpp" />
+    <ClCompile Include="lib\ImageRenderResult.cpp" />
+    <ClCompile Include="lib\RenderXamlToImageExecutionInstance.cpp" />
+    <ClCompile Include="lib\RenderXamlToImageTask.cpp" />
     <ClCompile Include="lib\Util.cpp" />
     <ClCompile Include="lib\XamlBuilder.cpp" />
     <ClCompile Include="lib\XamlCardRendererComponent.cpp" />
     <ClCompile Include="dll\dll.cpp" />
+    <ClInclude Include="lib\XamlHelpers.h" />
+    <ClInclude Include="lib\XamlStyleKeyGenerators.h" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="idl\AdaptiveCards.XamlCardRenderer.idl">

--- a/UWP/Renderer/XamlCardRenderer.vcxproj.filters
+++ b/UWP/Renderer/XamlCardRenderer.vcxproj.filters
@@ -9,6 +9,9 @@
     <ClCompile Include="lib\XamlBuilder.cpp" />
     <ClCompile Include="lib\AdaptiveImage.cpp" />
     <ClCompile Include="lib\ImageLoadTracker.cpp" />
+    <ClCompile Include="lib\ImageRenderResult.cpp" />
+    <ClCompile Include="lib\RenderXamlToImageExecutionInstance.cpp" />
+    <ClCompile Include="lib\RenderXamlToImageTask.cpp" />
     <ClCompile Include="lib\AdaptiveContainer.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -22,6 +25,16 @@
     <ClInclude Include="lib\Vector.h" />
     <ClInclude Include="lib\AdaptiveImage.h" />
     <ClInclude Include="lib\ImageLoadTracker.h" />
+    <ClInclude Include="lib\XamlHelpers.h" />
+    <ClInclude Include="lib\ImageRenderResult.h" />
+    <ClInclude Include="lib\RenderXamlToImageExecutionInstance.h" />
+    <ClInclude Include="lib\RenderXamlToImageTask.h" />
+    <ClInclude Include="lib\IRenderXamlToImageExecutionInstance.h" />
+    <ClInclude Include="lib\IImageLoadTrackerListener.h" />
+    <ClInclude Include="lib\IXamlBuilderListener.h" />
+    <ClInclude Include="lib\DefaultResourceDictionary.h" />
+    <ClInclude Include="lib\XamlStyleKeyGenerators.h" />
+    <ClInclude Include="lib\AsyncOperations.h" />
     <ClInclude Include="lib\AdaptiveContainer.h" />
   </ItemGroup>
   <ItemGroup>

--- a/UWP/Renderer/idl/AdaptiveCards.XamlCardRenderer.idl
+++ b/UWP/Renderer/idl/AdaptiveCards.XamlCardRenderer.idl
@@ -88,7 +88,8 @@ namespace AdaptiveCards
             interface Windows.Foundation.Collections.IVector<IAdaptiveCardElement*>;
             interface Windows.Foundation.Collections.IObservableVector<IAdaptiveCardElement*>;
             interface Windows.Foundation.IAsyncOperation<Windows.UI.Xaml.UIElement*>;
-            interface Windows.Foundation.IAsyncOperation<ImageRenderResult*>;
+            interface Windows.Foundation.IAsyncOperation<AdaptiveCards.XamlCardRenderer.ImageRenderResult*>;
+            interface Windows.Foundation.IReference<Windows.UI.Text.FontWeight>;
         }
 
         [
@@ -116,6 +117,9 @@ namespace AdaptiveCards
 
             [propget] HRESULT TextWeight([out, retval] TextWeight* value);
             [propput] HRESULT TextWeight([in] TextWeight value);
+
+            [propget] HRESULT TextColor([out, retval] TextColor* value);
+            [propput] HRESULT TextColor([in] TextColor value);
 
             [propget] HRESULT Text([out, retval] HSTRING* value);
             [propput] HRESULT Text([in] HSTRING value);
@@ -175,7 +179,6 @@ namespace AdaptiveCards
             activatable(NTDDI_WIN10_RS1)
         ]
         runtimeclass AdaptiveImage
-
         {
             [default] interface IAdaptiveImage;
             interface IAdaptiveCardElement;
@@ -199,10 +202,9 @@ namespace AdaptiveCards
             activatable(NTDDI_WIN10_RS1)
         ]
         runtimeclass AdaptiveContainer
-
         {
             [default] interface IAdaptiveContainer;
-            interface IAdaptiveContainer;
+            interface IAdaptiveCardElement;
         };
 
         [flags]
@@ -238,7 +240,8 @@ namespace AdaptiveCards
             HRESULT SetRenderOptions([in] RenderOptions options);
             HRESULT SetOverrideStyles([in] Windows.UI.Xaml.ResourceDictionary* overrideDictionary);
             HRESULT RenderCardAsXaml([in] AdaptiveCard* adaptiveCard,[out, retval] Windows.UI.Xaml.UIElement** result);
-            HRESULT RenderCardAsImage([in] AdaptiveCard* adaptiveCard,[out, retval] Windows.Foundation.IAsyncOperation<ImageRenderResult>** result);
+            HRESULT RenderCardAsXamlAsync([in] AdaptiveCard* adaptiveCard, [out, retval] Windows.Foundation.IAsyncOperation<Windows.UI.Xaml.UIElement*>** result);
+            HRESULT RenderCardAsImageAsync([in] AdaptiveCard* adaptiveCard, [out, retval] Windows.Foundation.IAsyncOperation<ImageRenderResult*>** result);
         }
 
         [

--- a/UWP/Renderer/lib/AdaptiveContainer.cpp
+++ b/UWP/Renderer/lib/AdaptiveContainer.cpp
@@ -1,6 +1,8 @@
 #include "pch.h"
 #include "AdaptiveContainer.h"
+
 #include "Util.h"
+#include "Vector.h"
 #include <windows.foundation.collections.h>
 #include "XamlCardRendererComponent.h"
 
@@ -15,6 +17,7 @@ namespace AdaptiveCards { namespace XamlCardRenderer
 {
     AdaptiveContainer::AdaptiveContainer() : m_container(std::make_unique<Container>())
     {
+        m_items = Microsoft::WRL::Make<Vector<IAdaptiveCardElement*>>();
     }
 
     _Use_decl_annotations_

--- a/UWP/Renderer/lib/AsyncOperations.h
+++ b/UWP/Renderer/lib/AsyncOperations.h
@@ -1,0 +1,230 @@
+#pragma once
+#include "pch.h"
+
+#include "AdaptiveCards.XamlCardRenderer.h"
+#include <wrl\async.h>
+#include "XamlBuilder.h"
+#include "XamlCardRendererComponent.h"
+#include "XamlHelpers.h"
+
+#define MakeAgileDispatcherCallback ::Microsoft::WRL::Callback<::Microsoft::WRL::Implements<::Microsoft::WRL::RuntimeClassFlags<::Microsoft::WRL::ClassicCom>, ::ABI::Windows::UI::Core::IDispatchedHandler, ::Microsoft::WRL::FtmBase>>
+
+/// A base class for IAsyncOperation<T> implementations for use with WRL
+template<typename T>
+class RenderAsyncBase :
+    public Microsoft::WRL::RuntimeClass<
+    Microsoft::WRL::AsyncBase<ABI::Windows::Foundation::IAsyncOperationCompletedHandler<T*>>,
+    ABI::Windows::Foundation::IAsyncOperation<T*>,
+    AdaptiveCards::XamlCardRenderer::IXamlBuilderListener>
+{
+    InspectableClass(L"Windows.Foundation.IAsyncInfo", BaseTrust)
+
+public:
+    typedef ABI::Windows::Foundation::IAsyncOperationCompletedHandler<T*> HandlerType;
+
+    RenderAsyncBase(
+        ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCard* card)
+        : m_card(card)
+    {
+        // Get the dispatcher to we can run an async operation to build the xaml tree
+        ComPtr<ICoreWindowStatic> coreWindowStatic;
+        THROW_IF_FAILED(Windows::Foundation::GetActivationFactory(HStringReference(RuntimeClass_Windows_UI_Core_CoreWindow).Get(), &coreWindowStatic));
+        ComPtr<ICoreWindow> coreWindow;
+        THROW_IF_FAILED(coreWindowStatic->GetForCurrentThread(coreWindow.GetAddressOf()));
+        THROW_IF_FAILED(coreWindow->get_Dispatcher(&m_dispatcher));
+
+        m_builder = Microsoft::WRL::Make<AdaptiveCards::XamlCardRenderer::XamlBuilder>();
+        AsyncBase::Start();
+    }
+
+    // IAsyncOperation
+    virtual auto STDMETHODCALLTYPE put_Completed(HandlerType* handler) -> HRESULT override
+    {
+        return AsyncBase::PutOnComplete(handler);
+    }
+
+    virtual auto STDMETHODCALLTYPE get_Completed(HandlerType** handler) -> HRESULT override
+    {
+        return AsyncBase::GetOnComplete(handler);
+    }
+
+    // IXamlBuilderListener
+    IFACEMETHODIMP AllImagesLoaded()
+    {
+        return OnXamlImagesLoaded();
+    }
+
+protected:
+    Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IUIElement> m_rootXamlElement;
+    Microsoft::WRL::ComPtr<ABI::Windows::UI::Core::ICoreDispatcher> m_dispatcher;
+    Microsoft::WRL::ComPtr<AdaptiveCards::XamlCardRenderer::XamlBuilder> m_builder;
+
+    HRESULT OnStart(void) override
+    {
+        Microsoft::WRL::ComPtr<ABI::Windows::Foundation::IAsyncAction> dispatcherAsyncAction;
+        m_dispatcher->RunAsync(ABI::Windows::UI::Core::CoreDispatcherPriority_Normal,
+            MakeAgileDispatcherCallback([this]() -> HRESULT
+        {
+            m_builder->AddListener(this);
+
+            ComPtr<IUIElement> rootElement;
+            m_builder->BuildXamlTreeFromAdaptiveCard(m_card.Get(), &m_rootXamlElement);
+            return S_OK;
+        }).Get(),
+            &dispatcherAsyncAction);
+
+        dispatcherAsyncAction->put_Completed(
+            Microsoft::WRL::Callback<ABI::Windows::Foundation::IAsyncActionCompletedHandler>(
+                [this](ABI::Windows::Foundation::IAsyncAction* action, ABI::Windows::Foundation::AsyncStatus status) -> HRESULT
+        {
+            return XamlRenderCompleted(action, status);
+        }).Get());
+        return S_OK;
+    }
+
+    void OnClose() override
+    {
+    }
+
+    void OnCancel() override
+    {
+    }
+
+    virtual HRESULT XamlRenderCompleted(ABI::Windows::Foundation::IAsyncAction* action, ABI::Windows::Foundation::AsyncStatus status) = 0;
+    virtual HRESULT OnXamlImagesLoaded() = 0;
+
+private:
+    Microsoft::WRL::ComPtr<ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCard> m_card;
+    std::function<ABI::Windows::UI::Xaml::IUIElement*(ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCard*)> m_dispatchFunction;
+};
+
+
+
+class RenderCardAsXamlAsyncOperation : 
+    public RenderAsyncBase<ABI::Windows::UI::Xaml::UIElement>
+{
+public:
+    RenderCardAsXamlAsyncOperation(
+        ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCard* card) 
+        : RenderAsyncBase<ABI::Windows::UI::Xaml::UIElement>(card)
+    {
+        AsyncBase::Start();
+    }
+
+    STDMETHODIMP ABI::Windows::Foundation::IAsyncOperation_impl<TResult_complex>::GetResults(ABI::Windows::UI::Xaml::IUIElement** rootElement)
+    {
+        return m_rootXamlElement.CopyTo(rootElement);
+    }
+
+protected:
+    HRESULT XamlRenderCompleted(ABI::Windows::Foundation::IAsyncAction* /*action*/, ABI::Windows::Foundation::AsyncStatus /*status*/) override
+    {
+        return S_OK;
+    }
+
+    HRESULT OnXamlImagesLoaded()
+    {
+        return AsyncBase::FireCompletion();
+    }
+
+};
+
+class RenderCardAsImageAsyncOperation :
+    public RenderAsyncBase<ABI::AdaptiveCards::XamlCardRenderer::ImageRenderResult>
+{
+public:
+    RenderCardAsImageAsyncOperation(
+        ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCard* card)
+        : RenderAsyncBase<ABI::AdaptiveCards::XamlCardRenderer::ImageRenderResult>(card)
+    {
+        AsyncBase::Start();
+    }
+
+    STDMETHODIMP ABI::Windows::Foundation::IAsyncOperation_impl<TResult_complex>::GetResults(ABI::AdaptiveCards::XamlCardRenderer::IImageRenderResult** imageRenderResult)
+    {
+        return m_imageRenderResult.CopyTo(imageRenderResult);
+    }
+
+protected:
+    HRESULT XamlRenderCompleted(ABI::Windows::Foundation::IAsyncAction* /*action*/, ABI::Windows::Foundation::AsyncStatus /*status*/) override
+    {
+        return S_OK;
+    }
+
+    HRESULT OnXamlImagesLoaded()
+    {
+        //TODO MSFT:10826539 XamlTileRenderer:Render image via RenderTargetBitmap
+        /*
+        RETURN_IF_FAILED(Microsoft::WRL::MakeAndInitialize<AdaptiveCards::XamlCardRenderer::RenderXamlToImageExecutionInstance>(&m_runInstance));
+        RETURN_IF_FAILED(m_runInstance->SetXamlRoot(m_rootXamlElement.Get()));
+
+        Microsoft::WRL::ComPtr<ABI::Windows::ApplicationModel::Background::IBackgroundTaskInstance> bgTaskInstance;
+        m_runInstance.As(&bgTaskInstance);
+
+        Microsoft::WRL::ComPtr<IInspectable> spTaskAsInspectable;
+        RETURN_IF_FAILED(Microsoft::WRL::MakeAndInitialize<AdaptiveCards::XamlCardRenderer::RenderXamlToImageTask>(&spTaskAsInspectable));
+        RETURN_IF_FAILED(spTaskAsInspectable.As(&m_backgroundTask));
+
+        RETURN_IF_FAILED(m_backgroundTask->Run(bgTaskInstance.Get()));
+        */
+
+        Microsoft::WRL::ComPtr<ABI::Windows::Foundation::IAsyncAction> dispatcherAsyncAction;
+        m_dispatcher->RunAsync(ABI::Windows::UI::Core::CoreDispatcherPriority_Normal,
+            MakeAgileDispatcherCallback([this]() -> HRESULT
+        {
+            m_renderTargetBitmap = AdaptiveCards::XamlCardRenderer::XamlHelpers::CreateXamlClass<ABI::Windows::UI::Xaml::Media::Imaging::IRenderTargetBitmap>(Microsoft::WRL::Wrappers::HStringReference(RuntimeClass_Windows_UI_Xaml_Media_Imaging_RenderTargetBitmap));
+            Microsoft::WRL::ComPtr<ABI::Windows::Foundation::IAsyncAction> renderAsyncAction;
+            m_renderTargetBitmap->RenderToSizeAsync(m_rootXamlElement.Get(), 100, 100, &renderAsyncAction);
+
+            renderAsyncAction->put_Completed(
+                Microsoft::WRL::Callback<ABI::Windows::Foundation::IAsyncActionCompletedHandler>(
+                    [this](ABI::Windows::Foundation::IAsyncAction* action, ABI::Windows::Foundation::AsyncStatus status) -> HRESULT
+            {
+                return RenderTargetBitmapRenderAsyncCompleted(action, status);
+            }).Get());
+
+            return S_OK;
+        }).Get(),
+            &dispatcherAsyncAction);
+
+        return S_OK;
+    }
+
+
+private:
+    Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::Media::Imaging::IRenderTargetBitmap> m_renderTargetBitmap;
+    Microsoft::WRL::ComPtr<ABI::AdaptiveCards::XamlCardRenderer::IImageRenderResult> m_imageRenderResult;
+
+    //Microsoft::WRL::ComPtr<AdaptiveCards::XamlCardRenderer::IRenderXamlToImageExecutionInstance> m_runInstance;
+    Microsoft::WRL::ComPtr<ABI::Windows::ApplicationModel::Background::IBackgroundTask> m_backgroundTask;
+
+    HRESULT RenderTargetBitmapRenderAsyncCompleted(ABI::Windows::Foundation::IAsyncAction* /*action*/, ABI::Windows::Foundation::AsyncStatus /*status*/)
+    {
+        Microsoft::WRL::ComPtr<ABI::Windows::Foundation::IAsyncOperation<ABI::Windows::Storage::Streams::IBuffer*>> getPixelsAsyncOperation;
+        m_renderTargetBitmap->GetPixelsAsync(&getPixelsAsyncOperation);
+        getPixelsAsyncOperation->put_Completed(
+            Microsoft::WRL::Callback<ABI::Windows::Foundation::IAsyncOperationCompletedHandler<ABI::Windows::Storage::Streams::IBuffer*>>(
+                [this](ABI::Windows::Foundation::IAsyncOperation<ABI::Windows::Storage::Streams::IBuffer*>* operation, AsyncStatus /*status*/) -> HRESULT
+        {
+            Microsoft::WRL::ComPtr<ABI::Windows::Storage::Streams::IBuffer> pixelsBuffer;
+            operation->GetResults(&pixelsBuffer);
+            return RenderTargetBitmapGetPixelsCompleted(pixelsBuffer.Get());
+        }).Get());
+
+        return S_OK;
+    }
+
+    HRESULT RenderTargetBitmapGetPixelsCompleted(ABI::Windows::Storage::Streams::IBuffer* /*pixelsBuffer*/)
+    {
+        int pixelHeight;
+        int pixelWidth;
+        RETURN_IF_FAILED(m_renderTargetBitmap->get_PixelHeight(&pixelHeight));
+        RETURN_IF_FAILED(m_renderTargetBitmap->get_PixelWidth(&pixelWidth));
+
+        //TODO MSFT:10826539 XamlTileRenderer:Render image via RenderTargetBitmap
+        //Microsoft::WRL::MakeAndInitialize<ABI::AdaptiveCards::XamlCardRenderer::ImageRenderResult>(&m_imageRenderResult,
+            //Microsoft::WRL::Wrappers::HStringReference(L"Alt Text").Get(), pixelsBuffer, pixelWidth, pixelHeight);
+                
+        return AsyncBase::FireCompletion();
+    }
+};

--- a/UWP/Renderer/lib/DefaultResourceDictionary.h
+++ b/UWP/Renderer/lib/DefaultResourceDictionary.h
@@ -1,0 +1,49 @@
+#pragma once
+
+const PCWSTR c_defaultResourceDictionary = L"\
+<ResourceDictionary \
+    xmlns=\"http://schemas.microsoft.com/winfx/2006/xaml/presentation\" \
+    xmlns:x=\"http://schemas.microsoft.com/winfx/2006/xaml\"> \
+\
+    <ResourceDictionary.ThemeDictionaries> \
+        <ResourceDictionary x:Key=\"Dark\"> \
+          <SolidColorBrush x:Key=\"TextColor.Accent\" Color=\"{ThemeResource SystemAccentColor}\"/> \
+          <SolidColorBrush x:Key=\"TextColor.Default\" Color=\"{ThemeResource SystemBaseHighColor}\"/> \
+        </ResourceDictionary> \
+\
+        <ResourceDictionary x:Key=\"Light\"> \
+          <SolidColorBrush x:Key=\"TextColor.Accent\" Color=\"{ThemeResource SystemAccentColor}\"/> \
+          <SolidColorBrush x:Key=\"TextColor.Default\" Color=\"{ThemeResource SystemBaseHighColor}\"/> \
+        </ResourceDictionary> \
+\
+        <ResourceDictionary x:Key=\"HighContrast\"> \
+          <SolidColorBrush x:Key=\"TextColor.Accent\" Color=\"{ThemeResource SystemColorWindowColor}\"/> \
+          <SolidColorBrush x:Key=\"TextColor.Default\" Color=\"{ThemeResource SystemColorButtonTextColor}\"/> \
+        </ResourceDictionary> \
+    </ResourceDictionary.ThemeDictionaries> \
+\
+    <SolidColorBrush x:Key=\"TextColor.Good\" Color=\"Green\"/> \
+    <SolidColorBrush x:Key=\"TextColor.Warning\" Color=\"Yellow\"/> \
+    <SolidColorBrush x:Key=\"TextColor.Attention\" Color=\"Red\"/> \
+\
+    <FontWeight x:Key=\"TextWeight.Lighter\">Light</FontWeight> \
+    <FontWeight x:Key=\"TextWeight.Normal\">Normal</FontWeight> \
+    <FontWeight x:Key=\"TextWeight.Bolder\">Bold</FontWeight> \
+\
+    <Style TargetType=\"TextBlock\" x:Key=\"TextBlock.Large\"> \
+        <Setter Property=\"FontSize\" Value=\"24\"/> \
+    </Style> \
+    <Style TargetType=\"TextBlock\" x:Key=\"TextBlock.Medium\"> \
+        <Setter Property=\"FontSize\" Value=\"18\"/> \
+    </Style> \
+    <Style TargetType=\"TextBlock\" x:Key=\"TextBlock.Small\"> \
+        <Setter Property=\"FontSize\" Value=\"12\"/> \
+    </Style> \
+\
+    <Style TargetType=\"StackPanel\" x:Key=\"Container\"> \
+        <Setter Property=\"Margin\" Value=\"0,0,0,0\"/> \
+    </Style> \
+    <Style TargetType=\"StackPanel\" x:Key=\"Container.StartGroup\"> \
+        <Setter Property=\"Margin\" Value=\"0,10,0,0\"/> \
+    </Style> \
+</ResourceDictionary>";

--- a/UWP/Renderer/lib/IImageLoadTrackerListener.h
+++ b/UWP/Renderer/lib/IImageLoadTrackerListener.h
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace AdaptiveCards { namespace XamlCardRenderer
+{
+
+MIDL_INTERFACE("D940E878-F2E0-4AF7-A844-4D090C7379E3")
+IImageLoadTrackerListener : public IInspectable
+{
+public:
+    IFACEMETHOD(AllImagesLoaded)() = 0;
+};
+
+}}

--- a/UWP/Renderer/lib/IXamlBuilderListener.h
+++ b/UWP/Renderer/lib/IXamlBuilderListener.h
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace AdaptiveCards { namespace XamlCardRenderer
+{
+
+MIDL_INTERFACE("BF58F7BB-A330-4C75-AF7F-6E5FD8C0C070")
+IXamlBuilderListener : public IInspectable
+{
+public:
+    IFACEMETHOD(AllImagesLoaded)() = 0;
+};
+
+}}

--- a/UWP/Renderer/lib/ImageLoadTracker.cpp
+++ b/UWP/Renderer/lib/ImageLoadTracker.cpp
@@ -43,6 +43,44 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         }
     }
 
+    void ImageLoadTracker::AbandonOutstandingImages()
+    {
+        auto exclusiveLock = m_lock.LockExclusive();
+        for (auto& eventRegistration : m_eventRegistrations)
+        {
+            UnsubscribeFromEvents(eventRegistration.first, eventRegistration.second);
+        }
+        m_eventRegistrations.clear();
+    }
+
+    _Use_decl_annotations_
+    HRESULT ImageLoadTracker::AddListener(IImageLoadTrackerListener* listener) try
+    {
+        if (m_listeners.find(listener) == m_listeners.end())
+        {
+            m_listeners.emplace(listener);
+        }
+        else
+        {
+            return E_INVALIDARG;
+        }
+        return S_OK;
+    } CATCH_RETURN;
+
+    _Use_decl_annotations_
+    HRESULT ImageLoadTracker::RemoveListener(IImageLoadTrackerListener* listener) try
+    {
+        if (m_listeners.find(listener) != m_listeners.end())
+        {
+            m_listeners.erase(listener);
+        }
+        else
+        {
+            return E_INVALIDARG;
+        }
+        return S_OK;
+    } CATCH_RETURN;
+
     _Use_decl_annotations_
     HRESULT ImageLoadTracker::trackedImage_ImageLoaded(IInspectable* sender, IRoutedEventArgs* /*eventArgs*/)
     {
@@ -66,12 +104,16 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         {
             UnsubscribeFromEvents(sender, m_eventRegistrations[sender]);
         }
+
+        if (m_trackedImageCount == 0)
+        {
+            FireAllImagesLoaded();
+        }
     }
 
     _Use_decl_annotations_
     void ImageLoadTracker::UnsubscribeFromEvents(IInspectable* bitmapImage, TrackedImageDetails& trackedImageDetails)
     {
-        auto exclusiveLock = m_lock.LockExclusive();
         ComPtr<IInspectable> inspectableBitmapImage(bitmapImage);
         ComPtr<IBitmapImage> localBitmapImage;
         inspectableBitmapImage.As(&localBitmapImage);
@@ -81,4 +123,11 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         localBitmapImage->remove_ImageFailed(trackedImageDetails.imageFailedRegistration);
     }
 
+    void ImageLoadTracker::FireAllImagesLoaded()
+    {
+        for (auto& listener : m_listeners)
+        {
+            listener->AllImagesLoaded();
+        }
+    }
 }}

--- a/UWP/Renderer/lib/ImageLoadTracker.h
+++ b/UWP/Renderer/lib/ImageLoadTracker.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "AdaptiveCards.XamlCardRenderer.h"
+#include "IImageLoadTrackerListener.h"
 
 namespace AdaptiveCards { namespace XamlCardRenderer
 {
@@ -16,14 +17,20 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         ~ImageLoadTracker();
         void TrackBitmapImage(_In_ ABI::Windows::UI::Xaml::Media::Imaging::IBitmapImage* bitmapImage);
 
+        void AbandonOutstandingImages();
+        HRESULT AddListener(_In_ IImageLoadTrackerListener* listener);
+        HRESULT RemoveListener(_In_ IImageLoadTrackerListener* listener);
+
     private:
         Microsoft::WRL::Wrappers::SRWLock m_lock;
         int m_trackedImageCount = 0;
         std::unordered_map<IInspectable*, TrackedImageDetails> m_eventRegistrations;
+        std::set<Microsoft::WRL::ComPtr<IImageLoadTrackerListener>> m_listeners;
 
         HRESULT trackedImage_ImageLoaded(_In_ IInspectable* sender, _In_ ABI::Windows::UI::Xaml::IRoutedEventArgs* eventArgs);
         HRESULT trackedImage_ImageFailed(_In_ IInspectable* sender, _In_ ABI::Windows::UI::Xaml::IExceptionRoutedEventArgs* eventArgs);
         void ImageLoadResultReceived(_In_ IInspectable* sender);
         void UnsubscribeFromEvents(_In_ IInspectable* bitmapImage, _In_ TrackedImageDetails& trackedImageDetails);
+        void FireAllImagesLoaded();
     };
 }}

--- a/UWP/Renderer/lib/ImageRenderResult.cpp
+++ b/UWP/Renderer/lib/ImageRenderResult.cpp
@@ -1,0 +1,56 @@
+﻿#include "pch.h"
+#include "ImageRenderResult.h"
+
+using namespace concurrency;
+using namespace Microsoft::WRL;
+using namespace Microsoft::WRL::Wrappers;
+using namespace ABI::AdaptiveCards::XamlCardRenderer;
+using namespace ABI::Windows::Foundation;
+using namespace ABI::Windows::Foundation::Collections;
+using namespace ABI::Windows::Storage::Streams;
+
+namespace AdaptiveCards { namespace XamlCardRenderer
+{
+    _Use_decl_annotations_
+    HRESULT ImageRenderResult::RuntimeClassInitialize(HSTRING altText, IBuffer* pixelBuffer, int width, int height)
+    {
+        m_altText.Attach(altText);
+        m_pixelBuffer = pixelBuffer;
+        m_pixelWidth = width;
+        m_pixelHeight = height;
+        return S_OK;
+    }
+
+    _Use_decl_annotations_
+    HRESULT ImageRenderResult::get_AltText(HSTRING* altText)
+    {
+        return m_altText.CopyTo(altText);
+    }
+
+    _Use_decl_annotations_
+    HRESULT ImageRenderResult::get_ImageBuffer(ABI::Windows::Storage::Streams::IBuffer** imageBuffer)
+    {
+        return m_pixelBuffer.CopyTo(imageBuffer);
+    }
+
+    _Use_decl_annotations_
+    HRESULT ImageRenderResult::get_IsAllContentClippedOut(boolean* /*allContentClipped*/)
+    {
+        return S_OK;
+    }
+
+    _Use_decl_annotations_
+    HRESULT ImageRenderResult::get_ImageWidthPixels(int* width)
+    {
+        *width = m_pixelWidth;
+        return S_OK;
+    }
+    
+    _Use_decl_annotations_
+    HRESULT ImageRenderResult::get_ImageHeightPixels(int* height)
+    {
+        *height = m_pixelHeight;
+        return S_OK;
+    }
+
+}}

--- a/UWP/Renderer/lib/ImageRenderResult.h
+++ b/UWP/Renderer/lib/ImageRenderResult.h
@@ -1,0 +1,32 @@
+﻿#pragma once
+
+#include "AdaptiveCards.XamlCardRenderer.h"
+
+namespace AdaptiveCards { namespace XamlCardRenderer
+{
+    // This class is effectively a singleton, and stays around between subsequent renders.
+    class ImageRenderResult :
+        public Microsoft::WRL::RuntimeClass<
+            Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
+            Microsoft::WRL::FtmBase,
+            ABI::AdaptiveCards::XamlCardRenderer::IImageRenderResult>
+    {
+        InspectableClass(RuntimeClass_AdaptiveCards_XamlCardRenderer_ImageRenderResult, BaseTrust)
+
+    public:
+        HRESULT RuntimeClassInitialize(_In_ HSTRING altText, _In_ ABI::Windows::Storage::Streams::IBuffer* pixelBuffer, _In_ int width, _In_ int height);
+
+        // IImageRenderResult
+        STDMETHODIMP get_AltText(_Out_ HSTRING* altText);
+        STDMETHODIMP get_ImageBuffer(_Out_ ABI::Windows::Storage::Streams::IBuffer **imageBuffer);
+        STDMETHODIMP get_IsAllContentClippedOut(_Out_ boolean *allContentClipped);
+        STDMETHODIMP get_ImageWidthPixels(_Out_ int *width);
+        STDMETHODIMP get_ImageHeightPixels(_Out_ int *height);
+
+    private:
+        int m_pixelWidth;
+        int m_pixelHeight;
+        Microsoft::WRL::ComPtr<ABI::Windows::Storage::Streams::IBuffer> m_pixelBuffer;
+        Microsoft::WRL::Wrappers::HString m_altText;
+    };
+}}

--- a/UWP/Renderer/lib/XamlBuilder.cpp
+++ b/UWP/Renderer/lib/XamlBuilder.cpp
@@ -1,19 +1,30 @@
 #include "pch.h"
 #include "XamlBuilder.h"
 
+#include "DefaultResourceDictionary.h"
 #include "XamlHelpers.h"
 #include "XamlStyleKeyGenerators.h"
 #include <windows.foundation.collections.h>
+#include <windows.storage.h>
+#include <windows.ui.xaml.markup.h>
+#include <windows.web.http.h>
+#include <windows.web.http.filters.h>
 
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;
 using namespace ABI::AdaptiveCards::XamlCardRenderer;
 using namespace ABI::Windows::Foundation;
 using namespace ABI::Windows::Foundation::Collections;
+using namespace ABI::Windows::Storage;
+using namespace ABI::Windows::Storage::Streams;
+using namespace ABI::Windows::UI::Text;
 using namespace ABI::Windows::UI::Xaml;
 using namespace ABI::Windows::UI::Xaml::Controls;
+using namespace ABI::Windows::UI::Xaml::Markup;
 using namespace ABI::Windows::UI::Xaml::Media;
 using namespace ABI::Windows::UI::Xaml::Media::Imaging;
+using namespace ABI::Windows::Web::Http;
+using namespace ABI::Windows::Web::Http::Filters;
 
 namespace AdaptiveCards { namespace XamlCardRenderer
 {
@@ -22,6 +33,20 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         // Populate the map of element types to their builder methods
         m_adaptiveElementBuilder[ElementType::TextBlock] = std::bind(&XamlBuilder::BuildTextBlock, this, std::placeholders::_1, std::placeholders::_2);
         m_adaptiveElementBuilder[ElementType::Image] = std::bind(&XamlBuilder::BuildImage, this, std::placeholders::_1, std::placeholders::_2);
+        m_adaptiveElementBuilder[ElementType::Container] = std::bind(&XamlBuilder::BuildContainer, this, std::placeholders::_1, std::placeholders::_2);
+
+        m_imageLoadTracker.AddListener(this);
+
+        THROW_IF_FAILED(GetActivationFactory(HStringReference(RuntimeClass_Windows_Storage_Streams_RandomAccessStream).Get(), &m_randomAccessStreamStatics));
+        THROW_IF_FAILED(GetActivationFactory(HStringReference(RuntimeClass_Windows_Foundation_PropertyValue).Get(), &m_propertyValueStatics));
+
+        InitializeDefaultResourceDictionary();
+    }
+
+    HRESULT XamlBuilder::AllImagesLoaded()
+    {
+        FireAllImagesLoaded();
+        return S_OK;
     }
 
     _Use_decl_annotations_
@@ -34,57 +59,122 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         // Enumerate the child items of the card and build xaml for them
         ComPtr<IVector<IAdaptiveCardElement*>> items;
         THROW_IF_FAILED(adaptiveCard->get_Items(&items));
-        XamlHelpers::IterateOverVector<IAdaptiveCardElement>(items, [&](IAdaptiveCardElement* element)
-        {
-            ElementType elementType;
-            THROW_IF_FAILED(element->get_ElementType(&elementType));
-            if (m_adaptiveElementBuilder.find(elementType) != m_adaptiveElementBuilder.end())
-            {
-                m_adaptiveElementBuilder[elementType](element, rootContainer.Get());
-            }
-        });
+        BuildPanelChildren(items.Get(), rootContainer.Get(), [](IUIElement*) {});
 
         THROW_IF_FAILED(rootContainer.CopyTo(xamlTreeRoot));
 
-        // Now that we're returning, make sure any outstanding image loads are no longer tracked
-        // since the tracker is going out of scope.
-        //m_imageLoadTracker.AbandonOutstandingImages();
-    }
-
-    void XamlBuilder::EnsurePropertyValueStatics()
-    {
-        if (!m_propertyValueStatics)
+        if (m_listeners.size() == 0)
         {
-            THROW_IF_FAILED(RoGetActivationFactory(HStringReference(RuntimeClass_Windows_Foundation_PropertyValue).Get(),
-                __uuidof(IPropertyValueStatics), reinterpret_cast<void**>(m_propertyValueStatics.GetAddressOf())));
+            // If we're done and no one's listening for the images to load, make sure 
+            // any outstanding image loads are no longer tracked.
+            m_imageLoadTracker.AbandonOutstandingImages();
         }
     }
 
+    HRESULT XamlBuilder::AddListener(IXamlBuilderListener* listener) try
+    {
+        if (m_listeners.find(listener) == m_listeners.end())
+        {
+            m_listeners.emplace(listener);
+        }
+        else
+        {
+            return E_INVALIDARG;
+        }
+        return S_OK;
+    } CATCH_RETURN;
+
+    HRESULT XamlBuilder::RemoveListener(IXamlBuilderListener* listener) try
+    {
+        if (m_listeners.find(listener) != m_listeners.end())
+        {
+            m_listeners.erase(listener);
+        }
+        else
+        {
+            return E_INVALIDARG;
+        }
+        return S_OK;
+    } CATCH_RETURN;
+
+    void XamlBuilder::InitializeDefaultResourceDictionary()
+    {
+        ComPtr<IXamlReaderStatics> xamlReaderStatics;
+        THROW_IF_FAILED(RoGetActivationFactory(HStringReference(RuntimeClass_Windows_UI_Xaml_Markup_XamlReader).Get(),
+            __uuidof(IXamlReaderStatics), reinterpret_cast<void**>(xamlReaderStatics.GetAddressOf())));
+
+        ComPtr<IInspectable> resourceDictionaryInspectable;
+        THROW_IF_FAILED(xamlReaderStatics->Load(HStringReference(c_defaultResourceDictionary).Get(), &resourceDictionaryInspectable));
+        ComPtr<IResourceDictionary> resourceDictionary;
+        THROW_IF_FAILED(resourceDictionaryInspectable.As(&resourceDictionary));
+
+        m_resourceDictionaries.push_back(resourceDictionary);
+    }
+
     _Use_decl_annotations_
-    bool XamlBuilder::TryGetStyleFromResourceDictionaries(std::wstring styleName, IStyle** style)
+    template<typename T>
+    bool XamlBuilder::TryGetResoureFromResourceDictionaries(std::wstring styleName, T** style)
     {
         *style = nullptr;
-        EnsurePropertyValueStatics();
-
-        // Get a resource key for the requested style that we can use for ResourceDistionary Lookups
-        ComPtr<IInspectable> resourceKey;
-        THROW_IF_FAILED(m_propertyValueStatics->CreateString(HStringReference(styleName.c_str()).Get(), resourceKey.GetAddressOf()));
-
-        // Search for the named resource in all known distionaries
-        ComPtr<IInspectable> dictionaryValue;
-        for (auto& resourceDictionary : m_resourceDictionaries)
+        try
         {
-            ComPtr<IMap<IInspectable*, IInspectable*>> resourceDictionaryMap;
-            if (SUCCEEDED(resourceDictionary.As(&resourceDictionaryMap)) &&
-                SUCCEEDED(resourceDictionaryMap->Lookup(resourceKey.Get(), dictionaryValue.GetAddressOf())))
+            // Get a resource key for the requested style that we can use for ResourceDistionary Lookups
+            ComPtr<IInspectable> resourceKey;
+            THROW_IF_FAILED(m_propertyValueStatics->CreateString(HStringReference(styleName.c_str()).Get(), resourceKey.GetAddressOf()));
+
+            // Search for the named resource in all known distionaries
+            ComPtr<IInspectable> dictionaryValue;
+            for (auto& resourceDictionary : m_resourceDictionaries)
             {
-                ComPtr<IStyle> styleToReturn;
-                if (SUCCEEDED(dictionaryValue.As(&styleToReturn)))
+                ComPtr<IMap<IInspectable*, IInspectable*>> resourceDictionaryMap;
+                if (SUCCEEDED(resourceDictionary.As(&resourceDictionaryMap)) &&
+                    SUCCEEDED(resourceDictionaryMap->Lookup(resourceKey.Get(), dictionaryValue.GetAddressOf())))
                 {
-                    THROW_IF_FAILED(styleToReturn.CopyTo(style));
-                    return true;
+                    ComPtr<T> resourceToReturn;
+                    if (SUCCEEDED(dictionaryValue.As(&resourceToReturn)))
+                    {
+                        THROW_IF_FAILED(resourceToReturn.CopyTo(style));
+                        return true;
+                    }
                 }
             }
+        }
+        catch (...)
+        {
+        }
+        return false;
+    }
+
+    template<typename T>
+    bool XamlBuilder::TryGetValueResoureFromResourceDictionaries(
+        _In_ std::wstring styleName,
+        _Out_ T* valueResource)
+    {
+        try
+        {
+            // Get a resource key for the requested style that we can use for ResourceDistionary Lookups
+            ComPtr<IInspectable> resourceKey;
+            THROW_IF_FAILED(m_propertyValueStatics->CreateString(HStringReference(styleName.c_str()).Get(), resourceKey.GetAddressOf()));
+
+            // Search for the named resource in all known distionaries
+            ComPtr<IInspectable> dictionaryValue;
+            for (auto& resourceDictionary : m_resourceDictionaries)
+            {
+                ComPtr<IMap<IInspectable*, IInspectable*>> resourceDictionaryMap;
+                if (SUCCEEDED(resourceDictionary.As(&resourceDictionaryMap)) &&
+                    SUCCEEDED(resourceDictionaryMap->Lookup(resourceKey.Get(), dictionaryValue.GetAddressOf())))
+                {
+                    ComPtr<T> resourceToReturn;
+                    if (SUCCEEDED(dictionaryValue.As(&styleToReturn)))
+                    {
+                        THROW_IF_FAILED(styleToReturn.CopyTo(style));
+                        return true;
+                    }
+                }
+            }
+        }
+        catch (...)
+        {
         }
         return false;
     }
@@ -94,26 +184,96 @@ namespace AdaptiveCards { namespace XamlCardRenderer
     {
         // We use a StackPanel as the panel type for the root adaptive card
         ComPtr<IStackPanel> stackPanel = XamlHelpers::CreateXamlClass<IStackPanel>(HStringReference(RuntimeClass_Windows_UI_Xaml_Controls_StackPanel));
-        
+
         ComPtr<IPanel> stackPanelAsPanel;
         THROW_IF_FAILED(stackPanel.As(&stackPanelAsPanel));
         return stackPanelAsPanel;
     }
 
     _Use_decl_annotations_
-    ComPtr<IImageSource> XamlBuilder::LoadImageFromUrl(IUriRuntimeClass* imageUri)
+    void XamlBuilder::PopulateImageFromUrlAsync(IUriRuntimeClass* imageUri, ABI::Windows::UI::Xaml::Controls::IImage* imageControl)
     {
+        // Create the HttpClient to load the image stream
+        ComPtr<IHttpBaseProtocolFilter> httpBaseProtocolFilter =
+            XamlHelpers::CreateXamlClass<IHttpBaseProtocolFilter>(HStringReference(RuntimeClass_Windows_Web_Http_Filters_HttpBaseProtocolFilter));
+        THROW_IF_FAILED(httpBaseProtocolFilter->put_AllowUI(false));
+        ComPtr<IHttpFilter> httpFilter;
+        THROW_IF_FAILED(httpBaseProtocolFilter.As(&httpFilter));
+        ComPtr<IHttpClient> httpClient;
+        ComPtr<IHttpClientFactory> httpClientFactory;
+        THROW_IF_FAILED(GetActivationFactory(HStringReference(RuntimeClass_Windows_Web_Http_HttpClient).Get(), httpClientFactory.ReleaseAndGetAddressOf()));
+        THROW_IF_FAILED(httpClientFactory->Create(httpFilter.Get(), httpClient.ReleaseAndGetAddressOf()));
+
+        // Create a BitmapImage to hold the image data.  We use BitmapImage in order to allow
+        // the tracker to subscribe to the ImageLoaded/Failed events
         ComPtr<IBitmapImage> bitmapImage = XamlHelpers::CreateXamlClass<IBitmapImage>(HStringReference(RuntimeClass_Windows_UI_Xaml_Media_Imaging_BitmapImage));
         m_imageLoadTracker.TrackBitmapImage(bitmapImage.Get());
+        THROW_IF_FAILED(bitmapImage->put_CreateOptions(BitmapCreateOptions::BitmapCreateOptions_None));
+        ComPtr<IBitmapSource> bitmapSource;
+        bitmapImage.As(&bitmapSource);
+        ComPtr<IAsyncOperationWithProgress<IInputStream*, HttpProgress>> getStreamOperation;
+        httpClient->GetInputStreamAsync(imageUri, &getStreamOperation);
 
-        THROW_IF_FAILED(bitmapImage->put_UriSource(imageUri));
-        ComPtr<IImageSource> imageSourceToReturn;
-        THROW_IF_FAILED(bitmapImage.As(&imageSourceToReturn));
-        return imageSourceToReturn;
+        getStreamOperation->put_Completed(Callback<Implements<RuntimeClassFlags<WinRtClassicComMix>, IAsyncOperationWithProgressCompletedHandler<IInputStream*, HttpProgress>>>
+            ([this, bitmapSource, imageControl](IAsyncOperationWithProgress<IInputStream*, HttpProgress>* operation, AsyncStatus /*status*/) -> HRESULT
+        {
+            // Load the image stream into an in memory random access stream, which is what
+            // SetSource needs
+            ComPtr<IInputStream> imageStream;
+            RETURN_IF_FAILED(operation->GetResults(&imageStream));
+            ComPtr<IRandomAccessStream> randomAccessStream = 
+            XamlHelpers::CreateXamlClass<IRandomAccessStream>(HStringReference(RuntimeClass_Windows_Storage_Streams_InMemoryRandomAccessStream));
+            ComPtr<IOutputStream> outputStream;
+            RETURN_IF_FAILED(randomAccessStream.As(&outputStream));
+            ComPtr<IAsyncOperationWithProgress<UINT64, UINT64>> copyStreamOperation;
+            RETURN_IF_FAILED(m_randomAccessStreamStatics->CopyAsync(imageStream.Get(), outputStream.Get(), &copyStreamOperation));
+
+            return copyStreamOperation->put_Completed(Callback<Implements<RuntimeClassFlags<WinRtClassicComMix>, IAsyncOperationWithProgressCompletedHandler<UINT64, UINT64>>>
+                ([this, bitmapSource, randomAccessStream, imageControl](IAsyncOperationWithProgress<UINT64, UINT64>* /*operation*/, AsyncStatus /*status*/) -> HRESULT
+            {
+                randomAccessStream->Seek(0);
+                RETURN_IF_FAILED(bitmapSource->SetSource(randomAccessStream.Get()));
+
+                ComPtr<IImageSource> imageSource;
+                RETURN_IF_FAILED(bitmapSource.As(&imageSource));
+                imageControl->put_Source(imageSource.Get());
+                return S_OK;
+            }).Get());
+        }).Get());
+    }
+
+    void XamlBuilder::FireAllImagesLoaded()
+    {
+        for (auto& listener : m_listeners)
+        {
+            listener->AllImagesLoaded();
+        }
     }
 
     _Use_decl_annotations_
-    void XamlBuilder::BuildTextBlock(IAdaptiveCardElement* adaptiveCardElement, IPanel* parentPanel)
+    void XamlBuilder::BuildPanelChildren(
+        IVector<IAdaptiveCardElement*>* children,
+        IPanel* parentPanel,
+        std::function<void(IUIElement* child)> childCreatedCallback)
+    {
+        XamlHelpers::IterateOverVector<IAdaptiveCardElement>(children, [&](IAdaptiveCardElement* element)
+        {
+            ElementType elementType;
+            THROW_IF_FAILED(element->get_ElementType(&elementType));
+            if (m_adaptiveElementBuilder.find(elementType) != m_adaptiveElementBuilder.end())
+            {
+                ComPtr<IUIElement> newControl;
+                m_adaptiveElementBuilder[elementType](element, &newControl);
+                XamlHelpers::AppendXamlElementToPanel(newControl.Get(), parentPanel);
+                childCreatedCallback(newControl.Get());
+            }
+        });
+    }
+
+    _Use_decl_annotations_
+    void XamlBuilder::BuildTextBlock(
+        IAdaptiveCardElement* adaptiveCardElement, 
+        IUIElement** textBlockControl)
     {
         ComPtr<IAdaptiveCardElement> cardElement(adaptiveCardElement);
         ComPtr<IAdaptiveTextBlock> adaptiveTextBlock;
@@ -127,16 +287,45 @@ namespace AdaptiveCards { namespace XamlCardRenderer
 
         ComPtr<IStyle> style;
         std::wstring styleName = XamlStyleKeyGenerators::GenerateKeyForTextBlock(adaptiveTextBlock.Get());
-        if (SUCCEEDED(TryGetStyleFromResourceDictionaries(styleName, &style)))
+        if (SUCCEEDED(TryGetResoureFromResourceDictionaries<IStyle>(styleName, &style)))
         {
-            // TODO: MSFT:10826544 - Programmatic xaml style generation
+            ComPtr<IFrameworkElement> textBlockAsFrameworkElement;
+            THROW_IF_FAILED(xamlTextBlock.As(&textBlockAsFrameworkElement));
+            THROW_IF_FAILED(textBlockAsFrameworkElement->put_Style(style.Get()));
         }
 
-        XamlHelpers::AppendXamlElementToPanel(xamlTextBlock, parentPanel);
+        ComPtr<IInspectable> fontWeightInspectable;
+        std::wstring fontWeightResourceName = XamlStyleKeyGenerators::GenerateKeyForTextBlockWeight(adaptiveTextBlock.Get());
+        if (SUCCEEDED(TryGetResoureFromResourceDictionaries<IInspectable>(fontWeightResourceName, &fontWeightInspectable)))
+        {
+            ComPtr<IReference<FontWeight>> fontWeightReference;
+            fontWeightInspectable.As(&fontWeightReference);
+            FontWeight fontWeight;
+            fontWeightReference.Get()->get_Value(&fontWeight);
+
+            THROW_IF_FAILED(xamlTextBlock->put_FontWeight(fontWeight));
+        }
+
+        ComPtr<IBrush> fontColorBrush;
+        std::wstring fontColorResourceName = XamlStyleKeyGenerators::GenerateKeyForTextBlockColor(adaptiveTextBlock.Get());
+        if (SUCCEEDED(TryGetResoureFromResourceDictionaries<IBrush>(fontColorResourceName, &fontColorBrush)))
+        {
+            THROW_IF_FAILED(xamlTextBlock->put_Foreground(fontColorBrush.Get()));
+        }
+
+        boolean shouldWrap = false;
+        THROW_IF_FAILED(adaptiveTextBlock->get_Wrap(&shouldWrap));
+        THROW_IF_FAILED(xamlTextBlock->put_TextWrapping(shouldWrap ? TextWrapping::TextWrapping_WrapWholeWords : TextWrapping::TextWrapping_NoWrap));
+
+        THROW_IF_FAILED(xamlTextBlock->put_TextTrimming(TextTrimming::TextTrimming_CharacterEllipsis));
+
+        THROW_IF_FAILED(xamlTextBlock.CopyTo(textBlockControl));
     }
 
     _Use_decl_annotations_
-    void XamlBuilder::BuildImage(IAdaptiveCardElement* adaptiveCardElement, IPanel* parentPanel)
+    void XamlBuilder::BuildImage(
+        IAdaptiveCardElement* adaptiveCardElement, 
+        IUIElement** imageControl)
     {
         ComPtr<IAdaptiveCardElement> cardElement(adaptiveCardElement);
         ComPtr<IAdaptiveImage> adaptiveImage;
@@ -146,8 +335,7 @@ namespace AdaptiveCards { namespace XamlCardRenderer
 
         ComPtr<IUriRuntimeClass> imageUri;
         THROW_IF_FAILED(adaptiveImage->get_Uri(imageUri.GetAddressOf()));
-        ComPtr<IImageSource> imageSource = LoadImageFromUrl(imageUri.Get());
-        THROW_IF_FAILED(xamlImage->put_Source(imageSource.Get()));
+        PopulateImageFromUrlAsync(imageUri.Get(), xamlImage.Get());
 
         ABI::AdaptiveCards::XamlCardRenderer::CardElementSize size;
         THROW_IF_FAILED(cardElement->get_Size(&size));
@@ -155,13 +343,44 @@ namespace AdaptiveCards { namespace XamlCardRenderer
 
         ComPtr<IStyle> style;
         std::wstring styleName = XamlStyleKeyGenerators::GenerateKeyForImage(adaptiveImage.Get());
-        if (SUCCEEDED(TryGetStyleFromResourceDictionaries(styleName, &style)))
+        if (SUCCEEDED(TryGetResoureFromResourceDictionaries<IStyle>(styleName, &style)))
         {
             ComPtr<IFrameworkElement> imageAsFrameworkElement;
             THROW_IF_FAILED(xamlImage.As(&imageAsFrameworkElement));
             THROW_IF_FAILED(imageAsFrameworkElement->put_Style(style.Get()));
         }
 
-        XamlHelpers::AppendXamlElementToPanel(xamlImage, parentPanel);
+        THROW_IF_FAILED(xamlImage.CopyTo(imageControl));
     }
+
+    _Use_decl_annotations_
+    void XamlBuilder::BuildContainer(
+        IAdaptiveCardElement* adaptiveCardElement, 
+        IUIElement** containerControl)
+    {
+        ComPtr<IAdaptiveCardElement> cardElement(adaptiveCardElement);
+        ComPtr<IAdaptiveContainer> adaptiveContainer;
+        THROW_IF_FAILED(cardElement.As(&adaptiveContainer));
+
+        ComPtr<IStackPanel> xamlStackPanel = XamlHelpers::CreateXamlClass<IStackPanel>(HStringReference(RuntimeClass_Windows_UI_Xaml_Controls_StackPanel));
+        xamlStackPanel->put_Orientation(Orientation::Orientation_Vertical);
+
+        ComPtr<IStyle> style;
+        std::wstring styleName = XamlStyleKeyGenerators::GenerateKeyForContainer(adaptiveContainer.Get());
+        if (SUCCEEDED(TryGetResoureFromResourceDictionaries<IStyle>(styleName, &style)))
+        {
+            ComPtr<IFrameworkElement> stackPanelAsFrameworkElement;
+            THROW_IF_FAILED(xamlStackPanel.As(&stackPanelAsFrameworkElement));
+            THROW_IF_FAILED(stackPanelAsFrameworkElement->put_Style(style.Get()));
+        }
+
+        ComPtr<IPanel> stackPanelAsPanel;
+        THROW_IF_FAILED(xamlStackPanel.As(&stackPanelAsPanel));
+        ComPtr<IVector<IAdaptiveCardElement*>> childItems;
+        THROW_IF_FAILED(adaptiveContainer->get_Items(&childItems));
+        BuildPanelChildren(childItems.Get(), stackPanelAsPanel.Get(), [](IUIElement*) {});
+
+        THROW_IF_FAILED(xamlStackPanel.CopyTo(containerControl));
+    }
+
 }}

--- a/UWP/Renderer/lib/XamlBuilder.h
+++ b/UWP/Renderer/lib/XamlBuilder.h
@@ -2,36 +2,62 @@
 
 #include "AdaptiveCards.XamlCardRenderer.h"
 #include "ImageLoadTracker.h"
+#include "IXamlBuilderListener.h"
+#include "IImageLoadTrackerListener.h"
+#include <windows.storage.h>
 
 namespace AdaptiveCards { namespace XamlCardRenderer
 {
-    class XamlBuilder
+    class XamlBuilder : public Microsoft::WRL::RuntimeClass<
+        Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
+        Microsoft::WRL::FtmBase,
+        AdaptiveCards::XamlCardRenderer::IImageLoadTrackerListener>
     {
     public:
         XamlBuilder();
 
+        // IImageLoadTrackerListener
+        STDMETHODIMP AllImagesLoaded();
+
         void BuildXamlTreeFromAdaptiveCard(_In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCard* adaptiveCard, _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** xamlTreeRoot);
+        HRESULT AddListener(IXamlBuilderListener* listener);
+        HRESULT RemoveListener(IXamlBuilderListener* listener);
 
     private:
         std::unordered_map<ABI::AdaptiveCards::XamlCardRenderer::ElementType, 
             std::function<void(ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCardElement*,
-                ABI::Windows::UI::Xaml::Controls::IPanel*)>> m_adaptiveElementBuilder;
+                ABI::Windows::UI::Xaml::IUIElement**)>> m_adaptiveElementBuilder;
         Microsoft::WRL::ComPtr<ABI::Windows::Foundation::IPropertyValueStatics> m_propertyValueStatics;
         std::vector<Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IResourceDictionary>> m_resourceDictionaries;
         ImageLoadTracker m_imageLoadTracker;
+        std::set<Microsoft::WRL::ComPtr<IXamlBuilderListener>> m_listeners;
+        Microsoft::WRL::ComPtr<ABI::Windows::Storage::Streams::IRandomAccessStreamStatics> m_randomAccessStreamStatics;
 
-        void EnsurePropertyValueStatics();
-        bool TryGetStyleFromResourceDictionaries(
+        void InitializeDefaultResourceDictionary();
+        template<typename T>
+        bool TryGetResoureFromResourceDictionaries(
             _In_ std::wstring styleName,
-            _COM_Outptr_result_maybenull_ ABI::Windows::UI::Xaml::IStyle** style);
+            _COM_Outptr_result_maybenull_ T** resource);
+        template<typename T>
+        bool TryGetValueResoureFromResourceDictionaries(
+            _In_ std::wstring styleName,
+            _Out_ T* valueResource);
         Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::Controls::IPanel> CreateRootPanelFromAdaptiveCard(_In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCard* adaptiveCard);
-        Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::Media::IImageSource> LoadImageFromUrl(_In_ ABI::Windows::Foundation::IUriRuntimeClass* imageUrl);
+        void PopulateImageFromUrlAsync(_In_ ABI::Windows::Foundation::IUriRuntimeClass* imageUrl, ABI::Windows::UI::Xaml::Controls::IImage* imageControl);
+        void FireAllImagesLoaded();
+        void BuildPanelChildren(
+            _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCardElement*>* children,
+            _In_ ABI::Windows::UI::Xaml::Controls::IPanel* parentPanel,
+            _In_ std::function<void(ABI::Windows::UI::Xaml::IUIElement* child)> childCreatedCallback);
 
         void BuildTextBlock(
             _In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCardElement* adaptiveCardElement,
-            _In_ ABI::Windows::UI::Xaml::Controls::IPanel* parentPanel);
+            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** textBlockControl);
         void BuildImage(
             _In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCardElement* adaptiveCardElement,
-            _In_ ABI::Windows::UI::Xaml::Controls::IPanel* parentPanel);
+            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** imageControl);
+        void BuildContainer(
+            _In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCardElement* adaptiveCardElement,
+            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** containerControl);
     };
 }}

--- a/UWP/Renderer/lib/XamlCardRendererComponent.cpp
+++ b/UWP/Renderer/lib/XamlCardRendererComponent.cpp
@@ -1,18 +1,25 @@
 ﻿#include "pch.h"
 #include "XamlCardRendererComponent.h"
 
+#include "AsyncOperations.h"
 #include <windows.foundation.collections.h>
+#include <Windows.UI.Xaml.h>
 #include "XamlBuilder.h"
+#include "XamlHelpers.h"
 
+using namespace concurrency;
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;
 using namespace ABI::AdaptiveCards::XamlCardRenderer;
 using namespace ABI::Windows::Foundation;
 using namespace ABI::Windows::Foundation::Collections;
+using namespace ABI::Windows::Storage::Streams;
 using namespace ABI::Windows::UI;
+using namespace ABI::Windows::UI::Core;
 using namespace ABI::Windows::UI::Xaml;
 using namespace ABI::Windows::UI::Xaml::Controls;
 using namespace ABI::Windows::UI::Xaml::Media;
+using namespace ABI::Windows::UI::Xaml::Media::Imaging;
 
 namespace AdaptiveCards { namespace XamlCardRenderer
 {
@@ -40,26 +47,40 @@ namespace AdaptiveCards { namespace XamlCardRenderer
     _Use_decl_annotations_
     HRESULT XamlCardRenderer::RenderCardAsXaml(
         IAdaptiveCard* adaptiveCard, 
-        IUIElement** root) try
+        IUIElement** result) try
     {
-        *root = nullptr;
+        *result = nullptr;
 
         if (adaptiveCard)
         {
             XamlBuilder builder;
             ComPtr<IUIElement> xamlTreeRoot;
             builder.BuildXamlTreeFromAdaptiveCard(adaptiveCard, &xamlTreeRoot);
-            RETURN_IF_FAILED(xamlTreeRoot.CopyTo(root));
+
+            *result = xamlTreeRoot.Detach();
         }
+
+        // TODO MSFT:10826542 - XamlTileRenderer:Delay rendering completion until images are fully available
+        
+        //*result = 
+
         return S_OK;
     } CATCH_RETURN;
 
     _Use_decl_annotations_
-    HRESULT XamlCardRenderer::RenderCardAsImage(
-        IAdaptiveCard* /*adaptiveCard*/,
+    HRESULT XamlCardRenderer::RenderCardAsXamlAsync(IAdaptiveCard* adaptiveCard,
+        IAsyncOperation<UIElement*>** result)
+    {
+        *result = Make<RenderCardAsXamlAsyncOperation>(adaptiveCard).Detach();
+        return S_OK;
+    }
+
+    _Use_decl_annotations_
+    HRESULT XamlCardRenderer::RenderCardAsImageAsync(
+        IAdaptiveCard* adaptiveCard,
         IAsyncOperation<ImageRenderResult*>** result)
     {
-        *result = nullptr;
+        *result = Make<RenderCardAsImageAsyncOperation>(adaptiveCard).Detach();
         return S_OK;
     }
 }}

--- a/UWP/Renderer/lib/XamlCardRendererComponent.h
+++ b/UWP/Renderer/lib/XamlCardRendererComponent.h
@@ -8,8 +8,8 @@ namespace AdaptiveCards { namespace XamlCardRenderer
     class XamlCardRenderer :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
-            Microsoft::WRL::FtmBase,
-            ABI::AdaptiveCards::XamlCardRenderer::IXamlCardRenderer>
+            Microsoft::WRL::Implements<ABI::AdaptiveCards::XamlCardRenderer::IXamlCardRenderer>,
+            Microsoft::WRL::FtmBase>
     {
         InspectableClass(RuntimeClass_AdaptiveCards_XamlCardRenderer_XamlCardRenderer, BaseTrust)
 
@@ -20,9 +20,13 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         IFACEMETHODIMP SetRenderOptions(_In_ ABI::AdaptiveCards::XamlCardRenderer::RenderOptions options);
         IFACEMETHODIMP SetOverrideStyles(_In_ ABI::Windows::UI::Xaml::IResourceDictionary* overrideDictionary);
         IFACEMETHODIMP RenderCardAsXaml(_In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCard* adaptiveCard,
-            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** root);
-        IFACEMETHODIMP RenderCardAsImage(_In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCard* adaptiveCard,
-            _COM_Outptr_result_maybenull_ ABI::Windows::Foundation::IAsyncOperation<ABI::AdaptiveCards::XamlCardRenderer::ImageRenderResult*>** result);
+            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
+        IFACEMETHODIMP RenderCardAsXamlAsync(_In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCard* adaptiveCard,
+            _COM_Outptr_ ABI::Windows::Foundation::IAsyncOperation<ABI::Windows::UI::Xaml::UIElement*>** result);
+        IFACEMETHODIMP RenderCardAsImageAsync(_In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCard* adaptiveCard,
+            _COM_Outptr_ ABI::Windows::Foundation::IAsyncOperation<ABI::AdaptiveCards::XamlCardRenderer::ImageRenderResult*>** result);
+
+    private:
     };
 
     ActivatableClass(XamlCardRenderer);

--- a/UWP/Renderer/lib/XamlHelpers.h
+++ b/UWP/Renderer/lib/XamlHelpers.h
@@ -20,13 +20,14 @@ namespace AdaptiveCards { namespace XamlCardRenderer
 
         template<typename T, typename C>
         static void IterateOverVector(
-            Microsoft::WRL::ComPtr<ABI::Windows::Foundation::Collections::IVector<T*>>& vector,
+            ABI::Windows::Foundation::Collections::IVector<T*>* vector,
             C iterationCallback)
         {
-            ComPtr<IIterable<T*>> vectorIterable;
-            THROW_IF_FAILED(vector.As<IIterable<T*>>(&vectorIterable));
+            Microsoft::WRL::ComPtr<IVector<T*>> localVector(vector);
+            Microsoft::WRL::ComPtr<IIterable<T*>> vectorIterable;
+            THROW_IF_FAILED(localVector.As<IIterable<T*>>(&vectorIterable));
 
-            ComPtr<IIterator<T*>> vectorIterator;
+            Microsoft::WRL::ComPtr<IIterator<T*>> vectorIterator;
             if (FAILED(vectorIterable->First(&vectorIterator)))
             {
                 return;
@@ -48,18 +49,14 @@ namespace AdaptiveCards { namespace XamlCardRenderer
             }
         }
 
-        template<typename T>
         static void AppendXamlElementToPanel(
-            Microsoft::WRL::ComPtr<T> xamlElement,
+            ABI::Windows::UI::Xaml::IUIElement* xamlElement,
             ABI::Windows::UI::Xaml::Controls::IPanel* panel)
         {
-            ComPtr<IUIElement> elementToAppend;
-            THROW_IF_FAILED(xamlElement.As(&elementToAppend));
-
-            ComPtr<IVector<UIElement*>> panelChildren;
+            Microsoft::WRL::ComPtr<ABI::Windows::Foundation::Collections::IVector<ABI::Windows::UI::Xaml::UIElement*>> panelChildren;
             THROW_IF_FAILED(panel->get_Children(panelChildren.ReleaseAndGetAddressOf()));
 
-            THROW_IF_FAILED(panelChildren->Append(elementToAppend.Get()));
+            THROW_IF_FAILED(panelChildren->Append(xamlElement));
         }
     };
 

--- a/UWP/Renderer/lib/XamlStyleKeyGenerators.h
+++ b/UWP/Renderer/lib/XamlStyleKeyGenerators.h
@@ -11,12 +11,55 @@ namespace AdaptiveCards { namespace XamlCardRenderer
     class XamlStyleKeyGenerators
     {
     public:
-        static std::wstring GenerateKeyForTextBlock(ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveTextBlock* /*textBlock*/)
+        static std::wstring GenerateKeyForTextBlock(ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveTextBlock* textBlock)
         {
+            Microsoft::WRL::ComPtr<ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveTextBlock> adaptiveTextBlock(textBlock);
+            Microsoft::WRL::ComPtr<ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCardElement> adaptiveCardElement;
+            THROW_IF_FAILED(adaptiveTextBlock.As(&adaptiveCardElement));
+
             std::wstring styleKey = GetElementTypeAsString(CardElementType::TextBlock);
+            styleKey.append(c_StyleSeparator);
+            styleKey.append(GetSizeFromCard(adaptiveCardElement.Get()).c_str());
 
-            // TODO: MSFT:10826544 - Programmatic xaml style generation
+            return styleKey;
+        }
 
+        static std::wstring GenerateKeyForTextBlockWeight(ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveTextBlock* textBlock)
+        {
+            Microsoft::WRL::ComPtr<ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveTextBlock> adaptiveTextBlock(textBlock);
+
+            std::wstring styleKey = L"TextWeight";
+            styleKey.append(c_StyleSeparator);
+            styleKey.append(GetWeightFromTextBlock(adaptiveTextBlock.Get()).c_str());
+
+            return styleKey;
+        }
+
+        static std::wstring GenerateKeyForTextBlockColor(ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveTextBlock* textBlock)
+        {
+            Microsoft::WRL::ComPtr<ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveTextBlock> adaptiveTextBlock(textBlock);
+
+            std::wstring styleKey = L"TextColor";
+            styleKey.append(c_StyleSeparator);
+            styleKey.append(GetColorFromTextBlock(adaptiveTextBlock.Get()).c_str());
+
+            return styleKey;
+        }
+
+        static std::wstring GenerateKeyForContainer(ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveContainer* container)
+        {
+            Microsoft::WRL::ComPtr<ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveContainer> adaptiveContainer(container);
+
+            // TODO: Use GetElementTypeAsString once MSFT:11028246 is fixed
+            std::wstring styleKey = L"Container"; 
+
+            boolean isStartGroup;
+            THROW_IF_FAILED(adaptiveContainer->get_StartGroup(&isStartGroup));
+            if (isStartGroup)
+            {
+                styleKey.append(c_StyleSeparator);
+                styleKey.append(L"StartGroup");
+            }
             return styleKey;
         }
 
@@ -50,6 +93,24 @@ namespace AdaptiveCards { namespace XamlCardRenderer
             std::string sizeString = AdaptiveCards::SizeToString(static_cast<AdaptiveCards::CardElementSize>(size));
             std::wstring sizeWideString(sizeString.begin(), sizeString.end());
             return sizeWideString;
+        }
+
+        static std::wstring GetWeightFromTextBlock(_In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveTextBlock* adaptiveTextBlock)
+        {
+            ABI::AdaptiveCards::XamlCardRenderer::TextWeight textWeight;
+            THROW_IF_FAILED(adaptiveTextBlock->get_TextWeight(&textWeight));
+            std::string weightString = AdaptiveCards::TextWeightToString(static_cast<AdaptiveCards::TextWeight>(textWeight));
+            std::wstring weightWideString(weightString.begin(), weightString.end());
+            return weightWideString;
+        }
+
+        static std::wstring GetColorFromTextBlock(_In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveTextBlock* adaptiveTextBlock)
+        {
+            ABI::AdaptiveCards::XamlCardRenderer::TextColor textColor;
+            THROW_IF_FAILED(adaptiveTextBlock->get_TextColor(&textColor));
+            std::string colorString = AdaptiveCards::TextColorToString(static_cast<AdaptiveCards::TextColor>(textColor));
+            std::wstring colorWideString(colorString.begin(), colorString.end());
+            return colorWideString;
         }
     };
 

--- a/UWP/Renderer/lib/pch.h
+++ b/UWP/Renderer/lib/pch.h
@@ -13,6 +13,7 @@
 #endif
 
 #include <unordered_map>
+#include <set>
 
 #include "ErrorHandling.h"
 

--- a/UWP/Visualizer/MainPage.xaml
+++ b/UWP/Visualizer/MainPage.xaml
@@ -35,7 +35,8 @@
             <TextBlock Text="Rendered As Xaml Output:" Grid.Row="0"/>
             <ContentPresenter x:Name="renderedXamlPresenter" Grid.Row="1"/>
             <TextBlock Text="Rendered As Image Output:" Grid.Row="2"/>
-            <Image x:Name="renderedXamlImage" Grid.Row="3"/>
+            <!--<Image x:Name="renderedXamlImage" Grid.Row="3"/> -->
+            <ContentPresenter x:Name="renderedImagePresenter" Grid.Row="3"/>
         </Grid>
     </Grid>
     

--- a/UWP/Visualizer/MainPage.xaml.cs
+++ b/UWP/Visualizer/MainPage.xaml.cs
@@ -30,27 +30,55 @@ namespace XamlCardVisualizer
 
             // Construct a temporary object model tree until the parser is available
             AdaptiveCard card = new AdaptiveCard();
+            AdaptiveContainer container1 = new AdaptiveContainer();
+
             AdaptiveTextBlock textBlock1 = new AdaptiveTextBlock();
             textBlock1.Text = "Hello";
-            card.Items.Add(textBlock1);
+            textBlock1.Size = CardElementSize.Medium;
+            textBlock1.TextWeight = TextWeight.Normal;
+            textBlock1.TextColor = TextColor.Default;
+            container1.Items.Add(textBlock1);
+            AdaptiveTextBlock textBlock2 = new AdaptiveTextBlock();
+            textBlock2.Text = "World";
+            textBlock2.Size = CardElementSize.Medium;
+            textBlock2.TextWeight = TextWeight.Normal;
+            textBlock2.TextColor = TextColor.Accent;
+            container1.Items.Add(textBlock2);
+
+            card.Items.Add(container1);
+
+            AdaptiveContainer container2 = new AdaptiveContainer();
+            container2.StartGroup = true;
+
+            AdaptiveTextBlock textBlock3 = new AdaptiveTextBlock();
+            textBlock3.Text = "In new container";
+            textBlock3.Size = CardElementSize.Medium;
+            textBlock3.TextWeight = TextWeight.Normal;
+            textBlock3.TextColor = TextColor.Default;
+            container2.Items.Add(textBlock3);
+
+            card.Items.Add(container2);
+
             AdaptiveImage image = new AdaptiveImage();
             image.Uri = new Uri("https://docs.microsoft.com/en-us/_themes/images/microsoft-header.png");
             card.Items.Add(image);
-            AdaptiveTextBlock textBlock2 = new AdaptiveTextBlock();
-            textBlock2.Text = "World";
-            card.Items.Add(textBlock2);
 
-            AdaptiveCards.XamlCardRenderer.XamlCardRenderer renderer = new AdaptiveCards.XamlCardRenderer.XamlCardRenderer();
-            this.renderedXamlPresenter.Content = renderer.RenderCardAsXaml(card);
+            m_renderer = new AdaptiveCards.XamlCardRenderer.XamlCardRenderer();
 
-            /* TODO MSFT:10826542 - XamlTileRenderer:Delay rendering completion until images are fully available
-            var renderAsyncOperation = renderer.RenderCardAsXamlAsync(card);
-            renderAsyncOperation.Completed = new AsyncOperationCompletedHandler<UIElement>(
-                (op, status) =>
-                {
-                    this.renderedXamlPresenter.Content = op.GetResults();
-                });
-            */
+            PopulateXamlContent(card);
+            PopulateImageContent(card);
         }
+
+        private async void PopulateXamlContent(AdaptiveCard card)
+        {
+            renderedXamlPresenter.Content = await m_renderer.RenderCardAsXamlAsync(card);
+        }
+
+        private async void PopulateImageContent(AdaptiveCard card)
+        {
+            //ImageRenderResult imageRenderResult = await m_renderer.RenderCardAsImageAsync(card);
+        }
+
+        private AdaptiveCards.XamlCardRenderer.XamlCardRenderer m_renderer;
     }
 }


### PR DESCRIPTION
This change creates a RenderCardAsXamlAsync that returns an async
operation
which only completes once all the images have been downloaded and are
ready
to be displayed.

There are a couple of main pieces to this changes:
1) Image loading is now done manually instead of letting
BitmapImage::SetSource do it.  This is
because Xaml delays image loading until the control is being rendered in
the tree.  Since that
will never happen, the ImageLoaded event neve fires it the source is set
this way.
2) I created a common async operation base class which will be reused to
provide the same functionality
for the implementation of the RenderCardAsImageAsync operation.
3) Both the ImageLoadTracker and the XamlBuilder now expose a callback
interface to notify clients
when all images have been loaded.

I also implemented a few bits of the default resource dictionary and the
usage of resource, just to
verify that strategy will work.