### PR TITLE
Fixing visualizer startup

### DIFF
--- a/source/html/visualizer/package.json
+++ b/source/html/visualizer/package.json
@@ -9,7 +9,7 @@
     "build": "webpack",
     "build-verbose": "webpack --display-error-details",
     "watch": "webpack --watch",
-    "start": "http-server ./dev.html -c-1 -o -a localhost",
+    "start": "http-server -c-1 -o",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {


### PR DESCRIPTION
I found this repository through the demo at the CaaP TWG, but noted an issue when I tried running it myself: the `-a localhost` option, when running the server appears to make the server return a 404 page at `localhost` instead of the index or the dev page. Removing the file reference and the `-a localhost` reference, seems to allow the server to serve all the contents in the directory (index.html + dev.html) at both `127.0.0.1` and `localhost`, whereas with the `-a localhost` option, it would only serve page at `127.0.0.1`. 