### PR TITLE
Fix UWP host config color parsing and add host config editor to UWP Visualizer

### DIFF
--- a/source/uwp/Renderer/lib/Util.cpp
+++ b/source/uwp/Renderer/lib/Util.cpp
@@ -225,16 +225,16 @@ HRESULT GetColorFromString(std::string colorString, Color *color) noexcept try
     std::string redString = colorString.substr(3, 2);
     INT32 red = strtol(redString.c_str(), nullptr, 16);
 
-    std::string blueString = colorString.substr(5, 2);
-    INT32 blue = strtol(blueString.c_str(), nullptr, 16);
-
-    std::string greenString = colorString.substr(7, 2);
+    std::string greenString = colorString.substr(5, 2);
     INT32 green = strtol(greenString.c_str(), nullptr, 16);
+
+    std::string blueString = colorString.substr(7, 2);
+    INT32 blue = strtol(blueString.c_str(), nullptr, 16);
 
     color->A = static_cast<BYTE>(alpha);
     color->R = static_cast<BYTE>(red);
-    color->B = static_cast<BYTE>(blue);
     color->G = static_cast<BYTE>(green);
+    color->B = static_cast<BYTE>(blue);
 
     return S_OK;
 } CATCH_RETURN;

--- a/source/uwp/Visualizer/DocumentView.xaml
+++ b/source/uwp/Visualizer/DocumentView.xaml
@@ -8,16 +8,7 @@
     mc:Ignorable="d"
     d:DesignHeight="300"
     d:DesignWidth="400"
-    xmlns:toolkitControls="using:Microsoft.Toolkit.Uwp.UI.Controls"
-    xmlns:converters="using:XamlCardVisualizer.Converters">
-
-    <UserControl.Resources>
-
-        <converters:ErrorViewModelTypeToIconBackgroundConverter x:Key="ErrorViewModelTypeToIconBackgroundConverter"/>
-        <converters:ErrorViewModelTypeToIconForegroundConverter x:Key="ErrorViewModelTypeToIconForegroundConverter"/>
-        <converters:ErrorViewModelTypeToSymbolConverter x:Key="ErrorViewModelTypeToSymbolConverter"/>
-
-    </UserControl.Resources>
+    xmlns:toolkitControls="using:Microsoft.Toolkit.Uwp.UI.Controls">
 
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <Grid.ColumnDefinitions>
@@ -26,74 +17,7 @@
         </Grid.ColumnDefinitions>
 
         <!--Editor and errors-->
-        <Grid>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="*"/>
-                <RowDefinition Height="Auto"/>
-            </Grid.RowDefinitions>
-            <ScrollViewer VerticalScrollBarVisibility="Auto">
-                <TextBox
-                    Text="{Binding Payload, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                    AcceptsReturn="True"
-                    VerticalAlignment="Stretch"
-                    TextWrapping="Wrap"
-                    FontSize="14"
-                    FontFamily="Consolas"
-                    BorderThickness="0"
-                    Margin="0,0,12,0"
-                    IsSpellCheckEnabled="False"/>
-            </ScrollViewer>
-
-            <!--Error info-->
-            <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" MaxHeight="200">
-                <ItemsControl ItemsSource="{Binding Errors}">
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <Grid Padding="12" Background="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto"/>
-                                    <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="Auto"/>
-                                </Grid.ColumnDefinitions>
-
-                                <Grid Margin="0,0,12,0" VerticalAlignment="Top">
-                                    <Ellipse
-                                    Fill="{Binding Type, Converter={StaticResource ErrorViewModelTypeToIconBackgroundConverter}}"
-                                    Width="30"
-                                    Height="30"/>
-                                    <SymbolIcon
-                                    Symbol="{Binding Type, Converter={StaticResource ErrorViewModelTypeToSymbolConverter}}"
-                                    Foreground="{Binding Type, Converter={StaticResource ErrorViewModelTypeToIconForegroundConverter}}"/>
-                                </Grid>
-
-                                <TextBlock
-                                Text="{Binding Message}"
-                                TextWrapping="Wrap"
-                                Grid.Column="1"
-                                    IsTextSelectionEnabled="True"/>
-
-                                <StackPanel
-                                            Grid.Column="2" Margin="3,0,0,0">
-
-                                    <TextBlock
-                                                    Text="Line"
-                                                    Style="{StaticResource CaptionTextBlockStyle}"
-                                                    TextAlignment="Right"
-                                                    HorizontalAlignment="Right"/>
-
-                                    <TextBlock
-                                                    Text="{Binding Position.LineNumber}"
-                                                    TextAlignment="Right"
-                                                    HorizontalAlignment="Right"
-                                                    Style="{StaticResource CaptionTextBlockStyle}"/>
-
-                                </StackPanel>
-                            </Grid>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </ScrollViewer>
-        </Grid>
+        <local:GenericDocumentView />
 
         <!--Preview-->
         <ScrollViewer Grid.Column="1" VerticalScrollBarVisibility="Auto" Margin="11,0,0,0" Background="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}">

--- a/source/uwp/Visualizer/DocumentView.xaml
+++ b/source/uwp/Visualizer/DocumentView.xaml
@@ -20,12 +20,23 @@
         <local:GenericDocumentView />
 
         <!--Preview-->
-        <ScrollViewer Grid.Column="1" VerticalScrollBarVisibility="Auto" Margin="11,0,0,0" Background="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}">
+        <Grid
+            Grid.Column="1">
+            <ScrollViewer VerticalScrollBarVisibility="Auto" Margin="11,0,0,0" Background="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}">
+                <Border
+                    x:Name="AdaptiveCardHostContainer"
+                    Child="{Binding RenderedCard}"
+                    Padding="12"/>
+            </ScrollViewer>
             <Border
-                x:Name="AdaptiveCardHostContainer"
-                Child="{Binding RenderedCard}"
-                Padding="12"/>
-        </ScrollViewer>
+                Background="#11000000"
+                Visibility="{Binding IsLoading}">
+                <ProgressRing
+                    IsActive="True"
+                    Width="40"
+                    Height="40"/>
+            </Border>
+        </Grid>
 
         <!--Vertical draggable column splitter-->
         <toolkitControls:GridSplitter

--- a/source/uwp/Visualizer/GenericDocumentView.xaml
+++ b/source/uwp/Visualizer/GenericDocumentView.xaml
@@ -1,0 +1,90 @@
+﻿<UserControl
+    x:Class="XamlCardVisualizer.GenericDocumentView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:XamlCardVisualizer"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400"
+    xmlns:converters="using:XamlCardVisualizer.Converters">
+
+    <UserControl.Resources>
+
+        <converters:ErrorViewModelTypeToIconBackgroundConverter x:Key="ErrorViewModelTypeToIconBackgroundConverter"/>
+        <converters:ErrorViewModelTypeToIconForegroundConverter x:Key="ErrorViewModelTypeToIconForegroundConverter"/>
+        <converters:ErrorViewModelTypeToSymbolConverter x:Key="ErrorViewModelTypeToSymbolConverter"/>
+
+    </UserControl.Resources>
+
+    <!--Editor and errors-->
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <ScrollViewer VerticalScrollBarVisibility="Auto">
+            <TextBox
+                    Text="{Binding Payload, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                    AcceptsReturn="True"
+                    VerticalAlignment="Stretch"
+                    TextWrapping="Wrap"
+                    FontSize="14"
+                    FontFamily="Consolas"
+                    BorderThickness="0"
+                    Margin="0,0,12,0"
+                    IsSpellCheckEnabled="False"/>
+        </ScrollViewer>
+
+        <!--Error info-->
+        <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" MaxHeight="200">
+            <ItemsControl ItemsSource="{Binding Errors}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Grid Padding="12" Background="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+
+                            <Grid Margin="0,0,12,0" VerticalAlignment="Top">
+                                <Ellipse
+                                    Fill="{Binding Type, Converter={StaticResource ErrorViewModelTypeToIconBackgroundConverter}}"
+                                    Width="30"
+                                    Height="30"/>
+                                <SymbolIcon
+                                    Symbol="{Binding Type, Converter={StaticResource ErrorViewModelTypeToSymbolConverter}}"
+                                    Foreground="{Binding Type, Converter={StaticResource ErrorViewModelTypeToIconForegroundConverter}}"/>
+                            </Grid>
+
+                            <TextBlock
+                                Text="{Binding Message}"
+                                TextWrapping="Wrap"
+                                Grid.Column="1"
+                                IsTextSelectionEnabled="True"/>
+
+                            <StackPanel
+                                Grid.Column="2" Margin="3,0,0,0">
+
+                                <TextBlock
+                                    Text="Line"
+                                    Style="{StaticResource CaptionTextBlockStyle}"
+                                    TextAlignment="Right"
+                                    HorizontalAlignment="Right"/>
+
+                                <TextBlock
+                                    Text="{Binding Position.LineNumber}"
+                                    TextAlignment="Right"
+                                    HorizontalAlignment="Right"
+                                    Style="{StaticResource CaptionTextBlockStyle}"/>
+
+                            </StackPanel>
+                        </Grid>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </ScrollViewer>
+    </Grid>
+</UserControl>

--- a/source/uwp/Visualizer/GenericDocumentView.xaml.cs
+++ b/source/uwp/Visualizer/GenericDocumentView.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace XamlCardVisualizer
+{
+    public sealed partial class GenericDocumentView : UserControl
+    {
+        public GenericDocumentView()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/source/uwp/Visualizer/HostConfigs/DefaultHostConfig.json
+++ b/source/uwp/Visualizer/HostConfigs/DefaultHostConfig.json
@@ -1,0 +1,140 @@
+﻿{
+  "spacing": {
+    "small": 3,
+    "default": 8,
+    "medium": 20,
+    "large": 30,
+    "extraLarge": 40,
+    "padding": 20
+  },
+  "separator": {
+    "lineThickness": 1,
+    "lineColor": "#EEEEEE"
+  },
+  "supportsInteractivity": true,
+  "fontFamily": "Segoe UI",
+  "fontSizes": {
+    "small": 12,
+    "default": 15,
+    "medium": 20,
+    "large": 24,
+    "extraLarge": 34
+  },
+  "fontWeights": {
+    "lighter": 200,
+    "default": 400,
+    "bolder": 600
+  },
+  "containerStyles": {
+    "default": {
+      "backgroundColor": "#00000000",
+      "fontColors": {
+        "default": {
+          "normal": "#FF000000",
+          "subtle": "#99000000"
+        },
+        "dark": {
+          "normal": "#FF000000",
+          "subtle": "#99000000"
+        },
+        "light": {
+          "normal": "#FFFFFFFF",
+          "subtle": "#99FFFFFF"
+        },
+        "accent": {
+          "normal": "#FF0078D7",
+          "subtle": "#990078D7"
+        },
+        "attention": {
+          "normal": "#FFE81123",
+          "subtle": "#99E81123"
+        },
+        "good": {
+          "normal": "#FF00CC6A",
+          "subtle": "#9900CC6A"
+        },
+        "warning": {
+          "normal": "#FFFFB900",
+          "subtle": "#99FFB900"
+        }
+      }
+    },
+    "emphasis": {
+      "backgroundColor": "#08000000",
+      "fontColors": {
+        "default": {
+          "normal": "#FF000000",
+          "subtle": "#99000000"
+        },
+        "dark": {
+          "normal": "#FF000000",
+          "subtle": "#99000000"
+        },
+        "light": {
+          "normal": "#FFFFFFFF",
+          "subtle": "#99FFFFFF"
+        },
+        "accent": {
+          "normal": "#FF0078D7",
+          "subtle": "#990078D7"
+        },
+        "attention": {
+          "normal": "#FFE81123",
+          "subtle": "#99E81123"
+        },
+        "good": {
+          "normal": "#FF00CC6A",
+          "subtle": "#9900CC6A"
+        },
+        "warning": {
+          "normal": "#FFFFB900",
+          "subtle": "#99FFB900"
+        }
+      }
+    }
+  },
+  "imageSizes": {
+    "small": 40,
+    "medium": 80,
+    "large": 160
+  },
+  "actions": {
+    "maxActions": 5,
+    "spacing": "default",
+    "buttonSpacing": 10,
+    "showCard": {
+      "actionMode": "inline",
+      "inlineTopMargin": 16
+    },
+    "actionsOrientation": "horizontal",
+    "actionAlignment": "stretch"
+  },
+  "adaptiveCard": {
+    "allowCustomStyle": false
+  },
+  "image": {
+    "size": "medium"
+  },
+  "imageSet": {
+    "imageSize": "medium",
+    "maxImageHeight": 100
+  },
+  "factSet": {
+    "title": {
+      "color": "default",
+      "size": "default",
+      "isSubtle": false,
+      "weight": "bolder",
+      "wrap": true,
+      "maxWidth": 150
+    },
+    "value": {
+      "color": "default",
+      "size": "default",
+      "isSubtle": false,
+      "weight": "default",
+      "wrap": true
+    },
+    "spacing": 10
+  }
+}

--- a/source/uwp/Visualizer/MainPage.xaml
+++ b/source/uwp/Visualizer/MainPage.xaml
@@ -41,6 +41,12 @@
                         Label="Save file"
                         Click="AppBarSave_Click"
                         IsCompact="True"/>
+                    <AppBarToggleButton
+                        x:Name="AppBarHostConfigEditor"
+                        Icon="Setting"
+                        Label="Host config"
+                        IsCompact="True"
+                        Click="AppBarHostConfigEditor_Click"/>
                 </StackPanel>
             </CommandBar.Content>
             <CommandBar.SecondaryCommands>
@@ -78,6 +84,37 @@
                 DataContext="{Binding CurrentDocument}"
                 Visibility="{Binding CurrentDocument, Converter={StaticResource NotNullToVisibilityConverter}}"/>
 
+        </Grid>
+        
+        <!--Host config editor-->
+        <Grid
+            Grid.Row="1"
+            x:Name="HostConfigEditorView"
+            Visibility="Collapsed">
+            
+            <Rectangle
+                Fill="Black"
+                Opacity="0.3"
+                Tapped="HostConfigTransparentBackdrop_Tapped"/>
+
+            <!--We apply padding on right to keep the preview visible-->
+            <Grid
+                Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+                BorderThickness="0,0,8,0"
+                BorderBrush="{ThemeResource SystemControlBackgroundAccentBrush}"
+                Margin="0,0,320,0">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <TextBlock
+                    Text="Host config"
+                    Style="{ThemeResource SubtitleTextBlockStyle}"
+                    Margin="6"/>
+                <local:GenericDocumentView
+                    Grid.Row="1"
+                    DataContext="{Binding HostConfigEditor}"/>
+            </Grid>
         </Grid>
 
 

--- a/source/uwp/Visualizer/MainPage.xaml.cs
+++ b/source/uwp/Visualizer/MainPage.xaml.cs
@@ -90,10 +90,38 @@ namespace XamlCardVisualizer
 
         private void SetIsCompactOnAppBarButtons(bool isCompact)
         {
-            foreach (var button in StackPanelMainAppBarButtons.Children.OfType<AppBarButton>())
+            foreach (var button in StackPanelMainAppBarButtons.Children.OfType<ICommandBarElement>())
             {
                 button.IsCompact = isCompact;
             }
+        }
+
+        private void AppBarHostConfigEditor_Click(object sender, RoutedEventArgs e)
+        {
+            SetIsInHostConfigEditor(!IsInHostConfigEditor);
+        }
+
+        public bool IsInHostConfigEditor { get; private set; }
+
+        private void SetIsInHostConfigEditor(bool isInHostConfigEditor)
+        {
+            IsInHostConfigEditor = isInHostConfigEditor;
+
+            foreach (var button in StackPanelMainAppBarButtons.Children.OfType<ButtonBase>())
+            {
+                if (button != AppBarHostConfigEditor)
+                {
+                    button.IsEnabled = !isInHostConfigEditor;
+                }
+            }
+
+            HostConfigEditorView.Visibility = isInHostConfigEditor ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        private void HostConfigTransparentBackdrop_Tapped(object sender, TappedRoutedEventArgs e)
+        {
+            AppBarHostConfigEditor.IsChecked = false;
+            SetIsInHostConfigEditor(false);
         }
     }
 }

--- a/source/uwp/Visualizer/ViewModel/DocumentViewModel.cs
+++ b/source/uwp/Visualizer/ViewModel/DocumentViewModel.cs
@@ -22,7 +22,7 @@ namespace XamlCardVisualizer.ViewModel
     {
         private static XamlCardRenderer _renderer;
 
-        public DocumentViewModel(MainPageViewModel mainPageViewModel) : base(mainPageViewModel) { }
+        private DocumentViewModel(MainPageViewModel mainPageViewModel) : base(mainPageViewModel) { }
 
         private UIElement _renderedCard;
         public UIElement RenderedCard
@@ -34,8 +34,16 @@ namespace XamlCardVisualizer.ViewModel
         public static async Task<DocumentViewModel> LoadFromFileAsync(MainPageViewModel mainPageViewModel, IStorageFile file, string token)
         {
             var answer = new DocumentViewModel(mainPageViewModel);
-            await answer.LoadFromFileAsync(file, token);
+            await answer.LoadFromFileAsync(file, token, assignPayloadWithoutLoading: true);
             return answer;
+        }
+
+        public static DocumentViewModel LoadFromPayload(MainPageViewModel mainPageViewModel, string payload)
+        {
+            return new DocumentViewModel(mainPageViewModel)
+            {
+                _payload = payload
+            };
         }
 
         protected override async void LoadPayload(string payload)

--- a/source/uwp/Visualizer/ViewModel/DocumentViewModel.cs
+++ b/source/uwp/Visualizer/ViewModel/DocumentViewModel.cs
@@ -18,77 +18,11 @@ using XamlCardVisualizer.ResourceResolvers;
 
 namespace XamlCardVisualizer.ViewModel
 {
-    public class DocumentViewModel : BindableBase
+    public class DocumentViewModel : GenericDocumentViewModel
     {
         private static XamlCardRenderer _renderer;
 
-        public MainPageViewModel MainPageViewModel { get; private set; }
-        public string Token { get; private set; }
-        public IStorageFile File { get; private set; }
-
-        private string _name = "Untitled";
-        public string Name
-        {
-            get { return _name; }
-            set { SetProperty(ref _name, value); }
-        }
-
-        private string _payload = "";
-        public string Payload
-        {
-            get { return _payload; }
-            set { SetPayload(value); }
-        }
-
-        private void SetPayload(string value)
-        {
-            if (value == null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
-
-            if (object.Equals(_payload, value))
-            {
-                return;
-            }
-
-            SetProperty(ref _payload, value);
-
-            ReRender();
-        }
-
-        public async void ReRender()
-        {
-            if (!IsRendering)
-            {
-                IsRendering = true;
-
-                await Task.Delay(1000);
-
-                IsRendering = false;
-                NotifyPropertyChanged(DelayedUpdatePayload);
-                Render();
-            }
-        }
-
-        private bool _isRendering;
-        /// <summary>
-        /// Represents whether the system is delaying rendering. Views should indicate this.
-        /// </summary>
-        public bool IsRendering
-        {
-            get { return _isRendering; }
-            private set { SetProperty(ref _isRendering, value); }
-        }
-
-        /// <summary>
-        /// This property will be notified of changes on a delayed schedule, so that it's not
-        /// changing every single time a character is typed. Views presenting 
-        /// </summary>
-        public string DelayedUpdatePayload
-        {
-            get { return Payload; }
-        }
+        public DocumentViewModel(MainPageViewModel mainPageViewModel) : base(mainPageViewModel) { }
 
         private UIElement _renderedCard;
         public UIElement RenderedCard
@@ -97,46 +31,15 @@ namespace XamlCardVisualizer.ViewModel
             private set { SetProperty(ref _renderedCard, value); }
         }
 
-        public ObservableCollection<ErrorViewModel> Errors { get; private set; } = new ObservableCollection<ErrorViewModel>();
-
         public static async Task<DocumentViewModel> LoadFromFileAsync(MainPageViewModel mainPageViewModel, IStorageFile file, string token)
         {
-            return new DocumentViewModel()
-            {
-                MainPageViewModel = mainPageViewModel,
-                Name = file.Name,
-                Payload = await FileIO.ReadTextAsync(file),
-                Token = token,
-                File = file
-            };
+            var answer = new DocumentViewModel(mainPageViewModel);
+            await answer.LoadFromFileAsync(file, token);
+            return answer;
         }
 
-        public async Task SaveAsync()
+        protected override async void LoadPayload(string payload)
         {
-            try
-            {
-                await FileIO.WriteTextAsync(File, Payload);
-            }
-            catch (Exception ex)
-            {
-                var dontWait = new MessageDialog(ex.ToString()).ShowAsync();
-            }
-        }
-
-        private async void Render()
-        {
-            if (string.IsNullOrWhiteSpace(Payload))
-            {
-                SetSingleError(new ErrorViewModel()
-                {
-                    Message = "Invalid payload",
-                    Type = ErrorViewModelType.Error
-                });
-                return;
-            }
-
-            string payload = Payload;
-
             var newErrors = await PayloadValidator.ValidateAsync(payload);
             if (newErrors.Any(i => i.Type == ErrorViewModelType.Error))
             {
@@ -148,7 +51,7 @@ namespace XamlCardVisualizer.ViewModel
             {
                 if (_renderer == null)
                 {
-                    InitializeRenderer();
+                    InitializeRenderer(MainPageViewModel.HostConfigEditor.HostConfig);
                 }
             }
             catch (Exception ex)
@@ -191,23 +94,15 @@ namespace XamlCardVisualizer.ViewModel
             }
         }
 
-        private void SetSingleError(ErrorViewModel error)
-        {
-            MakeErrorsLike(new List<ErrorViewModel>() { error });
-        }
-
-        private void MakeErrorsLike(List<ErrorViewModel> errors)
-        {
-            errors.Sort();
-            Errors.MakeListLike(errors);
-        }
-
-        private static void InitializeRenderer()
+        public static void InitializeRenderer(AdaptiveHostConfig hostConfig)
         {
             try
             {
                 _renderer = new XamlCardRenderer();
-                //_renderer.SetHostConfig
+                if (hostConfig != null)
+                {
+                    _renderer.SetHostConfig(hostConfig);
+                }
 
                 // Custom resource resolvers
                 _renderer.ResourceResolvers.Set("symbol", new MySymbolResourceResolver());

--- a/source/uwp/Visualizer/ViewModel/GenericDocumentViewModel.cs
+++ b/source/uwp/Visualizer/ViewModel/GenericDocumentViewModel.cs
@@ -29,7 +29,9 @@ namespace XamlCardVisualizer.ViewModel
             MainPageViewModel = model;
         }
 
-        private string _payload = "";
+        public bool IsOutdated { get; set; } = true;
+
+        protected string _payload = "";
         public string Payload
         {
             get { return _payload; }
@@ -55,6 +57,8 @@ namespace XamlCardVisualizer.ViewModel
 
         public async void Reload()
         {
+            IsOutdated = true;
+
             if (!IsReloading)
             {
                 IsReloading = true;
@@ -64,6 +68,14 @@ namespace XamlCardVisualizer.ViewModel
                 IsReloading = false;
                 NotifyPropertyChanged(DelayedUpdatePayload);
                 Load();
+            }
+        }
+
+        public void ReloadIfNeeded()
+        {
+            if (IsOutdated)
+            {
+                Reload();
             }
         }
 
@@ -88,12 +100,21 @@ namespace XamlCardVisualizer.ViewModel
 
         public ObservableCollection<ErrorViewModel> Errors { get; private set; } = new ObservableCollection<ErrorViewModel>();
 
-        protected async Task LoadFromFileAsync(IStorageFile file, string token)
+        protected async Task LoadFromFileAsync(IStorageFile file, string token, bool assignPayloadWithoutLoading)
         {
             this.Name = file.Name;
             this.File = file;
             this.Token = token;
-            Payload = await FileIO.ReadTextAsync(file);
+
+            string payloadText = await FileIO.ReadTextAsync(file);
+            if (assignPayloadWithoutLoading)
+            {
+                _payload = payloadText;
+            }
+            else
+            {
+                Payload = payloadText;
+            }
         }
 
         public async Task SaveAsync()
@@ -138,6 +159,8 @@ namespace XamlCardVisualizer.ViewModel
                     }
                 });
             }
+
+            IsOutdated = false;
         }
 
         protected abstract void LoadPayload(string payload);

--- a/source/uwp/Visualizer/ViewModel/GenericDocumentViewModel.cs
+++ b/source/uwp/Visualizer/ViewModel/GenericDocumentViewModel.cs
@@ -1,0 +1,156 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Storage;
+using Windows.UI.Popups;
+using XamlCardVisualizer.Helpers;
+
+namespace XamlCardVisualizer.ViewModel
+{
+    public abstract class GenericDocumentViewModel : BindableBase
+    {
+        public MainPageViewModel MainPageViewModel { get; private set; }
+        public string Token { get; private set; }
+        public IStorageFile File { get; private set; }
+
+        private string _name = "Untitled";
+        public string Name
+        {
+            get { return _name; }
+            set { SetProperty(ref _name, value); }
+        }
+
+        public GenericDocumentViewModel(MainPageViewModel model)
+        {
+            MainPageViewModel = model;
+        }
+
+        private string _payload = "";
+        public string Payload
+        {
+            get { return _payload; }
+            set { SetPayload(value); }
+        }
+
+        private void SetPayload(string value)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            if (object.Equals(_payload, value))
+            {
+                return;
+            }
+
+            SetProperty(ref _payload, value);
+
+            Reload();
+        }
+
+        public async void Reload()
+        {
+            if (!IsReloading)
+            {
+                IsReloading = true;
+
+                await Task.Delay(1000);
+
+                IsReloading = false;
+                NotifyPropertyChanged(DelayedUpdatePayload);
+                Load();
+            }
+        }
+
+        private bool _isReloading;
+        /// <summary>
+        /// Represents whether the system is delaying reloading. Views should indicate this.
+        /// </summary>
+        public bool IsReloading
+        {
+            get { return _isReloading; }
+            private set { SetProperty(ref _isReloading, value); }
+        }
+
+        /// <summary>
+        /// This property will be notified of changes on a delayed schedule, so that it's not
+        /// changing every single time a character is typed. Views presenting 
+        /// </summary>
+        public string DelayedUpdatePayload
+        {
+            get { return Payload; }
+        }
+
+        public ObservableCollection<ErrorViewModel> Errors { get; private set; } = new ObservableCollection<ErrorViewModel>();
+
+        protected async Task LoadFromFileAsync(IStorageFile file, string token)
+        {
+            this.Name = file.Name;
+            this.File = file;
+            this.Token = token;
+            Payload = await FileIO.ReadTextAsync(file);
+        }
+
+        public async Task SaveAsync()
+        {
+            try
+            {
+                await FileIO.WriteTextAsync(File, Payload);
+            }
+            catch (Exception ex)
+            {
+                var dontWait = new MessageDialog(ex.ToString()).ShowAsync();
+            }
+        }
+
+        private void Load()
+        {
+            if (string.IsNullOrWhiteSpace(Payload))
+            {
+                SetSingleError(new ErrorViewModel()
+                {
+                    Message = "Invalid payload",
+                    Type = ErrorViewModelType.Error
+                });
+                return;
+            }
+
+            string payload = Payload;
+
+            try
+            {
+                LoadPayload(payload);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine(ex.ToString());
+                MakeErrorsLike(new List<ErrorViewModel>()
+                {
+                    new ErrorViewModel()
+                    {
+                        Message = "Loading failed",
+                        Type = ErrorViewModelType.Error
+                    }
+                });
+            }
+        }
+
+        protected abstract void LoadPayload(string payload);
+
+        protected void SetSingleError(ErrorViewModel error)
+        {
+            MakeErrorsLike(new List<ErrorViewModel>() { error });
+        }
+
+        protected void MakeErrorsLike(List<ErrorViewModel> errors)
+        {
+            errors.Sort();
+            Errors.MakeListLike(errors);
+        }
+    }
+}

--- a/source/uwp/Visualizer/ViewModel/GenericDocumentViewModel.cs
+++ b/source/uwp/Visualizer/ViewModel/GenericDocumentViewModel.cs
@@ -59,13 +59,13 @@ namespace XamlCardVisualizer.ViewModel
         {
             IsOutdated = true;
 
-            if (!IsReloading)
+            if (!IsLoading)
             {
-                IsReloading = true;
+                IsLoading = true;
 
                 await Task.Delay(1000);
 
-                IsReloading = false;
+                IsLoading = false;
                 NotifyPropertyChanged(DelayedUpdatePayload);
                 Load();
             }
@@ -79,14 +79,14 @@ namespace XamlCardVisualizer.ViewModel
             }
         }
 
-        private bool _isReloading;
+        private bool _isLoading;
         /// <summary>
-        /// Represents whether the system is delaying reloading. Views should indicate this.
+        /// Represents whether the system is delaying loading. Views should indicate this.
         /// </summary>
-        public bool IsReloading
+        public bool IsLoading
         {
-            get { return _isReloading; }
-            private set { SetProperty(ref _isReloading, value); }
+            get { return _isLoading; }
+            private set { SetProperty(ref _isLoading, value); }
         }
 
         /// <summary>

--- a/source/uwp/Visualizer/ViewModel/HostConfigEditorViewModel.cs
+++ b/source/uwp/Visualizer/ViewModel/HostConfigEditorViewModel.cs
@@ -1,0 +1,58 @@
+﻿using AdaptiveCards.XamlCardRenderer;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Storage;
+using XamlCardVisualizer.Helpers;
+
+namespace XamlCardVisualizer.ViewModel
+{
+    public class HostConfigEditorViewModel : GenericDocumentViewModel
+    {
+        private HostConfigEditorViewModel(MainPageViewModel mainPageViewModel) : base(mainPageViewModel) { }
+
+        public event EventHandler<AdaptiveHostConfig> HostConfigChanged;
+
+        public AdaptiveHostConfig HostConfig { get; private set; }
+
+        protected override void LoadPayload(string payload)
+        {
+            try
+            {
+                HostConfig = AdaptiveHostConfig.CreateHostConfigFromJson(payload);
+
+                HostConfigChanged?.Invoke(this, HostConfig);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine(ex.ToString());
+                SetSingleError(new ErrorViewModel()
+                {
+                    Message = "Invalid Host Config payload",
+                    Type = ErrorViewModelType.ErrorButRenderAllowed
+                });
+            }
+        }
+
+        public static async Task<HostConfigEditorViewModel> LoadAsync(MainPageViewModel mainPageViewModel)
+        {
+            try
+            {
+                StorageFile file = await StorageFile.GetFileFromApplicationUriAsync(new Uri("ms-appx:///HostConfigs/DefaultHostConfig.json"));
+                string text = await FileIO.ReadTextAsync(file);
+
+                return new HostConfigEditorViewModel(mainPageViewModel)
+                {
+                    Payload = text
+                };
+            }
+            catch
+            {
+                return new HostConfigEditorViewModel(mainPageViewModel);
+            }
+        }
+    }
+}

--- a/source/uwp/Visualizer/ViewModel/MainPageViewModel.cs
+++ b/source/uwp/Visualizer/ViewModel/MainPageViewModel.cs
@@ -21,7 +21,15 @@ namespace XamlCardVisualizer.ViewModel
         public DocumentViewModel CurrentDocument
         {
             get { return _currentDocument; }
-            set { SetProperty(ref _currentDocument, value); }
+            set
+            {
+                SetProperty(ref _currentDocument, value);
+
+                if (value != null)
+                {
+                    value.ReloadIfNeeded();
+                }
+            }
         }
 
         public HostConfigEditorViewModel HostConfigEditor { get; private set; }
@@ -42,17 +50,22 @@ namespace XamlCardVisualizer.ViewModel
 
         private void ReRenderCards()
         {
+            // Set all card docs to outdated
             foreach (var doc in OpenDocuments)
             {
-                doc.Reload();
+                doc.IsOutdated = true;
+            }
+
+            if (CurrentDocument != null)
+            {
+                // Reload the current doc
+                CurrentDocument.ReloadIfNeeded();
             }
         }
 
         public void NewDocument()
         {
-            OpenDocuments.Add(new DocumentViewModel(this)
-            {
-                Payload = @"{
+            OpenDocuments.Add(DocumentViewModel.LoadFromPayload(this, @"{
   ""type"": ""AdaptiveCard"",
   ""version"": ""0.5"",
   ""body"": [
@@ -61,8 +74,7 @@ namespace XamlCardVisualizer.ViewModel
       ""text"": ""Untitled card""
     }
   ]
-}"
-            });
+}"));
             CurrentDocument = OpenDocuments.Last();
         }
 

--- a/source/uwp/Visualizer/XamlCardVisualizer.csproj
+++ b/source/uwp/Visualizer/XamlCardVisualizer.csproj
@@ -48,6 +48,9 @@
     <Compile Include="DocumentView.xaml.cs">
       <DependentUpon>DocumentView.xaml</DependentUpon>
     </Compile>
+    <Compile Include="GenericDocumentView.xaml.cs">
+      <DependentUpon>GenericDocumentView.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Helpers\BindableBase.cs" />
     <Compile Include="Helpers\IListExtensions.cs" />
     <Compile Include="Helpers\PayloadValidator.cs" />
@@ -61,6 +64,8 @@
       <DependentUpon>TabView.xaml</DependentUpon>
     </Compile>
     <Compile Include="ViewModel\ErrorViewModel.cs" />
+    <Compile Include="ViewModel\GenericDocumentViewModel.cs" />
+    <Compile Include="ViewModel\HostConfigEditorViewModel.cs" />
     <Compile Include="ViewModel\MainPageViewModel.cs" />
     <Compile Include="ViewModel\DocumentViewModel.cs" />
   </ItemGroup>
@@ -98,6 +103,7 @@
     <Content Include="..\..\..\schemas\host-config.json">
       <Link>Schemas\renderer-options.json</Link>
     </Content>
+    <Content Include="HostConfigs\DefaultHostConfig.json" />
     <None Include="XamlCardVisualizer_TemporaryKey.pfx" />
   </ItemGroup>
   <ItemGroup>
@@ -118,6 +124,10 @@
       <SubType>Designer</SubType>
     </ApplicationDefinition>
     <Page Include="DocumentView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="GenericDocumentView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -155,9 +165,7 @@
       <Version>3.0.3</Version>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="HostConfigs\" />
-  </ItemGroup>
+  <ItemGroup />
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>


### PR DESCRIPTION
This fixes #667 where colors specified in host config get rendered incorrectly in UWP renderer.

As part of this I also added a host config editor to the UWP Visualizer so we can test host config changes.

For the incorrect colors, UWP was parsing as ARBG, which is incorrect, it's supposed to be ARGB

That results in colors like this
![image](https://user-images.githubusercontent.com/13246069/30756189-797cf3c8-9f7e-11e7-9b15-4921e6533ac3.png)

```c
    std::string alphaString = colorString.substr(1, 2);
    INT32 alpha = strtol(alphaString.c_str(), nullptr, 16);

    std::string redString = colorString.substr(3, 2);
    INT32 red = strtol(redString.c_str(), nullptr, 16);

    // GREEN should be parsed here
    std::string blueString = colorString.substr(5, 2);
    INT32 blue = strtol(blueString.c_str(), nullptr, 16);

    std::string greenString = colorString.substr(7, 2);
    INT32 green = strtol(greenString.c_str(), nullptr, 16);
```

After that simple fix, it's displayed correctly

![image](https://user-images.githubusercontent.com/13246069/30756394-66173428-9f7f-11e7-9d8e-e5bbd6d06d7b.png)


As for the new host config editor, you can now edit the host config in the UWP Visualizer. I also made some improvements so that cards only get rendered when you select the tab (rather than rendering ALL tabs at once regardless of which one is actually open).

So lots of edits in the Visualizer code, but only one file modification in the actual renderer code.