### PR TITLE
Fix Action Titles in shared model

### DIFF
--- a/source/shared/cpp/ObjectModel/ShowCardAction.cpp
+++ b/source/shared/cpp/ObjectModel/ShowCardAction.cpp
@@ -28,16 +28,6 @@ std::string ShowCardAction::Serialize()
     return "";
 }
 
-std::string ShowCardAction::GetTitle() const
-{
-    return m_title;
-}
-
-void ShowCardAction::SetTitle(const std::string value)
-{
-    m_title = value;
-}
-
 std::shared_ptr<AdaptiveCard> AdaptiveCards::ShowCardAction::GetCard() const
 {
     return m_card;

--- a/source/shared/cpp/ObjectModel/ShowCardAction.h
+++ b/source/shared/cpp/ObjectModel/ShowCardAction.h
@@ -17,14 +17,10 @@ public:
 
     virtual std::string Serialize();
 
-    std::string GetTitle() const;
-    void SetTitle(const std::string value);
-
     std::shared_ptr<AdaptiveCard> GetCard() const;
     void SetCard(const std::shared_ptr<AdaptiveCard>);
 
 private:
-    std::string m_title;
     std::shared_ptr<AdaptiveCard> m_card;
 };
 }

--- a/source/shared/cpp/ObjectModel/SubmitAction.cpp
+++ b/source/shared/cpp/ObjectModel/SubmitAction.cpp
@@ -24,14 +24,4 @@ std::string SubmitAction::Serialize()
     return "";
 }
 
-std::string SubmitAction::GetTitle() const
-{
-    return m_title;
-}
-
-void SubmitAction::SetTitle(const std::string value)
-{
-    m_title = value;
-}
-
 

--- a/source/shared/cpp/ObjectModel/SubmitAction.h
+++ b/source/shared/cpp/ObjectModel/SubmitAction.h
@@ -15,11 +15,5 @@ public:
     static std::shared_ptr<SubmitAction> DeserializeFromString(const std::string& jsonString);
 
     virtual std::string Serialize();
-
-    std::string GetTitle() const;
-    void SetTitle(const std::string value);
-    
-private:
-    std::string m_title;
 };
 }


### PR DESCRIPTION
Some Action classes had title as member variables. This is now part of the BaseActionElement class.