### PR TITLE
Bug fix

### DIFF
--- a/source/html/renderer/src/card-elements.ts
+++ b/source/html/renderer/src/card-elements.ts
@@ -1669,12 +1669,11 @@ class ActionCollection {
 
         var renderedCard = action.card.render();
 
-        raiseInlineCardExpandedEvent(action, true);
-
         this._actionCard = renderedCard;
         this._expandedAction = action;
 
         this.refreshContainer();
+        raiseInlineCardExpandedEvent(action, true);
     }
 
     private actionClicked(actionButton: ActionButton) {


### PR DESCRIPTION
Move raiseInlineCardExpandedEvent after refreshContainer, otherwise the children elements haven't been appended to container.