### PR TITLE
Add parser errors to shared model

### DIFF
--- a/source/shared/cpp/ObjectModel/ActionParserRegistration.cpp
+++ b/source/shared/cpp/ObjectModel/ActionParserRegistration.cpp
@@ -28,7 +28,7 @@ namespace AdaptiveCards
         }
         else
         {
-            throw AdaptiveCardParseException("Overriding known action parsers is unsupported");
+            throw AdaptiveCardParseException(ErrorStatusCode::UnsupportedParserOverride, "Overriding known action parsers is unsupported");
         }
     }
 
@@ -40,7 +40,7 @@ namespace AdaptiveCards
         }
         else
         {
-            throw AdaptiveCardParseException("Overriding known action parsers is unsupported");
+            throw AdaptiveCardParseException(ErrorStatusCode::UnsupportedParserOverride, "Overriding known action parsers is unsupported");
         }
     }
 

--- a/source/shared/cpp/ObjectModel/AdaptiveCardParseException.cpp
+++ b/source/shared/cpp/ObjectModel/AdaptiveCardParseException.cpp
@@ -2,7 +2,7 @@
 
 using namespace AdaptiveCards;
 
-AdaptiveCardParseException::AdaptiveCardParseException(const std::string & message) : m_message(message)
+AdaptiveCardParseException::AdaptiveCardParseException(const ErrorStatusCode statusCode, const std::string & message) : m_statusCode(statusCode), m_message(message)
 {
 }
 
@@ -10,7 +10,17 @@ AdaptiveCardParseException::~AdaptiveCardParseException()
 {
 }
 
-const char * AdaptiveCardParseException::what() const throw()
+const char* AdaptiveCardParseException::what() const throw()
 {
     return m_message.c_str();
+}
+
+const ErrorStatusCode AdaptiveCardParseException::GetStatusCode() const
+{
+    return m_statusCode;
+}
+
+const std::string& AdaptiveCardParseException::GetMessage() const
+{
+    return m_message;
 }

--- a/source/shared/cpp/ObjectModel/AdaptiveCardParseException.h
+++ b/source/shared/cpp/ObjectModel/AdaptiveCardParseException.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "pch.h"
+#include "enums.h"
 
 namespace AdaptiveCards
 {
@@ -8,12 +9,15 @@ namespace AdaptiveCards
 class AdaptiveCardParseException : public std::exception
 {
 public:
-    AdaptiveCardParseException(const std::string& message);
+    AdaptiveCardParseException(const AdaptiveCards::ErrorStatusCode statusCode, const std::string& message);
     ~AdaptiveCardParseException();
 
     virtual const char* what() const throw();
+    const AdaptiveCards::ErrorStatusCode GetStatusCode() const;
+    const std::string& GetMessage() const;
 
 private:
+    const AdaptiveCards::ErrorStatusCode m_statusCode;
     const std::string m_message;
 };
 

--- a/source/shared/cpp/ObjectModel/ElementParserRegistration.cpp
+++ b/source/shared/cpp/ObjectModel/ElementParserRegistration.cpp
@@ -55,7 +55,7 @@ namespace AdaptiveCards
         }
         else
         {
-            throw AdaptiveCardParseException("Overriding known element parsers is unsupported");
+            throw AdaptiveCardParseException(ErrorStatusCode::UnsupportedParserOverride, "Overriding known element parsers is unsupported");
         }
     }
 
@@ -67,7 +67,7 @@ namespace AdaptiveCards
         }
         else
         {
-            throw AdaptiveCardParseException("Overriding known element parsers is unsupported");
+            throw AdaptiveCardParseException(ErrorStatusCode::UnsupportedParserOverride, "Overriding known element parsers is unsupported");
         }
     }
 

--- a/source/shared/cpp/ObjectModel/Enums.h
+++ b/source/shared/cpp/ObjectModel/Enums.h
@@ -276,6 +276,25 @@ enum class ContainerStyle {
     Emphasis
 };
 
+enum class ErrorStatusCode {
+    InvalidJson = 0,
+    UnsupportedSchemaVersion,
+    RenderFailed,
+    RequiredPropertyMissing,
+    InvalidPropertyValue,
+    UnsupportedParserOverride
+};
+
+enum class WarningStatusCode {
+    UnknownElementType = 0,
+    UnknownPropertyOnElement,
+    UnknownEnumValue,
+    NoRendererForType,
+    InteractivityNotSupported,
+    MaxActionsExceeded,
+    AssetLoadFailed
+};
+
 const std::string AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey type);
 AdaptiveCardSchemaKey AdaptiveCardSchemaKeyFromString(const std::string& type);
 

--- a/source/shared/cpp/ObjectModel/ParseUtil.cpp
+++ b/source/shared/cpp/ObjectModel/ParseUtil.cpp
@@ -9,7 +9,7 @@ namespace AdaptiveCards
 void ParseUtil::ThrowIfNotJsonObject(const Json::Value& json)
 {
     if (!json.isObject()) {
-        throw AdaptiveCardParseException("Expected JSON Object\n");
+        throw AdaptiveCardParseException(ErrorStatusCode::InvalidJson, "Expected JSON Object\n");
     }
 }
 
@@ -17,7 +17,7 @@ void ParseUtil::ExpectString(const Json::Value& json)
 {
     if (!json.isString())
     {
-        throw AdaptiveCardParseException("The JSON element did not have the expected type 'string'");
+        throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "The JSON element did not have the expected type 'string'");
     }
 }
 
@@ -27,7 +27,7 @@ std::string ParseUtil::GetTypeAsString(const Json::Value& json)
     std::string typeKey = "type";
     if (!json.isMember(typeKey))
     {
-        throw AdaptiveCardParseException("The JSON element is missing the following value: " + typeKey);
+        throw AdaptiveCardParseException(ErrorStatusCode::RequiredPropertyMissing, "The JSON element is missing the following value: " + typeKey);
     }
 
     return json.get(typeKey, Json::Value()).asString();
@@ -54,7 +54,7 @@ std::string ParseUtil::GetString(const Json::Value& json, AdaptiveCardSchemaKey 
     {
         if (isRequired)
         {
-            throw AdaptiveCardParseException("Property is required but was found empty: " + propertyName);
+            throw AdaptiveCardParseException(ErrorStatusCode::RequiredPropertyMissing, "Property is required but was found empty: " + propertyName);
         }
         else
         {
@@ -64,7 +64,7 @@ std::string ParseUtil::GetString(const Json::Value& json, AdaptiveCardSchemaKey 
 
     if (!propertyValue.isString())
     {
-        throw AdaptiveCardParseException("Value was invalid. Expected type string.");
+        throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "Value for property " + propertyName + " was invalid. Expected type string.");
     }
 
     return propertyValue.asString();
@@ -78,7 +78,7 @@ std::string ParseUtil::GetJsonString(const Json::Value& json, AdaptiveCardSchema
     {
         if (isRequired)
         {
-            throw AdaptiveCardParseException("Property is required but was found empty: " + propertyName);
+            throw AdaptiveCardParseException(ErrorStatusCode::RequiredPropertyMissing, "Property is required but was found empty: " + propertyName);
         }
         else
         {
@@ -97,7 +97,7 @@ std::string ParseUtil::GetValueAsString(const Json::Value& json, AdaptiveCardSch
     {
         if (isRequired)
         {
-            throw AdaptiveCardParseException("Property is required but was found empty: " + propertyName);
+            throw AdaptiveCardParseException(ErrorStatusCode::RequiredPropertyMissing, "Property is required but was found empty: " + propertyName);
         }
         else
         {
@@ -116,7 +116,7 @@ bool ParseUtil::GetBool(const Json::Value& json, AdaptiveCardSchemaKey key, bool
     {
         if (isRequired)
         {
-            throw AdaptiveCardParseException("Property is required but was found empty: " + propertyName);
+            throw AdaptiveCardParseException(ErrorStatusCode::RequiredPropertyMissing, "Property is required but was found empty: " + propertyName);
         }
         else
         {
@@ -126,7 +126,7 @@ bool ParseUtil::GetBool(const Json::Value& json, AdaptiveCardSchemaKey key, bool
 
     if (!propertyValue.isBool())
     {
-        throw AdaptiveCardParseException("Value was invalid. Expected type bool.");
+        throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "Value for property " + propertyName + " was invalid. Expected type bool.");
     }
 
     return propertyValue.asBool();
@@ -140,7 +140,7 @@ unsigned int ParseUtil::GetUInt(const Json::Value & json, AdaptiveCardSchemaKey 
     {
         if (isRequired)
         {
-            throw AdaptiveCardParseException("Property is required but was found empty: " + propertyName);
+            throw AdaptiveCardParseException(ErrorStatusCode::RequiredPropertyMissing, "Property is required but was found empty: " + propertyName);
         }
         else
         {
@@ -150,7 +150,7 @@ unsigned int ParseUtil::GetUInt(const Json::Value & json, AdaptiveCardSchemaKey 
 
     if (!propertyValue.isUInt())
     {
-        throw AdaptiveCardParseException("Value was invalid. Expected type uInt.");
+        throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "Value for property " + propertyName + " was invalid. Expected type uInt.");
     }
 
     return propertyValue.asUInt();
@@ -164,7 +164,7 @@ int ParseUtil::GetInt(const Json::Value & json, AdaptiveCardSchemaKey key, int d
     {
         if (isRequired)
         {
-            throw AdaptiveCardParseException("Property is required but was found empty: " + propertyName);
+            throw AdaptiveCardParseException(ErrorStatusCode::RequiredPropertyMissing, "Property is required but was found empty: " + propertyName);
         }
         else
         {
@@ -174,7 +174,7 @@ int ParseUtil::GetInt(const Json::Value & json, AdaptiveCardSchemaKey key, int d
 
     if (!propertyValue.isInt())
     {
-        throw AdaptiveCardParseException("Value was invalid. Expected type int.");
+        throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "Value for property " + propertyName + " was invalid. Expected type int.");
     }
 
     return propertyValue.asInt();
@@ -187,7 +187,7 @@ void ParseUtil::ExpectTypeString(const Json::Value& json, CardElementType bodyTy
     bool isTypeCorrect = expectedTypeStr.compare(actualType) == 0;
     if (!isTypeCorrect)
     {
-        throw AdaptiveCardParseException("The JSON element did not have the correct type. Expected: " + expectedTypeStr + ", Actual: " + actualType);
+        throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "The JSON element did not have the correct type. Expected: " + expectedTypeStr + ", Actual: " + actualType);
     }
 }
 
@@ -196,12 +196,12 @@ void ParseUtil::ExpectKeyAndValueType(const Json::Value& json, const char* expec
 {
     if (expectedKey == nullptr)
     {
-        throw AdaptiveCardParseException("null expectedKey");
+        throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "null expectedKey");
     }
 
     if (!json.isMember(expectedKey))
     {
-        throw AdaptiveCardParseException("The JSON element is missing the following key: " + std::string(expectedKey));
+        throw AdaptiveCardParseException(ErrorStatusCode::RequiredPropertyMissing, "The JSON element is missing the following key: " + std::string(expectedKey));
     }
 
     auto value = json.get(expectedKey, Json::Value());
@@ -217,7 +217,7 @@ CardElementType ParseUtil::GetCardElementType(const Json::Value& json)
     }
     catch (const std::out_of_range&)
     {
-        throw AdaptiveCardParseException("Invalid CardElementType");
+        throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "Invalid CardElementType");
     }
 }
 
@@ -242,7 +242,7 @@ ActionType ParseUtil::GetActionType(const Json::Value& json)
     }
     catch (const std::out_of_range&)
     {
-        throw AdaptiveCardParseException("Invalid ActionType");
+        throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "Invalid ActionType");
     }
 }
 
@@ -267,12 +267,12 @@ Json::Value ParseUtil::GetArray(
     auto elementArray = json.get(propertyName, Json::Value());
     if (isRequired && elementArray.empty())
     {
-        throw AdaptiveCardParseException("Could not parse required key: " + propertyName + ". It was not found");
+        throw AdaptiveCardParseException(ErrorStatusCode::RequiredPropertyMissing, "Could not parse required key: " + propertyName + ". It was not found");
     }
 
     if (!elementArray.empty() && !elementArray.isArray())
     {
-        throw AdaptiveCardParseException("Could not parse specified key: " + propertyName + ". It was not an array");
+        throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "Could not parse specified key: " + propertyName + ". It was not an array");
     }
     return elementArray;
 }
@@ -283,7 +283,7 @@ Json::Value ParseUtil::GetJsonValueFromString(const std::string jsonString)
     Json::Value jsonValue;
     if (!reader.parse(jsonString.c_str(), jsonValue))
     {
-        throw AdaptiveCardParseException("Expected JSON Object\n");
+        throw AdaptiveCardParseException(ErrorStatusCode::InvalidJson, "Expected JSON Object\n");
     }
     return jsonValue;
 }
@@ -294,7 +294,7 @@ Json::Value ParseUtil::ExtractJsonValue(const Json::Value& json, AdaptiveCardSch
     auto propertyValue = json.get(propertyName, Json::Value());
     if (isRequired && propertyValue.empty())
     {
-        throw AdaptiveCardParseException("Could not extract specified key: " + propertyName + ".");
+        throw AdaptiveCardParseException(ErrorStatusCode::RequiredPropertyMissing, "Could not extract required key: " + propertyName + ".");
     }
     return propertyValue;
 }
@@ -347,7 +347,7 @@ std::shared_ptr<BaseActionElement> ParseUtil::GetActionFromJsonValue(
 {
     if (json.empty() || !json.isObject())
     {
-        throw AdaptiveCardParseException("Expected a Json object to extract Action element");
+        throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "Expected a Json object to extract Action element");
     }
 
     // Get the element's type

--- a/source/shared/cpp/ObjectModel/ParseUtil.h
+++ b/source/shared/cpp/ObjectModel/ParseUtil.h
@@ -138,6 +138,7 @@ T ParseUtil::GetEnumValue(const Json::Value& json, AdaptiveCardSchemaKey key, T 
     }
     catch (const std::out_of_range&)
     {
+        // TODO: Uncomment and add to warnings instead of throwing.
         // throw AdaptiveCardParseException("Enum type was out of range. Actual: " + propertyValueStr);
         return defaultEnumValue;
     }

--- a/source/shared/cpp/ObjectModel/ParseUtil.h
+++ b/source/shared/cpp/ObjectModel/ParseUtil.h
@@ -120,7 +120,7 @@ T ParseUtil::GetEnumValue(const Json::Value& json, AdaptiveCardSchemaKey key, T 
         {
             if (isRequired)
             {
-                throw AdaptiveCardParseException("Property is required but was found empty: " + propertyName);
+                throw AdaptiveCardParseException(ErrorStatusCode::RequiredPropertyMissing, "Property is required but was found empty: " + propertyName);
             }
             else
             {
@@ -130,7 +130,7 @@ T ParseUtil::GetEnumValue(const Json::Value& json, AdaptiveCardSchemaKey key, T 
 
         if (!propertyValue.isString())
         {
-            throw AdaptiveCardParseException("Enum type was invalid. Expected type string.");
+            throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "Enum type was invalid. Expected type string.");
         }
 
         propertyValueStr = propertyValue.asString();
@@ -138,7 +138,8 @@ T ParseUtil::GetEnumValue(const Json::Value& json, AdaptiveCardSchemaKey key, T 
     }
     catch (const std::out_of_range&)
     {
-        throw AdaptiveCardParseException("Enum type was out of range. Actual: " + propertyValueStr);
+        // throw AdaptiveCardParseException("Enum type was out of range. Actual: " + propertyValueStr);
+        return defaultEnumValue;
     }
 }
 

--- a/source/uwp/Renderer/idl/AdaptiveCards.Uwp.idl
+++ b/source/uwp/Renderer/idl/AdaptiveCards.Uwp.idl
@@ -290,12 +290,12 @@ namespace AdaptiveCards
 
         [version(NTDDI_WIN10_RS1)]
         typedef [v1_enum] enum ErrorStatusCode {
-            // Errors
             InvalidJson = 0,
             UnsupportedSchemaVersion,
             RenderFailed,
             RequiredPropertyMissing,
-            InvalidPropertyValue
+            InvalidPropertyValue,
+            UnsupportedParserOverride
         } ErrorStatusCode;
 
         [version(NTDDI_WIN10_RS1)]

--- a/source/uwp/Renderer/lib/AdaptiveCardParseResult.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveCardParseResult.cpp
@@ -56,10 +56,10 @@ namespace AdaptiveCards { namespace Uwp
         return m_warnings.CopyTo(value);
     }
 
-        _Use_decl_annotations_
-        HRESULT AdaptiveCardParseResult::put_AdaptiveCard(_In_ IAdaptiveCard* value)
-        {
-                m_adaptiveCard = value;
-                return S_OK;
-        }
+    _Use_decl_annotations_
+    HRESULT AdaptiveCardParseResult::put_AdaptiveCard(_In_ IAdaptiveCard* value)
+    {
+            m_adaptiveCard = value;
+            return S_OK;
+    }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveCardParseResult.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveCardParseResult.cpp
@@ -55,4 +55,11 @@ namespace AdaptiveCards { namespace Uwp
     {
         return m_warnings.CopyTo(value);
     }
+
+        _Use_decl_annotations_
+        HRESULT AdaptiveCardParseResult::put_AdaptiveCard(_In_ IAdaptiveCard* value)
+        {
+                m_adaptiveCard = value;
+                return S_OK;
+        }
 }}

--- a/source/uwp/Renderer/lib/AdaptiveCardParseResult.h
+++ b/source/uwp/Renderer/lib/AdaptiveCardParseResult.h
@@ -19,6 +19,7 @@ namespace AdaptiveCards { namespace Uwp
 
         // IAdaptiveCardParseResult
         IFACEMETHODIMP get_AdaptiveCard(_COM_Outptr_ ABI::AdaptiveCards::Uwp::IAdaptiveCard** value);
+        HRESULT put_AdaptiveCard(_In_ ABI::AdaptiveCards::Uwp::IAdaptiveCard* value);
 
         IFACEMETHODIMP get_Errors(_COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveCards::Uwp::IAdaptiveError*>** value);
         IFACEMETHODIMP get_Warnings(_COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveCards::Uwp::IAdaptiveWarning*>** value);

--- a/source/uwp/Renderer/lib/AdaptiveCardRendererComponent.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveCardRendererComponent.cpp
@@ -142,7 +142,7 @@ namespace AdaptiveCards { namespace Uwp
             catch (...)
             {
                 RETURN_IF_FAILED(renderContext->AddError(
-                    ErrorStatusCode::RenderFailed,
+                    ABI::AdaptiveCards::Uwp::ErrorStatusCode::RenderFailed,
                     HStringReference(L"An unrecoverable error was encountered while rendering the card").Get()));
                 renderedCard->SetFrameworkElement(nullptr);
             }
@@ -170,8 +170,19 @@ namespace AdaptiveCards { namespace Uwp
 
         ComPtr<IAdaptiveCardParseResult> adaptiveCardParseResult;
         HRESULT hr = CreateAdaptiveCardFromJsonString(adaptiveJson, &adaptiveCardParseResult);
-        if (FAILED(hr))
-        {
+        ComPtr<IAdaptiveCard> parsedCard;
+        RETURN_IF_FAILED(adaptiveCardParseResult->get_AdaptiveCard(&parsedCard));
+        if (parsedCard == nullptr)
+        {            
+            ComPtr<IVector<IAdaptiveError*>> renderResultErrors;
+            RETURN_IF_FAILED(renderedCard->get_Errors(&renderResultErrors));
+            ComPtr<IVector<IAdaptiveError*>> parseErrors;
+            RETURN_IF_FAILED(adaptiveCardParseResult->get_Errors(&parseErrors));
+            XamlHelpers::IterateOverVector<IAdaptiveError>(parseErrors.Get(), [&](IAdaptiveError* error)
+            {
+                ComPtr<IAdaptiveError> localError(error);
+                return renderResultErrors->Append(localError.Get());
+            });
             *result = renderedCard.Detach();
             return S_OK;
         }
@@ -179,7 +190,6 @@ namespace AdaptiveCards { namespace Uwp
         {
             ComPtr<IAdaptiveCard> adaptiveCard;
             RETURN_IF_FAILED(adaptiveCardParseResult->get_AdaptiveCard(&adaptiveCard));
-
             return RenderAdaptiveCard(adaptiveCard.Get(), result);
         }
     }

--- a/source/uwp/Renderer/lib/AdaptiveRenderContext.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveRenderContext.cpp
@@ -67,7 +67,7 @@ namespace AdaptiveCards { namespace Uwp
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveRenderContext::AddError(ErrorStatusCode statusCode, HSTRING message)
+    HRESULT AdaptiveRenderContext::AddError(ABI::AdaptiveCards::Uwp::ErrorStatusCode statusCode, HSTRING message)
     {
         ComPtr<AdaptiveError> error;
         RETURN_IF_FAILED(MakeAndInitialize<AdaptiveError>(&error, statusCode, message));
@@ -77,7 +77,7 @@ namespace AdaptiveCards { namespace Uwp
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveRenderContext::AddWarning(WarningStatusCode statusCode, HSTRING message)
+    HRESULT AdaptiveRenderContext::AddWarning(ABI::AdaptiveCards::Uwp::WarningStatusCode statusCode, HSTRING message)
     {
         ComPtr<AdaptiveWarning> warning;
         RETURN_IF_FAILED(MakeAndInitialize<AdaptiveWarning>(&warning, statusCode, message));

--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -160,7 +160,7 @@ namespace AdaptiveCards { namespace Uwp
         else if (actionsSize > 0)
         {
             renderContext->AddWarning(
-                WarningStatusCode::InteractivityNotSupported,
+                ABI::AdaptiveCards::Uwp::WarningStatusCode::InteractivityNotSupported,
                 HStringReference(L"Actions collection was present in card, but interactivity is not supported").Get());
         }
 
@@ -654,7 +654,7 @@ namespace AdaptiveCards { namespace Uwp
                 std::wstring errorString = L"No Renderer found for type: ";
                 errorString += elementType.GetRawBuffer(nullptr);
                 renderContext->AddWarning(
-                    WarningStatusCode::NoRendererForType,
+                   ABI::AdaptiveCards::Uwp::WarningStatusCode::NoRendererForType,
                     HStringReference(errorString.c_str()).Get());
             }
         });
@@ -947,7 +947,7 @@ namespace AdaptiveCards { namespace Uwp
             else
             {
                 renderContext->AddWarning(
-                    WarningStatusCode::MaxActionsExceeded,
+                   ABI::AdaptiveCards::Uwp::WarningStatusCode::MaxActionsExceeded,
                     HStringReference(L"Some actions were not rendered due to exceeding the maximum number of actions allowed").Get());
                 return;
             }
@@ -1519,7 +1519,7 @@ namespace AdaptiveCards { namespace Uwp
             else
             {
                 renderContext->AddWarning(
-                    WarningStatusCode::InteractivityNotSupported,
+                   ABI::AdaptiveCards::Uwp::WarningStatusCode::InteractivityNotSupported,
                     HStringReference(L"SelectAction present in Container, but Interactivity is not supported").Get());
             }
         }
@@ -1615,7 +1615,7 @@ namespace AdaptiveCards { namespace Uwp
         if (columnRenderer == nullptr)
         {
             renderContext->AddWarning(
-                WarningStatusCode::NoRendererForType,
+               ABI::AdaptiveCards::Uwp::WarningStatusCode::NoRendererForType,
                 HStringReference(L"No renderer found for type: Column").Get());
             *columnSetControl = nullptr;
             return;
@@ -1731,7 +1731,7 @@ namespace AdaptiveCards { namespace Uwp
             else
             {
                 renderContext->AddWarning(
-                    WarningStatusCode::InteractivityNotSupported,
+                   ABI::AdaptiveCards::Uwp::WarningStatusCode::InteractivityNotSupported,
                     HStringReference(L"SelectAction present in ColumnSet, but Interactivity is not supported").Get());
             }
         }
@@ -1902,7 +1902,7 @@ namespace AdaptiveCards { namespace Uwp
         else
         {
             renderContext->AddWarning(
-                WarningStatusCode::NoRendererForType,
+               ABI::AdaptiveCards::Uwp::WarningStatusCode::NoRendererForType,
                 HStringReference(L"No renderer found for type: Image").Get());
             *imageSetControl = nullptr;
             return;
@@ -2045,7 +2045,7 @@ namespace AdaptiveCards { namespace Uwp
         if (!SupportsInteractivity(hostConfig.Get()))
         {
             renderContext->AddWarning(
-                WarningStatusCode::InteractivityNotSupported,
+               ABI::AdaptiveCards::Uwp::WarningStatusCode::InteractivityNotSupported,
                 HStringReference(L"ChoiceSet was stripped from card because interactivity is not supported").Get());
             return;
         }
@@ -2084,7 +2084,7 @@ namespace AdaptiveCards { namespace Uwp
         if (!SupportsInteractivity(hostConfig.Get()))
         {
             renderContext->AddWarning(
-                WarningStatusCode::InteractivityNotSupported,
+               ABI::AdaptiveCards::Uwp::WarningStatusCode::InteractivityNotSupported,
                 HStringReference(L"Date input was stripped from card because interactivity is not supported").Get());
             return;
         }
@@ -2124,7 +2124,7 @@ namespace AdaptiveCards { namespace Uwp
         if (!SupportsInteractivity(hostConfig.Get()))
         {
             renderContext->AddWarning(
-                WarningStatusCode::InteractivityNotSupported,
+               ABI::AdaptiveCards::Uwp::WarningStatusCode::InteractivityNotSupported,
                 HStringReference(L"Number input was stripped from card because interactivity is not supported").Get());
             return;
         }
@@ -2178,7 +2178,7 @@ namespace AdaptiveCards { namespace Uwp
         if (!SupportsInteractivity(hostConfig.Get()))
         {
             renderContext->AddWarning(
-                WarningStatusCode::InteractivityNotSupported,
+               ABI::AdaptiveCards::Uwp::WarningStatusCode::InteractivityNotSupported,
                 HStringReference(L"Text Input was stripped from card because interactivity is not supported").Get());
             return;
         }
@@ -2253,7 +2253,7 @@ namespace AdaptiveCards { namespace Uwp
         if (!SupportsInteractivity(hostConfig.Get()))
         {
             renderContext->AddWarning(
-                WarningStatusCode::InteractivityNotSupported,
+               ABI::AdaptiveCards::Uwp::WarningStatusCode::InteractivityNotSupported,
                 HStringReference(L"Time Input was stripped from card because interactivity is not supported").Get());
             return;
         }
@@ -2284,7 +2284,7 @@ namespace AdaptiveCards { namespace Uwp
         if (!SupportsInteractivity(hostConfig.Get()))
         {
             renderContext->AddWarning(
-                WarningStatusCode::InteractivityNotSupported,
+               ABI::AdaptiveCards::Uwp::WarningStatusCode::InteractivityNotSupported,
                 HStringReference(L"Toggle Input was stripped from card because interactivity is not supported").Get());
             return;
         }


### PR DESCRIPTION
Wires up parser errors from the shared model to the UWP renderer. Warnings pending.