### PR TITLE
Use shared xamlBuilder in image renderer

### DIFF
--- a/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
+++ b/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
@@ -920,9 +920,10 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
 
         HRESULT RenderAdaptiveCard([in] AdaptiveCard* adaptiveCard, [out, retval] RenderedAdaptiveCard** result);
 
+        // HRESULT RenderCardAsXamlAsync([in] AdaptiveCard* adaptiveCard, [out, retval] Windows.Foundation.IAsyncOperation<RenderedAdaptiveCard*>** result);
         HRESULT RenderAdaptiveCardFromJsonString([in] HSTRING adaptiveJson, [out, retval] RenderedAdaptiveCard** result);
-
         HRESULT RenderAdaptiveCardFromJson([in] Windows.Data.Json.JsonObject* adaptiveJson, [out, retval] RenderedAdaptiveCard** result);
+        // HRESULT RenderAdaptiveJsonAsXamlAsync([in] HSTRING adaptiveJson, [out, retval] Windows.Foundation.IAsyncOperation<RenderedAdaptiveCard*>** result);
 
         [propget] HRESULT ElementRenderers([out, retval] AdaptiveElementRendererRegistration** result);
     };

--- a/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
+++ b/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
@@ -920,10 +920,8 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
 
         HRESULT RenderAdaptiveCard([in] AdaptiveCard* adaptiveCard, [out, retval] RenderedAdaptiveCard** result);
 
-        // HRESULT RenderCardAsXamlAsync([in] AdaptiveCard* adaptiveCard, [out, retval] Windows.Foundation.IAsyncOperation<RenderedAdaptiveCard*>** result);
         HRESULT RenderAdaptiveCardFromJsonString([in] HSTRING adaptiveJson, [out, retval] RenderedAdaptiveCard** result);
         HRESULT RenderAdaptiveCardFromJson([in] Windows.Data.Json.JsonObject* adaptiveJson, [out, retval] RenderedAdaptiveCard** result);
-        // HRESULT RenderAdaptiveJsonAsXamlAsync([in] HSTRING adaptiveJson, [out, retval] Windows.Foundation.IAsyncOperation<RenderedAdaptiveCard*>** result);
 
         [propget] HRESULT ElementRenderers([out, retval] AdaptiveElementRendererRegistration** result);
     };

--- a/source/uwp/Renderer/lib/AdaptiveCardRendererComponent.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveCardRendererComponent.cpp
@@ -23,7 +23,6 @@
 #include "DefaultResourceDictionary.h"
 #include "InputItem.h"
 #include "RenderedAdaptiveCard.h"
-#include "XamlBuilder.h"
 #include "XamlHelpers.h"
 #include <windows.foundation.collections.h>
 #include <Windows.UI.Xaml.h>
@@ -49,6 +48,7 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
 {
     HRESULT AdaptiveCardRenderer::RuntimeClassInitialize()
     {
+        m_xamlBuilder = std::make_shared<XamlBuilder>();
         RETURN_IF_FAILED(MakeAndInitialize<AdaptiveElementRendererRegistration>(&m_elementRendererRegistration));
         RETURN_IF_FAILED(RegisterDefaultElementRenderers());
         RETURN_IF_FAILED(MakeAndInitialize<AdaptiveHostConfig>(&m_hostConfig));
@@ -108,15 +108,13 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         RETURN_IF_FAILED(MakeAndInitialize<::AdaptiveCards::Rendering::Uwp::RenderedAdaptiveCard>(&renderedCard));
         renderedCard->SetOriginatingCard(adaptiveCard);
 
-        XamlBuilder xamlBuilder;
-
         if (adaptiveCard)
         {
             ComPtr<IUIElement> xamlTreeRoot;
 
             if (m_explicitDimensions)
             {
-                RETURN_IF_FAILED(xamlBuilder.SetFixedDimensions(m_desiredWidth, m_desiredHeight));
+                RETURN_IF_FAILED(m_xamlBuilder->SetFixedDimensions(m_desiredWidth, m_desiredHeight));
             }
 
             ComPtr<AdaptiveRenderContext> renderContext;
@@ -131,10 +129,10 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
             // This path is used for synchronous Xaml card rendering, so we don't want
             // to manually download the image assets and instead just want xaml to do
             // that automatically
-            xamlBuilder.SetEnableXamlImageHandling(true);
+            m_xamlBuilder->SetEnableXamlImageHandling(true);
             try
             {
-                xamlBuilder.BuildXamlTreeFromAdaptiveCard(adaptiveCard, &xamlTreeRoot, this, renderContext.Get());
+                m_xamlBuilder->BuildXamlTreeFromAdaptiveCard(adaptiveCard, &xamlTreeRoot, this, renderContext.Get());
                 renderedCard->SetFrameworkElement(xamlTreeRoot.Get());
             }
             catch (...)
@@ -294,7 +292,7 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         RETURN_IF_FAILED(m_elementRendererRegistration->Set(HStringReference(L"Container").Get(), Make<AdaptiveContainerRenderer>().Get()));
         RETURN_IF_FAILED(m_elementRendererRegistration->Set(HStringReference(L"Input.Date").Get(), Make<AdaptiveDateInputRenderer>().Get()));
         RETURN_IF_FAILED(m_elementRendererRegistration->Set(HStringReference(L"FactSet").Get(), Make<AdaptiveFactSetRenderer>().Get()));
-        RETURN_IF_FAILED(m_elementRendererRegistration->Set(HStringReference(L"Image").Get(), Make<AdaptiveImageRenderer>().Get()));
+        RETURN_IF_FAILED(m_elementRendererRegistration->Set(HStringReference(L"Image").Get(), Make<AdaptiveImageRenderer>(m_xamlBuilder).Get()));
         RETURN_IF_FAILED(m_elementRendererRegistration->Set(HStringReference(L"ImageSet").Get(), Make<AdaptiveImageSetRenderer>().Get()));
         RETURN_IF_FAILED(m_elementRendererRegistration->Set(HStringReference(L"Input.Number").Get(), Make<AdaptiveNumberInputRenderer>().Get()));
         RETURN_IF_FAILED(m_elementRendererRegistration->Set(HStringReference(L"TextBlock").Get(), Make<AdaptiveTextBlockRenderer>().Get()));
@@ -302,6 +300,11 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         RETURN_IF_FAILED(m_elementRendererRegistration->Set(HStringReference(L"Input.Time").Get(), Make<AdaptiveTimeInputRenderer>().Get()));
         RETURN_IF_FAILED(m_elementRendererRegistration->Set(HStringReference(L"Input.Toggle").Get(), Make<AdaptiveToggleInputRenderer>().Get()));
         return S_OK;
+    }
+
+    std::shared_ptr<XamlBuilder> AdaptiveCardRenderer::GetXamlBuilder()
+    {
+        return m_xamlBuilder;
     }
 
 }}}

--- a/source/uwp/Renderer/lib/AdaptiveCardRendererComponent.h
+++ b/source/uwp/Renderer/lib/AdaptiveCardRendererComponent.h
@@ -1,9 +1,11 @@
 ﻿#pragma once
 
 #include "AdaptiveCards.Rendering.Uwp.h"
+#include "XamlBuilder.h"
 
 namespace AdaptiveCards { namespace Rendering { namespace Uwp
 {
+    class XamlBuilder;
 
     // This class is effectively a singleton, and stays around between subsequent renders.
     class AdaptiveCardRenderer :
@@ -43,6 +45,7 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveHostConfig* GetHostConfig();
         Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IResourceDictionary> GetMergedDictionary();
         bool GetFixedDimensions(_Out_ UINT32* width, _Out_ UINT32* height);
+        std::shared_ptr<AdaptiveCards::Rendering::Uwp::XamlBuilder> GetXamlBuilder();
 
         IFACEMETHODIMP get_ResourceResolvers(
             _COM_Outptr_ ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardResourceResolvers** value);
@@ -55,6 +58,7 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardResourceResolvers> m_resourceResolvers;
         Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveElementRendererRegistration> m_elementRendererRegistration;
 
+        std::shared_ptr<AdaptiveCards::Rendering::Uwp::XamlBuilder> m_xamlBuilder;
         bool m_explicitDimensions = false;
         UINT32 m_desiredWidth = 0;
         UINT32 m_desiredHeight = 0;

--- a/source/uwp/Renderer/lib/AdaptiveChoiceInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceInput.cpp
@@ -2,7 +2,6 @@
 #include "AdaptiveChoiceInput.h"
 #include "Util.h"
 #include <windows.foundation.collections.h>
-#include "AdaptiveCardRendererComponent.h"
 
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;

--- a/source/uwp/Renderer/lib/AdaptiveChoiceSetInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceSetInput.cpp
@@ -4,7 +4,6 @@
 #include "Util.h"
 #include "Vector.h"
 #include <windows.foundation.collections.h>
-#include "AdaptiveCardRendererComponent.h"
 
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;

--- a/source/uwp/Renderer/lib/AdaptiveColumn.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveColumn.cpp
@@ -4,7 +4,6 @@
 #include "Util.h"
 #include "Vector.h"
 #include <windows.foundation.collections.h>
-#include "AdaptiveCardRendererComponent.h"
 
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;

--- a/source/uwp/Renderer/lib/AdaptiveColumnSet.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveColumnSet.cpp
@@ -4,7 +4,6 @@
 #include "Util.h"
 #include "Vector.h"
 #include <windows.foundation.collections.h>
-#include "AdaptiveCardRendererComponent.h"
 #include "XamlHelpers.h"
 #include "AdaptiveColumn.h"
 

--- a/source/uwp/Renderer/lib/AdaptiveContainer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveContainer.cpp
@@ -4,7 +4,6 @@
 #include "Util.h"
 #include "Vector.h"
 #include <windows.foundation.collections.h>
-#include "AdaptiveCardRendererComponent.h"
 
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;

--- a/source/uwp/Renderer/lib/AdaptiveDateInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveDateInput.cpp
@@ -2,7 +2,6 @@
 #include "AdaptiveDateInput.h"
 #include "Util.h"
 #include <windows.foundation.collections.h>
-#include "AdaptiveCardRendererComponent.h"
 
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;

--- a/source/uwp/Renderer/lib/AdaptiveFact.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveFact.cpp
@@ -2,7 +2,6 @@
 #include "AdaptiveFact.h"
 #include "Util.h"
 #include <windows.foundation.collections.h>
-#include "AdaptiveCardRendererComponent.h"
 
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;

--- a/source/uwp/Renderer/lib/AdaptiveFactSet.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveFactSet.cpp
@@ -4,7 +4,6 @@
 #include "Util.h"
 #include "Vector.h"
 #include <windows.foundation.collections.h>
-#include "AdaptiveCardRendererComponent.h"
 
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;

--- a/source/uwp/Renderer/lib/AdaptiveImage.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImage.cpp
@@ -2,7 +2,6 @@
 #include "AdaptiveImage.h"
 
 #include "Util.h"
-#include "AdaptiveCardRendererComponent.h"
 
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;

--- a/source/uwp/Renderer/lib/AdaptiveImageRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImageRenderer.cpp
@@ -14,6 +14,15 @@ using namespace ABI::Windows::Foundation;
 namespace AdaptiveCards { namespace Rendering { namespace Uwp
 {
 
+    AdaptiveImageRenderer::AdaptiveImageRenderer()
+    {
+        m_xamlBuilder = std::make_shared<XamlBuilder>();
+    }
+
+    AdaptiveImageRenderer::AdaptiveImageRenderer(std::shared_ptr<XamlBuilder> xamlBuilder) : m_xamlBuilder(xamlBuilder)
+    {
+    }
+
     HRESULT AdaptiveImageRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -26,7 +35,7 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         IAdaptiveRenderArgs* renderArgs,
         ABI::Windows::UI::Xaml::IUIElement** result)
     {
-        m_xamlBuilder.BuildImage(cardElement, renderContext, renderArgs, result);
+        m_xamlBuilder->BuildImage(cardElement, renderContext, renderArgs, result);
         return S_OK;
     }
 

--- a/source/uwp/Renderer/lib/AdaptiveImageRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveImageRenderer.h
@@ -17,6 +17,8 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         InspectableClass(RuntimeClass_AdaptiveCards_Rendering_Uwp_AdaptiveImageRenderer, BaseTrust)
 
     public:
+        AdaptiveImageRenderer();
+        AdaptiveImageRenderer(std::shared_ptr<AdaptiveCards::Rendering::Uwp::XamlBuilder> xamlBuilder);
         HRESULT RuntimeClassInitialize() noexcept;
 
         IFACEMETHODIMP Render(
@@ -32,7 +34,7 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement** element);
 
     private:
-        AdaptiveCards::Rendering::Uwp::XamlBuilder m_xamlBuilder;
+        std::shared_ptr<AdaptiveCards::Rendering::Uwp::XamlBuilder> m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveImageRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveImageSet.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImageSet.cpp
@@ -4,7 +4,6 @@
 #include "Util.h"
 #include "Vector.h"
 #include <windows.foundation.collections.h>
-#include "AdaptiveCardRendererComponent.h"
 
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;

--- a/source/uwp/Renderer/lib/AdaptiveNumberInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveNumberInput.cpp
@@ -3,7 +3,6 @@
 
 #include "Util.h"
 #include <windows.foundation.collections.h>
-#include "AdaptiveCardRendererComponent.h"
 
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;

--- a/source/uwp/Renderer/lib/AdaptiveSeparator.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveSeparator.cpp
@@ -2,7 +2,6 @@
 #include "AdaptiveSeparator.h"
 #include "Util.h"
 #include <windows.foundation.collections.h>
-#include "AdaptiveCardRendererComponent.h"
 
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;

--- a/source/uwp/Renderer/lib/AdaptiveTextBlock.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTextBlock.cpp
@@ -2,7 +2,6 @@
 #include "AdaptiveTextBlock.h"
 #include "Util.h"
 #include <windows.foundation.collections.h>
-#include "AdaptiveCardRendererComponent.h"
 
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;

--- a/source/uwp/Renderer/lib/AdaptiveTextInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTextInput.cpp
@@ -3,7 +3,6 @@
 
 #include "Util.h"
 #include <windows.foundation.collections.h>
-#include "AdaptiveCardRendererComponent.h"
 
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;

--- a/source/uwp/Renderer/lib/AdaptiveTimeInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTimeInput.cpp
@@ -3,7 +3,6 @@
 
 #include "Util.h"
 #include <windows.foundation.collections.h>
-#include "AdaptiveCardRendererComponent.h"
 
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;

--- a/source/uwp/Renderer/lib/AdaptiveToggleInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveToggleInput.cpp
@@ -3,7 +3,6 @@
 
 #include "Util.h"
 #include <windows.foundation.collections.h>
-#include "AdaptiveCardRendererComponent.h"
 
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;

--- a/source/uwp/Renderer/lib/AsyncOperations.h
+++ b/source/uwp/Renderer/lib/AsyncOperations.h
@@ -34,13 +34,12 @@ public:
         THROW_IF_FAILED(coreWindowStatic->GetForCurrentThread(coreWindow.GetAddressOf()));
         THROW_IF_FAILED(coreWindow->get_Dispatcher(&m_dispatcher));
 
-        m_builder = Microsoft::WRL::Make<AdaptiveCards::Rendering::Uwp::XamlBuilder>();
         UINT32 width = 0;
         UINT32 height = 0;
         bool explicitDimensions = m_renderer->GetFixedDimensions(&width, &height);
         if (explicitDimensions)
         {
-            THROW_IF_FAILED(m_builder->SetFixedDimensions(width, height));
+            THROW_IF_FAILED(m_renderer->GetXamlBuilder()->SetFixedDimensions(width, height));
         }
     }
 
@@ -75,7 +74,6 @@ protected:
     Microsoft::WRL::ComPtr<AdaptiveCards::Rendering::Uwp::RenderedAdaptiveCard> m_renderResult;
     Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IUIElement> m_rootXamlElement;
     Microsoft::WRL::ComPtr<ABI::Windows::UI::Core::ICoreDispatcher> m_dispatcher;
-    Microsoft::WRL::ComPtr<AdaptiveCards::Rendering::Uwp::XamlBuilder> m_builder;
     Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCard> m_card;
     Microsoft::WRL::ComPtr<AdaptiveCards::Rendering::Uwp::AdaptiveCardRenderer> m_renderer;
 
@@ -85,10 +83,9 @@ protected:
         m_dispatcher->RunAsync(ABI::Windows::UI::Core::CoreDispatcherPriority_Normal,
             MakeAgileDispatcherCallback([this]() -> HRESULT
         {
-            m_builder->AddListener(this);
+            m_renderer->GetXamlBuilder()->AddListener(this);
             try
             {
-                THROW_IF_FAILED(MakeAndInitialize<AdaptiveCards::Rendering::Uwp::RenderedAdaptiveCard>(&m_renderResult));
                 ComPtr<ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveElementRendererRegistration> elementRenderers;
                 THROW_IF_FAILED(m_renderer->get_ElementRenderers(&elementRenderers));
                 ComPtr<ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardResourceResolvers> resourceResolvers;
@@ -104,7 +101,7 @@ protected:
                     overrideDictionary.Get(),
                     m_renderResult.Get()));
 
-                m_builder->BuildXamlTreeFromAdaptiveCard(m_card.Get(), &m_rootXamlElement, m_renderer.Get(), renderContext.Get());
+                m_renderer->GetXamlBuilder()->BuildXamlTreeFromAdaptiveCard(m_card.Get(), &m_rootXamlElement, m_renderer.Get(), renderContext.Get());
             }
             catch (...)
             {
@@ -143,6 +140,7 @@ protected:
     }
 
 private:
+
     std::function<ABI::AdaptiveCards::Rendering::Uwp::IRenderedAdaptiveCard*(ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCard*)> m_dispatchFunction;
 };
 
@@ -159,6 +157,7 @@ public:
     {
         AsyncBase::Start();
     }
+
 
     STDMETHODIMP ABI::Windows::Foundation::IAsyncOperation_impl<TResult_complex>::GetResults(ABI::AdaptiveCards::Rendering::Uwp::IRenderedAdaptiveCard** result)
     {

--- a/source/uwp/Renderer/lib/RenderedAdaptiveCard.cpp
+++ b/source/uwp/Renderer/lib/RenderedAdaptiveCard.cpp
@@ -34,7 +34,18 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         m_errors = Make<Vector<IAdaptiveError*>>();
         m_warnings = Make<Vector<IAdaptiveWarning*>>();
         RETURN_IF_FAILED(MakeAndInitialize<AdaptiveCards::Rendering::Uwp::AdaptiveInputs>(&m_inputs));
-        m_events.reset(new ActionEventSource);
+        m_events = std::make_shared<ActionEventSource>();
+        return S_OK;
+    }
+
+    HRESULT RenderedAdaptiveCard::RuntimeClassInitialize(
+        _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveError*>* errors,
+        _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveWarning*>* warnings)
+    {
+        m_errors = errors;
+        m_warnings = warnings;
+        RETURN_IF_FAILED(MakeAndInitialize<AdaptiveCards::Rendering::Uwp::AdaptiveInputs>(&m_inputs));
+        m_events = std::make_shared<ActionEventSource>();
         return S_OK;
     }
 

--- a/source/uwp/Renderer/lib/RenderedAdaptiveCard.h
+++ b/source/uwp/Renderer/lib/RenderedAdaptiveCard.h
@@ -19,6 +19,9 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         RenderedAdaptiveCard();
 
         HRESULT RuntimeClassInitialize();
+        HRESULT RuntimeClassInitialize(
+            _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveError*>* errors,
+            _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveWarning*>* warnings);
 
         // IRenderedAdaptiveCard
         IFACEMETHODIMP get_OriginatingCard(_COM_Outptr_ ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCard** value);

--- a/source/uwp/Renderer/lib/XamlBuilder.h
+++ b/source/uwp/Renderer/lib/XamlBuilder.h
@@ -4,7 +4,6 @@
 #include "ImageLoadTracker.h"
 #include "IXamlBuilderListener.h"
 #include "IImageLoadTrackerListener.h"
-#include "AdaptiveCardRendererComponent.h"
 #include <windows.storage.h>
 #include "InputItem.h"
 #include "RenderedAdaptiveCard.h"


### PR DESCRIPTION
Image renderer needs to share the same XamlBuilder as the AdaptiveCardRenderer, otherwise the XamlBuilder's image tracking capabilities and the settings to allow xaml to load the images do not sync correctly.

Fixes #991 