### PR TITLE
Deprecate Speak (except on AdaptiveCard) in dotnet

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Html/Rendering/HtmlRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Html/Rendering/HtmlRenderer.cs
@@ -990,6 +990,7 @@ namespace AdaptiveCards.Rendering
 
         protected static string GetFallbackText(CardElement cardElement)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             if (!string.IsNullOrEmpty(cardElement.Speak))
             {
 #if NET452
@@ -1004,6 +1005,7 @@ namespace AdaptiveCards.Rendering
                 return doc.InnerText;
 #endif
             }
+#pragma warning restore CS0618 // Type or member is obsolete
             return null;
         }
     }

--- a/source/dotnet/Library/AdaptiveCards.Xaml.Shared/Rendering/XamlUtilities.cs
+++ b/source/dotnet/Library/AdaptiveCards.Xaml.Shared/Rendering/XamlUtilities.cs
@@ -56,6 +56,7 @@ namespace AdaptiveCards.Rendering
         public static string GetFallbackText(CardElement cardElement)
         {
 #if WPF
+#pragma warning disable CS0618 // Type or member is obsolete
             if (!string.IsNullOrEmpty(cardElement.Speak))
             {
                 var doc = new System.Xml.XmlDocument();
@@ -67,6 +68,7 @@ namespace AdaptiveCards.Rendering
                 doc.LoadXml(xml);
                 return doc.InnerText;
             }
+#pragma warning restore CS0618 // Type or member is obsolete
 #elif XAMARIN
             // TODO: Xamarin fallback
 #endif

--- a/source/dotnet/Library/AdaptiveCards/ActionBase.cs
+++ b/source/dotnet/Library/AdaptiveCards/ActionBase.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using System;
 using System.Xml.Serialization;
 
 namespace AdaptiveCards
@@ -24,6 +25,7 @@ namespace AdaptiveCards
 #if NET452
         [XmlElement]
 #endif
+        [Obsolete("ActionBase.Speak has been deprecated.  Use AdaptiveCard.Speak", false)]
         public string Speak { get; set; }
     }
 }

--- a/source/dotnet/Library/AdaptiveCards/CardElement.cs
+++ b/source/dotnet/Library/AdaptiveCards/CardElement.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using System;
 using System.Xml.Serialization;
 
 namespace AdaptiveCards
@@ -15,6 +16,7 @@ namespace AdaptiveCards
 #if NET452
         [XmlElement]
 #endif
+        [Obsolete("CardElement.Speak has been deprecated.  Use AdaptiveCard.Speak", false)]
         public string Speak { get; set; }
 
         /// <summary>

--- a/source/dotnet/Library/AdaptiveCards/ChoiceSet.cs
+++ b/source/dotnet/Library/AdaptiveCards/ChoiceSet.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using System.Xml.Serialization;
+using System;
 
 namespace AdaptiveCards
 {
@@ -100,6 +101,7 @@ namespace AdaptiveCards
 #if NET452
         [XmlElement]
 #endif
+        [Obsolete("ChoiceSet.Speak has been deprecated.  Use AdaptiveCard.Speak", false)]
         public string Speak { get; set; }
 
         public bool ShouldSerializeIsSelected()

--- a/source/dotnet/Library/AdaptiveCards/FactSet.cs
+++ b/source/dotnet/Library/AdaptiveCards/FactSet.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using System.Xml.Serialization;
+using System;
 
 namespace AdaptiveCards
 {
@@ -41,7 +42,9 @@ namespace AdaptiveCards
         {
             Title = title;
             Value = value;
+#pragma warning disable CS0618 // Type or member is obsolete
             Speak = speak;
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         /// <summary>
@@ -69,6 +72,7 @@ namespace AdaptiveCards
 #if NET452
         [XmlElement]
 #endif
+        [Obsolete("FactSet.Speak has been deprecated.  Use AdaptiveCard.Speak", false)]
         public string Speak { get; set; }
     }
 }

--- a/source/dotnet/Samples/WPFVisualizer/MainWindow.xaml.cs
+++ b/source/dotnet/Samples/WPFVisualizer/MainWindow.xaml.cs
@@ -276,10 +276,12 @@ namespace WpfVisualizer
             {
                 foreach (var element in card.Body)
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     if (element.Speak != null)
                     {
                         _synth.SpeakSsmlAsync(FixSSML(element.Speak));
                     }
+#pragma warning restore CS0618 // Type or member is obsolete
                 }
             }
         }


### PR DESCRIPTION
Obsolete attribute added to Speak property on ActionBase, CardElement, ChoiceSet and FactSet.  

HtmlRenderer and WPFVisualizer still support .Speak on these types for backward compatibility (should maybe show/speak something about them being deprecated?).