### PR TITLE
Add Parser Registration to the shared model

### DIFF
--- a/source/shared/cpp/ObjectModel/ActionParserRegistration.cpp
+++ b/source/shared/cpp/ObjectModel/ActionParserRegistration.cpp
@@ -1,0 +1,46 @@
+#include "ActionParserRegistration.h"
+#include "OpenUrlAction.h"
+#include "ShowCardAction.h"
+#include "SubmitAction.h"
+
+namespace AdaptiveCards
+{
+    ActionParserRegistration::ActionParserRegistration()
+    {
+    }
+
+    std::shared_ptr<ActionParserRegistration> ActionParserRegistration::GetDefault()
+    {
+        std::shared_ptr<ActionParserRegistration> defaultParserRegistration = std::make_shared<ActionParserRegistration>();
+        defaultParserRegistration->m_cardElementParsers.insert({
+            { ActionTypeToString(ActionType::OpenUrl), std::make_shared<OpenUrlActionParser>() },
+            { ActionTypeToString(ActionType::ShowCard), std::make_shared<ShowCardActionParser>() },
+            { ActionTypeToString(ActionType::Submit), std::make_shared<SubmitActionParser>() }
+        });
+
+        return defaultParserRegistration;
+    }
+
+    void ActionParserRegistration::AddParser(std::string elementType, std::shared_ptr<IBaseActionElementParser> parser)
+    {
+        ActionParserRegistration::m_cardElementParsers[elementType] = parser;
+    }
+
+    void ActionParserRegistration::RemoveParser(std::string elementType)
+    {
+        ActionParserRegistration::m_cardElementParsers.erase(elementType);
+    }
+
+    std::shared_ptr<IBaseActionElementParser> ActionParserRegistration::GetParser(std::string elementType)
+    {
+        auto parser = m_cardElementParsers.find(elementType);
+        if (parser != ActionParserRegistration::m_cardElementParsers.end())
+        {
+            return parser->second; 
+        }
+        else
+        {
+            return std::shared_ptr<IBaseActionElementParser>(nullptr);
+        }
+    }
+}

--- a/source/shared/cpp/ObjectModel/ActionParserRegistration.h
+++ b/source/shared/cpp/ObjectModel/ActionParserRegistration.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "pch.h"
+#include "Enums.h"
+#include "json\json.h"
+
+namespace AdaptiveCards
+{
+    class BaseActionElement;
+    class ElementParserRegistration;
+    class ActionParserRegistration;
+
+    class IBaseActionElementParser
+    {
+    public:
+        virtual std::shared_ptr<BaseActionElement> Deserialize(
+            std::shared_ptr<AdaptiveCards::ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<AdaptiveCards::ActionParserRegistration> actionParserRegistration,
+            const Json::Value& value) = 0;
+    };
+
+    class ActionParserRegistration
+    {
+    public:
+
+        ActionParserRegistration();
+
+        static std::shared_ptr<ActionParserRegistration> GetDefault();
+
+        void AddParser(std::string elementType, std::shared_ptr<IBaseActionElementParser> parser);
+        void RemoveParser(std::string elementType);
+        std::shared_ptr<IBaseActionElementParser> GetParser(std::string elementType);
+
+    private:
+        std::unordered_map<std::string, std::shared_ptr<IBaseActionElementParser>, CaseInsensitiveHash, CaseInsensitiveEqualTo> m_cardElementParsers;
+    };
+}

--- a/source/shared/cpp/ObjectModel/BaseCardElement.cpp
+++ b/source/shared/cpp/ObjectModel/BaseCardElement.cpp
@@ -6,13 +6,6 @@
 
 using namespace AdaptiveCards;
 
-const std::unordered_map<ActionType, std::function<std::shared_ptr<BaseActionElement>(const Json::Value&)>, EnumHash> BaseCardElement::ActionParsers =
-{
-    { ActionType::OpenUrl, OpenUrlAction::Deserialize },
-    { ActionType::ShowCard, ShowCardAction::Deserialize },
-    { ActionType::Submit, SubmitAction::Deserialize },
-};
-
 BaseCardElement::BaseCardElement(
     CardElementType type,
     Spacing spacing,
@@ -86,12 +79,16 @@ Json::Value BaseCardElement::SerializeToJsonValue()
     return root;
 }
 
-std::shared_ptr<BaseActionElement> BaseCardElement::DeserializeSelectAction(const Json::Value & json, AdaptiveCardSchemaKey key)
+std::shared_ptr<BaseActionElement> BaseCardElement::DeserializeSelectAction(
+    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
+    const Json::Value& json, 
+    AdaptiveCardSchemaKey key)
 {
     Json::Value selectActionValue = ParseUtil::ExtractJsonValue(json, key, false);
     if (!selectActionValue.empty())
     {
-        return ParseUtil::GetActionFromJsonValue<BaseActionElement>(selectActionValue, BaseCardElement::ActionParsers);
+        return ParseUtil::GetActionFromJsonValue(elementParserRegistration, actionParserRegistration, selectActionValue);
     }
     return nullptr;
 }

--- a/source/shared/cpp/ObjectModel/BaseCardElement.h
+++ b/source/shared/cpp/ObjectModel/BaseCardElement.h
@@ -41,8 +41,12 @@ public:
 
     virtual Json::Value SerializeToJsonValue();
 
+    static std::shared_ptr<BaseActionElement> DeserializeSelectAction(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+        const Json::Value& json, AdaptiveCardSchemaKey key);
+
 protected:
-    static std::shared_ptr<BaseActionElement> DeserializeSelectAction(const Json::Value& json, AdaptiveCardSchemaKey key);
     static Json::Value SerializeSelectAction(const std::shared_ptr<BaseActionElement> selectAction);
 
 private:

--- a/source/shared/cpp/ObjectModel/ChoiceInput.cpp
+++ b/source/shared/cpp/ObjectModel/ChoiceInput.cpp
@@ -9,7 +9,10 @@ ChoiceInput::ChoiceInput() :
 {
 }
 
-std::shared_ptr<ChoiceInput> ChoiceInput::Deserialize(const Json::Value& json)
+std::shared_ptr<ChoiceInput> ChoiceInput::Deserialize(
+    std::shared_ptr<ElementParserRegistration>,
+    std::shared_ptr<ActionParserRegistration>, 
+    const Json::Value& json)
 {
     auto choice = std::make_shared<ChoiceInput>();
 
@@ -20,9 +23,12 @@ std::shared_ptr<ChoiceInput> ChoiceInput::Deserialize(const Json::Value& json)
     return choice;
 }
 
-std::shared_ptr<ChoiceInput> ChoiceInput::DeserializeFromString(const std::string& jsonString)
+std::shared_ptr<ChoiceInput> ChoiceInput::DeserializeFromString(
+    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+    const std::string& jsonString)
 {
-    return ChoiceInput::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
+    return ChoiceInput::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
 std::string ChoiceInput::Serialize()

--- a/source/shared/cpp/ObjectModel/ChoiceInput.h
+++ b/source/shared/cpp/ObjectModel/ChoiceInput.h
@@ -3,6 +3,7 @@
 #include "pch.h"
 #include "Enums.h"
 #include "json/json.h"
+#include "ElementParserRegistration.h"
 
 namespace AdaptiveCards
 {
@@ -23,8 +24,15 @@ public:
     bool GetIsSelected() const;
     void SetIsSelected(const bool value);
 
-    static std::shared_ptr<ChoiceInput> Deserialize(const Json::Value& root);
-    static std::shared_ptr<ChoiceInput> DeserializeFromString(const std::string& jsonString);
+    static std::shared_ptr<ChoiceInput> Deserialize(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+        const Json::Value& root);
+
+    static std::shared_ptr<ChoiceInput> DeserializeFromString(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+        const std::string& jsonString);
 
 private:
     std::string m_title;

--- a/source/shared/cpp/ObjectModel/ChoiceSetInput.cpp
+++ b/source/shared/cpp/ObjectModel/ChoiceSetInput.cpp
@@ -77,7 +77,10 @@ void AdaptiveCards::ChoiceSetInput::SetChoiceSetStyle(const ChoiceSetStyle choic
     m_choiceSetStyle = choiceSetStyle;
 }
 
-std::shared_ptr<ChoiceSetInput> ChoiceSetInput::Deserialize(const Json::Value& json)
+std::shared_ptr<BaseCardElement> ChoiceSetInputParser::Deserialize(
+    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+    const Json::Value& json)
 {
     ParseUtil::ExpectTypeString(json, CardElementType::ChoiceSetInput);
 
@@ -87,13 +90,16 @@ std::shared_ptr<ChoiceSetInput> ChoiceSetInput::Deserialize(const Json::Value& j
     choiceSet->SetIsMultiSelect(ParseUtil::GetBool(json, AdaptiveCardSchemaKey::IsMultiSelect, false));
 
     // Parse Choices
-    auto choices = ParseUtil::GetElementCollectionOfSingleType<ChoiceInput>(json, AdaptiveCardSchemaKey::Choices, ChoiceInput::Deserialize, true);
+    auto choices = ParseUtil::GetElementCollectionOfSingleType<ChoiceInput>(elementParserRegistration, actionParserRegistration, json, AdaptiveCardSchemaKey::Choices, ChoiceInput::Deserialize, true);
     choiceSet->m_choices = std::move(choices);
 
     return choiceSet;
 }
 
-std::shared_ptr<ChoiceSetInput> ChoiceSetInput::DeserializeFromString(const std::string& jsonString)
+std::shared_ptr<BaseCardElement> ChoiceSetInputParser::DeserializeFromString(
+    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+    const std::string& jsonString)
 {
-    return ChoiceSetInput::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
+    return ChoiceSetInputParser::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
 }

--- a/source/shared/cpp/ObjectModel/ChoiceSetInput.h
+++ b/source/shared/cpp/ObjectModel/ChoiceSetInput.h
@@ -4,12 +4,14 @@
 #include "BaseInputElement.h"
 #include "ChoiceInput.h"
 #include "Enums.h"
+#include "ElementParserRegistration.h"
 
 namespace AdaptiveCards
 {
 class BaseInputElement;
 class ChoiceSetInput : public BaseInputElement
 {
+friend class ChoiceSetInputParser;
 public:
     ChoiceSetInput();
     ChoiceSetInput(Spacing spacing, bool separation);
@@ -27,13 +29,24 @@ public:
     std::vector<std::shared_ptr<ChoiceInput>>& GetChoices();
     const std::vector<std::shared_ptr<ChoiceInput>>& GetChoices() const;
 
-    static std::shared_ptr<ChoiceSetInput> Deserialize(const Json::Value& root);
-    static std::shared_ptr<ChoiceSetInput> DeserializeFromString(const std::string& jsonString);
-
 private:
     bool m_isMultiSelect;
     ChoiceSetStyle m_choiceSetStyle;
 
     std::vector<std::shared_ptr<ChoiceInput>> m_choices; 
+};
+
+class ChoiceSetInputParser : public IBaseCardElementParser
+{
+public:
+    std::shared_ptr<BaseCardElement> Deserialize(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+        const Json::Value& root);
+    
+    std::shared_ptr<BaseCardElement> DeserializeFromString(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+        const std::string& jsonString);
 };
 }

--- a/source/shared/cpp/ObjectModel/Column.h
+++ b/source/shared/cpp/ObjectModel/Column.h
@@ -17,8 +17,15 @@ public:
     virtual std::string Serialize();
     virtual Json::Value SerializeToJsonValue();
 
-    static std::shared_ptr<Column> Deserialize(const Json::Value& root);
-    static std::shared_ptr<Column> DeserializeFromString(const std::string& jsonString);
+    static std::shared_ptr<Column> Deserialize(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+        const Json::Value& root);
+
+    static std::shared_ptr<Column> DeserializeFromString(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
+        const std::string& jsonString);
 
     std::string GetWidth() const;
     void SetWidth(const std::string value);
@@ -33,7 +40,6 @@ public:
     void SetSelectAction(const std::shared_ptr<BaseActionElement> action);
 
 private:
-    static const std::unordered_map<CardElementType, std::function<std::shared_ptr<BaseCardElement>(const Json::Value&)>, EnumHash> CardElementParsers;
     std::string m_width;
     std::vector<std::shared_ptr<AdaptiveCards::BaseCardElement>> m_items;
     std::shared_ptr<BaseActionElement> m_selectAction;

--- a/source/shared/cpp/ObjectModel/ColumnSet.cpp
+++ b/source/shared/cpp/ObjectModel/ColumnSet.cpp
@@ -55,22 +55,28 @@ Json::Value ColumnSet::SerializeToJsonValue()
     return root;
 }
 
-std::shared_ptr<ColumnSet> ColumnSet::Deserialize(const Json::Value& value)
+std::shared_ptr<BaseCardElement> ColumnSetParser::Deserialize(
+    std::shared_ptr<ElementParserRegistration> elementParserRegistration, 
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+    const Json::Value& value)
 {
     ParseUtil::ExpectTypeString(value, CardElementType::ColumnSet);
 
     auto container = BaseCardElement::Deserialize<ColumnSet>(value);
 
     // Parse Columns
-    auto cardElements = ParseUtil::GetElementCollectionOfSingleType<Column>(value, AdaptiveCardSchemaKey::Columns, Column::Deserialize, true);
+    auto cardElements = ParseUtil::GetElementCollectionOfSingleType<Column>(elementParserRegistration, actionParserRegistration, value, AdaptiveCardSchemaKey::Columns, Column::Deserialize, true);
     container->m_columns = std::move(cardElements);
 
-    container->SetSelectAction(BaseCardElement::DeserializeSelectAction(value, AdaptiveCardSchemaKey::SelectAction));
+    container->SetSelectAction(BaseCardElement::DeserializeSelectAction(elementParserRegistration, actionParserRegistration, value, AdaptiveCardSchemaKey::SelectAction));
 
     return container;
 }
 
-std::shared_ptr<ColumnSet> ColumnSet::DeserializeFromString(const std::string& jsonString)
+std::shared_ptr<BaseCardElement> ColumnSetParser::DeserializeFromString(
+    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
+    const std::string& jsonString)
 {
-    return ColumnSet::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
+    return ColumnSetParser::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
 }

--- a/source/shared/cpp/ObjectModel/ColumnSet.h
+++ b/source/shared/cpp/ObjectModel/ColumnSet.h
@@ -4,11 +4,13 @@
 #include "Enums.h"
 #include "BaseCardElement.h"
 #include "Column.h"
+#include "ElementParserRegistration.h"
 
 namespace AdaptiveCards
 {
 class ColumnSet : public BaseCardElement
 {
+friend class ColumnSetParser;
 public:
     ColumnSet();
     ColumnSet(std::vector<std::shared_ptr<Column>>& columns);
@@ -18,8 +20,6 @@ public:
 
     std::vector<std::shared_ptr<Column>>& GetColumns();
     const std::vector<std::shared_ptr<Column>>& GetColumns() const;
-    static std::shared_ptr<ColumnSet> Deserialize(const Json::Value& root);
-    static std::shared_ptr<ColumnSet> DeserializeFromString(const std::string& jsonString);
 
     std::shared_ptr<BaseActionElement> GetSelectAction() const;
     void SetSelectAction(const std::shared_ptr<BaseActionElement> action);
@@ -28,5 +28,19 @@ private:
     static const std::unordered_map<CardElementType, std::function<std::shared_ptr<Column>(const Json::Value&)>, EnumHash> ColumnParser;
     std::vector<std::shared_ptr<Column>> m_columns;
     std::shared_ptr<BaseActionElement> m_selectAction;
+};
+
+class ColumnSetParser : public IBaseCardElementParser
+{
+public:
+    std::shared_ptr<BaseCardElement> Deserialize(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+        const Json::Value& root);
+
+    std::shared_ptr<BaseCardElement> DeserializeFromString(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+        const std::string& jsonString);
 };
 }

--- a/source/shared/cpp/ObjectModel/Container.h
+++ b/source/shared/cpp/ObjectModel/Container.h
@@ -4,11 +4,13 @@
 #include "pch.h"
 #include "BaseActionElement.h"
 #include "BaseCardElement.h"
+#include "ElementParserRegistration.h"
 
 namespace AdaptiveCards
 {
 class Container : public BaseCardElement
 {
+friend class ContainerParser;
 public:
     Container();
     Container(Spacing spacing, bool separator, ContainerStyle style);
@@ -23,17 +25,26 @@ public:
     ContainerStyle GetStyle() const;
     void SetStyle(const ContainerStyle value);
 
-    static std::shared_ptr<Container> Deserialize(const Json::Value& root);
-    static std::shared_ptr<Container> DeserializeFromString(const std::string& jsonString);
-
     std::shared_ptr<BaseActionElement> GetSelectAction() const;
     void SetSelectAction(const std::shared_ptr<BaseActionElement> action);
 
 private:
-    static const std::unordered_map<CardElementType, std::function<std::shared_ptr<BaseCardElement>(const Json::Value&)>, EnumHash> CardElementParsers;
-
     ContainerStyle m_style;
     std::vector<std::shared_ptr<AdaptiveCards::BaseCardElement>> m_items;
     std::shared_ptr<BaseActionElement> m_selectAction;
+};
+
+class ContainerParser : public IBaseCardElementParser
+{
+public:
+    std::shared_ptr<BaseCardElement> Deserialize(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+        const Json::Value& root);
+
+    std::shared_ptr<BaseCardElement> DeserializeFromString(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+        const std::string& jsonString);
 };
 }

--- a/source/shared/cpp/ObjectModel/DateInput.cpp
+++ b/source/shared/cpp/ObjectModel/DateInput.cpp
@@ -8,25 +8,6 @@ DateInput::DateInput() :
 {
 }
 
-std::shared_ptr<DateInput> DateInput::Deserialize(const Json::Value& json)
-{
-    ParseUtil::ExpectTypeString(json, CardElementType::DateInput);
-
-    std::shared_ptr<DateInput> dateInput = BaseInputElement::Deserialize<DateInput>(json);
-
-    dateInput->SetMax(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Max));
-    dateInput->SetMin(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Min));
-    dateInput->SetPlaceholder(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Placeholder));
-    dateInput->SetValue(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Value));
-
-    return dateInput;
-}
-
-std::shared_ptr<DateInput> DateInput::DeserializeFromString(const std::string& jsonString)
-{
-    return DateInput::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
-}
-
 std::string DateInput::Serialize()
 {
     Json::FastWriter writer;
@@ -83,4 +64,29 @@ std::string DateInput::GetValue() const
 void DateInput::SetValue(const std::string value)
 {
     m_value = value;
+}
+
+std::shared_ptr<BaseCardElement> DateInputParser::Deserialize(
+    std::shared_ptr<ElementParserRegistration>,
+    std::shared_ptr<ActionParserRegistration>,
+    const Json::Value& json)
+{
+    ParseUtil::ExpectTypeString(json, CardElementType::DateInput);
+
+    std::shared_ptr<DateInput> dateInput = BaseInputElement::Deserialize<DateInput>(json);
+
+    dateInput->SetMax(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Max));
+    dateInput->SetMin(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Min));
+    dateInput->SetPlaceholder(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Placeholder));
+    dateInput->SetValue(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Value));
+
+    return dateInput;
+}
+
+std::shared_ptr<BaseCardElement> DateInputParser::DeserializeFromString(
+    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
+    const std::string& jsonString)
+{
+    return DateInputParser::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
 }

--- a/source/shared/cpp/ObjectModel/DateInput.h
+++ b/source/shared/cpp/ObjectModel/DateInput.h
@@ -3,6 +3,7 @@
 #include "pch.h"
 #include "BaseInputElement.h"
 #include "Enums.h"
+#include "ElementParserRegistration.h"
 
 namespace AdaptiveCards
 {
@@ -10,9 +11,6 @@ class DateInput : public BaseInputElement
 {
 public:
     DateInput();
-
-    static std::shared_ptr<DateInput> Deserialize(const Json::Value& root);
-    static std::shared_ptr<DateInput> DeserializeFromString(const std::string& jsonString);
 
     virtual std::string Serialize();
     virtual Json::Value SerializeToJsonValue();
@@ -34,5 +32,19 @@ private:
     std::string m_min;
     std::string m_placeholder;
     std::string m_value;
+};
+
+class DateInputParser : public IBaseCardElementParser
+{
+public:
+    std::shared_ptr<BaseCardElement> Deserialize(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+        const Json::Value& root);
+
+    std::shared_ptr<BaseCardElement> DeserializeFromString(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
+        const std::string& jsonString);
 };
 }

--- a/source/shared/cpp/ObjectModel/ElementParserRegistration.cpp
+++ b/source/shared/cpp/ObjectModel/ElementParserRegistration.cpp
@@ -1,0 +1,65 @@
+#include "ElementParserRegistration.h"
+#include "ChoiceSetInput.h"
+#include "ColumnSet.h"
+#include "Container.h"
+#include "DateInput.h"
+#include "FactSet.h"
+#include "Image.h"
+#include "ImageSet.h"
+#include "NumberInput.h"
+#include "TextBlock.h"
+#include "TextInput.h"
+#include "TimeInput.h"
+#include "ToggleInput.h"
+
+namespace AdaptiveCards
+{
+
+    ElementParserRegistration::ElementParserRegistration()
+    {
+    }
+
+    std::shared_ptr<ElementParserRegistration> ElementParserRegistration::GetDefault()
+    {
+        std::shared_ptr<ElementParserRegistration> defaultParserRegistration = std::make_shared<ElementParserRegistration>();
+        defaultParserRegistration->m_cardElementParsers.insert({
+            { CardElementTypeToString(CardElementType::Container), std::make_shared<ContainerParser>() },
+            { CardElementTypeToString(CardElementType::ColumnSet), std::make_shared<ColumnSetParser>() },
+            { CardElementTypeToString(CardElementType::FactSet), std::make_shared<FactSetParser>() },
+            { CardElementTypeToString(CardElementType::Image),  std::make_shared<ImageParser>() },
+            { CardElementTypeToString(CardElementType::ImageSet), std::make_shared<ImageSetParser>() },
+            { CardElementTypeToString(CardElementType::ChoiceSetInput), std::make_shared<ChoiceSetInputParser>() },
+            { CardElementTypeToString(CardElementType::DateInput), std::make_shared<DateInputParser>() },
+            { CardElementTypeToString(CardElementType::NumberInput), std::make_shared<NumberInputParser>() },
+            { CardElementTypeToString(CardElementType::TextBlock), std::make_shared<TextBlockParser>() },
+            { CardElementTypeToString(CardElementType::TextInput),  std::make_shared<TextInputParser>() },
+            { CardElementTypeToString(CardElementType::TimeInput), std::make_shared<TimeInputParser>() },
+            { CardElementTypeToString(CardElementType::ToggleInput), std::make_shared<ToggleInputParser>() }
+        });
+
+        return defaultParserRegistration;
+    }
+
+    void ElementParserRegistration::AddParser(std::string elementType, std::shared_ptr<IBaseCardElementParser> parser)
+    {
+        ElementParserRegistration::m_cardElementParsers[elementType] = parser;
+    }
+
+    void ElementParserRegistration::RemoveParser(std::string elementType)
+    {
+        ElementParserRegistration::m_cardElementParsers.erase(elementType);
+    }
+
+    std::shared_ptr<IBaseCardElementParser> ElementParserRegistration::GetParser(std::string elementType)
+    {
+        auto parser = m_cardElementParsers.find(elementType);
+        if (parser != ElementParserRegistration::m_cardElementParsers.end())
+        {
+            return parser->second;
+        }
+        else
+        {
+            return std::shared_ptr<IBaseCardElementParser>(nullptr);
+        }
+    }
+}

--- a/source/shared/cpp/ObjectModel/ElementParserRegistration.h
+++ b/source/shared/cpp/ObjectModel/ElementParserRegistration.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "pch.h"
+#include "Enums.h"
+#include "json\json.h"
+
+namespace AdaptiveCards
+{
+    class BaseCardElement;
+    class ElementParserRegistration;
+    class ActionParserRegistration;
+
+    class IBaseCardElementParser
+    {
+    public:
+        virtual std::shared_ptr<BaseCardElement> Deserialize(
+            std::shared_ptr<AdaptiveCards::ElementParserRegistration> elementParserRegistration, 
+            std::shared_ptr<AdaptiveCards::ActionParserRegistration> actionParserRegistration, 
+            const Json::Value& value) = 0;
+    };
+
+    class ElementParserRegistration
+    {
+    public:
+
+        ElementParserRegistration();
+
+        static std::shared_ptr<ElementParserRegistration> GetDefault();
+
+        void AddParser(std::string elementType, std::shared_ptr<IBaseCardElementParser> parser);
+        void RemoveParser(std::string elementType);
+        std::shared_ptr<IBaseCardElementParser> GetParser(std::string elementType);
+
+    private:
+        std::unordered_map<std::string, std::shared_ptr<IBaseCardElementParser>, CaseInsensitiveHash, CaseInsensitiveEqualTo> m_cardElementParsers;
+    };
+}

--- a/source/shared/cpp/ObjectModel/Fact.cpp
+++ b/source/shared/cpp/ObjectModel/Fact.cpp
@@ -12,7 +12,10 @@ Fact::Fact(std::string title, std::string value) :
 {
 }
 
-std::shared_ptr<Fact> Fact::Deserialize(const Json::Value& json)
+std::shared_ptr<Fact> Fact::Deserialize(
+    std::shared_ptr<ElementParserRegistration>,
+    std::shared_ptr<ActionParserRegistration>,
+    const Json::Value& json)
 {
     std::string title = ParseUtil::GetString(json, AdaptiveCardSchemaKey::Title, true);
     std::string value = ParseUtil::GetString(json, AdaptiveCardSchemaKey::Value, true);
@@ -21,9 +24,12 @@ std::shared_ptr<Fact> Fact::Deserialize(const Json::Value& json)
     return fact;
 }
 
-std::shared_ptr<Fact> Fact::DeserializeFromString(const std::string& jsonString)
+std::shared_ptr<Fact> Fact::DeserializeFromString(
+    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+    const std::string& jsonString)
 {
-    return Fact::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
+    return Fact::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
 std::string Fact::Serialize()

--- a/source/shared/cpp/ObjectModel/Fact.h
+++ b/source/shared/cpp/ObjectModel/Fact.h
@@ -3,6 +3,7 @@
 #include "pch.h"
 #include "Enums.h"
 #include "json/json.h"
+#include "ElementParserRegistration.h"
 
 namespace AdaptiveCards
 {
@@ -21,8 +22,15 @@ public:
     std::string GetValue() const;
     void SetValue(const std::string value);
 
-    static std::shared_ptr<Fact> Deserialize(const Json::Value& root);
-    static std::shared_ptr<Fact> DeserializeFromString(const std::string& jsonString);
+    static std::shared_ptr<Fact> Deserialize(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+        const Json::Value& root);
+
+    static std::shared_ptr<Fact> DeserializeFromString(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+        const std::string& jsonString);
 
 private:
     std::string m_title;

--- a/source/shared/cpp/ObjectModel/FactSet.cpp
+++ b/source/shared/cpp/ObjectModel/FactSet.cpp
@@ -54,20 +54,26 @@ Json::Value FactSet::SerializeToJsonValue()
     return root;
 }
 
-std::shared_ptr<FactSet> FactSet::Deserialize(const Json::Value& value)
+std::shared_ptr<BaseCardElement> FactSetParser::Deserialize(
+    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+    const Json::Value& value)
 {
     ParseUtil::ExpectTypeString(value, CardElementType::FactSet);
 
     auto factSet = BaseCardElement::Deserialize<FactSet>(value);
 
     // Parse Facts
-    auto facts = ParseUtil::GetElementCollectionOfSingleType<Fact>(value, AdaptiveCardSchemaKey::Facts, Fact::Deserialize, true);
+    auto facts = ParseUtil::GetElementCollectionOfSingleType<Fact>(elementParserRegistration, actionParserRegistration, value, AdaptiveCardSchemaKey::Facts, Fact::Deserialize, true);
     factSet->m_facts = std::move(facts);
 
     return factSet;
 }
 
-std::shared_ptr<FactSet> FactSet::DeserializeFromString(const std::string& jsonString)
+std::shared_ptr<BaseCardElement> FactSetParser::DeserializeFromString(
+    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+    const std::string& jsonString)
 {
-    return FactSet::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
+    return FactSetParser::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
 }

--- a/source/shared/cpp/ObjectModel/FactSet.h
+++ b/source/shared/cpp/ObjectModel/FactSet.h
@@ -4,12 +4,14 @@
 #include "Enums.h"
 #include "Fact.h"
 #include "BaseCardElement.h"
+#include "ElementParserRegistration.h"
 
 namespace AdaptiveCards
 {
 class BaseCardElement;
 class FactSet : public BaseCardElement
 {
+friend class FactSetParser;
 public:
     FactSet();
     FactSet(Spacing spacing, bool separation);
@@ -20,10 +22,22 @@ public:
 
     std::vector<std::shared_ptr<Fact>>& GetFacts();
     const std::vector<std::shared_ptr<Fact>>& GetFacts() const;
-    static std::shared_ptr<FactSet> Deserialize(const Json::Value& root);
-    static std::shared_ptr<FactSet> DeserializeFromString(const std::string& jsonString);
 
 private:
     std::vector<std::shared_ptr<Fact>> m_facts; 
+};
+
+class FactSetParser : public IBaseCardElementParser
+{
+public:
+    std::shared_ptr<BaseCardElement> Deserialize(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
+        const Json::Value& root);
+
+    std::shared_ptr<BaseCardElement> DeserializeFromString(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
+        const std::string& jsonString);
 };
 }

--- a/source/shared/cpp/ObjectModel/Image.cpp
+++ b/source/shared/cpp/ObjectModel/Image.cpp
@@ -28,27 +28,6 @@ Image::Image(
 {
 }
 
-std::shared_ptr<Image> Image::Deserialize(const Json::Value& json)
-{
-    ParseUtil::ExpectTypeString(json, CardElementType::Image);
-
-    return Image::DeserializeWithoutCheckingType(json);
-}
-
-std::shared_ptr<Image> Image::DeserializeWithoutCheckingType(const Json::Value& json)
-{
-    std::shared_ptr<Image> image = BaseCardElement::Deserialize<Image>(json);
-
-    image->SetUrl(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Url, true));
-    image->SetImageStyle(ParseUtil::GetEnumValue<ImageStyle>(json, AdaptiveCardSchemaKey::Style, ImageStyle::Default, ImageStyleFromString));
-    image->SetImageSize(ParseUtil::GetEnumValue<ImageSize>(json, AdaptiveCardSchemaKey::Size, ImageSize::None, ImageSizeFromString));
-    image->SetAltText(ParseUtil::GetString(json, AdaptiveCardSchemaKey::AltText));
-    image->SetHorizontalAlignment(ParseUtil::GetEnumValue<HorizontalAlignment>(json, AdaptiveCardSchemaKey::HorizontalAlignment, HorizontalAlignment::Left, HorizontalAlignmentFromString));
-    image->SetSelectAction(BaseCardElement::DeserializeSelectAction(json, AdaptiveCardSchemaKey::SelectAction));
-
-    return image;
-}
-
 std::string Image::Serialize()
 {
     Json::FastWriter writer;
@@ -126,11 +105,6 @@ void AdaptiveCards::Image::SetHorizontalAlignment(const HorizontalAlignment valu
     m_hAlignment = value;
 }
 
-std::shared_ptr<Image> Image::DeserializeFromString(const std::string& jsonString)
-{
-    return Image::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
-}
-
 std::shared_ptr<BaseActionElement> Image::GetSelectAction() const
 {
     return m_selectAction;
@@ -139,4 +113,38 @@ std::shared_ptr<BaseActionElement> Image::GetSelectAction() const
 void Image::SetSelectAction(const std::shared_ptr<BaseActionElement> action)
 {
     m_selectAction = action;
+}
+
+std::shared_ptr<BaseCardElement> ImageParser::DeserializeFromString(
+    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+    const std::string& jsonString)
+{
+    return ImageParser::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
+}
+
+std::shared_ptr<BaseCardElement> ImageParser::Deserialize(
+    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+    const Json::Value& json)
+{
+    ParseUtil::ExpectTypeString(json, CardElementType::Image);
+    return ImageParser::DeserializeWithoutCheckingType(elementParserRegistration, actionParserRegistration, json);
+}
+
+std::shared_ptr<BaseCardElement> ImageParser::DeserializeWithoutCheckingType(
+    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
+    const Json::Value& json)
+{
+    std::shared_ptr<Image> image = BaseCardElement::Deserialize<Image>(json);
+
+    image->SetUrl(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Url, true));
+    image->SetImageStyle(ParseUtil::GetEnumValue<ImageStyle>(json, AdaptiveCardSchemaKey::Style, ImageStyle::Default, ImageStyleFromString));
+    image->SetImageSize(ParseUtil::GetEnumValue<ImageSize>(json, AdaptiveCardSchemaKey::Size, ImageSize::None, ImageSizeFromString));
+    image->SetAltText(ParseUtil::GetString(json, AdaptiveCardSchemaKey::AltText));
+    image->SetHorizontalAlignment(ParseUtil::GetEnumValue<HorizontalAlignment>(json, AdaptiveCardSchemaKey::HorizontalAlignment, HorizontalAlignment::Left, HorizontalAlignmentFromString));
+    image->SetSelectAction(BaseCardElement::DeserializeSelectAction(elementParserRegistration, actionParserRegistration, json, AdaptiveCardSchemaKey::SelectAction));
+
+    return image;
 }

--- a/source/shared/cpp/ObjectModel/Image.h
+++ b/source/shared/cpp/ObjectModel/Image.h
@@ -4,6 +4,7 @@
 #include "BaseActionElement.h"
 #include "BaseCardElement.h"
 #include "Enums.h"
+#include "ElementParserRegistration.h"
 
 namespace AdaptiveCards
 {
@@ -19,10 +20,6 @@ public:
         ImageSize imageSize,
         std::string altText,
         HorizontalAlignment hAlignment);
-
-    static std::shared_ptr<Image> Deserialize(const Json::Value& root);
-    static std::shared_ptr<Image> DeserializeWithoutCheckingType(const Json::Value& root);
-    static std::shared_ptr<Image> DeserializeFromString(const std::string& jsonString);
 
     virtual std::string Serialize();
     virtual Json::Value SerializeToJsonValue();
@@ -52,5 +49,24 @@ private:
     std::string m_altText;
     HorizontalAlignment m_hAlignment;
     std::shared_ptr<BaseActionElement> m_selectAction;
+};
+
+class ImageParser : public IBaseCardElementParser
+{
+public:
+    std::shared_ptr<BaseCardElement> Deserialize(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+        const Json::Value& root);
+
+    std::shared_ptr<BaseCardElement> DeserializeWithoutCheckingType(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+        const Json::Value& root);
+
+    std::shared_ptr<BaseCardElement> DeserializeFromString(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+        const std::string& jsonString);
 };
 }

--- a/source/shared/cpp/ObjectModel/ImageSet.cpp
+++ b/source/shared/cpp/ObjectModel/ImageSet.cpp
@@ -74,7 +74,10 @@ Json::Value ImageSet::SerializeToJsonValue()
     return root;
 }
 
-std::shared_ptr<ImageSet> ImageSet::Deserialize(const Json::Value& value)
+std::shared_ptr<BaseCardElement> ImageSetParser::Deserialize(
+    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
+    const Json::Value& value)
 {
     ParseUtil::ExpectTypeString(value, CardElementType::ImageSet);
 
@@ -84,13 +87,20 @@ std::shared_ptr<ImageSet> ImageSet::Deserialize(const Json::Value& value)
     imageSet->m_imageSize = ParseUtil::GetEnumValue<ImageSize>(value, AdaptiveCardSchemaKey::ImageSize, ImageSize::None, ImageSizeFromString);
 
     // Parse Images
-    auto images = ParseUtil::GetElementCollectionOfSingleType<Image>(value, AdaptiveCardSchemaKey::Images, Image::DeserializeWithoutCheckingType, true);
-    imageSet->m_images = std::move(images);
+    auto images = ParseUtil::GetElementCollection(elementParserRegistration, actionParserRegistration, value, AdaptiveCardSchemaKey::Images, true);
+
+    for (auto image : images)
+    {
+        imageSet->m_images.push_back(std::static_pointer_cast<Image>(image));
+    }
 
     return imageSet;
 }
 
-std::shared_ptr<ImageSet> ImageSet::DeserializeFromString(const std::string& jsonString)
+std::shared_ptr<BaseCardElement> ImageSetParser::DeserializeFromString(
+    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
+    const std::string& jsonString)
 {
-    return ImageSet::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
+    return ImageSetParser::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
 }

--- a/source/shared/cpp/ObjectModel/ImageSet.h
+++ b/source/shared/cpp/ObjectModel/ImageSet.h
@@ -8,26 +8,39 @@
 namespace AdaptiveCards
 {
 class BaseCardElement;
-    class ImageSet : public BaseCardElement
-    {
-        public:
-        ImageSet();
-        ImageSet(Spacing spacing, bool separation);
-        ImageSet(Spacing spacing, bool separation, std::vector<std::shared_ptr<Image>>& images);
+class ImageSet : public BaseCardElement
+{
+friend class ImageSetParser;
+public:
+    ImageSet();
+    ImageSet(Spacing spacing, bool separation);
+    ImageSet(Spacing spacing, bool separation, std::vector<std::shared_ptr<Image>>& images);
 
-        virtual std::string Serialize();
-        virtual Json::Value SerializeToJsonValue();
+    virtual std::string Serialize();
+    virtual Json::Value SerializeToJsonValue();
 
-        ImageSize GetImageSize() const;
-        void SetImageSize(const ImageSize value);
+    ImageSize GetImageSize() const;
+    void SetImageSize(const ImageSize value);
 
-        std::vector<std::shared_ptr<Image>>& GetImages();
-        const std::vector<std::shared_ptr<Image>>& GetImages() const;
-        static std::shared_ptr<ImageSet> Deserialize(const Json::Value& root);
-        static std::shared_ptr<ImageSet> DeserializeFromString(const std::string& jsonString);
+    std::vector<std::shared_ptr<Image>>& GetImages();
+    const std::vector<std::shared_ptr<Image>>& GetImages() const;
 
-        private:
-        std::vector<std::shared_ptr<Image>> m_images;
-        ImageSize m_imageSize;
-    };
+private:
+    std::vector<std::shared_ptr<Image>> m_images;
+    ImageSize m_imageSize;
+};
+    
+class ImageSetParser : public IBaseCardElementParser
+{
+public:
+    std::shared_ptr<BaseCardElement> Deserialize(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
+        const Json::Value& root);
+
+    std::shared_ptr<BaseCardElement> DeserializeFromString(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
+        const std::string& jsonString);
+};
 }

--- a/source/shared/cpp/ObjectModel/NumberInput.cpp
+++ b/source/shared/cpp/ObjectModel/NumberInput.cpp
@@ -10,25 +10,6 @@ NumberInput::NumberInput() :
 {
 }
 
-std::shared_ptr<NumberInput> NumberInput::Deserialize(const Json::Value& json)
-{
-    ParseUtil::ExpectTypeString(json, CardElementType::NumberInput);
-
-    std::shared_ptr<NumberInput> numberInput = BaseInputElement::Deserialize<NumberInput>(json);
-
-    numberInput->SetPlaceholder(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Placeholder));
-    numberInput->SetValue(ParseUtil::GetInt(json, AdaptiveCardSchemaKey::Value, 0));
-    numberInput->SetMax(ParseUtil::GetInt(json, AdaptiveCardSchemaKey::Max, std::numeric_limits<int>::max()));
-    numberInput->SetMin(ParseUtil::GetInt(json, AdaptiveCardSchemaKey::Min, std::numeric_limits<int>::min()));
-
-    return numberInput;
-}
-
-std::shared_ptr<NumberInput> NumberInput::DeserializeFromString(const std::string& jsonString)
-{
-    return NumberInput::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
-}
-
 std::string NumberInput::Serialize()
 {
     Json::FastWriter writer;
@@ -85,4 +66,29 @@ int NumberInput::GetMin() const
 void NumberInput::SetMin(const int value)
 {
     m_min = value;
+}
+
+std::shared_ptr<BaseCardElement> NumberInputParser::Deserialize(
+    std::shared_ptr<ElementParserRegistration>,
+    std::shared_ptr<ActionParserRegistration>, 
+    const Json::Value& json)
+{
+    ParseUtil::ExpectTypeString(json, CardElementType::NumberInput);
+
+    std::shared_ptr<NumberInput> numberInput = BaseInputElement::Deserialize<NumberInput>(json);
+
+    numberInput->SetPlaceholder(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Placeholder));
+    numberInput->SetValue(ParseUtil::GetInt(json, AdaptiveCardSchemaKey::Value, 0));
+    numberInput->SetMax(ParseUtil::GetInt(json, AdaptiveCardSchemaKey::Max, std::numeric_limits<int>::max()));
+    numberInput->SetMin(ParseUtil::GetInt(json, AdaptiveCardSchemaKey::Min, std::numeric_limits<int>::min()));
+
+    return numberInput;
+}
+
+std::shared_ptr<BaseCardElement> NumberInputParser::DeserializeFromString(
+    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+    const std::string& jsonString)
+{
+    return NumberInputParser::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
 }

--- a/source/shared/cpp/ObjectModel/NumberInput.h
+++ b/source/shared/cpp/ObjectModel/NumberInput.h
@@ -3,6 +3,7 @@
 #include "pch.h"
 #include "BaseInputElement.h"
 #include "Enums.h"
+#include "ElementParserRegistration.h"
 
 namespace AdaptiveCards
 {
@@ -10,9 +11,6 @@ class NumberInput : public BaseInputElement
 {
 public:
     NumberInput();
-
-    static std::shared_ptr<NumberInput> Deserialize(const Json::Value& root);
-    static std::shared_ptr<NumberInput> DeserializeFromString(const std::string& jsonString);
 
     virtual std::string Serialize();
     virtual Json::Value SerializeToJsonValue();
@@ -34,5 +32,19 @@ private:
     int m_value;
     int m_max;
     int m_min;
+};
+
+class NumberInputParser : public IBaseCardElementParser
+{
+public:
+    std::shared_ptr<BaseCardElement> Deserialize(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+        const Json::Value& root);
+
+    std::shared_ptr<BaseCardElement> DeserializeFromString(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+        const std::string& jsonString);
 };
 }

--- a/source/shared/cpp/ObjectModel/OpenUrlAction.cpp
+++ b/source/shared/cpp/ObjectModel/OpenUrlAction.cpp
@@ -8,20 +8,6 @@ OpenUrlAction::OpenUrlAction() : BaseActionElement(ActionType::OpenUrl)
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Url));
 }
 
-std::shared_ptr<OpenUrlAction> OpenUrlAction::Deserialize(const Json::Value& json)
-{
-    std::shared_ptr<OpenUrlAction> openUrlAction = BaseActionElement::Deserialize<OpenUrlAction>(json);
-
-    openUrlAction->SetUrl(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Url, true));
-
-    return openUrlAction;
-}
-
-std::shared_ptr<OpenUrlAction> OpenUrlAction::DeserializeFromString(const std::string& jsonString)
-{
-    return OpenUrlAction::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
-}
-
 std::string OpenUrlAction::Serialize()
 {
     Json::FastWriter writer;
@@ -47,4 +33,22 @@ void OpenUrlAction::SetUrl(const std::string value)
     m_url = value;
 }
 
+std::shared_ptr<BaseActionElement> OpenUrlActionParser::Deserialize(
+    std::shared_ptr<ElementParserRegistration>,
+    std::shared_ptr<ActionParserRegistration>, 
+    const Json::Value& json)
+{
+    std::shared_ptr<OpenUrlAction> openUrlAction = BaseActionElement::Deserialize<OpenUrlAction>(json);
 
+    openUrlAction->SetUrl(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Url, true));
+
+    return openUrlAction;
+}
+
+std::shared_ptr<BaseActionElement> OpenUrlActionParser::DeserializeFromString(
+    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
+    const std::string& jsonString)
+{
+    return OpenUrlActionParser::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
+}

--- a/source/shared/cpp/ObjectModel/OpenUrlAction.h
+++ b/source/shared/cpp/ObjectModel/OpenUrlAction.h
@@ -3,6 +3,7 @@
 #include "pch.h"
 #include "BaseActionElement.h"
 #include "Enums.h"
+#include "ActionParserRegistration.h"
 
 namespace AdaptiveCards
 {
@@ -10,9 +11,6 @@ class OpenUrlAction : public BaseActionElement
 {
 public:
     OpenUrlAction();
-
-    static std::shared_ptr<OpenUrlAction> Deserialize(const Json::Value& root);
-    static std::shared_ptr<OpenUrlAction> DeserializeFromString(const std::string& jsonString);
 
     virtual std::string Serialize();
     virtual Json::Value SerializeToJsonValue();
@@ -22,5 +20,18 @@ public:
     
 private:
     std::string m_url;
+};
+
+class OpenUrlActionParser : public IBaseActionElementParser
+{
+    std::shared_ptr<BaseActionElement> Deserialize(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+        const Json::Value& value);
+
+    std::shared_ptr<BaseActionElement> DeserializeFromString(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+        const std::string& jsonString);
 };
 }

--- a/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
+++ b/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
@@ -1,45 +1,7 @@
 #include "SharedAdaptiveCard.h"
-#include "ChoiceSetInput.h"
-#include "ColumnSet.h"
-#include "Container.h"
-#include "DateInput.h"
-#include "FactSet.h"
-#include "Image.h"
-#include "ImageSet.h"
-#include "NumberInput.h"
-#include "OpenUrlAction.h"
 #include "ParseUtil.h"
-#include "ShowCardAction.h"
-#include "SubmitAction.h"
-#include "TextBlock.h"
-#include "TextInput.h"
-#include "TimeInput.h"
-#include "ToggleInput.h"
 
 using namespace AdaptiveCards;
-
-const std::unordered_map<CardElementType, std::function<std::shared_ptr<BaseCardElement>(const Json::Value&)>, EnumHash> AdaptiveCard::CardElementParsers =
-{
-    { CardElementType::Container, Container::Deserialize },
-    { CardElementType::ColumnSet, ColumnSet::Deserialize },
-    { CardElementType::FactSet, FactSet::Deserialize },
-    { CardElementType::Image, Image::Deserialize },
-    { CardElementType::ImageSet, ImageSet::Deserialize },
-    { CardElementType::TextBlock, TextBlock::Deserialize },
-    { CardElementType::ChoiceSetInput, ChoiceSetInput::Deserialize },
-    { CardElementType::DateInput, DateInput::Deserialize },
-    { CardElementType::NumberInput, NumberInput::Deserialize },
-    { CardElementType::TextInput, TextInput::Deserialize },
-    { CardElementType::TimeInput, TimeInput::Deserialize },
-    { CardElementType::ToggleInput, ToggleInput::Deserialize },
-};
-
-const std::unordered_map<ActionType, std::function<std::shared_ptr<BaseActionElement>(const Json::Value&)>, EnumHash> AdaptiveCard::ActionParsers =
-{
-    { ActionType::OpenUrl, OpenUrlAction::Deserialize },
-    { ActionType::ShowCard, ShowCardAction::Deserialize },
-    { ActionType::Submit, SubmitAction::Deserialize },
-};
 
 AdaptiveCard::AdaptiveCard()
 {
@@ -79,9 +41,15 @@ AdaptiveCard::AdaptiveCard(std::string version,
 }
 
 #ifdef __ANDROID__
-std::shared_ptr<AdaptiveCard> AdaptiveCard::DeserializeFromFile(const std::string& jsonFile) throw(AdaptiveCards::AdaptiveCardParseException)
+std::shared_ptr<AdaptiveCard> AdaptiveCard::DeserializeFromFile(
+    const std::string& jsonFile,
+    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration) throw(AdaptiveCards::AdaptiveCardParseException)
 #else
-std::shared_ptr<AdaptiveCard> AdaptiveCard::DeserializeFromFile(const std::string& jsonFile)
+std::shared_ptr<AdaptiveCard> AdaptiveCard::DeserializeFromFile(
+    const std::string& jsonFile,
+    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration)
 #endif // __ANDROID__
 {
     std::ifstream jsonFileStream(jsonFile);
@@ -89,13 +57,19 @@ std::shared_ptr<AdaptiveCard> AdaptiveCard::DeserializeFromFile(const std::strin
     Json::Value root;
     jsonFileStream >> root;
 
-    return AdaptiveCard::Deserialize(root);
+    return AdaptiveCard::Deserialize(root, elementParserRegistration, actionParserRegistration);
 }
 
 #ifdef __ANDROID__
-std::shared_ptr<AdaptiveCard> AdaptiveCard::Deserialize(const Json::Value& json) throw(AdaptiveCards::AdaptiveCardParseException)
+std::shared_ptr<AdaptiveCard> AdaptiveCard::Deserialize(
+    const Json::Value& json,
+    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration) throw(AdaptiveCards::AdaptiveCardParseException)
 #else
-std::shared_ptr<AdaptiveCard> AdaptiveCard::Deserialize(const Json::Value& json)
+std::shared_ptr<AdaptiveCard> AdaptiveCard::Deserialize(
+    const Json::Value& json,
+    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration)
 #endif // __ANDROID__
 {
     ParseUtil::ThrowIfNotJsonObject(json);
@@ -112,23 +86,38 @@ std::shared_ptr<AdaptiveCard> AdaptiveCard::Deserialize(const Json::Value& json)
     std::string speak = ParseUtil::GetString(json, AdaptiveCardSchemaKey::Speak);
     ContainerStyle style = ParseUtil::GetEnumValue<ContainerStyle>(json, AdaptiveCardSchemaKey::Style, ContainerStyle::None, ContainerStyleFromString);
 
+    if (elementParserRegistration == nullptr)
+    {
+        elementParserRegistration = ElementParserRegistration::GetDefault();
+    }
+    if (actionParserRegistration == nullptr)
+    {
+        actionParserRegistration = ActionParserRegistration::GetDefault();
+    }
+
     // Parse body
-    auto body = ParseUtil::GetElementCollection<BaseCardElement>(json, AdaptiveCardSchemaKey::Body, AdaptiveCard::CardElementParsers, false);
+    auto body = ParseUtil::GetElementCollection(elementParserRegistration, actionParserRegistration, json, AdaptiveCardSchemaKey::Body, false);
 
     // Parse actions if present
-    auto actions = ParseUtil::GetActionCollection<BaseActionElement>(json, AdaptiveCardSchemaKey::Actions, AdaptiveCard::ActionParsers);
+    auto actions = ParseUtil::GetActionCollection(elementParserRegistration, actionParserRegistration, json, AdaptiveCardSchemaKey::Actions);
 
     auto result = std::make_shared<AdaptiveCard>(version, minVersion, fallbackText, backgroundImage, style, speak, body, actions);
     return result;
 }
 
 #ifdef __ANDROID__
-std::shared_ptr<AdaptiveCard> AdaptiveCard::DeserializeFromString(const std::string& jsonString) throw(AdaptiveCards::AdaptiveCardParseException)
+std::shared_ptr<AdaptiveCard> AdaptiveCard::DeserializeFromString(
+    const std::string& jsonString,
+    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration) throw(AdaptiveCards::AdaptiveCardParseException)
 #else
-std::shared_ptr<AdaptiveCard> AdaptiveCard::DeserializeFromString(const std::string& jsonString)
+std::shared_ptr<AdaptiveCard> AdaptiveCard::DeserializeFromString(
+    const std::string& jsonString,
+    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration)
 #endif // __ANDROID__
 {
-    return AdaptiveCard::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
+    return AdaptiveCard::Deserialize(ParseUtil::GetJsonValueFromString(jsonString), elementParserRegistration, actionParserRegistration);
 }
 
 Json::Value AdaptiveCard::SerializeToJsonValue()

--- a/source/shared/cpp/ObjectModel/SharedAdaptiveCard.h
+++ b/source/shared/cpp/ObjectModel/SharedAdaptiveCard.h
@@ -49,20 +49,33 @@ public:
 
     const CardElementType GetElementType() const;
 #ifdef __ANDROID__
-    static std::shared_ptr<AdaptiveCard> DeserializeFromFile(const std::string& jsonFile) throw(AdaptiveCards::AdaptiveCardParseException);
-    static std::shared_ptr<AdaptiveCard> Deserialize(const Json::Value& json) throw(AdaptiveCards::AdaptiveCardParseException);
-    static std::shared_ptr<AdaptiveCard> DeserializeFromString(const std::string& jsonString) throw(AdaptiveCards::AdaptiveCardParseException);
+    static std::shared_ptr<AdaptiveCard> DeserializeFromFile(const std::string& jsonFile,
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration = nullptr,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration = nullptr) throw(AdaptiveCards::AdaptiveCardParseException);
+    static std::shared_ptr<AdaptiveCard> Deserialize(const Json::Value& json,
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration = nullptr,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration = nullptr) throw(AdaptiveCards::AdaptiveCardParseException);
+    static std::shared_ptr<AdaptiveCard> DeserializeFromString(const std::string& jsonString,
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration = nullptr,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration = nullptr) throw(AdaptiveCards::AdaptiveCardParseException);
 #else
-    static std::shared_ptr<AdaptiveCard> DeserializeFromFile(const std::string& jsonFile);
-    static std::shared_ptr<AdaptiveCard> Deserialize(const Json::Value& json);
-    static std::shared_ptr<AdaptiveCard> DeserializeFromString(const std::string& jsonString);
+    static std::shared_ptr<AdaptiveCard> DeserializeFromFile(
+        const std::string& jsonFile, 
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration = nullptr,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration = nullptr);
+
+    static std::shared_ptr<AdaptiveCard> Deserialize(const Json::Value& json,
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration = nullptr,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration = nullptr);
+
+    static std::shared_ptr<AdaptiveCard> DeserializeFromString(const std::string& jsonString,
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration = nullptr,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration = nullptr);
 #endif // __ANDROID__
     Json::Value SerializeToJsonValue();
     std::string Serialize();
 
 private:
-    static const std::unordered_map<CardElementType, std::function<std::shared_ptr<BaseCardElement>(const Json::Value&)>, EnumHash> CardElementParsers;
-    static const std::unordered_map<ActionType, std::function<std::shared_ptr<BaseActionElement>(const Json::Value&)>, EnumHash> ActionParsers;
     std::string m_version;
     std::string m_minVersion;
     std::string m_fallbackText;

--- a/source/shared/cpp/ObjectModel/ShowCardAction.cpp
+++ b/source/shared/cpp/ObjectModel/ShowCardAction.cpp
@@ -9,21 +9,6 @@ ShowCardAction::ShowCardAction() : BaseActionElement(ActionType::ShowCard)
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Card));
 }
 
-std::shared_ptr<ShowCardAction> ShowCardAction::Deserialize(const Json::Value& json)
-{
-    std::shared_ptr<ShowCardAction> showCardAction = BaseActionElement::Deserialize<ShowCardAction>(json);
-
-    std::string propertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Card);
-    showCardAction->SetCard(AdaptiveCard::Deserialize(json.get(propertyName, Json::Value())));
-
-    return showCardAction;
-}
-
-std::shared_ptr<ShowCardAction> ShowCardAction::DeserializeFromString(const std::string& jsonString)
-{
-    return ShowCardAction::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
-}
-
 std::string ShowCardAction::Serialize()
 {
     Json::FastWriter writer;
@@ -48,3 +33,25 @@ void AdaptiveCards::ShowCardAction::SetCard(const std::shared_ptr<AdaptiveCard> 
 {
     m_card = card;
 }
+
+std::shared_ptr<BaseActionElement> ShowCardActionParser::Deserialize(
+    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
+    const Json::Value& json)
+{
+    std::shared_ptr<ShowCardAction> showCardAction = BaseActionElement::Deserialize<ShowCardAction>(json);
+
+    std::string propertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Card);
+    showCardAction->SetCard(AdaptiveCard::Deserialize(json.get(propertyName, Json::Value()), elementParserRegistration, actionParserRegistration));
+
+    return showCardAction;
+}
+
+std::shared_ptr<BaseActionElement> ShowCardActionParser::DeserializeFromString(
+    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
+    const std::string& jsonString)
+{
+    return ShowCardActionParser::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
+}
+

--- a/source/shared/cpp/ObjectModel/ShowCardAction.h
+++ b/source/shared/cpp/ObjectModel/ShowCardAction.h
@@ -4,6 +4,7 @@
 #include "SharedAdaptiveCard.h"
 #include "BaseActionElement.h"
 #include "Enums.h"
+#include "ActionParserRegistration.h"
 
 namespace AdaptiveCards
 {
@@ -11,9 +12,6 @@ class ShowCardAction : public BaseActionElement
 {
 public:
     ShowCardAction();
-
-    static std::shared_ptr<ShowCardAction> Deserialize(const Json::Value& root);
-    static std::shared_ptr<ShowCardAction> DeserializeFromString(const std::string& jsonString);
 
     virtual std::string Serialize();
     virtual Json::Value SerializeToJsonValue();
@@ -23,5 +21,18 @@ public:
 
 private:
     std::shared_ptr<AdaptiveCard> m_card;
+};
+
+class ShowCardActionParser : public IBaseActionElementParser
+{
+    std::shared_ptr<BaseActionElement> Deserialize(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+        const Json::Value& value);
+
+    std::shared_ptr<BaseActionElement> DeserializeFromString(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+        const std::string& jsonString);
 };
 }

--- a/source/shared/cpp/ObjectModel/SubmitAction.cpp
+++ b/source/shared/cpp/ObjectModel/SubmitAction.cpp
@@ -18,20 +18,6 @@ void SubmitAction::SetDataJson(const std::string value)
     m_dataJson = value;
 }
 
-std::shared_ptr<SubmitAction> SubmitAction::Deserialize(const Json::Value& json)
-{
-    std::shared_ptr<SubmitAction> submitAction = BaseActionElement::Deserialize<SubmitAction>(json);
-
-    submitAction->SetDataJson(ParseUtil::GetJsonString(json, AdaptiveCardSchemaKey::Data));
-
-    return submitAction;
-}
-
-std::shared_ptr<SubmitAction> SubmitAction::DeserializeFromString(const std::string& jsonString)
-{
-    return SubmitAction::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
-}
-
 std::string SubmitAction::Serialize()
 {
     Json::FastWriter writer;
@@ -48,4 +34,23 @@ Json::Value SubmitAction::SerializeToJsonValue()
 }
 
 
+std::shared_ptr<BaseActionElement> SubmitActionParser::Deserialize(
+    std::shared_ptr<ElementParserRegistration>,
+    std::shared_ptr<ActionParserRegistration>, 
+    const Json::Value& json)
+{
+    std::shared_ptr<SubmitAction> submitAction = BaseActionElement::Deserialize<SubmitAction>(json);
+
+    submitAction->SetDataJson(ParseUtil::GetJsonString(json, AdaptiveCardSchemaKey::Data));
+
+    return submitAction;
+}
+
+std::shared_ptr<BaseActionElement> SubmitActionParser::DeserializeFromString(
+    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+    const std::string& jsonString)
+{
+    return SubmitActionParser::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
+}
 

--- a/source/shared/cpp/ObjectModel/SubmitAction.h
+++ b/source/shared/cpp/ObjectModel/SubmitAction.h
@@ -3,6 +3,7 @@
 #include "pch.h"
 #include "BaseActionElement.h"
 #include "Enums.h"
+#include "ActionParserRegistration.h"
 
 namespace AdaptiveCards
 {
@@ -14,13 +15,23 @@ public:
     std::string GetDataJson() const;
     void SetDataJson(const std::string value);
 
-    static std::shared_ptr<SubmitAction> Deserialize(const Json::Value& root);
-    static std::shared_ptr<SubmitAction> DeserializeFromString(const std::string& jsonString);
-
     virtual std::string Serialize();
     virtual Json::Value SerializeToJsonValue();
 
 private:
     std::string m_dataJson;
+};
+
+class SubmitActionParser : public IBaseActionElementParser
+{
+    std::shared_ptr<BaseActionElement> Deserialize(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+        const Json::Value& value);
+
+    std::shared_ptr<BaseActionElement> DeserializeFromString(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+        const std::string& jsonString);
 };
 }

--- a/source/shared/cpp/ObjectModel/TextBlock.cpp
+++ b/source/shared/cpp/ObjectModel/TextBlock.cpp
@@ -38,29 +38,6 @@ TextBlock::TextBlock(
 {
 }
 
-std::shared_ptr<TextBlock> TextBlock::Deserialize(const Json::Value& json)
-{
-    ParseUtil::ExpectTypeString(json, CardElementType::TextBlock);
-
-    std::shared_ptr<TextBlock> textBlock = BaseCardElement::Deserialize<TextBlock>(json);
-
-    textBlock->SetText(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Text, true));
-    textBlock->SetTextSize(ParseUtil::GetEnumValue<TextSize>(json, AdaptiveCardSchemaKey::Size, TextSize::Default, TextSizeFromString));
-    textBlock->SetTextColor(ParseUtil::GetEnumValue<ForegroundColor>(json, AdaptiveCardSchemaKey::Color, ForegroundColor::Default, ForegroundColorFromString));
-    textBlock->SetTextWeight(ParseUtil::GetEnumValue<TextWeight>(json, AdaptiveCardSchemaKey::TextWeight, TextWeight::Default, TextWeightFromString));
-    textBlock->SetWrap(ParseUtil::GetBool(json, AdaptiveCardSchemaKey::Wrap, false));
-    textBlock->SetIsSubtle(ParseUtil::GetBool(json, AdaptiveCardSchemaKey::IsSubtle, false));
-    textBlock->SetMaxLines(ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::MaxLines, 0));
-    textBlock->SetHorizontalAlignment(ParseUtil::GetEnumValue<HorizontalAlignment>(json, AdaptiveCardSchemaKey::HorizontalAlignment, HorizontalAlignment::Left, HorizontalAlignmentFromString));
-
-    return textBlock;
-}
-
-std::shared_ptr<TextBlock> TextBlock::DeserializeFromString(const std::string& jsonString)
-{
-    return TextBlock::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
-}
-
 std::string TextBlock::Serialize()
 {
     Json::FastWriter writer;
@@ -165,3 +142,31 @@ void TextBlock::SetHorizontalAlignment(const HorizontalAlignment value)
     m_hAlignment = value;
 }
 
+std::shared_ptr<BaseCardElement> TextBlockParser::Deserialize(
+    std::shared_ptr<ElementParserRegistration>,
+    std::shared_ptr<ActionParserRegistration>,
+    const Json::Value& json)
+{
+    ParseUtil::ExpectTypeString(json, CardElementType::TextBlock);
+
+    std::shared_ptr<TextBlock> textBlock = BaseCardElement::Deserialize<TextBlock>(json);
+
+    textBlock->SetText(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Text, true));
+    textBlock->SetTextSize(ParseUtil::GetEnumValue<TextSize>(json, AdaptiveCardSchemaKey::Size, TextSize::Default, TextSizeFromString));
+    textBlock->SetTextColor(ParseUtil::GetEnumValue<ForegroundColor>(json, AdaptiveCardSchemaKey::Color, ForegroundColor::Default, ForegroundColorFromString));
+    textBlock->SetTextWeight(ParseUtil::GetEnumValue<TextWeight>(json, AdaptiveCardSchemaKey::TextWeight, TextWeight::Default, TextWeightFromString));
+    textBlock->SetWrap(ParseUtil::GetBool(json, AdaptiveCardSchemaKey::Wrap, false));
+    textBlock->SetIsSubtle(ParseUtil::GetBool(json, AdaptiveCardSchemaKey::IsSubtle, false));
+    textBlock->SetMaxLines(ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::MaxLines, 0));
+    textBlock->SetHorizontalAlignment(ParseUtil::GetEnumValue<HorizontalAlignment>(json, AdaptiveCardSchemaKey::HorizontalAlignment, HorizontalAlignment::Left, HorizontalAlignmentFromString));
+
+    return textBlock;
+}
+
+std::shared_ptr<BaseCardElement> TextBlockParser::DeserializeFromString(
+    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
+    const std::string& jsonString)
+{
+    return TextBlockParser::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
+}

--- a/source/shared/cpp/ObjectModel/TextBlock.h
+++ b/source/shared/cpp/ObjectModel/TextBlock.h
@@ -3,6 +3,7 @@
 #include "pch.h"
 #include "BaseCardElement.h"
 #include "Enums.h"
+#include "ElementParserRegistration.h"
 
 namespace AdaptiveCards
 {
@@ -21,9 +22,6 @@ public:
         bool wrap,
         int maxLines,
         HorizontalAlignment hAlignment);
-
-    static std::shared_ptr<TextBlock> Deserialize(const Json::Value& root);
-    static std::shared_ptr<TextBlock> DeserializeFromString(const std::string& jsonString);
 
     virtual std::string Serialize();
     virtual Json::Value SerializeToJsonValue();
@@ -61,5 +59,19 @@ private:
     bool m_wrap;
     unsigned int m_maxLines;
     HorizontalAlignment m_hAlignment;
+};
+
+class TextBlockParser : public IBaseCardElementParser
+{
+public:
+    std::shared_ptr<BaseCardElement> Deserialize(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+        const Json::Value& root);
+
+    std::shared_ptr<BaseCardElement> DeserializeFromString(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
+        const std::string& jsonString);
 };
 }

--- a/source/shared/cpp/ObjectModel/TextInput.cpp
+++ b/source/shared/cpp/ObjectModel/TextInput.cpp
@@ -10,26 +10,6 @@ TextInput::TextInput() :
 {
 }
 
-std::shared_ptr<TextInput> TextInput::Deserialize(const Json::Value& json)
-{
-    ParseUtil::ExpectTypeString(json, CardElementType::TextInput);
-
-    std::shared_ptr<TextInput> textInput = BaseInputElement::Deserialize<TextInput>(json);
-
-    textInput->SetPlaceholder(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Placeholder));
-    textInput->SetValue(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Value));
-    textInput->SetIsMultiline(ParseUtil::GetBool(json, AdaptiveCardSchemaKey::IsMultiline, false));
-    textInput->SetMaxLength(ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::MaxLength, 0));
-    textInput->SetTextInputStyle(ParseUtil::GetEnumValue<TextInputStyle>(json, AdaptiveCardSchemaKey::Style, TextInputStyle::Text, TextInputStyleFromString));
-
-    return textInput;
-}
-
-std::shared_ptr<TextInput> TextInput::DeserializeFromString(const std::string& jsonString)
-{
-    return TextInput::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
-}
-
 std::string TextInput::Serialize()
 {
     Json::FastWriter writer;
@@ -97,4 +77,30 @@ TextInputStyle AdaptiveCards::TextInput::GetTextInputStyle() const
 void AdaptiveCards::TextInput::SetTextInputStyle(const TextInputStyle value)
 {
     m_style = value;
+}
+
+std::shared_ptr<BaseCardElement> TextInputParser::Deserialize(
+    std::shared_ptr<ElementParserRegistration>,
+    std::shared_ptr<ActionParserRegistration>,
+    const Json::Value& json)
+{
+    ParseUtil::ExpectTypeString(json, CardElementType::TextInput);
+
+    std::shared_ptr<TextInput> textInput = BaseInputElement::Deserialize<TextInput>(json);
+
+    textInput->SetPlaceholder(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Placeholder));
+    textInput->SetValue(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Value));
+    textInput->SetIsMultiline(ParseUtil::GetBool(json, AdaptiveCardSchemaKey::IsMultiline, false));
+    textInput->SetMaxLength(ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::MaxLength, 0));
+    textInput->SetTextInputStyle(ParseUtil::GetEnumValue<TextInputStyle>(json, AdaptiveCardSchemaKey::Style, TextInputStyle::Text, TextInputStyleFromString));
+
+    return textInput;
+}
+
+std::shared_ptr<BaseCardElement> TextInputParser::DeserializeFromString(
+    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
+    const std::string& jsonString)
+{
+    return TextInputParser::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
 }

--- a/source/shared/cpp/ObjectModel/TextInput.h
+++ b/source/shared/cpp/ObjectModel/TextInput.h
@@ -3,6 +3,7 @@
 #include "pch.h"
 #include "BaseInputElement.h"
 #include "Enums.h"
+#include "ElementParserRegistration.h"
 
 namespace AdaptiveCards
 {
@@ -10,9 +11,6 @@ class TextInput : public BaseInputElement
 {
 public:
     TextInput();
-
-    static std::shared_ptr<TextInput> Deserialize(const Json::Value& root);
-    static std::shared_ptr<TextInput> DeserializeFromString(const std::string& jsonString);
 
     virtual std::string Serialize();
     Json::Value SerializeToJsonValue();
@@ -38,5 +36,19 @@ private:
     bool m_isMultiline;
     unsigned int m_maxLength;
     TextInputStyle m_style;
+};
+
+class TextInputParser : public IBaseCardElementParser
+{
+public:
+    std::shared_ptr<BaseCardElement> Deserialize(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
+        const Json::Value& root);
+
+    std::shared_ptr<BaseCardElement> DeserializeFromString(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
+        const std::string& jsonString);
 };
 }

--- a/source/shared/cpp/ObjectModel/TimeInput.cpp
+++ b/source/shared/cpp/ObjectModel/TimeInput.cpp
@@ -8,25 +8,6 @@ TimeInput::TimeInput() :
 {
 }
 
-std::shared_ptr<TimeInput> TimeInput::Deserialize(const Json::Value& json)
-{
-    ParseUtil::ExpectTypeString(json, CardElementType::TimeInput);
-
-    std::shared_ptr<TimeInput> timeInput = BaseInputElement::Deserialize<TimeInput>(json);
-
-    timeInput->SetMax(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Max));
-    timeInput->SetMin(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Min));
-    timeInput->SetPlaceholder(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Placeholder));
-    timeInput->SetValue(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Value));
-
-    return timeInput;
-}
-
-std::shared_ptr<TimeInput> TimeInput::DeserializeFromString(const std::string& jsonString)
-{
-    return TimeInput::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
-}
-
 std::string TimeInput::Serialize()
 {
     Json::FastWriter writer;
@@ -84,3 +65,29 @@ void TimeInput::SetValue(const std::string value)
 {
     m_value = value;
 }
+
+std::shared_ptr<BaseCardElement> TimeInputParser::Deserialize(
+    std::shared_ptr<ElementParserRegistration>,
+    std::shared_ptr<ActionParserRegistration>,
+    const Json::Value& json)
+{
+    ParseUtil::ExpectTypeString(json, CardElementType::TimeInput);
+
+    std::shared_ptr<TimeInput> timeInput = BaseInputElement::Deserialize<TimeInput>(json);
+
+    timeInput->SetMax(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Max));
+    timeInput->SetMin(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Min));
+    timeInput->SetPlaceholder(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Placeholder));
+    timeInput->SetValue(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Value));
+
+    return timeInput;
+}
+
+std::shared_ptr<BaseCardElement> TimeInputParser::DeserializeFromString(
+    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
+    const std::string& jsonString)
+{
+    return TimeInputParser::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
+}
+

--- a/source/shared/cpp/ObjectModel/TimeInput.h
+++ b/source/shared/cpp/ObjectModel/TimeInput.h
@@ -3,6 +3,7 @@
 #include "pch.h"
 #include "BaseInputElement.h"
 #include "Enums.h"
+#include "ElementParserRegistration.h"
 
 namespace AdaptiveCards
 {
@@ -10,9 +11,6 @@ class TimeInput : public BaseInputElement
 {
 public:
     TimeInput();
-
-    static std::shared_ptr<TimeInput> Deserialize(const Json::Value& root);
-    static std::shared_ptr<TimeInput> DeserializeFromString(const std::string& jsonString);
 
     virtual std::string Serialize();
     Json::Value SerializeToJsonValue();
@@ -34,5 +32,19 @@ private:
     std::string m_min;
     std::string m_placeholder;
     std::string m_value;
+};
+
+class TimeInputParser : public IBaseCardElementParser
+{
+public:
+    std::shared_ptr<BaseCardElement> Deserialize(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+        const Json::Value& root);
+
+    std::shared_ptr<BaseCardElement> DeserializeFromString(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+        const std::string& jsonString);
 };
 }

--- a/source/shared/cpp/ObjectModel/ToggleInput.cpp
+++ b/source/shared/cpp/ObjectModel/ToggleInput.cpp
@@ -10,35 +10,6 @@ ToggleInput::ToggleInput() :
 {
 }
 
-std::shared_ptr<ToggleInput> ToggleInput::Deserialize(const Json::Value& json)
-{
-    ParseUtil::ExpectTypeString(json, CardElementType::ToggleInput);
-
-    std::shared_ptr<ToggleInput> toggleInput = BaseInputElement::Deserialize<ToggleInput>(json);
-
-    toggleInput->SetTitle(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Title, true));
-    toggleInput->SetValue(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Value));
-
-    std::string valueOff = ParseUtil::GetString(json, AdaptiveCardSchemaKey::ValueOff);
-    if (valueOff != "")
-    {
-        toggleInput->SetValueOff(valueOff);
-    }
-
-    std::string valueOn = ParseUtil::GetString(json, AdaptiveCardSchemaKey::ValueOn);
-    if (valueOn != "")
-    {
-        toggleInput->SetValueOn(valueOn);
-    }
-
-    return toggleInput;
-}
-
-std::shared_ptr<ToggleInput> ToggleInput::DeserializeFromString(const std::string& jsonString)
-{
-    return ToggleInput::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
-}
-
 std::string ToggleInput::Serialize()
 {
     Json::FastWriter writer;
@@ -94,4 +65,39 @@ std::string ToggleInput::GetValueOn() const
 void ToggleInput::SetValueOn(const std::string valueOn)
 {
     m_valueOn = valueOn;
+}
+
+std::shared_ptr<BaseCardElement> ToggleInputParser::Deserialize(
+    std::shared_ptr<ElementParserRegistration>,
+    std::shared_ptr<ActionParserRegistration>,
+    const Json::Value& json)
+{
+    ParseUtil::ExpectTypeString(json, CardElementType::ToggleInput);
+
+    std::shared_ptr<ToggleInput> toggleInput = BaseInputElement::Deserialize<ToggleInput>(json);
+
+    toggleInput->SetTitle(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Title, true));
+    toggleInput->SetValue(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Value));
+
+    std::string valueOff = ParseUtil::GetString(json, AdaptiveCardSchemaKey::ValueOff);
+    if (valueOff != "")
+    {
+        toggleInput->SetValueOff(valueOff);
+    }
+
+    std::string valueOn = ParseUtil::GetString(json, AdaptiveCardSchemaKey::ValueOn);
+    if (valueOn != "")
+    {
+        toggleInput->SetValueOn(valueOn);
+    }
+
+    return toggleInput;
+}
+
+std::shared_ptr<BaseCardElement> ToggleInputParser::DeserializeFromString(
+    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
+    const std::string& jsonString)
+{
+    return ToggleInputParser::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
 }

--- a/source/shared/cpp/ObjectModel/ToggleInput.h
+++ b/source/shared/cpp/ObjectModel/ToggleInput.h
@@ -3,6 +3,7 @@
 #include "pch.h"
 #include "BaseInputElement.h"
 #include "Enums.h"
+#include "ElementParserRegistration.h"
 
 namespace AdaptiveCards
 {
@@ -10,9 +11,6 @@ class ToggleInput : public BaseInputElement
 {
 public:
     ToggleInput();
-
-    static std::shared_ptr<ToggleInput> Deserialize(const Json::Value& root);
-    static std::shared_ptr<ToggleInput> DeserializeFromString(const std::string& jsonString);
 
     virtual std::string Serialize();
     Json::Value SerializeToJsonValue();
@@ -34,5 +32,19 @@ private:
     std::string m_value;
     std::string m_valueOff;
     std::string m_valueOn;
+};
+
+class ToggleInputParser : public IBaseCardElementParser
+{
+public:
+    std::shared_ptr<BaseCardElement> Deserialize(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, 
+        const Json::Value& root);
+
+    std::shared_ptr<BaseCardElement> DeserializeFromString(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
+        const std::string& jsonString);
 };
 }

--- a/source/uwp/ObjectModelProjection/ObjectModelProjection.vcxproj
+++ b/source/uwp/ObjectModelProjection/ObjectModelProjection.vcxproj
@@ -27,9 +27,11 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\shared\cpp\ObjectModel\ActionParserRegistration.cpp" />
     <ClCompile Include="..\..\shared\cpp\ObjectModel\AdaptiveCardParseException.cpp" />
     <ClCompile Include="..\..\shared\cpp\ObjectModel\BaseActionElement.cpp" />
     <ClCompile Include="..\..\shared\cpp\ObjectModel\BaseInputElement.cpp" />
+    <ClCompile Include="..\..\shared\cpp\ObjectModel\ElementParserRegistration.cpp" />
     <ClCompile Include="..\..\shared\cpp\ObjectModel\HostConfig.cpp" />
     <ClCompile Include="..\..\shared\cpp\ObjectModel\ChoiceInput.cpp" />
     <ClCompile Include="..\..\shared\cpp\ObjectModel\ChoiceSetInput.cpp" />
@@ -57,6 +59,7 @@
     <ClCompile Include="..\..\shared\cpp\ObjectModel\TextBlock.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\shared\cpp\ObjectModel\ActionParserRegistration.h" />
     <ClInclude Include="..\..\shared\cpp\ObjectModel\AdaptiveCardParseException.h" />
     <ClInclude Include="..\..\shared\cpp\ObjectModel\BaseActionElement.h" />
     <ClInclude Include="..\..\shared\cpp\ObjectModel\BaseInputElement.h" />
@@ -64,6 +67,7 @@
     <ClInclude Include="..\..\shared\cpp\ObjectModel\ChoiceSetInput.h" />
     <ClInclude Include="..\..\shared\cpp\ObjectModel\Column.h" />
     <ClInclude Include="..\..\shared\cpp\ObjectModel\ColumnSet.h" />
+    <ClInclude Include="..\..\shared\cpp\ObjectModel\ElementParserRegistration.h" />
     <ClInclude Include="..\..\shared\cpp\ObjectModel\Fact.h" />
     <ClInclude Include="..\..\shared\cpp\ObjectModel\FactSet.h" />
     <ClInclude Include="..\..\shared\cpp\ObjectModel\HostConfig.h" />

--- a/source/uwp/ObjectModelProjection/ObjectModelProjection.vcxproj.filters
+++ b/source/uwp/ObjectModelProjection/ObjectModelProjection.vcxproj.filters
@@ -31,6 +31,8 @@
     <ClCompile Include="..\..\shared\cpp\ObjectModel\SharedAdaptiveCard.cpp" />
     <ClCompile Include="..\..\shared\cpp\ObjectModel\HostConfig.cpp" />
     <ClCompile Include="..\..\shared\cpp\ObjectModel\Separator.cpp" />
+    <ClCompile Include="..\..\shared\cpp\ObjectModel\ElementParserRegistration.cpp" />
+    <ClCompile Include="..\..\shared\cpp\ObjectModel\ActionParserRegistration.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\shared\cpp\ObjectModel\Container.h" />
@@ -67,6 +69,8 @@
     <ClInclude Include="..\..\shared\cpp\ObjectModel\HostConfig.h" />
     <ClInclude Include="..\..\shared\cpp\ObjectModel\SharedAdaptiveCard.h" />
     <ClInclude Include="..\..\shared\cpp\ObjectModel\Separator.h" />
+    <ClInclude Include="..\..\shared\cpp\ObjectModel\ElementParserRegistration.h" />
+    <ClInclude Include="..\..\shared\cpp\ObjectModel\ActionParserRegistration.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="json">


### PR DESCRIPTION
This version passes around the parser registration rather than having it be static.