### PR TITLE
Move Resource Dictionaries to RenderContext

### DIFF
--- a/source/uwp/Renderer/idl/AdaptiveCards.Uwp.idl
+++ b/source/uwp/Renderer/idl/AdaptiveCards.Uwp.idl
@@ -891,7 +891,9 @@ namespace AdaptiveCards
             [propget] HRESULT HostConfig([out, retval] AdaptiveHostConfig** hostConfig);
             [propput] HRESULT HostConfig([in] AdaptiveHostConfig* hostConfig);
 
-            HRESULT SetOverrideStyles([in] Windows.UI.Xaml.ResourceDictionary* overrideDictionary);
+            [propget] HRESULT OverrideStyles([out, retval] Windows.UI.Xaml.ResourceDictionary** overrideDictionary);
+            [propput] HRESULT OverrideStyles([in] Windows.UI.Xaml.ResourceDictionary* overrideDictionary);
+
             HRESULT SetFixedDimensions([in] UINT32 desiredWidth, [in] UINT32 desiredHeight);
             HRESULT ResetFixedDimensions();
 
@@ -1763,6 +1765,8 @@ namespace AdaptiveCards
             [propget] HRESULT ResourceResolvers([out, retval] AdaptiveCardResourceResolvers** value);
 
             [propget] HRESULT ActionInvoker([out, retval] AdaptiveActionInvoker** value);
+
+            [propget] HRESULT OverrideStyles([out, retval] Windows.UI.Xaml.ResourceDictionary** overrideDictionary);
 
             HRESULT AddInputItem([in] IAdaptiveCardElement* cardElement, [in] Windows.UI.Xaml.UIElement* uiElement);
         };

--- a/source/uwp/Renderer/lib/AdaptiveCardRendererComponent.h
+++ b/source/uwp/Renderer/lib/AdaptiveCardRendererComponent.h
@@ -17,7 +17,8 @@ namespace AdaptiveCards { namespace Uwp
         HRESULT RuntimeClassInitialize();
 
         // IAdaptiveCardRenderer
-        IFACEMETHODIMP SetOverrideStyles(_In_ ABI::Windows::UI::Xaml::IResourceDictionary* overrideDictionary);
+        IFACEMETHODIMP put_OverrideStyles(_In_ ABI::Windows::UI::Xaml::IResourceDictionary* overrideDictionary);
+        IFACEMETHODIMP get_OverrideStyles(_COM_Outptr_ ABI::Windows::UI::Xaml::IResourceDictionary** overrideDictionary);
         IFACEMETHODIMP put_HostConfig(_In_ ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig* hostConfig);
         IFACEMETHODIMP get_HostConfig(_In_ ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig** hostConfig);
         IFACEMETHODIMP SetFixedDimensions(_In_ UINT32 desiredWidth, _In_ UINT32 desiredHeight);
@@ -39,7 +40,7 @@ namespace AdaptiveCards { namespace Uwp
         IFACEMETHODIMP get_ElementRenderers(_COM_Outptr_ ABI::AdaptiveCards::Uwp::IAdaptiveElementRendererRegistration** result);
 
         ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig* GetHostConfig();
-        ABI::Windows::UI::Xaml::IResourceDictionary* GetOverrideDictionary();
+        Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IResourceDictionary> GetMergedDictionary();
         bool GetFixedDimensions(_Out_ UINT32* width, _Out_ UINT32* height);
 
         IFACEMETHODIMP get_ResourceResolvers(
@@ -47,17 +48,20 @@ namespace AdaptiveCards { namespace Uwp
 
     private:
         Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IResourceDictionary> m_overrideDictionary;
+        Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IResourceDictionary> m_defaultResourceDictionary;
+        Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IResourceDictionary> m_mergedResourceDictionary;
         Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig> m_hostConfig;
         Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Uwp::IAdaptiveCardResourceResolvers> m_resourceResolvers;
         Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Uwp::IAdaptiveElementRendererRegistration> m_elementRendererRegistration;
-
-        HRESULT RegisterDefaultElementRenderers();
 
         bool m_explicitDimensions = false;
         UINT32 m_desiredWidth = 0;
         UINT32 m_desiredHeight = 0;
 
         HRESULT CreateAdaptiveCardFromJsonString(_In_ HSTRING adaptiveJson, _COM_Outptr_ ABI::AdaptiveCards::Uwp::IAdaptiveCardParseResult** adaptiveCard);
+        HRESULT RegisterDefaultElementRenderers();
+        void InitializeDefaultResourceDictionary();
+        HRESULT SetMergedDictionary();
     };
 
     ActivatableClass(AdaptiveCardRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.cpp
@@ -5,6 +5,7 @@
 #include "AdaptiveElementParserRegistration.h"
 #include "enums.h"
 #include "Util.h"
+#include "XamlBuilder.h"
 
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;
@@ -25,7 +26,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder.BuildChoiceSetInput(cardElement, renderContext, renderArgs, result);
+        XamlBuilder::BuildChoiceSetInput(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 

--- a/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.h
@@ -3,7 +3,6 @@
 #include "AdaptiveCards.Uwp.h"
 #include "Enums.h"
 #include "ChoiceSetInput.h"
-#include "XamlBuilder.h"
 
 namespace AdaptiveCards { namespace Uwp
 {
@@ -29,9 +28,6 @@ namespace AdaptiveCards { namespace Uwp
             ABI::AdaptiveCards::Uwp::IAdaptiveElementParserRegistration* elementParsers,
             ABI::AdaptiveCards::Uwp::IAdaptiveActionParserRegistration* actionParsers,
             ABI::AdaptiveCards::Uwp::IAdaptiveCardElement** element);
-
-    private:
-        AdaptiveCards::Uwp::XamlBuilder m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveChoiceSetInputRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveColumnRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveColumnRenderer.cpp
@@ -3,6 +3,7 @@
 #include "AdaptiveColumnRenderer.h"
 #include "enums.h"
 #include "Util.h"
+#include "XamlBuilder.h"
 
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;
@@ -23,7 +24,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder.BuildColumn(cardElement, renderContext, renderArgs, result);
+        XamlBuilder::BuildColumn(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 

--- a/source/uwp/Renderer/lib/AdaptiveColumnRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveColumnRenderer.h
@@ -3,7 +3,6 @@
 #include "AdaptiveCards.Uwp.h"
 #include "Enums.h"
 #include "Column.h"
-#include "XamlBuilder.h"
 
 namespace AdaptiveCards { namespace Uwp
 {
@@ -22,8 +21,6 @@ namespace AdaptiveCards { namespace Uwp
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result);
-    private:
-        AdaptiveCards::Uwp::XamlBuilder m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveColumnRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveColumnSetRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveColumnSetRenderer.cpp
@@ -5,6 +5,7 @@
 #include "AdaptiveElementParserRegistration.h"
 #include "enums.h"
 #include "Util.h"
+#include "XamlBuilder.h"
 
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;
@@ -25,7 +26,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder.BuildColumnSet(cardElement, renderContext, renderArgs, result);
+        XamlBuilder::BuildColumnSet(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 

--- a/source/uwp/Renderer/lib/AdaptiveColumnSetRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveColumnSetRenderer.h
@@ -3,7 +3,6 @@
 #include "AdaptiveCards.Uwp.h"
 #include "Enums.h"
 #include "ColumnSet.h"
-#include "XamlBuilder.h"
 
 namespace AdaptiveCards { namespace Uwp
 {
@@ -29,9 +28,6 @@ namespace AdaptiveCards { namespace Uwp
             ABI::AdaptiveCards::Uwp::IAdaptiveElementParserRegistration* elementParsers,
             ABI::AdaptiveCards::Uwp::IAdaptiveActionParserRegistration* actionParsers,
             ABI::AdaptiveCards::Uwp::IAdaptiveCardElement** element);
-
-    private:
-        AdaptiveCards::Uwp::XamlBuilder m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveColumnSetRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveContainerRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveContainerRenderer.cpp
@@ -5,6 +5,7 @@
 #include "AdaptiveElementParserRegistration.h"
 #include "enums.h"
 #include "Util.h"
+#include "XamlBuilder.h"
 
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;
@@ -25,7 +26,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder.BuildContainer(cardElement, renderContext, renderArgs, result);
+        XamlBuilder::BuildContainer(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 

--- a/source/uwp/Renderer/lib/AdaptiveContainerRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveContainerRenderer.h
@@ -3,7 +3,6 @@
 #include "AdaptiveCards.Uwp.h"
 #include "Enums.h"
 #include "Container.h"
-#include "XamlBuilder.h"
 
 namespace AdaptiveCards { namespace Uwp
 {
@@ -29,9 +28,6 @@ namespace AdaptiveCards { namespace Uwp
             ABI::AdaptiveCards::Uwp::IAdaptiveElementParserRegistration* elementParsers,
             ABI::AdaptiveCards::Uwp::IAdaptiveActionParserRegistration* actionParsers,
             ABI::AdaptiveCards::Uwp::IAdaptiveCardElement** element);
-
-    private:
-        AdaptiveCards::Uwp::XamlBuilder m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveContainerRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveDateInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveDateInputRenderer.cpp
@@ -5,6 +5,7 @@
 #include "AdaptiveElementParserRegistration.h"
 #include "enums.h"
 #include "Util.h"
+#include "XamlBuilder.h"
 
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;
@@ -25,7 +26,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder.BuildDateInput(cardElement, renderContext, renderArgs, result);
+        XamlBuilder::BuildDateInput(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 

--- a/source/uwp/Renderer/lib/AdaptiveDateInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveDateInputRenderer.h
@@ -3,7 +3,6 @@
 #include "AdaptiveCards.Uwp.h"
 #include "Enums.h"
 #include "DateInput.h"
-#include "XamlBuilder.h"
 
 namespace AdaptiveCards { namespace Uwp
 {
@@ -29,9 +28,6 @@ namespace AdaptiveCards { namespace Uwp
             ABI::AdaptiveCards::Uwp::IAdaptiveElementParserRegistration* elementParsers,
             ABI::AdaptiveCards::Uwp::IAdaptiveActionParserRegistration* actionParsers,
             ABI::AdaptiveCards::Uwp::IAdaptiveCardElement** element);
-
-    private:
-        AdaptiveCards::Uwp::XamlBuilder m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveDateInputRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveFactSetRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveFactSetRenderer.cpp
@@ -5,6 +5,7 @@
 #include "AdaptiveFactSetRenderer.h"
 #include "enums.h"
 #include "Util.h"
+#include "XamlBuilder.h"
 
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;
@@ -25,7 +26,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder.BuildFactSet(cardElement, renderContext, renderArgs, result);
+        XamlBuilder::BuildFactSet(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 

--- a/source/uwp/Renderer/lib/AdaptiveFactSetRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveFactSetRenderer.h
@@ -3,7 +3,6 @@
 #include "AdaptiveCards.Uwp.h"
 #include "Enums.h"
 #include "FactSet.h"
-#include "XamlBuilder.h"
 
 namespace AdaptiveCards { namespace Uwp
 {
@@ -29,9 +28,6 @@ namespace AdaptiveCards { namespace Uwp
             ABI::AdaptiveCards::Uwp::IAdaptiveElementParserRegistration* elementParsers,
             ABI::AdaptiveCards::Uwp::IAdaptiveActionParserRegistration* actionParsers,
             ABI::AdaptiveCards::Uwp::IAdaptiveCardElement** element);
-
-    private:
-        AdaptiveCards::Uwp::XamlBuilder m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveFactSetRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveImageSetRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImageSetRenderer.cpp
@@ -5,6 +5,7 @@
 #include "AdaptiveImageSetRenderer.h"
 #include "enums.h"
 #include "Util.h"
+#include "XamlBuilder.h"
 
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;
@@ -25,7 +26,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder.BuildImageSet(cardElement, renderContext, renderArgs, result);
+        XamlBuilder::BuildImageSet(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 

--- a/source/uwp/Renderer/lib/AdaptiveImageSetRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveImageSetRenderer.h
@@ -3,7 +3,6 @@
 #include "AdaptiveCards.Uwp.h"
 #include "Enums.h"
 #include "ImageSet.h"
-#include "XamlBuilder.h"
 
 namespace AdaptiveCards { namespace Uwp
 {
@@ -29,9 +28,6 @@ namespace AdaptiveCards { namespace Uwp
             ABI::AdaptiveCards::Uwp::IAdaptiveElementParserRegistration* elementParsers,
             ABI::AdaptiveCards::Uwp::IAdaptiveActionParserRegistration* actionParsers,
             ABI::AdaptiveCards::Uwp::IAdaptiveCardElement** element);
-
-    private:
-        AdaptiveCards::Uwp::XamlBuilder m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveImageSetRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveNumberInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveNumberInputRenderer.cpp
@@ -5,6 +5,7 @@
 #include "AdaptiveNumberInputRenderer.h"
 #include "enums.h"
 #include "Util.h"
+#include "XamlBuilder.h"
 
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;
@@ -25,7 +26,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder.BuildNumberInput(cardElement, renderContext, renderArgs, result);
+        XamlBuilder::BuildNumberInput(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 

--- a/source/uwp/Renderer/lib/AdaptiveNumberInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveNumberInputRenderer.h
@@ -3,7 +3,6 @@
 #include "AdaptiveCards.Uwp.h"
 #include "Enums.h"
 #include "NumberInput.h"
-#include "XamlBuilder.h"
 
 namespace AdaptiveCards { namespace Uwp
 {
@@ -29,9 +28,6 @@ namespace AdaptiveCards { namespace Uwp
             ABI::AdaptiveCards::Uwp::IAdaptiveElementParserRegistration* elementParsers,
             ABI::AdaptiveCards::Uwp::IAdaptiveActionParserRegistration* actionParsers,
             ABI::AdaptiveCards::Uwp::IAdaptiveCardElement** element);
-
-    private:
-        AdaptiveCards::Uwp::XamlBuilder m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveNumberInputRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveRenderContext.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveRenderContext.cpp
@@ -21,12 +21,15 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveHostConfig* hostConfig,
         IAdaptiveElementRendererRegistration* elementRendererRegistration,
         IAdaptiveCardResourceResolvers* resourceResolvers,
+        IResourceDictionary* overrideDictionary,
         RenderedAdaptiveCard* renderResult) noexcept try
     {
         m_hostConfig = hostConfig;
         m_elementRendererRegistration = elementRendererRegistration;
         m_renderResult = renderResult;
         m_resourceResolvers = resourceResolvers;
+        m_overrideDictionary = overrideDictionary;
+        RETURN_IF_FAILED(GetActivationFactory(HStringReference(RuntimeClass_Windows_Foundation_PropertyValue).Get(), &m_propertyValueStatics));
 
         return MakeAndInitialize<AdaptiveActionInvoker>(&m_actionInvoker, renderResult);
     } CATCH_RETURN;
@@ -53,6 +56,12 @@ namespace AdaptiveCards { namespace Uwp
     HRESULT AdaptiveRenderContext::get_ResourceResolvers(IAdaptiveCardResourceResolvers** value)
     {
         return m_resourceResolvers.CopyTo(value);
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveRenderContext::get_OverrideStyles(_COM_Outptr_ IResourceDictionary** overrideDictionary)
+    {
+        return m_overrideDictionary.CopyTo(overrideDictionary);
     }
 
     _Use_decl_annotations_

--- a/source/uwp/Renderer/lib/AdaptiveRenderContext.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveRenderContext.cpp
@@ -29,7 +29,6 @@ namespace AdaptiveCards { namespace Uwp
         m_renderResult = renderResult;
         m_resourceResolvers = resourceResolvers;
         m_overrideDictionary = overrideDictionary;
-        RETURN_IF_FAILED(GetActivationFactory(HStringReference(RuntimeClass_Windows_Foundation_PropertyValue).Get(), &m_propertyValueStatics));
 
         return MakeAndInitialize<AdaptiveActionInvoker>(&m_actionInvoker, renderResult);
     } CATCH_RETURN;

--- a/source/uwp/Renderer/lib/AdaptiveRenderContext.h
+++ b/source/uwp/Renderer/lib/AdaptiveRenderContext.h
@@ -37,7 +37,6 @@ namespace AdaptiveCards { namespace Uwp
         Microsoft::WRL::ComPtr<AdaptiveCards::Uwp::AdaptiveActionInvoker> m_actionInvoker;
         Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Uwp::IAdaptiveCardResourceResolvers> m_resourceResolvers;
         Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IResourceDictionary> m_overrideDictionary;
-        Microsoft::WRL::ComPtr<ABI::Windows::Foundation::IPropertyValueStatics> m_propertyValueStatics;
     };
 
     ActivatableClass(AdaptiveRenderContext);

--- a/source/uwp/Renderer/lib/AdaptiveRenderContext.h
+++ b/source/uwp/Renderer/lib/AdaptiveRenderContext.h
@@ -20,6 +20,7 @@ namespace AdaptiveCards { namespace Uwp
             ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig* hostConfig,
             ABI::AdaptiveCards::Uwp::IAdaptiveElementRendererRegistration* elementRendererRegistration,
             ABI::AdaptiveCards::Uwp::IAdaptiveCardResourceResolvers* resourceResolvers,
+            ABI::Windows::UI::Xaml::IResourceDictionary* overrideStyles,
             AdaptiveCards::Uwp::RenderedAdaptiveCard* renderResult) noexcept;
 
         IFACEMETHODIMP get_HostConfig(_COM_Outptr_ ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig** value);
@@ -27,6 +28,7 @@ namespace AdaptiveCards { namespace Uwp
         IFACEMETHODIMP get_ActionInvoker(_COM_Outptr_ ABI::AdaptiveCards::Uwp::IAdaptiveActionInvoker** value);
         IFACEMETHODIMP AddInputItem(_In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* cardElement, _In_ ABI::Windows::UI::Xaml::IUIElement* uiElement);
         IFACEMETHODIMP get_ResourceResolvers(_COM_Outptr_ ABI::AdaptiveCards::Uwp::IAdaptiveCardResourceResolvers** value);
+        IFACEMETHODIMP get_OverrideStyles(_COM_Outptr_ ABI::Windows::UI::Xaml::IResourceDictionary** overrideDictionary);
 
     private:
         Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig> m_hostConfig;
@@ -34,6 +36,8 @@ namespace AdaptiveCards { namespace Uwp
         Microsoft::WRL::ComPtr<AdaptiveCards::Uwp::RenderedAdaptiveCard> m_renderResult;
         Microsoft::WRL::ComPtr<AdaptiveCards::Uwp::AdaptiveActionInvoker> m_actionInvoker;
         Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Uwp::IAdaptiveCardResourceResolvers> m_resourceResolvers;
+        Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IResourceDictionary> m_overrideDictionary;
+        Microsoft::WRL::ComPtr<ABI::Windows::Foundation::IPropertyValueStatics> m_propertyValueStatics;
     };
 
     ActivatableClass(AdaptiveRenderContext);

--- a/source/uwp/Renderer/lib/AdaptiveTextBlockRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTextBlockRenderer.cpp
@@ -4,6 +4,7 @@
 #include "AdaptiveTextBlockRenderer.h"
 #include "AdaptiveRenderContext.h"
 #include "Util.h"
+#include "XamlBuilder.h"
 #include "AdaptiveElementParserRegistration.h"
 
 using namespace Microsoft::WRL;
@@ -25,7 +26,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder.BuildTextBlock(cardElement, renderContext, renderArgs, result);
+        XamlBuilder::BuildTextBlock(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 

--- a/source/uwp/Renderer/lib/AdaptiveTextBlockRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveTextBlockRenderer.h
@@ -3,7 +3,6 @@
 #include "AdaptiveCards.Uwp.h"
 #include "Enums.h"
 #include "TextBlock.h"
-#include "XamlBuilder.h"
 
 namespace AdaptiveCards { namespace Uwp {
     class AdaptiveTextBlockRenderer :
@@ -28,9 +27,6 @@ namespace AdaptiveCards { namespace Uwp {
             ABI::AdaptiveCards::Uwp::IAdaptiveElementParserRegistration* elementParsers,
             ABI::AdaptiveCards::Uwp::IAdaptiveActionParserRegistration* actionParsers,
             ABI::AdaptiveCards::Uwp::IAdaptiveCardElement** element);
-
-    private:
-        AdaptiveCards::Uwp::XamlBuilder m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveTextBlockRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.cpp
@@ -5,6 +5,7 @@
 #include "AdaptiveTextInputRenderer.h"
 #include "enums.h"
 #include "Util.h"
+#include "XamlBuilder.h"
 
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;
@@ -25,7 +26,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder.BuildTextInput(cardElement, renderContext, renderArgs, result);
+        XamlBuilder::BuildTextInput(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 

--- a/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.h
@@ -3,7 +3,6 @@
 #include "AdaptiveCards.Uwp.h"
 #include "Enums.h"
 #include "TextInput.h"
-#include "XamlBuilder.h"
 
 namespace AdaptiveCards { namespace Uwp
 {
@@ -29,9 +28,6 @@ namespace AdaptiveCards { namespace Uwp
             ABI::AdaptiveCards::Uwp::IAdaptiveElementParserRegistration* elementParsers,
             ABI::AdaptiveCards::Uwp::IAdaptiveActionParserRegistration* actionParsers,
             ABI::AdaptiveCards::Uwp::IAdaptiveCardElement** element);
-
-    private:
-        AdaptiveCards::Uwp::XamlBuilder m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveTextInputRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveTimeInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTimeInputRenderer.cpp
@@ -5,6 +5,7 @@
 #include "AdaptiveTimeInputRenderer.h"
 #include "enums.h"
 #include "Util.h"
+#include "XamlBuilder.h"
 
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;
@@ -25,7 +26,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder.BuildTimeInput(cardElement, renderContext, renderArgs, result);
+        XamlBuilder::BuildTimeInput(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 

--- a/source/uwp/Renderer/lib/AdaptiveTimeInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveTimeInputRenderer.h
@@ -3,7 +3,6 @@
 #include "AdaptiveCards.Uwp.h"
 #include "Enums.h"
 #include "TimeInput.h"
-#include "XamlBuilder.h"
 
 namespace AdaptiveCards { namespace Uwp
 {
@@ -29,9 +28,6 @@ namespace AdaptiveCards { namespace Uwp
             ABI::AdaptiveCards::Uwp::IAdaptiveElementParserRegistration* elementParsers,
             ABI::AdaptiveCards::Uwp::IAdaptiveActionParserRegistration* actionParsers,
             ABI::AdaptiveCards::Uwp::IAdaptiveCardElement** element);
-
-    private:
-        AdaptiveCards::Uwp::XamlBuilder m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveTimeInputRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveToggleInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveToggleInputRenderer.cpp
@@ -5,6 +5,7 @@
 #include "AdaptiveToggleInputRenderer.h"
 #include "enums.h"
 #include "Util.h"
+#include "XamlBuilder.h"
 
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;
@@ -25,7 +26,7 @@ namespace AdaptiveCards { namespace Uwp
         IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder.BuildToggleInput(cardElement, renderContext, renderArgs, result);
+        XamlBuilder::BuildToggleInput(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 

--- a/source/uwp/Renderer/lib/AdaptiveToggleInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveToggleInputRenderer.h
@@ -3,7 +3,6 @@
 #include "AdaptiveCards.Uwp.h"
 #include "Enums.h"
 #include "ToggleInput.h"
-#include "XamlBuilder.h"
 
 namespace AdaptiveCards { namespace Uwp
 {
@@ -29,9 +28,6 @@ namespace AdaptiveCards { namespace Uwp
             ABI::AdaptiveCards::Uwp::IAdaptiveElementParserRegistration* elementParsers,
             ABI::AdaptiveCards::Uwp::IAdaptiveActionParserRegistration* actionParsers,
             ABI::AdaptiveCards::Uwp::IAdaptiveCardElement** element);
-
-    private:
-        AdaptiveCards::Uwp::XamlBuilder m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveToggleInputRenderer);

--- a/source/uwp/Renderer/lib/AsyncOperations.h
+++ b/source/uwp/Renderer/lib/AsyncOperations.h
@@ -35,7 +35,6 @@ public:
         THROW_IF_FAILED(coreWindow->get_Dispatcher(&m_dispatcher));
 
         m_builder = Microsoft::WRL::Make<AdaptiveCards::Uwp::XamlBuilder>();
-        THROW_IF_FAILED(m_builder->SetOverrideDictionary(m_renderer->GetOverrideDictionary()));
         UINT32 width = 0;
         UINT32 height = 0;
         bool explicitDimensions = m_renderer->GetFixedDimensions(&width, &height);
@@ -94,6 +93,7 @@ protected:
                 THROW_IF_FAILED(m_renderer->get_ElementRenderers(&elementRenderers));
                 ComPtr<ABI::AdaptiveCards::Uwp::IAdaptiveCardResourceResolvers> resourceResolvers;
                 THROW_IF_FAILED(m_renderer->get_ResourceResolvers(&resourceResolvers));
+                ComPtr<ABI::Windows::UI::Xaml::IResourceDictionary> overrideDictionary = m_renderer->GetMergedDictionary();
 
                 ComPtr<AdaptiveCards::Uwp::AdaptiveRenderContext> renderContext;
                 RETURN_IF_FAILED(MakeAndInitialize<AdaptiveCards::Uwp::AdaptiveRenderContext>(
@@ -101,6 +101,7 @@ protected:
                     m_renderer->GetHostConfig(),
                     elementRenderers.Get(),
                     resourceResolvers.Get(),
+                    overrideDictionary.Get(),
                     renderResult.Get()));
 
                 m_builder->BuildXamlTreeFromAdaptiveCard(m_card.Get(), &m_rootXamlElement, m_renderer.Get(), renderContext.Get());

--- a/source/uwp/Renderer/lib/XamlBuilder.h
+++ b/source/uwp/Renderer/lib/XamlBuilder.h
@@ -38,84 +38,90 @@ namespace AdaptiveCards { namespace Uwp
         HRESULT RemoveListener(_In_ IXamlBuilderListener* listener) noexcept;
         HRESULT SetFixedDimensions(_In_ UINT width, _In_ UINT height) noexcept;
         HRESULT SetEnableXamlImageHandling(_In_ bool enableXamlImageHandling) noexcept;
-        HRESULT SetOverrideDictionary(_In_ ABI::Windows::UI::Xaml::IResourceDictionary* overrideDictionary) noexcept;
 
-        void BuildTextBlock(
-            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
-            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
-            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
-            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** textBlockControl);
         void BuildImage(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** imageControl);
-        void BuildContainer(
+
+        static void BuildTextBlock(
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
+            _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** textBlockControl);
+        static void BuildContainer(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** containerControl);
-        void BuildColumn(
+        static void BuildColumn(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** columnControl);
-        void BuildColumnSet(
+        static void BuildColumnSet(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** columnSetControl);
-        void BuildFactSet(
+        static void BuildFactSet(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** factSetControl);
-        void BuildImageSet(
+        static void BuildImageSet(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** imageSetControl);
-        void BuildChoiceSetInput(
+        static void BuildChoiceSetInput(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** choiceSetInputControl);
-        void BuildDateInput(
+        static void BuildDateInput(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** dateInputControl);
-        void BuildNumberInput(
+        static void BuildNumberInput(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** numberInputControl);
-        void BuildTextInput(
+        static void BuildTextInput(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** textInputControl);
-        void BuildTimeInput(
+        static void BuildTimeInput(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** timeInputControl);
-        void BuildToggleInput(
+        static void BuildToggleInput(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** toggleInputControl);
+        template<typename T>
+        static HRESULT TryGetResourceFromResourceDictionaries(
+            _In_ ABI::Windows::UI::Xaml::IResourceDictionary* resourceDictionary,
+            _In_ std::wstring resourceName,
+            _COM_Outptr_result_maybenull_ T** resource);
+        template<typename T>
+        static bool TryGetValueResourceFromResourceDictionaries(
+            _In_ ABI::Windows::UI::Xaml::IResourceDictionary* resourceDictionary,
+            _In_ std::wstring styleName,
+            _Out_ T* valueResource);
 
     private:
-
-        Microsoft::WRL::ComPtr<ABI::Windows::Foundation::IPropertyValueStatics> m_propertyValueStatics;
         ImageLoadTracker m_imageLoadTracker;
         std::set<Microsoft::WRL::ComPtr<IXamlBuilderListener>> m_listeners;
         Microsoft::WRL::ComPtr<ABI::Windows::Storage::Streams::IRandomAccessStreamStatics> m_randomAccessStreamStatics;
         std::vector<Microsoft::WRL::ComPtr<ABI::Windows::Foundation::IAsyncOperationWithProgress<ABI::Windows::Storage::Streams::IInputStream*, ABI::Windows::Web::Http::HttpProgress>>> m_getStreamOperations;
         std::vector<Microsoft::WRL::ComPtr<ABI::Windows::Foundation::IAsyncOperationWithProgress<UINT64, UINT64>>> m_copyStreamOperations;
-        Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IResourceDictionary> m_mergedResourceDictionary;
-        Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IResourceDictionary> m_defaultResourceDictionary;
 
         UINT m_fixedWidth = 0;
         UINT m_fixedHeight = 0;
@@ -123,36 +129,6 @@ namespace AdaptiveCards { namespace Uwp
         bool m_enableXamlImageHandling = false;
         Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Uwp::IAdaptiveCardResourceResolvers> m_resourceResolvers;
 
-        static Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IUIElement> CreateSeparator(
-            UINT spacing, UINT separatorThickness, ABI::Windows::UI::Color separatorColor, bool isHorizontal = true);
-        void ApplyMarginToXamlElement(
-            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig* hostConfig,
-            _Inout_ ABI::Windows::UI::Xaml::IFrameworkElement* element);
-        static Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::Media::IBrush> GetSolidColorBrush(_In_ ABI::Windows::UI::Color color);
-        void StyleXamlTextBlock(
-            _In_ ABI::AdaptiveCards::Uwp::TextSize size,
-            _In_ ABI::AdaptiveCards::Uwp::ForegroundColor color,
-            ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
-            _In_ bool isSubtle,
-            bool wrap,
-            UINT32 maxWidth,
-            _In_ ABI::AdaptiveCards::Uwp::TextWeight weight,
-            _In_ ABI::Windows::UI::Xaml::Controls::ITextBlock* xamlTextBlock,
-            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig* hostConfig);
-        void StyleXamlTextBlock(
-            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveTextConfig* textConfig,
-            ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
-            _In_ ABI::Windows::UI::Xaml::Controls::ITextBlock* xamlTextBlock,
-            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig* hostConfig);
-        void InitializeDefaultResourceDictionary();
-        template<typename T>
-        HRESULT TryGetResoureFromResourceDictionaries(
-            _In_ std::wstring resourceName,
-            _COM_Outptr_result_maybenull_ T** resource);
-        template<typename T>
-        bool TryGetValueResourceFromResourceDictionaries(
-            _In_ std::wstring styleName,
-            _Out_ T* valueResource);
         Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IUIElement> CreateRootCardElement(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCard* adaptiveCard,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
@@ -161,7 +137,7 @@ namespace AdaptiveCards { namespace Uwp
         void ApplyBackgroundToRoot(
             _In_ ABI::Windows::UI::Xaml::Controls::IPanel* rootPanel,
             _In_ ABI::Windows::Foundation::IUriRuntimeClass* uri,
-            _In_ _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext);
+            _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext);
         template<typename T>
         void SetImageSource(T* destination, ABI::Windows::UI::Xaml::Media::IImageSource* imageSource);
         template<typename T>
@@ -170,12 +146,6 @@ namespace AdaptiveCards { namespace Uwp
         void PopulateImageFromUrlAsync(_In_ ABI::Windows::Foundation::IUriRuntimeClass* imageUrl, T* imageControl);
         void FireAllImagesLoaded();
         void FireImagesLoadingHadError();
-        void BuildPanelChildren(
-            _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveCards::Uwp::IAdaptiveCardElement*>* children,
-            _In_ ABI::Windows::UI::Xaml::Controls::IPanel* parentPanel,
-            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* context,
-            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
-            _In_ std::function<void(ABI::Windows::UI::Xaml::IUIElement* child)> childCreatedCallback);
         void BuildShowCard(
             AdaptiveCards::Uwp::AdaptiveCardRenderer* renderer,
             ABI::AdaptiveCards::Uwp::IAdaptiveShowCardActionConfig* showCardActionConfig,
@@ -188,34 +158,63 @@ namespace AdaptiveCards { namespace Uwp
             _In_ ABI::Windows::UI::Xaml::Controls::IPanel* parentPanel,
             _In_ bool insertSeparator,
             _Inout_ AdaptiveCards::Uwp::AdaptiveRenderContext* renderContext);
-        void GetSeparationConfigForElement(
+
+        static Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IUIElement> CreateSeparator(
+            UINT spacing, UINT separatorThickness, ABI::Windows::UI::Color separatorColor, bool isHorizontal = true);
+        static void ApplyMarginToXamlElement(
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig* hostConfig,
+            _Inout_ ABI::Windows::UI::Xaml::IFrameworkElement* element);
+        static Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::Media::IBrush> GetSolidColorBrush(_In_ ABI::Windows::UI::Color color);
+        static void StyleXamlTextBlock(
+            _In_ ABI::AdaptiveCards::Uwp::TextSize size,
+            _In_ ABI::AdaptiveCards::Uwp::ForegroundColor color,
+            ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
+            _In_ bool isSubtle,
+            bool wrap,
+            UINT32 maxWidth,
+            _In_ ABI::AdaptiveCards::Uwp::TextWeight weight,
+            _In_ ABI::Windows::UI::Xaml::Controls::ITextBlock* xamlTextBlock,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig* hostConfig);
+        static void StyleXamlTextBlock(
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveTextConfig* textConfig,
+            ABI::AdaptiveCards::Uwp::ContainerStyle containerStyle,
+            _In_ ABI::Windows::UI::Xaml::Controls::ITextBlock* xamlTextBlock,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig* hostConfig);
+        static void BuildPanelChildren(
+            _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveCards::Uwp::IAdaptiveCardElement*>* children,
+            _In_ ABI::Windows::UI::Xaml::Controls::IPanel* parentPanel,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* context,
+            _In_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderArgs* renderArgs,
+            _In_ std::function<void(ABI::Windows::UI::Xaml::IUIElement* child)> childCreatedCallback);
+        static void GetSeparationConfigForElement(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* element,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig* hostConfig,
             _Out_ UINT* spacing,
             _Out_ UINT* separatorThickness,
             _Out_ ABI::Windows::UI::Color* separatorColor,
             _Out_ bool* needsSeparator);
-        void BuildCompactChoiceSetInput(
+        static void BuildCompactChoiceSetInput(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveChoiceSetInput* adaptiveChoiceSetInput,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** choiceInputSetControl);
-        void BuildExpandedChoiceSetInput(
+        static void BuildExpandedChoiceSetInput(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveChoiceSetInput* adaptiveChoiceInputSet,
             boolean isMultiSelect,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** choiceSetInputControl);
-        bool SupportsInteractivity(_In_ ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig* hostConfig);
+        static bool SupportsInteractivity(_In_ ABI::AdaptiveCards::Uwp::IAdaptiveHostConfig* hostConfig);
 
-        void WrapInFullWidthTouchTarget(
+        static void WrapInFullWidthTouchTarget(
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveCardElement* adaptiveCardElement,
             _In_ ABI::Windows::UI::Xaml::IUIElement* elementToWrap,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveActionElement* action,
             _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext,
             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** finalElement);
 
-        void WireButtonClickToAction(
+        static void WireButtonClickToAction(
             _In_ ABI::Windows::UI::Xaml::Controls::IButton* button,
             _In_ ABI::AdaptiveCards::Uwp::IAdaptiveActionElement* action,
             _Inout_ ABI::AdaptiveCards::Uwp::IAdaptiveRenderContext* renderContext);
 
-        HRESULT AddHandledTappedEvent(_In_ ABI::Windows::UI::Xaml::IUIElement* uiElement);
+        static HRESULT AddHandledTappedEvent(_In_ ABI::Windows::UI::Xaml::IUIElement* uiElement);
+
     };
 }}


### PR DESCRIPTION
This change moves the Resource dictionaries that were part of the XamlBuilder to the Render Context and AdaptiveCardRendererComponent. This helps set up the work to style elements via resource dictionaries, as well as allowing most of the XamlBuilder operations to be static. This will help with the complete retirement of XamlBuilder in the future.