### PR TITLE
Fix DeserializeFromString

### DIFF
--- a/source/shared/cpp/ObjectModel/AdaptiveCard.cpp
+++ b/source/shared/cpp/ObjectModel/AdaptiveCard.cpp
@@ -105,14 +105,7 @@ std::shared_ptr<AdaptiveCard> AdaptiveCard::Deserialize(const Json::Value& json)
 
 std::shared_ptr<AdaptiveCard> AdaptiveCard::DeserializeFromString(const std::string& jsonString) throw(AdaptiveCards::AdaptiveCardParseException)
 {
-    Json::Reader reader;
-    Json::Value jsonValue;
-    if (!reader.parse(jsonString.c_str(), jsonValue))
-    {
-        throw AdaptiveCardParseException("Expected JSON Object\n");
-    }
-
-    return AdaptiveCard::Deserialize(jsonValue);
+    return AdaptiveCard::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
 }
 
 std::string AdaptiveCard::GetVersion() const

--- a/source/shared/cpp/ObjectModel/Column.cpp
+++ b/source/shared/cpp/ObjectModel/Column.cpp
@@ -63,7 +63,5 @@ std::shared_ptr<Column> Column::Deserialize(const Json::Value& value)
 
 std::shared_ptr<Column> Column::DeserializeFromString(const std::string& jsonString)
 {
-    Json::Value jsonValue(jsonString);
-
-    return Column::Deserialize(jsonValue);
+    return Column::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
 }

--- a/source/shared/cpp/ObjectModel/ColumnSet.cpp
+++ b/source/shared/cpp/ObjectModel/ColumnSet.cpp
@@ -47,7 +47,5 @@ std::shared_ptr<ColumnSet> ColumnSet::Deserialize(const Json::Value& value)
 
 std::shared_ptr<ColumnSet> ColumnSet::DeserializeFromString(const std::string& jsonString)
 {
-    Json::Value jsonValue(jsonString);
-
-    return ColumnSet::Deserialize(jsonValue);
+    return ColumnSet::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
 }

--- a/source/shared/cpp/ObjectModel/Container.cpp
+++ b/source/shared/cpp/ObjectModel/Container.cpp
@@ -86,7 +86,5 @@ std::shared_ptr<Container> Container::Deserialize(const Json::Value& value)
 
 std::shared_ptr<Container> Container::DeserializeFromString(const std::string& jsonString)
 {
-    Json::Value jsonValue(jsonString);
-
-    return Container::Deserialize(jsonValue);
+    return Container::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
 }

--- a/source/shared/cpp/ObjectModel/Fact.cpp
+++ b/source/shared/cpp/ObjectModel/Fact.cpp
@@ -24,9 +24,7 @@ std::shared_ptr<Fact> Fact::Deserialize(const Json::Value& json)
 
 std::shared_ptr<Fact> Fact::DeserializeFromString(const std::string& jsonString)
 {
-    Json::Value jsonValue(jsonString);
-
-    return Fact::Deserialize(jsonValue);
+    return Fact::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
 }
 
 std::string Fact::Serialize()

--- a/source/shared/cpp/ObjectModel/FactSet.cpp
+++ b/source/shared/cpp/ObjectModel/FactSet.cpp
@@ -65,7 +65,5 @@ std::shared_ptr<FactSet> FactSet::Deserialize(const Json::Value& value)
 
 std::shared_ptr<FactSet> FactSet::DeserializeFromString(const std::string& jsonString)
 {
-    Json::Value jsonValue(jsonString);
-
-    return FactSet::Deserialize(jsonValue);
+    return FactSet::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
 }

--- a/source/shared/cpp/ObjectModel/Image.cpp
+++ b/source/shared/cpp/ObjectModel/Image.cpp
@@ -98,8 +98,6 @@ void AdaptiveCards::Image::SetHorizontalAlignment(const HorizontalAlignment valu
 
 std::shared_ptr<Image> Image::DeserializeFromString(const std::string& jsonString)
 {
-    Json::Value jsonValue(jsonString);
-
-    return Image::Deserialize(jsonValue);
+    return Image::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
 }
 

--- a/source/shared/cpp/ObjectModel/ImageSet.cpp
+++ b/source/shared/cpp/ObjectModel/ImageSet.cpp
@@ -80,3 +80,8 @@ std::shared_ptr<ImageSet> ImageSet::Deserialize(const Json::Value& value)
 
     return imageSet;
 }
+
+std::shared_ptr<ImageSet> ImageSet::DeserializeFromString(const std::string& jsonString)
+{
+    return ImageSet::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
+}

--- a/source/shared/cpp/ObjectModel/ImageSet.h
+++ b/source/shared/cpp/ObjectModel/ImageSet.h
@@ -23,6 +23,7 @@ namespace AdaptiveCards
             std::vector<std::shared_ptr<Image>>& GetImages();
             const std::vector<std::shared_ptr<Image>>& GetImages() const;
             static std::shared_ptr<ImageSet> Deserialize(const Json::Value& root);
+            static std::shared_ptr<ImageSet> DeserializeFromString(const std::string& jsonString);
 
             private:
             std::vector<std::shared_ptr<Image>> m_images;

--- a/source/shared/cpp/ObjectModel/InputChoice.cpp
+++ b/source/shared/cpp/ObjectModel/InputChoice.cpp
@@ -23,9 +23,7 @@ std::shared_ptr<InputChoice> InputChoice::Deserialize(const Json::Value& json)
 
 std::shared_ptr<InputChoice> InputChoice::DeserializeFromString(const std::string& jsonString)
 {
-    Json::Value jsonValue(jsonString);
-
-    return InputChoice::Deserialize(jsonValue);
+    return InputChoice::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
 }
 
 std::string InputChoice::Serialize()

--- a/source/shared/cpp/ObjectModel/InputChoiceSet.cpp
+++ b/source/shared/cpp/ObjectModel/InputChoiceSet.cpp
@@ -99,7 +99,5 @@ std::shared_ptr<InputChoiceSet> InputChoiceSet::Deserialize(const Json::Value& j
 
 std::shared_ptr<InputChoiceSet> InputChoiceSet::DeserializeFromString(const std::string& jsonString)
 {
-    Json::Value jsonValue(jsonString);
-
-    return InputChoiceSet::Deserialize(jsonValue);
+    return InputChoiceSet::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
 }

--- a/source/shared/cpp/ObjectModel/InputDate.cpp
+++ b/source/shared/cpp/ObjectModel/InputDate.cpp
@@ -24,9 +24,7 @@ std::shared_ptr<InputDate> InputDate::Deserialize(const Json::Value& json)
 
 std::shared_ptr<InputDate> InputDate::DeserializeFromString(const std::string& jsonString)
 {
-    Json::Value jsonValue(jsonString);
-
-    return InputDate::Deserialize(jsonValue);
+    return InputDate::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
 }
 
 std::string InputDate::Serialize()

--- a/source/shared/cpp/ObjectModel/InputNumber.cpp
+++ b/source/shared/cpp/ObjectModel/InputNumber.cpp
@@ -26,9 +26,7 @@ std::shared_ptr<InputNumber> InputNumber::Deserialize(const Json::Value& json)
 
 std::shared_ptr<InputNumber> InputNumber::DeserializeFromString(const std::string& jsonString)
 {
-    Json::Value jsonValue(jsonString);
-
-    return InputNumber::Deserialize(jsonValue);
+    return InputNumber::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
 }
 
 std::string InputNumber::Serialize()

--- a/source/shared/cpp/ObjectModel/InputText.cpp
+++ b/source/shared/cpp/ObjectModel/InputText.cpp
@@ -27,9 +27,7 @@ std::shared_ptr<InputText> InputText::Deserialize(const Json::Value& json)
 
 std::shared_ptr<InputText> InputText::DeserializeFromString(const std::string& jsonString)
 {
-    Json::Value jsonValue(jsonString);
-
-    return InputText::Deserialize(jsonValue);
+    return InputText::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
 }
 
 std::string InputText::Serialize()

--- a/source/shared/cpp/ObjectModel/InputTime.cpp
+++ b/source/shared/cpp/ObjectModel/InputTime.cpp
@@ -24,9 +24,7 @@ std::shared_ptr<InputTime> InputTime::Deserialize(const Json::Value& json)
 
 std::shared_ptr<InputTime> InputTime::DeserializeFromString(const std::string& jsonString)
 {
-    Json::Value jsonValue(jsonString);
-
-    return InputTime::Deserialize(jsonValue);
+    return InputTime::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
 }
 
 std::string InputTime::Serialize()

--- a/source/shared/cpp/ObjectModel/InputToggle.cpp
+++ b/source/shared/cpp/ObjectModel/InputToggle.cpp
@@ -24,9 +24,7 @@ std::shared_ptr<InputToggle> InputToggle::Deserialize(const Json::Value& json)
 
 std::shared_ptr<InputToggle> InputToggle::DeserializeFromString(const std::string& jsonString)
 {
-    Json::Value jsonValue(jsonString);
-
-    return InputToggle::Deserialize(jsonValue);
+    return InputToggle::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
 }
 
 std::string InputToggle::Serialize()

--- a/source/shared/cpp/ObjectModel/OpenUrlAction.cpp
+++ b/source/shared/cpp/ObjectModel/OpenUrlAction.cpp
@@ -19,9 +19,7 @@ std::shared_ptr<OpenUrlAction> OpenUrlAction::Deserialize(const Json::Value& jso
 
 std::shared_ptr<OpenUrlAction> OpenUrlAction::DeserializeFromString(const std::string& jsonString)
 {
-    Json::Value jsonValue(jsonString);
-
-    return OpenUrlAction::Deserialize(jsonValue);
+    return OpenUrlAction::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
 }
 
 std::string OpenUrlAction::Serialize()

--- a/source/shared/cpp/ObjectModel/ParseUtil.cpp
+++ b/source/shared/cpp/ObjectModel/ParseUtil.cpp
@@ -219,6 +219,17 @@ Json::Value ParseUtil::GetArray(
     return elementArray;
 }
 
+Json::Value ParseUtil::GetJsonValueFromString(const std::string jsonString)
+{
+    Json::Reader reader;
+    Json::Value jsonValue;
+    if (!reader.parse(jsonString.c_str(), jsonValue))
+    {
+        throw AdaptiveCardParseException("Expected JSON Object\n");
+    }
+    return jsonValue;
+}
+
 ParseUtil::ParseUtil()
 {
 }

--- a/source/shared/cpp/ObjectModel/ParseUtil.h
+++ b/source/shared/cpp/ObjectModel/ParseUtil.h
@@ -41,6 +41,8 @@ public:
 
     static Json::Value GetArray(const Json::Value& json, AdaptiveCardSchemaKey key);
 
+    static Json::Value GetJsonValueFromString(const std::string jsonString);
+
     template <typename T>
     static T GetEnumValue(const Json::Value& json, AdaptiveCardSchemaKey key, T defaultEnumValue, std::function<T(const std::string& name)> enumConverter);
 

--- a/source/shared/cpp/ObjectModel/ShowCardAction.cpp
+++ b/source/shared/cpp/ObjectModel/ShowCardAction.cpp
@@ -22,9 +22,7 @@ std::shared_ptr<ShowCardAction> ShowCardAction::Deserialize(const Json::Value& j
 
 std::shared_ptr<ShowCardAction> ShowCardAction::DeserializeFromString(const std::string& jsonString)
 {
-    Json::Value jsonValue(jsonString);
-
-    return ShowCardAction::Deserialize(jsonValue);
+    return ShowCardAction::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
 }
 
 std::string ShowCardAction::Serialize()

--- a/source/shared/cpp/ObjectModel/SubmitAction.cpp
+++ b/source/shared/cpp/ObjectModel/SubmitAction.cpp
@@ -18,9 +18,7 @@ std::shared_ptr<SubmitAction> SubmitAction::Deserialize(const Json::Value& json)
 
 std::shared_ptr<SubmitAction> SubmitAction::DeserializeFromString(const std::string& jsonString)
 {
-    Json::Value jsonValue(jsonString);
-
-    return SubmitAction::Deserialize(jsonValue);
+    return SubmitAction::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
 }
 
 std::string SubmitAction::Serialize()

--- a/source/shared/cpp/ObjectModel/TextBlock.cpp
+++ b/source/shared/cpp/ObjectModel/TextBlock.cpp
@@ -57,9 +57,7 @@ std::shared_ptr<TextBlock> TextBlock::Deserialize(const Json::Value& json)
 
 std::shared_ptr<TextBlock> TextBlock::DeserializeFromString(const std::string& jsonString)
 {
-    Json::Value jsonValue(jsonString);
-
-    return TextBlock::Deserialize(jsonValue);
+    return TextBlock::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
 }
 
 std::string TextBlock::Serialize()

--- a/source/uwp/Renderer/lib/AdaptiveCard.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveCard.cpp
@@ -23,15 +23,7 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         std::string adaptiveJsonString;
         RETURN_IF_FAILED(HStringToUTF8(adaptiveJson, adaptiveJsonString));
 
-        Json::Value adaptiveJsonRoot;
-        Json::Reader jsonRreader;
-        bool parsingSuccessful = jsonRreader.parse(adaptiveJsonString, adaptiveJsonRoot);
-        if (!parsingSuccessful)
-        {
-            return E_FAIL;
-        }
-
-        std::shared_ptr<::AdaptiveCards::AdaptiveCard> sharedAdaptiveCard = ::AdaptiveCards::AdaptiveCard::Deserialize(adaptiveJsonRoot);
+        std::shared_ptr<::AdaptiveCards::AdaptiveCard> sharedAdaptiveCard = ::AdaptiveCards::AdaptiveCard::DeserializeFromString(adaptiveJsonString);
         return MakeAndInitialize<AdaptiveCard>(card, sharedAdaptiveCard);
     } CATCH_RETURN;
 


### PR DESCRIPTION
UWP renderer also now uses the DeserializeFromString method rather than doing its own thing to render a card from a string.