### PR TITLE
Fix UWP person images that don't have size set

### DIFF
--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -1089,8 +1089,9 @@ namespace AdaptiveCards { namespace XamlCardRenderer
             ComPtr<IEllipse> ellipse = XamlHelpers::CreateXamlClass<IEllipse>(HStringReference(RuntimeClass_Windows_UI_Xaml_Shapes_Ellipse));
             SetImageOnUIElement(imageUri.Get(), ellipse.Get());
 
-            // Set both Auto and Stretch to Stretch_UniformToFill.  An ellipse set to Stretch_Uniform ends up with size 0.
+            // Set both Auto, Default, and Stretch to Stretch_UniformToFill.  An ellipse set to Stretch_Uniform ends up with size 0.
             if (size == ABI::AdaptiveCards::XamlCardRenderer::ImageSize::Auto ||
+                size == ABI::AdaptiveCards::XamlCardRenderer::ImageSize::Default ||
                 size == ABI::AdaptiveCards::XamlCardRenderer::ImageSize::Stretch)
             {
                 ComPtr<IShape> ellipseAsShape;


### PR DESCRIPTION
In the UWP renderer, if you're using an image with "person" style, and
you don't manually specify the size of the image, it was failing to
render, as described in issue #331. Non-person images render fine
without the style provided.

Code was forgetting to set the stretch behavior when image size was set
to Default inside the person logic branch of the code. Just had to add
that line so it included Default size.

Verified behavior in Visualizer. Now a "person" image behaves identically to a normal image when size is not specified.