### PR TITLE
Fix UWP parsing of HostConfig card padding

### DIFF
--- a/source/shared/cpp/ObjectModel/HostConfig.cpp
+++ b/source/shared/cpp/ObjectModel/HostConfig.cpp
@@ -148,7 +148,7 @@ AdaptiveCardConfig AdaptiveCardConfig::Deserialize(const Json::Value& json, cons
     result.padding = ParseUtil::ExtractJsonValueAndMergeWithDefault<SpacingDefinition>(
         json, AdaptiveCardSchemaKey::Padding, defaultValue.padding, SpacingDefinition::Deserialize);
 
-    std::string  backgroundColor = ParseUtil::GetString(json, AdaptiveCardSchemaKey::BackgroundColor);
+    std::string backgroundColor = ParseUtil::GetString(json, AdaptiveCardSchemaKey::BackgroundColor);
     result.backgroundColor = backgroundColor == "" ? defaultValue.backgroundColor : backgroundColor;
 
     return result;

--- a/source/shared/cpp/ObjectModel/HostConfig.cpp
+++ b/source/shared/cpp/ObjectModel/HostConfig.cpp
@@ -144,7 +144,10 @@ ImageSizesConfig ImageSizesConfig::Deserialize(const Json::Value& json, const Im
 AdaptiveCardConfig AdaptiveCardConfig::Deserialize(const Json::Value& json, const AdaptiveCardConfig& defaultValue)
 {
     AdaptiveCardConfig result;
-    result.padding = SpacingDefinition::Deserialize(json, defaultValue.padding);
+
+    result.padding = ParseUtil::ExtractJsonValueAndMergeWithDefault<SpacingDefinition>(
+        json, AdaptiveCardSchemaKey::Padding, defaultValue.padding, SpacingDefinition::Deserialize);
+
     std::string  backgroundColor = ParseUtil::GetString(json, AdaptiveCardSchemaKey::BackgroundColor);
     result.backgroundColor = backgroundColor == "" ? defaultValue.backgroundColor : backgroundColor;
 


### PR DESCRIPTION
Padding property of AdaptiveCardConfig wasn't being parsed since it wasn't first obtaining the JSON value of property "padding" before attempting to deserialize the padding values.

Updated it to match the other sections of code which also parse spacing.

Confirmed with Visualizer that padding specified in JSON host config is now respected instead of ignored.