### PR TITLE
UWP: Added DataJson property to Action.Submit

### DIFF
--- a/source/shared/cpp/ObjectModel/Enums.cpp
+++ b/source/shared/cpp/ObjectModel/Enums.cpp
@@ -33,6 +33,7 @@ static std::unordered_map<AdaptiveCardSchemaKey, std::string, EnumHash> Adaptive
     { AdaptiveCardSchemaKey::Container, "container" },
     { AdaptiveCardSchemaKey::ContainerStyleConfig, "containerStyleConfig" },
     { AdaptiveCardSchemaKey::Dark, "dark" },
+    { AdaptiveCardSchemaKey::Data, "data"},
     { AdaptiveCardSchemaKey::DateInput, "dateInput" },
     { AdaptiveCardSchemaKey::Default, "default" },
     { AdaptiveCardSchemaKey::Emphasis, "emphasis" },

--- a/source/shared/cpp/ObjectModel/Enums.h
+++ b/source/shared/cpp/ObjectModel/Enums.h
@@ -61,6 +61,7 @@ enum class AdaptiveCardSchemaKey
     Container,
     ContainerStyleConfig,
     Dark,
+    Data,
     DateInput,
     Default,
     Emphasis,

--- a/source/shared/cpp/ObjectModel/ParseUtil.cpp
+++ b/source/shared/cpp/ObjectModel/ParseUtil.cpp
@@ -71,6 +71,25 @@ std::string ParseUtil::GetString(const Json::Value& json, AdaptiveCardSchemaKey 
     return propertyValue.asString();
 }
 
+std::string ParseUtil::GetJsonString(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired)
+{
+    std::string propertyName = AdaptiveCardSchemaKeyToString(key);
+    auto propertyValue = json.get(propertyName, Json::Value());
+    if (propertyValue.empty())
+    {
+        if (isRequired)
+        {
+            throw AdaptiveCardParseException("Property is required but was found empty: " + propertyName);
+        }
+        else
+        {
+            return "";
+        }
+    }
+
+    return propertyValue.toStyledString();
+}
+
 std::string ParseUtil::GetValueAsString(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired)
 {
     std::string propertyName = AdaptiveCardSchemaKeyToString(key);

--- a/source/shared/cpp/ObjectModel/ParseUtil.h
+++ b/source/shared/cpp/ObjectModel/ParseUtil.h
@@ -23,6 +23,9 @@ public:
 
     static std::string GetString(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired = false);
 
+    // Gets the specified property and returns a JSON string of the value
+    static std::string GetJsonString(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired = false);
+
     static std::string GetValueAsString(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired = false);
 
     static bool GetBool(const Json::Value& json, AdaptiveCardSchemaKey key, bool defaultValue, bool isRequired = false);

--- a/source/shared/cpp/ObjectModel/SubmitAction.cpp
+++ b/source/shared/cpp/ObjectModel/SubmitAction.cpp
@@ -7,9 +7,21 @@ SubmitAction::SubmitAction() : BaseActionElement(ActionType::Submit)
 {
 }
 
+std::string SubmitAction::GetDataJson() const
+{
+    return m_dataJson;
+}
+
+void SubmitAction::SetDataJson(const std::string value)
+{
+    m_dataJson = value;
+}
+
 std::shared_ptr<SubmitAction> SubmitAction::Deserialize(const Json::Value& json)
 {
     std::shared_ptr<SubmitAction> submitAction = BaseActionElement::Deserialize<SubmitAction>(json);
+
+    submitAction->SetDataJson(ParseUtil::GetJsonString(json, AdaptiveCardSchemaKey::Data));
 
     return submitAction;
 }

--- a/source/shared/cpp/ObjectModel/SubmitAction.h
+++ b/source/shared/cpp/ObjectModel/SubmitAction.h
@@ -11,9 +11,15 @@ class SubmitAction : public BaseActionElement
 public:
     SubmitAction();
 
+    std::string GetDataJson() const;
+    void SetDataJson(const std::string value);
+
     static std::shared_ptr<SubmitAction> Deserialize(const Json::Value& root);
     static std::shared_ptr<SubmitAction> DeserializeFromString(const std::string& jsonString);
 
     virtual std::string Serialize();
+
+private:
+    std::string m_dataJson;
 };
 }

--- a/source/uwp/Renderer/idl/AdaptiveCards.XamlCardRenderer.idl
+++ b/source/uwp/Renderer/idl/AdaptiveCards.XamlCardRenderer.idl
@@ -1583,6 +1583,8 @@ namespace AdaptiveCards
         ]
         interface IAdaptiveSubmitAction : IInspectable
         {
+            [propget] HRESULT DataJson([out, retval] HSTRING* value);
+            [propput] HRESULT DataJson([in] HSTRING value);
         };
 
         [

--- a/source/uwp/Renderer/lib/AdaptiveSubmitAction.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveSubmitAction.cpp
@@ -56,4 +56,19 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         m_sharedSubmitAction->SetSpeak(out);
         return S_OK;
     }
+
+    _Use_decl_annotations_
+        HRESULT AdaptiveSubmitAction::get_DataJson(HSTRING* data)
+    {
+        return UTF8ToHString(m_sharedSubmitAction->GetDataJson(), data);
+    }
+
+    _Use_decl_annotations_
+        HRESULT AdaptiveSubmitAction::put_DataJson(HSTRING data)
+    {
+        std::string out;
+        RETURN_IF_FAILED(HStringToUTF8(data, out));
+        m_sharedSubmitAction->SetDataJson(out);
+        return S_OK;
+    }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveSubmitAction.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveSubmitAction.cpp
@@ -58,13 +58,13 @@ namespace AdaptiveCards { namespace XamlCardRenderer
     }
 
     _Use_decl_annotations_
-        HRESULT AdaptiveSubmitAction::get_DataJson(HSTRING* data)
+    HRESULT AdaptiveSubmitAction::get_DataJson(HSTRING* data)
     {
         return UTF8ToHString(m_sharedSubmitAction->GetDataJson(), data);
     }
 
     _Use_decl_annotations_
-        HRESULT AdaptiveSubmitAction::put_DataJson(HSTRING data)
+    HRESULT AdaptiveSubmitAction::put_DataJson(HSTRING data)
     {
         std::string out;
         RETURN_IF_FAILED(HStringToUTF8(data, out));

--- a/source/uwp/Renderer/lib/AdaptiveSubmitAction.h
+++ b/source/uwp/Renderer/lib/AdaptiveSubmitAction.h
@@ -26,6 +26,9 @@ namespace AdaptiveCards { namespace XamlCardRenderer
 
         IFACEMETHODIMP get_Title(_Out_ HSTRING* title);
         IFACEMETHODIMP put_Title(_In_ HSTRING title);
+
+        IFACEMETHODIMP get_DataJson(_Out_ HSTRING* data);
+        IFACEMETHODIMP put_DataJson(_In_ HSTRING data);
     private:
         std::shared_ptr<AdaptiveCards::SubmitAction> m_sharedSubmitAction;
     };


### PR DESCRIPTION
Added the DataJson property to the UWP object model. DataJson returns a string of the JSON, consistent with the .NET version of the library that has a DataJson property.

Tested with visualizer app and Notifications Visualizer, confirmed that the "data" property is now being passed through and accessible by renderer hosts.

Fixes #387 