### PR TITLE
Enable use of Per-element renderers PT1.

### DIFF
--- a/source/shared/cpp/ObjectModel/Enums.h
+++ b/source/shared/cpp/ObjectModel/Enums.h
@@ -211,12 +211,13 @@ enum class CardElementType
     FactSet,
     Fact,
     ImageSet,
+    ChoiceInput,
+    ChoiceSetInput,
     DateInput,
     NumberInput,
     TextInput,
     TimeInput,
     ToggleInput,
-    ChoiceSetInput,
     Custom
 };
 

--- a/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj
+++ b/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj
@@ -114,6 +114,7 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="lib\AdaptiveActionInvoker.h" />
     <ClInclude Include="lib\AdaptiveActionParserRegistration.h" />
     <ClInclude Include="lib\AdaptiveActionRendererRegistration.h" />
     <ClInclude Include="lib\AdaptiveActionsConfig.h" />
@@ -192,6 +193,7 @@
     <ClInclude Include="lib\Util.h" />
     <ClInclude Include="lib\Vector.h" />
     <ClInclude Include="lib\XamlBuilder.h" />
+    <ClCompile Include="lib\AdaptiveActionInvoker.cpp" />
     <ClCompile Include="lib\AdaptiveActionParserRegistration.cpp" />
     <ClCompile Include="lib\AdaptiveActionRendererRegistration.cpp" />
     <ClCompile Include="lib\AdaptiveActionsConfig.cpp" />

--- a/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj
+++ b/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj
@@ -140,6 +140,7 @@
     <ClInclude Include="lib\AdaptiveImageSizesConfig.h" />
     <ClInclude Include="lib\AdaptiveInputs.h" />
     <ClInclude Include="lib\AdaptiveNumberInputRenderer.h" />
+    <ClInclude Include="lib\AdaptiveRenderArgs.h" />
     <ClInclude Include="lib\AdaptiveOpenUrlActionRenderer.h" />
     <ClInclude Include="lib\AdaptiveRenderContext.h" />
     <ClInclude Include="lib\AdaptiveSeparator.h" />
@@ -217,6 +218,7 @@
     <ClCompile Include="lib\AdaptiveImageSizesConfig.cpp" />
     <ClCompile Include="lib\AdaptiveInputs.cpp" />
     <ClCompile Include="lib\AdaptiveNumberInputRenderer.cpp" />
+    <ClCompile Include="lib\AdaptiveRenderArgs.cpp" />
     <ClCompile Include="lib\AdaptiveOpenUrlActionRenderer.cpp" />
     <ClCompile Include="lib\AdaptiveRenderContext.cpp" />
     <ClCompile Include="lib\AdaptiveSeparator.cpp" />

--- a/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj.filters
+++ b/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj.filters
@@ -70,6 +70,9 @@
     <ClCompile Include="lib\AdaptiveSubmitActionRenderer.cpp" />
     <ClCompile Include="lib\AdaptiveCardParseResult.cpp" />
     <ClCompile Include="lib\AdaptiveHostConfigParseResult.cpp" />
+    <ClCompile Include="lib\AdaptiveColumnSetRenderer.cpp" />
+    <ClCompile Include="lib\AdaptiveContainerRenderer.cpp" />
+    <ClCompile Include="lib\AdaptiveRenderArgs.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="lib\AdaptiveCard.h" />
@@ -151,6 +154,7 @@
     <ClInclude Include="lib\AdaptiveSubmitActionRenderer.h" />
     <ClInclude Include="lib\AdaptiveCardParseResult.h" />
     <ClInclude Include="lib\AdaptiveHostConfigParseResult.h" />
+    <ClInclude Include="lib\AdaptiveRenderArgs.h" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="idl\AdaptiveCards.Uwp.idl" />

--- a/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj.filters
+++ b/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj.filters
@@ -73,6 +73,7 @@
     <ClCompile Include="lib\AdaptiveColumnSetRenderer.cpp" />
     <ClCompile Include="lib\AdaptiveContainerRenderer.cpp" />
     <ClCompile Include="lib\AdaptiveRenderArgs.cpp" />
+    <ClCompile Include="lib\AdaptiveActionInvoker.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="lib\AdaptiveCard.h" />
@@ -155,6 +156,7 @@
     <ClInclude Include="lib\AdaptiveCardParseResult.h" />
     <ClInclude Include="lib\AdaptiveHostConfigParseResult.h" />
     <ClInclude Include="lib\AdaptiveRenderArgs.h" />
+    <ClInclude Include="lib\AdaptiveActionInvoker.h" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="idl\AdaptiveCards.Uwp.idl" />

--- a/source/uwp/Renderer/idl/AdaptiveCards.Uwp.idl
+++ b/source/uwp/Renderer/idl/AdaptiveCards.Uwp.idl
@@ -72,6 +72,7 @@ namespace AdaptiveCards
         runtimeclass AdaptiveOpenUrlActionRenderer;
         runtimeclass AdaptiveRenderContext;
         runtimeclass AdaptiveRenderArgs;
+        runtimeclass AdaptiveActionInvoker;
         runtimeclass AdaptiveShowCardActionRenderer;
         runtimeclass AdaptiveSubmitActionRenderer;
         runtimeclass AdaptiveTextBlockRenderer;
@@ -138,6 +139,7 @@ namespace AdaptiveCards
         interface IAdaptiveElementRendererRegistration;
         interface IAdaptiveRenderContext;
         interface IAdaptiveRenderArgs;
+        interface IAdaptiveActionInvoker;
 
         [version(NTDDI_WIN10_RS1)]
         typedef [v1_enum] enum TextSize
@@ -1732,6 +1734,25 @@ namespace AdaptiveCards
         };
 
         [
+            uuid(c7435e94-1028-4543-b52e-54126fcb411f),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveActionInvoker)
+        ]
+        interface IAdaptiveActionInvoker : IInspectable
+        {
+            HRESULT SendActionEvent([in] IAdaptiveActionElement* actionElement);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveActionInvoker
+        {
+            [default] interface IAdaptiveActionInvoker;
+        };
+
+        [
             uuid(d2ad59a2-01aa-4b39-b2a7-5ce1d4028fbb),
             version(NTDDI_WIN10_RS1),
             exclusiveto(AdaptiveRenderContext)
@@ -1744,12 +1765,9 @@ namespace AdaptiveCards
 
             [propget] HRESULT ActionRenderers([out, retval] AdaptiveActionRendererRegistration** value);
 
-            [propget] HRESULT UserInputs([out, retval] AdaptiveInputs** value);
+            [propget] HRESULT ActionInvoker([out, retval] AdaptiveActionInvoker** value);
 
             HRESULT AddInputItem([in] IAdaptiveCardElement* cardElement, [in] Windows.UI.Xaml.UIElement* uiElement);
-
-            HRESULT SendActionEvent([in] AdaptiveActionEventArgs* eventArgs);
-
         };
 
         [

--- a/source/uwp/Renderer/idl/AdaptiveCards.Uwp.idl
+++ b/source/uwp/Renderer/idl/AdaptiveCards.Uwp.idl
@@ -71,6 +71,7 @@ namespace AdaptiveCards
         runtimeclass AdaptiveNumberInputRenderer;
         runtimeclass AdaptiveOpenUrlActionRenderer;
         runtimeclass AdaptiveRenderContext;
+        runtimeclass AdaptiveRenderArgs;
         runtimeclass AdaptiveShowCardActionRenderer;
         runtimeclass AdaptiveSubmitActionRenderer;
         runtimeclass AdaptiveTextBlockRenderer;
@@ -136,6 +137,7 @@ namespace AdaptiveCards
         interface IAdaptiveElementRenderer;
         interface IAdaptiveElementRendererRegistration;
         interface IAdaptiveRenderContext;
+        interface IAdaptiveRenderArgs;
 
         [version(NTDDI_WIN10_RS1)]
         typedef [v1_enum] enum TextSize
@@ -1742,9 +1744,6 @@ namespace AdaptiveCards
 
             [propget] HRESULT ActionRenderers([out, retval] AdaptiveActionRendererRegistration** value);
 
-            [propget] HRESULT ParentContainerStyle([out, retval] ContainerStyle* value);
-            [propput] HRESULT ParentContainerStyle([in] ContainerStyle value);
-
             [propget] HRESULT UserInputs([out, retval] AdaptiveInputs** value);
 
             HRESULT AddInputItem([in] IAdaptiveCardElement* cardElement, [in] Windows.UI.Xaml.UIElement* uiElement);
@@ -1768,7 +1767,7 @@ namespace AdaptiveCards
         ]
         interface IAdaptiveElementRenderer : IInspectable
         {
-            HRESULT Render([in] IAdaptiveCardElement* element, [in] AdaptiveRenderContext* context, [out, retval] Windows.UI.Xaml.UIElement** result);
+            HRESULT Render([in] IAdaptiveCardElement* element, [in] AdaptiveRenderContext* context, [in] AdaptiveRenderArgs* renderArgs, [out, retval] Windows.UI.Xaml.UIElement** result);
         };
 
         [
@@ -1931,6 +1930,25 @@ namespace AdaptiveCards
         runtimeclass AdaptiveShowCardActionRenderer
         {
             [default] interface IAdaptiveActionRenderer;
+        };
+
+        [
+            uuid(8615baba-2695-46d2-a764-9ab473c65bb9),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveRenderArgs)
+        ]
+        interface IAdaptiveRenderArgs : IInspectable
+        {
+            [propget] HRESULT ContainerStyle([out, retval] ContainerStyle* value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveRenderArgs
+        {
+            [default] interface IAdaptiveRenderArgs;
         };
 
     }

--- a/source/uwp/Renderer/idl/AdaptiveCards.Uwp.idl
+++ b/source/uwp/Renderer/idl/AdaptiveCards.Uwp.idl
@@ -849,15 +849,6 @@ namespace AdaptiveCards
             interface IAdaptiveCardElement;
         };
 
-        [flags]
-        [version(NTDDI_WIN10_RS1)]
-        typedef [v1_enum] enum RenderOptions
-        {
-            None = 0x0,
-            SupportsActionBar = 0x1,
-            SupportsInlineActions = 0x2,
-        }RenderOptions;
-
         [
             uuid(b0586bc4-b62a-4520-84b8-6c2afb88d022),
             version(NTDDI_WIN10_RS1),
@@ -1750,6 +1741,15 @@ namespace AdaptiveCards
             [propget] HRESULT ElementRenderers([out, retval] AdaptiveElementRendererRegistration** value);
 
             [propget] HRESULT ActionRenderers([out, retval] AdaptiveActionRendererRegistration** value);
+
+            [propget] HRESULT ParentContainerStyle([out, retval] ContainerStyle* value);
+            [propput] HRESULT ParentContainerStyle([in] ContainerStyle value);
+
+            [propget] HRESULT UserInputs([out, retval] AdaptiveInputs** value);
+
+            HRESULT AddInputItem([in] IAdaptiveCardElement* cardElement, [in] Windows.UI.Xaml.UIElement* uiElement);
+
+            HRESULT SendActionEvent([in] AdaptiveActionEventArgs* eventArgs);
 
         };
 

--- a/source/uwp/Renderer/lib/AdaptiveActionInvoker.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveActionInvoker.cpp
@@ -26,9 +26,7 @@ namespace AdaptiveCards { namespace Uwp
     _Use_decl_annotations_
     HRESULT AdaptiveActionInvoker::SendActionEvent(IAdaptiveActionElement* actionElement)
     {
-
         return m_renderResult->SendActionEvent(actionElement);
     }
-
 
 }}

--- a/source/uwp/Renderer/lib/AdaptiveActionInvoker.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveActionInvoker.cpp
@@ -1,0 +1,34 @@
+#include "pch.h"
+
+#include "AdaptiveActionInvoker.h"
+#include "Util.h"
+
+using namespace Microsoft::WRL;
+using namespace Microsoft::WRL::Wrappers;
+using namespace ABI::AdaptiveCards::Uwp;
+using namespace ABI::Windows::Foundation;
+using namespace ABI::Windows::UI::Xaml;
+
+namespace AdaptiveCards { namespace Uwp
+{
+    HRESULT AdaptiveActionInvoker::RuntimeClassInitialize() noexcept
+    {
+        return S_OK;
+    }
+
+    HRESULT AdaptiveActionInvoker::RuntimeClassInitialize(
+        RenderedAdaptiveCard* renderResult) noexcept try
+    {
+        m_renderResult = renderResult;
+        return S_OK;
+    } CATCH_RETURN;
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveActionInvoker::SendActionEvent(IAdaptiveActionElement* actionElement)
+    {
+
+        return m_renderResult->SendActionEvent(actionElement);
+    }
+
+
+}}

--- a/source/uwp/Renderer/lib/AdaptiveActionInvoker.h
+++ b/source/uwp/Renderer/lib/AdaptiveActionInvoker.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "AdaptiveCards.Uwp.h"
+#include "RenderedAdaptiveCard.h"
+
+namespace AdaptiveCards { namespace Uwp
+{
+    class AdaptiveActionInvoker :
+        public Microsoft::WRL::RuntimeClass<
+        Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
+        ABI::AdaptiveCards::Uwp::IAdaptiveActionInvoker>
+    {
+        InspectableClass(RuntimeClass_AdaptiveCards_Uwp_AdaptiveActionInvoker, BaseTrust)
+
+    public:
+        HRESULT RuntimeClassInitialize() noexcept;
+
+        HRESULT RuntimeClassInitialize(AdaptiveCards::Uwp::RenderedAdaptiveCard* renderResult) noexcept;
+
+        IFACEMETHODIMP SendActionEvent(ABI::AdaptiveCards::Uwp::IAdaptiveActionElement* actionElement);
+
+    private:
+        Microsoft::WRL::ComPtr<AdaptiveCards::Uwp::RenderedAdaptiveCard> m_renderResult;
+    };
+
+    ActivatableClass(AdaptiveActionInvoker);
+}}

--- a/source/uwp/Renderer/lib/AdaptiveCardRendererComponent.h
+++ b/source/uwp/Renderer/lib/AdaptiveCardRendererComponent.h
@@ -1,9 +1,12 @@
 ﻿#pragma once
 
 #include "AdaptiveCards.Uwp.h"
+#include "XamlBuilder.h"
 
 namespace AdaptiveCards { namespace Uwp
 {
+    class XamlBuilder;
+
     // This class is effectively a singleton, and stays around between subsequent renders.
     class AdaptiveCardRenderer :
         public Microsoft::WRL::RuntimeClass<
@@ -18,7 +21,6 @@ namespace AdaptiveCards { namespace Uwp
         HRESULT RuntimeClassInitialize();
 
         // IAdaptiveCardRenderer
-        IFACEMETHODIMP SetRenderOptions(_In_ ABI::AdaptiveCards::Uwp::RenderOptions options);
         IFACEMETHODIMP SetOverrideStyles(_In_ ABI::Windows::UI::Xaml::IResourceDictionary* overrideDictionary);
         IFACEMETHODIMP put_HostConfig(_In_ ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig* hostConfig);
         IFACEMETHODIMP get_HostConfig(_In_ ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig** hostConfig);
@@ -54,8 +56,8 @@ namespace AdaptiveCards { namespace Uwp
         Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Uwp::IAdaptiveCardResourceResolvers> m_resourceResolvers;
         Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Uwp::IAdaptiveElementRendererRegistration> m_elementRendererRegistration;
         Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Uwp::IAdaptiveActionRendererRegistration> m_actionRendererRegistration;
-        Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext> m_renderContext;
 
+        std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;
         HRESULT RegisterDefaultElementRenderers();
         HRESULT RegisterDefaultActionRenderers();
 

--- a/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.cpp
@@ -11,6 +11,15 @@ using namespace ABI::Windows::Foundation;
 
 namespace AdaptiveCards { namespace Uwp
 {
+    AdaptiveChoiceSetInputRenderer::AdaptiveChoiceSetInputRenderer()
+    {
+    }
+
+    AdaptiveChoiceSetInputRenderer::AdaptiveChoiceSetInputRenderer(const std::shared_ptr<XamlBuilder> xamlBuilder) :
+        m_xamlBuilder(xamlBuilder)
+    {
+    }
+
     HRESULT AdaptiveChoiceSetInputRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -22,7 +31,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderContext* renderContext,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
+        m_xamlBuilder->BuildChoiceSetInput(cardElement, renderContext, result);
         return S_OK;
     }
-
 }}

--- a/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.cpp
@@ -29,9 +29,10 @@ namespace AdaptiveCards { namespace Uwp
     HRESULT AdaptiveChoiceSetInputRenderer::Render(
         IAdaptiveCardElement* cardElement,
         IAdaptiveRenderContext* renderContext,
+        IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder->BuildChoiceSetInput(cardElement, renderContext, result);
+        m_xamlBuilder->BuildChoiceSetInput(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.h
@@ -3,6 +3,7 @@
 #include "AdaptiveCards.Uwp.h"
 #include "Enums.h"
 #include "ChoiceSetInput.h"
+#include "XamlBuilder.h"
 
 namespace AdaptiveCards { namespace Uwp
 {
@@ -16,10 +17,15 @@ namespace AdaptiveCards { namespace Uwp
     public:
         HRESULT RuntimeClassInitialize() noexcept;
 
+        AdaptiveChoiceSetInputRenderer();
+        AdaptiveChoiceSetInputRenderer(const std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> xamlBuilder);
+
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
+    private:
+        std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveChoiceSetInputRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.h
@@ -23,6 +23,7 @@ namespace AdaptiveCards { namespace Uwp
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
     private:
         std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;

--- a/source/uwp/Renderer/lib/AdaptiveColumnRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveColumnRenderer.cpp
@@ -11,6 +11,15 @@ using namespace ABI::Windows::Foundation;
 
 namespace AdaptiveCards { namespace Uwp
 {
+    AdaptiveColumnRenderer::AdaptiveColumnRenderer()
+    {
+    }
+
+    AdaptiveColumnRenderer::AdaptiveColumnRenderer(const std::shared_ptr<XamlBuilder> xamlBuilder) :
+        m_xamlBuilder(xamlBuilder)
+    {
+    }
+
     HRESULT AdaptiveColumnRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -22,6 +31,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderContext* renderContext,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
+        m_xamlBuilder->BuildColumn(cardElement, renderContext, result);
         return S_OK;
     }
 

--- a/source/uwp/Renderer/lib/AdaptiveColumnRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveColumnRenderer.cpp
@@ -29,9 +29,10 @@ namespace AdaptiveCards { namespace Uwp
     HRESULT AdaptiveColumnRenderer::Render(
         IAdaptiveCardElement* cardElement,
         IAdaptiveRenderContext* renderContext,
+        IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder->BuildColumn(cardElement, renderContext, result);
+        m_xamlBuilder->BuildColumn(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 

--- a/source/uwp/Renderer/lib/AdaptiveColumnRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveColumnRenderer.h
@@ -3,6 +3,7 @@
 #include "AdaptiveCards.Uwp.h"
 #include "Enums.h"
 #include "Column.h"
+#include "XamlBuilder.h"
 
 namespace AdaptiveCards { namespace Uwp
 {
@@ -16,10 +17,15 @@ namespace AdaptiveCards { namespace Uwp
     public:
         HRESULT RuntimeClassInitialize() noexcept;
 
+        AdaptiveColumnRenderer();
+        AdaptiveColumnRenderer(const std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> xamlBuilder);
+
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
+    private:
+        std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveColumnRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveColumnRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveColumnRenderer.h
@@ -23,6 +23,7 @@ namespace AdaptiveCards { namespace Uwp
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
     private:
         std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;

--- a/source/uwp/Renderer/lib/AdaptiveColumnSetRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveColumnSetRenderer.cpp
@@ -11,6 +11,15 @@ using namespace ABI::Windows::Foundation;
 
 namespace AdaptiveCards { namespace Uwp
 {
+    AdaptiveColumnSetRenderer::AdaptiveColumnSetRenderer()
+    {
+    }
+
+    AdaptiveColumnSetRenderer::AdaptiveColumnSetRenderer(const std::shared_ptr<XamlBuilder> xamlBuilder) :
+        m_xamlBuilder(xamlBuilder)
+    {
+    }
+
     HRESULT AdaptiveColumnSetRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -22,6 +31,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderContext* renderContext,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
+        m_xamlBuilder->BuildColumnSet(cardElement, renderContext, result);
         return S_OK;
     }
 

--- a/source/uwp/Renderer/lib/AdaptiveColumnSetRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveColumnSetRenderer.cpp
@@ -29,9 +29,10 @@ namespace AdaptiveCards { namespace Uwp
     HRESULT AdaptiveColumnSetRenderer::Render(
         IAdaptiveCardElement* cardElement,
         IAdaptiveRenderContext* renderContext,
+        IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder->BuildColumnSet(cardElement, renderContext, result);
+        m_xamlBuilder->BuildColumnSet(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 

--- a/source/uwp/Renderer/lib/AdaptiveColumnSetRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveColumnSetRenderer.h
@@ -3,6 +3,7 @@
 #include "AdaptiveCards.Uwp.h"
 #include "Enums.h"
 #include "ColumnSet.h"
+#include "XamlBuilder.h"
 
 namespace AdaptiveCards { namespace Uwp
 {
@@ -16,11 +17,15 @@ namespace AdaptiveCards { namespace Uwp
     public:
         HRESULT RuntimeClassInitialize() noexcept;
 
+        AdaptiveColumnSetRenderer();
+        AdaptiveColumnSetRenderer(const std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> xamlBuilder);
+
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
-
+    private:
+        std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveColumnSetRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveColumnSetRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveColumnSetRenderer.h
@@ -23,6 +23,7 @@ namespace AdaptiveCards { namespace Uwp
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
     private:
         std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;

--- a/source/uwp/Renderer/lib/AdaptiveContainerRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveContainerRenderer.cpp
@@ -11,6 +11,15 @@ using namespace ABI::Windows::Foundation;
 
 namespace AdaptiveCards { namespace Uwp
 {
+    AdaptiveContainerRenderer::AdaptiveContainerRenderer()
+    {
+    }
+
+    AdaptiveContainerRenderer::AdaptiveContainerRenderer(const std::shared_ptr<XamlBuilder> xamlBuilder) :
+        m_xamlBuilder(xamlBuilder)
+    {
+    }
+
     HRESULT AdaptiveContainerRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -22,6 +31,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderContext* renderContext,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
+        m_xamlBuilder->BuildContainer(cardElement, renderContext, result);
         return S_OK;
     }
 

--- a/source/uwp/Renderer/lib/AdaptiveContainerRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveContainerRenderer.cpp
@@ -29,9 +29,10 @@ namespace AdaptiveCards { namespace Uwp
     HRESULT AdaptiveContainerRenderer::Render(
         IAdaptiveCardElement* cardElement,
         IAdaptiveRenderContext* renderContext,
+        IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder->BuildContainer(cardElement, renderContext, result);
+        m_xamlBuilder->BuildContainer(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 

--- a/source/uwp/Renderer/lib/AdaptiveContainerRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveContainerRenderer.h
@@ -3,6 +3,7 @@
 #include "AdaptiveCards.Uwp.h"
 #include "Enums.h"
 #include "Container.h"
+#include "XamlBuilder.h"
 
 namespace AdaptiveCards { namespace Uwp
 {
@@ -16,11 +17,15 @@ namespace AdaptiveCards { namespace Uwp
     public:
         HRESULT RuntimeClassInitialize() noexcept;
 
+        AdaptiveContainerRenderer();
+        AdaptiveContainerRenderer(const std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> xamlBuilder);
+
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
-
+    private:
+        std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveContainerRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveContainerRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveContainerRenderer.h
@@ -23,6 +23,7 @@ namespace AdaptiveCards { namespace Uwp
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
     private:
         std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;

--- a/source/uwp/Renderer/lib/AdaptiveDateInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveDateInputRenderer.cpp
@@ -11,6 +11,15 @@ using namespace ABI::Windows::Foundation;
 
 namespace AdaptiveCards { namespace Uwp
 {
+    AdaptiveDateInputRenderer::AdaptiveDateInputRenderer()
+    {
+    }
+
+    AdaptiveDateInputRenderer::AdaptiveDateInputRenderer(const std::shared_ptr<XamlBuilder> xamlBuilder) :
+        m_xamlBuilder(xamlBuilder)
+    {
+    }
+
     HRESULT AdaptiveDateInputRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -22,7 +31,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderContext* renderContext,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
+        m_xamlBuilder->BuildDateInput(cardElement, renderContext, result);
         return S_OK;
     }
-
 }}

--- a/source/uwp/Renderer/lib/AdaptiveDateInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveDateInputRenderer.cpp
@@ -29,9 +29,10 @@ namespace AdaptiveCards { namespace Uwp
     HRESULT AdaptiveDateInputRenderer::Render(
         IAdaptiveCardElement* cardElement,
         IAdaptiveRenderContext* renderContext,
+        IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder->BuildDateInput(cardElement, renderContext, result);
+        m_xamlBuilder->BuildDateInput(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveDateInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveDateInputRenderer.h
@@ -3,6 +3,7 @@
 #include "AdaptiveCards.Uwp.h"
 #include "Enums.h"
 #include "DateInput.h"
+#include "XamlBuilder.h"
 
 namespace AdaptiveCards { namespace Uwp
 {
@@ -16,11 +17,15 @@ namespace AdaptiveCards { namespace Uwp
     public:
         HRESULT RuntimeClassInitialize() noexcept;
 
+        AdaptiveDateInputRenderer();
+        AdaptiveDateInputRenderer(const std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> xamlBuilder);
+
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
-
+    private:
+        std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveDateInputRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveDateInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveDateInputRenderer.h
@@ -23,6 +23,7 @@ namespace AdaptiveCards { namespace Uwp
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
     private:
         std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;

--- a/source/uwp/Renderer/lib/AdaptiveElementRendererRegistration.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveElementRendererRegistration.cpp
@@ -33,7 +33,7 @@ namespace AdaptiveCards { namespace Uwp {
         RegistrationMap::iterator found = m_registration->find(HStringToUTF8(type));
         if (found != m_registration->end())
         {
-            *result = found->second.Get();
+            found->second.CopyTo(result);
         }
         return S_OK;
     }

--- a/source/uwp/Renderer/lib/AdaptiveFactSetRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveFactSetRenderer.cpp
@@ -11,6 +11,15 @@ using namespace ABI::Windows::Foundation;
 
 namespace AdaptiveCards { namespace Uwp
 {
+    AdaptiveFactSetRenderer::AdaptiveFactSetRenderer()
+    {
+    }
+
+    AdaptiveFactSetRenderer::AdaptiveFactSetRenderer(const std::shared_ptr<XamlBuilder> xamlBuilder) :
+        m_xamlBuilder(xamlBuilder)
+    {
+    }
+
     HRESULT AdaptiveFactSetRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -22,6 +31,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderContext* renderContext,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
+        m_xamlBuilder->BuildFactSet(cardElement, renderContext, result);
         return S_OK;
     }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveFactSetRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveFactSetRenderer.cpp
@@ -29,9 +29,10 @@ namespace AdaptiveCards { namespace Uwp
     HRESULT AdaptiveFactSetRenderer::Render(
         IAdaptiveCardElement* cardElement,
         IAdaptiveRenderContext* renderContext,
+        IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder->BuildFactSet(cardElement, renderContext, result);
+        m_xamlBuilder->BuildFactSet(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveFactSetRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveFactSetRenderer.h
@@ -3,6 +3,7 @@
 #include "AdaptiveCards.Uwp.h"
 #include "Enums.h"
 #include "FactSet.h"
+#include "XamlBuilder.h"
 
 namespace AdaptiveCards { namespace Uwp
 {
@@ -16,10 +17,15 @@ namespace AdaptiveCards { namespace Uwp
     public:
         HRESULT RuntimeClassInitialize() noexcept;
 
+        AdaptiveFactSetRenderer();
+        AdaptiveFactSetRenderer(const std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> xamlBuilder);
+
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
+    private:
+        std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveFactSetRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveFactSetRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveFactSetRenderer.h
@@ -23,6 +23,7 @@ namespace AdaptiveCards { namespace Uwp
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
     private:
         std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;

--- a/source/uwp/Renderer/lib/AdaptiveImageRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImageRenderer.cpp
@@ -11,6 +11,15 @@ using namespace ABI::Windows::Foundation;
 
 namespace AdaptiveCards { namespace Uwp
 {
+    AdaptiveImageRenderer::AdaptiveImageRenderer()
+    {
+    }
+
+    AdaptiveImageRenderer::AdaptiveImageRenderer(const std::shared_ptr<XamlBuilder> xamlBuilder) :
+        m_xamlBuilder(xamlBuilder)
+    {
+    }
+
     HRESULT AdaptiveImageRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -22,6 +31,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderContext* renderContext,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
+        m_xamlBuilder->BuildImage(cardElement, renderContext, result);
         return S_OK;
     }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveImageRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImageRenderer.cpp
@@ -29,9 +29,10 @@ namespace AdaptiveCards { namespace Uwp
     HRESULT AdaptiveImageRenderer::Render(
         IAdaptiveCardElement* cardElement,
         IAdaptiveRenderContext* renderContext,
+        IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder->BuildImage(cardElement, renderContext, result);
+        m_xamlBuilder->BuildImage(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveImageRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveImageRenderer.h
@@ -3,6 +3,7 @@
 #include "AdaptiveCards.Uwp.h"
 #include "Enums.h"
 #include "Image.h"
+#include "XamlBuilder.h"
 
 namespace AdaptiveCards { namespace Uwp
 {
@@ -16,10 +17,15 @@ namespace AdaptiveCards { namespace Uwp
     public:
         HRESULT RuntimeClassInitialize() noexcept;
 
+        AdaptiveImageRenderer();
+        AdaptiveImageRenderer(const std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> xamlBuilder);
+
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
+    private:
+        std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveImageRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveImageRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveImageRenderer.h
@@ -23,6 +23,7 @@ namespace AdaptiveCards { namespace Uwp
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
     private:
         std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;

--- a/source/uwp/Renderer/lib/AdaptiveImageSetRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImageSetRenderer.cpp
@@ -11,6 +11,15 @@ using namespace ABI::Windows::Foundation;
 
 namespace AdaptiveCards { namespace Uwp
 {
+    AdaptiveImageSetRenderer::AdaptiveImageSetRenderer()
+    {
+    }
+
+    AdaptiveImageSetRenderer::AdaptiveImageSetRenderer(const std::shared_ptr<XamlBuilder> xamlBuilder) :
+        m_xamlBuilder(xamlBuilder)
+    {
+    }
+
     HRESULT AdaptiveImageSetRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -22,6 +31,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderContext* renderContext,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
+        m_xamlBuilder->BuildImageSet(cardElement, renderContext, result);
         return S_OK;
     }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveImageSetRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImageSetRenderer.cpp
@@ -29,9 +29,10 @@ namespace AdaptiveCards { namespace Uwp
     HRESULT AdaptiveImageSetRenderer::Render(
         IAdaptiveCardElement* cardElement,
         IAdaptiveRenderContext* renderContext,
+        IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder->BuildImageSet(cardElement, renderContext, result);
+        m_xamlBuilder->BuildImageSet(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveImageSetRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveImageSetRenderer.h
@@ -3,6 +3,7 @@
 #include "AdaptiveCards.Uwp.h"
 #include "Enums.h"
 #include "ImageSet.h"
+#include "XamlBuilder.h"
 
 namespace AdaptiveCards { namespace Uwp
 {
@@ -16,10 +17,15 @@ namespace AdaptiveCards { namespace Uwp
     public:
         HRESULT RuntimeClassInitialize() noexcept;
 
+        AdaptiveImageSetRenderer();
+        AdaptiveImageSetRenderer(const std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> xamlBuilder);
+
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
+    private:
+        std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveImageSetRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveImageSetRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveImageSetRenderer.h
@@ -23,6 +23,7 @@ namespace AdaptiveCards { namespace Uwp
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
     private:
         std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;

--- a/source/uwp/Renderer/lib/AdaptiveNumberInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveNumberInputRenderer.cpp
@@ -11,6 +11,15 @@ using namespace ABI::Windows::Foundation;
 
 namespace AdaptiveCards { namespace Uwp
 {
+    AdaptiveNumberInputRenderer::AdaptiveNumberInputRenderer()
+    {
+    }
+
+    AdaptiveNumberInputRenderer::AdaptiveNumberInputRenderer(const std::shared_ptr<XamlBuilder> xamlBuilder) :
+        m_xamlBuilder(xamlBuilder)
+    {
+    }
+
     HRESULT AdaptiveNumberInputRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -22,7 +31,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderContext* renderContext,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
+        m_xamlBuilder->BuildNumberInput(cardElement, renderContext, result);
         return S_OK;
     }
-
 }}

--- a/source/uwp/Renderer/lib/AdaptiveNumberInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveNumberInputRenderer.cpp
@@ -29,9 +29,10 @@ namespace AdaptiveCards { namespace Uwp
     HRESULT AdaptiveNumberInputRenderer::Render(
         IAdaptiveCardElement* cardElement,
         IAdaptiveRenderContext* renderContext,
+        IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder->BuildNumberInput(cardElement, renderContext, result);
+        m_xamlBuilder->BuildNumberInput(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveNumberInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveNumberInputRenderer.h
@@ -3,6 +3,7 @@
 #include "AdaptiveCards.Uwp.h"
 #include "Enums.h"
 #include "NumberInput.h"
+#include "XamlBuilder.h"
 
 namespace AdaptiveCards { namespace Uwp
 {
@@ -16,10 +17,15 @@ namespace AdaptiveCards { namespace Uwp
     public:
         HRESULT RuntimeClassInitialize() noexcept;
 
+        AdaptiveNumberInputRenderer();
+        AdaptiveNumberInputRenderer(const std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> xamlBuilder);
+
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
+    private:
+        std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveNumberInputRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveNumberInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveNumberInputRenderer.h
@@ -23,6 +23,7 @@ namespace AdaptiveCards { namespace Uwp
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
     private:
         std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;

--- a/source/uwp/Renderer/lib/AdaptiveRenderArgs.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveRenderArgs.cpp
@@ -28,4 +28,11 @@ namespace AdaptiveCards { namespace Uwp
         *value = m_containerStyle;
         return S_OK;
     }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveRenderArgs::put_ContainerStyle(ABI::AdaptiveCards::Uwp::ContainerStyle value)
+    {
+        m_containerStyle = value;
+        return S_OK;
+    }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveRenderArgs.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveRenderArgs.cpp
@@ -1,0 +1,31 @@
+#include "pch.h"
+
+#include "AdaptiveRenderArgs.h"
+
+using namespace Microsoft::WRL;
+using namespace Microsoft::WRL::Wrappers;
+using namespace ABI::AdaptiveCards::Uwp;
+using namespace ABI::Windows::Foundation;
+using namespace ABI::Windows::UI::Xaml;
+
+namespace AdaptiveCards { namespace Uwp
+{
+    HRESULT AdaptiveRenderArgs::RuntimeClassInitialize() noexcept
+    {
+        return S_OK;
+    }
+
+    HRESULT AdaptiveRenderArgs::RuntimeClassInitialize(
+        ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle) noexcept try
+    {
+        m_containerStyle = containerStyle;
+        return S_OK;
+    } CATCH_RETURN;
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveRenderArgs::get_ContainerStyle(ABI::AdaptiveCards::Uwp::ContainerStyle *value)
+    {
+        *value = m_containerStyle;
+        return S_OK;
+    }
+}}

--- a/source/uwp/Renderer/lib/AdaptiveRenderArgs.h
+++ b/source/uwp/Renderer/lib/AdaptiveRenderArgs.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "AdaptiveCards.Uwp.h"
+
+namespace AdaptiveCards { namespace Uwp
+{
+    class AdaptiveRenderArgs :
+        public Microsoft::WRL::RuntimeClass<
+        Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
+        ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs>
+    {
+        InspectableClass(RuntimeClass_AdaptiveCards_Uwp_AdaptiveRenderArgs, BaseTrust)
+
+    public:
+        HRESULT RuntimeClassInitialize() noexcept;
+
+        HRESULT RuntimeClassInitialize(
+            ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle) noexcept;
+
+        IFACEMETHODIMP get_ContainerStyle(_Out_ ABI::AdaptiveCards::Uwp::ContainerStyle *value);
+
+
+    private:
+        ABI::AdaptiveCards::Uwp::ContainerStyle m_containerStyle;
+    };
+
+    ActivatableClass(AdaptiveRenderArgs);
+}}
+#pragma once

--- a/source/uwp/Renderer/lib/AdaptiveRenderArgs.h
+++ b/source/uwp/Renderer/lib/AdaptiveRenderArgs.h
@@ -18,6 +18,7 @@ namespace AdaptiveCards { namespace Uwp
             ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle) noexcept;
 
         IFACEMETHODIMP get_ContainerStyle(_Out_ ABI::AdaptiveCards::Uwp::ContainerStyle *value);
+        IFACEMETHODIMP put_ContainerStyle(_In_ ABI::AdaptiveCards::Uwp::ContainerStyle value);
 
 
     private:

--- a/source/uwp/Renderer/lib/AdaptiveRenderContext.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveRenderContext.cpp
@@ -2,13 +2,14 @@
 
 #include "AdaptiveRenderContext.h"
 #include "AdaptiveHostConfig.h"
-#include "AdaptiveElementRendererRegistration.h"
+#include "InputItem.h"
 #include "Util.h"
 
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;
 using namespace ABI::AdaptiveCards::Uwp;
 using namespace ABI::Windows::Foundation;
+using namespace ABI::Windows::UI::Xaml;
 
 namespace AdaptiveCards { namespace Uwp
 {
@@ -18,34 +19,82 @@ namespace AdaptiveCards { namespace Uwp
     }
 
     HRESULT AdaptiveRenderContext::RuntimeClassInitialize(
-        ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig* hostConfig,
-        ABI::AdaptiveCards::Uwp::IAdaptiveElementRendererRegistration* elementRendererRegistration,
-        ABI::AdaptiveCards::Uwp::IAdaptiveActionRendererRegistration* actionRendererRegistration) noexcept try
+        IAdaptiveHostConfig* hostConfig,
+        IAdaptiveElementRendererRegistration* elementRendererRegistration,
+        IAdaptiveActionRendererRegistration* actionRendererRegistration,
+        RenderedAdaptiveCard* renderResult) noexcept try
     {
-        m_hostConfig.Attach(hostConfig);
-        m_elementRendererRegistration.Attach(elementRendererRegistration);
-        m_actionRendererRegistration.Attach(actionRendererRegistration);
+        m_hostConfig = hostConfig;
+        m_elementRendererRegistration = elementRendererRegistration;
+        m_actionRendererRegistration = actionRendererRegistration;
+        m_renderResult = renderResult;
+
         return S_OK;
     } CATCH_RETURN;
 
     _Use_decl_annotations_
     HRESULT AdaptiveRenderContext::get_HostConfig(IAdaptiveHostConfig** value)
     {
-        value = &m_hostConfig;
+        m_hostConfig.CopyTo(value);
         return S_OK;
     }
 
     _Use_decl_annotations_
     HRESULT AdaptiveRenderContext::get_ElementRenderers(IAdaptiveElementRendererRegistration** value)
     {
-        value = &m_elementRendererRegistration;
+        m_elementRendererRegistration.CopyTo(value);
         return S_OK;
     }
 
     _Use_decl_annotations_
     HRESULT AdaptiveRenderContext::get_ActionRenderers(IAdaptiveActionRendererRegistration** value)
     {
-        value = &m_actionRendererRegistration;
+        m_actionRendererRegistration.CopyTo(value);
         return S_OK;
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveRenderContext::AddInputItem(IAdaptiveCardElement* cardElement, ABI::Windows::UI::Xaml::IUIElement* uiElement)
+    {
+        ComPtr<IAdaptiveCardElement> localCardElement(cardElement);
+        ComPtr<IAdaptiveInputElement> inputElement;
+        THROW_IF_FAILED(localCardElement.As(&inputElement));
+
+        ComPtr<IUIElement> localUiElement(uiElement);
+
+        InputItem item(inputElement.Get(), localUiElement.Get());
+        auto inputItems = m_renderResult->GetInputItems();
+
+        if (inputItems != nullptr)
+        {
+            inputItems->push_back(item);
+        }
+
+        return S_OK;
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveRenderContext::SendActionEvent(IAdaptiveActionEventArgs* eventArgs)
+    {
+        return m_renderResult->SendActionEvent(eventArgs);
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveRenderContext::get_ParentContainerStyle(ABI::AdaptiveCards::Uwp::ContainerStyle *value)
+    {
+        *value = m_containerStyle;
+        return S_OK;
+    }
+    _Use_decl_annotations_
+    HRESULT AdaptiveRenderContext::put_ParentContainerStyle(ABI::AdaptiveCards::Uwp::ContainerStyle value)
+    {
+        m_containerStyle = value;
+        return S_OK;
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveRenderContext::get_UserInputs(IAdaptiveInputs** value)
+    {
+        return m_renderResult->get_UserInputs(value);
     }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveRenderContext.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveRenderContext.cpp
@@ -1,7 +1,6 @@
 #include "pch.h"
 
 #include "AdaptiveRenderContext.h"
-#include "AdaptiveHostConfig.h"
 #include "InputItem.h"
 #include "Util.h"
 
@@ -29,7 +28,7 @@ namespace AdaptiveCards { namespace Uwp
         m_actionRendererRegistration = actionRendererRegistration;
         m_renderResult = renderResult;
 
-        return S_OK;
+        return MakeAndInitialize<AdaptiveActionInvoker>(&m_actionInvoker, renderResult);
     } CATCH_RETURN;
 
     _Use_decl_annotations_
@@ -54,6 +53,13 @@ namespace AdaptiveCards { namespace Uwp
     }
 
     _Use_decl_annotations_
+    HRESULT AdaptiveRenderContext::get_ActionInvoker(IAdaptiveActionInvoker** value)
+    {
+        m_actionInvoker.CopyTo(value);
+        return S_OK;
+    }
+
+    _Use_decl_annotations_
     HRESULT AdaptiveRenderContext::AddInputItem(IAdaptiveCardElement* cardElement, ABI::Windows::UI::Xaml::IUIElement* uiElement)
     {
         ComPtr<IAdaptiveCardElement> localCardElement(cardElement);
@@ -63,38 +69,18 @@ namespace AdaptiveCards { namespace Uwp
         ComPtr<IUIElement> localUiElement(uiElement);
 
         InputItem item(inputElement.Get(), localUiElement.Get());
+
         auto inputItems = m_renderResult->GetInputItems();
 
         if (inputItems != nullptr)
         {
             inputItems->push_back(item);
         }
+        else
+        {
+            // Add to Errors
+        }
 
         return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveRenderContext::SendActionEvent(IAdaptiveActionEventArgs* eventArgs)
-    {
-        return m_renderResult->SendActionEvent(eventArgs);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveRenderContext::get_ContainerStyle(ABI::AdaptiveCards::Uwp::ContainerStyle *value)
-    {
-        *value = m_containerStyle;
-        return S_OK;
-    }
-    _Use_decl_annotations_
-    HRESULT AdaptiveRenderContext::put_ParentContainerStyle(ABI::AdaptiveCards::Uwp::ContainerStyle value)
-    {
-        m_containerStyle = value;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveRenderContext::get_UserInputs(IAdaptiveInputs** value)
-    {
-        return m_renderResult->get_UserInputs(value);
     }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveRenderContext.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveRenderContext.cpp
@@ -80,7 +80,7 @@ namespace AdaptiveCards { namespace Uwp
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveRenderContext::get_ParentContainerStyle(ABI::AdaptiveCards::Uwp::ContainerStyle *value)
+    HRESULT AdaptiveRenderContext::get_ContainerStyle(ABI::AdaptiveCards::Uwp::ContainerStyle *value)
     {
         *value = m_containerStyle;
         return S_OK;

--- a/source/uwp/Renderer/lib/AdaptiveRenderContext.h
+++ b/source/uwp/Renderer/lib/AdaptiveRenderContext.h
@@ -1,8 +1,7 @@
 #pragma once
 
 #include "AdaptiveCards.Uwp.h"
-#include "Enums.h"
-#include "TextBlock.h"
+#include "RenderedAdaptiveCard.h"
 
 namespace AdaptiveCards { namespace Uwp
 {
@@ -19,16 +18,26 @@ namespace AdaptiveCards { namespace Uwp
         HRESULT RuntimeClassInitialize(
             ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig* hostConfig,
             ABI::AdaptiveCards::Uwp::IAdaptiveElementRendererRegistration* elementRendererRegistration,
-            ABI::AdaptiveCards::Uwp::IAdaptiveActionRendererRegistration* actionRendererRegistration) noexcept;
+            ABI::AdaptiveCards::Uwp::IAdaptiveActionRendererRegistration* actionRendererRegistration,
+            AdaptiveCards::Uwp::RenderedAdaptiveCard* renderResult) noexcept;
 
         IFACEMETHODIMP get_HostConfig(_COM_Outptr_ ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig** value);
         IFACEMETHODIMP get_ElementRenderers(_COM_Outptr_ ABI::AdaptiveCards::Uwp::IAdaptiveElementRendererRegistration** value);
         IFACEMETHODIMP get_ActionRenderers(_COM_Outptr_ ABI::AdaptiveCards::Uwp::IAdaptiveActionRendererRegistration** value);
+        IFACEMETHODIMP AddInputItem(_In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement, _In_ ABI::Windows::UI::Xaml::IUIElement* uiElement);
+        IFACEMETHODIMP SendActionEvent(ABI::AdaptiveCards::Uwp::IAdaptiveActionEventArgs* eventArgs);
+        IFACEMETHODIMP get_UserInputs(_COM_Outptr_ ABI::AdaptiveCards::Uwp::IAdaptiveInputs** value);
+
+        IFACEMETHODIMP get_ParentContainerStyle(_Out_ ABI::AdaptiveCards::Uwp::ContainerStyle *value);
+        IFACEMETHODIMP put_ParentContainerStyle(_In_ ABI::AdaptiveCards::Uwp::ContainerStyle value);
+
 
     private:
         Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig> m_hostConfig;
         Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Uwp::IAdaptiveElementRendererRegistration> m_elementRendererRegistration;
         Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Uwp::IAdaptiveActionRendererRegistration> m_actionRendererRegistration;
+        Microsoft::WRL::ComPtr<AdaptiveCards::Uwp::RenderedAdaptiveCard> m_renderResult;
+        ABI::AdaptiveCards::Uwp::ContainerStyle m_containerStyle;
     };
 
     ActivatableClass(AdaptiveRenderContext);

--- a/source/uwp/Renderer/lib/AdaptiveRenderContext.h
+++ b/source/uwp/Renderer/lib/AdaptiveRenderContext.h
@@ -28,7 +28,7 @@ namespace AdaptiveCards { namespace Uwp
         IFACEMETHODIMP SendActionEvent(ABI::AdaptiveCards::Uwp::IAdaptiveActionEventArgs* eventArgs);
         IFACEMETHODIMP get_UserInputs(_COM_Outptr_ ABI::AdaptiveCards::Uwp::IAdaptiveInputs** value);
 
-        IFACEMETHODIMP get_ParentContainerStyle(_Out_ ABI::AdaptiveCards::Uwp::ContainerStyle *value);
+        IFACEMETHODIMP get_ContainerStyle(_Out_ ABI::AdaptiveCards::Uwp::ContainerStyle *value);
         IFACEMETHODIMP put_ParentContainerStyle(_In_ ABI::AdaptiveCards::Uwp::ContainerStyle value);
 
 

--- a/source/uwp/Renderer/lib/AdaptiveRenderContext.h
+++ b/source/uwp/Renderer/lib/AdaptiveRenderContext.h
@@ -2,6 +2,7 @@
 
 #include "AdaptiveCards.Uwp.h"
 #include "RenderedAdaptiveCard.h"
+#include "AdaptiveActionInvoker.h"
 
 namespace AdaptiveCards { namespace Uwp
 {
@@ -24,20 +25,15 @@ namespace AdaptiveCards { namespace Uwp
         IFACEMETHODIMP get_HostConfig(_COM_Outptr_ ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig** value);
         IFACEMETHODIMP get_ElementRenderers(_COM_Outptr_ ABI::AdaptiveCards::Uwp::IAdaptiveElementRendererRegistration** value);
         IFACEMETHODIMP get_ActionRenderers(_COM_Outptr_ ABI::AdaptiveCards::Uwp::IAdaptiveActionRendererRegistration** value);
+        IFACEMETHODIMP get_ActionInvoker(_COM_Outptr_ ABI::AdaptiveCards::Uwp::IAdaptiveActionInvoker** value);
         IFACEMETHODIMP AddInputItem(_In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement, _In_ ABI::Windows::UI::Xaml::IUIElement* uiElement);
-        IFACEMETHODIMP SendActionEvent(ABI::AdaptiveCards::Uwp::IAdaptiveActionEventArgs* eventArgs);
-        IFACEMETHODIMP get_UserInputs(_COM_Outptr_ ABI::AdaptiveCards::Uwp::IAdaptiveInputs** value);
-
-        IFACEMETHODIMP get_ContainerStyle(_Out_ ABI::AdaptiveCards::Uwp::ContainerStyle *value);
-        IFACEMETHODIMP put_ParentContainerStyle(_In_ ABI::AdaptiveCards::Uwp::ContainerStyle value);
-
 
     private:
         Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig> m_hostConfig;
         Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Uwp::IAdaptiveElementRendererRegistration> m_elementRendererRegistration;
         Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Uwp::IAdaptiveActionRendererRegistration> m_actionRendererRegistration;
         Microsoft::WRL::ComPtr<AdaptiveCards::Uwp::RenderedAdaptiveCard> m_renderResult;
-        ABI::AdaptiveCards::Uwp::ContainerStyle m_containerStyle;
+        Microsoft::WRL::ComPtr<AdaptiveCards::Uwp::AdaptiveActionInvoker> m_actionInvoker;
     };
 
     ActivatableClass(AdaptiveRenderContext);

--- a/source/uwp/Renderer/lib/AdaptiveTextBlockRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTextBlockRenderer.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 
 #include "AdaptiveTextBlockRenderer.h"
+#include "AdaptiveRenderContext.h"
 #include "Util.h"
 
 using namespace Microsoft::WRL;
@@ -10,6 +11,15 @@ using namespace ABI::Windows::Foundation;
 
 namespace AdaptiveCards { namespace Uwp
 {
+    AdaptiveTextBlockRenderer::AdaptiveTextBlockRenderer()
+    {
+    }
+
+    AdaptiveTextBlockRenderer::AdaptiveTextBlockRenderer(const std::shared_ptr<XamlBuilder> xamlBuilder) :
+        m_xamlBuilder(xamlBuilder)
+    {
+    }
+
     HRESULT AdaptiveTextBlockRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -21,6 +31,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderContext* renderContext,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
+        m_xamlBuilder->BuildTextBlock(cardElement, renderContext, result);
         return S_OK;
     }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveTextBlockRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTextBlockRenderer.cpp
@@ -29,9 +29,10 @@ namespace AdaptiveCards { namespace Uwp
     HRESULT AdaptiveTextBlockRenderer::Render(
         IAdaptiveCardElement* cardElement,
         IAdaptiveRenderContext* renderContext,
+        IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder->BuildTextBlock(cardElement, renderContext, result);
+        m_xamlBuilder->BuildTextBlock(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveTextBlockRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveTextBlockRenderer.h
@@ -3,24 +3,32 @@
 #include "AdaptiveCards.Uwp.h"
 #include "Enums.h"
 #include "TextBlock.h"
+#include "XamlBuilder.h"
 
-namespace AdaptiveCards { namespace Uwp
-{
-    class AdaptiveTextBlockRenderer :
-        public Microsoft::WRL::RuntimeClass<
-        Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
-        ABI::AdaptiveCards::Uwp::IAdaptiveElementRenderer>
+namespace AdaptiveCards {
+    namespace Uwp
     {
-        InspectableClass(RuntimeClass_AdaptiveCards_Uwp_AdaptiveTextBlockRenderer, BaseTrust)
+        class AdaptiveTextBlockRenderer :
+            public Microsoft::WRL::RuntimeClass<
+            Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
+            ABI::AdaptiveCards::Uwp::IAdaptiveElementRenderer>
+        {
+            InspectableClass(RuntimeClass_AdaptiveCards_Uwp_AdaptiveTextBlockRenderer, BaseTrust)
 
-    public:
-        HRESULT RuntimeClassInitialize() noexcept;
+        public:
+            HRESULT RuntimeClassInitialize() noexcept;
 
-        IFACEMETHODIMP Render(
-            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
-            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
-            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
-    };
+            AdaptiveTextBlockRenderer();
+            AdaptiveTextBlockRenderer(const std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> xamlBuilder);
 
-    ActivatableClass(AdaptiveTextBlockRenderer);
-}}
+            IFACEMETHODIMP Render(
+                _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
+                _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+                _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
+        private:
+            std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;
+        };
+
+        ActivatableClass(AdaptiveTextBlockRenderer);
+    }
+}

--- a/source/uwp/Renderer/lib/AdaptiveTextBlockRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveTextBlockRenderer.h
@@ -24,6 +24,7 @@ namespace AdaptiveCards {
             IFACEMETHODIMP Render(
                 _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
                 _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+                _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
                 _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
         private:
             std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;

--- a/source/uwp/Renderer/lib/AdaptiveTextBlockRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveTextBlockRenderer.h
@@ -5,31 +5,28 @@
 #include "TextBlock.h"
 #include "XamlBuilder.h"
 
-namespace AdaptiveCards {
-    namespace Uwp
+namespace AdaptiveCards { namespace Uwp {
+    class AdaptiveTextBlockRenderer :
+        public Microsoft::WRL::RuntimeClass<
+        Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
+        ABI::AdaptiveCards::Uwp::IAdaptiveElementRenderer>
     {
-        class AdaptiveTextBlockRenderer :
-            public Microsoft::WRL::RuntimeClass<
-            Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
-            ABI::AdaptiveCards::Uwp::IAdaptiveElementRenderer>
-        {
-            InspectableClass(RuntimeClass_AdaptiveCards_Uwp_AdaptiveTextBlockRenderer, BaseTrust)
+        InspectableClass(RuntimeClass_AdaptiveCards_Uwp_AdaptiveTextBlockRenderer, BaseTrust)
 
-        public:
-            HRESULT RuntimeClassInitialize() noexcept;
+    public:
+        HRESULT RuntimeClassInitialize() noexcept;
 
-            AdaptiveTextBlockRenderer();
-            AdaptiveTextBlockRenderer(const std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> xamlBuilder);
+        AdaptiveTextBlockRenderer();
+        AdaptiveTextBlockRenderer(const std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> xamlBuilder);
 
-            IFACEMETHODIMP Render(
-                _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
-                _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
-                _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
-                _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
-        private:
-            std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;
-        };
+        IFACEMETHODIMP Render(
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
+            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
+    private:
+        std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;
+    };
 
-        ActivatableClass(AdaptiveTextBlockRenderer);
-    }
-}
+    ActivatableClass(AdaptiveTextBlockRenderer);
+}}

--- a/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.cpp
@@ -11,6 +11,15 @@ using namespace ABI::Windows::Foundation;
 
 namespace AdaptiveCards { namespace Uwp
 {
+    AdaptiveTextInputRenderer::AdaptiveTextInputRenderer()
+    {
+    }
+
+    AdaptiveTextInputRenderer::AdaptiveTextInputRenderer(const std::shared_ptr<XamlBuilder> xamlBuilder) :
+        m_xamlBuilder(xamlBuilder)
+    {
+    }
+
     HRESULT AdaptiveTextInputRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -22,6 +31,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderContext* renderContext,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
+        m_xamlBuilder->BuildTextInput(cardElement, renderContext, result);
         return S_OK;
     }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.cpp
@@ -29,9 +29,10 @@ namespace AdaptiveCards { namespace Uwp
     HRESULT AdaptiveTextInputRenderer::Render(
         IAdaptiveCardElement* cardElement,
         IAdaptiveRenderContext* renderContext,
+        IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder->BuildTextInput(cardElement, renderContext, result);
+        m_xamlBuilder->BuildTextInput(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.h
@@ -3,6 +3,7 @@
 #include "AdaptiveCards.Uwp.h"
 #include "Enums.h"
 #include "TextInput.h"
+#include "XamlBuilder.h"
 
 namespace AdaptiveCards { namespace Uwp
 {
@@ -16,10 +17,15 @@ namespace AdaptiveCards { namespace Uwp
     public:
         HRESULT RuntimeClassInitialize() noexcept;
 
+        AdaptiveTextInputRenderer();
+        AdaptiveTextInputRenderer(const std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> xamlBuilder);
+
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
+    private:
+        std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveTextInputRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.h
@@ -23,6 +23,7 @@ namespace AdaptiveCards { namespace Uwp
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
     private:
         std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;

--- a/source/uwp/Renderer/lib/AdaptiveTimeInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTimeInputRenderer.cpp
@@ -11,6 +11,15 @@ using namespace ABI::Windows::Foundation;
 
 namespace AdaptiveCards { namespace Uwp
 {
+    AdaptiveTimeInputRenderer::AdaptiveTimeInputRenderer()
+    {
+    }
+
+    AdaptiveTimeInputRenderer::AdaptiveTimeInputRenderer(const std::shared_ptr<XamlBuilder> xamlBuilder) :
+        m_xamlBuilder(xamlBuilder)
+    {
+    }
+
     HRESULT AdaptiveTimeInputRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -22,6 +31,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderContext* renderContext,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
+        m_xamlBuilder->BuildTimeInput(cardElement, renderContext, result);
         return S_OK;
     }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveTimeInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTimeInputRenderer.cpp
@@ -29,9 +29,10 @@ namespace AdaptiveCards { namespace Uwp
     HRESULT AdaptiveTimeInputRenderer::Render(
         IAdaptiveCardElement* cardElement,
         IAdaptiveRenderContext* renderContext,
+        IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder->BuildTimeInput(cardElement, renderContext, result);
+        m_xamlBuilder->BuildTimeInput(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveTimeInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveTimeInputRenderer.h
@@ -3,6 +3,7 @@
 #include "AdaptiveCards.Uwp.h"
 #include "Enums.h"
 #include "TimeInput.h"
+#include "XamlBuilder.h"
 
 namespace AdaptiveCards { namespace Uwp
 {
@@ -16,10 +17,15 @@ namespace AdaptiveCards { namespace Uwp
     public:
         HRESULT RuntimeClassInitialize() noexcept;
 
+        AdaptiveTimeInputRenderer();
+        AdaptiveTimeInputRenderer(const std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> xamlBuilder);
+
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
+    private:
+        std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveTimeInputRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveTimeInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveTimeInputRenderer.h
@@ -23,6 +23,7 @@ namespace AdaptiveCards { namespace Uwp
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
     private:
         std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;

--- a/source/uwp/Renderer/lib/AdaptiveToggleInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveToggleInputRenderer.cpp
@@ -11,6 +11,15 @@ using namespace ABI::Windows::Foundation;
 
 namespace AdaptiveCards { namespace Uwp
 {
+    AdaptiveToggleInputRenderer::AdaptiveToggleInputRenderer()
+    {
+    }
+
+    AdaptiveToggleInputRenderer::AdaptiveToggleInputRenderer(const std::shared_ptr<XamlBuilder> xamlBuilder) :
+        m_xamlBuilder(xamlBuilder)
+    {
+    }
+
     HRESULT AdaptiveToggleInputRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -22,6 +31,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderContext* renderContext,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
+        m_xamlBuilder->BuildToggleInput(cardElement, renderContext, result);
         return S_OK;
     }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveToggleInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveToggleInputRenderer.cpp
@@ -29,9 +29,10 @@ namespace AdaptiveCards { namespace Uwp
     HRESULT AdaptiveToggleInputRenderer::Render(
         IAdaptiveCardElement* cardElement,
         IAdaptiveRenderContext* renderContext,
+        IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder->BuildToggleInput(cardElement, renderContext, result);
+        m_xamlBuilder->BuildToggleInput(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveToggleInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveToggleInputRenderer.h
@@ -3,6 +3,7 @@
 #include "AdaptiveCards.Uwp.h"
 #include "Enums.h"
 #include "ToggleInput.h"
+#include "XamlBuilder.h"
 
 namespace AdaptiveCards { namespace Uwp
 {
@@ -16,10 +17,15 @@ namespace AdaptiveCards { namespace Uwp
     public:
         HRESULT RuntimeClassInitialize() noexcept;
 
+        AdaptiveToggleInputRenderer();
+        AdaptiveToggleInputRenderer(const std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> xamlBuilder);
+
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
+    private:
+        std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveToggleInputRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveToggleInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveToggleInputRenderer.h
@@ -23,6 +23,7 @@ namespace AdaptiveCards { namespace Uwp
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
     private:
         std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;

--- a/source/uwp/Renderer/lib/AsyncOperations.h
+++ b/source/uwp/Renderer/lib/AsyncOperations.h
@@ -5,6 +5,7 @@
 #include "AdaptiveCardRendererComponent.h"
 #include "XamlHelpers.h"
 #include "RenderedAdaptiveCard.h"
+#include "AdaptiveRenderContext.h"
 
 #define MakeAgileDispatcherCallback ::Microsoft::WRL::Callback<::Microsoft::WRL::Implements<::Microsoft::WRL::RuntimeClassFlags<::Microsoft::WRL::ClassicCom>, ::ABI::Windows::UI::Core::IDispatchedHandler, ::Microsoft::WRL::FtmBase>>
 
@@ -90,7 +91,20 @@ protected:
             {
                 ComPtr<AdaptiveCards::Uwp::RenderedAdaptiveCard> renderResult;
                 THROW_IF_FAILED(MakeAndInitialize<AdaptiveCards::Uwp::RenderedAdaptiveCard>(&renderResult));
-                m_builder->BuildXamlTreeFromAdaptiveCard(m_card.Get(), &m_rootXamlElement, m_renderer.Get(), renderResult.Get());
+                ComPtr<ABI::AdaptiveCards::Uwp::IAdaptiveElementRendererRegistration> elementRenderers;
+                THROW_IF_FAILED(m_renderer->get_ElementRenderers(&elementRenderers));
+                ComPtr<ABI::AdaptiveCards::Uwp::IAdaptiveActionRendererRegistration> actionRenderers;
+                THROW_IF_FAILED(m_renderer->get_ActionRenderers(&actionRenderers));
+
+                ComPtr<AdaptiveCards::Uwp::AdaptiveRenderContext> renderContext;
+                RETURN_IF_FAILED(MakeAndInitialize<AdaptiveCards::Uwp::AdaptiveRenderContext>(
+                    &renderContext,
+                    m_renderer->GetHostConfig(),
+                    elementRenderers.Get(),
+                    actionRenderers.Get(),
+                    renderResult.Get()));
+
+                m_builder->BuildXamlTreeFromAdaptiveCard(m_card.Get(), &m_rootXamlElement, m_renderer.Get(), renderContext.Get());
             }
             catch (...)
             {

--- a/source/uwp/Renderer/lib/RenderedAdaptiveCard.cpp
+++ b/source/uwp/Renderer/lib/RenderedAdaptiveCard.cpp
@@ -7,12 +7,14 @@
 #include "XamlBuilder.h"
 #include "XamlHelpers.h"
 #include "AdaptiveHostConfig.h"
+#include "AdaptiveActionEventArgs.h"
 #include "vector.h"
 
 using namespace concurrency;
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;
 using namespace ABI::AdaptiveCards::Uwp;
+using namespace ABI::Windows::Data::Json;
 using namespace ABI::Windows::Foundation;
 using namespace ABI::Windows::Foundation::Collections;
 using namespace ABI::Windows::UI;
@@ -78,9 +80,18 @@ namespace AdaptiveCards { namespace Uwp
         return m_warnings.CopyTo(value);
     }
 
-    HRESULT RenderedAdaptiveCard::SendActionEvent(IAdaptiveActionEventArgs* eventArgs)
+    HRESULT RenderedAdaptiveCard::SendActionEvent(IAdaptiveActionElement* actionElement)
     {
-        return m_events->InvokeAll(this, eventArgs);
+        // get the inputElements in Json form.
+        ComPtr<IAdaptiveInputs> gatheredInputs;
+        RETURN_IF_FAILED(get_UserInputs(&gatheredInputs));
+        ComPtr<IJsonObject> inputsAsJson;
+        RETURN_IF_FAILED(gatheredInputs->AsJson(InputValueMode::RawString, &inputsAsJson));
+
+        ComPtr<IAdaptiveActionEventArgs> eventArgs;
+        RETURN_IF_FAILED(MakeAndInitialize<AdaptiveActionEventArgs>(&eventArgs, actionElement, inputsAsJson.Get()));
+
+        return m_events->InvokeAll(this, eventArgs.Get());
     }
 
     void RenderedAdaptiveCard::SetFrameworkElement(ABI::Windows::UI::Xaml::IUIElement* value)

--- a/source/uwp/Renderer/lib/RenderedAdaptiveCard.h
+++ b/source/uwp/Renderer/lib/RenderedAdaptiveCard.h
@@ -36,7 +36,7 @@ namespace AdaptiveCards { namespace Uwp
         std::shared_ptr<std::vector<InputItem>> GetInputItems();
         void SetFrameworkElement(ABI::Windows::UI::Xaml::IUIElement* value);
         void SetOriginatingCard(ABI::AdaptiveCards::Uwp::IAdaptiveCard* value);
-        HRESULT SendActionEvent(ABI::AdaptiveCards::Uwp::IAdaptiveActionEventArgs* eventArgs);
+        HRESULT SendActionEvent(ABI::AdaptiveCards::Uwp::IAdaptiveActionElement* eventArgs);
 
     private:
         Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Uwp::IAdaptiveCard> m_originatingCard;

--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -47,20 +47,6 @@ namespace AdaptiveCards { namespace Uwp
 {
     XamlBuilder::XamlBuilder()
     {
-        // Populate the map of element types to their builder methods
-        m_adaptiveElementBuilder[ElementType::TextBlock] = std::bind(&XamlBuilder::BuildTextBlock, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4);
-        m_adaptiveElementBuilder[ElementType::Image] = std::bind(&XamlBuilder::BuildImage, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4);
-        m_adaptiveElementBuilder[ElementType::Container] = std::bind(&XamlBuilder::BuildContainer, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4);
-        m_adaptiveElementBuilder[ElementType::ColumnSet] = std::bind(&XamlBuilder::BuildColumnSet, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4);
-        m_adaptiveElementBuilder[ElementType::FactSet] = std::bind(&XamlBuilder::BuildFactSet, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4);
-        m_adaptiveElementBuilder[ElementType::ImageSet] = std::bind(&XamlBuilder::BuildImageSet, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4);
-        m_adaptiveElementBuilder[ElementType::ChoiceSetInput] = std::bind(&XamlBuilder::BuildChoiceSetInput, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4);
-        m_adaptiveElementBuilder[ElementType::DateInput] = std::bind(&XamlBuilder::BuildDateInput, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4);
-        m_adaptiveElementBuilder[ElementType::NumberInput] = std::bind(&XamlBuilder::BuildNumberInput, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4);
-        m_adaptiveElementBuilder[ElementType::TextInput] = std::bind(&XamlBuilder::BuildTextInput, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4);
-        m_adaptiveElementBuilder[ElementType::TimeInput] = std::bind(&XamlBuilder::BuildTimeInput, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4);
-        m_adaptiveElementBuilder[ElementType::ToggleInput] = std::bind(&XamlBuilder::BuildToggleInput, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4);
-
         m_hostConfig = Make<AdaptiveHostConfig>();
 
         m_imageLoadTracker.AddListener(dynamic_cast<IImageLoadTrackerListener*>(this));
@@ -124,7 +110,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveCard* adaptiveCard,
         IUIElement** xamlTreeRoot, 
         AdaptiveCardRenderer* renderer,
-        RenderedAdaptiveCard* renderResult,
+        IAdaptiveRenderContext* renderContext,
         boolean isOuterCard,
         ABI::AdaptiveCards::Uwp::ContainerStyle defaultContainerStyle)
     {
@@ -148,16 +134,15 @@ namespace AdaptiveCards { namespace Uwp
                 containerStyle = cardStyle;
             }
         }
-
+        renderContext->put_ParentContainerStyle(containerStyle);
         ComPtr<IPanel> childElementContainer;
-        ComPtr<IUIElement> rootElement = CreateRootCardElement(adaptiveCard, containerStyle, &childElementContainer);
+        ComPtr<IUIElement> rootElement = CreateRootCardElement(adaptiveCard, renderContext, &childElementContainer);
 
         // Enumerate the child items of the card and build xaml for them
         ComPtr<IVector<IAdaptiveCardElement*>> body;
         THROW_IF_FAILED(adaptiveCard->get_Body(&body));
-
-        std::shared_ptr<std::vector<InputItem>> inputElements = std::make_shared<std::vector<InputItem>>();
-        BuildPanelChildren(body.Get(), childElementContainer.Get(), renderResult->GetInputItems(), containerStyle, [](IUIElement*) {});
+        THROW_IF_FAILED(renderContext->put_ParentContainerStyle(containerStyle));
+        BuildPanelChildren(body.Get(), childElementContainer.Get(), renderContext, [](IUIElement*) {});
 
         if (this->SupportsInteractivity())
         {
@@ -165,7 +150,7 @@ namespace AdaptiveCards { namespace Uwp
             THROW_IF_FAILED(adaptiveCard->get_Actions(&actions));
             unsigned int bodyCount;
             THROW_IF_FAILED(body->get_Size(&bodyCount));
-            BuildActions(actions.Get(), renderer, childElementContainer.Get(), bodyCount > 0, renderResult);
+            BuildActions(actions.Get(), renderer, childElementContainer.Get(), bodyCount > 0, renderContext);
         }
 
         THROW_IF_FAILED(rootElement.CopyTo(xamlTreeRoot));
@@ -220,12 +205,6 @@ namespace AdaptiveCards { namespace Uwp
         m_fixedDimensions = true;
         m_fixedWidth = width;
         m_fixedHeight = height;
-        return S_OK;
-    }
-
-    HRESULT XamlBuilder::SetRenderOptions(_In_ RenderOptions renderOptions) noexcept
-    {
-        m_renderOptions = renderOptions;
         return S_OK;
     }
 
@@ -332,8 +311,8 @@ namespace AdaptiveCards { namespace Uwp
 
     _Use_decl_annotations_
     ComPtr<IUIElement> XamlBuilder::CreateRootCardElement(
-        IAdaptiveCard* adaptiveCard, 
-        ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
+        IAdaptiveCard* adaptiveCard,
+        IAdaptiveRenderContext* renderContext,
         IPanel** childElementContainer)
     {
         // The root of an adaptive card is a composite of several elements, depending on the card
@@ -348,6 +327,8 @@ namespace AdaptiveCards { namespace Uwp
 
         ComPtr<IPanel> rootAsPanel;
         THROW_IF_FAILED(rootElement.As(&rootAsPanel));
+        ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle;
+        THROW_IF_FAILED(renderContext->get_ParentContainerStyle(&containerStyle));
 
         ABI::Windows::UI::Color backgroundColor;
         if (SUCCEEDED(GetBackgroundColorFromStyle(containerStyle, m_hostConfig.Get(), &backgroundColor)))
@@ -359,7 +340,7 @@ namespace AdaptiveCards { namespace Uwp
         ComPtr<IUriRuntimeClass> backgroundImageUrl;
         if (SUCCEEDED(adaptiveCard->get_BackgroundImage(&backgroundImageUrl)))
         {
-            ApplyBackgroundToRoot(rootAsPanel.Get(), backgroundImageUrl.Get());
+            ApplyBackgroundToRoot(rootAsPanel.Get(), backgroundImageUrl.Get(), renderContext);
         }
 
         // Now create the inner stack panel to serve as the root host for all the 
@@ -387,7 +368,7 @@ namespace AdaptiveCards { namespace Uwp
     }
 
     _Use_decl_annotations_
-    void XamlBuilder::ApplyBackgroundToRoot(ABI::Windows::UI::Xaml::Controls::IPanel* rootPanel, ABI::Windows::Foundation::IUriRuntimeClass* url)
+    void XamlBuilder::ApplyBackgroundToRoot(ABI::Windows::UI::Xaml::Controls::IPanel* rootPanel, ABI::Windows::Foundation::IUriRuntimeClass* url, IAdaptiveRenderContext* renderContext)
     {
         // In order to reuse the image creation code paths, we simply create an adaptive card
         // image element and then build that into xaml and apply to the root.
@@ -399,7 +380,7 @@ namespace AdaptiveCards { namespace Uwp
         ComPtr<IAdaptiveCardElement> adaptiveCardElement;
         THROW_IF_FAILED(adaptiveImage.As(&adaptiveCardElement));
         ComPtr<IUIElement> backgroundImage;
-        BuildImage(adaptiveCardElement.Get(), ContainerStyle_Default, nullptr, &backgroundImage);
+        BuildImage(adaptiveCardElement.Get(), renderContext, &backgroundImage);
         XamlHelpers::AppendXamlElementToPanel(backgroundImage.Get(), rootPanel);
 
         // The overlay applied to the background image is determined by a resouce, so create
@@ -626,18 +607,23 @@ namespace AdaptiveCards { namespace Uwp
     void XamlBuilder::BuildPanelChildren(
         IVector<IAdaptiveCardElement*>* children,
         IPanel* parentPanel,
-        std::shared_ptr<std::vector<InputItem>> inputElements,
-        ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
+        ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* context,
         std::function<void(IUIElement* child)> childCreatedCallback)
     {
         int currentElement = 0;
         unsigned int childrenSize;
         THROW_IF_FAILED(children->get_Size(&childrenSize));
-        XamlHelpers::IterateOverVector<IAdaptiveCardElement>(children, [&](IAdaptiveCardElement* element)
+        ComPtr<IVector<IAdaptiveCardElement*>> localChildren(children);
+        XamlHelpers::IterateOverVector<IAdaptiveCardElement>(localChildren.Get(), [&](IAdaptiveCardElement* element)
         {
-            ElementType elementType;
-            THROW_IF_FAILED(element->get_ElementType(&elementType));
-            if (m_adaptiveElementBuilder.find(elementType) != m_adaptiveElementBuilder.end())
+            ComPtr<IAdaptiveRenderContext> localContext(context);
+            HSTRING elementType;
+            THROW_IF_FAILED(element->get_ElementTypeString(&elementType));
+            ComPtr<IAdaptiveElementRendererRegistration> elementRenderers;
+            THROW_IF_FAILED(context->get_ElementRenderers(&elementRenderers));
+            ComPtr<IAdaptiveElementRenderer> elementRenderer;
+            THROW_IF_FAILED(elementRenderers->Get(elementType, &elementRenderer));
+            if (elementRenderer != nullptr)
             {
                 // First element does not need a separator added
                 if (currentElement++ > 0)
@@ -654,7 +640,7 @@ namespace AdaptiveCards { namespace Uwp
                     }
                 }
                 ComPtr<IUIElement> newControl;
-                m_adaptiveElementBuilder[elementType](element, containerStyle, inputElements, &newControl);
+                elementRenderer->Render(element, localContext.Get(), &newControl);
                 XamlHelpers::AppendXamlElementToPanel(newControl.Get(), parentPanel);
                 childCreatedCallback(newControl.Get());
             }
@@ -665,11 +651,11 @@ namespace AdaptiveCards { namespace Uwp
         AdaptiveCardRenderer* renderer,
         IAdaptiveShowCardActionConfig* showCardActionConfig,
         IAdaptiveActionElement* action,
-        RenderedAdaptiveCard* renderResult,
+        IAdaptiveRenderContext* renderContext,
         IUIElement** uiShowCard)
     {
         ComPtr<IAdaptiveActionElement> localAction(action);
-        ComPtr<RenderedAdaptiveCard> localRenderResult(renderResult);
+        ComPtr<IAdaptiveRenderContext> localRenderContext(renderContext);
         ComPtr<IAdaptiveShowCardAction> showCardAction;
         THROW_IF_FAILED(localAction.As(&showCardAction));
 
@@ -680,7 +666,7 @@ namespace AdaptiveCards { namespace Uwp
         THROW_IF_FAILED(showCardAction->get_Card(showCard.GetAddressOf()));
 
         ComPtr<IUIElement> localUiShowCard;
-        BuildXamlTreeFromAdaptiveCard(showCard.Get(), localUiShowCard.GetAddressOf(), renderer, localRenderResult.Get(), false, showCardConfigStyle);
+        BuildXamlTreeFromAdaptiveCard(showCard.Get(), localUiShowCard.GetAddressOf(), renderer, localRenderContext.Get(), false, showCardConfigStyle);
 
         ComPtr<IGrid2> showCardGrid;
         THROW_IF_FAILED(localUiShowCard.As(&showCardGrid));
@@ -719,11 +705,11 @@ namespace AdaptiveCards { namespace Uwp
         AdaptiveCardRenderer* renderer,
         IPanel* parentPanel,
         bool insertSeparator,
-        RenderedAdaptiveCard* renderResult)
+        IAdaptiveRenderContext* renderContext)
     {
         ComPtr<IAdaptiveActionsConfig> actionsConfig;
         THROW_IF_FAILED(m_hostConfig->get_Actions(actionsConfig.GetAddressOf()));
-        ComPtr<RenderedAdaptiveCard> strongRenderResult(renderResult);
+        ComPtr<IAdaptiveRenderContext> strongRenderContext(renderContext);
         // Create a separator between the body and the actions
         if (insertSeparator)
         {
@@ -884,7 +870,7 @@ namespace AdaptiveCards { namespace Uwp
                 if (actionType == ABI::AdaptiveCards::Uwp::ActionType::ShowCard && 
                     showCardActionMode == ABI::AdaptiveCards::Uwp::ActionMode::Inline)
                 {
-                    BuildShowCard(strongRenderer.Get(), showCardActionConfig.Get(), action.Get(), strongRenderResult.Get(), uiShowCard.GetAddressOf());
+                    BuildShowCard(strongRenderer.Get(), showCardActionConfig.Get(), action.Get(), strongRenderContext.Get(), uiShowCard.GetAddressOf());
                     allShowCards->push_back(uiShowCard);
 
                     ComPtr<IPanel> showCardsPanel;
@@ -897,7 +883,7 @@ namespace AdaptiveCards { namespace Uwp
                 THROW_IF_FAILED(button.As(&buttonBase));
 
                 EventRegistrationToken clickToken;
-                THROW_IF_FAILED(buttonBase->add_Click(Callback<IRoutedEventHandler>([action, actionType, showCardActionMode, uiShowCard, allShowCards, strongRenderer, strongRenderResult](IInspectable* /*sender*/, IRoutedEventArgs* /*args*/) -> HRESULT
+                THROW_IF_FAILED(buttonBase->add_Click(Callback<IRoutedEventHandler>([action, actionType, showCardActionMode, uiShowCard, allShowCards, strongRenderer, strongRenderContext](IInspectable* /*sender*/, IRoutedEventArgs* /*args*/) -> HRESULT
                 {
                     if (actionType == ABI::AdaptiveCards::Uwp::ActionType::ShowCard &&
                         showCardActionMode != ABI::AdaptiveCards::Uwp::ActionMode_Popup)
@@ -922,14 +908,13 @@ namespace AdaptiveCards { namespace Uwp
                     {
                         // get the inputElements in Json form.
                         ComPtr<IAdaptiveInputs> gatheredInputs;
-                        THROW_IF_FAILED(strongRenderResult->get_UserInputs(&gatheredInputs));
+                        THROW_IF_FAILED(strongRenderContext->get_UserInputs(&gatheredInputs));
                         ComPtr<IJsonObject> inputsAsJson;
                         THROW_IF_FAILED(gatheredInputs->AsJson(InputValueMode::RawString, &inputsAsJson));
 
-                        // TODO: Data binding for inputs 
                         ComPtr<IAdaptiveActionEventArgs> eventArgs;
                         THROW_IF_FAILED(MakeAndInitialize<AdaptiveCards::Uwp::AdaptiveActionEventArgs>(&eventArgs, action.Get(), inputsAsJson.Get()));
-                        THROW_IF_FAILED(strongRenderResult->SendActionEvent(eventArgs.Get()));
+                        THROW_IF_FAILED(strongRenderContext->SendActionEvent(eventArgs.Get()));
                     }
 
                     return S_OK;
@@ -1114,8 +1099,7 @@ namespace AdaptiveCards { namespace Uwp
     _Use_decl_annotations_
     void XamlBuilder::BuildTextBlock(
         IAdaptiveCardElement* adaptiveCardElement, 
-        ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
-        std::shared_ptr<std::vector<InputItem>> inputElements,
+        IAdaptiveRenderContext* renderContext,
         IUIElement** textBlockControl)
     {
         ComPtr<IAdaptiveCardElement> cardElement(adaptiveCardElement);
@@ -1193,6 +1177,8 @@ namespace AdaptiveCards { namespace Uwp
         THROW_IF_FAILED(xamlTextBlock2->put_OpticalMarginAlignment(OpticalMarginAlignment_TrimSideBearings));
 
         //Style the TextBlock using Host Options
+        ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle;
+        THROW_IF_FAILED(renderContext->get_ParentContainerStyle(&containerStyle));
         StyleXamlTextBlock(textblockSize, textColor, containerStyle, isSubtle, shouldWrap, MAXUINT32, textWeight, xamlTextBlock.Get());
 
         THROW_IF_FAILED(xamlTextBlock.CopyTo(textBlockControl));
@@ -1201,8 +1187,7 @@ namespace AdaptiveCards { namespace Uwp
     _Use_decl_annotations_
     void XamlBuilder::BuildImage(
         IAdaptiveCardElement* adaptiveCardElement,
-        ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
-        std::shared_ptr<std::vector<InputItem>> inputElements,
+        IAdaptiveRenderContext* renderContext,
         IUIElement** imageControl)
     {
         ComPtr<IAdaptiveCardElement> cardElement(adaptiveCardElement);
@@ -1332,8 +1317,7 @@ namespace AdaptiveCards { namespace Uwp
     _Use_decl_annotations_
     void XamlBuilder::BuildContainer(
         IAdaptiveCardElement* adaptiveCardElement,
-        ABI::AdaptiveCards::Uwp::ContainerStyle parentContainerStyle,
-        std::shared_ptr<std::vector<InputItem>> inputElements,
+        IAdaptiveRenderContext* renderContext,
         IUIElement** containerControl)
     {
         ComPtr<IAdaptiveCardElement> cardElement(adaptiveCardElement);
@@ -1347,14 +1331,16 @@ namespace AdaptiveCards { namespace Uwp
         THROW_IF_FAILED(adaptiveContainer->get_Style(&containerStyle));
         if (containerStyle == ABI::AdaptiveCards::Uwp::ContainerStyle::None)
         {
+            ABI::AdaptiveCards::Uwp::ContainerStyle parentContainerStyle;
+            THROW_IF_FAILED(renderContext->get_ParentContainerStyle(&parentContainerStyle));
             containerStyle = parentContainerStyle;
         }
-
+        renderContext->put_ParentContainerStyle(containerStyle);
         ComPtr<IPanel> stackPanelAsPanel;
         THROW_IF_FAILED(xamlStackPanel.As(&stackPanelAsPanel));
         ComPtr<IVector<IAdaptiveCardElement*>> childItems;
         THROW_IF_FAILED(adaptiveContainer->get_Items(&childItems));
-        BuildPanelChildren(childItems.Get(), stackPanelAsPanel.Get(), inputElements, containerStyle, [](IUIElement*) {});
+        BuildPanelChildren(childItems.Get(), stackPanelAsPanel.Get(), renderContext, [](IUIElement*) {});
 
         ComPtr<IBorder> containerBorder = XamlHelpers::CreateXamlClass<IBorder>(HStringReference(RuntimeClass_Windows_UI_Xaml_Controls_Border));
         ABI::Windows::UI::Color backgroundColor;
@@ -1381,8 +1367,7 @@ namespace AdaptiveCards { namespace Uwp
     _Use_decl_annotations_
     void XamlBuilder::BuildColumn(
         IAdaptiveCardElement* adaptiveCardElement,
-        ABI::AdaptiveCards::Uwp::ContainerStyle parentContainerStyle,
-        std::shared_ptr<std::vector<InputItem>> inputElements,
+        IAdaptiveRenderContext* renderContext,
         IUIElement** ColumnControl)
     {
         ComPtr<IAdaptiveCardElement> cardElement(adaptiveCardElement);
@@ -1396,8 +1381,11 @@ namespace AdaptiveCards { namespace Uwp
         THROW_IF_FAILED(adaptiveColumn->get_Style(&containerStyle));
         if (containerStyle == ABI::AdaptiveCards::Uwp::ContainerStyle::None)
         {
+            ABI::AdaptiveCards::Uwp::ContainerStyle parentContainerStyle;
+            THROW_IF_FAILED(renderContext->get_ParentContainerStyle(&parentContainerStyle));
             containerStyle = parentContainerStyle;
         }
+        renderContext->put_ParentContainerStyle(containerStyle);
 
         ABI::Windows::UI::Color backgroundColor;
         if (SUCCEEDED(GetBackgroundColorFromStyle(containerStyle, m_hostConfig.Get(), &backgroundColor)))
@@ -1413,7 +1401,7 @@ namespace AdaptiveCards { namespace Uwp
         THROW_IF_FAILED(xamlStackPanel.As(&stackPanelAsPanel));
         ComPtr<IVector<IAdaptiveCardElement*>> childItems;
         THROW_IF_FAILED(adaptiveColumn->get_Items(&childItems));
-        BuildPanelChildren(childItems.Get(), stackPanelAsPanel.Get(), inputElements, containerStyle, [](IUIElement*) {});
+        BuildPanelChildren(childItems.Get(), stackPanelAsPanel.Get(), renderContext, [](IUIElement*) {});
 
         THROW_IF_FAILED(xamlStackPanel.CopyTo(ColumnControl));
     }
@@ -1421,8 +1409,7 @@ namespace AdaptiveCards { namespace Uwp
     _Use_decl_annotations_
     void XamlBuilder::BuildColumnSet(
         IAdaptiveCardElement* adaptiveCardElement,
-        ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
-        std::shared_ptr<std::vector<InputItem>> inputElements,
+        IAdaptiveRenderContext* renderContext,
         IUIElement** columnSetControl)
     {
         ComPtr<IAdaptiveCardElement> cardElement(adaptiveCardElement);
@@ -1436,7 +1423,7 @@ namespace AdaptiveCards { namespace Uwp
         ComPtr<IVector<IAdaptiveColumn*>> columns;
         THROW_IF_FAILED(adaptiveColumnSet->get_Columns(&columns));
         int currentColumn = 0;
-        XamlHelpers::IterateOverVector<IAdaptiveColumn>(columns.Get(), [this, xamlGrid, gridStatics, &currentColumn, containerStyle, inputElements](IAdaptiveColumn* column)
+        XamlHelpers::IterateOverVector<IAdaptiveColumn>(columns.Get(), [this, xamlGrid, gridStatics, &currentColumn, renderContext](IAdaptiveColumn* column)
         {
             ComPtr<IAdaptiveCardElement> columnAsCardElement;
             ComPtr<IAdaptiveColumn> localColumn(column);
@@ -1510,7 +1497,7 @@ namespace AdaptiveCards { namespace Uwp
 
             // Build the Column
             ComPtr<IUIElement> xamlColumn;
-            BuildColumn(columnAsCardElement.Get(), containerStyle, inputElements, &xamlColumn);
+            BuildColumn(columnAsCardElement.Get(), renderContext, &xamlColumn);
 
             // Mark the column container with the current column
             ComPtr<IFrameworkElement> columnAsFrameworkElement;
@@ -1536,8 +1523,7 @@ namespace AdaptiveCards { namespace Uwp
     _Use_decl_annotations_
     void XamlBuilder::BuildFactSet(
         IAdaptiveCardElement* adaptiveCardElement,
-        ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
-        std::shared_ptr<std::vector<InputItem>> inputElements,
+        IAdaptiveRenderContext* renderContext,
         IUIElement** factSetControl)
     {
         ComPtr<IAdaptiveCardElement> cardElement(adaptiveCardElement);
@@ -1560,11 +1546,10 @@ namespace AdaptiveCards { namespace Uwp
         THROW_IF_FAILED(columnDefinitions->Append(titleColumn.Get()));
         THROW_IF_FAILED(columnDefinitions->Append(valueColumn.Get()));
 
-        // Create 
         ComPtr<IVector<IAdaptiveFact*>> facts;
         THROW_IF_FAILED(adaptiveFactSet->get_Facts(&facts));
         int currentFact = 0;
-        XamlHelpers::IterateOverVector<IAdaptiveFact>(facts.Get(), [this, xamlGrid, gridStatics, factSetGridLength, &currentFact, containerStyle](IAdaptiveFact* fact)
+        XamlHelpers::IterateOverVector<IAdaptiveFact>(facts.Get(), [this, xamlGrid, gridStatics, factSetGridLength, &currentFact, renderContext](IAdaptiveFact* fact)
         {
             ComPtr<IRowDefinition> factRow = XamlHelpers::CreateXamlClass<IRowDefinition>(HStringReference(RuntimeClass_Windows_UI_Xaml_Controls_RowDefinition));
             THROW_IF_FAILED(factRow->put_Height(factSetGridLength));
@@ -1585,6 +1570,8 @@ namespace AdaptiveCards { namespace Uwp
             ComPtr<IAdaptiveTextConfig> titleTextConfig;
             THROW_IF_FAILED(factSetConfig->get_Title(&titleTextConfig));
 
+            ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle;
+            THROW_IF_FAILED(renderContext->get_ParentContainerStyle(&containerStyle));
             StyleXamlTextBlock(titleTextConfig.Get(), containerStyle, titleTextBlock.Get());
 
             // Create the value xaml textblock and style it from Host options
@@ -1630,8 +1617,7 @@ namespace AdaptiveCards { namespace Uwp
     _Use_decl_annotations_
     void XamlBuilder::BuildImageSet(
         IAdaptiveCardElement* adaptiveCardElement,
-        ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
-        std::shared_ptr<std::vector<InputItem>> inputElements,
+        IAdaptiveRenderContext* renderContext,
         IUIElement** imageSetControl)
     {
         ComPtr<IAdaptiveCardElement> cardElement(adaptiveCardElement);
@@ -1655,7 +1641,7 @@ namespace AdaptiveCards { namespace Uwp
             THROW_IF_FAILED(imageSetConfig->get_ImageSize(&imageSize));
         }
 
-        XamlHelpers::IterateOverVector<IAdaptiveImage>(images.Get(), [this, imageSize, xamlGrid, inputElements, containerStyle](IAdaptiveImage* adaptiveImage)
+        XamlHelpers::IterateOverVector<IAdaptiveImage>(images.Get(), [this, imageSize, xamlGrid, renderContext](IAdaptiveImage* adaptiveImage)
         {
             ComPtr<IAdaptiveImage> localAdaptiveImage(adaptiveImage);
             THROW_IF_FAILED(localAdaptiveImage->put_Size(imageSize));
@@ -1664,7 +1650,7 @@ namespace AdaptiveCards { namespace Uwp
             localAdaptiveImage.As(&adaptiveElementImage);
 
             ComPtr<IUIElement> uiImage;
-            BuildImage(adaptiveElementImage.Get(), containerStyle, inputElements, &uiImage);
+            BuildImage(adaptiveElementImage.Get(), renderContext, &uiImage);
 
             ComPtr<IPanel> gridAsPanel;
             THROW_IF_FAILED(xamlGrid.As(&gridAsPanel));
@@ -1672,26 +1658,7 @@ namespace AdaptiveCards { namespace Uwp
             XamlHelpers::AppendXamlElementToPanel(uiImage.Get(), gridAsPanel.Get());
         });
 
-        // TODO: 11508861
         THROW_IF_FAILED(xamlGrid.CopyTo(imageSetControl));
-    }
-
-    template<typename T>
-    void XamlBuilder::AddInputItemToVector(
-        std::shared_ptr<std::vector<InputItem>> inputElements,
-        IAdaptiveCardElement* cardElement,
-        T* tElement)
-    {
-        ComPtr<IAdaptiveCardElement> localCardElement(cardElement);
-        ComPtr<IAdaptiveInputElement> inputElement;
-        THROW_IF_FAILED(localCardElement.As(&inputElement));
-
-        ComPtr<T> localTElement(tElement);
-        ComPtr<IUIElement> uiElement;
-        THROW_IF_FAILED(localTElement.As(&uiElement));
-
-        InputItem item(inputElement.Get(), uiElement.Get());
-        inputElements->push_back(item);
     }
 
     void XamlBuilder::BuildCompactChoiceSetInput(
@@ -1795,8 +1762,7 @@ namespace AdaptiveCards { namespace Uwp
 
     void XamlBuilder::BuildChoiceSetInput(
         IAdaptiveCardElement* adaptiveCardElement,
-        ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
-        std::shared_ptr<std::vector<InputItem>> inputElements,
+        IAdaptiveRenderContext* renderContext,
         IUIElement** choiceInputSet)
     {
         if (!this->SupportsInteractivity())
@@ -1824,13 +1790,12 @@ namespace AdaptiveCards { namespace Uwp
             BuildExpandedChoiceSetInput(adaptiveChoiceSetInput.Get(), isMultiSelect, choiceInputSet);
         }
 
-        AddInputItemToVector(inputElements, adaptiveCardElement, *choiceInputSet);
+        renderContext->AddInputItem(adaptiveCardElement, *choiceInputSet);
     }
 
     void XamlBuilder::BuildDateInput(
         IAdaptiveCardElement* adaptiveCardElement,
-        ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
-        std::shared_ptr<std::vector<InputItem>> inputElements,
+        IAdaptiveRenderContext* renderContext,
         IUIElement** dateInputControl)
     {
         if (!this->SupportsInteractivity())
@@ -1853,18 +1818,14 @@ namespace AdaptiveCards { namespace Uwp
         THROW_IF_FAILED(datePicker.As(&datePickerAsFrameworkElement));
         THROW_IF_FAILED(datePickerAsFrameworkElement->put_HorizontalAlignment(HorizontalAlignment_Stretch));
 
-        AddInputItemToVector(inputElements, adaptiveCardElement, datePicker.Get());
-            
-        // TODO: Handle parsing dates for min/max and value
-
-        // TODO: 11508861
         THROW_IF_FAILED(datePicker.CopyTo(dateInputControl));
+        THROW_IF_FAILED(renderContext->AddInputItem(adaptiveCardElement, *dateInputControl));
+        // TODO: Handle parsing dates for min/max and value
     }
 
     void XamlBuilder::BuildNumberInput(
         IAdaptiveCardElement* adaptiveCardElement,
-        ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
-        std::shared_ptr<std::vector<InputItem>> inputElements,
+        IAdaptiveRenderContext* renderContext,
         IUIElement** numberInputControl)
     {
         if (!this->SupportsInteractivity())
@@ -1901,17 +1862,14 @@ namespace AdaptiveCards { namespace Uwp
         THROW_IF_FAILED(adaptiveNumberInput->get_Placeholder(placeHolderText.GetAddressOf()));
         THROW_IF_FAILED(textBox2->put_PlaceholderText(placeHolderText.Get()));
 
-        AddInputItemToVector(inputElements, adaptiveCardElement, textBox.Get());
-
         // TODO: Handle max and min?
-
         THROW_IF_FAILED(textBox.CopyTo(numberInputControl));
+        THROW_IF_FAILED(renderContext->AddInputItem(adaptiveCardElement, *numberInputControl));
     }
 
     void XamlBuilder::BuildTextInput(
         IAdaptiveCardElement* adaptiveCardElement,
-        ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
-        std::shared_ptr<std::vector<InputItem>> inputElements,
+        IAdaptiveRenderContext* renderContext,
         IUIElement** textInputControl)
     {
         if (!this->SupportsInteractivity())
@@ -1970,16 +1928,13 @@ namespace AdaptiveCards { namespace Uwp
 
         THROW_IF_FAILED(textBox->put_InputScope(inputScope.Get()));
 
-        AddInputItemToVector(inputElements, adaptiveCardElement, textBox.Get());
-
-        // TODO: 11508861
         THROW_IF_FAILED(textBox.CopyTo(textInputControl));
+        THROW_IF_FAILED(renderContext->AddInputItem(adaptiveCardElement, *textInputControl));
     }
 
     void XamlBuilder::BuildTimeInput(
         IAdaptiveCardElement* adaptiveCardElement,
-        ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
-        std::shared_ptr<std::vector<InputItem>> inputElements,
+        IAdaptiveRenderContext* renderContext,
         IUIElement** timeInputControl)
     {
         if (!this->SupportsInteractivity())
@@ -1994,18 +1949,15 @@ namespace AdaptiveCards { namespace Uwp
         THROW_IF_FAILED(timePicker.As(&timePickerAsFrameworkElement));
         THROW_IF_FAILED(timePickerAsFrameworkElement->put_HorizontalAlignment(HorizontalAlignment_Stretch));
 
-        AddInputItemToVector(inputElements, adaptiveCardElement, timePicker.Get());
-
         // TODO: Handle placeholder text and parsing times for min/max and value
 
-        // TODO: 11508861
         THROW_IF_FAILED(timePicker.CopyTo(timeInputControl));
+        THROW_IF_FAILED(renderContext->AddInputItem(adaptiveCardElement, *timeInputControl));
     }
 
     void XamlBuilder::BuildToggleInput(
         IAdaptiveCardElement* adaptiveCardElement,
-        ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
-        std::shared_ptr<std::vector<InputItem>> inputElements,
+        IAdaptiveRenderContext* renderContext,
         IUIElement** toggleInputControl)
     {
         if (!this->SupportsInteractivity())
@@ -2035,10 +1987,8 @@ namespace AdaptiveCards { namespace Uwp
 
         XamlHelpers::SetToggleValue(checkBox.Get(), (compareValueOn == 0));
 
-        AddInputItemToVector(inputElements, adaptiveCardElement, checkBox.Get());
-
-        // TODO: 11508861
         THROW_IF_FAILED(checkBox.CopyTo(toggleInputControl));
+        renderContext->AddInputItem(adaptiveCardElement, *toggleInputControl);
     }
 
     bool XamlBuilder::SupportsInteractivity()

--- a/source/uwp/Renderer/lib/XamlBuilder.h
+++ b/source/uwp/Renderer/lib/XamlBuilder.h
@@ -31,7 +31,7 @@ namespace AdaptiveCards { namespace Uwp
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCard* adaptiveCard,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** xamlTreeRoot,
             _In_ AdaptiveCards::Uwp::AdaptiveCardRenderer* renderer,
-            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ AdaptiveCards::Uwp::AdaptiveRenderContext* renderContext,
             boolean isOuterCard = true,
             ABI::AdaptiveCards::Uwp::ContainerStyle defaultContainerStyle = ABI::AdaptiveCards::Uwp::ContainerStyle::Default);
         HRESULT AddListener(_In_ IXamlBuilderListener* listener) noexcept;
@@ -180,14 +180,14 @@ namespace AdaptiveCards { namespace Uwp
             AdaptiveCards::Uwp::AdaptiveCardRenderer* renderer,
             ABI::AdaptiveCards::Uwp::IAdaptiveShowCardActionConfig* showCardActionConfig,
             ABI::AdaptiveCards::Uwp::IAdaptiveActionElement* action,
-            _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _Inout_ AdaptiveCards::Uwp::AdaptiveRenderContext* renderContext,
             ABI::Windows::UI::Xaml::IUIElement** uiShowCard);
         void BuildActions(
             _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveCards::Uwp::IAdaptiveActionElement*>* children,
             _In_ AdaptiveCards::Uwp::AdaptiveCardRenderer* renderer,
             _In_ ABI::Windows::UI::Xaml::Controls::IPanel* parentPanel,
             _In_ bool insertSeparator,
-            _Inout_ _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext);
+            _Inout_ AdaptiveCards::Uwp::AdaptiveRenderContext* renderContext);
         void GetSeparationConfigForElement(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* element,
             _Out_ UINT* spacing,

--- a/source/uwp/Renderer/lib/XamlBuilder.h
+++ b/source/uwp/Renderer/lib/XamlBuilder.h
@@ -8,9 +8,12 @@
 #include <windows.storage.h>
 #include "InputItem.h"
 #include "RenderedAdaptiveCard.h"
+#include "AdaptiveRenderContext.h"
 
 namespace AdaptiveCards { namespace Uwp
 {
+    class AdaptiveCardRenderer;
+
     class XamlBuilder : public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
         Microsoft::WRL::FtmBase,
@@ -28,23 +31,70 @@ namespace AdaptiveCards { namespace Uwp
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCard* adaptiveCard,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** xamlTreeRoot,
             _In_ AdaptiveCards::Uwp::AdaptiveCardRenderer* renderer,
-            _Inout_ AdaptiveCards::Uwp::RenderedAdaptiveCard* renderResult,
+            _Inout_ _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             boolean isOuterCard = true,
             ABI::AdaptiveCards::Uwp::ContainerStyle defaultContainerStyle = ABI::AdaptiveCards::Uwp::ContainerStyle::Default);
         HRESULT AddListener(_In_ IXamlBuilderListener* listener) noexcept;
         HRESULT RemoveListener(_In_ IXamlBuilderListener* listener) noexcept;
         HRESULT SetFixedDimensions(_In_ UINT width, _In_ UINT height) noexcept;
-        HRESULT SetRenderOptions(_In_ ABI::AdaptiveCards::Uwp::RenderOptions renderOptions) noexcept;
         HRESULT SetEnableXamlImageHandling(_In_ bool enableXamlImageHandling) noexcept;
         HRESULT SetOverrideDictionary(_In_ ABI::Windows::UI::Xaml::IResourceDictionary* overrideDictionary) noexcept;
         HRESULT SetHostConfig(_In_ ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig* hostConfig) noexcept;
 
+        void BuildTextBlock(
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
+            _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** textBlockControl);
+        void BuildImage(
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
+            _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** imageControl);
+        void BuildContainer(
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
+            _Inout_ _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** containerControl);
+        void BuildColumn(
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
+            _Inout_ _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** columnControl);
+        void BuildColumnSet(
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
+            _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** columnSetControl);
+        void BuildFactSet(
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
+            _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** factSetControl);
+        void BuildImageSet(
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
+            _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** imageSetControl);
+        void BuildChoiceSetInput(
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
+            _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** choiceSetInputControl);
+        void BuildDateInput(
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
+            _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** dateInputControl);
+        void BuildNumberInput(
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
+            _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** numberInputControl);
+        void BuildTextInput(
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
+            _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** textInputControl);
+        void BuildTimeInput(
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
+            _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** timeInputControl);
+        void BuildToggleInput(
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
+            _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** toggleInputControl);
+
     private:
-        std::unordered_map<ABI::AdaptiveCards::Uwp::ElementType, 
-            std::function<void(ABI::AdaptiveCards::Uwp::IAdaptiveCardElement*,
-                ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
-                std::shared_ptr<std::vector<InputItem>> inputElements,
-                ABI::Windows::UI::Xaml::IUIElement**)>> m_adaptiveElementBuilder;
 
         Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Uwp::IAdaptiveCardRenderer> m_renderer;
         Microsoft::WRL::ComPtr<ABI::Windows::Foundation::IPropertyValueStatics> m_propertyValueStatics;
@@ -60,7 +110,6 @@ namespace AdaptiveCards { namespace Uwp
         UINT m_fixedWidth = 0;
         UINT m_fixedHeight = 0;
         bool m_fixedDimensions = false;
-        ABI::AdaptiveCards::Uwp::RenderOptions m_renderOptions = ABI::AdaptiveCards::Uwp::RenderOptions::None;
         bool m_enableXamlImageHandling = false;
         Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Uwp::IAdaptiveCardResourceResolvers> m_resourceResolvers;
 
@@ -93,9 +142,12 @@ namespace AdaptiveCards { namespace Uwp
             _Out_ T* valueResource);
         Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IUIElement> CreateRootCardElement(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCard* adaptiveCard,
-            ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
+            _In_ _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _COM_Outptr_ ABI::Windows::UI::Xaml::Controls::IPanel** childElementContainer);
-        void ApplyBackgroundToRoot(_In_ ABI::Windows::UI::Xaml::Controls::IPanel* rootPanel, _In_ ABI::Windows::Foundation::IUriRuntimeClass* uri);
+        void ApplyBackgroundToRoot(
+            _In_ ABI::Windows::UI::Xaml::Controls::IPanel* rootPanel,
+            _In_ ABI::Windows::Foundation::IUriRuntimeClass* uri,
+            _In_ _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext);
         template<typename T>
         void SetImageSource(T* destination, ABI::Windows::UI::Xaml::Media::IImageSource* imageSource);
         template<typename T>
@@ -107,69 +159,26 @@ namespace AdaptiveCards { namespace Uwp
         void BuildPanelChildren(
             _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveCards::Uwp::IAdaptiveCardElement*>* children,
             _In_ ABI::Windows::UI::Xaml::Controls::IPanel* parentPanel,
-            std::shared_ptr<std::vector<InputItem>> inputElements,
-            ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* context,
             _In_ std::function<void(ABI::Windows::UI::Xaml::IUIElement* child)> childCreatedCallback);
         void BuildShowCard(
             AdaptiveCards::Uwp::AdaptiveCardRenderer* renderer,
             ABI::AdaptiveCards::Uwp::IAdaptiveShowCardActionConfig* showCardActionConfig,
             ABI::AdaptiveCards::Uwp::IAdaptiveActionElement* action,
-            AdaptiveCards::Uwp::RenderedAdaptiveCard* renderResult,
+            _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             ABI::Windows::UI::Xaml::IUIElement** uiShowCard);
         void BuildActions(
             _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveCards::Uwp::IAdaptiveActionElement*>* children,
             _In_ AdaptiveCards::Uwp::AdaptiveCardRenderer* renderer,
             _In_ ABI::Windows::UI::Xaml::Controls::IPanel* parentPanel,
             _In_ bool insertSeparator,
-            _Inout_ AdaptiveCards::Uwp::RenderedAdaptiveCard* renderResult);
+            _Inout_ _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext);
         void GetSeparationConfigForElement(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* element,
             _Out_ UINT* spacing,
             _Out_ UINT* separatorThickness,
             _Out_ ABI::Windows::UI::Color* separatorColor,
             _Out_ bool* needsSeparator);
-
-        template<typename T>
-        void AddInputItemToVector(
-            std::shared_ptr<std::vector<InputItem>> inputElements,
-            ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
-            T* tElement);
-
-        void BuildTextBlock(
-            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
-            ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
-            std::shared_ptr<std::vector<InputItem>> inputElements,
-            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** textBlockControl);
-        void BuildImage(
-            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
-            ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
-            std::shared_ptr<std::vector<InputItem>> inputElements,
-            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** imageControl);
-        void BuildContainer(
-            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
-            ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
-            std::shared_ptr<std::vector<InputItem>> inputElements,
-            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** containerControl);
-        void BuildColumn(
-            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
-            ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
-            std::shared_ptr<std::vector<InputItem>> inputElements,
-            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** columnControl);
-        void BuildColumnSet(
-            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
-            ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
-            std::shared_ptr<std::vector<InputItem>> inputElements,
-            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** columnSetControl);
-        void BuildFactSet(
-            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
-            ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
-            std::shared_ptr<std::vector<InputItem>> inputElements,
-            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** factSetControl);
-        void BuildImageSet(
-            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
-            ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
-            std::shared_ptr<std::vector<InputItem>> inputElements,
-            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** imageSetControl);
         void BuildCompactChoiceSetInput(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveChoiceSetInput* adaptiveChoiceSetInput,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** choiceInputSetControl);
@@ -177,36 +186,6 @@ namespace AdaptiveCards { namespace Uwp
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveChoiceSetInput* adaptiveChoiceInputSet,
             boolean isMultiSelect,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** choiceSetInputControl);
-        void BuildChoiceSetInput(
-            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
-            ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
-            std::shared_ptr<std::vector<InputItem>> inputElements,
-            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** choiceSetInputControl);
-        void BuildDateInput(
-            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
-            ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
-            std::shared_ptr<std::vector<InputItem>> inputElements,
-            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** dateInputControl);
-        void BuildNumberInput(
-            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
-            ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
-            std::shared_ptr<std::vector<InputItem>> inputElements,
-            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** numberInputControl);
-        void BuildTextInput(
-            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
-            ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
-            std::shared_ptr<std::vector<InputItem>> inputElements,
-            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** textInputControl);
-        void BuildTimeInput(
-            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
-            ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
-            std::shared_ptr<std::vector<InputItem>> inputElements,
-            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** timeInputControl);
-        void BuildToggleInput(
-            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
-            ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
-            std::shared_ptr<std::vector<InputItem>> inputElements,
-            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** toggleInputControl);
         bool SupportsInteractivity();
     };
 }}

--- a/source/uwp/Renderer/lib/XamlBuilder.h
+++ b/source/uwp/Renderer/lib/XamlBuilder.h
@@ -31,7 +31,7 @@ namespace AdaptiveCards { namespace Uwp
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCard* adaptiveCard,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** xamlTreeRoot,
             _In_ AdaptiveCards::Uwp::AdaptiveCardRenderer* renderer,
-            _Inout_ _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             boolean isOuterCard = true,
             ABI::AdaptiveCards::Uwp::ContainerStyle defaultContainerStyle = ABI::AdaptiveCards::Uwp::ContainerStyle::Default);
         HRESULT AddListener(_In_ IXamlBuilderListener* listener) noexcept;
@@ -43,55 +43,68 @@ namespace AdaptiveCards { namespace Uwp
 
         void BuildTextBlock(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
-            _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** textBlockControl);
         void BuildImage(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
-            _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** imageControl);
         void BuildContainer(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
-            _Inout_ _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** containerControl);
         void BuildColumn(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
-            _Inout_ _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** columnControl);
         void BuildColumnSet(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
-            _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** columnSetControl);
         void BuildFactSet(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
-            _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** factSetControl);
         void BuildImageSet(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
-            _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** imageSetControl);
         void BuildChoiceSetInput(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
-            _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** choiceSetInputControl);
         void BuildDateInput(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
-            _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** dateInputControl);
         void BuildNumberInput(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
-            _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** numberInputControl);
         void BuildTextInput(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
-            _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** textInputControl);
         void BuildTimeInput(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
-            _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** timeInputControl);
         void BuildToggleInput(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
-            _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** toggleInputControl);
 
     private:
@@ -142,7 +155,8 @@ namespace AdaptiveCards { namespace Uwp
             _Out_ T* valueResource);
         Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IUIElement> CreateRootCardElement(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCard* adaptiveCard,
-            _In_ _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::Controls::IPanel** childElementContainer);
         void ApplyBackgroundToRoot(
             _In_ ABI::Windows::UI::Xaml::Controls::IPanel* rootPanel,
@@ -160,6 +174,7 @@ namespace AdaptiveCards { namespace Uwp
             _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveCards::Uwp::IAdaptiveCardElement*>* children,
             _In_ ABI::Windows::UI::Xaml::Controls::IPanel* parentPanel,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* context,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _In_ std::function<void(ABI::Windows::UI::Xaml::IUIElement* child)> childCreatedCallback);
         void BuildShowCard(
             AdaptiveCards::Uwp::AdaptiveCardRenderer* renderer,


### PR DESCRIPTION
This change keeps usage of xamlBuilder internally.
Also adds the RenderContext object that will be passed around.
Only CardElements use the new Registration entries. Actions require a bigger refactor.