### PR TITLE
Fixed UWP column auto/stretch behavior

### DIFF
--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -1435,18 +1435,21 @@ namespace AdaptiveCards { namespace XamlCardRenderer
             double sizeAsDouble = _wtof(adaptiveColumnSize.GetRawBuffer(nullptr));
 
             GridLength columnWidth;
-            if (isStretchResult == 0)
+            if (isAutoResult == 0)
             {
+                // If auto specified, use auto width
                 columnWidth.GridUnitType = GridUnitType::GridUnitType_Auto;
                 columnWidth.Value = 0;
             }
-            else if (!adaptiveColumnSize.IsValid() || (isAutoResult == 0) || (sizeAsDouble == 0))
+            else if (isStretchResult == 0 || !adaptiveColumnSize.IsValid() || (sizeAsDouble <= 0))
             {
+                // If stretch specified, or column size invalid or set to non-positive, use stretch with default of 1
                 columnWidth.GridUnitType = GridUnitType::GridUnitType_Star;
                 columnWidth.Value = 1;
             }
             else
             {
+                // If user specified specific valid size, use that star size
                 columnWidth.GridUnitType = GridUnitType::GridUnitType_Star;
                 columnWidth.Value = _wtof(adaptiveColumnSize.GetRawBuffer(nullptr));
             }


### PR DESCRIPTION
The boolean logic for auto/stretch was inverted. When dev specified stretch, auto was being assigned, and vice versa.

Fixed the boolean logic (also added check to invalidate negative star size entries) and verified changes using UWP Visualizer and Notifications Visualizer with all of the sample payloads

Before
![image](https://user-images.githubusercontent.com/13246069/26940909-62bec1d4-4c31-11e7-8696-6d74a05aec62.png)

After
![image](https://user-images.githubusercontent.com/13246069/26940926-6b8beeae-4c31-11e7-83d5-13c8498e9f73.png)