### PR TITLE
Render TextInput with textarea element

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Html/Rendering/HtmlRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Html/Rendering/HtmlRenderer.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Reflection;
 using System.Xml;
 using HtmlTags;
@@ -620,16 +621,24 @@ namespace AdaptiveCards.Rendering
         protected static HtmlTag TextInputRender(TypedElement element, RenderContext context)
         {
             TextInput input = (TextInput)element;
-            var container = new Container { Separation = input.Separation };
-            container.Items.Add(new TextBlock { Text = GetFallbackText(input) ?? input.Placeholder });
-            if (input.Value != null)
-                container.Items.Add(new TextBlock
-                {
-                    Text = input.Value,
-                    Color = TextColor.Accent,
-                    Wrap = true
-                });
-            return context.Render(container);
+
+            var uiTextInput = new HtmlTag("textarea")
+                .AddClass("ac-textinput")
+                .AddClass("ac-input")
+                .Style("width", "100%")
+                .Style("box-sizing", "border-box");
+
+            if (!string.IsNullOrEmpty(input.Placeholder))
+            {
+                uiTextInput.Attr("placeholder", WebUtility.HtmlEncode(input.Placeholder));
+            }
+
+            if (!string.IsNullOrEmpty(input.Value))
+            {
+                uiTextInput.Text = input.Value;
+            }
+
+            return uiTextInput;
         }
 
         protected static HtmlTag TimeInputRender(TypedElement element, RenderContext context)

--- a/source/dotnet/Library/AdaptiveCards.Html/Rendering/HtmlRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Html/Rendering/HtmlRenderer.cs
@@ -621,20 +621,39 @@ namespace AdaptiveCards.Rendering
         {
             TextInput input = (TextInput)element;
 
-            var uiTextInput = new HtmlTag("textarea")
+            HtmlTag uiTextInput;
+            if (input.IsMultiline)
+            {
+                uiTextInput = new HtmlTag("textarea");
+
+                if (!string.IsNullOrEmpty(input.Value))
+                {
+                    uiTextInput.Text = input.Value;
+                }
+            }
+            else
+            {
+                uiTextInput = new HtmlTag("input").Attr("type", "text");
+
+                if (!string.IsNullOrEmpty(input.Value))
+                {
+                    uiTextInput.Attr("value", input.Value);
+                }
+            }
+
+            uiTextInput
                 .AddClass("ac-textinput")
                 .AddClass("ac-input")
-                .Style("width", "100%")
-                .Style("box-sizing", "border-box");
+                .Style("width", "100%");
 
             if (!string.IsNullOrEmpty(input.Placeholder))
             {
-                uiTextInput.Attr("placeholder",input.Placeholder);
+                uiTextInput.Attr("placeholder", input.Placeholder);
             }
 
-            if (!string.IsNullOrEmpty(input.Value))
+            if (input.MaxLength > 0)
             {
-                uiTextInput.Text = input.Value;
+                uiTextInput.Attr("maxLength", input.MaxLength.ToString());
             }
 
             return uiTextInput;

--- a/source/dotnet/Library/AdaptiveCards.Html/Rendering/HtmlRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Html/Rendering/HtmlRenderer.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Reflection;
 using System.Xml;
 using HtmlTags;
@@ -630,7 +629,7 @@ namespace AdaptiveCards.Rendering
 
             if (!string.IsNullOrEmpty(input.Placeholder))
             {
-                uiTextInput.Attr("placeholder", WebUtility.HtmlEncode(input.Placeholder));
+                uiTextInput.Attr("placeholder",input.Placeholder);
             }
 
             if (!string.IsNullOrEmpty(input.Value))


### PR DESCRIPTION
Render the TextInput with <textarea> instead of <p>. The class is ac-input and ac-textinput to match the client renderer.