### PR TITLE
Shared Model: Optional type property on Set children

### DIFF
--- a/source/shared/cpp/ObjectModel/ChoiceSetInput.cpp
+++ b/source/shared/cpp/ObjectModel/ChoiceSetInput.cpp
@@ -87,20 +87,9 @@ std::shared_ptr<ChoiceSetInput> ChoiceSetInput::Deserialize(const Json::Value& j
     choiceSet->SetIsMultiSelect(ParseUtil::GetBool(json, AdaptiveCardSchemaKey::IsMultiSelect, false));
 
     // Parse Choices
-    auto choicesArray = ParseUtil::GetArray(json, AdaptiveCardSchemaKey::Choices, true);
-    std::vector<std::shared_ptr<ChoiceInput>> choices;
-
-    // Deserialize every choice in the array
-    for (const Json::Value& element : choicesArray)
-    {
-        auto choice = ChoiceInput::Deserialize(element);
-        if (choice != nullptr)
-        {
-            choices.push_back(choice);
-        }
-    }
-
+    auto choices = ParseUtil::GetElementCollectionOfSingleType<ChoiceInput>(json, AdaptiveCardSchemaKey::Choices, ChoiceInput::Deserialize, true);
     choiceSet->m_choices = std::move(choices);
+
     return choiceSet;
 }
 

--- a/source/shared/cpp/ObjectModel/Column.cpp
+++ b/source/shared/cpp/ObjectModel/Column.cpp
@@ -98,8 +98,6 @@ Json::Value Column::SerializeToJsonValue()
 
 std::shared_ptr<Column> Column::Deserialize(const Json::Value& value)
 {
-    ParseUtil::ExpectTypeString(value, CardElementType::Column);
-
     auto column = BaseCardElement::Deserialize<Column>(value);
 
     column->SetSize(ParseUtil::GetValueAsString(value, AdaptiveCardSchemaKey::Size));

--- a/source/shared/cpp/ObjectModel/ColumnSet.cpp
+++ b/source/shared/cpp/ObjectModel/ColumnSet.cpp
@@ -5,11 +5,6 @@
 
 using namespace AdaptiveCards;
 
-const std::unordered_map<CardElementType, std::function<std::shared_ptr<Column>(const Json::Value&)>, EnumHash> ColumnSet::ColumnParser =
-{
-    { CardElementType::Column, Column::Deserialize }
-};
-
 ColumnSet::ColumnSet() : BaseCardElement(CardElementType::ColumnSet)
 {
 }
@@ -55,7 +50,7 @@ std::shared_ptr<ColumnSet> ColumnSet::Deserialize(const Json::Value& value)
     auto container = BaseCardElement::Deserialize<ColumnSet>(value);
 
     // Parse Columns
-    auto cardElements = ParseUtil::GetElementCollection<Column>(value, AdaptiveCardSchemaKey::Columns, ColumnParser, true);
+    auto cardElements = ParseUtil::GetElementCollectionOfSingleType<Column>(value, AdaptiveCardSchemaKey::Columns, Column::Deserialize, true);
     container->m_columns = std::move(cardElements);
     return container;
 }

--- a/source/shared/cpp/ObjectModel/FactSet.cpp
+++ b/source/shared/cpp/ObjectModel/FactSet.cpp
@@ -61,20 +61,9 @@ std::shared_ptr<FactSet> FactSet::Deserialize(const Json::Value& value)
     auto factSet = BaseCardElement::Deserialize<FactSet>(value);
 
     // Parse Facts
-    auto factsArray = ParseUtil::GetArray(value, AdaptiveCardSchemaKey::Facts, true);
-    std::vector<std::shared_ptr<Fact>> facts;
-
-    // Deserialize every fact in the array
-    for (const Json::Value& element : factsArray)
-    {
-        auto fact = Fact::Deserialize(element);
-        if (fact != nullptr)
-        {
-            facts.push_back(fact);
-        }
-    }
-
+    auto facts = ParseUtil::GetElementCollectionOfSingleType<Fact>(value, AdaptiveCardSchemaKey::Facts, Fact::Deserialize, true);
     factSet->m_facts = std::move(facts);
+
     return factSet;
 }
 

--- a/source/shared/cpp/ObjectModel/Image.cpp
+++ b/source/shared/cpp/ObjectModel/Image.cpp
@@ -31,6 +31,11 @@ std::shared_ptr<Image> Image::Deserialize(const Json::Value& json)
 {
     ParseUtil::ExpectTypeString(json, CardElementType::Image);
 
+    return Image::DeserializeWithoutCheckingType(json);
+}
+
+std::shared_ptr<Image> Image::DeserializeWithoutCheckingType(const Json::Value& json)
+{
     std::shared_ptr<Image> image = BaseCardElement::Deserialize<Image>(json);
 
     image->SetUrl(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Url, true));

--- a/source/shared/cpp/ObjectModel/Image.h
+++ b/source/shared/cpp/ObjectModel/Image.h
@@ -20,6 +20,7 @@ public:
         HorizontalAlignment hAlignment);
 
     static std::shared_ptr<Image> Deserialize(const Json::Value& root);
+    static std::shared_ptr<Image> DeserializeWithoutCheckingType(const Json::Value& root);
     static std::shared_ptr<Image> DeserializeFromString(const std::string& jsonString);
 
     virtual std::string Serialize();

--- a/source/shared/cpp/ObjectModel/ImageSet.cpp
+++ b/source/shared/cpp/ObjectModel/ImageSet.cpp
@@ -80,19 +80,7 @@ std::shared_ptr<ImageSet> ImageSet::Deserialize(const Json::Value& value)
     imageSet->m_imageSize = ParseUtil::GetEnumValue<ImageSize>(value, AdaptiveCardSchemaKey::ImageSize, ImageSize::Auto, ImageSizeFromString);
 
     // Parse Images
-    auto imagesArray = ParseUtil::GetArray(value, AdaptiveCardSchemaKey::Images, true);
-    std::vector<std::shared_ptr<Image>> images;
-
-    // Deserialize every image in the array
-    for (const Json::Value& element : imagesArray)
-    {
-        auto image = Image::Deserialize(element);
-        if (image != nullptr)
-        {
-            images.push_back(image);
-        }
-    }
-
+    auto images = ParseUtil::GetElementCollectionOfSingleType<Image>(value, AdaptiveCardSchemaKey::Images, Image::DeserializeWithoutCheckingType, true);
     imageSet->m_images = std::move(images);
 
     return imageSet;

--- a/source/shared/cpp/ObjectModel/ParseUtil.h
+++ b/source/shared/cpp/ObjectModel/ParseUtil.h
@@ -64,6 +64,13 @@ public:
         bool isRequired = false);
 
     template <typename T>
+    static std::vector<std::shared_ptr<T>> GetElementCollectionOfSingleType(
+        const Json::Value& json,
+        AdaptiveCardSchemaKey key,
+        const std::function<std::shared_ptr<T>(const Json::Value&)>& deserializer,
+        bool isRequired = false);
+
+    template <typename T>
     static std::vector<std::shared_ptr<T>> GetActionCollection(
         const Json::Value& json,
         AdaptiveCardSchemaKey key,
@@ -155,6 +162,37 @@ std::vector<std::shared_ptr<T>> ParseUtil::GetElementCollection(
         {
             // Use the parser that maps to the type
             elements.push_back(parsers.at(curElementType)(curJsonValue));
+        }
+    }
+
+    return elements;
+}
+
+template <typename T>
+std::vector<std::shared_ptr<T>> ParseUtil::GetElementCollectionOfSingleType(
+    const Json::Value& json,
+    AdaptiveCardSchemaKey key,
+    const std::function<std::shared_ptr<T>(const Json::Value&)>& deserializer,
+    bool isRequired)
+{
+    auto elementArray = GetArray(json, key, isRequired);
+
+    std::vector<std::shared_ptr<T>> elements;
+    if (elementArray.empty())
+    {
+        return elements;
+    }
+
+    elements.reserve(elementArray.size());
+
+    // Deserialize every element in the array
+    for (const Json::Value& curJsonValue : elementArray)
+    {
+        // Parse the element
+        auto el = deserializer(curJsonValue);
+        if (el != nullptr)
+        {
+            elements.push_back(el);
         }
     }
 


### PR DESCRIPTION
Updated the shared model so that columns don't require a type property (since their type is implicit) and images inside ImageSet don't require a type property. Facts and ChoiceInputs already didn't require the type property.

Also refactored fact/choicesetinput code to use the new shared method for parsing an array of single type.

Tested/verified all changes in UWP Visualizer app for ChoiceSet, ColumnSet, FactSet, ImageSet, and normal inline images both with and without types specified, all worked correctly.

![image](https://user-images.githubusercontent.com/13246069/29285882-f10fda8a-80e4-11e7-8019-a37670f0025b.png)

![image](https://user-images.githubusercontent.com/13246069/29285911-0873c31c-80e5-11e7-9a93-c22a8dd08d74.png)
