### PR TITLE
Fix on issue #878 AdaptiveTextBlock rendering size

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveTextBlockRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveTextBlockRenderer.cs
@@ -82,6 +82,7 @@ namespace AdaptiveCards.Rendering.Wpf
                 {
                     Style = uiTextBlock.Style,
                     FontWeight = uiTextBlock.FontWeight,
+                    FontSize = uiTextBlock.FontSize,
                     Visibility = Visibility.Hidden,
                     TextWrapping = TextWrapping.NoWrap,
                     HorizontalAlignment = System.Windows.HorizontalAlignment.Left,


### PR DESCRIPTION
Change made to binding measure block to correctly size the rendered textblock