### PR TITLE
Stop UWP renderer from crashing due to Image loading/XamlBuilder exceptions.

### DIFF
--- a/source/uwp/Renderer/lib/AsyncOperations.h
+++ b/source/uwp/Renderer/lib/AsyncOperations.h
@@ -53,6 +53,12 @@ public:
         return OnXamlImagesLoaded();
     }
 
+    // IXamlBuilderListener
+    IFACEMETHODIMP ImagesLoadingHadError()
+    {
+        return OnXamlImagesHadError();
+    }
+
 protected:
     Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IUIElement> m_rootXamlElement;
     Microsoft::WRL::ComPtr<ABI::Windows::UI::Core::ICoreDispatcher> m_dispatcher;
@@ -91,6 +97,7 @@ protected:
 
     virtual HRESULT XamlRenderCompleted(ABI::Windows::Foundation::IAsyncAction* action, ABI::Windows::Foundation::AsyncStatus status) = 0;
     virtual HRESULT OnXamlImagesLoaded() = 0;
+    virtual HRESULT OnXamlImagesHadError() = 0;
 
 private:
     std::function<ABI::Windows::UI::Xaml::IUIElement*(ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCard*)> m_dispatchFunction;
@@ -123,6 +130,12 @@ protected:
 
     HRESULT OnXamlImagesLoaded()
     {
+        return AsyncBase::FireCompletion();
+    }
+
+    HRESULT OnXamlImagesHadError()
+    {
+        AsyncBase::TryTransitionToError(E_FAIL);
         return AsyncBase::FireCompletion();
     }
 

--- a/source/uwp/Renderer/lib/IImageLoadTrackerListener.h
+++ b/source/uwp/Renderer/lib/IImageLoadTrackerListener.h
@@ -8,6 +8,7 @@ IImageLoadTrackerListener : public IInspectable
 {
 public:
     IFACEMETHOD(AllImagesLoaded)() = 0;
+    IFACEMETHOD(ImagesLoadingHadError)() = 0;
 };
 
 }}

--- a/source/uwp/Renderer/lib/IXamlBuilderListener.h
+++ b/source/uwp/Renderer/lib/IXamlBuilderListener.h
@@ -9,6 +9,7 @@ IXamlBuilderListener : public IInspectable
 public:
     IFACEMETHOD(AllImagesLoaded)() = 0;
     IFACEMETHOD(ImagesLoadingHadError)() = 0;
+    IFACEMETHOD(XamlBuilderHadError)() = 0;
 };
 
 }}

--- a/source/uwp/Renderer/lib/IXamlBuilderListener.h
+++ b/source/uwp/Renderer/lib/IXamlBuilderListener.h
@@ -8,6 +8,7 @@ IXamlBuilderListener : public IInspectable
 {
 public:
     IFACEMETHOD(AllImagesLoaded)() = 0;
+    IFACEMETHOD(ImagesLoadingHadError)() = 0;
 };
 
 }}

--- a/source/uwp/Renderer/lib/ImageLoadTracker.h
+++ b/source/uwp/Renderer/lib/ImageLoadTracker.h
@@ -16,6 +16,7 @@ namespace AdaptiveCards { namespace XamlCardRenderer
     public:
         ~ImageLoadTracker();
         void TrackBitmapImage(_In_ ABI::Windows::UI::Xaml::Media::Imaging::IBitmapImage* bitmapImage);
+        void MarkFailedLoadBitmapImage(_In_ ABI::Windows::UI::Xaml::Media::Imaging::IBitmapImage* bitmapImage);
 
         void AbandonOutstandingImages();
         HRESULT AddListener(_In_ IImageLoadTrackerListener* listener);
@@ -26,6 +27,7 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         Microsoft::WRL::Wrappers::SRWLock m_lock;
         int m_trackedImageCount = 0;
         int m_totalImageCount = 0;
+        bool m_hasFailure = false;
         std::unordered_map<IInspectable*, TrackedImageDetails> m_eventRegistrations;
         std::set<Microsoft::WRL::ComPtr<IImageLoadTrackerListener>> m_listeners;
 
@@ -34,5 +36,6 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         void ImageLoadResultReceived(_In_ IInspectable* sender);
         void UnsubscribeFromEvents(_In_ IInspectable* bitmapImage, _In_ TrackedImageDetails& trackedImageDetails);
         void FireAllImagesLoaded();
+        void FireImagesLoadingHadError();
     };
 }}

--- a/source/uwp/Renderer/lib/XamlBuilder.h
+++ b/source/uwp/Renderer/lib/XamlBuilder.h
@@ -21,6 +21,7 @@ namespace AdaptiveCards { namespace XamlCardRenderer
 
         // IImageLoadTrackerListener
         STDMETHODIMP AllImagesLoaded();
+        STDMETHODIMP ImagesLoadingHadError();
 
         void BuildXamlTreeFromAdaptiveCard(
             _In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCard* adaptiveCard, 
@@ -95,6 +96,7 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         template<typename T>
         void PopulateImageFromUrlAsync(_In_ ABI::Windows::Foundation::IUriRuntimeClass* imageUrl, T* imageControl);
         void FireAllImagesLoaded();
+        void FireImagesLoadingHadError();
         void BuildPanelChildren(
             _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCardElement*>* children,
             _In_ ABI::Windows::UI::Xaml::Controls::IPanel* parentPanel,


### PR DESCRIPTION
Exceptions thrown while building the Xaml tree were not being caught and reported to the async operation. This resulted in the Async operation never completing.

This change adds two error results to the async operation:
Image Loading related Errors
All other XamlBuilder errors.

This will be overhauled once we switch the renderer to return a RenderResult instead of the Xaml elements directly.