### PR TITLE
Bug fixes

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Html/Rendering/HtmlRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Html/Rendering/HtmlRenderer.cs
@@ -422,8 +422,8 @@ namespace AdaptiveCards.Rendering
                         uiColumnSet.Children.Add(new DivTag()
                             .AddClass($"ac-columnseparator")
                             .Style("flex", "0 0 auto")
-                            .Style("padding-left", $"{sep.Spacing}")
-                            .Style("margin-left", $"{sep.Spacing}")
+                            .Style("padding-left", $"{sep.Spacing}px")
+                            .Style("margin-left", $"{sep.Spacing}px")
                             .Style("border-left-color", $"{context.GetRGBColor(sep.LineColor)}")
                             .Style("border-left-width", $"{sep.LineThickness}px")
                             .Style("border-left-style", $"solid"));

--- a/source/dotnet/Library/AdaptiveCards.Html/Rendering/RenderContext.cs
+++ b/source/dotnet/Library/AdaptiveCards.Html/Rendering/RenderContext.cs
@@ -122,6 +122,10 @@ namespace AdaptiveCards.Rendering
                     return this.Config.TimeInput.Separation;
                 case NumberInput.TYPE:
                     return this.Config.NumberInput.Separation;
+                case ToggleInput.TYPE:
+                    return this.Config.ToggleInput.Separation;
+                case FactSet.TYPE:
+                    return this.Config.FactSet.Separation;
             }
             throw new Exception("Unknown type " + element.Type);
         }


### PR DESCRIPTION
1. ColumnSet padding does not set the unit thus padding is not effective.
2. RenderContext.GetElementSeparation() does not accept FactSet and ToggleInput thus will throw exceptions when factset and toggle input is present and contains separation.