### PR TITLE
Decouple XamlCardRenderer from XamlBuilder.

### DIFF
--- a/source/uwp/Renderer/idl/AdaptiveCards.Uwp.idl
+++ b/source/uwp/Renderer/idl/AdaptiveCards.Uwp.idl
@@ -1744,6 +1744,8 @@ namespace AdaptiveCards
 
             [propget] HRESULT ElementRenderers([out, retval] AdaptiveElementRendererRegistration** value);
 
+            [propget] HRESULT ResourceResolvers([out, retval] AdaptiveCardResourceResolvers** value);
+
             [propget] HRESULT ActionInvoker([out, retval] AdaptiveActionInvoker** value);
 
             HRESULT AddInputItem([in] IAdaptiveCardElement* cardElement, [in] Windows.UI.Xaml.UIElement* uiElement);

--- a/source/uwp/Renderer/lib/AdaptiveCardRendererComponent.h
+++ b/source/uwp/Renderer/lib/AdaptiveCardRendererComponent.h
@@ -1,12 +1,9 @@
 ﻿#pragma once
 
 #include "AdaptiveCards.Uwp.h"
-#include "XamlBuilder.h"
 
 namespace AdaptiveCards { namespace Uwp
 {
-    class XamlBuilder;
-
     // This class is effectively a singleton, and stays around between subsequent renders.
     class AdaptiveCardRenderer :
         public Microsoft::WRL::RuntimeClass<
@@ -17,7 +14,6 @@ namespace AdaptiveCards { namespace Uwp
         InspectableClass(RuntimeClass_AdaptiveCards_Uwp_AdaptiveCardRenderer, BaseTrust)
 
     public:
-        AdaptiveCardRenderer();
         HRESULT RuntimeClassInitialize();
 
         // IAdaptiveCardRenderer
@@ -55,7 +51,6 @@ namespace AdaptiveCards { namespace Uwp
         Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Uwp::IAdaptiveCardResourceResolvers> m_resourceResolvers;
         Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Uwp::IAdaptiveElementRendererRegistration> m_elementRendererRegistration;
 
-        std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;
         HRESULT RegisterDefaultElementRenderers();
 
         bool m_explicitDimensions = false;

--- a/source/uwp/Renderer/lib/AdaptiveCardResourceResolvers.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveCardResourceResolvers.cpp
@@ -27,8 +27,6 @@ namespace AdaptiveCards { namespace Uwp
         std::string schemeString;
         RETURN_IF_FAILED(HStringToUTF8(scheme, schemeString));
         ComPtr<IAdaptiveCardResourceResolver> resolverPtr = m_resourceResolvers[schemeString];
-        ComPtr<IAdaptiveCardResourceResolver> localResolver(resolverPtr);
-        *resolver = localResolver.Detach();
-        return S_OK;
+        return resolverPtr.CopyTo(resolver);
     }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.cpp
@@ -11,15 +11,6 @@ using namespace ABI::Windows::Foundation;
 
 namespace AdaptiveCards { namespace Uwp
 {
-    AdaptiveChoiceSetInputRenderer::AdaptiveChoiceSetInputRenderer()
-    {
-    }
-
-    AdaptiveChoiceSetInputRenderer::AdaptiveChoiceSetInputRenderer(const std::shared_ptr<XamlBuilder> xamlBuilder) :
-        m_xamlBuilder(xamlBuilder)
-    {
-    }
-
     HRESULT AdaptiveChoiceSetInputRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -32,7 +23,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder->BuildChoiceSetInput(cardElement, renderContext, renderArgs, result);
+        m_xamlBuilder.BuildChoiceSetInput(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.h
@@ -17,16 +17,13 @@ namespace AdaptiveCards { namespace Uwp
     public:
         HRESULT RuntimeClassInitialize() noexcept;
 
-        AdaptiveChoiceSetInputRenderer();
-        AdaptiveChoiceSetInputRenderer(const std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> xamlBuilder);
-
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
     private:
-        std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;
+        AdaptiveCards::Uwp::XamlBuilder m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveChoiceSetInputRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveColumnRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveColumnRenderer.cpp
@@ -11,15 +11,6 @@ using namespace ABI::Windows::Foundation;
 
 namespace AdaptiveCards { namespace Uwp
 {
-    AdaptiveColumnRenderer::AdaptiveColumnRenderer()
-    {
-    }
-
-    AdaptiveColumnRenderer::AdaptiveColumnRenderer(const std::shared_ptr<XamlBuilder> xamlBuilder) :
-        m_xamlBuilder(xamlBuilder)
-    {
-    }
-
     HRESULT AdaptiveColumnRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -32,7 +23,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder->BuildColumn(cardElement, renderContext, renderArgs, result);
+        m_xamlBuilder.BuildColumn(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 

--- a/source/uwp/Renderer/lib/AdaptiveColumnRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveColumnRenderer.h
@@ -17,16 +17,13 @@ namespace AdaptiveCards { namespace Uwp
     public:
         HRESULT RuntimeClassInitialize() noexcept;
 
-        AdaptiveColumnRenderer();
-        AdaptiveColumnRenderer(const std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> xamlBuilder);
-
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
     private:
-        std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;
+        AdaptiveCards::Uwp::XamlBuilder m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveColumnRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveColumnSetRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveColumnSetRenderer.cpp
@@ -11,15 +11,6 @@ using namespace ABI::Windows::Foundation;
 
 namespace AdaptiveCards { namespace Uwp
 {
-    AdaptiveColumnSetRenderer::AdaptiveColumnSetRenderer()
-    {
-    }
-
-    AdaptiveColumnSetRenderer::AdaptiveColumnSetRenderer(const std::shared_ptr<XamlBuilder> xamlBuilder) :
-        m_xamlBuilder(xamlBuilder)
-    {
-    }
-
     HRESULT AdaptiveColumnSetRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -32,7 +23,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder->BuildColumnSet(cardElement, renderContext, renderArgs, result);
+        m_xamlBuilder.BuildColumnSet(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 

--- a/source/uwp/Renderer/lib/AdaptiveColumnSetRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveColumnSetRenderer.h
@@ -17,16 +17,13 @@ namespace AdaptiveCards { namespace Uwp
     public:
         HRESULT RuntimeClassInitialize() noexcept;
 
-        AdaptiveColumnSetRenderer();
-        AdaptiveColumnSetRenderer(const std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> xamlBuilder);
-
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
     private:
-        std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;
+        AdaptiveCards::Uwp::XamlBuilder m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveColumnSetRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveContainerRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveContainerRenderer.cpp
@@ -11,15 +11,6 @@ using namespace ABI::Windows::Foundation;
 
 namespace AdaptiveCards { namespace Uwp
 {
-    AdaptiveContainerRenderer::AdaptiveContainerRenderer()
-    {
-    }
-
-    AdaptiveContainerRenderer::AdaptiveContainerRenderer(const std::shared_ptr<XamlBuilder> xamlBuilder) :
-        m_xamlBuilder(xamlBuilder)
-    {
-    }
-
     HRESULT AdaptiveContainerRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -32,7 +23,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder->BuildContainer(cardElement, renderContext, renderArgs, result);
+        m_xamlBuilder.BuildContainer(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 

--- a/source/uwp/Renderer/lib/AdaptiveContainerRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveContainerRenderer.h
@@ -17,16 +17,13 @@ namespace AdaptiveCards { namespace Uwp
     public:
         HRESULT RuntimeClassInitialize() noexcept;
 
-        AdaptiveContainerRenderer();
-        AdaptiveContainerRenderer(const std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> xamlBuilder);
-
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
     private:
-        std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;
+        AdaptiveCards::Uwp::XamlBuilder m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveContainerRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveDateInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveDateInputRenderer.cpp
@@ -11,15 +11,6 @@ using namespace ABI::Windows::Foundation;
 
 namespace AdaptiveCards { namespace Uwp
 {
-    AdaptiveDateInputRenderer::AdaptiveDateInputRenderer()
-    {
-    }
-
-    AdaptiveDateInputRenderer::AdaptiveDateInputRenderer(const std::shared_ptr<XamlBuilder> xamlBuilder) :
-        m_xamlBuilder(xamlBuilder)
-    {
-    }
-
     HRESULT AdaptiveDateInputRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -32,7 +23,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder->BuildDateInput(cardElement, renderContext, renderArgs, result);
+        m_xamlBuilder.BuildDateInput(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveDateInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveDateInputRenderer.h
@@ -17,16 +17,13 @@ namespace AdaptiveCards { namespace Uwp
     public:
         HRESULT RuntimeClassInitialize() noexcept;
 
-        AdaptiveDateInputRenderer();
-        AdaptiveDateInputRenderer(const std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> xamlBuilder);
-
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
     private:
-        std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;
+        AdaptiveCards::Uwp::XamlBuilder m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveDateInputRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveFactSetRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveFactSetRenderer.cpp
@@ -11,15 +11,6 @@ using namespace ABI::Windows::Foundation;
 
 namespace AdaptiveCards { namespace Uwp
 {
-    AdaptiveFactSetRenderer::AdaptiveFactSetRenderer()
-    {
-    }
-
-    AdaptiveFactSetRenderer::AdaptiveFactSetRenderer(const std::shared_ptr<XamlBuilder> xamlBuilder) :
-        m_xamlBuilder(xamlBuilder)
-    {
-    }
-
     HRESULT AdaptiveFactSetRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -32,7 +23,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder->BuildFactSet(cardElement, renderContext, renderArgs, result);
+        m_xamlBuilder.BuildFactSet(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveFactSetRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveFactSetRenderer.h
@@ -17,16 +17,13 @@ namespace AdaptiveCards { namespace Uwp
     public:
         HRESULT RuntimeClassInitialize() noexcept;
 
-        AdaptiveFactSetRenderer();
-        AdaptiveFactSetRenderer(const std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> xamlBuilder);
-
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
     private:
-        std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;
+        AdaptiveCards::Uwp::XamlBuilder m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveFactSetRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveImageRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImageRenderer.cpp
@@ -11,15 +11,6 @@ using namespace ABI::Windows::Foundation;
 
 namespace AdaptiveCards { namespace Uwp
 {
-    AdaptiveImageRenderer::AdaptiveImageRenderer()
-    {
-    }
-
-    AdaptiveImageRenderer::AdaptiveImageRenderer(const std::shared_ptr<XamlBuilder> xamlBuilder) :
-        m_xamlBuilder(xamlBuilder)
-    {
-    }
-
     HRESULT AdaptiveImageRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -32,7 +23,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder->BuildImage(cardElement, renderContext, renderArgs, result);
+        m_xamlBuilder.BuildImage(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveImageRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveImageRenderer.h
@@ -17,16 +17,13 @@ namespace AdaptiveCards { namespace Uwp
     public:
         HRESULT RuntimeClassInitialize() noexcept;
 
-        AdaptiveImageRenderer();
-        AdaptiveImageRenderer(const std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> xamlBuilder);
-
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
     private:
-        std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;
+        AdaptiveCards::Uwp::XamlBuilder m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveImageRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveImageSetRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImageSetRenderer.cpp
@@ -11,15 +11,6 @@ using namespace ABI::Windows::Foundation;
 
 namespace AdaptiveCards { namespace Uwp
 {
-    AdaptiveImageSetRenderer::AdaptiveImageSetRenderer()
-    {
-    }
-
-    AdaptiveImageSetRenderer::AdaptiveImageSetRenderer(const std::shared_ptr<XamlBuilder> xamlBuilder) :
-        m_xamlBuilder(xamlBuilder)
-    {
-    }
-
     HRESULT AdaptiveImageSetRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -32,7 +23,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder->BuildImageSet(cardElement, renderContext, renderArgs, result);
+        m_xamlBuilder.BuildImageSet(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveImageSetRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveImageSetRenderer.h
@@ -17,16 +17,13 @@ namespace AdaptiveCards { namespace Uwp
     public:
         HRESULT RuntimeClassInitialize() noexcept;
 
-        AdaptiveImageSetRenderer();
-        AdaptiveImageSetRenderer(const std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> xamlBuilder);
-
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
     private:
-        std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;
+        AdaptiveCards::Uwp::XamlBuilder m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveImageSetRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveInputs.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveInputs.cpp
@@ -1,12 +1,6 @@
 #include "pch.h"
 #include "AdaptiveInputs.h"
 
-#include "AdaptiveCard.h"
-#include "AsyncOperations.h"
-#include <windows.foundation.collections.h>
-#include <Windows.UI.Xaml.h>
-#include "XamlHelpers.h"
-
 using namespace concurrency;
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;

--- a/source/uwp/Renderer/lib/AdaptiveNumberInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveNumberInputRenderer.cpp
@@ -11,15 +11,6 @@ using namespace ABI::Windows::Foundation;
 
 namespace AdaptiveCards { namespace Uwp
 {
-    AdaptiveNumberInputRenderer::AdaptiveNumberInputRenderer()
-    {
-    }
-
-    AdaptiveNumberInputRenderer::AdaptiveNumberInputRenderer(const std::shared_ptr<XamlBuilder> xamlBuilder) :
-        m_xamlBuilder(xamlBuilder)
-    {
-    }
-
     HRESULT AdaptiveNumberInputRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -32,7 +23,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder->BuildNumberInput(cardElement, renderContext, renderArgs, result);
+        m_xamlBuilder.BuildNumberInput(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveNumberInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveNumberInputRenderer.h
@@ -17,16 +17,13 @@ namespace AdaptiveCards { namespace Uwp
     public:
         HRESULT RuntimeClassInitialize() noexcept;
 
-        AdaptiveNumberInputRenderer();
-        AdaptiveNumberInputRenderer(const std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> xamlBuilder);
-
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
     private:
-        std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;
+        AdaptiveCards::Uwp::XamlBuilder m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveNumberInputRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveRenderContext.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveRenderContext.cpp
@@ -20,11 +20,13 @@ namespace AdaptiveCards { namespace Uwp
     HRESULT AdaptiveRenderContext::RuntimeClassInitialize(
         IAdaptiveHostConfig* hostConfig,
         IAdaptiveElementRendererRegistration* elementRendererRegistration,
+        IAdaptiveCardResourceResolvers* resourceResolvers,
         RenderedAdaptiveCard* renderResult) noexcept try
     {
         m_hostConfig = hostConfig;
         m_elementRendererRegistration = elementRendererRegistration;
         m_renderResult = renderResult;
+        m_resourceResolvers = resourceResolvers;
 
         return MakeAndInitialize<AdaptiveActionInvoker>(&m_actionInvoker, renderResult);
     } CATCH_RETURN;
@@ -32,22 +34,25 @@ namespace AdaptiveCards { namespace Uwp
     _Use_decl_annotations_
     HRESULT AdaptiveRenderContext::get_HostConfig(IAdaptiveHostConfig** value)
     {
-        m_hostConfig.CopyTo(value);
-        return S_OK;
+        return m_hostConfig.CopyTo(value);
     }
 
     _Use_decl_annotations_
     HRESULT AdaptiveRenderContext::get_ElementRenderers(IAdaptiveElementRendererRegistration** value)
     {
-        m_elementRendererRegistration.CopyTo(value);
-        return S_OK;
+        return m_elementRendererRegistration.CopyTo(value);
     }
 
     _Use_decl_annotations_
     HRESULT AdaptiveRenderContext::get_ActionInvoker(IAdaptiveActionInvoker** value)
     {
-        m_actionInvoker.CopyTo(value);
-        return S_OK;
+        return m_actionInvoker.CopyTo(value);
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveRenderContext::get_ResourceResolvers(IAdaptiveCardResourceResolvers** value)
+    {
+        return m_resourceResolvers.CopyTo(value);
     }
 
     _Use_decl_annotations_

--- a/source/uwp/Renderer/lib/AdaptiveRenderContext.h
+++ b/source/uwp/Renderer/lib/AdaptiveRenderContext.h
@@ -19,18 +19,21 @@ namespace AdaptiveCards { namespace Uwp
         HRESULT RuntimeClassInitialize(
             ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig* hostConfig,
             ABI::AdaptiveCards::Uwp::IAdaptiveElementRendererRegistration* elementRendererRegistration,
+            ABI::AdaptiveCards::Uwp::IAdaptiveCardResourceResolvers* resourceResolvers,
             AdaptiveCards::Uwp::RenderedAdaptiveCard* renderResult) noexcept;
 
         IFACEMETHODIMP get_HostConfig(_COM_Outptr_ ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig** value);
         IFACEMETHODIMP get_ElementRenderers(_COM_Outptr_ ABI::AdaptiveCards::Uwp::IAdaptiveElementRendererRegistration** value);
         IFACEMETHODIMP get_ActionInvoker(_COM_Outptr_ ABI::AdaptiveCards::Uwp::IAdaptiveActionInvoker** value);
         IFACEMETHODIMP AddInputItem(_In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement, _In_ ABI::Windows::UI::Xaml::IUIElement* uiElement);
+        IFACEMETHODIMP get_ResourceResolvers(_COM_Outptr_ ABI::AdaptiveCards::Uwp::IAdaptiveCardResourceResolvers** value);
 
     private:
         Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig> m_hostConfig;
         Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Uwp::IAdaptiveElementRendererRegistration> m_elementRendererRegistration;
         Microsoft::WRL::ComPtr<AdaptiveCards::Uwp::RenderedAdaptiveCard> m_renderResult;
         Microsoft::WRL::ComPtr<AdaptiveCards::Uwp::AdaptiveActionInvoker> m_actionInvoker;
+        Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Uwp::IAdaptiveCardResourceResolvers> m_resourceResolvers;
     };
 
     ActivatableClass(AdaptiveRenderContext);

--- a/source/uwp/Renderer/lib/AdaptiveTextBlockRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTextBlockRenderer.cpp
@@ -11,15 +11,6 @@ using namespace ABI::Windows::Foundation;
 
 namespace AdaptiveCards { namespace Uwp
 {
-    AdaptiveTextBlockRenderer::AdaptiveTextBlockRenderer()
-    {
-    }
-
-    AdaptiveTextBlockRenderer::AdaptiveTextBlockRenderer(const std::shared_ptr<XamlBuilder> xamlBuilder) :
-        m_xamlBuilder(xamlBuilder)
-    {
-    }
-
     HRESULT AdaptiveTextBlockRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -32,7 +23,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder->BuildTextBlock(cardElement, renderContext, renderArgs, result);
+        m_xamlBuilder.BuildTextBlock(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveTextBlockRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveTextBlockRenderer.h
@@ -16,16 +16,13 @@ namespace AdaptiveCards { namespace Uwp {
     public:
         HRESULT RuntimeClassInitialize() noexcept;
 
-        AdaptiveTextBlockRenderer();
-        AdaptiveTextBlockRenderer(const std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> xamlBuilder);
-
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
     private:
-        std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;
+        AdaptiveCards::Uwp::XamlBuilder m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveTextBlockRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.cpp
@@ -11,15 +11,6 @@ using namespace ABI::Windows::Foundation;
 
 namespace AdaptiveCards { namespace Uwp
 {
-    AdaptiveTextInputRenderer::AdaptiveTextInputRenderer()
-    {
-    }
-
-    AdaptiveTextInputRenderer::AdaptiveTextInputRenderer(const std::shared_ptr<XamlBuilder> xamlBuilder) :
-        m_xamlBuilder(xamlBuilder)
-    {
-    }
-
     HRESULT AdaptiveTextInputRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -32,7 +23,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder->BuildTextInput(cardElement, renderContext, renderArgs, result);
+        m_xamlBuilder.BuildTextInput(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.h
@@ -17,16 +17,13 @@ namespace AdaptiveCards { namespace Uwp
     public:
         HRESULT RuntimeClassInitialize() noexcept;
 
-        AdaptiveTextInputRenderer();
-        AdaptiveTextInputRenderer(const std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> xamlBuilder);
-
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
     private:
-        std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;
+        AdaptiveCards::Uwp::XamlBuilder m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveTextInputRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveTimeInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTimeInputRenderer.cpp
@@ -11,15 +11,6 @@ using namespace ABI::Windows::Foundation;
 
 namespace AdaptiveCards { namespace Uwp
 {
-    AdaptiveTimeInputRenderer::AdaptiveTimeInputRenderer()
-    {
-    }
-
-    AdaptiveTimeInputRenderer::AdaptiveTimeInputRenderer(const std::shared_ptr<XamlBuilder> xamlBuilder) :
-        m_xamlBuilder(xamlBuilder)
-    {
-    }
-
     HRESULT AdaptiveTimeInputRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -32,7 +23,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder->BuildTimeInput(cardElement, renderContext, renderArgs, result);
+        m_xamlBuilder.BuildTimeInput(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveTimeInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveTimeInputRenderer.h
@@ -17,16 +17,13 @@ namespace AdaptiveCards { namespace Uwp
     public:
         HRESULT RuntimeClassInitialize() noexcept;
 
-        AdaptiveTimeInputRenderer();
-        AdaptiveTimeInputRenderer(const std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> xamlBuilder);
-
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
     private:
-        std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;
+        AdaptiveCards::Uwp::XamlBuilder m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveTimeInputRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveToggleInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveToggleInputRenderer.cpp
@@ -11,15 +11,6 @@ using namespace ABI::Windows::Foundation;
 
 namespace AdaptiveCards { namespace Uwp
 {
-    AdaptiveToggleInputRenderer::AdaptiveToggleInputRenderer()
-    {
-    }
-
-    AdaptiveToggleInputRenderer::AdaptiveToggleInputRenderer(const std::shared_ptr<XamlBuilder> xamlBuilder) :
-        m_xamlBuilder(xamlBuilder)
-    {
-    }
-
     HRESULT AdaptiveToggleInputRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -32,7 +23,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder->BuildToggleInput(cardElement, renderContext, renderArgs, result);
+        m_xamlBuilder.BuildToggleInput(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveToggleInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveToggleInputRenderer.h
@@ -17,16 +17,13 @@ namespace AdaptiveCards { namespace Uwp
     public:
         HRESULT RuntimeClassInitialize() noexcept;
 
-        AdaptiveToggleInputRenderer();
-        AdaptiveToggleInputRenderer(const std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> xamlBuilder);
-
         IFACEMETHODIMP Render(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
     private:
-        std::shared_ptr<AdaptiveCards::Uwp::XamlBuilder> m_xamlBuilder;
+        AdaptiveCards::Uwp::XamlBuilder m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveToggleInputRenderer);

--- a/source/uwp/Renderer/lib/AsyncOperations.h
+++ b/source/uwp/Renderer/lib/AsyncOperations.h
@@ -35,7 +35,6 @@ public:
         THROW_IF_FAILED(coreWindow->get_Dispatcher(&m_dispatcher));
 
         m_builder = Microsoft::WRL::Make<AdaptiveCards::Uwp::XamlBuilder>();
-        THROW_IF_FAILED(m_builder->SetHostConfig(m_renderer->GetHostConfig()));
         THROW_IF_FAILED(m_builder->SetOverrideDictionary(m_renderer->GetOverrideDictionary()));
         UINT32 width = 0;
         UINT32 height = 0;
@@ -93,12 +92,15 @@ protected:
                 THROW_IF_FAILED(MakeAndInitialize<AdaptiveCards::Uwp::RenderedAdaptiveCard>(&renderResult));
                 ComPtr<ABI::AdaptiveCards::Uwp::IAdaptiveElementRendererRegistration> elementRenderers;
                 THROW_IF_FAILED(m_renderer->get_ElementRenderers(&elementRenderers));
+                ComPtr<ABI::AdaptiveCards::Uwp::IAdaptiveCardResourceResolvers> resourceResolvers;
+                THROW_IF_FAILED(m_renderer->get_ResourceResolvers(&resourceResolvers));
 
                 ComPtr<AdaptiveCards::Uwp::AdaptiveRenderContext> renderContext;
                 RETURN_IF_FAILED(MakeAndInitialize<AdaptiveCards::Uwp::AdaptiveRenderContext>(
                     &renderContext,
                     m_renderer->GetHostConfig(),
                     elementRenderers.Get(),
+                    resourceResolvers.Get(),
                     renderResult.Get()));
 
                 m_builder->BuildXamlTreeFromAdaptiveCard(m_card.Get(), &m_rootXamlElement, m_renderer.Get(), renderContext.Get());

--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -47,7 +47,6 @@ namespace AdaptiveCards { namespace Uwp
 {
     XamlBuilder::XamlBuilder()
     {
-        m_hostConfig = Make<AdaptiveHostConfig>();
 
         m_imageLoadTracker.AddListener(dynamic_cast<IImageLoadTrackerListener*>(this));
 
@@ -115,10 +114,10 @@ namespace AdaptiveCards { namespace Uwp
         ABI::AdaptiveCards::Uwp::ContainerStyle defaultContainerStyle)
     {
         *xamlTreeRoot = nullptr;
-        m_renderer = renderer;
-
+        ComPtr<IAdaptiveHostConfig> hostConfig;
+        THROW_IF_FAILED(renderContext->get_HostConfig(&hostConfig));
         ComPtr<IAdaptiveCardConfig> adaptiveCardConfig;
-        THROW_IF_FAILED(m_hostConfig->get_AdaptiveCard(&adaptiveCardConfig));
+        THROW_IF_FAILED(hostConfig->get_AdaptiveCard(&adaptiveCardConfig));
 
         boolean allowCustomStyle;
         THROW_IF_FAILED(adaptiveCardConfig->get_AllowCustomStyle(&allowCustomStyle));
@@ -145,7 +144,7 @@ namespace AdaptiveCards { namespace Uwp
         THROW_IF_FAILED(adaptiveCard->get_Body(&body));
         BuildPanelChildren(body.Get(), childElementContainer.Get(), renderContext, renderArgs.Get(), [](IUIElement*) {});
 
-        if (this->SupportsInteractivity())
+        if (this->SupportsInteractivity(hostConfig.Get()))
         {
             ComPtr<IVector<IAdaptiveActionElement*>> actions;
             THROW_IF_FAILED(adaptiveCard->get_Actions(&actions));
@@ -224,12 +223,6 @@ namespace AdaptiveCards { namespace Uwp
             m_mergedResourceDictionary->get_MergedDictionaries(&mergedDictionaries);
             mergedDictionaries->Append(m_defaultResourceDictionary.Get());
         }
-        return S_OK;
-    } CATCH_RETURN;
-
-    HRESULT XamlBuilder::SetHostConfig(_In_ ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig* hostConfig) noexcept try
-    {
-        m_hostConfig = hostConfig;
         return S_OK;
     } CATCH_RETURN;
 
@@ -324,8 +317,10 @@ namespace AdaptiveCards { namespace Uwp
         // Shape (optional) - Provides the background image overlay, if one is set
         // StackPanel - The container for all the card's body elements
         ComPtr<IGrid> rootElement = XamlHelpers::CreateXamlClass<IGrid>(HStringReference(RuntimeClass_Windows_UI_Xaml_Controls_Grid));
+        ComPtr<IAdaptiveHostConfig> hostConfig;
+        THROW_IF_FAILED(renderContext->get_HostConfig(&hostConfig));
         ComPtr<IAdaptiveCardConfig> adaptiveCardConfig;
-        THROW_IF_FAILED(m_hostConfig->get_AdaptiveCard(&adaptiveCardConfig));
+        THROW_IF_FAILED(hostConfig->get_AdaptiveCard(&adaptiveCardConfig));
 
         ComPtr<IPanel> rootAsPanel;
         THROW_IF_FAILED(rootElement.As(&rootAsPanel));
@@ -333,7 +328,7 @@ namespace AdaptiveCards { namespace Uwp
         THROW_IF_FAILED(renderArgs->get_ContainerStyle(&containerStyle));
 
         ABI::Windows::UI::Color backgroundColor;
-        if (SUCCEEDED(GetBackgroundColorFromStyle(containerStyle, m_hostConfig.Get(), &backgroundColor)))
+        if (SUCCEEDED(GetBackgroundColorFromStyle(containerStyle, hostConfig.Get(), &backgroundColor)))
         {
             ComPtr<IBrush> backgroundColorBrush = GetSolidColorBrush(backgroundColor);
             THROW_IF_FAILED(rootAsPanel->put_Background(backgroundColorBrush.Get()));
@@ -350,7 +345,7 @@ namespace AdaptiveCards { namespace Uwp
         ComPtr<IStackPanel> bodyElementHost = XamlHelpers::CreateXamlClass<IStackPanel>(HStringReference(RuntimeClass_Windows_UI_Xaml_Controls_StackPanel));
         ComPtr<IFrameworkElement> bodyElementHostAsElement;
         THROW_IF_FAILED(bodyElementHost.As(&bodyElementHostAsElement));
-        ApplyMarginToXamlElement(bodyElementHostAsElement.Get());
+        ApplyMarginToXamlElement(hostConfig.Get(), bodyElementHostAsElement.Get());
 
         XamlHelpers::AppendXamlElementToPanel(bodyElementHost.Get(), rootAsPanel.Get());
         THROW_IF_FAILED(bodyElementHost.CopyTo(childElementContainer));
@@ -432,11 +427,11 @@ namespace AdaptiveCards { namespace Uwp
 
     _Use_decl_annotations_
     template<typename T>
-    void XamlBuilder::SetImageOnUIElement(_In_ ABI::Windows::Foundation::IUriRuntimeClass* imageUri, T* uiElement)
+    void XamlBuilder::SetImageOnUIElement(_In_ ABI::Windows::Foundation::IUriRuntimeClass* imageUri, T* uiElement, IAdaptiveRenderContext* renderContext)
     {
         // Get the resource resolvers
         ComPtr<IAdaptiveCardResourceResolvers> resolvers;
-        THROW_IF_FAILED(m_renderer->get_ResourceResolvers(&resolvers));
+        THROW_IF_FAILED(renderContext->get_ResourceResolvers(&resolvers));
 
         // Get the image url scheme
         HSTRING schemeName;
@@ -609,7 +604,7 @@ namespace AdaptiveCards { namespace Uwp
     void XamlBuilder::BuildPanelChildren(
         IVector<IAdaptiveCardElement*>* children,
         IPanel* parentPanel,
-        ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* context,
+        ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
         ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
         std::function<void(IUIElement* child)> childCreatedCallback)
     {
@@ -621,11 +616,13 @@ namespace AdaptiveCards { namespace Uwp
             HSTRING elementType;
             THROW_IF_FAILED(element->get_ElementTypeString(&elementType));
             ComPtr<IAdaptiveElementRendererRegistration> elementRenderers;
-            THROW_IF_FAILED(context->get_ElementRenderers(&elementRenderers));
+            THROW_IF_FAILED(renderContext->get_ElementRenderers(&elementRenderers));
             ComPtr<IAdaptiveElementRenderer> elementRenderer;
             THROW_IF_FAILED(elementRenderers->Get(elementType, &elementRenderer));
             if (elementRenderer != nullptr)
             {
+                ComPtr<IAdaptiveHostConfig> hostConfig;
+                THROW_IF_FAILED(renderContext->get_HostConfig(&hostConfig));
                 // First element does not need a separator added
                 if (currentElement++ > 0)
                 {
@@ -633,7 +630,7 @@ namespace AdaptiveCards { namespace Uwp
                     UINT spacing;
                     UINT separatorThickness;
                     ABI::Windows::UI::Color separatorColor;
-                    GetSeparationConfigForElement(element, &spacing, &separatorThickness, &separatorColor, &needsSeparator);
+                    GetSeparationConfigForElement(element, hostConfig.Get(), &spacing, &separatorThickness, &separatorColor, &needsSeparator);
                     if (needsSeparator)
                     {
                         auto separator = CreateSeparator(spacing, separatorThickness, separatorColor);
@@ -641,7 +638,7 @@ namespace AdaptiveCards { namespace Uwp
                     }
                 }
                 ComPtr<IUIElement> newControl;
-                elementRenderer->Render(element, context, renderArgs, &newControl);
+                elementRenderer->Render(element, renderContext, renderArgs, &newControl);
                 XamlHelpers::AppendXamlElementToPanel(newControl.Get(), parentPanel);
                 childCreatedCallback(newControl.Get());
             }
@@ -673,8 +670,10 @@ namespace AdaptiveCards { namespace Uwp
         THROW_IF_FAILED(localUiShowCard.As(&showCardGrid));
 
         // Set the padding
+        ComPtr<IAdaptiveHostConfig> hostConfig;
+        THROW_IF_FAILED(renderContext->get_HostConfig(&hostConfig));
         ComPtr<IAdaptiveSpacingConfig> spacingConfig;
-        THROW_IF_FAILED(m_hostConfig->get_Spacing(&spacingConfig));
+        THROW_IF_FAILED(hostConfig->get_Spacing(&spacingConfig));
 
         UINT32 padding;
         THROW_IF_FAILED(spacingConfig->get_Padding(&padding));
@@ -708,8 +707,10 @@ namespace AdaptiveCards { namespace Uwp
         bool insertSeparator,
         AdaptiveRenderContext* renderContext)
     {
+        ComPtr<IAdaptiveHostConfig> hostConfig;
+        THROW_IF_FAILED(renderContext->get_HostConfig(&hostConfig));
         ComPtr<IAdaptiveActionsConfig> actionsConfig;
-        THROW_IF_FAILED(m_hostConfig->get_Actions(actionsConfig.GetAddressOf()));
+        THROW_IF_FAILED(hostConfig->get_Actions(actionsConfig.GetAddressOf()));
         ComPtr<AdaptiveRenderContext> strongRenderContext(renderContext);
         // Create a separator between the body and the actions
         if (insertSeparator)
@@ -718,7 +719,7 @@ namespace AdaptiveCards { namespace Uwp
             THROW_IF_FAILED(actionsConfig->get_Spacing(&spacing)); 
 
             UINT spacingSize;
-            THROW_IF_FAILED(GetSpacingSizeFromSpacing(m_hostConfig.Get(), spacing, &spacingSize));
+            THROW_IF_FAILED(GetSpacingSizeFromSpacing(hostConfig.Get(), spacing, &spacingSize));
 
             ABI::Windows::UI::Color color = { 0 };
             auto separator = CreateSeparator(spacingSize, 0, color);
@@ -937,11 +938,12 @@ namespace AdaptiveCards { namespace Uwp
 
     _Use_decl_annotations_
     void XamlBuilder::ApplyMarginToXamlElement(
+        IAdaptiveHostConfig* hostConfig,
         IFrameworkElement* element)
     {
         ComPtr<IFrameworkElement> localElement(element);
         ComPtr<IAdaptiveSpacingConfig> spacingConfig;
-        THROW_IF_FAILED(m_hostConfig->get_Spacing(&spacingConfig));
+        THROW_IF_FAILED(hostConfig->get_Spacing(&spacingConfig));
 
         UINT32 padding;
         spacingConfig->get_Padding(&padding);
@@ -953,6 +955,7 @@ namespace AdaptiveCards { namespace Uwp
     _Use_decl_annotations_
     void XamlBuilder::GetSeparationConfigForElement(
         IAdaptiveCardElement* cardElement,
+        IAdaptiveHostConfig* hostConfig,
         UINT* spacing,
         UINT* separatorThickness,
         ABI::Windows::UI::Color* separatorColor,
@@ -962,7 +965,7 @@ namespace AdaptiveCards { namespace Uwp
         THROW_IF_FAILED(cardElement->get_Spacing(&elementSpacing));
 
         UINT localSpacing;
-        THROW_IF_FAILED(GetSpacingSizeFromSpacing(m_hostConfig.Get(), elementSpacing, &localSpacing));
+        THROW_IF_FAILED(GetSpacingSizeFromSpacing(hostConfig, elementSpacing, &localSpacing));
 
         boolean hasSeparator;
         THROW_IF_FAILED(cardElement->get_Separator(&hasSeparator));
@@ -972,7 +975,7 @@ namespace AdaptiveCards { namespace Uwp
         if (hasSeparator)
         {
             ComPtr<IAdaptiveSeparatorConfig> separatorConfig;
-            THROW_IF_FAILED(m_hostConfig->get_Separator(&separatorConfig));
+            THROW_IF_FAILED(hostConfig->get_Separator(&separatorConfig));
 
             THROW_IF_FAILED(separatorConfig->get_LineColor(&localColor));
             THROW_IF_FAILED(separatorConfig->get_LineThickness(&localThickness));
@@ -1005,19 +1008,20 @@ namespace AdaptiveCards { namespace Uwp
         bool wrap, 
         UINT32 maxWidth,
         ABI::AdaptiveCards::Uwp::TextWeight weight,
-        ABI::Windows::UI::Xaml::Controls::ITextBlock* xamlTextBlock)
+        ABI::Windows::UI::Xaml::Controls::ITextBlock* xamlTextBlock,
+        IAdaptiveHostConfig* hostConfig)
     {
         ComPtr<ITextBlock> localTextBlock(xamlTextBlock);
 
         ABI::Windows::UI::Color fontColor;
-        THROW_IF_FAILED(GetColorFromAdaptiveColor(m_hostConfig.Get(), color, containerStyle, isSubtle, &fontColor));
+        THROW_IF_FAILED(GetColorFromAdaptiveColor(hostConfig, color, containerStyle, isSubtle, &fontColor));
 
         ComPtr<IBrush> fontColorBrush = GetSolidColorBrush(fontColor);
         THROW_IF_FAILED(localTextBlock->put_Foreground(fontColorBrush.Get()));
 
         // Retrieve the Font Size from Host Options
         ComPtr<IAdaptiveFontSizesConfig> fontSizesConfig;
-        THROW_IF_FAILED(m_hostConfig->get_FontSizes(&fontSizesConfig));
+        THROW_IF_FAILED(hostConfig->get_FontSizes(&fontSizesConfig));
         UINT32 fontSize;
         switch (size)
         {
@@ -1041,7 +1045,7 @@ namespace AdaptiveCards { namespace Uwp
         THROW_IF_FAILED(localTextBlock->put_FontSize((double)fontSize));
 
         ComPtr<IAdaptiveFontWeightsConfig> fontWeightsConfig;
-        THROW_IF_FAILED(m_hostConfig->get_FontWeights(&fontWeightsConfig));
+        THROW_IF_FAILED(hostConfig->get_FontWeights(&fontWeightsConfig));
 
         ABI::Windows::UI::Text::FontWeight xamlFontWeight;
         switch (weight)
@@ -1071,23 +1075,24 @@ namespace AdaptiveCards { namespace Uwp
 
     _Use_decl_annotations_
     void XamlBuilder::StyleXamlTextBlock(
-        ABI::AdaptiveCards::Uwp::IAdaptiveTextConfig* options,
+        IAdaptiveTextConfig* textConfig,
         ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
-        ABI::Windows::UI::Xaml::Controls::ITextBlock* xamlTextBlock)
+        ITextBlock* xamlTextBlock,
+        IAdaptiveHostConfig* hostConfig)
     {
         ABI::AdaptiveCards::Uwp::TextWeight textWeight;
-        THROW_IF_FAILED(options->get_Weight(&textWeight));
+        THROW_IF_FAILED(textConfig->get_Weight(&textWeight));
         ABI::AdaptiveCards::Uwp::ForegroundColor textColor;
-        THROW_IF_FAILED(options->get_Color(&textColor));
+        THROW_IF_FAILED(textConfig->get_Color(&textColor));
         ABI::AdaptiveCards::Uwp::TextSize textSize;
-        THROW_IF_FAILED(options->get_Size(&textSize));
+        THROW_IF_FAILED(textConfig->get_Size(&textSize));
         boolean isSubtle;
-        THROW_IF_FAILED(options->get_IsSubtle(&isSubtle));
+        THROW_IF_FAILED(textConfig->get_IsSubtle(&isSubtle));
         boolean wrap;
-        THROW_IF_FAILED(options->get_Wrap(&wrap));
+        THROW_IF_FAILED(textConfig->get_Wrap(&wrap));
         UINT32 maxWidth;
-        THROW_IF_FAILED(options->get_MaxWidth(&maxWidth));
-        StyleXamlTextBlock(textSize, textColor, containerStyle, Boolify(isSubtle), wrap, maxWidth, textWeight, xamlTextBlock);
+        THROW_IF_FAILED(textConfig->get_MaxWidth(&maxWidth));
+        StyleXamlTextBlock(textSize, textColor, containerStyle, Boolify(isSubtle), wrap, maxWidth, textWeight, xamlTextBlock, hostConfig);
     }
 
     _Use_decl_annotations_
@@ -1111,7 +1116,6 @@ namespace AdaptiveCards { namespace Uwp
         adaptiveTextBlock->get_Text(text.GetAddressOf());
         xamlTextBlock->put_Text(text.Get());
 
-        // Retrieve the Text Color from Host Options.
         ABI::AdaptiveCards::Uwp::ForegroundColor textColor;
         THROW_IF_FAILED(adaptiveTextBlock->get_Color(&textColor));
         boolean isSubtle = false;
@@ -1171,10 +1175,12 @@ namespace AdaptiveCards { namespace Uwp
         // are flush on the left edge of the card by enabling TrimSideBearings
         THROW_IF_FAILED(xamlTextBlock2->put_OpticalMarginAlignment(OpticalMarginAlignment_TrimSideBearings));
 
-        //Style the TextBlock using Host Options
+        //Style the TextBlock using Host config
+        ComPtr<IAdaptiveHostConfig> hostConfig;
+        THROW_IF_FAILED(renderContext->get_HostConfig(&hostConfig));
         ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle;
         THROW_IF_FAILED(renderArgs->get_ContainerStyle(&containerStyle));
-        StyleXamlTextBlock(textblockSize, textColor, containerStyle, isSubtle, shouldWrap, MAXUINT32, textWeight, xamlTextBlock.Get());
+        StyleXamlTextBlock(textblockSize, textColor, containerStyle, isSubtle, shouldWrap, MAXUINT32, textWeight, xamlTextBlock.Get(), hostConfig.Get());
 
         THROW_IF_FAILED(xamlTextBlock.CopyTo(textBlockControl));
     }
@@ -1197,10 +1203,12 @@ namespace AdaptiveCards { namespace Uwp
         ABI::AdaptiveCards::Uwp::ImageSize size;
         THROW_IF_FAILED(adaptiveImage->get_Size(&size));
 
+        ComPtr<IAdaptiveHostConfig> hostConfig;
+        THROW_IF_FAILED(renderContext->get_HostConfig(&hostConfig));
         if (size == ABI::AdaptiveCards::Uwp::ImageSize::None)
         {
             ComPtr<IAdaptiveImageConfig> imageConfig;
-            THROW_IF_FAILED(m_hostConfig->get_Image(&imageConfig));
+            THROW_IF_FAILED(hostConfig->get_Image(&imageConfig));
             THROW_IF_FAILED(imageConfig->get_ImageSize(&size));
         }
 
@@ -1211,7 +1219,7 @@ namespace AdaptiveCards { namespace Uwp
         if (imageStyle == ImageStyle_Person)
         {
             ComPtr<IEllipse> ellipse = XamlHelpers::CreateXamlClass<IEllipse>(HStringReference(RuntimeClass_Windows_UI_Xaml_Shapes_Ellipse));
-            SetImageOnUIElement(imageUri.Get(), ellipse.Get());
+            SetImageOnUIElement(imageUri.Get(), ellipse.Get(), renderContext);
 
             // Set Auto, None, and Stretch to Stretch_UniformToFill.  An ellipse set to Stretch_Uniform ends up with size 0.
             if (size == ABI::AdaptiveCards::Uwp::ImageSize::Auto ||
@@ -1229,7 +1237,7 @@ namespace AdaptiveCards { namespace Uwp
         else
         {
             ComPtr<IImage> xamlImage = XamlHelpers::CreateXamlClass<IImage>(HStringReference(RuntimeClass_Windows_UI_Xaml_Controls_Image));
-            SetImageOnUIElement(imageUri.Get(), xamlImage.Get());
+            SetImageOnUIElement(imageUri.Get(), xamlImage.Get(), renderContext);
 
             switch (size)
             {
@@ -1247,7 +1255,7 @@ namespace AdaptiveCards { namespace Uwp
         }
 
         ComPtr<IAdaptiveImageSizesConfig> sizeOptions;
-        THROW_IF_FAILED(m_hostConfig->get_ImageSizes(sizeOptions.GetAddressOf()));
+        THROW_IF_FAILED(hostConfig->get_ImageSizes(sizeOptions.GetAddressOf()));
 
         switch (size)
         {
@@ -1301,7 +1309,7 @@ namespace AdaptiveCards { namespace Uwp
         // Generate the style name from the adaptive element and apply it to the xaml
         // element if it exists in the resource dictionaries
         ComPtr<IStyle> style;
-        std::wstring styleName = XamlStyleKeyGenerators::GenerateKeyForImage(m_hostConfig.Get(), adaptiveImage.Get());
+        std::wstring styleName = XamlStyleKeyGenerators::GenerateKeyForImage(hostConfig.Get(), adaptiveImage.Get());
         if (SUCCEEDED(TryGetResoureFromResourceDictionaries<IStyle>(styleName, &style)))
         {
             THROW_IF_FAILED(frameworkElement->put_Style(style.Get()));
@@ -1350,8 +1358,10 @@ namespace AdaptiveCards { namespace Uwp
         // If container style was explicitly assigned, apply background
         if (hasExplicitContainerStyle)
         {
+            ComPtr<IAdaptiveHostConfig> hostConfig;
+            THROW_IF_FAILED(renderContext->get_HostConfig(&hostConfig));
             ABI::Windows::UI::Color backgroundColor;
-            THROW_IF_FAILED(GetBackgroundColorFromStyle(containerStyle, m_hostConfig.Get(), &backgroundColor));
+            THROW_IF_FAILED(GetBackgroundColorFromStyle(containerStyle, hostConfig.Get(), &backgroundColor));
             ComPtr<IBrush> backgroundColorBrush = GetSolidColorBrush(backgroundColor);
             THROW_IF_FAILED(containerBorder->put_Background(backgroundColorBrush.Get()));
 
@@ -1424,8 +1434,10 @@ namespace AdaptiveCards { namespace Uwp
         THROW_IF_FAILED(MakeAndInitialize<AdaptiveRenderArgs>(&newRenderArgs, containerStyle));
 
         // If container style was explicitly assigned, apply background
+        ComPtr<IAdaptiveHostConfig> hostConfig;
+        THROW_IF_FAILED(renderContext->get_HostConfig(&hostConfig));
         ABI::Windows::UI::Color backgroundColor;
-        if (hasExplicitContainerStyle && SUCCEEDED(GetBackgroundColorFromStyle(containerStyle, m_hostConfig.Get(), &backgroundColor)))
+        if (hasExplicitContainerStyle && SUCCEEDED(GetBackgroundColorFromStyle(containerStyle, hostConfig.Get(), &backgroundColor)))
         {
             ComPtr<IPanel> columnAsPanel;
             THROW_IF_FAILED(xamlStackPanel.As(&columnAsPanel));
@@ -1465,7 +1477,6 @@ namespace AdaptiveCards { namespace Uwp
         THROW_IF_FAILED(renderContext->get_ElementRenderers(&elementRenderers));
         ComPtr<IAdaptiveElementRenderer> columnRenderer;
         THROW_IF_FAILED(elementRenderers->Get(HStringReference(L"Column").Get(), &columnRenderer));
-
         XamlHelpers::IterateOverVector<IAdaptiveColumn>(columns.Get(), [this, xamlGrid, gridStatics, &currentColumn, renderContext, renderArgs, columnRenderer](IAdaptiveColumn* column)
         {
             ComPtr<IAdaptiveCardElement> columnAsCardElement;
@@ -1479,12 +1490,14 @@ namespace AdaptiveCards { namespace Uwp
             // If not the first column
             if (currentColumn > 0)
             {
+                ComPtr<IAdaptiveHostConfig> hostConfig;
+                THROW_IF_FAILED(renderContext->get_HostConfig(&hostConfig));
                 // Add Separator to the columnSet
                 bool needsSeparator;
                 UINT spacing;
                 UINT separatorThickness;
                 ABI::Windows::UI::Color separatorColor;
-                GetSeparationConfigForElement(columnAsCardElement.Get(), &spacing, &separatorThickness, &separatorColor, &needsSeparator);
+                GetSeparationConfigForElement(columnAsCardElement.Get(), hostConfig.Get(), &spacing, &separatorThickness, &separatorColor, &needsSeparator);
 
                 if (needsSeparator)
                 {
@@ -1614,8 +1627,10 @@ namespace AdaptiveCards { namespace Uwp
             THROW_IF_FAILED(rowDefinitions->Append(factRow.Get()));
 
             ComPtr<IAdaptiveFact> localFact(fact);
+            ComPtr<IAdaptiveHostConfig> hostConfig;
+            THROW_IF_FAILED(renderContext->get_HostConfig(&hostConfig));
             ComPtr<IAdaptiveFactSetConfig> factSetConfig;
-            THROW_IF_FAILED(m_hostConfig->get_FactSet(&factSetConfig));
+            THROW_IF_FAILED(hostConfig->get_FactSet(&factSetConfig));
 
             // Create the title xaml textblock and style it from Host options
             ComPtr<ITextBlock> titleTextBlock = XamlHelpers::CreateXamlClass<ITextBlock>(HStringReference(RuntimeClass_Windows_UI_Xaml_Controls_TextBlock));
@@ -1627,7 +1642,7 @@ namespace AdaptiveCards { namespace Uwp
 
             ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle;
             THROW_IF_FAILED(renderArgs->get_ContainerStyle(&containerStyle));
-            StyleXamlTextBlock(titleTextConfig.Get(), containerStyle, titleTextBlock.Get());
+            StyleXamlTextBlock(titleTextConfig.Get(), containerStyle, titleTextBlock.Get(), hostConfig.Get());
 
             // Create the value xaml textblock and style it from Host options
             ComPtr<ITextBlock> valueTextBlock = XamlHelpers::CreateXamlClass<ITextBlock>(HStringReference(RuntimeClass_Windows_UI_Xaml_Controls_TextBlock));
@@ -1636,7 +1651,7 @@ namespace AdaptiveCards { namespace Uwp
             THROW_IF_FAILED(valueTextBlock->put_Text(factValue.Get()));
             ComPtr<IAdaptiveTextConfig> valueTextConfig;
             THROW_IF_FAILED(factSetConfig->get_Value(&valueTextConfig));
-            StyleXamlTextBlock(valueTextConfig.Get(), containerStyle, valueTextBlock.Get());
+            StyleXamlTextBlock(valueTextConfig.Get(), containerStyle, valueTextBlock.Get(), hostConfig.Get());
 
             // Mark the column container with the current column
             ComPtr<IFrameworkElement> titleTextBlockAsFrameWorkElement;
@@ -1692,8 +1707,10 @@ namespace AdaptiveCards { namespace Uwp
 
         if (imageSize == ABI::AdaptiveCards::Uwp::ImageSize::None)
         {
+            ComPtr<IAdaptiveHostConfig> hostConfig;
+            THROW_IF_FAILED(renderContext->get_HostConfig(&hostConfig));
             ComPtr<IAdaptiveImageSetConfig> imageSetConfig;
-            THROW_IF_FAILED(m_hostConfig->get_ImageSet(&imageSetConfig));
+            THROW_IF_FAILED(hostConfig->get_ImageSet(&imageSetConfig));
             THROW_IF_FAILED(imageSetConfig->get_ImageSize(&imageSize));
         }
 
@@ -1832,7 +1849,9 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderArgs* /*renderArgs*/,
         IUIElement** choiceInputSet)
     {
-        if (!this->SupportsInteractivity())
+        ComPtr<IAdaptiveHostConfig> hostConfig;
+        THROW_IF_FAILED(renderContext->get_HostConfig(&hostConfig));
+        if (!this->SupportsInteractivity(hostConfig.Get()))
         {
             return;
         }
@@ -1866,7 +1885,9 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderArgs* /*renderArgs*/,
         IUIElement** dateInputControl)
     {
-        if (!this->SupportsInteractivity())
+        ComPtr<IAdaptiveHostConfig> hostConfig;
+        THROW_IF_FAILED(renderContext->get_HostConfig(&hostConfig));
+        if (!this->SupportsInteractivity(hostConfig.Get()))
         {
             return;
         }
@@ -1897,7 +1918,9 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderArgs* /*renderArgs*/,
         IUIElement** numberInputControl)
     {
-        if (!this->SupportsInteractivity())
+        ComPtr<IAdaptiveHostConfig> hostConfig;
+        THROW_IF_FAILED(renderContext->get_HostConfig(&hostConfig));
+        if (!this->SupportsInteractivity(hostConfig.Get()))
         {
             return;
         }
@@ -1942,7 +1965,9 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderArgs* renderArgs,
         IUIElement** textInputControl)
     {
-        if (!this->SupportsInteractivity())
+        ComPtr<IAdaptiveHostConfig> hostConfig;
+        THROW_IF_FAILED(renderContext->get_HostConfig(&hostConfig));
+        if (!this->SupportsInteractivity(hostConfig.Get()))
         {
             return;
         }
@@ -2008,7 +2033,9 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderArgs* renderArgs,
         IUIElement** timeInputControl)
     {
-        if (!this->SupportsInteractivity())
+        ComPtr<IAdaptiveHostConfig> hostConfig;
+        THROW_IF_FAILED(renderContext->get_HostConfig(&hostConfig));
+        if (!this->SupportsInteractivity(hostConfig.Get()))
         {
             return;
         }
@@ -2032,7 +2059,9 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderArgs* renderArgs,
         IUIElement** toggleInputControl)
     {
-        if (!this->SupportsInteractivity())
+        ComPtr<IAdaptiveHostConfig> hostConfig;
+        THROW_IF_FAILED(renderContext->get_HostConfig(&hostConfig));
+        if (!this->SupportsInteractivity(hostConfig.Get()))
         {
             return;
         }
@@ -2067,10 +2096,10 @@ namespace AdaptiveCards { namespace Uwp
         THROW_IF_FAILED(checkboxAsUIElement.CopyTo(toggleInputControl));
     }
 
-    bool XamlBuilder::SupportsInteractivity()
+    bool XamlBuilder::SupportsInteractivity(IAdaptiveHostConfig* hostConfig)
     {
         boolean supportsInteractivity;
-        THROW_IF_FAILED(m_hostConfig->get_SupportsInteractivity(&supportsInteractivity));
+        THROW_IF_FAILED(hostConfig->get_SupportsInteractivity(&supportsInteractivity));
         return Boolify(supportsInteractivity);
     }
 
@@ -2080,7 +2109,9 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveActionElement* action,
         IAdaptiveRenderContext* renderContext,
         IUIElement** finalElement)
-    {
+    {        
+        ComPtr<IAdaptiveHostConfig> hostConfig;
+        THROW_IF_FAILED(renderContext->get_HostConfig(&hostConfig));
         ABI::AdaptiveCards::Uwp::ActionType actionType;
         THROW_IF_FAILED(action->get_ActionType(&actionType));
 
@@ -2088,7 +2119,7 @@ namespace AdaptiveCards { namespace Uwp
         if (actionType == ABI::AdaptiveCards::Uwp::ActionType::ShowCard)
         {
             ComPtr<IAdaptiveActionsConfig> actionsConfig;
-            THROW_IF_FAILED(m_hostConfig->get_Actions(actionsConfig.GetAddressOf()));
+            THROW_IF_FAILED(hostConfig->get_Actions(actionsConfig.GetAddressOf()));
             ComPtr<IAdaptiveShowCardActionConfig> showCardActionConfig;
             THROW_IF_FAILED(actionsConfig->get_ShowCard(&showCardActionConfig));
             ABI::AdaptiveCards::Uwp::ActionMode showCardActionMode;
@@ -2109,7 +2140,7 @@ namespace AdaptiveCards { namespace Uwp
         THROW_IF_FAILED(buttonAsContentControl->put_Content(elementToWrap));
 
         ComPtr<IAdaptiveSpacingConfig> spacingConfig;
-        THROW_IF_FAILED(m_hostConfig->get_Spacing(&spacingConfig));
+        THROW_IF_FAILED(hostConfig->get_Spacing(&spacingConfig));
 
         UINT32 cardPadding;
         THROW_IF_FAILED(spacingConfig->get_Padding(&cardPadding));
@@ -2121,7 +2152,7 @@ namespace AdaptiveCards { namespace Uwp
         ABI::AdaptiveCards::Uwp::Spacing elementSpacing;
         THROW_IF_FAILED(adaptiveCardElement->get_Spacing(&elementSpacing));
         UINT spacingSize;
-        THROW_IF_FAILED(GetSpacingSizeFromSpacing(m_hostConfig.Get(), elementSpacing, &spacingSize));
+        THROW_IF_FAILED(GetSpacingSizeFromSpacing(hostConfig.Get(), elementSpacing, &spacingSize));
         double topBottomPadding = spacingSize / 2.0;
 
         // For button padding, we apply the cardPadding and topBottomPadding (and then we negate these in the margin)

--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -1369,12 +1369,13 @@ namespace AdaptiveCards { namespace Uwp
             if (containerStyle != parentContainerStyle)
             {
                 ComPtr<IAdaptiveSpacingConfig> spacingConfig;
-                THROW_IF_FAILED(m_hostConfig->get_Spacing(&spacingConfig));
+                THROW_IF_FAILED(hostConfig->get_Spacing(&spacingConfig));
 
                 UINT32 padding;
                 THROW_IF_FAILED(spacingConfig->get_Padding(&padding));
+                DOUBLE paddingAsDouble = static_cast<DOUBLE>(padding);
 
-                Thickness paddingThickness = {padding, padding, padding, padding};
+                Thickness paddingThickness = {paddingAsDouble, paddingAsDouble, paddingAsDouble, paddingAsDouble};
                 THROW_IF_FAILED(containerBorder->put_Padding(paddingThickness));
             }
         }

--- a/source/uwp/Renderer/lib/XamlBuilder.h
+++ b/source/uwp/Renderer/lib/XamlBuilder.h
@@ -39,7 +39,6 @@ namespace AdaptiveCards { namespace Uwp
         HRESULT SetFixedDimensions(_In_ UINT width, _In_ UINT height) noexcept;
         HRESULT SetEnableXamlImageHandling(_In_ bool enableXamlImageHandling) noexcept;
         HRESULT SetOverrideDictionary(_In_ ABI::Windows::UI::Xaml::IResourceDictionary* overrideDictionary) noexcept;
-        HRESULT SetHostConfig(_In_ ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig* hostConfig) noexcept;
 
         void BuildTextBlock(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
@@ -109,7 +108,6 @@ namespace AdaptiveCards { namespace Uwp
 
     private:
 
-        Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Uwp::IAdaptiveCardRenderer> m_renderer;
         Microsoft::WRL::ComPtr<ABI::Windows::Foundation::IPropertyValueStatics> m_propertyValueStatics;
         ImageLoadTracker m_imageLoadTracker;
         std::set<Microsoft::WRL::ComPtr<IXamlBuilderListener>> m_listeners;
@@ -118,7 +116,6 @@ namespace AdaptiveCards { namespace Uwp
         std::vector<Microsoft::WRL::ComPtr<ABI::Windows::Foundation::IAsyncOperationWithProgress<UINT64, UINT64>>> m_copyStreamOperations;
         Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IResourceDictionary> m_mergedResourceDictionary;
         Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IResourceDictionary> m_defaultResourceDictionary;
-        Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig> m_hostConfig;
 
         UINT m_fixedWidth = 0;
         UINT m_fixedHeight = 0;
@@ -129,6 +126,7 @@ namespace AdaptiveCards { namespace Uwp
         static Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IUIElement> CreateSeparator(
             UINT spacing, UINT separatorThickness, ABI::Windows::UI::Color separatorColor, bool isHorizontal = true);
         void ApplyMarginToXamlElement(
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig* hostConfig,
             _Inout_ ABI::Windows::UI::Xaml::IFrameworkElement* element);
         static Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::Media::IBrush> GetSolidColorBrush(_In_ ABI::Windows::UI::Color color);
         void StyleXamlTextBlock(
@@ -139,11 +137,13 @@ namespace AdaptiveCards { namespace Uwp
             bool wrap,
             UINT32 maxWidth,
             _In_ ABI::AdaptiveCards::Uwp::TextWeight weight,
-            _In_ ABI::Windows::UI::Xaml::Controls::ITextBlock* xamlTextBlock);
+            _In_ ABI::Windows::UI::Xaml::Controls::ITextBlock* xamlTextBlock,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig* hostConfig);
         void StyleXamlTextBlock(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveTextConfig* textConfig,
             ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
-            _In_ ABI::Windows::UI::Xaml::Controls::ITextBlock* xamlTextBlock);
+            _In_ ABI::Windows::UI::Xaml::Controls::ITextBlock* xamlTextBlock,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig* hostConfig);
         void InitializeDefaultResourceDictionary();
         template<typename T>
         HRESULT TryGetResoureFromResourceDictionaries(
@@ -165,7 +165,7 @@ namespace AdaptiveCards { namespace Uwp
         template<typename T>
         void SetImageSource(T* destination, ABI::Windows::UI::Xaml::Media::IImageSource* imageSource);
         template<typename T>
-        void SetImageOnUIElement(_In_ ABI::Windows::Foundation::IUriRuntimeClass* imageUrl, T* uiElement);
+        void SetImageOnUIElement(_In_ ABI::Windows::Foundation::IUriRuntimeClass* imageUrl, T* uiElement, ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext);
         template<typename T>
         void PopulateImageFromUrlAsync(_In_ ABI::Windows::Foundation::IUriRuntimeClass* imageUrl, T* imageControl);
         void FireAllImagesLoaded();
@@ -190,6 +190,7 @@ namespace AdaptiveCards { namespace Uwp
             _Inout_ AdaptiveCards::Uwp::AdaptiveRenderContext* renderContext);
         void GetSeparationConfigForElement(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* element,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig* hostConfig,
             _Out_ UINT* spacing,
             _Out_ UINT* separatorThickness,
             _Out_ ABI::Windows::UI::Color* separatorColor,
@@ -201,7 +202,7 @@ namespace AdaptiveCards { namespace Uwp
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveChoiceSetInput* adaptiveChoiceInputSet,
             boolean isMultiSelect,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** choiceSetInputControl);
-        bool SupportsInteractivity();
+        bool SupportsInteractivity(_In_ ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig* hostConfig);
 
         void WrapInFullWidthTouchTarget(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,


### PR DESCRIPTION
Next step in retiring the XamlBuilder class.

XamlBuilder no longer has any dependencies on the Renderer component. This enables the scenario where hosts want to modify an existing element renderer but only want to apply minor tweaks to the resulting xaml UIElement we return from the out of the box renderers.

Creating this Custom Element renderer:
```csharp
    class CustomImageRenderer : IAdaptiveElementRenderer
    {
        public UIElement Render(IAdaptiveCardElement element, AdaptiveRenderContext context, AdaptiveRenderArgs renderArgs)
        {
            AdaptiveImageRenderer imageRenderer = new AdaptiveImageRenderer();
            UIElement imageUIElement = imageRenderer.Render(element, context, renderArgs);
            Image image = imageUIElement as Image;
            if (image != null)
            {
                image.Opacity = 0.5;
            }

            return imageUIElement;
        }
    }
```
And assigining it to the AdaptiveCardRenderer
```csharp
_renderer = new AdaptiveCardRenderer();
_renderer.ElementRenderers.Set("Image", new CustomImageRenderer());

```
results in:
![image](https://user-images.githubusercontent.com/23242101/31300745-42e4683c-aaaa-11e7-88e4-bace8f7cadf5.png)

