### PR TITLE
Fix crash in image size code

### DIFF
--- a/source/shared/cpp/ObjectModel/Enums.cpp
+++ b/source/shared/cpp/ObjectModel/Enums.cpp
@@ -185,7 +185,8 @@ static std::unordered_map<ImageSize, std::string, EnumHash> ImageSizeEnumToName 
     { ImageSize::Stretch, "Stretch" },
     { ImageSize::Small, "Small" },
     { ImageSize::Medium, "Medium" },
-    { ImageSize::Large, "Large" }
+    { ImageSize::Large, "Large" },
+    { ImageSize::Default, "Auto" },
 };
 
 static std::unordered_map<std::string, HorizontalAlignment, CaseInsensitiveHash, CaseInsensitiveEqualTo> HorizontalAlignmentNameToEnum =


### PR DESCRIPTION
When I added the default image size to handle image set host config, I introduced a crash cause trying to map the default image size back to a string.  Fixed by adding a mapping for default image size to auto.