### PR TITLE
Update .NET nuget packages

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Html/AdaptiveCards.Html.csproj
+++ b/source/dotnet/Library/AdaptiveCards.Html/AdaptiveCards.Html.csproj
@@ -2,27 +2,27 @@
 
   <PropertyGroup>
     <TargetFrameworks>net4.5.2;netstandard1.3</TargetFrameworks>
-    <PackageId>Microsoft.AdaptiveCards.Html</PackageId>
-    <Authors>Microsoft Corporation</Authors>
+    <PackageId>AdaptiveCards.Renderer.Html</PackageId>
+    <Authors>Microsoft</Authors>
     <summary>Adaptive Card HTML Rednobject model for .NET</summary>
     <Description>This library implements classes for rendering adaptive card objects into HTML</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageTags>adaptivecards</PackageTags>
-    <PackageProjectUrl>http://adaptivecards.io</PackageProjectUrl>
+    <PackageTags>Adaptive Cards</PackageTags>
+    <PackageProjectUrl>https://github.com/Microsoft/AdaptiveCards</PackageProjectUrl>
     <PacakgeIconUrl>https://bots.botframework.com/Client/Images/bot-framework-default-1.png</PacakgeIconUrl>
     <language>en-US</language>
     <PackageLicenseUrl>https://github.com/Microsoft/AdaptiveCards/blob/master/LICENSE</PackageLicenseUrl>
     <Copyright>Microsoft Corporation</Copyright>
-    <Company>Microsoft Corporation</Company>
+    <Company>Microsoft</Company>
     <PackageIconUrl>http://adaptivecards.io/content/icons_blue/blue-48.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/Microsoft/AdaptiveCards</RepositoryUrl>
     <RepositoryType />
     <PackageReleaseNotes />
-    <Version>0.5.3</Version>
-    <VersionPrefix>0.5.2</VersionPrefix>
-    <Product>Microsoft.AdaptiveCards.Html</Product>
-    <AssemblyVersion>0.5.3.0</AssemblyVersion>
-    <FileVersion>0.5.3.0</FileVersion>
+    <Version>1.0.0-beta1</Version>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <Product>AdaptiveCards.Renderer.Html</Product>
+    <AssemblyVersion>1.0.0</AssemblyVersion>
+    <FileVersion>1.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/dotnet/Library/AdaptiveCards.Xaml.Wpf/AdaptiveCards.Xaml.Wpf.nuspec
+++ b/source/dotnet/Library/AdaptiveCards.Xaml.Wpf/AdaptiveCards.Xaml.Wpf.nuspec
@@ -1,18 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" >
   <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
-    <id>$id$</id>
-    <version>$version$</version>
+    <id>AdaptiveCards.Renderer.Wpf</id>
+    <version>1.0.0-beta1</version>
     <authors>Microsoft</authors>
+    <owners>microsoft</owners>
     <iconUrl>http://adaptivecards.io/content/icons_blue/blue-48.png</iconUrl>
     <projectUrl>https://github.com/Microsoft/AdaptiveCards</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <summary>Adaptive Card renderer for XAML/WPF</summary>
-    <description>This library implements classes for rendering adaptive card objects into XAML/WPF</description>
+    <summary>Adaptive Card renderer for WPF</summary>
+    <description>This library implements classes for rendering adaptive card objects into WPF XAML</description>
     <language>en-US</language>
-    <tags>adaptivecards</tags>
+    <tags>Adaptive Cards</tags>
     <dependencies>
-      <dependency id="Microsoft.AdaptiveCards" version="0.5.0" />
+      <dependency id="AdaptiveCards" version="1.0.0-beta" />
     </dependencies>
   </metadata>
 </package>

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveCards.csproj
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveCards.csproj
@@ -2,23 +2,23 @@
 
   <PropertyGroup>
     <TargetFrameworks>net4.5.2;netstandard1.3</TargetFrameworks>
-    <PackageId>Microsoft.AdaptiveCards</PackageId>
-    <VersionPrefix>1.0.14</VersionPrefix>
+    <PackageId>AdaptiveCards</PackageId>
+    <VersionPrefix>1.0.0</VersionPrefix>
     <Authors>Microsoft</Authors>
-    <summary>Adaptive Card object model for .NET</summary>
-    <Description>This library implements classes for building and serializing adaptive card objects</Description>
+    <Owners>microsoft</Owners>
+    <summary>Adaptive Card library for .NET C# developers, including UWP C# developers.</summary>
+    <Description>This library exposes the Adaptive Card object model for authoring Adaptive Cards. Built for .NET C#, including UWP C#.</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageTags>adaptivecards</PackageTags>
-    <PackageProjectUrl>http://adaptivecards.io</PackageProjectUrl>
-    <PacakgeIconUrl>https://bots.botframework.com/Client/Images/bot-framework-default-1.png</PacakgeIconUrl>
+    <PackageTags>Adaptive Cards</PackageTags>
+    <PackageProjectUrl>https://github.com/Microsoft/AdaptiveCards</PackageProjectUrl>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <PackageIconUrl>http://adaptivecards.io/content/icons_blue/blue-48.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/Microsoft/AdaptiveCards</RepositoryUrl>
     <RepositoryType></RepositoryType>
     <PackageLicenseUrl>https://github.com/Microsoft/AdaptiveCards/blob/master/LICENSE</PackageLicenseUrl>
-    <AssemblyVersion>0.5.1.0</AssemblyVersion>
-    <Version>0.5.1</Version>
-    <FileVersion>0.5.1.0</FileVersion>
+    <AssemblyVersion>1.0.0</AssemblyVersion>
+    <Version>1.0.0-beta1</Version>
+    <FileVersion>1.0.0</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net4.5.2|AnyCPU'">


### PR DESCRIPTION
Main AdaptiveCards library definitely works

AdaptiveCards.Renderer.Html keeps on referencing Microsoft.AdaptiveCards instead of just AdaptiveCards so won't work

Not sure how to build the Wpf Nuget, but I updated the nuspec file to be correct, so if you build it somehow it should be right