### PR TITLE
Remove pre-expansion for single Action.ShiowCard

### DIFF
--- a/source/html/renderer/src/enums.ts
+++ b/source/html/renderer/src/enums.ts
@@ -25,6 +25,7 @@ export enum ValidationError {
     CollectionCantBeEmpty,
     ElementTypeNotAllowed,
     InteractivityNotAllowed,
+    InvalidPropertyValue,
     MissingCardType,
     PropertyCantBeNull,
     TooManyActions,

--- a/source/html/visualizer/src/app.ts
+++ b/source/html/visualizer/src/app.ts
@@ -90,8 +90,8 @@ function filePickerChanged(evt) {
         let reader = new FileReader();
 
         reader.onload = function (e: ProgressEvent) {
-            // editor.session.setValue((e.target as FileReader).result);
-            setEditorText((e.target as FileReader).result);
+            currentCardPayload = (e.target as FileReader).result;
+            switchToCardEditor();
         }
 
         reader.readAsText(file);


### PR DESCRIPTION
Better parsing logic for Column.size (and better errors in visualizer)
Fix visualizer that didn't switch back to card editor after a sample was loaded from file