### PR TITLE
Show ellipses when truncating TextBlocks due to maxLines

### DIFF
--- a/source/nodejs/adaptivecards-visualizer/src/app.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/app.ts
@@ -32,7 +32,7 @@ function setContent(element) {
     contentContainer.appendChild(element);
 }
 
-function renderCard(): HTMLElement {
+function renderCard(target: HTMLElement): HTMLElement {
     document.getElementById("errorContainer").hidden = true;
     lastValidationErrors = [];
 
@@ -50,23 +50,21 @@ function renderCard(): HTMLElement {
 
     showValidationErrors();
 
-    return hostContainer.render(adaptiveCard.render(), adaptiveCard.renderSpeech());
+    return hostContainer.render(adaptiveCard, target);
 }
 
 function tryRenderCard() {
-    var renderedCard: HTMLElement;
-
-    try {
-        renderedCard = renderCard();
-    }
-    catch (ex) {
-        renderedCard = document.createElement("div");
-        renderedCard.innerText = ex.message;
-    }
-
     var contentContainer = document.getElementById("content");
     contentContainer.innerHTML = '';
-    contentContainer.appendChild(renderedCard);
+
+    try {
+        renderCard(contentContainer);
+    }
+    catch (ex) {
+        var renderedCard = document.createElement("div");
+        renderedCard.innerText = ex.message;
+        contentContainer.appendChild(renderedCard);
+    }
 
     try {
         sessionStorage.setItem("AdaptivePayload", currentCardPayload);
@@ -372,17 +370,15 @@ function showPopupCard(action: AdaptiveCards.ShowCardAction) {
     cardContainer.className = "popupCardContainer";
     cardContainer.onclick = (e) => { e.stopPropagation() };
 
-    var hostContainer = getSelectedHostContainer();
-
-    cardContainer.appendChild(hostContainer.render(action.card.render(), action.card.renderSpeech()));
-
-    overlayElement.appendChild(cardContainer);
-
-    document.body.appendChild(overlayElement);
-
     var cardContainerBounds = cardContainer.getBoundingClientRect();
     cardContainer.style.left = (window.innerWidth - cardContainerBounds.width) / 2 + "px";
     cardContainer.style.top = (window.innerHeight - cardContainerBounds.height) / 2 + "px";
+
+    overlayElement.appendChild(cardContainer);
+    document.body.appendChild(overlayElement);
+
+    var hostContainer = getSelectedHostContainer();
+    hostContainer.render(action.card, cardContainer);
 }
 
 function showValidationErrors() {

--- a/source/nodejs/adaptivecards-visualizer/src/containers/bf-image.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/bf-image.ts
@@ -1,5 +1,6 @@
 import { HostContainer } from "./host-container";
 import {
+    AdaptiveCard,
     HostConfig,
     Size,
     TextSize,
@@ -21,11 +22,12 @@ export class BotFrameworkImageContainer extends HostContainer {
         this.supportsActionBar = false;
     }
 
-    protected renderContainer(renderedCard: HTMLElement): HTMLElement {
+    protected renderContainer(adaptiveCard: AdaptiveCard, target: HTMLElement): HTMLElement {
         var outerElement = document.createElement("div");
         outerElement.className = "kikOuterContainer";
         outerElement.style.width = this._width + "px";
-        outerElement.appendChild(renderedCard);
+        target.appendChild(outerElement);
+        adaptiveCard.render(outerElement);
         return outerElement;
     }
 

--- a/source/nodejs/adaptivecards-visualizer/src/containers/headless.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/headless.ts
@@ -1,5 +1,6 @@
 import { HostContainer } from "./host-container";
 import {
+    AdaptiveCard,
     HostConfig,
     Size,
     TextSize,
@@ -12,7 +13,7 @@ import {
 } from "adaptivecards";
 
 export class HeadlessContainer extends HostContainer {
-    protected renderContainer(renderedCard: HTMLElement): HTMLElement {
+    protected renderContainer(adaptiveCard: AdaptiveCard, target: HTMLElement): HTMLElement {
         var outerElement = document.createElement("div");
         outerElement.className = "headlessOuterContainer";
 
@@ -40,8 +41,9 @@ export class HeadlessContainer extends HostContainer {
         var innerElement = document.createElement("div");
         innerElement.className = "headlessInnerContainer";
 
-        innerElement.appendChild(renderedCard);
         outerElement.appendChild(innerElement);
+        target.appendChild(outerElement);
+        adaptiveCard.render(innerElement);
 
         return outerElement;
     }

--- a/source/nodejs/adaptivecards-visualizer/src/containers/host-container.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/host-container.ts
@@ -237,7 +237,7 @@ export abstract class HostContainer {
         });
     }
 
-    protected renderContainer(adaptiveCard: AdaptiveCard, target:HTMLElement): HTMLElement {
+    protected renderContainer(adaptiveCard: AdaptiveCard, target: HTMLElement): HTMLElement {
         return null;
     }
 

--- a/source/nodejs/adaptivecards-visualizer/src/containers/host-container.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/host-container.ts
@@ -237,7 +237,7 @@ export abstract class HostContainer {
         });
     }
 
-    protected renderContainer(renderedCard: HTMLElement): HTMLElement {
+    protected renderContainer(adaptiveCard: AdaptiveCard, target:HTMLElement): HTMLElement {
         return null;
     }
 
@@ -304,22 +304,20 @@ export abstract class HostContainer {
         this.styleSheet = styleSheet;
     }
 
-    render(renderedCard: HTMLElement, speechString: string, showSpeechXml: boolean = false): HTMLElement {
+    render(adaptiveCard: AdaptiveCard, target: HTMLElement, showSpeechXml: boolean = false): HTMLElement {
         var element = document.createElement("div");
+        target.appendChild(element);
 
-        if (renderedCard) {
-            var renderedContainer = this.renderContainer(renderedCard);
+        if (adaptiveCard) {
+            var renderedContainer = this.renderContainer(adaptiveCard, element);
 
             if (renderedContainer) {
-                element.appendChild(renderedContainer);
-
                 var separator = document.createElement("div");
                 separator.style.height = "20px";
-
                 element.appendChild(separator);
             }
 
-            var renderedSpeech = this.renderSpeech(speechString);
+            var renderedSpeech = this.renderSpeech(adaptiveCard.renderSpeech());
 
             if (renderedSpeech) {
                 element.appendChild(renderedSpeech);

--- a/source/nodejs/adaptivecards-visualizer/src/containers/outlook.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/outlook.ts
@@ -19,14 +19,15 @@ import {
 } from "adaptivecards";
 
 export class OutlookContainer extends HostContainer {
-    protected renderContainer(renderedCard: HTMLElement): HTMLElement {
+    protected renderContainer(adaptiveCard: AdaptiveCard, target: HTMLElement): HTMLElement {
         var element = document.createElement("div");
         element.style.borderTop = "1px solid #F1F1F1";
         element.style.borderRight = "1px solid #F1F1F1";
         element.style.borderBottom = "1px solid #F1F1F1";
         element.style.border = "1px solid #F1F1F1"
+        target.appendChild(element);
 
-        element.appendChild(renderedCard);
+        adaptiveCard.render(element);
 
         return element;
     }

--- a/source/nodejs/adaptivecards-visualizer/src/containers/skype.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/skype.ts
@@ -1,5 +1,6 @@
 import { HostContainer } from "./host-container";
 import {
+    AdaptiveCard,
     HostConfig,
     Size,
     TextSize,
@@ -14,7 +15,7 @@ import {
 export class SkypeContainer extends HostContainer {
     private _width: number;
 
-    protected renderContainer(renderedCard: HTMLElement): HTMLElement {
+    protected renderContainer(adaptiveCard: AdaptiveCard, target: HTMLElement): HTMLElement {
         var element = document.createElement("div");
         element.className = "skypeContainer";
 
@@ -31,10 +32,10 @@ export class SkypeContainer extends HostContainer {
         botElementIn1.appendChild(botElementIn2);
 
         element.appendChild(botElement);
+        target.appendChild(element)
 
+        var renderedCard = adaptiveCard.render(element);
         renderedCard.style.width = this._width + "px";
-
-        element.appendChild(renderedCard);
 
         return element;
     }

--- a/source/nodejs/adaptivecards-visualizer/src/containers/skype.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/skype.ts
@@ -31,11 +31,14 @@ export class SkypeContainer extends HostContainer {
         botElementIn2.className = "hexagon-in2";
         botElementIn1.appendChild(botElementIn2);
 
-        element.appendChild(botElement);
-        target.appendChild(element)
+        var cardWrapper = document.createElement("div");
+        cardWrapper.style.width = this._width + "px";
 
-        var renderedCard = adaptiveCard.render(element);
-        renderedCard.style.width = this._width + "px";
+        element.appendChild(botElement);
+        element.appendChild(cardWrapper);
+        target.appendChild(element);
+
+        var renderedCard = adaptiveCard.render(cardWrapper);
 
         return element;
     }

--- a/source/nodejs/adaptivecards-visualizer/src/containers/teams.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/teams.ts
@@ -1,5 +1,6 @@
 import { HostContainer } from "./host-container";
 import {
+    AdaptiveCard,
     HostConfig,
     Size,
     TextSize,
@@ -12,14 +13,15 @@ import {
 } from "adaptivecards";
 
 export class TeamsContainer extends HostContainer {
-    protected renderContainer(renderedCard: HTMLElement): HTMLElement {
+    protected renderContainer(adaptiveCard: AdaptiveCard, target: HTMLElement): HTMLElement {
         var element = document.createElement("div");
         element.style.borderTop = "1px solid #F1F1F1";
         element.style.borderRight = "1px solid #F1F1F1";
         element.style.borderBottom = "1px solid #F1F1F1";
         element.style.border = "1px solid #F1F1F1"
+        target.appendChild(element);
 
-        element.appendChild(renderedCard);
+        adaptiveCard.render(element);
 
         return element;
     }

--- a/source/nodejs/adaptivecards-visualizer/src/containers/timeline.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/timeline.ts
@@ -1,5 +1,6 @@
 import { HostContainer } from "./host-container";
 import {
+    AdaptiveCard,
     HostConfig,
     Size,
     TextSize,
@@ -25,16 +26,16 @@ export class TimelineContainer extends HostContainer {
         this.supportsActionBar = false;
     }
 
-    protected renderContainer(renderedCard: HTMLElement): HTMLElement {
+    protected renderContainer(adaptiveCard: AdaptiveCard, target: HTMLElement): HTMLElement {
         var element = document.createElement("div");
         element.style.width = this._width + "px";
         element.style.height = this._height + "px";
         // element.style.backgroundColor = TimelineContainer.backgroundColor;
         element.style.overflow = "hidden";
+        target.appendChild(element);
 
+        var renderedCard = adaptiveCard.render(element);
         renderedCard.style.height = "100%";
-
-        element.appendChild(renderedCard);
 
         return element;
     }

--- a/source/nodejs/adaptivecards-visualizer/src/containers/toast.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/toast.ts
@@ -1,5 +1,6 @@
 import { HostContainer } from "./host-container";
 import {
+    AdaptiveCard,
     HostConfig,
     Size,
     TextSize,
@@ -14,13 +15,14 @@ import {
 export class ToastContainer extends HostContainer {
     private _width: number;
 
-    protected renderContainer(renderedCard: HTMLElement): HTMLElement {
+    protected renderContainer(adaptiveCard: AdaptiveCard, target: HTMLElement): HTMLElement {
         var element = document.createElement("div");
         element.style.border = "#474747 1px solid";
         element.style.width = this._width + "px";
         element.style.overflow = "hidden";
+        target.appendChild(element);
 
-        element.appendChild(renderedCard);
+        adaptiveCard.render(element);
 
         return element;
     }

--- a/source/nodejs/adaptivecards-visualizer/src/containers/webchat.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/webchat.ts
@@ -17,33 +17,38 @@ export class WebChatContainer extends HostContainer {
         var outerElement = document.createElement("div");
         outerElement.className = "webChatOuterContainer";
 
-        window.addEventListener(
-            "resize",
-            () => {
-                if (outerElement.parentElement) {
-                    var bounds = outerElement.parentElement.getBoundingClientRect();
+        var resizeCard = () => {
+            if (outerElement.parentElement) {
+                var bounds = outerElement.parentElement.getBoundingClientRect();
 
-                    var newWidth: string = "216px";
+                var newWidth: string = "216px";
 
-                    if (bounds.width >= 500) {
-                        newWidth = "416px";
-                    }
-                    else if (bounds.width >= 400) {
-                        newWidth = "320px";
-                    }
-
-                    if (outerElement.style.width != newWidth) {
-                        outerElement.style.width = newWidth;
-                    }
+                if (bounds.width >= 500) {
+                    newWidth = "416px";
                 }
-            });
+                else if (bounds.width >= 400) {
+                    newWidth = "320px";
+                }
+
+                if (outerElement.style.width != newWidth) {
+                    outerElement.style.width = newWidth;
+                }
+
+                adaptiveCard.updateLayout();
+            }
+        };
+
+        window.addEventListener("resize", resizeCard);
 
         var innerElement = document.createElement("div");
         innerElement.className = "webChatInnerContainer";
 
         target.appendChild(outerElement);
         outerElement.appendChild(innerElement);
-        adaptiveCard.render(innerElement);
+
+        var renderedCard = adaptiveCard.render();
+        innerElement.appendChild(renderedCard);
+        resizeCard();
 
         return outerElement;
     }

--- a/source/nodejs/adaptivecards-visualizer/src/containers/webchat.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/webchat.ts
@@ -1,5 +1,6 @@
 import { HostContainer } from "./host-container";
 import {
+    AdaptiveCard,
     HostConfig,
     Size,
     TextSize,
@@ -12,7 +13,7 @@ import {
 } from "adaptivecards";
 
 export class WebChatContainer extends HostContainer {
-    protected renderContainer(renderedCard: HTMLElement): HTMLElement {
+    protected renderContainer(adaptiveCard: AdaptiveCard, target: HTMLElement): HTMLElement {
         var outerElement = document.createElement("div");
         outerElement.className = "webChatOuterContainer";
 
@@ -40,8 +41,9 @@ export class WebChatContainer extends HostContainer {
         var innerElement = document.createElement("div");
         innerElement.className = "webChatInnerContainer";
 
-        innerElement.appendChild(renderedCard);
+        target.appendChild(outerElement);
         outerElement.appendChild(innerElement);
+        adaptiveCard.render(innerElement);
 
         return outerElement;
     }

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -394,7 +394,7 @@ export class TextBlock extends CardElement {
     maxLines: number;
 
     private _computedLineHeight: number;
-    private _innerHtml: string;
+    private _originalInnerHtml: string;
 
     protected internalRender(): HTMLElement {
         if (!Utils.isNullOrEmpty(this.text)) {
@@ -532,7 +532,7 @@ export class TextBlock extends CardElement {
             }
 
             if (AdaptiveCard.useAdvancedTextBlockTruncation) {
-                this._innerHtml = element.innerHTML;
+                this._originalInnerHtml = element.innerHTML;
             }
 
             return element;
@@ -601,7 +601,7 @@ export class TextBlock extends CardElement {
         if (AdaptiveCard.useAdvancedTextBlockTruncation) {
             // Reset the element's innerHTML in case the available room for
             // content has increased
-            this.renderedElement.innerHTML = this._innerHtml;
+            this.renderedElement.innerHTML = this._originalInnerHtml;
             this.truncateIfSupported();
         }
     }

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -666,7 +666,8 @@ export class TextBlock extends CardElement {
                 if (fits()) {
                     bestBreakIdx = idx;
                     idx = TextBlock.findNextCharacter(fullText, idx);
-                } else {
+                }
+                else {
                     break;
                 }
             }

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -531,7 +531,10 @@ export class TextBlock extends CardElement {
                 element.style.whiteSpace = "nowrap";
             }
 
-            this.innerHtml = element.innerHTML;
+            if (AdaptiveCard.useAdvancedTextBlockTruncation) {
+                this.innerHtml = element.innerHTML;
+            }
+
             return element;
         }
         else {
@@ -595,10 +598,12 @@ export class TextBlock extends CardElement {
     }
 
     updateLayout(processChildren: boolean = false) {
-        // Reset the element's innerHTML in case the available room for content
-        // has increased
-        this.renderedElement.innerHTML = this.innerHtml;
-        this.truncateIfSupported();
+        if (AdaptiveCard.useAdvancedTextBlockTruncation) {
+            // Reset the element's innerHTML in case the available room for
+            // content has increased
+            this.renderedElement.innerHTML = this.innerHtml;
+            this.truncateIfSupported();
+        }
     }
 
     private truncateIfSupported() {
@@ -3527,6 +3532,7 @@ export class AdaptiveCard extends ContainerWithActions {
     private static currentVersion: Version = new Version(1, 0);
 
     static preExpandSingleShowCardAction: boolean = false;
+    static useAdvancedTextBlockTruncation: boolean = true;
 
     static readonly elementTypeRegistry = new ElementTypeRegistry();
     static readonly actionTypeRegistry = new ActionTypeRegistry();

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -3565,7 +3565,7 @@ export class AdaptiveCard extends ContainerWithActions {
         super.parse(json, "body");
     }
 
-    render(): HTMLElement {
+    render(target?: HTMLElement): HTMLElement {
         var renderedCard: HTMLElement;
 
         if (!this.isVersionSupported()) {
@@ -3582,6 +3582,11 @@ export class AdaptiveCard extends ContainerWithActions {
                     renderedCard.setAttribute("aria-label", this.speak);
                 }
             }
+        }
+
+        if (target) {
+            target.appendChild(renderedCard);
+            this.updateLayout();
         }
 
         return renderedCard;

--- a/source/nodejs/adaptivecards/src/rendercard.ts
+++ b/source/nodejs/adaptivecards/src/rendercard.ts
@@ -11,7 +11,10 @@ export interface IRenderOptions {
     processMarkdown?: (text: string) => string;
 }
 
-export function renderCard(card: IAdaptiveCard | string, options?: IRenderOptions): HTMLElement {
+export function renderCard(card: IAdaptiveCard | string,
+                           options?: IRenderOptions,
+                           target?: HTMLElement): HTMLElement {
+
     if (typeof card === "string") {
         card = <IAdaptiveCard>JSON.parse(card);
     }
@@ -45,5 +48,5 @@ export function renderCard(card: IAdaptiveCard | string, options?: IRenderOption
     adaptiveCard.parse(card);
     
     // Render the card
-    return adaptiveCard.render();
+    return adaptiveCard.render(target);
 }

--- a/source/nodejs/adaptivecards/src/utils.ts
+++ b/source/nodejs/adaptivecards/src/utils.ts
@@ -153,3 +153,88 @@ export class StringWithSubstitutions {
         this._isProcessed = false;
     }
 }
+
+export function truncate(element: HTMLElement,
+                         maxHeight: number,
+                         lineHeight?: number) {
+    var fits = () => {
+        // Allow a one pixel overflow to account for rounding differences
+        // between browsers
+        return maxHeight - element.scrollHeight >= -1.0;
+    };
+
+    if (fits()) return;
+
+    var fullText = element.innerHTML;
+    var truncateAt = (idx) => {
+        element.innerHTML = fullText.substring(0, idx) + '...';
+    }
+
+    var breakableIndices = findBreakableIndices(fullText);
+    var lo = 0;
+    var hi = breakableIndices.length;
+    var bestBreakIdx = 0;
+
+    // Do a binary search for the longest string that fits
+    while (lo < hi) {
+        var mid = Math.floor((lo + hi) / 2);
+        truncateAt(breakableIndices[mid]);
+
+        if (fits()) {
+            bestBreakIdx = breakableIndices[mid];
+            lo = mid + 1;
+        }
+        else {
+            hi = mid;
+        }
+    }
+
+    truncateAt(bestBreakIdx);
+
+    // If we have extra room, try to expand the string letter by letter
+    // (covers the case where we have to break in the middle of a long word)
+    if (lineHeight && maxHeight - element.scrollHeight >= lineHeight - 1.0) {
+        let idx = findNextCharacter(fullText, bestBreakIdx);
+
+        while (idx < fullText.length) {
+            truncateAt(idx);
+
+            if (fits()) {
+                bestBreakIdx = idx;
+                idx = findNextCharacter(fullText, idx);
+            }
+            else {
+                break;
+            }
+        }
+
+        truncateAt(bestBreakIdx);
+    }
+}
+
+function findBreakableIndices(html: string): Array<number> {
+    var results: Array<number> = [];
+    var idx = findNextCharacter(html, -1);
+
+    while (idx < html.length) {
+        if (html[idx] == ' ') {
+            results.push(idx);
+        }
+
+        idx = findNextCharacter(html, idx);
+    }
+
+    return results;
+}
+
+function findNextCharacter(html: string, currIdx: number): number {
+    currIdx += 1;
+
+    // If we found the start of an HTML tag, keep advancing until we get
+    // past it, so we don't end up truncating in the middle of the tag
+    while (currIdx < html.length && html[currIdx] == '<') {
+        while (currIdx < html.length && html[currIdx++] != '>');
+    }
+
+    return currIdx;
+}


### PR DESCRIPTION
*This is an updated approach to PR #791 -- creating a new PR since the render callback behavior is no longer desired.*

Updates the TypeScript renderer so that multi-line `TextBlock` elements get truncated and show ellipses, instead of overflowing with no indication that there is more content. Uses the `updateLayout()` function to trigger truncation.

This approach includes the following changes:

- Changes the signature of the `AdaptiveCard.render()` function to take an optional `HTMLElement` argument, which the card is then rendered into (as opposed to just returning an `HTMLElement` containing the card -- we need at least some control over when the card is rendered into the DOM so we can execute JS afterwards)

  - This matches the way it's done in React with the `ReactDOM.render()` method, and abstracts the `element.appendChild` call away from users
 &nbsp;

- Updates the visualizer containers to match the new signature, and ensures that cards always get rendered into an element which is part of the DOM

- Adds a toggle so the JS truncation can be turned off if desired (e.g. in performance critical situations)

This addresses #779.