### PR TITLE
Remove LiteralTag and convert markdown into full HtmlTag objects

### DIFF
--- a/source/dotnet/AdaptiveCards.sln
+++ b/source/dotnet/AdaptiveCards.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26403.7
+VisualStudioVersion = 15.0.26430.16
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{C443BF0A-C616-4E98-8994-C5BAE76AE556}"
 EndProject
@@ -21,7 +21,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AdaptiveCards.Sample.BotCli
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "WPFVisualizer", "WPFVisualizer", "{C7DBAF87-4295-4AA7-AADB-959B048187FD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AdaptiveCards.Html", "Library\AdaptiveCards.Html\AdaptiveCards.Html.csproj", "{13F4F606-87AA-4543-A37E-7118FD72C39B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AdaptiveCards.Html", "Library\AdaptiveCards.Html\AdaptiveCards.Html.csproj", "{13F4F606-87AA-4543-A37E-7118FD72C39B}"
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "AdaptiveCards.Xaml.Shared", "Library\AdaptiveCards.Xaml.Shared\AdaptiveCards.Xaml.Shared.shproj", "{D4E691C8-F685-4E48-83D8-A063868E5E51}"
 EndProject
@@ -34,6 +34,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Render2Image", "Samples\RenderImage\Render2Image.csproj", "{FEA3DF44-B05F-47F2-8F26-6EF45BB9B4F8}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Render2Html", "Samples\Render2Html\Render2Html.csproj", "{C21F0338-D2A7-4CD8-99BB-0C58C00CBA77}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Test", "Test", "{57CE90F5-EDC6-4CA5-9680-4A106621B4AF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AdaptiveCards.Html.Test", "Test\AdaptiveCards.Html.Test\AdaptiveCards.Html.Test.csproj", "{9B454519-D567-47E4-ADEF-2DF0D60F69B6}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -629,6 +633,54 @@ Global
 		{C21F0338-D2A7-4CD8-99BB-0C58C00CBA77}.Release|x64.Build.0 = Release|Any CPU
 		{C21F0338-D2A7-4CD8-99BB-0C58C00CBA77}.Release|x86.ActiveCfg = Release|Any CPU
 		{C21F0338-D2A7-4CD8-99BB-0C58C00CBA77}.Release|x86.Build.0 = Release|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Ad-Hoc|Any CPU.ActiveCfg = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Ad-Hoc|Any CPU.Build.0 = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Ad-Hoc|ARM.ActiveCfg = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Ad-Hoc|ARM.Build.0 = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Ad-Hoc|iPhone.ActiveCfg = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Ad-Hoc|iPhone.Build.0 = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Ad-Hoc|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Ad-Hoc|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Ad-Hoc|x64.ActiveCfg = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Ad-Hoc|x64.Build.0 = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Ad-Hoc|x86.ActiveCfg = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Ad-Hoc|x86.Build.0 = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.AppStore|Any CPU.ActiveCfg = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.AppStore|Any CPU.Build.0 = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.AppStore|ARM.ActiveCfg = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.AppStore|ARM.Build.0 = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.AppStore|iPhone.ActiveCfg = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.AppStore|iPhone.Build.0 = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.AppStore|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.AppStore|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.AppStore|x64.ActiveCfg = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.AppStore|x64.Build.0 = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.AppStore|x86.ActiveCfg = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.AppStore|x86.Build.0 = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Debug|ARM.Build.0 = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Debug|x64.Build.0 = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Debug|x86.Build.0 = Debug|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Release|ARM.ActiveCfg = Release|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Release|ARM.Build.0 = Release|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Release|iPhone.Build.0 = Release|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Release|x64.ActiveCfg = Release|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Release|x64.Build.0 = Release|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Release|x86.ActiveCfg = Release|Any CPU
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -648,5 +700,6 @@ Global
 		{23E6248B-CE11-47DB-BADE-D65E1B24E33B} = {C7727147-4AD9-4005-A8D0-EEEED82347D3}
 		{FEA3DF44-B05F-47F2-8F26-6EF45BB9B4F8} = {C7DBAF87-4295-4AA7-AADB-959B048187FD}
 		{C21F0338-D2A7-4CD8-99BB-0C58C00CBA77} = {C7DBAF87-4295-4AA7-AADB-959B048187FD}
+		{9B454519-D567-47E4-ADEF-2DF0D60F69B6} = {57CE90F5-EDC6-4CA5-9680-4A106621B4AF}
 	EndGlobalSection
 EndGlobal

--- a/source/dotnet/Library/AdaptiveCards.Html/MarkdownToHtmlTagConverter.cs
+++ b/source/dotnet/Library/AdaptiveCards.Html/MarkdownToHtmlTagConverter.cs
@@ -1,0 +1,76 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Xml;
+using System.Xml.Linq;
+using HtmlTags;
+using Microsoft.MarkedNet;
+using System;
+
+namespace AdaptiveCards.Html
+{
+    public static class MarkdownToHtmlTagConverter
+    {
+        public static IEnumerable<HtmlTag> Convert(string markdown)
+        {
+            var marked = new Marked();
+            marked.Options.Mangle = false;
+            marked.Options.Sanitize = true;
+            marked.Options.XHtml = true;
+
+            var rawXhtml = marked.Parse(markdown);
+            var root = XElement.Parse($"<root>{rawXhtml}</root>");
+
+            return root.Elements().Select(RawXhtmlToHtmlTag);
+        }
+
+
+        private static HtmlTag RawXhtmlToHtmlTag(XElement element)
+        {
+            var htmlTag = new HtmlTag(element.Name.LocalName);
+
+            foreach (var node in element.Nodes())
+            {
+                switch (node.NodeType)
+                {
+                    case XmlNodeType.Text:
+                        {
+                            var textTag = new HtmlTag(null);
+                            textTag.Text = ((XText)node).Value;
+                            htmlTag.Children.Add(textTag);
+                        }
+                        break;
+
+                    case XmlNodeType.Element:
+                        htmlTag.Children.Add(RawXhtmlToHtmlTag((XElement)node));
+                        break;
+                }
+            }
+
+            foreach (var attribute in element.Attributes())
+            {
+                switch (attribute.Name.LocalName.ToLowerInvariant())
+                {
+                    case "style":
+                        // Style needs to be parsed out into the Styles attribute of the HtmlTag.
+                        // But we don't ever expect the markdown processor to return it, so we don't need to handle it for now.
+                        throw new InvalidOperationException();
+
+                    case "class":
+                        var classNames = attribute.Value.Split(' ').Where(className => !string.IsNullOrWhiteSpace(className));
+                        foreach (var className in classNames)
+                        {
+                            htmlTag.AddClass(className.Trim());
+                        }
+
+                        break;
+
+                    default:
+                        htmlTag.Attr(attribute.Name.LocalName, attribute.Value);
+                        break;
+                }
+            }
+
+            return htmlTag;
+        }
+    }
+}

--- a/source/dotnet/Test/AdaptiveCards.Html.Test/AdaptiveCards.Html.Test.csproj
+++ b/source/dotnet/Test/AdaptiveCards.Html.Test/AdaptiveCards.Html.Test.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.1.11" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.1.11" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Library\AdaptiveCards.Html\AdaptiveCards.Html.csproj" />
+    <ProjectReference Include="..\..\Library\AdaptiveCards\AdaptiveCards.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
+</Project>

--- a/source/dotnet/Test/AdaptiveCards.Html.Test/HtmlRendererTests.cs
+++ b/source/dotnet/Test/AdaptiveCards.Html.Test/HtmlRendererTests.cs
@@ -1,0 +1,46 @@
+﻿using AdaptiveCards.Rendering;
+using AdaptiveCards.Rendering.Config;
+using HtmlTags;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+
+namespace AdaptiveCards.Html.Test
+{
+    [TestClass]
+    public class HtmlRendererTests
+    {
+        [TestMethod]
+        public void TextBlockRender_ParagraphElementStylesAdded()
+        {
+            var renderContext = new RenderContext(
+                new HostConfig(),
+                new Dictionary<Type, Func<TypedElement, RenderContext, HtmlTag>>());
+
+            var textBlock = new TextBlock
+            {
+                Text = "first line\n\nsecond line",
+            };
+
+            var generatedHtml = TestHtmlRenderer.CallTextBlockRender(textBlock, renderContext).ToString();
+
+            // Generated HTML should have two <p> tags, with appropriate styles set.
+            Assert.AreEqual(
+                "<div class='ac-textblock' style='text-align: left;box-sizing: border-box;color: rgba(0, 0, 0, 1.00);line-height: 14.40px;font-size: 12px;font-weight: 400;font-family: Calibri;white-space: nowrap;'><p style='margin-top: 0px;margin-bottom: 0px;width: 100%;text-overflow: ellipsis;overflow: hidden;'>first line</p><p style='margin-top: 0px;margin-bottom: 0px;width: 100%;text-overflow: ellipsis;overflow: hidden;'>second line</p></div>",
+                generatedHtml);
+        }
+
+        private class TestHtmlRenderer : HtmlRenderer
+        {
+            public TestHtmlRenderer(HostConfig config)
+                : base(config)
+            {
+            }
+
+            public static HtmlTag CallTextBlockRender(TypedElement element, RenderContext context)
+            {
+                return TextBlockRender(element, context);
+            }
+        }
+    }
+}

--- a/source/dotnet/Test/AdaptiveCards.Html.Test/MarkdownToHtmlTagConverterTests.cs
+++ b/source/dotnet/Test/AdaptiveCards.Html.Test/MarkdownToHtmlTagConverterTests.cs
@@ -1,0 +1,239 @@
+using System.Collections.Generic;
+using System.Linq;
+using HtmlTags;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AdaptiveCards.Html.Test
+{
+    [TestClass]
+    public class MarkdownToHtmlTagConverterTests
+    {
+        [TestMethod]
+        public void BasicString()
+        {
+            List<HtmlTag> tags = MarkdownToHtmlTagConverter.Convert("hello world <>!@#$%^&*()/\\").ToList();
+
+            Assert.AreEqual(1, tags.Count);
+
+            Assert.AreEqual("p", tags[0].Element);
+            Assert.AreEqual(null, tags[0].Text);
+            Assert.AreEqual(1, tags[0].Children.Count);
+            Assert.AreEqual(0, tags[0].Classes.Count);
+            Assert.AreEqual(0, tags[0].Attributes.Count);
+            Assert.AreEqual(0, tags[0].Styles.Count);
+
+            Assert.AreEqual(null, tags[0].Children[0].Element);
+            Assert.AreEqual("hello world <>!@#$%^&*()/\\", tags[0].Children[0].Text);
+            Assert.AreEqual(0, tags[0].Children[0].Children.Count);
+            Assert.AreEqual(0, tags[0].Children[0].Classes.Count);
+            Assert.AreEqual(0, tags[0].Children[0].Attributes.Count);
+            Assert.AreEqual(0, tags[0].Children[0].Styles.Count);
+
+            var fullHtml = string.Join(string.Empty, tags);
+            Assert.AreEqual("<p>hello world &lt;&gt;!@#$%^&amp;*()/\\</p>", fullHtml);
+        }
+
+        [TestMethod]
+        public void ParagraphBreak()
+        {
+            List<HtmlTag> tags = MarkdownToHtmlTagConverter.Convert("hello\n\nworld").ToList();
+
+            Assert.AreEqual(2, tags.Count);
+
+            Assert.AreEqual("p", tags[0].Element);
+            Assert.AreEqual(null, tags[0].Text);
+            Assert.AreEqual(1, tags[0].Children.Count);
+            Assert.AreEqual(0, tags[0].Classes.Count);
+            Assert.AreEqual(0, tags[0].Attributes.Count);
+            Assert.AreEqual(0, tags[0].Styles.Count);
+
+            Assert.AreEqual(null, tags[0].Children[0].Element);
+            Assert.AreEqual("hello", tags[0].Children[0].Text);
+            Assert.AreEqual(0, tags[0].Children[0].Children.Count);
+            Assert.AreEqual(0, tags[0].Children[0].Classes.Count);
+            Assert.AreEqual(0, tags[0].Children[0].Attributes.Count);
+            Assert.AreEqual(0, tags[0].Children[0].Styles.Count);
+
+            Assert.AreEqual("p", tags[1].Element);
+            Assert.AreEqual(null, tags[1].Text);
+            Assert.AreEqual(1, tags[1].Children.Count);
+            Assert.AreEqual(0, tags[1].Classes.Count);
+            Assert.AreEqual(0, tags[1].Attributes.Count);
+            Assert.AreEqual(0, tags[1].Styles.Count);
+
+            Assert.AreEqual(null, tags[1].Children[0].Element);
+            Assert.AreEqual("world", tags[1].Children[0].Text);
+            Assert.AreEqual(0, tags[1].Children[0].Children.Count);
+            Assert.AreEqual(0, tags[1].Children[0].Classes.Count);
+            Assert.AreEqual(0, tags[1].Children[0].Attributes.Count);
+            Assert.AreEqual(0, tags[1].Children[0].Styles.Count);
+
+            var fullHtml = string.Join(string.Empty, tags);
+            Assert.AreEqual("<p>hello</p><p>world</p>", fullHtml);
+        }
+
+        [TestMethod]
+        public void BoldAndItalics()
+        {
+            List<HtmlTag> tags = MarkdownToHtmlTagConverter.Convert("normal1 *italic* normal2 **bold** normal3").ToList();
+
+            Assert.AreEqual(1, tags.Count);
+
+            Assert.AreEqual("p", tags[0].Element);
+            Assert.AreEqual(null, tags[0].Text);
+            Assert.AreEqual(5, tags[0].Children.Count);
+            Assert.AreEqual(0, tags[0].Classes.Count);
+            Assert.AreEqual(0, tags[0].Attributes.Count);
+            Assert.AreEqual(0, tags[0].Styles.Count);
+
+            Assert.AreEqual(null, tags[0].Children[0].Element);
+            Assert.AreEqual("normal1 ", tags[0].Children[0].Text);
+            Assert.AreEqual(0, tags[0].Children[0].Children.Count);
+            Assert.AreEqual(0, tags[0].Children[0].Classes.Count);
+            Assert.AreEqual(0, tags[0].Children[0].Attributes.Count);
+            Assert.AreEqual(0, tags[0].Children[0].Styles.Count);
+
+            Assert.AreEqual("em", tags[0].Children[1].Element);
+            Assert.AreEqual(null, tags[0].Children[1].Text);
+            Assert.AreEqual(1, tags[0].Children[1].Children.Count);
+            Assert.AreEqual(0, tags[0].Children[1].Classes.Count);
+            Assert.AreEqual(0, tags[0].Children[1].Attributes.Count);
+            Assert.AreEqual(0, tags[0].Children[1].Styles.Count);
+
+            Assert.AreEqual(null, tags[0].Children[1].Children[0].Element);
+            Assert.AreEqual("italic", tags[0].Children[1].Children[0].Text);
+            Assert.AreEqual(0, tags[0].Children[1].Children[0].Children.Count);
+            Assert.AreEqual(0, tags[0].Children[1].Children[0].Classes.Count);
+            Assert.AreEqual(0, tags[0].Children[1].Children[0].Attributes.Count);
+            Assert.AreEqual(0, tags[0].Children[1].Children[0].Styles.Count);
+
+            Assert.AreEqual(null, tags[0].Children[2].Element);
+            Assert.AreEqual(" normal2 ", tags[0].Children[2].Text);
+            Assert.AreEqual(0, tags[0].Children[2].Children.Count);
+            Assert.AreEqual(0, tags[0].Children[2].Classes.Count);
+            Assert.AreEqual(0, tags[0].Children[2].Attributes.Count);
+            Assert.AreEqual(0, tags[0].Children[2].Styles.Count);
+
+            Assert.AreEqual("strong", tags[0].Children[3].Element);
+            Assert.AreEqual(null, tags[0].Children[3].Text);
+            Assert.AreEqual(1, tags[0].Children[3].Children.Count);
+            Assert.AreEqual(0, tags[0].Children[3].Classes.Count);
+            Assert.AreEqual(0, tags[0].Children[3].Attributes.Count);
+            Assert.AreEqual(0, tags[0].Children[3].Styles.Count);
+
+            Assert.AreEqual(null, tags[0].Children[3].Children[0].Element);
+            Assert.AreEqual("bold", tags[0].Children[3].Children[0].Text);
+            Assert.AreEqual(0, tags[0].Children[3].Children[0].Children.Count);
+            Assert.AreEqual(0, tags[0].Children[3].Children[0].Classes.Count);
+            Assert.AreEqual(0, tags[0].Children[3].Children[0].Attributes.Count);
+            Assert.AreEqual(0, tags[0].Children[3].Children[0].Styles.Count);
+
+            Assert.AreEqual(null, tags[0].Children[4].Element);
+            Assert.AreEqual(" normal3", tags[0].Children[4].Text);
+            Assert.AreEqual(0, tags[0].Children[4].Children.Count);
+            Assert.AreEqual(0, tags[0].Children[4].Classes.Count);
+            Assert.AreEqual(0, tags[0].Children[4].Attributes.Count);
+            Assert.AreEqual(0, tags[0].Children[4].Styles.Count);
+
+            var fullHtml = string.Join(string.Empty, tags);
+            Assert.AreEqual("<p>normal1 <em>italic</em> normal2 <strong>bold</strong> normal3</p>", fullHtml);
+        }
+
+        [TestMethod]
+        public void Link()
+        {
+            List<HtmlTag> tags = MarkdownToHtmlTagConverter.Convert("[Bing](https://www.bing.com/)").ToList();
+
+            Assert.AreEqual(1, tags.Count);
+
+            Assert.AreEqual("p", tags[0].Element);
+            Assert.AreEqual(null, tags[0].Text);
+            Assert.AreEqual(1, tags[0].Children.Count);
+            Assert.AreEqual(0, tags[0].Classes.Count);
+            Assert.AreEqual(0, tags[0].Attributes.Count);
+            Assert.AreEqual(0, tags[0].Styles.Count);
+
+            Assert.AreEqual("a", tags[0].Children[0].Element);
+            Assert.AreEqual(null, tags[0].Children[0].Text);
+            Assert.AreEqual(1, tags[0].Children[0].Children.Count);
+            Assert.AreEqual(0, tags[0].Children[0].Classes.Count);
+            Assert.AreEqual(1, tags[0].Children[0].Attributes.Count);
+            Assert.AreEqual(true, tags[0].Children[0].Attributes.ContainsKey("href"));
+            Assert.AreEqual("https://www.bing.com/", tags[0].Children[0].Attributes["href"]);
+            Assert.AreEqual(0, tags[0].Children[0].Styles.Count);
+
+            Assert.AreEqual(null, tags[0].Children[0].Children[0].Element);
+            Assert.AreEqual("Bing", tags[0].Children[0].Children[0].Text);
+            Assert.AreEqual(0, tags[0].Children[0].Children[0].Children.Count);
+            Assert.AreEqual(0, tags[0].Children[0].Children[0].Classes.Count);
+            Assert.AreEqual(0, tags[0].Children[0].Children[0].Attributes.Count);
+            Assert.AreEqual(0, tags[0].Children[0].Children[0].Styles.Count);
+
+            var fullHtml = string.Join(string.Empty, tags);
+            Assert.AreEqual("<p><a href='https://www.bing.com/'>Bing</a></p>", fullHtml);
+        }
+
+        [TestMethod]
+        public void HorizontalRule()
+        {
+            List<HtmlTag> tags = MarkdownToHtmlTagConverter.Convert("text\n*********\ntext").ToList();
+
+            Assert.AreEqual(3, tags.Count);
+
+            Assert.AreEqual("p", tags[0].Element);
+            Assert.AreEqual(null, tags[0].Text);
+            Assert.AreEqual(1, tags[0].Children.Count);
+            Assert.AreEqual(0, tags[0].Classes.Count);
+            Assert.AreEqual(0, tags[0].Attributes.Count);
+            Assert.AreEqual(0, tags[0].Styles.Count);
+
+            Assert.AreEqual(null, tags[0].Children[0].Element);
+            Assert.AreEqual("text", tags[0].Children[0].Text);
+            Assert.AreEqual(0, tags[0].Children[0].Children.Count);
+            Assert.AreEqual(0, tags[0].Children[0].Classes.Count);
+            Assert.AreEqual(0, tags[0].Children[0].Attributes.Count);
+            Assert.AreEqual(0, tags[0].Children[0].Styles.Count);
+
+            Assert.AreEqual("hr", tags[1].Element);
+            Assert.AreEqual(null, tags[1].Text);
+            Assert.AreEqual(0, tags[1].Children.Count);
+            Assert.AreEqual(0, tags[1].Classes.Count);
+            Assert.AreEqual(0, tags[1].Attributes.Count);
+            Assert.AreEqual(0, tags[1].Styles.Count);
+
+            Assert.AreEqual("p", tags[2].Element);
+            Assert.AreEqual(null, tags[2].Text);
+            Assert.AreEqual(1, tags[2].Children.Count);
+            Assert.AreEqual(0, tags[2].Classes.Count);
+            Assert.AreEqual(0, tags[2].Attributes.Count);
+            Assert.AreEqual(0, tags[2].Styles.Count);
+
+            Assert.AreEqual(null, tags[2].Children[0].Element);
+            Assert.AreEqual("text", tags[2].Children[0].Text);
+            Assert.AreEqual(0, tags[2].Children[0].Children.Count);
+            Assert.AreEqual(0, tags[2].Children[0].Classes.Count);
+            Assert.AreEqual(0, tags[2].Children[0].Attributes.Count);
+            Assert.AreEqual(0, tags[2].Children[0].Styles.Count);
+
+            var fullHtml = string.Join(string.Empty, tags);
+            Assert.AreEqual("<p>text</p><hr/><p>text</p>", fullHtml);
+        }
+
+        [TestMethod]
+        public void ClassAttributeSetCorrectly()
+        {
+            // Using triple back ticks because it's the only place I can find in Marked.Net where the output HTML includes a class name.
+            List<HtmlTag> tags = MarkdownToHtmlTagConverter.Convert("```CSharp\nusing System;\n```").ToList();
+
+            var codeTag = tags[0].Children[0];
+
+            Assert.AreEqual("code", codeTag.Element);
+            Assert.AreEqual(0, codeTag.Attributes.Count);
+            Assert.AreEqual(1, codeTag.Classes.Count);
+            Assert.AreEqual("lang-CSharp", codeTag.Classes[0]);
+
+            var fullHtml = string.Join(string.Empty, tags);
+            Assert.AreEqual("<pre><code class='lang-CSharp'>using System;\n</code></pre>", fullHtml);
+        }
+    }
+}


### PR DESCRIPTION
The markdown processor has the ability to return XHTML, so I'm leveraging that to parse the returned markup and convert it into full-fidelity HtmlTag objects. Doing so lets me remove the LiteralTag class and the IHtmlTag interface, and therefore have all returned objects be of type HtmlTag. With this change, it becomes possible to post-process the HtmlTag objects outside of the AdaptiveCards renderer project and actually be able to touch everything in the object tree.

Also added unit tests for the markdown rendering to ensure that the conversion operates as expected, and that the HtmlTag.ToString() is working correctly.