### PR TITLE
Enable element render callbacks & truncate multi-line TextBlocks

### DIFF
--- a/source/nodejs/adaptivecards-visualizer/src/app.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/app.ts
@@ -34,7 +34,7 @@ function setContent(element) {
     contentContainer.appendChild(element);
 }
 
-function renderCard(): HTMLElement {
+function renderCard(target: HTMLElement) {
     document.getElementById("errorContainer").hidden = true;
     lastValidationErrors = [];
 
@@ -54,23 +54,21 @@ function renderCard(): HTMLElement {
 
     showValidationErrors();
 
-    return hostContainer.render(adaptiveCard.render(), adaptiveCard.renderSpeech());
+    hostContainer.render(adaptiveCard, target);
 }
 
 function tryRenderCard() {
-    var renderedCard: HTMLElement;
-
-    try {
-        renderedCard = renderCard();
-    }
-    catch (ex) {
-        renderedCard = document.createElement("div");
-        renderedCard.innerText = ex.message;
-    }
-
     var contentContainer = document.getElementById("content");
     contentContainer.innerHTML = '';
-    contentContainer.appendChild(renderedCard);
+
+    try {
+        renderCard(contentContainer);
+    }
+    catch (ex) {
+        var renderedCard = document.createElement("div");
+        renderedCard.innerText = ex.message;
+        contentContainer.appendChild(renderedCard);
+    }
 
     try {
         sessionStorage.setItem("AdaptivePayload", currentCardPayload);
@@ -411,15 +409,14 @@ function showPopupCard(action: Adaptive.ShowCardAction) {
 
     var hostContainer = hostContainerOptions[hostContainerPicker.selectedIndex].hostContainer;
 
-    cardContainer.appendChild(hostContainer.render(action.card.render(), action.card.renderSpeech()));
-
-    overlayElement.appendChild(cardContainer);
-
-    document.body.appendChild(overlayElement);
-
     var cardContainerBounds = cardContainer.getBoundingClientRect();
     cardContainer.style.left = (window.innerWidth - cardContainerBounds.width) / 2 + "px";
     cardContainer.style.top = (window.innerHeight - cardContainerBounds.height) / 2 + "px";
+
+    overlayElement.appendChild(cardContainer);
+    document.body.appendChild(overlayElement);
+
+    hostContainer.render(action.card, cardContainer);
 }
 
 function showValidationErrors() {

--- a/source/nodejs/adaptivecards-visualizer/src/containers/bing.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/bing.ts
@@ -1,5 +1,6 @@
 import { HostContainer } from "./host-container";
 import {
+    AdaptiveCard,
     HostConfig,
     Size,
     TextSize,
@@ -22,17 +23,15 @@ export class BingContainer extends HostContainer {
         this._width = width;
     }
 
-    protected renderContainer(renderedCard: HTMLElement): HTMLElement {
+    protected renderContainer(adaptiveCard: AdaptiveCard, target: HTMLElement)  {
         var element = document.createElement("div");
         element.style.width = this._width + "px";
         element.style.backgroundColor = BingContainer.backgroundColor;
         element.style.overflow = "hidden";
+        target.appendChild(element);
 
+        var renderedCard = adaptiveCard.render(element);
         renderedCard.style.height = "100%";
-
-        element.appendChild(renderedCard);
-
-        return element;
     }
 
     public getHostConfig(): HostConfig {

--- a/source/nodejs/adaptivecards-visualizer/src/containers/bing.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/bing.ts
@@ -23,7 +23,7 @@ export class BingContainer extends HostContainer {
         this._width = width;
     }
 
-    protected renderContainer(adaptiveCard: AdaptiveCard, target: HTMLElement)  {
+    protected renderContainer(adaptiveCard: AdaptiveCard, target: HTMLElement) {
         var element = document.createElement("div");
         element.style.width = this._width + "px";
         element.style.backgroundColor = BingContainer.backgroundColor;

--- a/source/nodejs/adaptivecards-visualizer/src/containers/facebook.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/facebook.ts
@@ -1,5 +1,6 @@
 import { HostContainer } from "./host-container";
 import {
+    AdaptiveCard,
     HostConfig,
     Size,
     TextSize,
@@ -23,12 +24,12 @@ export class FacebookContainer extends HostContainer {
         this.supportsActionBar = false;
     }
 
-    protected renderContainer(renderedCard: HTMLElement): HTMLElement {
+    protected renderContainer(adaptiveCard: AdaptiveCard, target: HTMLElement) {
         var outerElement = document.createElement("div");
         outerElement.className = "facebookOuterContainer";
         outerElement.style.width = this._width + "px";
-        outerElement.appendChild(renderedCard);
-        return outerElement;
+        target.appendChild(outerElement);
+        adaptiveCard.render(outerElement);
     }
 
     public getHostConfig(): HostConfig {

--- a/source/nodejs/adaptivecards-visualizer/src/containers/groupme.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/groupme.ts
@@ -1,5 +1,6 @@
 import { HostContainer } from "./host-container";
 import {
+    AdaptiveCard,
     HostConfig,
     Size,
     TextSize,
@@ -21,12 +22,12 @@ export class GroupMeContainer extends HostContainer {
         this.supportsActionBar = false;
     }
 
-    protected renderContainer(renderedCard: HTMLElement): HTMLElement {
+    protected renderContainer(adaptiveCard: AdaptiveCard, target: HTMLElement) {
         var outerElement = document.createElement("div");
         outerElement.className = "groupmeOuterContainer";
         outerElement.style.width = this._width + "px";
-        outerElement.appendChild(renderedCard);
-        return outerElement;
+        target.appendChild(outerElement);
+        adaptiveCard.render(outerElement);
     }
 
     public getHostConfig(): HostConfig {

--- a/source/nodejs/adaptivecards-visualizer/src/containers/headless.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/headless.ts
@@ -1,5 +1,6 @@
 import { HostContainer } from "./host-container";
 import {
+    AdaptiveCard,
     HostConfig,
     Size,
     TextSize,
@@ -12,7 +13,7 @@ import {
 } from "adaptivecards";
 
 export class HeadlessContainer extends HostContainer {
-    protected renderContainer(renderedCard: HTMLElement): HTMLElement {
+    protected renderContainer(adaptiveCard: AdaptiveCard, target: HTMLElement) {
         var outerElement = document.createElement("div");
         outerElement.className = "headlessOuterContainer";
 
@@ -40,10 +41,9 @@ export class HeadlessContainer extends HostContainer {
         var innerElement = document.createElement("div");
         innerElement.className = "headlessInnerContainer";
 
-        innerElement.appendChild(renderedCard);
+        target.appendChild(outerElement);
         outerElement.appendChild(innerElement);
-
-        return outerElement;
+        adaptiveCard.render(innerElement);
     }
 
     public getHostConfig(): HostConfig {

--- a/source/nodejs/adaptivecards-visualizer/src/containers/host-container.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/host-container.ts
@@ -1,4 +1,5 @@
 import {
+    AdaptiveCard,
     HostConfig,
     Size,
     TextSize,
@@ -223,9 +224,7 @@ export abstract class HostContainer {
         });
     }
 
-    protected renderContainer(renderedCard: HTMLElement): HTMLElement {
-        return null;
-    }
+    protected abstract renderContainer(adaptiveCard: AdaptiveCard, target: HTMLElement);
 
     protected renderSpeech(speechString: string, showXml: boolean = false): HTMLElement {
         if (!speechString) {
@@ -290,22 +289,18 @@ export abstract class HostContainer {
         this.styleSheet = styleSheet;
     }
 
-    render(renderedCard: HTMLElement, speechString: string, showSpeechXml: boolean = false): HTMLElement {
+    render(adaptiveCard: AdaptiveCard, target: HTMLElement, showSpeechXml: boolean = false) {
         var element = document.createElement("div");
+        target.appendChild(element);
 
-        if (renderedCard) {
-            var renderedContainer = this.renderContainer(renderedCard);
+        if (adaptiveCard) {
+            this.renderContainer(adaptiveCard, element);
 
-            if (renderedContainer) {
-                element.appendChild(renderedContainer);
+            var separator = document.createElement("div");
+            separator.style.height = "20px";
+            element.appendChild(separator);
 
-                var separator = document.createElement("div");
-                separator.style.height = "20px";
-
-                element.appendChild(separator);
-            }
-
-            var renderedSpeech = this.renderSpeech(speechString);
+            var renderedSpeech = this.renderSpeech(adaptiveCard.renderSpeech());
 
             if (renderedSpeech) {
                 element.appendChild(renderedSpeech);
@@ -314,8 +309,6 @@ export abstract class HostContainer {
         else {
             element.innerText = "The card is empty."
         }
-
-        return element;
     }
 }
 

--- a/source/nodejs/adaptivecards-visualizer/src/containers/kik.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/kik.ts
@@ -1,5 +1,6 @@
 import { HostContainer } from "./host-container";
 import {
+    AdaptiveCard,
     HostConfig,
     Size,
     TextSize,
@@ -21,12 +22,12 @@ export class KikContainer extends HostContainer {
         this.supportsActionBar = false;
     }
 
-    protected renderContainer(renderedCard: HTMLElement): HTMLElement {
+    protected renderContainer(adaptiveCard: AdaptiveCard, target: HTMLElement) {
         var outerElement = document.createElement("div");
         outerElement.className = "kikOuterContainer";
         outerElement.style.width = this._width + "px";
-        outerElement.appendChild(renderedCard);
-        return outerElement;
+        target.appendChild(outerElement);
+        adaptiveCard.render(outerElement);
     }
 
     public getHostConfig(): HostConfig {

--- a/source/nodejs/adaptivecards-visualizer/src/containers/live-tile.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/live-tile.ts
@@ -1,5 +1,6 @@
 import { HostContainer } from "./host-container";
 import {
+    AdaptiveCard,
     HostConfig,
     Size,
     TextSize,
@@ -25,18 +26,16 @@ export class LiveTileContainer extends HostContainer {
         this.supportsActionBar = false;
     }
 
-    protected renderContainer(renderedCard: HTMLElement): HTMLElement {
+    protected renderContainer(adaptiveCard: AdaptiveCard, target: HTMLElement) {
         var element = document.createElement("div");
         element.style.width = this._width + "px";
         element.style.height = this._height + "px";
         // element.style.backgroundColor = LiveTileContainer.backgroundColor;
         element.style.overflow = "hidden";
+        target.appendChild(element);
 
+        var renderedCard = adaptiveCard.render(element);
         renderedCard.style.height = "100%";
-
-        element.appendChild(renderedCard);
-
-        return element;
     }
 
     public getHostConfig(): HostConfig {

--- a/source/nodejs/adaptivecards-visualizer/src/containers/outlook.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/outlook.ts
@@ -1,5 +1,6 @@
 import { HostContainer } from "./host-container";
 import {
+    AdaptiveCard,
     HostConfig,
     Size,
     TextSize,
@@ -12,16 +13,14 @@ import {
 } from "adaptivecards";
 
 export class OutlookContainer extends HostContainer {
-    protected renderContainer(renderedCard: HTMLElement): HTMLElement {
+    protected renderContainer(adaptiveCard: AdaptiveCard, target: HTMLElement) {
         var element = document.createElement("div");
         element.style.borderTop = "1px solid #F1F1F1";
         element.style.borderRight = "1px solid #F1F1F1";
         element.style.borderBottom = "1px solid #F1F1F1";
         element.style.border = "1px solid #F1F1F1"
-
-        element.appendChild(renderedCard);
-
-        return element;
+        target.appendChild(element);
+        adaptiveCard.render(element);
     }
 
     public getHostConfig(): HostConfig {

--- a/source/nodejs/adaptivecards-visualizer/src/containers/skype.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/skype.ts
@@ -1,5 +1,6 @@
 import { HostContainer } from "./host-container";
 import {
+    AdaptiveCard,
     HostConfig,
     Size,
     TextSize,
@@ -14,7 +15,7 @@ import {
 export class SkypeContainer extends HostContainer {
     private _width: number;
 
-    protected renderContainer(renderedCard: HTMLElement): HTMLElement {
+    protected renderContainer(adaptiveCard: AdaptiveCard, target: HTMLElement) {
         var element = document.createElement("div");
         element.className = "skypeContainer";
 
@@ -31,12 +32,10 @@ export class SkypeContainer extends HostContainer {
         botElementIn1.appendChild(botElementIn2);
 
         element.appendChild(botElement);
+        target.appendChild(element);
 
+        var renderedCard = adaptiveCard.render(element);
         renderedCard.style.width = this._width + "px";
-
-        element.appendChild(renderedCard);
-
-        return element;
     }
 
     constructor(width: number, styleSheet: string) {

--- a/source/nodejs/adaptivecards-visualizer/src/containers/slack.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/slack.ts
@@ -1,5 +1,6 @@
 import { HostContainer } from "./host-container";
 import {
+    AdaptiveCard,
     HostConfig,
     Size,
     TextSize,
@@ -22,12 +23,12 @@ export class SlackContainer extends HostContainer {
         this.supportsActionBar = false;
     }
 
-    protected renderContainer(renderedCard: HTMLElement): HTMLElement {
+    protected renderContainer(adaptiveCard: AdaptiveCard, target: HTMLElement) {
         var outerElement = document.createElement("div");
         outerElement.className = "slackOuterContainer";
         outerElement.style.width = this._width + "px";
-        outerElement.appendChild(renderedCard);
-        return outerElement;
+        target.appendChild(outerElement);
+        adaptiveCard.render(outerElement);
     }
 
     public getHostConfig(): HostConfig {

--- a/source/nodejs/adaptivecards-visualizer/src/containers/sms.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/sms.ts
@@ -1,5 +1,6 @@
 import { HostContainer } from "./host-container";
 import {
+    AdaptiveCard,
     HostConfig,
     Size,
     TextSize,
@@ -21,12 +22,12 @@ export class SMSContainer extends HostContainer {
         this.supportsActionBar = false;
     }
 
-    protected renderContainer(renderedCard: HTMLElement): HTMLElement {
+    protected renderContainer(adaptiveCard: AdaptiveCard, target: HTMLElement) {
         var outerElement = document.createElement("div");
         outerElement.className = "smsOuterContainer";
         outerElement.style.width = this._width + "px";
-        outerElement.appendChild(renderedCard);
-        return outerElement;
+        target.appendChild(outerElement);
+        adaptiveCard.render(outerElement);
     }
 
     public getHostConfig(): HostConfig {

--- a/source/nodejs/adaptivecards-visualizer/src/containers/teams.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/teams.ts
@@ -1,5 +1,6 @@
 import { HostContainer } from "./host-container";
 import {
+    AdaptiveCard,
     HostConfig,
     Size,
     TextSize,
@@ -12,16 +13,14 @@ import {
 } from "adaptivecards";
 
 export class TeamsContainer extends HostContainer {
-    protected renderContainer(renderedCard: HTMLElement): HTMLElement {
-        var element = document.createElement("div");
+    protected renderContainer(adaptiveCard: AdaptiveCard, target: HTMLElement) {
+        var element = document.createElement("div")
         element.style.borderTop = "1px solid #F1F1F1";
         element.style.borderRight = "1px solid #F1F1F1";
         element.style.borderBottom = "1px solid #F1F1F1";
         element.style.border = "1px solid #F1F1F1"
-
-        element.appendChild(renderedCard);
-
-        return element;
+        target.appendChild(element);
+        adaptiveCard.render(element);
     }
 
     public getHostConfig(): HostConfig {

--- a/source/nodejs/adaptivecards-visualizer/src/containers/telegram.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/telegram.ts
@@ -1,5 +1,6 @@
 import { HostContainer } from "./host-container";
 import {
+    AdaptiveCard,
     HostConfig,
     Size,
     TextSize,
@@ -21,13 +22,12 @@ export class TelegramContainer extends HostContainer {
         this.supportsActionBar = false;
     }
 
-    protected renderContainer(renderedCard: HTMLElement): HTMLElement {
+    protected renderContainer(adaptiveCard: AdaptiveCard, target: HTMLElement) {
         var outerElement = document.createElement("div");
         outerElement.className = "telegramOuterContainer";
-
         outerElement.style.width = this._width + "px";
-        outerElement.appendChild(renderedCard);
-        return outerElement;
+        target.appendChild(outerElement);
+        adaptiveCard.render(outerElement);
     }
 
     public getHostConfig(): HostConfig {

--- a/source/nodejs/adaptivecards-visualizer/src/containers/timeline.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/timeline.ts
@@ -1,5 +1,6 @@
 import { HostContainer } from "./host-container";
 import {
+    AdaptiveCard,
     HostConfig,
     Size,
     TextSize,
@@ -25,18 +26,16 @@ export class TimelineContainer extends HostContainer {
         this.supportsActionBar = false;
     }
 
-    protected renderContainer(renderedCard: HTMLElement): HTMLElement {
+    protected renderContainer(adaptiveCard: AdaptiveCard, target: HTMLElement) {
         var element = document.createElement("div");
         element.style.width = this._width + "px";
         element.style.height = this._height + "px";
         // element.style.backgroundColor = TimelineContainer.backgroundColor;
         element.style.overflow = "hidden";
+        target.appendChild(element);
 
+        var renderedCard = adaptiveCard.render(element);
         renderedCard.style.height = "100%";
-
-        element.appendChild(renderedCard);
-
-        return element;
     }
 
     public getHostConfig(): HostConfig {

--- a/source/nodejs/adaptivecards-visualizer/src/containers/toast.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/toast.ts
@@ -1,5 +1,6 @@
 import { HostContainer } from "./host-container";
 import {
+    AdaptiveCard,
     HostConfig,
     Size,
     TextSize,
@@ -14,15 +15,13 @@ import {
 export class ToastContainer extends HostContainer {
     private _width: number;
 
-    protected renderContainer(renderedCard: HTMLElement): HTMLElement {
+    protected renderContainer(adaptiveCard: AdaptiveCard, target: HTMLElement) {
         var element = document.createElement("div");
         element.style.border = "#474747 1px solid";
         element.style.width = this._width + "px";
         element.style.overflow = "hidden";
-
-        element.appendChild(renderedCard);
-
-        return element;
+        target.appendChild(element);
+        adaptiveCard.render(element);
     }
 
     constructor(width: number, styleSheet: string) {

--- a/source/nodejs/adaptivecards-visualizer/src/containers/webchat.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/webchat.ts
@@ -1,5 +1,6 @@
 import { HostContainer } from "./host-container";
 import {
+    AdaptiveCard,
     HostConfig,
     Size,
     TextSize,
@@ -12,7 +13,7 @@ import {
 } from "adaptivecards";
 
 export class WebChatContainer extends HostContainer {
-    protected renderContainer(renderedCard: HTMLElement): HTMLElement {
+    protected renderContainer(adaptiveCard: AdaptiveCard, target: HTMLElement) {
         var outerElement = document.createElement("div");
         outerElement.className = "webChatOuterContainer";
 
@@ -40,10 +41,9 @@ export class WebChatContainer extends HostContainer {
         var innerElement = document.createElement("div");
         innerElement.className = "webChatInnerContainer";
 
-        innerElement.appendChild(renderedCard);
+        target.appendChild(outerElement);
         outerElement.appendChild(innerElement);
-
-        return outerElement;
+        adaptiveCard.render(innerElement);
     }
 
     public getHostConfig(): HostConfig {

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -625,10 +625,7 @@ export class TextBlock extends CardElement {
 
         if (truncationSupported) {
             var firstParagraph = <HTMLElement>children[0];
-            var originalText = firstParagraph.innerHTML;
-
             this.addRenderCallback(() => {
-                firstParagraph.innerHTML = originalText;
                 TextBlock.truncate(firstParagraph, maxHeight, lineHeight);
             });
         }
@@ -694,7 +691,6 @@ export class TextBlock extends CardElement {
             } while (idx < fullText.length)
             truncateAt(bestBreakIdx);
         }
-
     }
 
     private static findNextCharacter(html: string, currIdx: number): number {


### PR DESCRIPTION
Updates the TypeScript renderer so that multi-line `TextBlock` elements get truncated and show ellipses, instead of overflowing with no indication that there is more content. Since there's no good CSS solution for truncating multi-line text, this is accomplished with a callback function that executes after the element gets rendered (can't do it before because height and width info isn't accessible then).

This approach includes the following changes:

- Adds support for registering callbacks that get called when an element is rendered

- Changes the signature of the `AdaptiveCard.render()` function to take an `HTMLElement` argument, which the card is then rendered into (as opposed to just returning an `HTMLElement` containing the card -- we need at least some control over when the card is rendered into the DOM so we can fire the `onRender` callbacks)

    - This matches the way it's done in React with the `ReactDOM.render()` method, and abstracts the `element.appendChild` call away from users

    - No rush to merge this PR if the spec for the v1.0 SDK is already locked down; Bing API cards can work off the fork if needed
  
- Renames the old `render()` methods that would return an HTMLElement to `renderElement()`

- Updates the visualizer containers to match the new signature, and ensures that cards always get rendered into an element which is part of the DOM

This addresses #779.