### PR TITLE
Add SetFixedDimensions to the Xaml Card Renderer

### DIFF
--- a/source/uwp/Renderer/idl/AdaptiveCards.XamlCardRenderer.idl
+++ b/source/uwp/Renderer/idl/AdaptiveCards.XamlCardRenderer.idl
@@ -769,6 +769,8 @@ namespace AdaptiveCards
             HRESULT SetRenderOptions([in] RenderOptions options);
             HRESULT SetOverrideStyles([in] Windows.UI.Xaml.ResourceDictionary* overrideDictionary);
             HRESULT SetHostConfig([in] AdaptiveHostConfig* hostConfig);
+            HRESULT SetFixedDimensions([in] UINT32 desiredWidth, [in] UINT32 desiredHeight);
+            HRESULT ResetFixedDimensions();
 
             HRESULT RenderCardAsXaml([in] AdaptiveCard* adaptiveCard, [out, retval] Windows.UI.Xaml.UIElement** result);
             HRESULT RenderCardAsXamlAsync([in] AdaptiveCard* adaptiveCard, [out, retval] Windows.Foundation.IAsyncOperation<Windows.UI.Xaml.UIElement*>** result);

--- a/source/uwp/Renderer/lib/AsyncOperations.h
+++ b/source/uwp/Renderer/lib/AsyncOperations.h
@@ -33,7 +33,15 @@ public:
         THROW_IF_FAILED(coreWindow->get_Dispatcher(&m_dispatcher));
 
         m_builder = Microsoft::WRL::Make<AdaptiveCards::XamlCardRenderer::XamlBuilder>();
-        m_builder->SetHostConfig(m_renderer->GetHostConfig());
+        THROW_IF_FAILED(m_builder->SetHostConfig(m_renderer->GetHostConfig()));
+        THROW_IF_FAILED(m_builder->SetOverrideDictionary(m_renderer->GetOverrideDictionary()));
+        UINT32 width = 0;
+        UINT32 height = 0;
+        bool explicitDimensions = m_renderer->GetFixedDimensions(&width, &height);
+        if (explicitDimensions)
+        {
+            THROW_IF_FAILED(m_builder->SetFixedDimensions(width, height));
+        }
     }
 
     // IAsyncOperation

--- a/source/uwp/Renderer/lib/XamlCardRendererComponent.cpp
+++ b/source/uwp/Renderer/lib/XamlCardRendererComponent.cpp
@@ -56,6 +56,23 @@ namespace AdaptiveCards { namespace XamlCardRenderer
     }
 
     _Use_decl_annotations_
+    HRESULT  XamlCardRenderer::SetFixedDimensions(_In_ UINT32 desiredWidth, _In_ UINT32 desiredHeight)
+    {
+        m_explicitDimensions = true;
+        m_desiredWidth = desiredWidth;
+        m_desiredHeight = desiredHeight;
+
+        return S_OK;
+    }
+
+    _Use_decl_annotations_
+    HRESULT  XamlCardRenderer::ResetFixedDimensions()
+    {
+        m_explicitDimensions = false;
+        return S_OK;
+    }
+
+    _Use_decl_annotations_
     HRESULT XamlCardRenderer::add_Action(
         ABI::Windows::Foundation::ITypedEventHandler<ABI::AdaptiveCards::XamlCardRenderer::XamlCardRenderer*, ABI::AdaptiveCards::XamlCardRenderer::AdaptiveActionEventArgs*>* handler,
         EventRegistrationToken* token)
@@ -83,12 +100,17 @@ namespace AdaptiveCards { namespace XamlCardRenderer
             
             if (m_overrideDictionary != nullptr)
             {
-                builder.SetOverrideDictionary(m_overrideDictionary.Get());
+                THROW_IF_FAILED(builder.SetOverrideDictionary(m_overrideDictionary.Get()));
             }
 
             if (m_hostConfig != nullptr)
             {
-                builder.SetHostConfig(m_hostConfig.Get());
+                THROW_IF_FAILED(builder.SetHostConfig(m_hostConfig.Get()));
+            }
+
+            if (m_explicitDimensions)
+            {
+                THROW_IF_FAILED(builder.SetFixedDimensions(m_desiredWidth, m_desiredHeight));
             }
 
             // This path is used for synchronous Xaml card rendering, so we don't want
@@ -151,6 +173,25 @@ namespace AdaptiveCards { namespace XamlCardRenderer
     IAdaptiveHostConfig* XamlCardRenderer::GetHostConfig()
     {
         return m_hostConfig.Get();
+    }
+
+    ABI::Windows::UI::Xaml::IResourceDictionary* XamlCardRenderer::GetOverrideDictionary()
+    {
+        return m_overrideDictionary.Get();
+    }
+
+    bool XamlCardRenderer::GetFixedDimensions(_Out_ UINT32* width, _Out_ UINT32* height)
+    {
+        *width = 0;
+        *height = 0;
+
+        if (m_explicitDimensions)
+        {
+            *width = m_desiredWidth;
+            *height = m_desiredHeight;
+        }
+
+        return m_explicitDimensions;
     }
 
 }}

--- a/source/uwp/Renderer/lib/XamlCardRendererComponent.h
+++ b/source/uwp/Renderer/lib/XamlCardRendererComponent.h
@@ -21,6 +21,8 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         IFACEMETHODIMP SetRenderOptions(_In_ ABI::AdaptiveCards::XamlCardRenderer::RenderOptions options);
         IFACEMETHODIMP SetOverrideStyles(_In_ ABI::Windows::UI::Xaml::IResourceDictionary* overrideDictionary);
         IFACEMETHODIMP SetHostConfig(_In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveHostConfig* hostConfig);
+        IFACEMETHODIMP SetFixedDimensions(_In_ UINT32 desiredWidth, _In_ UINT32 desiredHeight);
+        IFACEMETHODIMP ResetFixedDimensions();
 
         IFACEMETHODIMP add_Action(
             _In_ ABI::Windows::Foundation::ITypedEventHandler<ABI::AdaptiveCards::XamlCardRenderer::XamlCardRenderer*, ABI::AdaptiveCards::XamlCardRenderer::AdaptiveActionEventArgs*>* handler,
@@ -41,10 +43,16 @@ namespace AdaptiveCards { namespace XamlCardRenderer
 
         HRESULT SendActionEvent(ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveActionEventArgs* eventArgs);
         ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveHostConfig* GetHostConfig();
+        ABI::Windows::UI::Xaml::IResourceDictionary* GetOverrideDictionary();
+        bool GetFixedDimensions(_Out_ UINT32* width, _Out_ UINT32* height);
 
     private:
         Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IResourceDictionary> m_overrideDictionary;
         Microsoft::WRL::ComPtr<ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveHostConfig> m_hostConfig;
+
+        bool m_explicitDimensions = false;
+        UINT32 m_desiredWidth = 0;
+        UINT32 m_desiredHeight = 0;
 
         std::shared_ptr<ActionEventSource> m_events;
 


### PR DESCRIPTION
Adding SetFixedDimensions to the XAML card renderer component so that we  can get timeline image renderer off the XAML builder to use the public APIs directly.