### PR TITLE
Shared Parser now understands Optional and required properties in the schema

### DIFF
--- a/source/shared/cpp/ObjectModel/AdaptiveCard.cpp
+++ b/source/shared/cpp/ObjectModel/AdaptiveCard.cpp
@@ -88,16 +88,10 @@ std::shared_ptr<AdaptiveCard> AdaptiveCard::Deserialize(const Json::Value& json)
     std::string backgroundImageUrl = ParseUtil::GetString(json, AdaptiveCardSchemaKey::BackgroundImageUrl);
 
     // Parse body
-    auto body = ParseUtil::GetElementCollection<BaseCardElement>(json, AdaptiveCardSchemaKey::Body, AdaptiveCard::CardElementParsers);
+    auto body = ParseUtil::GetElementCollection<BaseCardElement>(json, AdaptiveCardSchemaKey::Body, AdaptiveCard::CardElementParsers, true);
 
     // Parse actions if present
-    std::string propertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Actions);
-    auto elementArray = json.get(propertyName, Json::Value());
-    std::vector<std::shared_ptr<AdaptiveCards::BaseActionElement>> actions;
-    if (!elementArray.empty())
-    {
-        actions = ParseUtil::GetActionCollection<BaseActionElement>(json, AdaptiveCardSchemaKey::Actions, AdaptiveCard::CardActionParsers);
-    }
+    auto actions = ParseUtil::GetActionCollection<BaseActionElement>(json, AdaptiveCardSchemaKey::Actions, AdaptiveCard::CardActionParsers);
 
     auto result = std::make_shared<AdaptiveCard>(version, minVersion, fallbackText, backgroundImageUrl, body, actions);
     return result;

--- a/source/shared/cpp/ObjectModel/BaseActionElement.h
+++ b/source/shared/cpp/ObjectModel/BaseActionElement.h
@@ -43,6 +43,7 @@ std::shared_ptr<T> BaseActionElement::Deserialize(const Json::Value& json)
 
     ParseUtil::ThrowIfNotJsonObject(json);
 
+    BaseActionElement->SetTitle(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Title, true));
     BaseActionElement->SetSpeak(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Speak));
 
     return cardElement;

--- a/source/shared/cpp/ObjectModel/Column.cpp
+++ b/source/shared/cpp/ObjectModel/Column.cpp
@@ -86,8 +86,9 @@ std::shared_ptr<Column> Column::Deserialize(const Json::Value& value)
     column->SetSize(ParseUtil::GetValueAsString(value, AdaptiveCardSchemaKey::Size));
 
     // Parse Items
-    auto cardElements = ParseUtil::GetElementCollection<BaseCardElement>(value, AdaptiveCardSchemaKey::Items, Column::CardElementParsers);
+    auto cardElements = ParseUtil::GetElementCollection<BaseCardElement>(value, AdaptiveCardSchemaKey::Items, CardElementParsers, true);
     column->m_items = std::move(cardElements);
+
     return column;
 }
 

--- a/source/shared/cpp/ObjectModel/ColumnSet.cpp
+++ b/source/shared/cpp/ObjectModel/ColumnSet.cpp
@@ -40,7 +40,7 @@ std::shared_ptr<ColumnSet> ColumnSet::Deserialize(const Json::Value& value)
     auto container = BaseCardElement::Deserialize<ColumnSet>(value);
 
     // Parse Columns
-    auto cardElements = ParseUtil::GetElementCollection<Column>(value, AdaptiveCardSchemaKey::Columns, ColumnParser);
+    auto cardElements = ParseUtil::GetElementCollection<Column>(value, AdaptiveCardSchemaKey::Columns, ColumnParser, true);
     container->m_columns = std::move(cardElements);
     return container;
 }

--- a/source/shared/cpp/ObjectModel/Container.cpp
+++ b/source/shared/cpp/ObjectModel/Container.cpp
@@ -89,7 +89,7 @@ std::shared_ptr<Container> Container::Deserialize(const Json::Value& value)
         ParseUtil::GetEnumValue<ContainerStyle>(value, AdaptiveCardSchemaKey::Style, ContainerStyle::Normal, ContainerStyleFromString));
 
     // Parse Items
-    auto cardElements = ParseUtil::GetElementCollection<BaseCardElement>(value, AdaptiveCardSchemaKey::Items, Container::CardElementParsers);
+    auto cardElements = ParseUtil::GetElementCollection<BaseCardElement>(value, AdaptiveCardSchemaKey::Items, Container::CardElementParsers, true);
     container->m_items = std::move(cardElements);
     return container;
 }

--- a/source/shared/cpp/ObjectModel/Fact.cpp
+++ b/source/shared/cpp/ObjectModel/Fact.cpp
@@ -14,8 +14,8 @@ Fact::Fact(std::string title, std::string value, std::string speak) :
 
 std::shared_ptr<Fact> Fact::Deserialize(const Json::Value& json)
 {
-    std::string title = ParseUtil::GetString(json, AdaptiveCardSchemaKey::Title);
-    std::string value = ParseUtil::GetString(json, AdaptiveCardSchemaKey::Value);
+    std::string title = ParseUtil::GetString(json, AdaptiveCardSchemaKey::Title, true);
+    std::string value = ParseUtil::GetString(json, AdaptiveCardSchemaKey::Value, true);
     std::string speak = ParseUtil::GetString(json, AdaptiveCardSchemaKey::Speak);
 
     auto fact = std::make_shared<Fact>(title, value, speak);

--- a/source/shared/cpp/ObjectModel/FactSet.cpp
+++ b/source/shared/cpp/ObjectModel/FactSet.cpp
@@ -46,7 +46,7 @@ std::shared_ptr<FactSet> FactSet::Deserialize(const Json::Value& value)
     auto factSet = BaseCardElement::Deserialize<FactSet>(value);
 
     // Parse Facts
-    auto factsArray = ParseUtil::GetArray(value, AdaptiveCardSchemaKey::Facts);
+    auto factsArray = ParseUtil::GetArray(value, AdaptiveCardSchemaKey::Facts, true);
     std::vector<std::shared_ptr<Fact>> facts;
 
     // Deserialize every fact in the array

--- a/source/shared/cpp/ObjectModel/HttpAction.cpp
+++ b/source/shared/cpp/ObjectModel/HttpAction.cpp
@@ -11,10 +11,9 @@ std::shared_ptr<HttpAction> HttpAction::Deserialize(const Json::Value& json)
 {
     std::shared_ptr<HttpAction> httpAction = BaseActionElement::Deserialize<HttpAction>(json);
 
-    httpAction->SetTitle(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Title));
-    httpAction->SetUrl(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Url));
+    httpAction->SetUrl(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Url, true));
     httpAction->SetBody(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Body));
-    httpAction->SetMethod(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Method));
+    httpAction->SetMethod(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Method, true));
 
     return httpAction;
 }

--- a/source/shared/cpp/ObjectModel/Image.cpp
+++ b/source/shared/cpp/ObjectModel/Image.cpp
@@ -33,7 +33,7 @@ std::shared_ptr<Image> Image::Deserialize(const Json::Value& json)
 
     std::shared_ptr<Image> image = BaseCardElement::Deserialize<Image>(json);
 
-    image->SetUrl(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Url));
+    image->SetUrl(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Url, true));
     image->SetImageStyle(ParseUtil::GetEnumValue<ImageStyle>(json, AdaptiveCardSchemaKey::ImageStyle, ImageStyle::Normal, ImageStyleFromString));
     image->SetImageSize(ParseUtil::GetEnumValue<ImageSize>(json, AdaptiveCardSchemaKey::Size, ImageSize::Default, ImageSizeFromString));
     image->SetAltText(ParseUtil::GetString(json, AdaptiveCardSchemaKey::AltText));

--- a/source/shared/cpp/ObjectModel/ImageSet.cpp
+++ b/source/shared/cpp/ObjectModel/ImageSet.cpp
@@ -63,7 +63,7 @@ std::shared_ptr<ImageSet> ImageSet::Deserialize(const Json::Value& value)
     imageSet->m_imageSize = ParseUtil::GetEnumValue<ImageSize>(value, AdaptiveCardSchemaKey::ImageSize, ImageSize::Auto, ImageSizeFromString);
 
     // Parse Images
-    auto imagesArray = ParseUtil::GetArray(value, AdaptiveCardSchemaKey::Images);
+    auto imagesArray = ParseUtil::GetArray(value, AdaptiveCardSchemaKey::Images, true);
     std::vector<std::shared_ptr<Image>> images;
 
     // Deserialize every image in the array

--- a/source/shared/cpp/ObjectModel/InputChoice.cpp
+++ b/source/shared/cpp/ObjectModel/InputChoice.cpp
@@ -13,8 +13,8 @@ std::shared_ptr<InputChoice> InputChoice::Deserialize(const Json::Value& json)
 {
     auto choice = std::make_shared<InputChoice>();
 
-    choice->SetTitle(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Title));
-    choice->SetValue(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Value));
+    choice->SetTitle(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Title, true));
+    choice->SetValue(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Value, true));
     choice->SetSpeak(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Speak));
     choice->SetIsSelected(ParseUtil::GetBool(json, AdaptiveCardSchemaKey::IsSelected, false));
 

--- a/source/shared/cpp/ObjectModel/InputChoiceSet.cpp
+++ b/source/shared/cpp/ObjectModel/InputChoiceSet.cpp
@@ -80,7 +80,7 @@ std::shared_ptr<InputChoiceSet> InputChoiceSet::Deserialize(const Json::Value& j
     choiceSet->SetIsRequired(ParseUtil::GetBool(json, AdaptiveCardSchemaKey::IsRequired, false));
     
     // Parse Choices
-    auto choicesArray = ParseUtil::GetArray(json, AdaptiveCardSchemaKey::Choices);
+    auto choicesArray = ParseUtil::GetArray(json, AdaptiveCardSchemaKey::Choices, true);
     std::vector<std::shared_ptr<InputChoice>> choices;
 
     // Deserialize every choice in the array

--- a/source/shared/cpp/ObjectModel/InputToggle.cpp
+++ b/source/shared/cpp/ObjectModel/InputToggle.cpp
@@ -14,7 +14,7 @@ std::shared_ptr<InputToggle> InputToggle::Deserialize(const Json::Value& json)
 
     std::shared_ptr<InputToggle> inputToggle = BaseCardElement::Deserialize<InputToggle>(json);
 
-    inputToggle->SetTitle(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Title));
+    inputToggle->SetTitle(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Title, true));
     inputToggle->SetValue(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Value));
     inputToggle->SetValueOff(ParseUtil::GetString(json, AdaptiveCardSchemaKey::ValueOff));
     inputToggle->SetValueOn(ParseUtil::GetString(json, AdaptiveCardSchemaKey::ValueOn));

--- a/source/shared/cpp/ObjectModel/OpenUrlAction.cpp
+++ b/source/shared/cpp/ObjectModel/OpenUrlAction.cpp
@@ -11,8 +11,7 @@ std::shared_ptr<OpenUrlAction> OpenUrlAction::Deserialize(const Json::Value& jso
 {
     std::shared_ptr<OpenUrlAction> openUrlAction = BaseActionElement::Deserialize<OpenUrlAction>(json);
 
-    openUrlAction->SetTitle(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Title));
-    openUrlAction->SetUrl(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Url));
+    openUrlAction->SetUrl(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Url, true));
 
     return openUrlAction;
 }

--- a/source/shared/cpp/ObjectModel/ParseUtil.cpp
+++ b/source/shared/cpp/ObjectModel/ParseUtil.cpp
@@ -47,13 +47,20 @@ std::string ParseUtil::TryGetTypeAsString(const Json::Value& json)
 
 }
 
-std::string ParseUtil::GetString(const Json::Value& json, AdaptiveCardSchemaKey key)
+std::string ParseUtil::GetString(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired)
 {
     std::string propertyName = AdaptiveCardSchemaKeyToString(key);
     auto propertyValue = json.get(propertyName, Json::Value());
     if (propertyValue.empty())
     {
-        return "";
+        if (isRequired)
+        {
+            throw AdaptiveCardParseException("Property is required but was found empty: " + propertyName);
+        }
+        else
+        {
+            return "";
+        }
     }
 
     if (!propertyValue.isString())
@@ -64,25 +71,39 @@ std::string ParseUtil::GetString(const Json::Value& json, AdaptiveCardSchemaKey 
     return propertyValue.asString();
 }
 
-std::string ParseUtil::GetValueAsString(const Json::Value& json, AdaptiveCardSchemaKey key)
+std::string ParseUtil::GetValueAsString(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired)
 {
     std::string propertyName = AdaptiveCardSchemaKeyToString(key);
     auto propertyValue = json.get(propertyName, Json::Value());
     if (propertyValue.empty())
     {
-        return "";
+        if (isRequired)
+        {
+            throw AdaptiveCardParseException("Property is required but was found empty: " + propertyName);
+        }
+        else
+        {
+            return "";
+        }
     }
 
     return propertyValue.asString();
 }
 
-bool ParseUtil::GetBool(const Json::Value& json, AdaptiveCardSchemaKey key, bool defaultValue)
+bool ParseUtil::GetBool(const Json::Value& json, AdaptiveCardSchemaKey key, bool defaultValue, bool isRequired)
 {
     std::string propertyName = AdaptiveCardSchemaKeyToString(key);
     auto propertyValue = json.get(propertyName, Json::Value());
     if (propertyValue.empty())
     {
-        return defaultValue;
+        if (isRequired)
+        {
+            throw AdaptiveCardParseException("Property is required but was found empty: " + propertyName);
+        }
+        else
+        {
+            return defaultValue;
+        }
     }
 
     if (!propertyValue.isBool())
@@ -93,13 +114,20 @@ bool ParseUtil::GetBool(const Json::Value& json, AdaptiveCardSchemaKey key, bool
     return propertyValue.asBool();
 }
 
-unsigned int ParseUtil::GetUInt(const Json::Value & json, AdaptiveCardSchemaKey key, unsigned int defaultValue)
+unsigned int ParseUtil::GetUInt(const Json::Value & json, AdaptiveCardSchemaKey key, unsigned int defaultValue, bool isRequired)
 {
     std::string propertyName = AdaptiveCardSchemaKeyToString(key);
     auto propertyValue = json.get(propertyName, Json::Value());
     if (propertyValue.empty())
     {
-        return defaultValue;
+        if (isRequired)
+        {
+            throw AdaptiveCardParseException("Property is required but was found empty: " + propertyName);
+        }
+        else
+        {
+            return defaultValue;
+        }
     }
 
     if (!propertyValue.isUInt())
@@ -110,13 +138,20 @@ unsigned int ParseUtil::GetUInt(const Json::Value & json, AdaptiveCardSchemaKey 
     return propertyValue.asUInt();
 }
 
-int ParseUtil::GetInt(const Json::Value & json, AdaptiveCardSchemaKey key, int defaultValue)
+int ParseUtil::GetInt(const Json::Value & json, AdaptiveCardSchemaKey key, int defaultValue, bool isRequired)
 {
     std::string propertyName = AdaptiveCardSchemaKeyToString(key);
     auto propertyValue = json.get(propertyName, Json::Value());
     if (propertyValue.empty())
     {
-        return defaultValue;
+        if (isRequired)
+        {
+            throw AdaptiveCardParseException("Property is required but was found empty: " + propertyName);
+        }
+        else
+        {
+            return defaultValue;
+        }
     }
 
     if (!propertyValue.isInt())
@@ -207,14 +242,19 @@ ActionType ParseUtil::TryGetActionType(const Json::Value& json)
 
 Json::Value ParseUtil::GetArray(
     const Json::Value& json,
-    AdaptiveCardSchemaKey key)
+    AdaptiveCardSchemaKey key,
+    bool isRequired)
 {
     std::string propertyName = AdaptiveCardSchemaKeyToString(key);
     auto elementArray = json.get(propertyName, Json::Value());
-
-    if (!elementArray.isArray() || elementArray.empty())
+    if (isRequired && elementArray.empty())
     {
-        throw AdaptiveCardParseException("Could not parse specified key " + propertyName + ". It was not an array");
+        throw AdaptiveCardParseException("Could not parse required key: " + propertyName + ". It was not found");
+    }
+
+    if (!elementArray.empty() && !elementArray.isArray())
+    {
+        throw AdaptiveCardParseException("Could not parse specified key: " + propertyName + ". It was not an array");
     }
     return elementArray;
 }

--- a/source/shared/cpp/ObjectModel/ParseUtil.h
+++ b/source/shared/cpp/ObjectModel/ParseUtil.h
@@ -21,15 +21,15 @@ public:
 
     static std::string TryGetTypeAsString(const Json::Value& json);
 
-    static std::string GetString(const Json::Value& json, AdaptiveCardSchemaKey key);
+    static std::string GetString(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired = false);
 
-    static std::string GetValueAsString(const Json::Value& json, AdaptiveCardSchemaKey key);
+    static std::string GetValueAsString(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired = false);
 
-    static bool GetBool(const Json::Value& json, AdaptiveCardSchemaKey key, bool defaultValue);
+    static bool GetBool(const Json::Value& json, AdaptiveCardSchemaKey key, bool defaultValue, bool isRequired = false);
 
-    static unsigned int GetUInt(const Json::Value& json, AdaptiveCardSchemaKey key, unsigned int defaultValue);
+    static unsigned int GetUInt(const Json::Value& json, AdaptiveCardSchemaKey key, unsigned int defaultValue, bool isRequired = false);
 
-    static int GetInt(const Json::Value& json, AdaptiveCardSchemaKey key, int defaultValue);
+    static int GetInt(const Json::Value& json, AdaptiveCardSchemaKey key, int defaultValue, bool isRequired = false);
 
     static CardElementType GetCardElementType(const Json::Value& json);
 
@@ -39,16 +39,29 @@ public:
 
     static ActionType TryGetActionType(const Json::Value& json);
 
-    static Json::Value GetArray(const Json::Value& json, AdaptiveCardSchemaKey key);
+    static Json::Value GetArray(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired = false);
 
     template <typename T>
-    static T GetEnumValue(const Json::Value& json, AdaptiveCardSchemaKey key, T defaultEnumValue, std::function<T(const std::string& name)> enumConverter);
+    static T GetEnumValue(
+        const Json::Value& json,
+        AdaptiveCardSchemaKey key,
+        T defaultEnumValue,
+        std::function<T(const std::string& name)> enumConverter,
+        bool isRequired = false);
 
     template <typename T>
-    static std::vector<std::shared_ptr<T>> GetElementCollection(const Json::Value& json, AdaptiveCardSchemaKey key, const std::unordered_map<CardElementType, std::function<std::shared_ptr<T>(const Json::Value&)>, EnumHash>& parsers);
+    static std::vector<std::shared_ptr<T>> GetElementCollection(
+        const Json::Value& json,
+        AdaptiveCardSchemaKey key,
+        const std::unordered_map<CardElementType, std::function<std::shared_ptr<T>(const Json::Value&)>, EnumHash>& parsers,
+        bool isRequired = false);
 
     template <typename T>
-    static std::vector<std::shared_ptr<T>> GetActionCollection(const Json::Value& json, AdaptiveCardSchemaKey key, const std::unordered_map<ActionType, std::function<std::shared_ptr<T>(const Json::Value&)>, EnumHash>& parsers);
+    static std::vector<std::shared_ptr<T>> GetActionCollection(
+        const Json::Value& json,
+        AdaptiveCardSchemaKey key,
+        const std::unordered_map<ActionType, std::function<std::shared_ptr<T>(const Json::Value&)>, EnumHash>& parsers,
+        bool isRequired = false);
 
     static void ExpectTypeString(const Json::Value& json, CardElementType bodyType);
 
@@ -63,7 +76,7 @@ private:
 };
 
 template <typename T>
-T ParseUtil::GetEnumValue(const Json::Value& json, AdaptiveCardSchemaKey key, T defaultEnumValue, std::function<T(const std::string& name)> enumConverter)
+T ParseUtil::GetEnumValue(const Json::Value& json, AdaptiveCardSchemaKey key, T defaultEnumValue, std::function<T(const std::string& name)> enumConverter, bool isRequired)
 {
     std::string propertyValueStr = "";
     try
@@ -72,7 +85,14 @@ T ParseUtil::GetEnumValue(const Json::Value& json, AdaptiveCardSchemaKey key, T 
         auto propertyValue = json.get(propertyName, Json::Value());
         if (propertyValue.empty())
         {
-            return defaultEnumValue;
+            if (isRequired)
+            {
+                throw AdaptiveCardParseException("Property is required but was found empty: " + propertyName);
+            }
+            else
+            {
+                return defaultEnumValue;
+            }
         }
 
         if (!propertyValue.isString())
@@ -93,9 +113,10 @@ template <typename T>
 std::vector<std::shared_ptr<T>> ParseUtil::GetElementCollection(
     const Json::Value& json,
     AdaptiveCardSchemaKey key,
-    const std::unordered_map<CardElementType, std::function<std::shared_ptr<T>(const Json::Value&)>, EnumHash>& parsers)
+    const std::unordered_map<CardElementType, std::function<std::shared_ptr<T>(const Json::Value&)>, EnumHash>& parsers,
+    bool isRequired)
 {
-    auto elementArray = GetArray(json, key);
+    auto elementArray = GetArray(json, key, isRequired);
 
     std::vector<std::shared_ptr<T>> elements;
     if (elementArray.empty())
@@ -103,23 +124,20 @@ std::vector<std::shared_ptr<T>> ParseUtil::GetElementCollection(
         return elements;
     }
 
-    // Make sure the container fits the elements in the json file
-    elements.resize(elementArray.size());
+    elements.reserve(elementArray.size());
 
-    std::transform(elementArray.begin(), elementArray.end(), elements.begin(), [&parsers](const Json::Value& cur)
+    for (const auto& curJsonValue : elementArray)
     {
         // Get the element's type
-        CardElementType curElementType = ParseUtil::TryGetCardElementType(cur);
+        CardElementType curElementType = ParseUtil::TryGetCardElementType(curJsonValue);
 
         //Parse it if it's allowed by the current parsers
         if (parsers.find(curElementType) != parsers.end())
         {
             // Use the parser that maps to the type
-            std::shared_ptr<T> element = parsers.at(curElementType)(cur);
-            return element;
+            elements.push_back(parsers.at(curElementType)(curJsonValue));
         }
-        return std::shared_ptr<T>();
-    });
+    }
 
     return elements;
 }
@@ -128,33 +146,32 @@ template <typename T>
 std::vector<std::shared_ptr<T>> ParseUtil::GetActionCollection(
     const Json::Value& json,
     AdaptiveCardSchemaKey key,
-    const std::unordered_map<ActionType, std::function<std::shared_ptr<T>(const Json::Value&)>, EnumHash>& parsers)
+    const std::unordered_map<ActionType, std::function<std::shared_ptr<T>(const Json::Value&)>, EnumHash>& parsers,
+    bool isRequired)
 {
-    auto elementArray = GetArray(json, key);
+    auto elementArray = GetArray(json, key, isRequired);
 
     std::vector<std::shared_ptr<T>> elements;
+
     if (elementArray.empty())
     {
         return elements;
     }
 
-    // Make sure the container fits the elements in the json file
-    elements.resize(elementArray.size());
+    elements.reserve(elementArray.size());
 
-    std::transform(elementArray.begin(), elementArray.end(), elements.begin(), [&parsers](const Json::Value& cur)
+    for (const auto& curJsonValue : elementArray)
     {
         // Get the element's type
-        ActionType curElementType = ParseUtil::TryGetActionType(cur);
+        ActionType curActionType = ParseUtil::TryGetActionType(curJsonValue);
 
         //Parse it if it's allowed by the current parsers
-        if (parsers.find(curElementType) != parsers.end())
+        if (parsers.find(curActionType) != parsers.end())
         {
             // Use the parser that maps to the type
-            std::shared_ptr<T> element = parsers.at(curElementType)(cur);
-            return element;
+            elements.push_back(parsers.at(curActionType)(curJsonValue));
         }
-        return std::shared_ptr<T>();
-    });
+    }
 
     return elements;
 }

--- a/source/shared/cpp/ObjectModel/ShowCardAction.cpp
+++ b/source/shared/cpp/ObjectModel/ShowCardAction.cpp
@@ -12,8 +12,6 @@ std::shared_ptr<ShowCardAction> ShowCardAction::Deserialize(const Json::Value& j
 {
     std::shared_ptr<ShowCardAction> showCardAction = BaseActionElement::Deserialize<ShowCardAction>(json);
 
-    showCardAction->SetTitle(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Title));
-
     std::string propertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Card);
     showCardAction->SetCard(AdaptiveCard::Deserialize(json.get(propertyName, Json::Value())));
 

--- a/source/shared/cpp/ObjectModel/SubmitAction.cpp
+++ b/source/shared/cpp/ObjectModel/SubmitAction.cpp
@@ -11,8 +11,6 @@ std::shared_ptr<SubmitAction> SubmitAction::Deserialize(const Json::Value& json)
 {
     std::shared_ptr<SubmitAction> submitAction = BaseActionElement::Deserialize<SubmitAction>(json);
 
-    submitAction->SetTitle(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Title));
-
     return submitAction;
 }
 

--- a/source/shared/cpp/ObjectModel/TextBlock.cpp
+++ b/source/shared/cpp/ObjectModel/TextBlock.cpp
@@ -43,7 +43,7 @@ std::shared_ptr<TextBlock> TextBlock::Deserialize(const Json::Value& json)
 
     std::shared_ptr<TextBlock> textBlock = BaseCardElement::Deserialize<TextBlock>(json);
 
-    textBlock->SetText(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Text));
+    textBlock->SetText(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Text, true));
     textBlock->SetTextSize(ParseUtil::GetEnumValue<TextSize>(json, AdaptiveCardSchemaKey::TextSize, TextSize::Normal, TextSizeFromString));
     textBlock->SetTextColor(ParseUtil::GetEnumValue<TextColor>(json, AdaptiveCardSchemaKey::TextColor, TextColor::Default, TextColorFromString));
     textBlock->SetTextWeight(ParseUtil::GetEnumValue<TextWeight>(json, AdaptiveCardSchemaKey::TextWeight, TextWeight::Normal, TextWeightFromString));


### PR DESCRIPTION
Parser was being too permissive with missing required properties. Parser will now throw if a required property is missing. It will keep ignoring extra fields, and allow for missing optional fields.