### PR TITLE
Add unit test for dotnet card serializing

### DIFF
--- a/source/dotnet/Test/AdaptiveCards.Test/AdaptiveCardSerializationTests.cs
+++ b/source/dotnet/Test/AdaptiveCards.Test/AdaptiveCardSerializationTests.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AdaptiveCards.Test
+{
+    [TestClass]
+    public class AdaptiveCardSerializationTests
+    {
+        [TestMethod]
+        public void TestSerializingTextBlock()
+        {
+            var card = new AdaptiveCard()
+            {
+                Body =
+                {
+                    new TextBlock()
+                    {
+                        Text = "Hello world"
+                    }
+                }
+            };
+
+            string json = card.ToJson();
+
+            // Re-parse the card
+            card = AdaptiveCard.FromJson(json).Card;
+
+            // Ensure there's a text element
+            Assert.AreEqual(1, card.Body.Count);
+            Assert.IsInstanceOfType(card.Body[0], typeof(TextBlock));
+            Assert.AreEqual("Hello world", (card.Body[0] as TextBlock).Text);
+        }
+    }
+}

--- a/source/dotnet/Test/AdaptiveCards.Test/AdaptiveCards.Test.csproj
+++ b/source/dotnet/Test/AdaptiveCards.Test/AdaptiveCards.Test.csproj
@@ -48,6 +48,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AdaptiveCardSerializationTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="AdaptiveCardApiTests.cs" />
     <Compile Include="HostConfigApiTests.cs" />


### PR DESCRIPTION
We didn't have any unit tests that tested the dotnet library's serialization to JSON. Added a simple one that validates it can serialize and then it can deserialize and get back what it originally had.