### PR TITLE
Fix shared model not parsing separator hostConfig

### DIFF
--- a/source/shared/cpp/ObjectModel/HostConfig.cpp
+++ b/source/shared/cpp/ObjectModel/HostConfig.cpp
@@ -27,6 +27,9 @@ HostConfig HostConfig::Deserialize(const Json::Value& json)
     result.imageSizes = ParseUtil::ExtractJsonValueAndMergeWithDefault<ImageSizesConfig>(
         json, AdaptiveCardSchemaKey::ImageSizes, result.imageSizes, ImageSizesConfig::Deserialize);
 
+    result.separator = ParseUtil::ExtractJsonValueAndMergeWithDefault<SeparatorConfig>(
+        json, AdaptiveCardSchemaKey::Separator, result.separator, SeparatorConfig::Deserialize);
+
     result.spacing = ParseUtil::ExtractJsonValueAndMergeWithDefault<SpacingConfig>(
         json, AdaptiveCardSchemaKey::Spacing, result.spacing, SpacingConfig::Deserialize);
 

--- a/source/uwp/Visualizer/HostConfigs/DefaultHostConfig.json
+++ b/source/uwp/Visualizer/HostConfigs/DefaultHostConfig.json
@@ -9,7 +9,7 @@
   },
   "separator": {
     "lineThickness": 1,
-    "lineColor": "#EEEEEE"
+    "lineColor": "#66000000"
   },
   "supportsInteractivity": true,
   "fontFamily": "Segoe UI",


### PR DESCRIPTION
Fixes #732

![image](https://user-images.githubusercontent.com/13246069/31035956-f0867c50-a51e-11e7-8979-c58425774cd2.png)

One-line fix. Tested and verified with UWP Visualizer. After the changes...

![image](https://user-images.githubusercontent.com/13246069/31036306-5af2c250-a520-11e7-8686-3d19c93311e5.png)

I also updated the UWP Visualizer's default HostConfig JSON payload with a nicer looking separator color