### PR TITLE
Conditional throw statement (Build error in windows with it, build error in Android without it)

### DIFF
--- a/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
+++ b/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
@@ -77,7 +77,7 @@ AdaptiveCard::AdaptiveCard(std::string version,
 #ifdef __ANDROID__
 std::shared_ptr<AdaptiveCard> AdaptiveCard::DeserializeFromFile(const std::string& jsonFile) throw(AdaptiveCards::AdaptiveCardParseException)
 #else
-std::shared_ptr<AdaptiveCard> AdaptiveCard::DeserializeFromFile(const std::string& jsonFile) throw (AdaptiveCards::AdaptiveCardParseException)
+std::shared_ptr<AdaptiveCard> AdaptiveCard::DeserializeFromFile(const std::string& jsonFile)
 #endif // __ANDROID__
 {
     std::ifstream jsonFileStream(jsonFile);
@@ -91,8 +91,7 @@ std::shared_ptr<AdaptiveCard> AdaptiveCard::DeserializeFromFile(const std::strin
 #ifdef __ANDROID__
 std::shared_ptr<AdaptiveCard> AdaptiveCard::Deserialize(const Json::Value& json) throw(AdaptiveCards::AdaptiveCardParseException)
 #else
-std::shared_ptr<AdaptiveCard> AdaptiveCard::Deserialize(const Json::Value& json) throw(AdaptiveCards::AdaptiveCardParseException)
-#endif // __ANDROID__
+std::shared_ptr<AdaptiveCard> AdaptiveCard::Deserialize(const Json::Value& json)
 {
     ParseUtil::ThrowIfNotJsonObject(json);
 

--- a/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
+++ b/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
@@ -74,7 +74,11 @@ AdaptiveCard::AdaptiveCard(std::string version,
 {
 }
 
+#ifdef __ANDROID__
+std::shared_ptr<AdaptiveCard> AdaptiveCard::DeserializeFromFile(const std::string& jsonFile) throw(AdaptiveCards::AdaptiveCardParseException)
+#else
 std::shared_ptr<AdaptiveCard> AdaptiveCard::DeserializeFromFile(const std::string& jsonFile) throw (AdaptiveCards::AdaptiveCardParseException)
+#endif // __ANDROID__
 {
     std::ifstream jsonFileStream(jsonFile);
 
@@ -84,7 +88,11 @@ std::shared_ptr<AdaptiveCard> AdaptiveCard::DeserializeFromFile(const std::strin
     return AdaptiveCard::Deserialize(root);
 }
 
+#ifdef __ANDROID__
 std::shared_ptr<AdaptiveCard> AdaptiveCard::Deserialize(const Json::Value& json) throw(AdaptiveCards::AdaptiveCardParseException)
+#else
+std::shared_ptr<AdaptiveCard> AdaptiveCard::Deserialize(const Json::Value& json) throw(AdaptiveCards::AdaptiveCardParseException)
+#endif // __ANDROID__
 {
     ParseUtil::ThrowIfNotJsonObject(json);
 
@@ -107,6 +115,15 @@ std::shared_ptr<AdaptiveCard> AdaptiveCard::Deserialize(const Json::Value& json)
 
     auto result = std::make_shared<AdaptiveCard>(version, minVersion, fallbackText, backgroundImage, speak, body, actions);
     return result;
+}
+
+#ifdef __ANDROID__
+std::shared_ptr<AdaptiveCard> AdaptiveCard::DeserializeFromString(const std::string& jsonString) throw(AdaptiveCards::AdaptiveCardParseException)
+#else
+std::shared_ptr<AdaptiveCard> AdaptiveCard::DeserializeFromString(const std::string& jsonString)
+#endif // __ANDROID__
+{
+    return AdaptiveCard::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
 }
 
 Json::Value AdaptiveCard::SerializeToJsonValue()
@@ -140,12 +157,6 @@ std::string AdaptiveCard::Serialize()
 {
     Json::FastWriter writer;
     return writer.write(SerializeToJsonValue());
-}
-
-std::shared_ptr<AdaptiveCard> AdaptiveCard::DeserializeFromString(const std::string& jsonString) throw(AdaptiveCards::AdaptiveCardParseException)
-{
-    return AdaptiveCard::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
-}
 
 std::string AdaptiveCard::GetVersion() const
 {

--- a/source/shared/cpp/ObjectModel/SharedAdaptiveCard.h
+++ b/source/shared/cpp/ObjectModel/SharedAdaptiveCard.h
@@ -44,10 +44,15 @@ public:
     const std::vector<std::shared_ptr<BaseActionElement>>& GetActions() const;
 
     const CardElementType GetElementType() const;
-
+#ifdef __ANDROID__
     static std::shared_ptr<AdaptiveCard> DeserializeFromFile(const std::string& jsonFile) throw(AdaptiveCards::AdaptiveCardParseException);
     static std::shared_ptr<AdaptiveCard> Deserialize(const Json::Value& json) throw(AdaptiveCards::AdaptiveCardParseException);
     static std::shared_ptr<AdaptiveCard> DeserializeFromString(const std::string& jsonString) throw(AdaptiveCards::AdaptiveCardParseException);
+#else
+    static std::shared_ptr<AdaptiveCard> DeserializeFromFile(const std::string& jsonFile) throw(AdaptiveCards::AdaptiveCardParseException);
+    static std::shared_ptr<AdaptiveCard> Deserialize(const Json::Value& json) throw(AdaptiveCards::AdaptiveCardParseException);
+    static std::shared_ptr<AdaptiveCard> DeserializeFromString(const std::string& jsonString) throw(AdaptiveCards::AdaptiveCardParseException);
+#endif // __ANDROID__
     Json::Value SerializeToJsonValue();
     std::string Serialize();
 

--- a/source/shared/cpp/ObjectModel/SharedAdaptiveCard.h
+++ b/source/shared/cpp/ObjectModel/SharedAdaptiveCard.h
@@ -49,9 +49,9 @@ public:
     static std::shared_ptr<AdaptiveCard> Deserialize(const Json::Value& json) throw(AdaptiveCards::AdaptiveCardParseException);
     static std::shared_ptr<AdaptiveCard> DeserializeFromString(const std::string& jsonString) throw(AdaptiveCards::AdaptiveCardParseException);
 #else
-    static std::shared_ptr<AdaptiveCard> DeserializeFromFile(const std::string& jsonFile) throw(AdaptiveCards::AdaptiveCardParseException);
-    static std::shared_ptr<AdaptiveCard> Deserialize(const Json::Value& json) throw(AdaptiveCards::AdaptiveCardParseException);
-    static std::shared_ptr<AdaptiveCard> DeserializeFromString(const std::string& jsonString) throw(AdaptiveCards::AdaptiveCardParseException);
+    static std::shared_ptr<AdaptiveCard> DeserializeFromFile(const std::string& jsonFile);
+    static std::shared_ptr<AdaptiveCard> Deserialize(const Json::Value& json);
+    static std::shared_ptr<AdaptiveCard> DeserializeFromString(const std::string& jsonString);
 #endif // __ANDROID__
     Json::Value SerializeToJsonValue();
     std::string Serialize();


### PR DESCRIPTION
This change makes the throws clause conditional depending on whether we are compiling for android or Windows. The throws clause is needed for SWIG to generate the correct exception specification, but it causes build errors in the Windows codebase.