### PR TITLE
UWP: Add new height property (and change column size to width)

### DIFF
--- a/source/shared/cpp/ObjectModel/BaseCardElement.cpp
+++ b/source/shared/cpp/ObjectModel/BaseCardElement.cpp
@@ -34,6 +34,16 @@ AdaptiveCards::BaseCardElement::~BaseCardElement()
 {
 }
 
+Height BaseCardElement::GetHeight() const
+{
+    return m_height;
+}
+
+void BaseCardElement::SetHeight(const Height value)
+{
+    m_height = value;
+}
+
 SeparationStyle BaseCardElement::GetSeparationStyle() const
 {
     return m_separationStyle;
@@ -63,6 +73,7 @@ Json::Value BaseCardElement::SerializeToJsonValue()
  {
     Json::Value root;
     root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Type)] = CardElementTypeToString(GetElementType());
+    root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Height)] = Height::SerializeToString(GetHeight());
     root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Speak)] = GetSpeak();
     root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Separation)] = SeparationStyleToString(GetSeparationStyle());
     return root;

--- a/source/shared/cpp/ObjectModel/BaseCardElement.h
+++ b/source/shared/cpp/ObjectModel/BaseCardElement.h
@@ -2,6 +2,7 @@
 
 #include "pch.h"
 #include "Enums.h"
+#include "Height.h"
 #include "json/json.h"
 #include "BaseActionElement.h"
 #include "ParseUtil.h"
@@ -16,6 +17,9 @@ public:
     BaseCardElement(CardElementType type);
 
     virtual ~BaseCardElement();
+
+    Height GetHeight() const;
+    void SetHeight(const Height value);
 
     SeparationStyle GetSeparationStyle() const;
     void SetSeparationStyle(const SeparationStyle value);
@@ -39,6 +43,7 @@ protected:
 private:
     static const std::unordered_map<ActionType, std::function<std::shared_ptr<BaseActionElement>(const Json::Value&)>, EnumHash> ActionParsers;
     CardElementType m_type;
+    Height m_height;
     SeparationStyle m_separationStyle;
     std::string m_speak;
 };
@@ -51,6 +56,8 @@ std::shared_ptr<T> BaseCardElement::Deserialize(const Json::Value& json)
 
     ParseUtil::ThrowIfNotJsonObject(json);
 
+    baseCardElement->SetHeight(
+            ParseUtil::ExtractJsonValueAndMergeWithDefault<Height>(json, AdaptiveCardSchemaKey::Height, Height(), Height::Deserialize));
     baseCardElement->SetSpeak(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Speak));
     baseCardElement->SetSeparationStyle(
             ParseUtil::GetEnumValue<SeparationStyle>(json, AdaptiveCardSchemaKey::Separation, SeparationStyle::Default, SeparationStyleFromString));

--- a/source/shared/cpp/ObjectModel/Column.cpp
+++ b/source/shared/cpp/ObjectModel/Column.cpp
@@ -31,35 +31,35 @@ const std::unordered_map<CardElementType, std::function<std::shared_ptr<BaseCard
     { CardElementType::ToggleInput, ToggleInput::Deserialize },
 };
 
-Column::Column() : BaseCardElement(CardElementType::Column), m_size("Auto")
+Column::Column() : BaseCardElement(CardElementType::Column), m_width("Auto")
 {
 }
 
 Column::Column(
     SeparationStyle separation,
     std::string speak,
-    std::string size,
+    std::string width,
     std::vector<std::shared_ptr<BaseCardElement>>& items) :
-    BaseCardElement(CardElementType::Column, separation, speak), m_size(size), m_items(items)
+    BaseCardElement(CardElementType::Column, separation, speak), m_width(width), m_items(items)
 {
 }
 
 Column::Column(
     SeparationStyle separation,
     std::string speak,
-    std::string size) :
-    BaseCardElement(CardElementType::Column, separation, speak), m_size(size)
+    std::string width) :
+    BaseCardElement(CardElementType::Column, separation, speak), m_width(width)
 {
 }
 
-std::string Column::GetSize() const
+std::string Column::GetWidth() const
 {
-    return m_size;
+    return m_width;
 }
 
-void Column::SetSize(const std::string value)
+void Column::SetWidth(const std::string value)
 {
-    m_size = value;
+    m_width = value;
 }
 
 const std::vector<std::shared_ptr<BaseCardElement>>& Column::GetItems() const
@@ -82,7 +82,7 @@ Json::Value Column::SerializeToJsonValue()
 {
     Json::Value root = BaseCardElement::SerializeToJsonValue();
 
-    root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Size)] = GetSize();
+    root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Width)] = GetWidth();
 
     std::string propertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Items);
     root[propertyName] = Json::Value(Json::arrayValue);
@@ -102,7 +102,7 @@ std::shared_ptr<Column> Column::Deserialize(const Json::Value& value)
 
     auto column = BaseCardElement::Deserialize<Column>(value);
 
-    column->SetSize(ParseUtil::GetValueAsString(value, AdaptiveCardSchemaKey::Size));
+    column->SetWidth(ParseUtil::GetValueAsString(value, AdaptiveCardSchemaKey::Width));
 
     // Parse Items
     auto cardElements = ParseUtil::GetElementCollection<BaseCardElement>(value, AdaptiveCardSchemaKey::Items, CardElementParsers, true);

--- a/source/shared/cpp/ObjectModel/Column.h
+++ b/source/shared/cpp/ObjectModel/Column.h
@@ -11,8 +11,8 @@ class Column : public BaseCardElement
 {
 public:
     Column();
-    Column(SeparationStyle separation, std::string speak, std::string size);
-    Column(SeparationStyle separation, std::string speak, std::string size, std::vector<std::shared_ptr<BaseCardElement>>& items);
+    Column(SeparationStyle separation, std::string speak, std::string width);
+    Column(SeparationStyle separation, std::string speak, std::string width, std::vector<std::shared_ptr<BaseCardElement>>& items);
 
     virtual std::string Serialize();
     virtual Json::Value SerializeToJsonValue();
@@ -20,8 +20,8 @@ public:
     static std::shared_ptr<Column> Deserialize(const Json::Value& root);
     static std::shared_ptr<Column> DeserializeFromString(const std::string& jsonString);
 
-    std::string GetSize() const;
-    void SetSize(const std::string value);
+    std::string GetWidth() const;
+    void SetWidth(const std::string value);
 
     std::vector<std::shared_ptr<BaseCardElement>>& GetItems();
     const std::vector<std::shared_ptr<BaseCardElement>>& GetItems() const;
@@ -31,7 +31,7 @@ public:
 
 private:
     static const std::unordered_map<CardElementType, std::function<std::shared_ptr<BaseCardElement>(const Json::Value&)>, EnumHash> CardElementParsers;
-    std::string m_size;
+    std::string m_width;
     std::vector<std::shared_ptr<AdaptiveCards::BaseCardElement>> m_items;
     std::shared_ptr<BaseActionElement> m_selectAction;
 };

--- a/source/shared/cpp/ObjectModel/Enums.cpp
+++ b/source/shared/cpp/ObjectModel/Enums.cpp
@@ -110,6 +110,7 @@ static std::unordered_map<AdaptiveCardSchemaKey, std::string, EnumHash> Adaptive
     { AdaptiveCardSchemaKey::Version, "version" },
     { AdaptiveCardSchemaKey::Warning, "warning" },
     { AdaptiveCardSchemaKey::Weight, "weight" },
+    { AdaptiveCardSchemaKey::Width, "width" },
     { AdaptiveCardSchemaKey::Wrap, "wrap" },
 };
 

--- a/source/shared/cpp/ObjectModel/Enums.cpp
+++ b/source/shared/cpp/ObjectModel/Enums.cpp
@@ -45,6 +45,7 @@ static std::unordered_map<AdaptiveCardSchemaKey, std::string, EnumHash> Adaptive
     { AdaptiveCardSchemaKey::FontFamily, "fontFamily" },
     { AdaptiveCardSchemaKey::FontSizes, "fontSizes" },
     { AdaptiveCardSchemaKey::Good, "good" },
+    { AdaptiveCardSchemaKey::Height, "height"},
     { AdaptiveCardSchemaKey::HorizontalAlignment, "horizontalAlignment" },
     { AdaptiveCardSchemaKey::Id, "id" },
     { AdaptiveCardSchemaKey::Image, "image" },
@@ -147,6 +148,15 @@ static std::unordered_map<ActionType, std::string, EnumHash> ActionTypeEnumToNam
 
 static std::unordered_map<std::string, ActionType, CaseInsensitiveHash, CaseInsensitiveEqualTo>
 ActionTypeNameToEnum = GenerateStringToEnumMap<ActionType>(ActionTypeEnumToName);
+
+static std::unordered_map<HeightType, std::string, EnumHash> HeightTypeEnumToName =
+{
+    { HeightType::Auto, "Auto" },
+    { HeightType::Stretch, "Stretch" }
+};
+
+static std::unordered_map<std::string, HeightType, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+HeightTypeNameToEnum = GenerateStringToEnumMap<HeightType>(HeightTypeEnumToName);
 
 static std::unordered_map<SeparationStyle, std::string, EnumHash> SeparationStyleEnumToName =
 {
@@ -343,6 +353,26 @@ ActionType ActionTypeFromString(const std::string& actionType)
     }
 
     return ActionTypeNameToEnum[actionType];
+}
+
+const std::string HeightTypeToString(HeightType heightType)
+{
+    if (HeightTypeEnumToName.find(heightType) == HeightTypeEnumToName.end())
+    {
+        throw std::out_of_range("Invalid HeightType type");
+    }
+
+    return HeightTypeEnumToName[heightType];
+}
+
+HeightType HeightTypeFromString(const std::string& heightType)
+{
+    if (HeightTypeNameToEnum.find(heightType) == HeightTypeNameToEnum.end())
+    {
+        throw std::out_of_range("Invalid HeightType: " + heightType);
+    }
+
+    return HeightTypeNameToEnum[heightType];
 }
 
 const std::string HorizontalAlignmentToString(HorizontalAlignment alignment)

--- a/source/shared/cpp/ObjectModel/Enums.h
+++ b/source/shared/cpp/ObjectModel/Enums.h
@@ -73,6 +73,7 @@ enum class AdaptiveCardSchemaKey
     FontFamily,
     FontSizes,
     Good,
+    Height,
     HorizontalAlignment,
     Id,
     Image,
@@ -257,6 +258,11 @@ enum class ContainerStyle {
     Emphasis
 };
 
+enum class HeightType {
+    Auto = 0,
+    Stretch
+};
+
 const std::string AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey type);
 AdaptiveCardSchemaKey AdaptiveCardSchemaKeyFromString(const std::string& type);
 
@@ -265,6 +271,9 @@ CardElementType CardElementTypeFromString(const std::string& elementType);
 
 const std::string ActionTypeToString(ActionType actionType);
 ActionType ActionTypeFromString(const std::string& actionType);
+
+const std::string HeightTypeToString(HeightType heightType);
+HeightType HeightTypeFromString(const std::string& heightType);
 
 const std::string HorizontalAlignmentToString(HorizontalAlignment alignment);
 HorizontalAlignment HorizontalAlignmentFromString(const std::string& alignment);

--- a/source/shared/cpp/ObjectModel/Enums.h
+++ b/source/shared/cpp/ObjectModel/Enums.h
@@ -138,6 +138,7 @@ enum class AdaptiveCardSchemaKey
     Version,
     Warning,
     Weight,
+    Width,
     Wrap,
 };
 

--- a/source/shared/cpp/ObjectModel/Height.cpp
+++ b/source/shared/cpp/ObjectModel/Height.cpp
@@ -1,0 +1,23 @@
+#include "Height.h"
+#include "ParseUtil.h"
+
+using namespace AdaptiveCards;
+
+Height Height::Deserialize(const Json::Value& json, const Height& defaultValue)
+{
+    Height result;
+
+    if (!json.isString())
+    {
+        throw AdaptiveCardParseException("Height property type was invalid. Expected type string.");
+    }
+
+    result.heightType = HeightTypeFromString(json.asString());
+
+    return result;
+}
+
+std::string Height::SerializeToString(const Height& defaultValue)
+{
+    return HeightTypeToString(defaultValue.heightType);
+}

--- a/source/shared/cpp/ObjectModel/Height.h
+++ b/source/shared/cpp/ObjectModel/Height.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "pch.h"
+#include "Enums.h"
+#include "json/json.h"
+
+namespace AdaptiveCards
+{
+struct Height
+{
+    // Height is a struct rather than an enum since in the future it's possible that we'll have
+    // heights of pixel heights, or star-based heights. So following a similar pattern to XAML GridLength.
+    HeightType heightType = HeightType::Auto;
+
+    static Height Deserialize(const Json::Value& json, const Height& defaultValue);
+    static std::string SerializeToString(const Height& defaultValue);
+};
+}

--- a/source/uwp/ObjectModelProjection/ObjectModelProjection.vcxproj
+++ b/source/uwp/ObjectModelProjection/ObjectModelProjection.vcxproj
@@ -38,6 +38,7 @@
     <ClCompile Include="..\..\shared\cpp\ObjectModel\ColumnSet.cpp" />
     <ClCompile Include="..\..\shared\cpp\ObjectModel\Fact.cpp" />
     <ClCompile Include="..\..\shared\cpp\ObjectModel\FactSet.cpp" />
+    <ClCompile Include="..\..\shared\cpp\ObjectModel\Height.cpp" />
     <ClCompile Include="..\..\shared\cpp\ObjectModel\Image.cpp" />
     <ClCompile Include="..\..\shared\cpp\ObjectModel\ImageSet.cpp" />
     <ClCompile Include="..\..\shared\cpp\ObjectModel\DateInput.cpp" />
@@ -67,6 +68,7 @@
     <ClInclude Include="..\..\shared\cpp\ObjectModel\ColumnSet.h" />
     <ClInclude Include="..\..\shared\cpp\ObjectModel\Fact.h" />
     <ClInclude Include="..\..\shared\cpp\ObjectModel\FactSet.h" />
+    <ClInclude Include="..\..\shared\cpp\ObjectModel\Height.h" />
     <ClInclude Include="..\..\shared\cpp\ObjectModel\HostConfig.h" />
     <ClInclude Include="..\..\shared\cpp\ObjectModel\Image.h" />
     <ClInclude Include="..\..\shared\cpp\ObjectModel\ImageSet.h" />

--- a/source/uwp/Renderer/XamlCardRenderer.vcxproj
+++ b/source/uwp/Renderer/XamlCardRenderer.vcxproj
@@ -138,6 +138,7 @@
     <ClInclude Include="lib\AdaptiveFact.h" />
     <ClInclude Include="lib\AdaptiveFactSet.h" />
     <ClInclude Include="lib\AdaptiveFactSetConfig.h" />
+    <ClInclude Include="lib\AdaptiveHeight.h" />
     <ClInclude Include="lib\AdaptiveHostConfig.h" />
     <ClInclude Include="lib\AdaptiveImage.h" />
     <ClInclude Include="lib\AdaptiveImageConfig.h" />
@@ -196,6 +197,7 @@
     <ClCompile Include="lib\AdaptiveFact.cpp" />
     <ClCompile Include="lib\AdaptiveFactSet.cpp" />
     <ClCompile Include="lib\AdaptiveFactSetConfig.cpp" />
+    <ClCompile Include="lib\AdaptiveHeight.cpp" />
     <ClCompile Include="lib\AdaptiveHostConfig.cpp" />
     <ClCompile Include="lib\AdaptiveImage.cpp" />
     <ClCompile Include="lib\AdaptiveImageConfig.cpp" />

--- a/source/uwp/Renderer/idl/AdaptiveCards.XamlCardRenderer.idl
+++ b/source/uwp/Renderer/idl/AdaptiveCards.XamlCardRenderer.idl
@@ -26,6 +26,7 @@ namespace AdaptiveCards
         runtimeclass AdaptiveTextInput;
         runtimeclass AdaptiveTimeInput;
         runtimeclass AdaptiveToggleInput;
+        runtimeclass AdaptiveHeight;
 
         runtimeclass AdaptiveSpacingDefinition;
         runtimeclass AdaptiveFontSizesConfig;
@@ -72,6 +73,7 @@ namespace AdaptiveCards
         interface IAdaptiveNumberInput;
         interface IAdaptiveTimeInput;
         interface IAdaptiveToggleInput;
+        interface IAdaptiveHeight;
 
         interface IAdaptiveSpacingDefinition;
         interface IAdaptiveFontSizesConfig;
@@ -99,6 +101,13 @@ namespace AdaptiveCards
         interface IAdaptiveChoiceSetInputConfig;
         interface IAdaptiveHostConfig;
         interface IAdaptiveActionEventArgs;
+
+        [version(NTDDI_WIN10_RS1)]
+        typedef [v1_enum] enum HeightType
+        {
+            Auto = 0,
+            Stretch
+        } HeightType;
 
         [version(NTDDI_WIN10_RS1)]
         typedef [v1_enum] enum TextSize
@@ -250,11 +259,14 @@ namespace AdaptiveCards
 
         [
             uuid(74D69C2F-7F1C-47FD-A319-F4B4E7F72EE9),
-            version(NTDDI_WIN10_RS1),
+            version(NTDDI_WIN10_RS1)
         ]
         interface IAdaptiveCardElement : IInspectable
         {
             [propget] HRESULT ElementType([out, retval] ElementType* value);
+
+            [propget] HRESULT Height([out, retval] AdaptiveHeight** value);
+            [propput] HRESULT Height([in] AdaptiveHeight* value);
 
             [propget] HRESULT Speak([out, retval] HSTRING* value);
             [propput] HRESULT Speak([in] HSTRING value);
@@ -633,6 +645,26 @@ namespace AdaptiveCards
             [default] interface IAdaptiveToggleInput;
             interface IAdaptiveInputElement;
             interface IAdaptiveCardElement;
+        };
+
+        [
+            uuid(d37a48d6-6cd8-11e7-907b-a6006ad3dba0),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveHeight)
+        ]
+        interface IAdaptiveHeight : IInspectable
+        {
+            [propget] HRESULT HeightType([out, retval] HeightType* value);
+            [propput] HRESULT HeightType([in] HeightType value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveHeight
+        {
+            [default] interface IAdaptiveHeight;
         };
 
         [

--- a/source/uwp/Renderer/idl/AdaptiveCards.XamlCardRenderer.idl
+++ b/source/uwp/Renderer/idl/AdaptiveCards.XamlCardRenderer.idl
@@ -695,8 +695,8 @@ namespace AdaptiveCards
         ]
         interface IAdaptiveColumn : IInspectable
         {
-            [propget] HRESULT Size([out, retval] HSTRING* value);
-            [propput] HRESULT Size([in] HSTRING value);
+            [propget] HRESULT Width([out, retval] HSTRING* value);
+            [propput] HRESULT Width([in] HSTRING value);
 
             [propget] HRESULT Items([out, retval] Windows.Foundation.Collections.IVector<IAdaptiveCardElement*>** value);
         };

--- a/source/uwp/Renderer/lib/AdaptiveChoiceSetInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceSetInput.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "AdaptiveHeight.h"
 #include "AdaptiveChoiceSetInput.h"
 
 #include "Util.h"
@@ -102,6 +103,18 @@ namespace AdaptiveCards { namespace XamlCardRenderer
     {
         *elementType = ElementType::ChoiceSetInput;
         return S_OK;
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveChoiceSetInput::get_Height(IAdaptiveHeight** height)
+    {
+        return MakeAndInitialize<AdaptiveHeight>(height, m_sharedChoiceSetInput->GetHeight());
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveChoiceSetInput::put_Height(IAdaptiveHeight* height)
+    {
+        return E_NOTIMPL;
     }
 
     _Use_decl_annotations_

--- a/source/uwp/Renderer/lib/AdaptiveChoiceSetInput.h
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceSetInput.h
@@ -42,6 +42,9 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         // IAdaptiveCardElement
         IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveCards::XamlCardRenderer::ElementType* elementType);
 
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveHeight** height);
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveHeight* height);
+
         IFACEMETHODIMP get_Separation(_Out_ ABI::AdaptiveCards::XamlCardRenderer::SeparationStyle* separation);
         IFACEMETHODIMP put_Separation(_In_ ABI::AdaptiveCards::XamlCardRenderer::SeparationStyle separation);
 

--- a/source/uwp/Renderer/lib/AdaptiveColumn.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveColumn.cpp
@@ -36,17 +36,17 @@ namespace AdaptiveCards { namespace XamlCardRenderer
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveColumn::get_Size(HSTRING* size)
+    HRESULT AdaptiveColumn::get_Width(HSTRING* width)
     {
-        return UTF8ToHString(m_sharedColumn->GetSize(), size);
+        return UTF8ToHString(m_sharedColumn->GetWidth(), width);
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveColumn::put_Size(HSTRING size)
+    HRESULT AdaptiveColumn::put_Width(HSTRING width)
     {
         std::string out;
-        RETURN_IF_FAILED(HStringToUTF8(size, out));
-        m_sharedColumn->SetSize(out);
+        RETURN_IF_FAILED(HStringToUTF8(width, out));
+        m_sharedColumn->SetWidth(out);
         return S_OK;
     }
 

--- a/source/uwp/Renderer/lib/AdaptiveColumn.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveColumn.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "AdaptiveHeight.h"
 #include "AdaptiveColumn.h"
 
 #include "Util.h"
@@ -59,6 +60,18 @@ namespace AdaptiveCards { namespace XamlCardRenderer
     {
         *elementType = ElementType::Column;
         return S_OK;
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveColumn::get_Height(IAdaptiveHeight** height)
+    {
+        return MakeAndInitialize<AdaptiveHeight>(height, m_sharedColumn->GetHeight());
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveColumn::put_Height(IAdaptiveHeight* height)
+    {
+        return E_NOTIMPL;
     }
 
     _Use_decl_annotations_

--- a/source/uwp/Renderer/lib/AdaptiveColumn.h
+++ b/source/uwp/Renderer/lib/AdaptiveColumn.h
@@ -29,6 +29,9 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         // IAdaptiveCardElement
         IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveCards::XamlCardRenderer::ElementType* elementType);
 
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveHeight** height);
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveHeight* height);
+
         IFACEMETHODIMP get_Separation(_Out_ ABI::AdaptiveCards::XamlCardRenderer::SeparationStyle* separation);
         IFACEMETHODIMP put_Separation(_In_ ABI::AdaptiveCards::XamlCardRenderer::SeparationStyle separation);
 

--- a/source/uwp/Renderer/lib/AdaptiveColumn.h
+++ b/source/uwp/Renderer/lib/AdaptiveColumn.h
@@ -21,8 +21,8 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         HRESULT RuntimeClassInitialize(_In_ const std::shared_ptr<AdaptiveCards::Column>& sharedColumn);
 
         // IAdaptiveColumn
-        IFACEMETHODIMP get_Size(_Out_ HSTRING* size);
-        IFACEMETHODIMP put_Size(_In_ HSTRING size);
+        IFACEMETHODIMP get_Width(_Out_ HSTRING* width);
+        IFACEMETHODIMP put_Width(_In_ HSTRING width);
 
         IFACEMETHODIMP get_Items(_COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCardElement*>** items);
 

--- a/source/uwp/Renderer/lib/AdaptiveColumnSet.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveColumnSet.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "AdaptiveHeight.h"
 #include "AdaptiveColumnSet.h"
 
 #include "Util.h"
@@ -45,6 +46,18 @@ namespace AdaptiveCards { namespace XamlCardRenderer
     {
         *elementType = ElementType::ColumnSet;
         return S_OK;
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveColumnSet::get_Height(IAdaptiveHeight** height)
+    {
+        return MakeAndInitialize<AdaptiveHeight>(height, m_sharedColumnSet->GetHeight());
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveColumnSet::put_Height(IAdaptiveHeight* height)
+    {
+        return E_NOTIMPL;
     }
 
     _Use_decl_annotations_

--- a/source/uwp/Renderer/lib/AdaptiveColumnSet.h
+++ b/source/uwp/Renderer/lib/AdaptiveColumnSet.h
@@ -26,6 +26,9 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         // IAdaptiveCardElement
         IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveCards::XamlCardRenderer::ElementType* elementType);
 
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveHeight** height);
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveHeight* height);
+
         IFACEMETHODIMP get_Separation(_Out_ ABI::AdaptiveCards::XamlCardRenderer::SeparationStyle* separation);
         IFACEMETHODIMP put_Separation(_In_ ABI::AdaptiveCards::XamlCardRenderer::SeparationStyle separation);
 

--- a/source/uwp/Renderer/lib/AdaptiveContainer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveContainer.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "AdaptiveHeight.h"
 #include "AdaptiveContainer.h"
 
 #include "Util.h"
@@ -45,6 +46,18 @@ namespace AdaptiveCards { namespace XamlCardRenderer
     {
         *elementType = ElementType::Container;
         return S_OK;
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveContainer::get_Height(IAdaptiveHeight** height)
+    {
+        return MakeAndInitialize<AdaptiveHeight>(height, m_sharedContainer->GetHeight());
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveContainer::put_Height(IAdaptiveHeight* height)
+    {
+        return E_NOTIMPL;
     }
 
     _Use_decl_annotations_

--- a/source/uwp/Renderer/lib/AdaptiveContainer.h
+++ b/source/uwp/Renderer/lib/AdaptiveContainer.h
@@ -29,6 +29,9 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         // IAdaptiveCardElement
         IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveCards::XamlCardRenderer::ElementType* elementType);
 
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveHeight** height);
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveHeight* height);
+
         IFACEMETHODIMP get_Separation(_Out_ ABI::AdaptiveCards::XamlCardRenderer::SeparationStyle* separation);
         IFACEMETHODIMP put_Separation(_In_ ABI::AdaptiveCards::XamlCardRenderer::SeparationStyle separation);
 

--- a/source/uwp/Renderer/lib/AdaptiveDateInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveDateInput.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "AdaptiveHeight.h"
 #include "AdaptiveDateInput.h"
 #include "Util.h"
 #include <windows.foundation.collections.h>
@@ -106,6 +107,18 @@ namespace AdaptiveCards { namespace XamlCardRenderer
     {
         *elementType = ElementType::DateInput;
         return S_OK;
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveDateInput::get_Height(IAdaptiveHeight** height)
+    {
+        return MakeAndInitialize<AdaptiveHeight>(height, m_sharedDateInput->GetHeight());
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveDateInput::put_Height(IAdaptiveHeight* height)
+    {
+        return E_NOTIMPL;
     }
 
     _Use_decl_annotations_

--- a/source/uwp/Renderer/lib/AdaptiveDateInput.h
+++ b/source/uwp/Renderer/lib/AdaptiveDateInput.h
@@ -42,6 +42,9 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         // IAdaptiveCardElement
         IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveCards::XamlCardRenderer::ElementType* elementType);
 
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveHeight** height);
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveHeight* height);
+
         IFACEMETHODIMP get_Separation(_Out_ ABI::AdaptiveCards::XamlCardRenderer::SeparationStyle* separation);
         IFACEMETHODIMP put_Separation(_In_ ABI::AdaptiveCards::XamlCardRenderer::SeparationStyle separation);
 

--- a/source/uwp/Renderer/lib/AdaptiveFactSet.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveFactSet.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "AdaptiveHeight.h"
 #include "AdaptiveFactSet.h"
 
 #include "Util.h"
@@ -45,6 +46,18 @@ namespace AdaptiveCards { namespace XamlCardRenderer
     {
         *elementType = ElementType::FactSet;
         return S_OK;
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveFactSet::get_Height(IAdaptiveHeight** height)
+    {
+        return MakeAndInitialize<AdaptiveHeight>(height, m_sharedFactSet->GetHeight());
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveFactSet::put_Height(IAdaptiveHeight* height)
+    {
+        return E_NOTIMPL;
     }
 
     _Use_decl_annotations_

--- a/source/uwp/Renderer/lib/AdaptiveFactSet.h
+++ b/source/uwp/Renderer/lib/AdaptiveFactSet.h
@@ -27,6 +27,9 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         // IAdaptiveCardElement
         IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveCards::XamlCardRenderer::ElementType* elementType);
 
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveHeight** height);
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveHeight* height);
+
         IFACEMETHODIMP get_Separation(_Out_ ABI::AdaptiveCards::XamlCardRenderer::SeparationStyle* separation);
         IFACEMETHODIMP put_Separation(_In_ ABI::AdaptiveCards::XamlCardRenderer::SeparationStyle separation);
 

--- a/source/uwp/Renderer/lib/AdaptiveHeight.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveHeight.cpp
@@ -1,0 +1,34 @@
+#include "pch.h"
+#include "AdaptiveHeight.h"
+
+using namespace Microsoft::WRL;
+using namespace ABI::AdaptiveCards::XamlCardRenderer;
+
+namespace AdaptiveCards { namespace XamlCardRenderer
+{
+    HRESULT AdaptiveHeight::RuntimeClassInitialize() noexcept try
+    {
+        return S_OK;
+    } CATCH_RETURN;
+
+    HRESULT AdaptiveHeight::RuntimeClassInitialize(Height Height) noexcept
+    {
+        m_sharedHeight = Height;
+        return S_OK;
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveHeight::get_HeightType(ABI::AdaptiveCards::XamlCardRenderer::HeightType* heightType)
+    {
+        *heightType = static_cast<ABI::AdaptiveCards::XamlCardRenderer::HeightType>(m_sharedHeight.heightType);
+        return S_OK;
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveHeight::put_HeightType(ABI::AdaptiveCards::XamlCardRenderer::HeightType heightType)
+    {
+        m_sharedHeight.heightType = static_cast<AdaptiveCards::HeightType>(heightType);
+        return S_OK;
+    }
+}
+}

--- a/source/uwp/Renderer/lib/AdaptiveHeight.h
+++ b/source/uwp/Renderer/lib/AdaptiveHeight.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "AdaptiveCards.XamlCardRenderer.h"
+#include "Enums.h"
+#include "Height.h"
+
+namespace AdaptiveCards { namespace XamlCardRenderer
+{
+    class AdaptiveHeight :
+        public Microsoft::WRL::RuntimeClass<
+            Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
+            ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveHeight>
+    {
+        InspectableClass(RuntimeClass_AdaptiveCards_XamlCardRenderer_AdaptiveHeight, BaseTrust)
+
+    public:
+        HRESULT RuntimeClassInitialize() noexcept;
+        HRESULT RuntimeClassInitialize(Height height) noexcept;
+
+        IFACEMETHODIMP get_HeightType(_Out_ ABI::AdaptiveCards::XamlCardRenderer::HeightType* heightType);
+        IFACEMETHODIMP put_HeightType(_In_ ABI::AdaptiveCards::XamlCardRenderer::HeightType heightType);
+
+    private:
+        Height m_sharedHeight;
+    };
+
+    ActivatableClass(AdaptiveHeight);
+}}

--- a/source/uwp/Renderer/lib/AdaptiveImage.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImage.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "AdaptiveHeight.h"
 #include "AdaptiveImage.h"
 
 #include "Util.h"
@@ -127,6 +128,18 @@ namespace AdaptiveCards { namespace XamlCardRenderer
     {
         *elementType = ElementType::Image;
         return S_OK;
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveImage::get_Height(IAdaptiveHeight** height)
+    {
+        return MakeAndInitialize<AdaptiveHeight>(height, m_sharedImage->GetHeight());
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveImage::put_Height(IAdaptiveHeight* height)
+    {
+        return E_NOTIMPL;
     }
 
     _Use_decl_annotations_

--- a/source/uwp/Renderer/lib/AdaptiveImage.h
+++ b/source/uwp/Renderer/lib/AdaptiveImage.h
@@ -39,6 +39,9 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         // IAdaptiveCardElement
         IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveCards::XamlCardRenderer::ElementType* elementType);
 
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveHeight** height);
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveHeight* height);
+
         IFACEMETHODIMP get_Separation(_Out_ ABI::AdaptiveCards::XamlCardRenderer::SeparationStyle* separation);
         IFACEMETHODIMP put_Separation(_In_ ABI::AdaptiveCards::XamlCardRenderer::SeparationStyle separation);
 

--- a/source/uwp/Renderer/lib/AdaptiveImageSet.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImageSet.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "AdaptiveHeight.h"
 #include "AdaptiveImageSet.h"
 
 #include "Util.h"
@@ -59,6 +60,18 @@ namespace AdaptiveCards { namespace XamlCardRenderer
     {
         *elementType = ElementType::ImageSet;
         return S_OK;
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveImageSet::get_Height(IAdaptiveHeight** height)
+    {
+        return MakeAndInitialize<AdaptiveHeight>(height, m_sharedImageSet->GetHeight());
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveImageSet::put_Height(IAdaptiveHeight* height)
+    {
+        return E_NOTIMPL;
     }
 
     _Use_decl_annotations_

--- a/source/uwp/Renderer/lib/AdaptiveImageSet.h
+++ b/source/uwp/Renderer/lib/AdaptiveImageSet.h
@@ -31,6 +31,9 @@ namespace AdaptiveCards {
             // IAdaptiveCardElement
             IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveCards::XamlCardRenderer::ElementType* elementType);
 
+            IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveHeight** height);
+            IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveHeight* height);
+
             IFACEMETHODIMP get_Separation(_Out_ ABI::AdaptiveCards::XamlCardRenderer::SeparationStyle* separation);
             IFACEMETHODIMP put_Separation(_In_ ABI::AdaptiveCards::XamlCardRenderer::SeparationStyle separation);
 

--- a/source/uwp/Renderer/lib/AdaptiveNumberInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveNumberInput.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "AdaptiveHeight.h"
 #include "AdaptiveNumberInput.h"
 #include "Util.h"
 #include <windows.foundation.collections.h>
@@ -103,6 +104,18 @@ namespace AdaptiveCards { namespace XamlCardRenderer
     {
         *elementType = ElementType::NumberInput;
         return S_OK;
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveNumberInput::get_Height(IAdaptiveHeight** height)
+    {
+        return MakeAndInitialize<AdaptiveHeight>(height, m_sharedNumberInput->GetHeight());
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveNumberInput::put_Height(IAdaptiveHeight* height)
+    {
+        return E_NOTIMPL;
     }
 
     _Use_decl_annotations_

--- a/source/uwp/Renderer/lib/AdaptiveNumberInput.h
+++ b/source/uwp/Renderer/lib/AdaptiveNumberInput.h
@@ -42,6 +42,9 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         // IAdaptiveCardElement
         IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveCards::XamlCardRenderer::ElementType* elementType);
 
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveHeight** height);
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveHeight* height);
+
         IFACEMETHODIMP get_Separation(_Out_ ABI::AdaptiveCards::XamlCardRenderer::SeparationStyle* separation);
         IFACEMETHODIMP put_Separation(_In_ ABI::AdaptiveCards::XamlCardRenderer::SeparationStyle separation);
 

--- a/source/uwp/Renderer/lib/AdaptiveTextBlock.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTextBlock.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "AdaptiveHeight.h"
 #include "AdaptiveTextBlock.h"
 #include "Util.h"
 #include <windows.foundation.collections.h>
@@ -144,6 +145,18 @@ namespace AdaptiveCards { namespace XamlCardRenderer
     {
         *elementType = ElementType::TextBlock;
         return S_OK;
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveTextBlock::get_Height(IAdaptiveHeight** height)
+    {
+        return MakeAndInitialize<AdaptiveHeight>(height, m_sharedTextBlock->GetHeight());
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveTextBlock::put_Height(IAdaptiveHeight* height)
+    {
+        return E_NOTIMPL;
     }
 
     _Use_decl_annotations_

--- a/source/uwp/Renderer/lib/AdaptiveTextBlock.h
+++ b/source/uwp/Renderer/lib/AdaptiveTextBlock.h
@@ -46,6 +46,9 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         // IAdaptiveCardElement
         IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveCards::XamlCardRenderer::ElementType* elementType);
 
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveHeight** height);
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveHeight* height);
+
         IFACEMETHODIMP get_Separation(_Out_ ABI::AdaptiveCards::XamlCardRenderer::SeparationStyle* separation);
         IFACEMETHODIMP put_Separation(_In_ ABI::AdaptiveCards::XamlCardRenderer::SeparationStyle separation);
 

--- a/source/uwp/Renderer/lib/AdaptiveTextInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTextInput.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "AdaptiveHeight.h"
 #include "AdaptiveTextInput.h"
 #include "Util.h"
 #include <windows.foundation.collections.h>
@@ -116,6 +117,18 @@ namespace AdaptiveCards { namespace XamlCardRenderer
     {
         *elementType = ElementType::TextInput;
         return S_OK;
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveTextInput::get_Height(IAdaptiveHeight** height)
+    {
+        return MakeAndInitialize<AdaptiveHeight>(height, m_sharedTextInput->GetHeight());
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveTextInput::put_Height(IAdaptiveHeight* height)
+    {
+        return E_NOTIMPL;
     }
 
     _Use_decl_annotations_

--- a/source/uwp/Renderer/lib/AdaptiveTextInput.h
+++ b/source/uwp/Renderer/lib/AdaptiveTextInput.h
@@ -45,6 +45,9 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         // IAdaptiveCardElement
         IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveCards::XamlCardRenderer::ElementType* elementType);
 
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveHeight** height);
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveHeight* height);
+
         IFACEMETHODIMP get_Separation(_Out_ ABI::AdaptiveCards::XamlCardRenderer::SeparationStyle* separation);
         IFACEMETHODIMP put_Separation(_In_ ABI::AdaptiveCards::XamlCardRenderer::SeparationStyle separation);
 

--- a/source/uwp/Renderer/lib/AdaptiveTimeInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTimeInput.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "AdaptiveHeight.h"
 #include "AdaptiveTimeInput.h"
 #include "Util.h"
 #include <windows.foundation.collections.h>
@@ -106,6 +107,18 @@ namespace AdaptiveCards { namespace XamlCardRenderer
     {
         *elementType = ElementType::TimeInput;
         return S_OK;
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveTimeInput::get_Height(IAdaptiveHeight** height)
+    {
+        return MakeAndInitialize<AdaptiveHeight>(height, m_sharedTimeInput->GetHeight());
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveTimeInput::put_Height(IAdaptiveHeight* height)
+    {
+        return E_NOTIMPL;
     }
 
     _Use_decl_annotations_

--- a/source/uwp/Renderer/lib/AdaptiveTimeInput.h
+++ b/source/uwp/Renderer/lib/AdaptiveTimeInput.h
@@ -42,6 +42,9 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         // IAdaptiveCardElement
         IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveCards::XamlCardRenderer::ElementType* elementType);
 
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveHeight** height);
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveHeight* height);
+
         IFACEMETHODIMP get_Separation(_Out_ ABI::AdaptiveCards::XamlCardRenderer::SeparationStyle* separation);
         IFACEMETHODIMP put_Separation(_In_ ABI::AdaptiveCards::XamlCardRenderer::SeparationStyle separation);
 

--- a/source/uwp/Renderer/lib/AdaptiveToggleInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveToggleInput.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "AdaptiveHeight.h"
 #include "AdaptiveToggleInput.h"
 #include "Util.h"
 #include <windows.foundation.collections.h>
@@ -106,6 +107,18 @@ namespace AdaptiveCards { namespace XamlCardRenderer
     {
         *elementType = ElementType::ToggleInput;
         return S_OK;
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveToggleInput::get_Height(IAdaptiveHeight** height)
+    {
+        return MakeAndInitialize<AdaptiveHeight>(height, m_sharedToggleInput->GetHeight());
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveToggleInput::put_Height(IAdaptiveHeight* height)
+    {
+        return E_NOTIMPL;
     }
 
     _Use_decl_annotations_

--- a/source/uwp/Renderer/lib/AdaptiveToggleInput.h
+++ b/source/uwp/Renderer/lib/AdaptiveToggleInput.h
@@ -42,6 +42,9 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         // IAdaptiveCardElement
         IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveCards::XamlCardRenderer::ElementType* elementType);
 
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveHeight** height);
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveHeight* height);
+
         IFACEMETHODIMP get_Separation(_Out_ ABI::AdaptiveCards::XamlCardRenderer::SeparationStyle* separation);
         IFACEMETHODIMP put_Separation(_In_ ABI::AdaptiveCards::XamlCardRenderer::SeparationStyle separation);
 

--- a/source/uwp/Renderer/lib/DefaultResourceDictionary.h
+++ b/source/uwp/Renderer/lib/DefaultResourceDictionary.h
@@ -46,10 +46,10 @@ const PCWSTR c_defaultResourceDictionary = L"\
         <Setter Property=\"FontSize\" Value=\"8\"/> \
     </Style> \
 \
-    <Style TargetType=\"StackPanel\" x:Key=\"Container\"> \
+    <Style TargetType=\"Grid\" x:Key=\"Container\"> \
         <Setter Property=\"Margin\" Value=\"0,0,0,0\"/> \
     </Style> \
-    <Style TargetType=\"StackPanel\" x:Key=\"Container.StartGroup\"> \
+    <Style TargetType=\"Grid\" x:Key=\"Container.StartGroup\"> \
         <Setter Property=\"Margin\" Value=\"0,10,0,0\"/> \
     </Style> \
 \

--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -1502,16 +1502,16 @@ namespace AdaptiveCards { namespace XamlCardRenderer
             // Determine if the column is auto, stretch, or percentage width, and set the column width appropriately
             ComPtr<IColumnDefinition> columnDefinition = XamlHelpers::CreateXamlClass<IColumnDefinition>(HStringReference(RuntimeClass_Windows_UI_Xaml_Controls_ColumnDefinition));
 
-            HString adaptiveColumnSize;
-            THROW_IF_FAILED(column->get_Size(adaptiveColumnSize.GetAddressOf()));
+            HString adaptiveColumnWidth;
+            THROW_IF_FAILED(column->get_Width(adaptiveColumnWidth.GetAddressOf()));
 
             INT32 isStretchResult;
-            THROW_IF_FAILED(WindowsCompareStringOrdinal(adaptiveColumnSize.Get(), HStringReference(L"stretch").Get(), &isStretchResult));
+            THROW_IF_FAILED(WindowsCompareStringOrdinal(adaptiveColumnWidth.Get(), HStringReference(L"stretch").Get(), &isStretchResult));
 
             INT32 isAutoResult;
-            THROW_IF_FAILED(WindowsCompareStringOrdinal(adaptiveColumnSize.Get(), HStringReference(L"auto").Get(), &isAutoResult));
+            THROW_IF_FAILED(WindowsCompareStringOrdinal(adaptiveColumnWidth.Get(), HStringReference(L"auto").Get(), &isAutoResult));
 
-            double sizeAsDouble = _wtof(adaptiveColumnSize.GetRawBuffer(nullptr));
+            double widthAsDouble = _wtof(adaptiveColumnWidth.GetRawBuffer(nullptr));
 
             GridLength columnWidth;
             if (isAutoResult == 0)
@@ -1520,17 +1520,17 @@ namespace AdaptiveCards { namespace XamlCardRenderer
                 columnWidth.GridUnitType = GridUnitType::GridUnitType_Auto;
                 columnWidth.Value = 0;
             }
-            else if (isStretchResult == 0 || !adaptiveColumnSize.IsValid() || (sizeAsDouble <= 0))
+            else if (isStretchResult == 0 || !adaptiveColumnWidth.IsValid() || (widthAsDouble <= 0))
             {
-                // If stretch specified, or column size invalid or set to non-positive, use stretch with default of 1
+                // If stretch specified, or column width invalid or set to non-positive, use stretch with default of 1
                 columnWidth.GridUnitType = GridUnitType::GridUnitType_Star;
                 columnWidth.Value = 1;
             }
             else
             {
-                // If user specified specific valid size, use that star size
+                // If user specified specific valid width, use that star width
                 columnWidth.GridUnitType = GridUnitType::GridUnitType_Star;
-                columnWidth.Value = _wtof(adaptiveColumnSize.GetRawBuffer(nullptr));
+                columnWidth.Value = _wtof(adaptiveColumnWidth.GetRawBuffer(nullptr));
             }
 
             THROW_IF_FAILED(columnDefinition->put_Width(columnWidth));

--- a/source/uwp/Renderer/lib/XamlBuilder.h
+++ b/source/uwp/Renderer/lib/XamlBuilder.h
@@ -86,7 +86,7 @@ namespace AdaptiveCards { namespace XamlCardRenderer
             _Out_ T* valueResource);
         Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IUIElement> CreateRootCardElement(
             _In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCard* adaptiveCard,
-            _COM_Outptr_ ABI::Windows::UI::Xaml::Controls::IPanel** childElementContainer);
+            _COM_Outptr_ ABI::Windows::UI::Xaml::Controls::IGrid** childElementContainer);
         void ApplyBackgroundToRoot(_In_ ABI::Windows::UI::Xaml::Controls::IPanel* rootPanel, _In_ ABI::Windows::Foundation::IUriRuntimeClass* uri);
         template<typename T>
         void SetImageSource(T* destination, ABI::Windows::UI::Xaml::Media::IImageSource* imageSource);
@@ -97,7 +97,7 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         void FireAllImagesLoaded();
         void BuildPanelChildren(
             _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCardElement*>* children,
-            _In_ ABI::Windows::UI::Xaml::Controls::IPanel* parentPanel,
+            _In_ ABI::Windows::UI::Xaml::Controls::IGrid* parentGrid,
             std::shared_ptr<std::vector<InputItem>> inputElements,
             _In_ std::function<void(ABI::Windows::UI::Xaml::IUIElement* child)> childCreatedCallback);
         void BuildShowCard(
@@ -109,7 +109,7 @@ namespace AdaptiveCards { namespace XamlCardRenderer
             _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveActionElement*>* children,
             AdaptiveCards::XamlCardRenderer::XamlCardRenderer* renderer,
             std::shared_ptr<std::vector<InputItem>> inputElements,
-            _In_ ABI::Windows::UI::Xaml::Controls::IPanel* parentPanel);
+            _In_ ABI::Windows::UI::Xaml::Controls::IGrid* parentGrid);
         void GetSeparationConfigForElement(
             _In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCardElement* element,
             _In_ ABI::AdaptiveCards::XamlCardRenderer::SeparationStyle separation,

--- a/source/uwp/Renderer/lib/XamlHelpers.h
+++ b/source/uwp/Renderer/lib/XamlHelpers.h
@@ -120,5 +120,34 @@ namespace AdaptiveCards { namespace XamlCardRenderer
             THROW_IF_FAILED(content->put_Text(contentString));
             THROW_IF_FAILED(contentControl->put_Content(content.Get()));
         }
+
+        template<typename T>
+        static void AddRow(
+            T* item,
+            ABI::Windows::UI::Xaml::Controls::IGrid* grid,
+            ABI::Windows::UI::Xaml::GridLength rowHeight)
+        {
+            ComPtr<ABI::Windows::UI::Xaml::Controls::IGrid> localGrid(grid);
+
+            ComPtr<IVector<RowDefinition*>> rowDefinitions;
+            THROW_IF_FAILED(localGrid->get_RowDefinitions(&rowDefinitions));
+
+            unsigned int rowIndex;
+            THROW_IF_FAILED(rowDefinitions->get_Size(&rowIndex));
+            ComPtr<IGridStatics> gridStatics;
+            THROW_IF_FAILED(GetActivationFactory(HStringReference(RuntimeClass_Windows_UI_Xaml_Controls_Grid).Get(), &gridStatics));
+            Microsoft::WRL::ComPtr<T> localItem(item);
+            ComPtr<IFrameworkElement> localItemAsFrameworkElement;
+            THROW_IF_FAILED(localItem.As(&localItemAsFrameworkElement));
+            gridStatics->SetRow(localItemAsFrameworkElement.Get(), rowIndex);
+
+            ComPtr<IRowDefinition> rowDefinition = XamlHelpers::CreateXamlClass<IRowDefinition>(HStringReference(RuntimeClass_Windows_UI_Xaml_Controls_RowDefinition));
+            THROW_IF_FAILED(rowDefinition->put_Height(rowHeight));
+            THROW_IF_FAILED(rowDefinitions->Append(rowDefinition.Get()));
+
+            ComPtr<ABI::Windows::UI::Xaml::Controls::IPanel> localPanel;
+            THROW_IF_FAILED(localGrid.As(&localPanel));
+            XamlHelpers::AppendXamlElementToPanel(item, localPanel.Get());
+        }
     };
 }}


### PR DESCRIPTION
As decided in #484, we're adding a height property to all card element types.

Adding this to the UWP renderer involved swapping the existing stack panel for a Grid, so that when height is set to "stretch", we can use a star-GridLength on the row that the item is being added in.

But the change is super verbose since adding the property to the UWP projection means adding the property to every single class that inherits from the card element. 

I created an AdaptiveHeight class rather than using a string or enum, since in the future you could definitely imagine that there might be pixel heights supported. So by using a class, the class would be able to support both pixel heights and values like "auto" and "stretch" - equivalent to the pattern used for XAML GridLength.

Output matches the HTML renderer which has already been updated. First screenshot is HTML, second one is UWP

![image](https://user-images.githubusercontent.com/1334689/28285299-1356c5b6-6ae9-11e7-8df4-b572778f14ce.png)

![image](https://user-images.githubusercontent.com/13246069/28484015-fcf8d2f2-6e24-11e7-9a42-ee682ca0f017.png)

Other card scenarios were validated and confirmed still working.

As part of this, we've also renamed the column "size" property to "width", since size became ambiguous with the introduction of height. Android and iOS utilizing the shared model will have to be updated since the shared model methods have changed.

Also note I didn't add support for setting the Height property programmatically, similar to how HostConfig doesn't support setting HostConfig values programmatically. It's the same problem of having the UWP projection update the actual shared model - whoever adds support for that in HostConfig can also add support for that in the Height property.