### PR TITLE
Fix stretch behavior on UWP rendered actions

### DIFF
--- a/source/shared/cpp/ObjectModel/Enums.cpp
+++ b/source/shared/cpp/ObjectModel/Enums.cpp
@@ -237,6 +237,7 @@ ActionsOrientationNameToEnum = GenerateStringToEnumMap<ActionsOrientation>(Actio
 
 static std::unordered_map<ActionMode, std::string, EnumHash> ActionModeEnumToName =
 {
+    { ActionMode::InlineEdgeToEdge, "InlineEdgeToEdge" },
     { ActionMode::Inline, "Inline" },
     { ActionMode::Popup, "Popup" }
 };

--- a/source/shared/cpp/ObjectModel/HostConfig.cpp
+++ b/source/shared/cpp/ObjectModel/HostConfig.cpp
@@ -34,6 +34,9 @@ HostConfig HostConfig::Deserialize(const Json::Value& json)
     result.adaptiveCard = ParseUtil::ExtractJsonValueAndMergeWithDefault<AdaptiveCardConfig>(
         json, AdaptiveCardSchemaKey::AdaptiveCard, result.adaptiveCard, AdaptiveCardConfig::Deserialize);
 
+    result.actions = ParseUtil::ExtractJsonValueAndMergeWithDefault<ActionsConfig>(
+        json, AdaptiveCardSchemaKey::Actions, result.actions, ActionsConfig::Deserialize);
+
     return result;
 }
 

--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -674,18 +674,18 @@ namespace AdaptiveCards { namespace XamlCardRenderer
 
             switch (actionAlignment)
             {
-                case ABI::AdaptiveCards::XamlCardRenderer::ActionAlignment::Center:
-                    actionsFrameworkElement->put_HorizontalAlignment(HorizontalAlignment_Center);
-                    break;
-                case ABI::AdaptiveCards::XamlCardRenderer::ActionAlignment::Left:
-                    actionsFrameworkElement->put_HorizontalAlignment(HorizontalAlignment_Left);
-                    break;
-                case ABI::AdaptiveCards::XamlCardRenderer::ActionAlignment::Right:
-                    actionsFrameworkElement->put_HorizontalAlignment(HorizontalAlignment_Right);
-                    break;
-                case ABI::AdaptiveCards::XamlCardRenderer::ActionAlignment::Stretch:
-                    actionsFrameworkElement->put_HorizontalAlignment(HorizontalAlignment_Stretch);
-                    break;
+            case ABI::AdaptiveCards::XamlCardRenderer::ActionAlignment::Center:
+                actionsFrameworkElement->put_HorizontalAlignment(HorizontalAlignment_Center);
+                break;
+            case ABI::AdaptiveCards::XamlCardRenderer::ActionAlignment::Left:
+                actionsFrameworkElement->put_HorizontalAlignment(HorizontalAlignment_Left);
+                break;
+            case ABI::AdaptiveCards::XamlCardRenderer::ActionAlignment::Right:
+                actionsFrameworkElement->put_HorizontalAlignment(HorizontalAlignment_Right);
+                break;
+            case ABI::AdaptiveCards::XamlCardRenderer::ActionAlignment::Stretch:
+                actionsFrameworkElement->put_HorizontalAlignment(HorizontalAlignment_Stretch);
+                break;
             }
 
             // Add the action buttons to the stack panel
@@ -756,18 +756,18 @@ namespace AdaptiveCards { namespace XamlCardRenderer
                 {
                     switch (actionAlignment)
                     {
-                        case ABI::AdaptiveCards::XamlCardRenderer::ActionAlignment::Center:
-                            THROW_IF_FAILED(buttonFrameworkElement->put_HorizontalAlignment(HorizontalAlignment_Center));
-                            break;
-                        case ABI::AdaptiveCards::XamlCardRenderer::ActionAlignment::Left:
-                            THROW_IF_FAILED(buttonFrameworkElement->put_HorizontalAlignment(HorizontalAlignment_Left));
-                            break;
-                        case ABI::AdaptiveCards::XamlCardRenderer::ActionAlignment::Right:
-                            THROW_IF_FAILED(buttonFrameworkElement->put_HorizontalAlignment(HorizontalAlignment_Right));
-                            break;
-                        case ABI::AdaptiveCards::XamlCardRenderer::ActionAlignment::Stretch:
-                            THROW_IF_FAILED(buttonFrameworkElement->put_HorizontalAlignment(HorizontalAlignment_Stretch));
-                            break;
+                    case ABI::AdaptiveCards::XamlCardRenderer::ActionAlignment::Center:
+                        THROW_IF_FAILED(buttonFrameworkElement->put_HorizontalAlignment(HorizontalAlignment_Center));
+                        break;
+                    case ABI::AdaptiveCards::XamlCardRenderer::ActionAlignment::Left:
+                        THROW_IF_FAILED(buttonFrameworkElement->put_HorizontalAlignment(HorizontalAlignment_Left));
+                        break;
+                    case ABI::AdaptiveCards::XamlCardRenderer::ActionAlignment::Right:
+                        THROW_IF_FAILED(buttonFrameworkElement->put_HorizontalAlignment(HorizontalAlignment_Right));
+                        break;
+                    case ABI::AdaptiveCards::XamlCardRenderer::ActionAlignment::Stretch:
+                        THROW_IF_FAILED(buttonFrameworkElement->put_HorizontalAlignment(HorizontalAlignment_Stretch));
+                        break;
                     }
                 }
 


### PR DESCRIPTION
This pull request addresses two issues: (1) Shared model wasn't parsing the actions property in HostConfig, and (2) UWP renderer wasn't properly displaying actions that were set to stretch (and also fixed up the vertical display behaviors too).

1) Parsing the actions property, that was a super simple one. The line of code to call parse actions was simply missing. Also noticed a subsequent bug where the mapping of inlineEdgeToEdge enum to string was missing so added that too.

2) For the buttons, the images below illustrate it best.

When HostConfig set to Horizontal, Stretch, the renderer used to be displaying this...
![image](https://user-images.githubusercontent.com/13246069/28142198-a86312f0-6714-11e7-88dd-5191d0d91802.png)

After my first fixes, it correctly displayed this
![image](https://user-images.githubusercontent.com/13246069/28142214-b82da902-6714-11e7-9e72-847de0e7eb2f.png)

But notice there's extra padding on the left and right of the buttons. That's because for the button spacing, the code is applying a left/right margin to each button, regardless of whether it's the first or last button. One's first solution to fixing this would likely be "Don't apply the margin to the first and the last button" - however, that would result in unequal columns, since the first and last button would actually be larger since they don't have that extra margin included in their size. Therefore, I simply negated the left/right button margins on the outside parent container, so that the parent container actually starts further left and further right to compensate for the margins that the buttons themselves have.

After that, the horizontal stretch behavior was correct
![image](https://user-images.githubusercontent.com/13246069/28142293-19b16ad8-6715-11e7-9c3c-2052c6db0245.png)

Left, center, and right are still correct too and have flush margins on the edges after that fix
![image](https://user-images.githubusercontent.com/13246069/28142307-2b1bf752-6715-11e7-8b48-f75c345c151b.png)
![image](https://user-images.githubusercontent.com/13246069/28142310-2e21d570-6715-11e7-8f02-20854dc7b931.png)
![image](https://user-images.githubusercontent.com/13246069/28142313-30b96d3e-6715-11e7-8bd5-75d632a38ee3.png)

The vertical alignment needed some fixing up too so that the buttons would be properly aligned depending on what alignment the host config has set, so after a super minor change there, here's all the possible vertical layouts...
![image](https://user-images.githubusercontent.com/13246069/28142345-4fa792f2-6715-11e7-8d25-6c11ec5b351c.png)
![image](https://user-images.githubusercontent.com/13246069/28142347-5333067c-6715-11e7-9882-0b763f545b64.png)
![image](https://user-images.githubusercontent.com/13246069/28142350-55b1b178-6715-11e7-964e-ddff16482767.png)
![image](https://user-images.githubusercontent.com/13246069/28142352-583b7f78-6715-11e7-8471-7c7ec53819d6.png)
