### PR TITLE
Fixed UWP subtle vs normal colors being inverted

### DIFF
--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -1009,7 +1009,7 @@ namespace AdaptiveCards { namespace XamlCardRenderer
             break;
         }
         Color fontColor;
-        THROW_IF_FAILED(isSubtle ? colorConfig->get_Normal(&fontColor) : colorConfig->get_Subtle(&fontColor));
+        THROW_IF_FAILED(isSubtle ? colorConfig->get_Subtle(&fontColor) : colorConfig->get_Normal(&fontColor));
 
         ComPtr<IBrush> fontColorBrush = GetSolidColorBrush(fontColor);
         THROW_IF_FAILED(localTextBlock->put_Foreground(fontColorBrush.Get()));


### PR DESCRIPTION
Boolean logic for assigning subtle vs normal text color was inverted, so normal text was getting subtle color and vice versa. Reversed this logic to fix that problem.