### PR TITLE
UWP polish hit target visuals

### DIFF
--- a/source/uwp/Renderer/lib/DefaultResourceDictionary.h
+++ b/source/uwp/Renderer/lib/DefaultResourceDictionary.h
@@ -7,18 +7,45 @@ const PCWSTR c_defaultResourceDictionary = L"\
 \
     <ResourceDictionary.ThemeDictionaries> \
         <ResourceDictionary x:Key=\"Dark\"> \
-          <SolidColorBrush x:Key=\"TextColor.Accent\" Color=\"{ThemeResource SystemAccentColor}\"/> \
-          <SolidColorBrush x:Key=\"TextColor.Default\" Color=\"{ThemeResource SystemBaseHighColor}\"/> \
+            <SolidColorBrush x:Key=\"TextColor.Accent\" Color=\"{ThemeResource SystemAccentColor}\"/> \
+            <SolidColorBrush x:Key=\"TextColor.Default\" Color=\"{ThemeResource SystemBaseHighColor}\"/> \
+\
+            <!-- Resources for HitTarget --> \
+            <StaticResource x:Key=\"HitTargetBackground\" ResourceKey=\"SystemControlTransparentBrush\" /> \
+            <StaticResource x:Key=\"HitTargetBackgroundPointerOver\" ResourceKey=\"SystemControlHighlightListLowBrush\" /> \
+            <StaticResource x:Key=\"HitTargetBackgroundPressed\" ResourceKey=\"SystemControlHighlightListMediumBrush\" /> \
+            <StaticResource x:Key=\"HitTargetFocusVisualPrimaryBrush\" ResourceKey=\"SystemControlFocusVisualPrimaryBrush\" /> \
+            <StaticResource x:Key=\"HitTargetFocusVisualSecondaryBrush\" ResourceKey=\"SystemControlFocusVisualSecondaryBrush\" /> \
+            <StaticResource x:Key=\"HitTargetFocusBorderBrush\" ResourceKey=\"SystemControlForegroundAltHighBrush\" /> \
+            <StaticResource x:Key=\"HitTargetFocusSecondaryBorderBrush\" ResourceKey=\"SystemControlForegroundBaseHighBrush\" /> \
         </ResourceDictionary> \
 \
         <ResourceDictionary x:Key=\"Light\"> \
-          <SolidColorBrush x:Key=\"TextColor.Accent\" Color=\"{ThemeResource SystemAccentColor}\"/> \
-          <SolidColorBrush x:Key=\"TextColor.Default\" Color=\"{ThemeResource SystemBaseHighColor}\"/> \
+            <SolidColorBrush x:Key=\"TextColor.Accent\" Color=\"{ThemeResource SystemAccentColor}\"/> \
+            <SolidColorBrush x:Key=\"TextColor.Default\" Color=\"{ThemeResource SystemBaseHighColor}\"/> \
+\
+            <!-- Resources for HitTarget --> \
+            <StaticResource x:Key=\"HitTargetBackground\" ResourceKey=\"SystemControlTransparentBrush\" /> \
+            <StaticResource x:Key=\"HitTargetBackgroundPointerOver\" ResourceKey=\"SystemControlHighlightListLowBrush\" /> \
+            <StaticResource x:Key=\"HitTargetBackgroundPressed\" ResourceKey=\"SystemControlHighlightListMediumBrush\" /> \
+            <StaticResource x:Key=\"HitTargetFocusVisualPrimaryBrush\" ResourceKey=\"SystemControlFocusVisualPrimaryBrush\" /> \
+            <StaticResource x:Key=\"HitTargetFocusVisualSecondaryBrush\" ResourceKey=\"SystemControlFocusVisualSecondaryBrush\" /> \
+            <StaticResource x:Key=\"HitTargetFocusBorderBrush\" ResourceKey=\"SystemControlForegroundAltHighBrush\" /> \
+            <StaticResource x:Key=\"HitTargetFocusSecondaryBorderBrush\" ResourceKey=\"SystemControlForegroundBaseHighBrush\" /> \
         </ResourceDictionary> \
 \
         <ResourceDictionary x:Key=\"HighContrast\"> \
-          <SolidColorBrush x:Key=\"TextColor.Accent\" Color=\"{ThemeResource SystemColorWindowColor}\"/> \
-          <SolidColorBrush x:Key=\"TextColor.Default\" Color=\"{ThemeResource SystemColorButtonTextColor}\"/> \
+            <SolidColorBrush x:Key=\"TextColor.Accent\" Color=\"{ThemeResource SystemColorWindowColor}\"/> \
+            <SolidColorBrush x:Key=\"TextColor.Default\" Color=\"{ThemeResource SystemColorButtonTextColor}\"/> \
+\
+            <!-- Resources for HitTarget --> \
+            <StaticResource x:Key=\"HitTargetBackground\" ResourceKey=\"SystemControlTransparentBrush\" /> \
+            <StaticResource x:Key=\"HitTargetBackgroundPointerOver\" ResourceKey=\"SystemControlHighlightListLowBrush\" /> \
+            <StaticResource x:Key=\"HitTargetBackgroundPressed\" ResourceKey=\"SystemControlHighlightListMediumBrush\" /> \
+            <StaticResource x:Key=\"HitTargetFocusVisualPrimaryBrush\" ResourceKey=\"SystemControlFocusVisualPrimaryBrush\" /> \
+            <StaticResource x:Key=\"HitTargetFocusVisualSecondaryBrush\" ResourceKey=\"SystemControlFocusVisualSecondaryBrush\" /> \
+            <StaticResource x:Key=\"HitTargetFocusBorderBrush\" ResourceKey=\"SystemControlForegroundAltHighBrush\" /> \
+            <StaticResource x:Key=\"HitTargetFocusSecondaryBorderBrush\" ResourceKey=\"SystemControlForegroundBaseHighBrush\" /> \
         </ResourceDictionary> \
     </ResourceDictionary.ThemeDictionaries> \
 \
@@ -44,8 +71,10 @@ const PCWSTR c_defaultResourceDictionary = L"\
     </Style> \
     <Style TargetType=\"TextBlock\" x:Key=\"TextBlock.Small\"> \
         <Setter Property=\"FontSize\" Value=\"8\"/> \
-    </Style> \
-\
+    </Style>"
+
+// Split into two strings, otherwise we hit "string too big" error
+"\
     <Style TargetType=\"StackPanel\" x:Key=\"Container\"> \
         <Setter Property=\"Margin\" Value=\"0,0,0,0\"/> \
     </Style> \
@@ -55,5 +84,63 @@ const PCWSTR c_defaultResourceDictionary = L"\
 \
     <Style TargetType=\"Grid\" x:Key=\"ColumnSet\"> \
         <Setter Property=\"Margin\" Value=\"0,0,0,0\"/> \
+    </Style> \
+\
+    <Style x:Key=\"HitTarget\" TargetType=\"Button\"> \
+        <Setter Property=\"Background\" Value=\"{ThemeResource HitTargetBackground}\" /> \
+        <Setter Property=\"BorderThickness\" Value=\"0\" /> \
+        <Setter Property=\"Padding\" Value=\"0\" /> \
+        <Setter Property=\"HorizontalAlignment\" Value=\"Stretch\" /> \
+        <Setter Property=\"HorizontalContentAlignment\" Value=\"Stretch\" /> \
+        <Setter Property=\"VerticalAlignment\" Value=\"Center\" /> \
+        <Setter Property=\"UseSystemFocusVisuals\" Value=\"True\" /> \
+        <Setter Property=\"FocusVisualMargin\" Value=\"0\" /> \
+        <Setter Property=\"FocusVisualPrimaryBrush\" Value=\"{ThemeResource HitTargetFocusVisualPrimaryBrush}\" /> \
+        <Setter Property=\"FocusVisualPrimaryThickness\" Value=\"2\" /> \
+        <Setter Property=\"FocusVisualSecondaryBrush\" Value=\"{ThemeResource HitTargetFocusVisualSecondaryBrush}\" /> \
+        <Setter Property=\"FocusVisualSecondaryThickness\" Value=\"1\" /> \
+        <Setter Property=\"Template\"> \
+            <Setter.Value> \
+                <ControlTemplate TargetType=\"Button\"> \
+                    <Grid x:Name=\"RootGrid\" Background=\"{TemplateBinding Background}\"> \
+                        <VisualStateManager.VisualStateGroups> \
+                            <VisualStateGroup x:Name=\"CommonStates\"> \
+                                <VisualState x:Name=\"Normal\"> \
+                                    <Storyboard> \
+                                        <PointerUpThemeAnimation Storyboard.TargetName=\"RootGrid\" /> \
+                                    </Storyboard> \
+                                </VisualState> \
+                                <VisualState x:Name=\"PointerOver\"> \
+                                    <Storyboard> \
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName=\"RootGrid\" Storyboard.TargetProperty=\"Background\"> \
+                                            <DiscreteObjectKeyFrame KeyTime=\"0\" Value=\"{ThemeResource HitTargetBackgroundPointerOver}\" /> \
+                                        </ObjectAnimationUsingKeyFrames> \
+                                        <PointerUpThemeAnimation Storyboard.TargetName=\"RootGrid\" /> \
+                                    </Storyboard> \
+                                </VisualState> \
+                                <VisualState x:Name=\"Pressed\"> \
+                                    <Storyboard> \
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName=\"RootGrid\" Storyboard.TargetProperty=\"Background\"> \
+                                            <DiscreteObjectKeyFrame KeyTime=\"0\" Value=\"{ThemeResource HitTargetBackgroundPressed}\" /> \
+                                        </ObjectAnimationUsingKeyFrames> \
+                                        <PointerDownThemeAnimation Storyboard.TargetName=\"RootGrid\" /> \
+                                    </Storyboard> \
+                                </VisualState> \
+                            </VisualStateGroup> \
+                        </VisualStateManager.VisualStateGroups> \
+                        <ContentPresenter x:Name=\"ContentPresenter\" \
+                            BorderBrush=\"{TemplateBinding BorderBrush}\" \
+                            BorderThickness=\"{TemplateBinding BorderThickness}\" \
+                            Content=\"{TemplateBinding Content}\" \
+                            ContentTransitions=\"{TemplateBinding ContentTransitions}\" \
+                            ContentTemplate=\"{TemplateBinding ContentTemplate}\" \
+                            Padding=\"{TemplateBinding Padding}\" \
+                            HorizontalContentAlignment=\"{TemplateBinding HorizontalContentAlignment}\" \
+                            VerticalContentAlignment=\"{TemplateBinding VerticalContentAlignment}\" \
+                            AutomationProperties.AccessibilityView=\"Raw\" /> \
+                    </Grid> \
+                </ControlTemplate> \
+            </Setter.Value> \
+        </Setter> \
     </Style> \
 </ResourceDictionary>";

--- a/source/uwp/Renderer/lib/DefaultResourceDictionary.h
+++ b/source/uwp/Renderer/lib/DefaultResourceDictionary.h
@@ -7,18 +7,18 @@ const PCWSTR c_defaultResourceDictionary = L"\
 \
     <ResourceDictionary.ThemeDictionaries> \
         <ResourceDictionary x:Key=\"Dark\"> \
-            <SolidColorBrush x:Key=\"TextColor.Accent\" Color=\"{ThemeResource SystemAccentColor}\"/> \
-            <SolidColorBrush x:Key=\"TextColor.Default\" Color=\"{ThemeResource SystemBaseHighColor}\"/> \
+          <SolidColorBrush x:Key=\"TextColor.Accent\" Color=\"{ThemeResource SystemAccentColor}\"/> \
+          <SolidColorBrush x:Key=\"TextColor.Default\" Color=\"{ThemeResource SystemBaseHighColor}\"/> \
         </ResourceDictionary> \
 \
         <ResourceDictionary x:Key=\"Light\"> \
-            <SolidColorBrush x:Key=\"TextColor.Accent\" Color=\"{ThemeResource SystemAccentColor}\"/> \
-            <SolidColorBrush x:Key=\"TextColor.Default\" Color=\"{ThemeResource SystemBaseHighColor}\"/> \
+          <SolidColorBrush x:Key=\"TextColor.Accent\" Color=\"{ThemeResource SystemAccentColor}\"/> \
+          <SolidColorBrush x:Key=\"TextColor.Default\" Color=\"{ThemeResource SystemBaseHighColor}\"/> \
         </ResourceDictionary> \
 \
         <ResourceDictionary x:Key=\"HighContrast\"> \
-            <SolidColorBrush x:Key=\"TextColor.Accent\" Color=\"{ThemeResource SystemColorWindowColor}\"/> \
-            <SolidColorBrush x:Key=\"TextColor.Default\" Color=\"{ThemeResource SystemColorButtonTextColor}\"/> \
+          <SolidColorBrush x:Key=\"TextColor.Accent\" Color=\"{ThemeResource SystemColorWindowColor}\"/> \
+          <SolidColorBrush x:Key=\"TextColor.Default\" Color=\"{ThemeResource SystemColorButtonTextColor}\"/> \
         </ResourceDictionary> \
     </ResourceDictionary.ThemeDictionaries> \
 \

--- a/source/uwp/Renderer/lib/DefaultResourceDictionary.h
+++ b/source/uwp/Renderer/lib/DefaultResourceDictionary.h
@@ -57,7 +57,7 @@ const PCWSTR c_defaultResourceDictionary = L"\
         <Setter Property=\"Margin\" Value=\"0,0,0,0\"/> \
     </Style> \
 \
-    <Style x:Key=\"HitTarget\" TargetType=\"Button\"> \
+    <Style x:Key=\"SelectAction\" TargetType=\"Button\"> \
         <Setter Property=\"Background\" Value=\"{ThemeResource ListViewItemBackground}\" /> \
         <Setter Property=\"BorderThickness\" Value=\"0\" /> \
         <Setter Property=\"Padding\" Value=\"0\" /> \

--- a/source/uwp/Renderer/lib/DefaultResourceDictionary.h
+++ b/source/uwp/Renderer/lib/DefaultResourceDictionary.h
@@ -9,43 +9,16 @@ const PCWSTR c_defaultResourceDictionary = L"\
         <ResourceDictionary x:Key=\"Dark\"> \
             <SolidColorBrush x:Key=\"TextColor.Accent\" Color=\"{ThemeResource SystemAccentColor}\"/> \
             <SolidColorBrush x:Key=\"TextColor.Default\" Color=\"{ThemeResource SystemBaseHighColor}\"/> \
-\
-            <!-- Resources for HitTarget --> \
-            <StaticResource x:Key=\"HitTargetBackground\" ResourceKey=\"SystemControlTransparentBrush\" /> \
-            <StaticResource x:Key=\"HitTargetBackgroundPointerOver\" ResourceKey=\"SystemControlHighlightListLowBrush\" /> \
-            <StaticResource x:Key=\"HitTargetBackgroundPressed\" ResourceKey=\"SystemControlHighlightListMediumBrush\" /> \
-            <StaticResource x:Key=\"HitTargetFocusVisualPrimaryBrush\" ResourceKey=\"SystemControlFocusVisualPrimaryBrush\" /> \
-            <StaticResource x:Key=\"HitTargetFocusVisualSecondaryBrush\" ResourceKey=\"SystemControlFocusVisualSecondaryBrush\" /> \
-            <StaticResource x:Key=\"HitTargetFocusBorderBrush\" ResourceKey=\"SystemControlForegroundAltHighBrush\" /> \
-            <StaticResource x:Key=\"HitTargetFocusSecondaryBorderBrush\" ResourceKey=\"SystemControlForegroundBaseHighBrush\" /> \
         </ResourceDictionary> \
 \
         <ResourceDictionary x:Key=\"Light\"> \
             <SolidColorBrush x:Key=\"TextColor.Accent\" Color=\"{ThemeResource SystemAccentColor}\"/> \
             <SolidColorBrush x:Key=\"TextColor.Default\" Color=\"{ThemeResource SystemBaseHighColor}\"/> \
-\
-            <!-- Resources for HitTarget --> \
-            <StaticResource x:Key=\"HitTargetBackground\" ResourceKey=\"SystemControlTransparentBrush\" /> \
-            <StaticResource x:Key=\"HitTargetBackgroundPointerOver\" ResourceKey=\"SystemControlHighlightListLowBrush\" /> \
-            <StaticResource x:Key=\"HitTargetBackgroundPressed\" ResourceKey=\"SystemControlHighlightListMediumBrush\" /> \
-            <StaticResource x:Key=\"HitTargetFocusVisualPrimaryBrush\" ResourceKey=\"SystemControlFocusVisualPrimaryBrush\" /> \
-            <StaticResource x:Key=\"HitTargetFocusVisualSecondaryBrush\" ResourceKey=\"SystemControlFocusVisualSecondaryBrush\" /> \
-            <StaticResource x:Key=\"HitTargetFocusBorderBrush\" ResourceKey=\"SystemControlForegroundAltHighBrush\" /> \
-            <StaticResource x:Key=\"HitTargetFocusSecondaryBorderBrush\" ResourceKey=\"SystemControlForegroundBaseHighBrush\" /> \
         </ResourceDictionary> \
 \
         <ResourceDictionary x:Key=\"HighContrast\"> \
             <SolidColorBrush x:Key=\"TextColor.Accent\" Color=\"{ThemeResource SystemColorWindowColor}\"/> \
             <SolidColorBrush x:Key=\"TextColor.Default\" Color=\"{ThemeResource SystemColorButtonTextColor}\"/> \
-\
-            <!-- Resources for HitTarget --> \
-            <StaticResource x:Key=\"HitTargetBackground\" ResourceKey=\"SystemControlTransparentBrush\" /> \
-            <StaticResource x:Key=\"HitTargetBackgroundPointerOver\" ResourceKey=\"SystemControlHighlightListLowBrush\" /> \
-            <StaticResource x:Key=\"HitTargetBackgroundPressed\" ResourceKey=\"SystemControlHighlightListMediumBrush\" /> \
-            <StaticResource x:Key=\"HitTargetFocusVisualPrimaryBrush\" ResourceKey=\"SystemControlFocusVisualPrimaryBrush\" /> \
-            <StaticResource x:Key=\"HitTargetFocusVisualSecondaryBrush\" ResourceKey=\"SystemControlFocusVisualSecondaryBrush\" /> \
-            <StaticResource x:Key=\"HitTargetFocusBorderBrush\" ResourceKey=\"SystemControlForegroundAltHighBrush\" /> \
-            <StaticResource x:Key=\"HitTargetFocusSecondaryBorderBrush\" ResourceKey=\"SystemControlForegroundBaseHighBrush\" /> \
         </ResourceDictionary> \
     </ResourceDictionary.ThemeDictionaries> \
 \
@@ -71,10 +44,8 @@ const PCWSTR c_defaultResourceDictionary = L"\
     </Style> \
     <Style TargetType=\"TextBlock\" x:Key=\"TextBlock.Small\"> \
         <Setter Property=\"FontSize\" Value=\"8\"/> \
-    </Style>"
-
-// Split into two strings, otherwise we hit "string too big" error
-"\
+    </Style> \
+\
     <Style TargetType=\"StackPanel\" x:Key=\"Container\"> \
         <Setter Property=\"Margin\" Value=\"0,0,0,0\"/> \
     </Style> \
@@ -87,7 +58,7 @@ const PCWSTR c_defaultResourceDictionary = L"\
     </Style> \
 \
     <Style x:Key=\"HitTarget\" TargetType=\"Button\"> \
-        <Setter Property=\"Background\" Value=\"{ThemeResource HitTargetBackground}\" /> \
+        <Setter Property=\"Background\" Value=\"{ThemeResource ListViewItemBackground}\" /> \
         <Setter Property=\"BorderThickness\" Value=\"0\" /> \
         <Setter Property=\"Padding\" Value=\"0\" /> \
         <Setter Property=\"HorizontalAlignment\" Value=\"Stretch\" /> \
@@ -95,9 +66,9 @@ const PCWSTR c_defaultResourceDictionary = L"\
         <Setter Property=\"VerticalAlignment\" Value=\"Center\" /> \
         <Setter Property=\"UseSystemFocusVisuals\" Value=\"True\" /> \
         <Setter Property=\"FocusVisualMargin\" Value=\"0\" /> \
-        <Setter Property=\"FocusVisualPrimaryBrush\" Value=\"{ThemeResource HitTargetFocusVisualPrimaryBrush}\" /> \
+        <Setter Property=\"FocusVisualPrimaryBrush\" Value=\"{ThemeResource ListViewItemFocusVisualPrimaryBrush}\" /> \
         <Setter Property=\"FocusVisualPrimaryThickness\" Value=\"2\" /> \
-        <Setter Property=\"FocusVisualSecondaryBrush\" Value=\"{ThemeResource HitTargetFocusVisualSecondaryBrush}\" /> \
+        <Setter Property=\"FocusVisualSecondaryBrush\" Value=\"{ThemeResource ListViewItemFocusVisualSecondaryBrush}\" /> \
         <Setter Property=\"FocusVisualSecondaryThickness\" Value=\"1\" /> \
         <Setter Property=\"Template\"> \
             <Setter.Value> \
@@ -113,7 +84,7 @@ const PCWSTR c_defaultResourceDictionary = L"\
                                 <VisualState x:Name=\"PointerOver\"> \
                                     <Storyboard> \
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName=\"RootGrid\" Storyboard.TargetProperty=\"Background\"> \
-                                            <DiscreteObjectKeyFrame KeyTime=\"0\" Value=\"{ThemeResource HitTargetBackgroundPointerOver}\" /> \
+                                            <DiscreteObjectKeyFrame KeyTime=\"0\" Value=\"{ThemeResource ListViewItemBackgroundPointerOver}\" /> \
                                         </ObjectAnimationUsingKeyFrames> \
                                         <PointerUpThemeAnimation Storyboard.TargetName=\"RootGrid\" /> \
                                     </Storyboard> \
@@ -121,7 +92,7 @@ const PCWSTR c_defaultResourceDictionary = L"\
                                 <VisualState x:Name=\"Pressed\"> \
                                     <Storyboard> \
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName=\"RootGrid\" Storyboard.TargetProperty=\"Background\"> \
-                                            <DiscreteObjectKeyFrame KeyTime=\"0\" Value=\"{ThemeResource HitTargetBackgroundPressed}\" /> \
+                                            <DiscreteObjectKeyFrame KeyTime=\"0\" Value=\"{ThemeResource ListViewItemBackgroundPressed}\" /> \
                                         </ObjectAnimationUsingKeyFrames> \
                                         <PointerDownThemeAnimation Storyboard.TargetName=\"RootGrid\" /> \
                                     </Storyboard> \

--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -1373,7 +1373,7 @@ namespace AdaptiveCards { namespace Uwp
         {
             ComPtr<IUIElement> containerBorderAsUIElement;
             THROW_IF_FAILED(containerBorder.As(&containerBorderAsUIElement));
-            WrapInFullWidthTouchTarget(containerBorderAsUIElement.Get(), selectAction.Get(), renderContext, containerControl);
+            WrapInFullWidthTouchTarget(adaptiveCardElement, containerBorderAsUIElement.Get(), selectAction.Get(), renderContext, containerControl);
         }
         else
         {
@@ -1551,7 +1551,7 @@ namespace AdaptiveCards { namespace Uwp
         {
             ComPtr<IUIElement> gridAsUIElement;
             THROW_IF_FAILED(xamlGrid.As(&gridAsUIElement));
-            WrapInFullWidthTouchTarget(gridAsUIElement.Get(), selectAction.Get(), renderContext, columnSetControl);
+            WrapInFullWidthTouchTarget(adaptiveCardElement, gridAsUIElement.Get(), selectAction.Get(), renderContext, columnSetControl);
         }
         else
         {
@@ -2050,6 +2050,7 @@ namespace AdaptiveCards { namespace Uwp
     }
 
     void XamlBuilder::WrapInFullWidthTouchTarget(
+        IAdaptiveCardElement* adaptiveCardElement,
         IUIElement* elementToWrap,
         IAdaptiveActionElement* action,
         IAdaptiveRenderContext* renderContext,
@@ -2088,26 +2089,34 @@ namespace AdaptiveCards { namespace Uwp
         UINT32 cardPadding;
         THROW_IF_FAILED(spacingConfig->get_Padding(&cardPadding));
 
-        // For button padding, we apply the cardPadding (since we negate the card padding in the margin)
+        // We want the hit target to equally split the vertical space above and below the current item.
+        // However, all we know is the spacing of the current item, which only applies to the spacing above.
+        // We don't know what the spacing of the NEXT element will be, so we can't calculate the correct spacing below.
+        // For now, we'll simply assume the bottom spacing is the same as the top.
+        ABI::AdaptiveCards::Uwp::Spacing elementSpacing;
+        THROW_IF_FAILED(adaptiveCardElement->get_Spacing(&elementSpacing));
+        UINT spacingSize;
+        THROW_IF_FAILED(GetSpacingSizeFromSpacing(m_hostConfig.Get(), elementSpacing, &spacingSize));
+        double topBottomPadding = spacingSize / 2.0;
+
+        // For button padding, we apply the cardPadding and topBottomPadding (and then we negate these in the margin)
         ComPtr<IControl> buttonAsControl;
         THROW_IF_FAILED(button.As(&buttonAsControl));
-        THROW_IF_FAILED(buttonAsControl->put_Padding({ (double)cardPadding, 0, (double)cardPadding, 0 }));
+        THROW_IF_FAILED(buttonAsControl->put_Padding({ (double)cardPadding, topBottomPadding, (double)cardPadding, topBottomPadding }));
 
-        // Style the hit target button
+        double negativeCardMargin = cardPadding * -1.0;
+        double negativeTopBottomMargin = topBottomPadding * -1.0;
+
         ComPtr<IFrameworkElement> buttonAsFrameworkElement;
         THROW_IF_FAILED(button.As(&buttonAsFrameworkElement));
+        THROW_IF_FAILED(buttonAsFrameworkElement->put_Margin({ negativeCardMargin, negativeTopBottomMargin, negativeCardMargin, negativeTopBottomMargin }));
+
+        // Style the hit target button
         ComPtr<IStyle> style;
         if (SUCCEEDED(TryGetResoureFromResourceDictionaries<IStyle>(L"HitTarget", &style)))
         {
             THROW_IF_FAILED(buttonAsFrameworkElement->put_Style(style.Get()));
         }
-
-        double negativeCardMargin = cardPadding * -1.0;
-
-        // TODO: Apply negative margin to top/bottom that causes button to appear halfway between spacing between elements.
-        // However this will be tricky, since to get the spacing for the bottom, we need to know the NEXT card element.
-
-        THROW_IF_FAILED(buttonAsFrameworkElement->put_Margin({ negativeCardMargin, 0, negativeCardMargin, 0 }));
 
         WireButtonClickToAction(button.Get(), action, renderContext);
 

--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -2113,7 +2113,7 @@ namespace AdaptiveCards { namespace Uwp
 
         // Style the hit target button
         ComPtr<IStyle> style;
-        if (SUCCEEDED(TryGetResoureFromResourceDictionaries<IStyle>(L"HitTarget", &style)))
+        if (SUCCEEDED(TryGetResoureFromResourceDictionaries<IStyle>(L"SelectAction", &style)))
         {
             THROW_IF_FAILED(buttonAsFrameworkElement->put_Style(style.Get()));
         }

--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -2088,18 +2088,19 @@ namespace AdaptiveCards { namespace Uwp
         UINT32 cardPadding;
         THROW_IF_FAILED(spacingConfig->get_Padding(&cardPadding));
 
+        // For button padding, we apply the cardPadding (since we negate the card padding in the margin)
         ComPtr<IControl> buttonAsControl;
         THROW_IF_FAILED(button.As(&buttonAsControl));
-        THROW_IF_FAILED(buttonAsControl->put_HorizontalContentAlignment(HorizontalAlignment_Stretch));
-        ComPtr<IBrush> buttonBackgroundBrush = GetSolidColorBrush(Color());
-        THROW_IF_FAILED(buttonAsControl->put_Background(buttonBackgroundBrush.Get()));
+        THROW_IF_FAILED(buttonAsControl->put_Padding({ (double)cardPadding, 0, (double)cardPadding, 0 }));
 
-        // For button padding, we apply the cardPadding minus two pixels, since the button's BorderThickness defaults to 2
-        THROW_IF_FAILED(buttonAsControl->put_Padding({ (double)cardPadding - 2, -2, (double)cardPadding - 2, -2 }));
-
+        // Style the hit target button
         ComPtr<IFrameworkElement> buttonAsFrameworkElement;
         THROW_IF_FAILED(button.As(&buttonAsFrameworkElement));
-        THROW_IF_FAILED(buttonAsFrameworkElement->put_HorizontalAlignment(HorizontalAlignment_Stretch));
+        ComPtr<IStyle> style;
+        if (SUCCEEDED(TryGetResoureFromResourceDictionaries<IStyle>(L"HitTarget", &style)))
+        {
+            THROW_IF_FAILED(buttonAsFrameworkElement->put_Style(style.Get()));
+        }
 
         double negativeCardMargin = cardPadding * -1.0;
 

--- a/source/uwp/Renderer/lib/XamlBuilder.h
+++ b/source/uwp/Renderer/lib/XamlBuilder.h
@@ -204,6 +204,7 @@ namespace AdaptiveCards { namespace Uwp
         bool SupportsInteractivity();
 
         void WrapInFullWidthTouchTarget(
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
             _In_ ABI::Windows::UI::Xaml::IUIElement* elementToWrap,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveActionElement* action,
             _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,


### PR DESCRIPTION
Designer feedback was that hit targets should be styled the same as list view items are. Plus the hit targets need to split the vertical spacing between rows evenly, in order to provide padding around items. Definitely looks better now :)

## Implementation details

- Created a custom `HitTarget` style for Button in `DefaultResourceDictionary.h` that styles the button similar to a ListViewItem
- Use the `spacing` on the current element to assume the same spacing on the next element and make the touch target expand its height vertically halfway between row items

(In future we should improve that behavior to actually figure out the next item's spacing, but this is good enough for now and it can be considered a bug that when different spacings are used, things get funky)

## How tested
Used `samples\v1.0\Elements\ColumnSet.SelectAction.json` and `Container.SelectAction.json` and tested/verified both of these in the UWP Visualizer, and also tested Notifications Visualizer scenarios, plus some other card payloads

## What was tested

- Keyboard accessibility
- High contrast
- When selectAction provided on Container/ColumnSet, it becomes clickable
- When not provided, still functions normally
- When clicked on, invokes the action
- Action.OpenUrl works
- Action.Submit works
- Existing buttons (actions) work
- Emphasis behavior on columns/containers
- All main scenario payloads (ActivityUpdate, CalendarReminder, FlightItinerary, etc)

## New visuals

![image](https://user-images.githubusercontent.com/13246069/31259947-85b8764a-a9ff-11e7-8b0b-14f6b2f956ce.png)

![image](https://user-images.githubusercontent.com/13246069/31259924-697c4114-a9ff-11e7-8e38-99095008442e.png)

![image](https://user-images.githubusercontent.com/13246069/31259926-6e87af90-a9ff-11e7-9048-6153ec4ca9bc.png)