### PR TITLE
Change text color definition keys from normal to default

### DIFF
--- a/source/nodejs/adaptivecards-visualizer/src/containers/bf-image.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/bf-image.ts
@@ -64,23 +64,23 @@ export class BotFrameworkImageContainer extends HostContainer {
                     backgroundColor: "#FFFFFF",
                     foregroundColors: {
                         default: {
-                            normal: "#FF101010",
+                            default: "#FF101010",
                             subtle: "#b2101010"
                         },
                         accent: {
-                            normal: "#FF0000FF",
+                            default: "#FF0000FF",
                             subtle: "#b20000FF"
                         },
                         good: {
-                            normal: "#FF008000",
+                            default: "#FF008000",
                             subtle: "#b2008000"
                         },
                         warning: {
-                            normal: "#FFFFD700",
+                            default: "#FFFFD700",
                             subtle: "#b2FFD700"
                         },
                         attention: {
-                            normal: "#FF8B0000",
+                            default: "#FF8B0000",
                             subtle: "#b28B0000"
                         }
                     }
@@ -89,23 +89,23 @@ export class BotFrameworkImageContainer extends HostContainer {
                     backgroundColor: "#08000000",
                     foregroundColors: {
                         default: {
-                            normal: "#FF101010",
+                            default: "#FF101010",
                             subtle: "#b2101010"
                         },
                         accent: {
-                            normal: "#FF0000FF",
+                            default: "#FF0000FF",
                             subtle: "#b20000FF"
                         },
                         good: {
-                            normal: "#FF008000",
+                            default: "#FF008000",
                             subtle: "#b2008000"
                         },
                         warning: {
-                            normal: "#FFFFD700",
+                            default: "#FFFFD700",
                             subtle: "#b2FFD700"
                         },
                         attention: {
-                            normal: "#FF8B0000",
+                            default: "#FF8B0000",
                             subtle: "#b28B0000"
                         }
                     }

--- a/source/nodejs/adaptivecards-visualizer/src/containers/headless.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/headless.ts
@@ -81,23 +81,23 @@ export class HeadlessContainer extends HostContainer {
                     backgroundColor: "#FFFFFF",
                     foregroundColors: {
                         default: {
-                            normal: "#333333",
+                            default: "#333333",
                             subtle: "#EE333333"
                         },
                         accent: {
-                            normal: "#2E89FC",
+                            default: "#2E89FC",
                             subtle: "#882E89FC"
                         },
                         attention: {
-                            normal: "#FFD800",
+                            default: "#FFD800",
                             subtle: "#DDFFD800"
                         },
                         good: {
-                            normal: "#00FF00",
+                            default: "#00FF00",
                             subtle: "#DD00FF00"
                         },
                         warning: {
-                            normal: "#FF0000",
+                            default: "#FF0000",
                             subtle: "#DDFF0000"
                         }
                     }
@@ -106,23 +106,23 @@ export class HeadlessContainer extends HostContainer {
                     backgroundColor: "#08000000",
                     foregroundColors: {
                         default: {
-                            normal: "#333333",
+                            default: "#333333",
                             subtle: "#EE333333"
                         },
                         accent: {
-                            normal: "#2E89FC",
+                            default: "#2E89FC",
                             subtle: "#882E89FC"
                         },
                         attention: {
-                            normal: "#FFD800",
+                            default: "#FFD800",
                             subtle: "#DDFFD800"
                         },
                         good: {
-                            normal: "#00FF00",
+                            default: "#00FF00",
                             subtle: "#DD00FF00"
                         },
                         warning: {
-                            normal: "#FF0000",
+                            default: "#FF0000",
                             subtle: "#DDFF0000"
                         }
                     }

--- a/source/nodejs/adaptivecards-visualizer/src/containers/host-container.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/host-container.ts
@@ -146,23 +146,23 @@ export abstract class HostContainer {
                     backgroundColor: "#00000000",
                     foregroundColors: {
                         default: {
-                            normal: "#333333",
+                            default: "#333333",
                             subtle: "#EE333333"
                         },
                         accent: {
-                            normal: "#2E89FC",
+                            default: "#2E89FC",
                             subtle: "#882E89FC"
                         },
                         attention: {
-                            normal: "#FFD800",
+                            default: "#FFD800",
                             subtle: "#DDFFD800"
                         },
                         good: {
-                            normal: "#00FF00",
+                            default: "#00FF00",
                             subtle: "#DD00FF00"
                         },
                         warning: {
-                            normal: "#FF0000",
+                            default: "#FF0000",
                             subtle: "#DDFF0000"
                         }
                     }
@@ -171,23 +171,23 @@ export abstract class HostContainer {
                     backgroundColor: "08000000",
                     foregroundColors: {
                         default: {
-                            normal: "#333333",
+                            default: "#333333",
                             subtle: "#EE333333"
                         },
                         accent: {
-                            normal: "#2E89FC",
+                            default: "#2E89FC",
                             subtle: "#882E89FC"
                         },
                         attention: {
-                            normal: "#FFD800",
+                            default: "#FFD800",
                             subtle: "#DDFFD800"
                         },
                         good: {
-                            normal: "#00FF00",
+                            default: "#00FF00",
                             subtle: "#DD00FF00"
                         },
                         warning: {
-                            normal: "#FF0000",
+                            default: "#FF0000",
                             subtle: "#DDFF0000"
                         }
                     }

--- a/source/nodejs/adaptivecards-visualizer/src/containers/outlook.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/outlook.ts
@@ -110,23 +110,23 @@ export class OutlookContainer extends HostContainer {
                     backgroundColor: "#FFFFFF",
                     foregroundColors: {
                         default: {
-                            normal: "#333333",
+                            default: "#333333",
                             subtle: "#EE333333"
                         },
                         accent: {
-                            normal: "#2E89FC",
+                            default: "#2E89FC",
                             subtle: "#882E89FC"
                         },
                         attention: {
-                            normal: "#cc3300",
+                            default: "#cc3300",
                             subtle: "#DDcc3300"
                         },
                         good: {
-                            normal: "#54a254",
+                            default: "#54a254",
                             subtle: "#DD54a254"
                         },
                         warning: {
-                            normal: "#e69500",
+                            default: "#e69500",
                             subtle: "#DDe69500"
                         }
                     }
@@ -135,23 +135,23 @@ export class OutlookContainer extends HostContainer {
                     backgroundColor: "#08000000",
                     foregroundColors: {
                         default: {
-                            normal: "#333333",
+                            default: "#333333",
                             subtle: "#EE333333"
                         },
                         accent: {
-                            normal: "#2E89FC",
+                            default: "#2E89FC",
                             subtle: "#882E89FC"
                         },
                         attention: {
-                            normal: "#cc3300",
+                            default: "#cc3300",
                             subtle: "#DDcc3300"
                         },
                         good: {
-                            normal: "#54a254",
+                            default: "#54a254",
                             subtle: "#DD54a254"
                         },
                         warning: {
-                            normal: "#e69500",
+                            default: "#e69500",
                             subtle: "#DDe69500"
                         }
                     }

--- a/source/nodejs/adaptivecards-visualizer/src/containers/skype.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/skype.ts
@@ -82,23 +82,23 @@ export class SkypeContainer extends HostContainer {
                     backgroundColor: "#EAEAEA",
                     foregroundColors: {
                         default: {
-                            normal: "#333333",
+                            default: "#333333",
                             subtle: "#EE333333"
                         },
                         accent: {
-                            normal: "#2E89FC",
+                            default: "#2E89FC",
                             subtle: "#882E89FC"
                         },
                         attention: {
-                            normal: "#FF0000",
+                            default: "#FF0000",
                             subtle: "#DDFF0000"
                         },
                         good: {
-                            normal: "#54a254",
+                            default: "#54a254",
                             subtle: "#DD54a254"
                         },
                         warning: {
-                            normal: "#c3ab23",
+                            default: "#c3ab23",
                             subtle: "#DDc3ab23"
                         }
                     }
@@ -107,23 +107,23 @@ export class SkypeContainer extends HostContainer {
                     backgroundColor: "#08000000",
                     foregroundColors: {
                         default: {
-                            normal: "#333333",
+                            default: "#333333",
                             subtle: "#EE333333"
                         },
                         accent: {
-                            normal: "#2E89FC",
+                            default: "#2E89FC",
                             subtle: "#882E89FC"
                         },
                         attention: {
-                            normal: "#FF0000",
+                            default: "#FF0000",
                             subtle: "#DDFF0000"
                         },
                         good: {
-                            normal: "#54a254",
+                            default: "#54a254",
                             subtle: "#DD54a254"
                         },
                         warning: {
-                            normal: "#c3ab23",
+                            default: "#c3ab23",
                             subtle: "#DDc3ab23"
                         }
                     }

--- a/source/nodejs/adaptivecards-visualizer/src/containers/teams.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/teams.ts
@@ -59,23 +59,23 @@ export class TeamsContainer extends HostContainer {
                     backgroundColor: "#00000000",
                     foregroundColors: {
                         default: {
-                            normal: "#333333",
+                            default: "#333333",
                             subtle: "#EE333333"
                         },
                         accent: {
-                            normal: "#2E89FC",
+                            default: "#2E89FC",
                             subtle: "#882E89FC"
                         },
                         attention: {
-                            normal: "#cc3300",
+                            default: "#cc3300",
                             subtle: "#DDcc3300"
                         },
                         good: {
-                            normal: "#54a254",
+                            default: "#54a254",
                             subtle: "#DD54a254"
                         },
                         warning: {
-                            normal: "#e69500",
+                            default: "#e69500",
                             subtle: "#DDe69500"
                         }
                     }
@@ -84,23 +84,23 @@ export class TeamsContainer extends HostContainer {
                     backgroundColor: "#08000000",
                     foregroundColors: {
                         default: {
-                            normal: "#333333",
+                            default: "#333333",
                             subtle: "#EE333333"
                         },
                         accent: {
-                            normal: "#2E89FC",
+                            default: "#2E89FC",
                             subtle: "#882E89FC"
                         },
                         attention: {
-                            normal: "#cc3300",
+                            default: "#cc3300",
                             subtle: "#DDcc3300"
                         },
                         good: {
-                            normal: "#54a254",
+                            default: "#54a254",
                             subtle: "#DD54a254"
                         },
                         warning: {
-                            normal: "#e69500",
+                            default: "#e69500",
                             subtle: "#DDe69500"
                         }
                     }

--- a/source/nodejs/adaptivecards-visualizer/src/containers/timeline.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/timeline.ts
@@ -73,23 +73,23 @@ export class TimelineContainer extends HostContainer {
                     backgroundColor: "#535454",
                     foregroundColors: {
                         default: {
-                            "normal": "#FFFFFF",
+                            "default": "#FFFFFF",
                             "subtle": "#9C9E9F"
                         },
                         accent: {
-                            "normal": "#2E89FC",
+                            "default": "#2E89FC",
                             "subtle": "#882E89FC"
                         },
                         attention: {
-                            "normal": "#FF0000",
+                            "default": "#FF0000",
                             "subtle": "#DDFF0000"
                         },
                         good: {
-                            "normal": "#00FF00",
+                            "default": "#00FF00",
                             "subtle": "#DD00FF00"
                         },
                         warning: {
-                            "normal": "#FFD800",
+                            "default": "#FFD800",
                             "subtle": "#DDFFD800"
                         }
                     }
@@ -98,23 +98,23 @@ export class TimelineContainer extends HostContainer {
                     backgroundColor: "#33000000",
                     foregroundColors: {
                         default: {
-                            "normal": "#FFFFFF",
+                            "default": "#FFFFFF",
                             "subtle": "#9C9E9F"
                         },
                         accent: {
-                            "normal": "#2E89FC",
+                            "default": "#2E89FC",
                             "subtle": "#882E89FC"
                         },
                         attention: {
-                            "normal": "#FF0000",
+                            "default": "#FF0000",
                             "subtle": "#DDFF0000"
                         },
                         good: {
-                            "normal": "#00FF00",
+                            "default": "#00FF00",
                             "subtle": "#DD00FF00"
                         },
                         warning: {
-                            "normal": "#FFD800",
+                            "default": "#FFD800",
                             "subtle": "#DDFFD800"
                         }
                     }

--- a/source/nodejs/adaptivecards-visualizer/src/containers/toast.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/toast.ts
@@ -66,23 +66,23 @@ export class ToastContainer extends HostContainer {
                     backgroundColor: "#1F1F1F",
                     foregroundColors: {
                         default: {
-                            normal: "#FFFFFF",
+                            default: "#FFFFFF",
                             subtle: "#88FFFFFF"
                         },
                         accent: {
-                            normal: "#2E89FC",
+                            default: "#2E89FC",
                             subtle: "#882E89FC"
                         },
                         attention: {
-                            normal: "#FF0000",
+                            default: "#FF0000",
                             subtle: "#DDFF0000"
                         },
                         good: {
-                            normal: "#00FF00",
+                            default: "#00FF00",
                             subtle: "#DD00FF00"
                         },
                         warning: {
-                            normal: "#FFD800",
+                            default: "#FFD800",
                             subtle: "#DDFFD800"
                         }                    
                     }
@@ -91,23 +91,23 @@ export class ToastContainer extends HostContainer {
                     backgroundColor: "#19FFFFFF",
                     foregroundColors: {
                         default: {
-                            normal: "#FFFFFF",
+                            default: "#FFFFFF",
                             subtle: "#88FFFFFF"
                         },
                         accent: {
-                            normal: "#2E89FC",
+                            default: "#2E89FC",
                             subtle: "#882E89FC"
                         },
                         attention: {
-                            normal: "#FFD800",
+                            default: "#FFD800",
                             subtle: "#DDFFD800"
                         },
                         good: {
-                            normal: "#00FF00",
+                            default: "#00FF00",
                             subtle: "#DD00FF00"
                         },
                         warning: {
-                            normal: "#FF0000",
+                            default: "#FF0000",
                             subtle: "#DDFF0000"
                         }
                     }

--- a/source/nodejs/adaptivecards-visualizer/src/containers/webchat.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/webchat.ts
@@ -86,23 +86,23 @@ export class WebChatContainer extends HostContainer {
                     backgroundColor: "#FFFFFF",
                     foregroundColors: {
                         default: {
-                            normal: "#333333",
+                            default: "#333333",
                             subtle: "#EE333333"
                         },
                         accent: {
-                            normal: "#2E89FC",
+                            default: "#2E89FC",
                             subtle: "#882E89FC"
                         },
                         attention: {
-                            normal: "#FF0000",
+                            default: "#FF0000",
                             subtle: "#DDFF0000"
                         },
                         good: {
-                            normal: "#54a254",
+                            default: "#54a254",
                             subtle: "#DD54a254"
                         },
                         warning: {
-                            normal: "#c3ab23",
+                            default: "#c3ab23",
                             subtle: "#DDc3ab23"
                         }
                     }
@@ -111,23 +111,23 @@ export class WebChatContainer extends HostContainer {
                     backgroundColor: "#08000000",
                     foregroundColors: {
                         default: {
-                            normal: "#333333",
+                            default: "#333333",
                             subtle: "#EE333333"
                         },
                         accent: {
-                            normal: "#2E89FC",
+                            default: "#2E89FC",
                             subtle: "#882E89FC"
                         },
                         attention: {
-                            normal: "#FF0000",
+                            default: "#FF0000",
                             subtle: "#DDFF0000"
                         },
                         good: {
-                            normal: "#54a254",
+                            default: "#54a254",
                             subtle: "#DD54a254"
                         },
                         warning: {
-                            normal: "#c3ab23",
+                            default: "#c3ab23",
                             subtle: "#DDc3ab23"
                         }
                     }

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -3710,31 +3710,31 @@ const defaultHostConfig: HostConfig.HostConfig = new HostConfig.HostConfig(
             backgroundColor: "#FFFFFF",
             foregroundColors: {
                 default: {
-                    normal: "#333333",
+                    default: "#333333",
                     subtle: "#EE333333"
                 },
                 dark: {
-                    normal: "#000000",
+                    default: "#000000",
                     subtle: "#66000000"
                 },
                 light: {
-                    normal: "#FFFFFF",
+                    default: "#FFFFFF",
                     subtle: "#33000000"
                 },
                 accent: {
-                    normal: "#2E89FC",
+                    default: "#2E89FC",
                     subtle: "#882E89FC"
                 },
                 attention: {
-                    normal: "#cc3300",
+                    default: "#cc3300",
                     subtle: "#DDcc3300"
                 },
                 good: {
-                    normal: "#54a254",
+                    default: "#54a254",
                     subtle: "#DD54a254"
                 },
                 warning: {
-                    normal: "#e69500",
+                    default: "#e69500",
                     subtle: "#DDe69500"
                 }
             }
@@ -3743,31 +3743,31 @@ const defaultHostConfig: HostConfig.HostConfig = new HostConfig.HostConfig(
             backgroundColor: "#08000000",
             foregroundColors: {
                 default: {
-                    normal: "#333333",
+                    default: "#333333",
                     subtle: "#EE333333"
                 },
                 dark: {
-                    normal: "#000000",
+                    default: "#000000",
                     subtle: "#66000000"
                 },
                 light: {
-                    normal: "#FFFFFF",
+                    default: "#FFFFFF",
                     subtle: "#33000000"
                 },
                 accent: {
-                    normal: "#2E89FC",
+                    default: "#2E89FC",
                     subtle: "#882E89FC"
                 },
                 attention: {
-                    normal: "#cc3300",
+                    default: "#cc3300",
                     subtle: "#DDcc3300"
                 },
                 good: {
-                    normal: "#54a254",
+                    default: "#54a254",
                     subtle: "#DD54a254"
                 },
                 warning: {
-                    normal: "#e69500",
+                    default: "#e69500",
                     subtle: "#DDe69500"
                 }
             }


### PR DESCRIPTION
Looks like a previous commit changed the code in host-config.ts to look for `default` instead of `normal` in text color definitions without changing the hard-coded host config values. This PR updates those values so that text colors work as expected in the visualizer again (especially noticeable for the Windows Notification and Timeline containers).