### PR TITLE
Ensure UWP text elements are perfectly left aligned

### DIFF
--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -990,6 +990,10 @@ namespace AdaptiveCards { namespace XamlCardRenderer
 
         ComPtr<ITextBlock> xamlTextBlock = XamlHelpers::CreateXamlClass<ITextBlock>(HStringReference(RuntimeClass_Windows_UI_Xaml_Controls_TextBlock));
 
+        // ITextBlock2 will be used later on
+        ComPtr<ITextBlock2> xamlTextBlock2;
+        THROW_IF_FAILED(xamlTextBlock.As(&xamlTextBlock2));
+
         HString text;
         adaptiveTextBlock->get_Text(text.GetAddressOf());
         xamlTextBlock->put_Text(text.Get());
@@ -1029,8 +1033,6 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         // Set the maximum number of lines the text block should show in cases where wrapping is enabled.
         if (shouldWrap)
         {
-            ComPtr<ITextBlock2> xamlTextBlock2;
-            THROW_IF_FAILED(xamlTextBlock.As(&xamlTextBlock2));
             UINT maxLines;
             THROW_IF_FAILED(adaptiveTextBlock->get_MaxLines(&maxLines));
             THROW_IF_FAILED(xamlTextBlock2->put_MaxLines(maxLines));
@@ -1057,6 +1059,10 @@ namespace AdaptiveCards { namespace XamlCardRenderer
 
         ABI::AdaptiveCards::XamlCardRenderer::TextWeight textWeight;
         THROW_IF_FAILED(adaptiveTextBlock->get_Weight(&textWeight));
+
+        // Ensure left edge of text is consistent regardless of font size, so both small and large fonts
+        // are flush on the left edge of the card by enabling TrimSideBearings
+        THROW_IF_FAILED(xamlTextBlock2->put_OpticalMarginAlignment(OpticalMarginAlignment_TrimSideBearings));
 
         //Style the TextBlock using Host Options
         StyleXamlTextBlock(textblockSize, textColor, isSubtle, textWeight, xamlTextBlock.Get());


### PR DESCRIPTION
Enabling TrimSideBearings to ensure that regardless of the font size,
the left of the text is consistently in line with each other, fixing
issue #357

Simply had to assign that property (and moved the code to obtain
ITextBlock2 to the top since it's used in two places now)

Verified changes using Visualizer, text is now always flush to the left, pixel perfect!

![image](https://cloud.githubusercontent.com/assets/13246069/26225813/df0581ba-3bdd-11e7-99a5-8708058beb3f.png)

