### PR TITLE
Fix appending choices to existing ChoiceSetInput on ReplaceElement

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -1340,6 +1340,7 @@ export class ChoiceSetInput extends Input {
 
         if (json["choices"] != undefined) {
             var choiceArray = json["choices"] as Array<any>;
+            this.choices = [];
 
             for (var i = 0; i < choiceArray.length; i++) {
                 var choice = new Choice();


### PR DESCRIPTION
New choices are appended to existing choices on ReplaceElement. Clear the old ones first.