### PR TITLE
Make body optional

### DIFF
--- a/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
+++ b/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
@@ -88,7 +88,7 @@ std::shared_ptr<AdaptiveCard> AdaptiveCard::Deserialize(const Json::Value& json)
     std::string backgroundImageUrl = ParseUtil::GetString(json, AdaptiveCardSchemaKey::BackgroundImageUrl);
 
     // Parse body
-    auto body = ParseUtil::GetElementCollection<BaseCardElement>(json, AdaptiveCardSchemaKey::Body, AdaptiveCard::CardElementParsers, true);
+    auto body = ParseUtil::GetElementCollection<BaseCardElement>(json, AdaptiveCardSchemaKey::Body, AdaptiveCard::CardElementParsers, false);
 
     // Parse actions if present
     auto actions = ParseUtil::GetActionCollection<BaseActionElement>(json, AdaptiveCardSchemaKey::Actions, AdaptiveCard::ActionParsers);

--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -142,7 +142,9 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         {
             ComPtr<IVector<IAdaptiveActionElement*>> actions;
             THROW_IF_FAILED(adaptiveCard->get_Actions(&actions));
-            BuildActions(actions.Get(), renderer, inputElements, childElementContainer.Get());
+            unsigned int bodyCount;
+            THROW_IF_FAILED(body->get_Size(&bodyCount));
+            BuildActions(actions.Get(), renderer, inputElements, childElementContainer.Get(), bodyCount > 0);
         }
 
         THROW_IF_FAILED(rootElement.CopyTo(xamlTreeRoot));
@@ -625,17 +627,21 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         IVector<IAdaptiveActionElement*>* children,
         XamlCardRenderer* renderer,
         std::shared_ptr<std::vector<InputItem>> inputElements,
-        IPanel* parentPanel)
+        IPanel* parentPanel,
+        bool insertSeparator)
     {
-        // Create a separator between the body and the actions
         ComPtr<IAdaptiveActionsConfig> actionsConfig;
         THROW_IF_FAILED(m_hostConfig->get_Actions(actionsConfig.GetAddressOf()));
 
-        ComPtr<IAdaptiveSeparationConfig> separationConfig;
-        THROW_IF_FAILED(actionsConfig->get_Separation(&separationConfig));
-            
-        auto separator = CreateSeparator(separationConfig.Get());
-        XamlHelpers::AppendXamlElementToPanel(separator.Get(), parentPanel);
+        // Create a separator between the body and the actions
+        if (insertSeparator)
+        {
+            ComPtr<IAdaptiveSeparationConfig> separationConfig;
+            THROW_IF_FAILED(actionsConfig->get_Separation(&separationConfig));
+
+            auto separator = CreateSeparator(separationConfig.Get());
+            XamlHelpers::AppendXamlElementToPanel(separator.Get(), parentPanel);
+        }
 
         ABI::AdaptiveCards::XamlCardRenderer::ActionAlignment actionAlignment;
         THROW_IF_FAILED(actionsConfig->get_ActionAlignment(&actionAlignment));

--- a/source/uwp/Renderer/lib/XamlBuilder.h
+++ b/source/uwp/Renderer/lib/XamlBuilder.h
@@ -109,7 +109,8 @@ namespace AdaptiveCards { namespace XamlCardRenderer
             _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveActionElement*>* children,
             AdaptiveCards::XamlCardRenderer::XamlCardRenderer* renderer,
             std::shared_ptr<std::vector<InputItem>> inputElements,
-            _In_ ABI::Windows::UI::Xaml::Controls::IPanel* parentPanel);
+            _In_ ABI::Windows::UI::Xaml::Controls::IPanel* parentPanel,
+            _In_ bool insertSeparator);
         void GetSeparationConfigForElement(
             _In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCardElement* element,
             _In_ ABI::AdaptiveCards::XamlCardRenderer::SeparationStyle separation,


### PR DESCRIPTION
Also ensures that UWP doesn't add separation padding above the actions if the body is empty. Tested/verified changes in the UWP Visualizer.

Addresses #545 #548 

Tested/verified fixes with UWP Visualizer with both body elements and no body elements, all good!

![image](https://user-images.githubusercontent.com/13246069/29235020-29a19460-7eb0-11e7-8cab-484a1413fb03.png)