### PR TITLE
Rename normal to default

### DIFF
--- a/samples/v1.0/Elements/Image.Style.json
+++ b/samples/v1.0/Elements/Image.Style.json
@@ -5,7 +5,7 @@
   "body": [
     {
       "type": "TextBlock",
-      "text": "style: normal",
+      "text": "style: default",
       "weight": "bolder"
     },
     {

--- a/source/shared/cpp/ObjectModel/Enums.cpp
+++ b/source/shared/cpp/ObjectModel/Enums.cpp
@@ -73,7 +73,6 @@ static std::unordered_map<AdaptiveCardSchemaKey, std::string, EnumHash> Adaptive
     { AdaptiveCardSchemaKey::Method, "method" },
     { AdaptiveCardSchemaKey::Min, "min" },
     { AdaptiveCardSchemaKey::MinVersion, "minVersion" },
-    { AdaptiveCardSchemaKey::Normal, "normal" },
     { AdaptiveCardSchemaKey::NumberInput, "numberInput" },
     { AdaptiveCardSchemaKey::Padding, "padding" },
     { AdaptiveCardSchemaKey::Placeholder, "placeholder" },
@@ -174,12 +173,16 @@ SeparatorThicknessNameToEnum = GenerateStringToEnumMap<SeparatorThickness>(Separ
 
 static std::unordered_map<ImageStyle, std::string, EnumHash> ImageStyleEnumToName =
 {
-    {ImageStyle::Normal, "normal"},
+    {ImageStyle::Default, "default"},
     {ImageStyle::Person, "person"}
 };
 
-static std::unordered_map<std::string, ImageStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo>
-ImageStyleNameToEnum = GenerateStringToEnumMap<ImageStyle>(ImageStyleEnumToName);
+static std::unordered_map<std::string, ImageStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo> ImageStyleNameToEnum = 
+{
+    { "default", ImageStyle::Default},
+    { "person", ImageStyle::Person},
+    { "normal", ImageStyle::Default} // Back compat to support "Normal" for "Default" for pre V1.0 payloads
+};
 
 static std::unordered_map<ImageSize, std::string, EnumHash> ImageSizeEnumToName =
 {
@@ -222,23 +225,35 @@ static std::unordered_map<TextWeight, std::string, EnumHash> TextWeightEnumToNam
 {
     {TextWeight::Bolder, "Bolder"},
     {TextWeight::Lighter, "Lighter"},
-    {TextWeight::Normal, "Normal"},
+    {TextWeight::Default, "Default"},
 };
 
-static std::unordered_map<std::string, TextWeight, CaseInsensitiveHash, CaseInsensitiveEqualTo>
-TextWeightNameToEnum = GenerateStringToEnumMap<TextWeight>(TextWeightEnumToName);
+static std::unordered_map<std::string, TextWeight, CaseInsensitiveHash, CaseInsensitiveEqualTo> TextWeightNameToEnum = 
+{
+    { "Bolder", TextWeight::Bolder},
+    { "Lighter", TextWeight::Lighter},
+    { "Default", TextWeight::Default},
+    { "Normal", TextWeight::Default }, // Back compat to support "Normal" for "Default" for pre V1.0 payloads
+};
 
 static std::unordered_map<TextSize, std::string, EnumHash> TextSizeEnumToName =
 {
     {TextSize::ExtraLarge, "ExtraLarge"},
     {TextSize::Large, "Large"},
     {TextSize::Medium, "Medium"},
-    {TextSize::Normal, "Normal"},
+    {TextSize::Default, "Default"},
     {TextSize::Small, "Small"},
 };
 
-static std::unordered_map<std::string, TextSize, CaseInsensitiveHash, CaseInsensitiveEqualTo>
-TextSizeNameToEnum = GenerateStringToEnumMap<TextSize>(TextSizeEnumToName);
+static std::unordered_map<std::string, TextSize, CaseInsensitiveHash, CaseInsensitiveEqualTo> TextSizeNameToEnum = 
+{
+    { "ExtraLarge", TextSize::ExtraLarge },
+    { "Large", TextSize::Large },
+    { "Medium", TextSize::Medium },
+    { "Default", TextSize::Default },
+    { "Small", TextSize::Small },
+    { "Normal", TextSize::Default }, // Back compat to support "Normal" for "Default" for pre V1.0 payloads
+};
 
 static std::unordered_map<ActionsOrientation, std::string, EnumHash> ActionsOrientationEnumToName =
 {

--- a/source/shared/cpp/ObjectModel/Enums.h
+++ b/source/shared/cpp/ObjectModel/Enums.h
@@ -102,7 +102,6 @@ enum class AdaptiveCardSchemaKey
     Method,
     Min,
     MinVersion,
-    Normal,
     NumberInput,
     Padding,
     Placeholder,
@@ -146,7 +145,7 @@ enum class AdaptiveCardSchemaKey
 enum class TextSize
 {
     Small = 0,
-    Normal,
+    Default,
     Medium,
     Large,
     ExtraLarge
@@ -154,7 +153,7 @@ enum class TextSize
 
 enum class TextWeight {
     Lighter = 0,
-    Normal,
+    Default,
     Bolder
 };
 
@@ -175,7 +174,7 @@ enum class HorizontalAlignment {
 };
 
 enum class ImageStyle {
-    Normal = 0,
+    Default = 0,
     Person
 };
 

--- a/source/shared/cpp/ObjectModel/HostConfig.cpp
+++ b/source/shared/cpp/ObjectModel/HostConfig.cpp
@@ -47,7 +47,7 @@ FontSizesConfig FontSizesConfig::Deserialize(const Json::Value& json, const Font
 {
     FontSizesConfig result;
     result.smallFontSize = ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::Small, defaultValue.smallFontSize);
-    result.normalFontSize = ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::Normal, defaultValue.normalFontSize);
+    result.defaultFontSize = ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::Default, defaultValue.defaultFontSize);
     result.mediumFontSize = ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::Medium, defaultValue.mediumFontSize);
     result.largeFontSize = ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::Large, defaultValue.largeFontSize);
     result.extraLargeFontSize = ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::ExtraLarge, defaultValue.extraLargeFontSize);
@@ -69,11 +69,11 @@ SpacingDefinition SpacingDefinition::Deserialize(const Json::Value& json, const 
 ColorConfig ColorConfig::Deserialize(const Json::Value& json, const ColorConfig& defaultValue)
 {
     ColorConfig result;
-    std::string normal = ParseUtil::GetString(json, AdaptiveCardSchemaKey::Normal);
-    result.normal = normal == "" ? defaultValue.normal : normal;
+    std::string defaultColor = ParseUtil::GetString(json, AdaptiveCardSchemaKey::Default);
+    result.defaultColor = defaultColor == "" ? defaultValue.defaultColor : defaultColor;
 
-    std::string subtle = ParseUtil::GetString(json, AdaptiveCardSchemaKey::Subtle);
-    result.subtle = subtle == "" ? defaultValue.subtle: subtle;
+    std::string subtleColor = ParseUtil::GetString(json, AdaptiveCardSchemaKey::Subtle);
+    result.subtleColor = subtleColor == "" ? defaultValue.subtleColor: subtleColor;
 
     return result;
 }

--- a/source/shared/cpp/ObjectModel/HostConfig.h
+++ b/source/shared/cpp/ObjectModel/HostConfig.h
@@ -19,7 +19,7 @@ struct SpacingDefinition
 struct FontSizesConfig
 {
     unsigned int smallFontSize = 10;
-    unsigned int normalFontSize = 12;
+    unsigned int defaultFontSize = 12;
     unsigned int mediumFontSize = 14;
     unsigned int largeFontSize = 17;
     unsigned int extraLargeFontSize = 20;
@@ -29,8 +29,8 @@ struct FontSizesConfig
 
 struct ColorConfig
 {
-    std::string normal;
-    std::string subtle;
+    std::string defaultColor;
+    std::string subtleColor;
 
     static ColorConfig Deserialize(const Json::Value& json, const ColorConfig& defaultValue);
 };
@@ -50,8 +50,8 @@ struct ColorsConfig
 
 struct TextConfig
 {
-    TextWeight weight = TextWeight::Normal;
-    TextSize size = TextSize::Normal;
+    TextWeight weight = TextWeight::Default;
+    TextSize size = TextSize::Default;
     ForegroundColor color = ForegroundColor::Default;
     bool isSubtle = false;
 

--- a/source/shared/cpp/ObjectModel/Image.cpp
+++ b/source/shared/cpp/ObjectModel/Image.cpp
@@ -5,7 +5,7 @@ using namespace AdaptiveCards;
 
 Image::Image() :
     BaseCardElement(CardElementType::Image),
-    m_imageStyle(ImageStyle::Normal),
+    m_imageStyle(ImageStyle::Default),
     m_imageSize(ImageSize::Auto),
     m_hAlignment(HorizontalAlignment::Left)
 {
@@ -40,7 +40,7 @@ std::shared_ptr<Image> Image::DeserializeWithoutCheckingType(const Json::Value& 
     std::shared_ptr<Image> image = BaseCardElement::Deserialize<Image>(json);
 
     image->SetUrl(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Url, true));
-    image->SetImageStyle(ParseUtil::GetEnumValue<ImageStyle>(json, AdaptiveCardSchemaKey::Style, ImageStyle::Normal, ImageStyleFromString));
+    image->SetImageStyle(ParseUtil::GetEnumValue<ImageStyle>(json, AdaptiveCardSchemaKey::Style, ImageStyle::Default, ImageStyleFromString));
     image->SetImageSize(ParseUtil::GetEnumValue<ImageSize>(json, AdaptiveCardSchemaKey::Size, ImageSize::Default, ImageSizeFromString));
     image->SetAltText(ParseUtil::GetString(json, AdaptiveCardSchemaKey::AltText));
     image->SetHorizontalAlignment(ParseUtil::GetEnumValue<HorizontalAlignment>(json, AdaptiveCardSchemaKey::HorizontalAlignment, HorizontalAlignment::Left, HorizontalAlignmentFromString));

--- a/source/shared/cpp/ObjectModel/TextBlock.cpp
+++ b/source/shared/cpp/ObjectModel/TextBlock.cpp
@@ -5,8 +5,8 @@ using namespace AdaptiveCards;
 
 TextBlock::TextBlock() :
     BaseCardElement(CardElementType::TextBlock),
-    m_textSize(TextSize::Normal),
-    m_textWeight(TextWeight::Normal),
+    m_textSize(TextSize::Default),
+    m_textWeight(TextWeight::Default),
     m_textColor(ForegroundColor::Default),
     m_isSubtle(false),
     m_wrap(false),
@@ -45,9 +45,9 @@ std::shared_ptr<TextBlock> TextBlock::Deserialize(const Json::Value& json)
     std::shared_ptr<TextBlock> textBlock = BaseCardElement::Deserialize<TextBlock>(json);
 
     textBlock->SetText(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Text, true));
-    textBlock->SetTextSize(ParseUtil::GetEnumValue<TextSize>(json, AdaptiveCardSchemaKey::Size, TextSize::Normal, TextSizeFromString));
+    textBlock->SetTextSize(ParseUtil::GetEnumValue<TextSize>(json, AdaptiveCardSchemaKey::Size, TextSize::Default, TextSizeFromString));
     textBlock->SetTextColor(ParseUtil::GetEnumValue<ForegroundColor>(json, AdaptiveCardSchemaKey::Color, ForegroundColor::Default, ForegroundColorFromString));
-    textBlock->SetTextWeight(ParseUtil::GetEnumValue<TextWeight>(json, AdaptiveCardSchemaKey::TextWeight, TextWeight::Normal, TextWeightFromString));
+    textBlock->SetTextWeight(ParseUtil::GetEnumValue<TextWeight>(json, AdaptiveCardSchemaKey::TextWeight, TextWeight::Default, TextWeightFromString));
     textBlock->SetWrap(ParseUtil::GetBool(json, AdaptiveCardSchemaKey::Wrap, false));
     textBlock->SetIsSubtle(ParseUtil::GetBool(json, AdaptiveCardSchemaKey::IsSubtle, false));
     textBlock->SetMaxLines(ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::MaxLines, 0));

--- a/source/uwp/Renderer/idl/AdaptiveCards.XamlCardRenderer.idl
+++ b/source/uwp/Renderer/idl/AdaptiveCards.XamlCardRenderer.idl
@@ -100,7 +100,7 @@ namespace AdaptiveCards
         typedef [v1_enum] enum TextSize
         {
             Small = 0,
-            Normal,
+            Default,
             Medium,
             Large,
             ExtraLarge
@@ -110,7 +110,7 @@ namespace AdaptiveCards
         typedef [v1_enum] enum TextWeight
         {
             Lighter = 0,
-            Normal,
+            Default,
             Bolder
         } TextWeight;
 
@@ -167,7 +167,7 @@ namespace AdaptiveCards
 
         [version(NTDDI_WIN10_RS1)]
         typedef [v1_enum] enum ImageStyle {
-            Normal = 0,
+            Default = 0,
             Person
         } ImageStyle;
 
@@ -925,8 +925,8 @@ namespace AdaptiveCards
             [propget] HRESULT Small([out, retval] UINT32 *value);
             [propput] HRESULT Small([in] UINT32 value);
 
-            [propget] HRESULT Normal([out, retval] UINT32 *value);
-            [propput] HRESULT Normal([in] UINT32 value);
+            [propget] HRESULT Default([out, retval] UINT32 *value);
+            [propput] HRESULT Default([in] UINT32 value);
 
             [propget] HRESULT Medium([out, retval] UINT32 *value);
             [propput] HRESULT Medium([in] UINT32 value);
@@ -954,8 +954,8 @@ namespace AdaptiveCards
         ]
         interface IAdaptiveColorConfig : IInspectable
         {
-            [propget] HRESULT Normal([out][retval] Windows.UI.Color* value);
-            [propput] HRESULT Normal([in] Windows.UI.Color value);
+            [propget] HRESULT Default([out][retval] Windows.UI.Color* value);
+            [propput] HRESULT Default([in] Windows.UI.Color value);
 
             [propget] HRESULT Subtle([out][retval] Windows.UI.Color* value);
             [propput] HRESULT Subtle([in] Windows.UI.Color value);

--- a/source/uwp/Renderer/lib/AdaptiveColorConfig.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveColorConfig.cpp
@@ -21,13 +21,13 @@ namespace AdaptiveCards { namespace XamlCardRenderer
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveColorConfig::get_Normal(ABI::Windows::UI::Color* value)
+    HRESULT AdaptiveColorConfig::get_Default(ABI::Windows::UI::Color* value)
     {
-        return GetColorFromString(m_sharedColorConfig.normal, value);
+        return GetColorFromString(m_sharedColorConfig.defaultColor, value);
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveColorConfig::put_Normal(ABI::Windows::UI::Color /*value*/)
+    HRESULT AdaptiveColorConfig::put_Default(ABI::Windows::UI::Color /*value*/)
     {
         return E_NOTIMPL;
     }
@@ -35,7 +35,7 @@ namespace AdaptiveCards { namespace XamlCardRenderer
     _Use_decl_annotations_
     HRESULT AdaptiveColorConfig::get_Subtle(ABI::Windows::UI::Color* value)
     {
-        return GetColorFromString(m_sharedColorConfig.subtle, value);
+        return GetColorFromString(m_sharedColorConfig.subtleColor, value);
     }
 
     _Use_decl_annotations_

--- a/source/uwp/Renderer/lib/AdaptiveColorConfig.h
+++ b/source/uwp/Renderer/lib/AdaptiveColorConfig.h
@@ -17,8 +17,8 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         HRESULT RuntimeClassInitialize() noexcept;
         HRESULT RuntimeClassInitialize(ColorConfig colorConfig) noexcept;
 
-        IFACEMETHODIMP get_Normal(_Out_ ABI::Windows::UI::Color* value);
-        IFACEMETHODIMP put_Normal(_In_ ABI::Windows::UI::Color value);
+        IFACEMETHODIMP get_Default(_Out_ ABI::Windows::UI::Color* value);
+        IFACEMETHODIMP put_Default(_In_ ABI::Windows::UI::Color value);
 
         IFACEMETHODIMP get_Subtle(_Out_ ABI::Windows::UI::Color* value);
         IFACEMETHODIMP put_Subtle(_In_ ABI::Windows::UI::Color value);

--- a/source/uwp/Renderer/lib/AdaptiveFontSizesConfig.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveFontSizesConfig.cpp
@@ -33,16 +33,16 @@ namespace AdaptiveCards { namespace XamlCardRenderer
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveFontSizesConfig::get_Normal(UINT32* normalFontSize)
+    HRESULT AdaptiveFontSizesConfig::get_Default(UINT32* defaultFontSize)
     {
-        *normalFontSize = m_sharedFontSizesConfig.normalFontSize;
+        *defaultFontSize = m_sharedFontSizesConfig.defaultFontSize;
         return S_OK;
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveFontSizesConfig::put_Normal(UINT32 normalFontSize)
+    HRESULT AdaptiveFontSizesConfig::put_Default(UINT32 defaultFontSize)
     {
-        m_sharedFontSizesConfig.normalFontSize = normalFontSize;
+        m_sharedFontSizesConfig.defaultFontSize = defaultFontSize;
         return S_OK;
     }
 

--- a/source/uwp/Renderer/lib/AdaptiveFontSizesConfig.h
+++ b/source/uwp/Renderer/lib/AdaptiveFontSizesConfig.h
@@ -20,8 +20,8 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         IFACEMETHODIMP get_Small(_Out_ UINT32 *value);
         IFACEMETHODIMP put_Small(_In_ UINT32 value);
 
-        IFACEMETHODIMP get_Normal(_Out_ UINT32 *value);
-        IFACEMETHODIMP put_Normal(_In_ UINT32 value);
+        IFACEMETHODIMP get_Default(_Out_ UINT32 *value);
+        IFACEMETHODIMP put_Default(_In_ UINT32 value);
 
         IFACEMETHODIMP get_Medium(_Out_ UINT32 *value);
         IFACEMETHODIMP put_Medium(_In_ UINT32 value);

--- a/source/uwp/Renderer/lib/Util.cpp
+++ b/source/uwp/Renderer/lib/Util.cpp
@@ -315,7 +315,7 @@ HRESULT GetColorFromAdaptiveColor(
         break;
     }
 
-    RETURN_IF_FAILED(isSubtle ? colorConfig->get_Subtle(uiColor) : colorConfig->get_Normal(uiColor));
+    RETURN_IF_FAILED(isSubtle ? colorConfig->get_Subtle(uiColor) : colorConfig->get_Default(uiColor));
 
     return S_OK;
 } CATCH_RETURN;

--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -1093,9 +1093,6 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         case ABI::AdaptiveCards::XamlCardRenderer::TextSize::Small:
             THROW_IF_FAILED(fontSizesConfig->get_Small(&fontSize));
             break;
-        case ABI::AdaptiveCards::XamlCardRenderer::TextSize::Normal:
-            THROW_IF_FAILED(fontSizesConfig->get_Normal(&fontSize));
-            break;
         case ABI::AdaptiveCards::XamlCardRenderer::TextSize::Medium:
             THROW_IF_FAILED(fontSizesConfig->get_Medium(&fontSize));
             break;
@@ -1105,8 +1102,9 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         case ABI::AdaptiveCards::XamlCardRenderer::TextSize::ExtraLarge:
             THROW_IF_FAILED(fontSizesConfig->get_ExtraLarge(&fontSize));
             break;
+        case ABI::AdaptiveCards::XamlCardRenderer::TextSize::Default:
         default:
-            THROW_IF_FAILED(fontSizesConfig->get_Normal(&fontSize));
+            THROW_IF_FAILED(fontSizesConfig->get_Default(&fontSize));
             break;
         }
         THROW_IF_FAILED(localTextBlock->put_FontSize((double)fontSize));
@@ -1117,12 +1115,10 @@ namespace AdaptiveCards { namespace XamlCardRenderer
         case ABI::AdaptiveCards::XamlCardRenderer::TextWeight::Lighter:
             THROW_IF_FAILED(m_fontWeightsStatics->get_Light(&xamlFontWeight));
             break;
-        case ABI::AdaptiveCards::XamlCardRenderer::TextWeight::Normal:
-            THROW_IF_FAILED(m_fontWeightsStatics->get_Normal(&xamlFontWeight));
-            break;
         case ABI::AdaptiveCards::XamlCardRenderer::TextWeight::Bolder:
             THROW_IF_FAILED(m_fontWeightsStatics->get_Bold(&xamlFontWeight));
             break;
+        case ABI::AdaptiveCards::XamlCardRenderer::TextWeight::Default:
         default:
             THROW_IF_FAILED(m_fontWeightsStatics->get_Normal(&xamlFontWeight));
             break;


### PR DESCRIPTION
Address issue #630.  Rename normal to default, but support "normal" in cards where we do today to preserve back compat.