### PR TITLE
Fix UWP date/time not stretching full width

### DIFF
--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -693,16 +693,16 @@ namespace AdaptiveCards { namespace XamlCardRenderer
             switch (actionAlignment)
             {
             case ABI::AdaptiveCards::XamlCardRenderer::ActionAlignment::Center:
-                actionsFrameworkElement->put_HorizontalAlignment(HorizontalAlignment_Center);
+                THROW_IF_FAILED(actionsFrameworkElement->put_HorizontalAlignment(HorizontalAlignment_Center));
                 break;
             case ABI::AdaptiveCards::XamlCardRenderer::ActionAlignment::Left:
-                actionsFrameworkElement->put_HorizontalAlignment(HorizontalAlignment_Left);
+                THROW_IF_FAILED(actionsFrameworkElement->put_HorizontalAlignment(HorizontalAlignment_Left));
                 break;
             case ABI::AdaptiveCards::XamlCardRenderer::ActionAlignment::Right:
-                actionsFrameworkElement->put_HorizontalAlignment(HorizontalAlignment_Right);
+                THROW_IF_FAILED(actionsFrameworkElement->put_HorizontalAlignment(HorizontalAlignment_Right));
                 break;
             case ABI::AdaptiveCards::XamlCardRenderer::ActionAlignment::Stretch:
-                actionsFrameworkElement->put_HorizontalAlignment(HorizontalAlignment_Stretch);
+                THROW_IF_FAILED(actionsFrameworkElement->put_HorizontalAlignment(HorizontalAlignment_Stretch));
                 break;
             }
 
@@ -1353,13 +1353,13 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         switch (adaptiveHorizontalAlignment)
         {
             case ABI::AdaptiveCards::XamlCardRenderer::HAlignment::Left:
-                THROW_IF_FAILED(frameworkElement->put_HorizontalAlignment(ABI::Windows::UI::Xaml::HorizontalAlignment::HorizontalAlignment_Left));
+                THROW_IF_FAILED(frameworkElement->put_HorizontalAlignment(HorizontalAlignment_Left));
                 break;
             case ABI::AdaptiveCards::XamlCardRenderer::HAlignment::Right:
-                THROW_IF_FAILED(frameworkElement->put_HorizontalAlignment(ABI::Windows::UI::Xaml::HorizontalAlignment::HorizontalAlignment_Right));
+                THROW_IF_FAILED(frameworkElement->put_HorizontalAlignment(HorizontalAlignment_Right));
                 break;
             case ABI::AdaptiveCards::XamlCardRenderer::HAlignment::Center:
-                THROW_IF_FAILED(frameworkElement->put_HorizontalAlignment(ABI::Windows::UI::Xaml::HorizontalAlignment::HorizontalAlignment_Center));
+                THROW_IF_FAILED(frameworkElement->put_HorizontalAlignment(HorizontalAlignment_Center));
                 break;
         }
 
@@ -1886,7 +1886,7 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         // Make the picker stretch full width
         ComPtr<IFrameworkElement> datePickerAsFrameworkElement;
         THROW_IF_FAILED(datePicker.As(&datePickerAsFrameworkElement));
-        datePickerAsFrameworkElement->put_HorizontalAlignment(ABI::Windows::UI::Xaml::HorizontalAlignment::HorizontalAlignment_Stretch);
+        THROW_IF_FAILED(datePickerAsFrameworkElement->put_HorizontalAlignment(HorizontalAlignment_Stretch));
 
         AddInputItemToVector(inputElements, adaptiveCardElement, datePicker.Get());
             
@@ -2024,7 +2024,7 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         // Make the picker stretch full width
         ComPtr<IFrameworkElement> timePickerAsFrameworkElement;
         THROW_IF_FAILED(timePicker.As(&timePickerAsFrameworkElement));
-        timePickerAsFrameworkElement->put_HorizontalAlignment(ABI::Windows::UI::Xaml::HorizontalAlignment::HorizontalAlignment_Stretch);
+        THROW_IF_FAILED(timePickerAsFrameworkElement->put_HorizontalAlignment(HorizontalAlignment_Stretch));
 
         AddInputItemToVector(inputElements, adaptiveCardElement, timePicker.Get());
 

--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -1883,6 +1883,11 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         THROW_IF_FAILED(adaptiveDateInput->get_Placeholder(placeHolderText.GetAddressOf()));
         THROW_IF_FAILED(datePicker->put_PlaceholderText(placeHolderText.Get()));
 
+        // Make the picker stretch full width
+        ComPtr<IFrameworkElement> datePickerAsFrameworkElement;
+        THROW_IF_FAILED(datePicker.As(&datePickerAsFrameworkElement));
+        datePickerAsFrameworkElement->put_HorizontalAlignment(ABI::Windows::UI::Xaml::HorizontalAlignment::HorizontalAlignment_Stretch);
+
         AddInputItemToVector(inputElements, adaptiveCardElement, datePicker.Get());
             
         // TODO: Handle parsing dates for min/max and value
@@ -2015,6 +2020,11 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         }
 
         ComPtr<ITimePicker> timePicker = XamlHelpers::CreateXamlClass<ITimePicker>(HStringReference(RuntimeClass_Windows_UI_Xaml_Controls_TimePicker));
+
+        // Make the picker stretch full width
+        ComPtr<IFrameworkElement> timePickerAsFrameworkElement;
+        THROW_IF_FAILED(timePicker.As(&timePickerAsFrameworkElement));
+        timePickerAsFrameworkElement->put_HorizontalAlignment(ABI::Windows::UI::Xaml::HorizontalAlignment::HorizontalAlignment_Stretch);
 
         AddInputItemToVector(inputElements, adaptiveCardElement, timePicker.Get());
 


### PR DESCRIPTION
Fixes #616. Simply had to assign horizontal alignment stretch.

**BEFORE**
![image](https://user-images.githubusercontent.com/13246069/30288714-96fae2be-96de-11e7-8f48-a82d531756c9.png)

**AFTER**
![image](https://user-images.githubusercontent.com/13246069/30289175-1f3a6e0a-96e0-11e7-9347-990d060538de.png)


Note that at very wide sizes, the time picker will reach a max width and stop growing. Not sure there's an easy way to fix that (I believe that's a limitation in the time picker itself). Plus it seems like we have a TODO to support displaying placeholder text on the time picker, which would require creating a brand new control, so that new control would support super wide widths... no need to invest time in making the time picker we have today support ultra-wide sizes.

![image](https://user-images.githubusercontent.com/13246069/30289246-62c01ee0-96e0-11e7-8110-4b1d9236b4dc.png)
