### PR TITLE
Check for SupportInteractivity setting before rendering inputs

### DIFF
--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -135,10 +135,7 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         std::shared_ptr<std::vector<InputItem>> inputElements = std::make_shared<std::vector<InputItem>>();
         BuildPanelChildren(body.Get(), childElementContainer.Get(), inputElements, [](IUIElement*) {});
 
-        boolean supportsInteractivity;
-        THROW_IF_FAILED(m_hostConfig->get_SupportsInteractivity(&supportsInteractivity));
-
-        if (supportsInteractivity)
+        if (this->SupportsInteractivity())
         {
             ComPtr<IVector<IAdaptiveActionElement*>> actions;
             THROW_IF_FAILED(adaptiveCard->get_Actions(&actions));
@@ -466,7 +463,7 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         ComPtr<IBitmapSource> bitmapSource;
         bitmapImage.As(&bitmapSource);
         ComPtr<IAsyncOperationWithProgress<IInputStream*, HttpProgress>> getStreamOperation;
-        httpClient->GetInputStreamAsync(imageUri, &getStreamOperation);
+        THROW_IF_FAILED(httpClient->GetInputStreamAsync(imageUri, &getStreamOperation));
 
         ComPtr<T> strongImageControl(imageControl);
         ComPtr<XamlBuilder> strongThis(this);
@@ -1817,6 +1814,11 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         std::shared_ptr<std::vector<InputItem>> inputElements,
         IUIElement** choiceInputSet)
     {
+        if (!this->SupportsInteractivity())
+        {
+            return;
+        }
+
         ComPtr<IAdaptiveCardElement> cardElement(adaptiveCardElement);
         ComPtr<IAdaptiveChoiceSetInput> adaptiveChoiceSetInput;
         THROW_IF_FAILED(cardElement.As(&adaptiveChoiceSetInput));
@@ -1845,6 +1847,11 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         std::shared_ptr<std::vector<InputItem>> inputElements,
         IUIElement** dateInputControl)
     {
+        if (!this->SupportsInteractivity())
+        {
+            return;
+        }
+
         ComPtr<IAdaptiveCardElement> cardElement(adaptiveCardElement);
         ComPtr<IAdaptiveDateInput> adaptiveDateInput;
         THROW_IF_FAILED(cardElement.As(&adaptiveDateInput));
@@ -1868,6 +1875,11 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         std::shared_ptr<std::vector<InputItem>> inputElements,
         IUIElement** numberInputControl)
     {
+        if (!this->SupportsInteractivity())
+        {
+            return;
+        }
+
         ComPtr<IAdaptiveCardElement> cardElement(adaptiveCardElement);
         ComPtr<IAdaptiveNumberInput> adaptiveNumberInput;
         THROW_IF_FAILED(cardElement.As(&adaptiveNumberInput));
@@ -1909,6 +1921,11 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         std::shared_ptr<std::vector<InputItem>> inputElements,
         IUIElement** textInputControl)
     {
+        if (!this->SupportsInteractivity())
+        {
+            return;
+        }
+
         ComPtr<IAdaptiveCardElement> cardElement(adaptiveCardElement);
         ComPtr<IAdaptiveTextInput> adaptiveTextInput;
         THROW_IF_FAILED(cardElement.As(&adaptiveTextInput));
@@ -1971,6 +1988,11 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         std::shared_ptr<std::vector<InputItem>> inputElements,
         IUIElement** timeInputControl)
     {
+        if (!this->SupportsInteractivity())
+        {
+            return;
+        }
+
         ComPtr<ITimePicker> timePicker = XamlHelpers::CreateXamlClass<ITimePicker>(HStringReference(RuntimeClass_Windows_UI_Xaml_Controls_TimePicker));
 
         AddInputItemToVector(inputElements, adaptiveCardElement, timePicker.Get());
@@ -1986,6 +2008,11 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         std::shared_ptr<std::vector<InputItem>> inputElements,
         IUIElement** toggleInputControl)
     {
+        if (!this->SupportsInteractivity())
+        {
+            return;
+        }
+
         ComPtr<IAdaptiveCardElement> cardElement(adaptiveCardElement);
         ComPtr<IAdaptiveToggleInput> adaptiveToggleInput;
         THROW_IF_FAILED(cardElement.As(&adaptiveToggleInput));
@@ -2012,5 +2039,12 @@ namespace AdaptiveCards { namespace XamlCardRenderer
 
         // TODO: 11508861
         THROW_IF_FAILED(checkBox.CopyTo(toggleInputControl));
+    }
+
+    bool XamlBuilder::SupportsInteractivity()
+    {
+        boolean supportsInteractivity;
+        THROW_IF_FAILED(m_hostConfig->get_SupportsInteractivity(&supportsInteractivity));
+        return Boolify(supportsInteractivity);
     }
 }}

--- a/source/uwp/Renderer/lib/XamlBuilder.h
+++ b/source/uwp/Renderer/lib/XamlBuilder.h
@@ -180,5 +180,6 @@ namespace AdaptiveCards { namespace XamlCardRenderer
             _In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCardElement* adaptiveCardElement,
             std::shared_ptr<std::vector<InputItem>> inputElements,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** toggleInputControl);
+        bool SupportsInteractivity();
     };
 }}

--- a/source/uwp/Renderer/lib/XamlHelpers.h
+++ b/source/uwp/Renderer/lib/XamlHelpers.h
@@ -54,6 +54,11 @@ namespace AdaptiveCards { namespace XamlCardRenderer
             T* xamlElement,
             ABI::Windows::UI::Xaml::Controls::IPanel* panel)
         {
+            if (!xamlElement)
+            {
+                return;
+            }
+
             Microsoft::WRL::ComPtr<T> localXamlElement(xamlElement);
 
             ComPtr<IUIElement> elementToAppend;


### PR DESCRIPTION
Fixes #540

Inputs and actions are silently ignored per current desired behavior and will just not show up in the resulting card.