### PR TITLE
Fixed an ultra minor typo

### DIFF
--- a/source/website/wwwroot/samples/cards/Stock Update.json
+++ b/source/website/wwwroot/samples/cards/Stock Update.json
@@ -27,7 +27,7 @@
                     "columns": [
                         {
                             "type": "Column",
-                            "size": "strech",
+                            "size": "stretch",
                             "items": [
                                 {
                                     "type": "TextBlock",


### PR DESCRIPTION
strech => stretch

Noticed a `Invalid column size: strech` when reading through the samples. http://imgur.com/a/lsAbP   Hence, this minor fix to the typo.