### PR TITLE
Fix ref-counting issue in UWP renderer Ivector implementation

### DIFF
--- a/source/uwp/Renderer/lib/Vector.h
+++ b/source/uwp/Renderer/lib/Vector.h
@@ -49,8 +49,7 @@ namespace AdaptiveCards { namespace Uwp
         typename typedef ComPtr<T> type;
         static ComPtr<T> MakeWrap(T* t)
         {
-            ComPtr<T> ptr;
-            ptr.Attach(t);
+            ComPtr<T> ptr(t);
             return ptr;
         }
         static T* Unwrap(ComPtr<T> t)


### PR DESCRIPTION
ComPtr::Attach() and Detach() Do not increase or decrease the refcount. Changed MakeWrap to increase the refcount during insertion to the vector,

Verified by testing the creation of object model elements and adding them into containers. Previously this would cause an access violation during destruction that is no longer present.


