### PR TITLE
Remove actions.stretch

### DIFF
--- a/source/html/renderer/src/card-elements.ts
+++ b/source/html/renderer/src/card-elements.ts
@@ -1605,6 +1605,7 @@ class ActionCollection {
         }
 
         var element = document.createElement("div");
+
         var buttonStrip = document.createElement("div");
 
         switch (hostConfig.actions.actionAlignment) {
@@ -1621,16 +1622,19 @@ class ActionCollection {
         }
 
         if (hostConfig.actions.actionsOrientation == "horizontal") {
-            if (hostConfig.actions.stretch) {
+            if (hostConfig.actions.actionAlignment == "stretch") {
                 buttonStrip.style.display = "flex";
             }
             else {
                 buttonStrip.style.display = "inline-flex";
-                buttonStrip.style.width = "100%";
             }
         }
         else {
             buttonStrip.style.display = "inline-table";
+
+            if (hostConfig.actions.actionAlignment == "stretch") {
+                buttonStrip.style.width = "100%";
+            }
         }
 
         this._actionCardContainer = document.createElement("div");
@@ -1663,7 +1667,7 @@ class ActionCollection {
                     buttonStripItem.style.whiteSpace = "nowrap";
                     buttonStripItem.style.overflow = "hidden";
                     buttonStripItem.style.overflow = "table-cell";
-                    buttonStripItem.style.flex = hostConfig.actions.stretch ? "0 1 100%" : "0 1 auto";
+                    buttonStripItem.style.flex = hostConfig.actions.actionAlignment == "stretch" ? "0 1 100%" : "0 1 auto";
 
                     let actionButton = new ActionButton(this.items[i], actionButtonStyle);
                     actionButton.text = this.items[i].title;
@@ -1693,7 +1697,11 @@ class ActionCollection {
                 }
             }
 
-            Utils.appendChild(element, buttonStrip);
+            var buttonStripContainer = document.createElement("div");
+            buttonStripContainer.style.overflow = "hidden";
+            buttonStripContainer.appendChild(buttonStrip);
+            
+            Utils.appendChild(element, buttonStripContainer);
         }
 
         Utils.appendChild(element, this._actionCardContainer);
@@ -2507,7 +2515,6 @@ var defaultHostConfig: HostConfig.IHostConfig = {
             spacing: 20
         },
         buttonSpacing: 20,
-        stretch: false,
         showCard: {
             actionMode: "inlineEdgeToEdge",
             inlineTopMargin: 16,

--- a/source/html/renderer/src/enums.ts
+++ b/source/html/renderer/src/enums.ts
@@ -8,6 +8,8 @@ export type TextColor = "dark" | "light" | "accent" | "good" | "warning" | "atte
 
 export type HorizontalAlignment = "left" | "center" | "right";
 
+export type ActionAlignment = "left" | "center" | "right" | "stretch";
+
 export type ContainerStyle = "normal" | "emphasis";
 
 export type ImageStyle = "normal" | "person";

--- a/source/html/renderer/src/host-config.ts
+++ b/source/html/renderer/src/host-config.ts
@@ -221,10 +221,9 @@ export interface IActionsConfig {
     supportedActionTypes?: Array<string>,
     separation: ISeparationDefinition,
     buttonSpacing: number,
-    stretch: boolean,
     showCard: IShowCardActionConfig,
     actionsOrientation: Enums.Orientation,
-    actionAlignment: Enums.HorizontalAlignment
+    actionAlignment: Enums.ActionAlignment
 }
 
 function parseActionsConfiguration(obj: any): IActionsConfig {
@@ -233,7 +232,6 @@ function parseActionsConfiguration(obj: any): IActionsConfig {
         supportedActionTypes: obj["supportedActionTypes"],
         separation: parseSeparationDefinition(obj["separation"]),
         buttonSpacing: obj["buttonSpacing"],
-        stretch: obj["stretch"],
         showCard: parseShowCardActionConfiguration(obj["showCard"]),
         actionsOrientation: obj["actionsOrientation"],
         actionAlignment: obj["actionAlignment"]

--- a/source/html/visualizer/src/app.ts
+++ b/source/html/visualizer/src/app.ts
@@ -265,9 +265,10 @@ function setupContainerPicker() {
     if (hostContainerPicker) {
         hostContainerPicker.addEventListener(
             "change", () => {
-                // Disable this for now because it interferes with dev.html
-                // update the query string
-                // history.pushState(hostContainerPicker.value, `Visualizer - ${hostContainerPicker.value}`, `index.html?hostApp=${hostContainerPicker.value}`);
+                // Update the query string
+                var htmlFileName = location.pathname.indexOf("index.html") >= 0 ? "index.html" : "dev.html";
+
+                history.pushState(hostContainerPicker.value, `Visualizer - ${hostContainerPicker.value}`, htmlFileName + `?hostApp=${hostContainerPicker.value}`);
 
                 loadStyleSheetAndConfig();
                 tryRenderCard();

--- a/source/html/visualizer/src/containers/bing.ts
+++ b/source/html/visualizer/src/containers/bing.ts
@@ -87,7 +87,6 @@ export class BingContainer extends HostContainer {
                     spacing: 20
                 },
                 buttonSpacing: 20,
-                stretch: false,
                 showCard: {
                     actionMode: "inlineEdgeToEdge",
                     inlineTopMargin: 16,

--- a/source/html/visualizer/src/containers/cortana-car.ts
+++ b/source/html/visualizer/src/containers/cortana-car.ts
@@ -88,7 +88,6 @@ export class CortanaCarContainer extends HostContainer {
                     spacing: 20
                 },
                 buttonSpacing: 20,
-                stretch: false,
                 showCard: {
                     actionMode: "inlineEdgeToEdge",
                     inlineTopMargin: 16,

--- a/source/html/visualizer/src/containers/host-container.ts
+++ b/source/html/visualizer/src/containers/host-container.ts
@@ -145,7 +145,6 @@ export abstract class HostContainer {
                     spacing: 20
                 },
                 buttonSpacing: 20,
-                stretch: false,
                 showCard: {
                     actionMode: "inlineEdgeToEdge",
                     inlineTopMargin: 16,

--- a/source/html/visualizer/src/containers/live-tile.ts
+++ b/source/html/visualizer/src/containers/live-tile.ts
@@ -88,7 +88,6 @@ export class LiveTileContainer extends HostContainer {
                     spacing: 20
                 },
                 buttonSpacing: 20,
-                stretch: false,
                 showCard: {
                     actionMode: "inlineEdgeToEdge",
                     inlineTopMargin: 16,

--- a/source/html/visualizer/src/containers/skype.ts
+++ b/source/html/visualizer/src/containers/skype.ts
@@ -94,7 +94,6 @@ export class SkypeContainer extends HostContainer {
                     spacing: 20
                 },
                 buttonSpacing: 20,
-                stretch: false,
                 showCard: {
                     actionMode: "popup",
                     inlineTopMargin: 16,

--- a/source/html/visualizer/src/containers/teams-connector.ts
+++ b/source/html/visualizer/src/containers/teams-connector.ts
@@ -73,7 +73,6 @@ export class TeamsConnectorContainer extends HostContainer {
                     spacing: 20
                 },
                 buttonSpacing: 10,
-                stretch: true,
                 showCard: {
                     actionMode: "inlineEdgeToEdge",
                     inlineTopMargin: 16,
@@ -86,7 +85,7 @@ export class TeamsConnectorContainer extends HostContainer {
                     }
                 },
                 actionsOrientation: "horizontal",
-                actionAlignment: "left"
+                actionAlignment: "stretch"
             },
             adaptiveCard: {
                 backgroundColor: "#00000000",

--- a/source/html/visualizer/src/containers/toast.ts
+++ b/source/html/visualizer/src/containers/toast.ts
@@ -80,7 +80,6 @@ export class ToastContainer extends HostContainer {
                     spacing: 10
                 },
                 buttonSpacing: 10,
-                stretch: true,
                 showCard: {
                     actionMode: "inlineEdgeToEdge",
                     inlineTopMargin: 16,
@@ -93,7 +92,7 @@ export class ToastContainer extends HostContainer {
                     }
                 },
                 actionsOrientation: "horizontal",
-                actionAlignment: "left"
+                actionAlignment: "stretch"
             },
             adaptiveCard: {
                 backgroundColor: "#1F1F1F",

--- a/source/html/visualizer/src/containers/webchat.ts
+++ b/source/html/visualizer/src/containers/webchat.ts
@@ -95,7 +95,6 @@ export class WebChatContainer extends HostContainer {
                     spacing: 8
                 },
                 buttonSpacing: 20,
-                stretch: false,
                 showCard: {
                     actionMode: "inlineEdgeToEdge",
                     inlineTopMargin: 16,


### PR DESCRIPTION
Add actions.actionAlignment = stretch
Bring back navigation history in visualizer

NOTE: actions buttons will not shrink when aligned left, center or right. I just can't figure out how to do it without writing complex code (which seems to be the only solution based on what I found on the web)
So for now, when there isn't enough space, buttons will be truncated.