### PR TITLE
Fix UWP ComboBox not stretching width

### DIFF
--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -1469,6 +1469,11 @@ namespace AdaptiveCards { namespace XamlCardRenderer
     {
         ComPtr<IComboBox> comboBox = XamlHelpers::CreateXamlClass<IComboBox>(HStringReference(RuntimeClass_Windows_UI_Xaml_Controls_ComboBox));
 
+        // Set HorizontalAlignment to Stretch (defaults to Left for combo boxes)
+        ComPtr<IFrameworkElement> comboBoxAsFrameworkElement;
+        THROW_IF_FAILED(comboBox.As(&comboBoxAsFrameworkElement));
+        THROW_IF_FAILED(comboBoxAsFrameworkElement->put_HorizontalAlignment(HorizontalAlignment_Stretch));
+
         ComPtr<IItemsControl> itemsControl;
         THROW_IF_FAILED(comboBox.As(&itemsControl));
 


### PR DESCRIPTION
The UWP ComboBox defaults horizontal alignment to left, whereas in the
compact ChoiceSet picker, it's desired that the picker displays
full-width just like text boxes, as described in issue #337

Simply assigned HorizontalAlignment to Stretch on the ComboBox to fix
this. Verified changes with Visualizer.

**Before**
![image](https://cloud.githubusercontent.com/assets/13246069/26217946/20806120-3bbe-11e7-9407-034fbf5db7ac.png)

**After**
![image](https://cloud.githubusercontent.com/assets/13246069/26217953/2885b10e-3bbe-11e7-99d3-113b0cb4054b.png)