### PR TITLE
Truncate bottom overflows for fixed height cards

### DIFF
--- a/source/nodejs/adaptivecards-visualizer/src/containers/timeline.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/timeline.ts
@@ -27,6 +27,8 @@ export class TimelineContainer extends HostContainer {
     }
 
     protected renderContainer(adaptiveCard: AdaptiveCard, target: HTMLElement): HTMLElement {
+        AdaptiveCard.useAdvancedCardBottomTruncation = true;
+
         var element = document.createElement("div");
         element.style.width = this._width + "px";
         element.style.height = this._height + "px";

--- a/source/nodejs/adaptivecards-visualizer/src/containers/timeline.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/timeline.ts
@@ -34,8 +34,10 @@ export class TimelineContainer extends HostContainer {
         element.style.overflow = "hidden";
         target.appendChild(element);
 
-        var renderedCard = adaptiveCard.render(element);
+        var renderedCard = adaptiveCard.render();
         renderedCard.style.height = "100%";
+        element.appendChild(renderedCard);
+        adaptiveCard.updateLayout();
 
         return element;
     }

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -443,7 +443,7 @@ export abstract class CardElement {
         // If the element is going to be hidden, reset any changes that were due
         // to overflow truncation (this ensures that if the element is later
         // un-hidden it has the right content)
-        if (!value) {
+        if (AdaptiveCard.useAdvancedCardBottomTruncation && !value) {
             this.undoOverflowTruncation();
         }
 
@@ -620,7 +620,8 @@ export class TextBlock extends CardElement {
                 element.style.whiteSpace = "nowrap";
             }
 
-            if (AdaptiveCard.useAdvancedTextBlockTruncation) {
+            if (AdaptiveCard.useAdvancedTextBlockTruncation
+                || AdaptiveCard.useAdvancedCardBottomTruncation) {
                 this._originalInnerHtml = element.innerHTML;
             }
 
@@ -3575,6 +3576,7 @@ export class AdaptiveCard extends ContainerWithActions {
 
     static preExpandSingleShowCardAction: boolean = false;
     static useAdvancedTextBlockTruncation: boolean = true;
+    static useAdvancedCardBottomTruncation: boolean = false;
 
     static readonly elementTypeRegistry = new ElementTypeRegistry();
     static readonly actionTypeRegistry = new ActionTypeRegistry();
@@ -3747,7 +3749,10 @@ export class AdaptiveCard extends ContainerWithActions {
 
     updateLayout(processChildren: boolean = true) {
         super.updateLayout(processChildren);
-        this.handleBottomOverflows();
+
+        if (AdaptiveCard.useAdvancedCardBottomTruncation) {
+            this.handleBottomOverflows();
+        }
     }
 
     canContentBleed(): boolean {

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -3377,11 +3377,12 @@ function raiseInlineCardExpandedEvent(action: ShowCardAction, isExpanded: boolea
 
 function raiseElementVisibilityChangedEvent(element: CardElement,
                                             shouldUpdateLayout: boolean = true) {
+    let card = element.getRootElement() as AdaptiveCard;
+
     if (shouldUpdateLayout) {
-        element.getRootElement().updateLayout();
+        card.updateLayout();
     }
 
-    let card = element.getRootElement() as AdaptiveCard;
     let onElementVisibilityChangedHandler = (card && card.onElementVisibilityChanged) ? card.onElementVisibilityChanged : AdaptiveCard.onElementVisibilityChanged;
 
     if (onElementVisibilityChangedHandler != null) {

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -3801,22 +3801,24 @@ export class AdaptiveCard extends ContainerWithActions {
         var handleElement = (cardElement: CardElement) => {
             let elt = cardElement.renderedElement;
 
-            switch (Utils.getFitStatus(elt, boundary)) {
-                case Enums.ContainerFitStatus.FullyInContainer:
-                    let sizeChanged = cardElement.resetOverflow();
-                    // If the element's size changed after resetting content,
-                    // we have to check if it still fits fully in the card
-                    if (sizeChanged) {
-                        handleElement(cardElement);
-                    }
-                    break;
-                case Enums.ContainerFitStatus.Overflowing:
-                    let maxHeight = boundary - elt.offsetTop;
-                    cardElement.handleOverflow(maxHeight);
-                    break;
-                case Enums.ContainerFitStatus.FullyOutOfContainer:
-                    cardElement.handleOverflow(0);
-                    break;
+            if (elt) {
+                switch (Utils.getFitStatus(elt, boundary)) {
+                    case Enums.ContainerFitStatus.FullyInContainer:
+                        let sizeChanged = cardElement.resetOverflow();
+                        // If the element's size changed after resetting content,
+                        // we have to check if it still fits fully in the card
+                        if (sizeChanged) {
+                            handleElement(cardElement);
+                        }
+                        break;
+                    case Enums.ContainerFitStatus.Overflowing:
+                        let maxHeight = boundary - elt.offsetTop;
+                        cardElement.handleOverflow(maxHeight);
+                        break;
+                    case Enums.ContainerFitStatus.FullyOutOfContainer:
+                        cardElement.handleOverflow(0);
+                        break;
+                }
             }
         };
 

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -724,11 +724,16 @@ export class TextBlock extends CardElement {
         // paragraph -- since the maxLines calculation doesn't take into
         // account Markdown lists
         var children = this.renderedElement.children;
-        var truncationSupported = children.length == 1
+        var isTextOnly = !children.length;
+
+        var truncationSupported = isTextOnly || children.length == 1
             && (<HTMLElement>children[0]).tagName.toLowerCase() == 'p';
 
         if (truncationSupported) {
-            var element = <HTMLElement>children[0];
+            var element = isTextOnly
+                ? this.renderedElement
+                : <HTMLElement>children[0];
+
             Utils.truncate(element, maxHeight, this._computedLineHeight);
             return true;
         }

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -2657,6 +2657,21 @@ export class Container extends CardElement {
         element.style.display = "flex";
         element.style.flexDirection = "column";
 
+        if (AdaptiveCard.useAdvancedCardBottomTruncation) {
+            // Forces the container to be at least as tall as its content.
+            //
+            // Fixes a quirk in Chrome where, for nested flex elements, the
+            // inner element's height would never exceed the outer element's
+            // height. This caused overflow truncation to break -- containers
+            // would always be measured as not overflowing, since their heights
+            // were constrained by their parents as opposed to truly reflecting
+            // the height of their content.
+            //
+            // See the "Browser Rendering Notes" section of this answer:
+            // https://stackoverflow.com/questions/36247140/why-doesnt-flex-item-shrink-past-content-size
+            element.style.minHeight = '-webkit-min-content';
+        }
+
         switch (this.verticalContentAlignment) {
             case Enums.VerticalAlignment.Center:
                 element.style.justifyContent = "center";
@@ -3120,6 +3135,11 @@ export class ColumnSet extends CardElement {
             var element = document.createElement("div");
             element.className = "ac-columnSet";
             element.style.display = "flex";
+
+            if (AdaptiveCard.useAdvancedCardBottomTruncation) {
+                // See comment in Container.internalRender()
+                element.style.minHeight = '-webkit-min-content';
+            }
 
             if (this.selectAction && this.hostConfig.supportsInteractivity) {
                 element.classList.add("ac-selectable");
@@ -3698,6 +3718,19 @@ export class AdaptiveCard extends ContainerWithActions {
         this.renderedElement.style.paddingRight = effectivePadding.right + "px";
         this.renderedElement.style.paddingBottom = effectivePadding.bottom + "px";
         this.renderedElement.style.paddingLeft = effectivePadding.left + "px";
+    }
+
+    protected internalRender(): HTMLElement {
+        var renderedElement = super.internalRender();
+
+        if (AdaptiveCard.useAdvancedCardBottomTruncation) {
+            // Unlike containers, the root card element should be allowed to
+            // be shorter than its content (otherwise the overflow truncation
+            // logic would never get triggered)
+            renderedElement.style.minHeight = null;
+        }
+
+        return renderedElement;
     }
 
     protected get bypassVersionCheck(): boolean {

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -708,6 +708,11 @@ export class TextBlock extends CardElement {
 
     protected undoOverflowTruncation() {
         this.restoreOriginalContent();
+
+        if (AdaptiveCard.useAdvancedTextBlockTruncation && this.maxLines) {
+            var maxHeight = this._computedLineHeight * this.maxLines;
+            this.truncateIfSupported(maxHeight);
+        }
     }
 
     private restoreOriginalContent() {

--- a/source/nodejs/adaptivecards/src/enums.ts
+++ b/source/nodejs/adaptivecards/src/enums.ts
@@ -106,3 +106,9 @@ export enum ValidationError {
     UnknownElementType,
     UnsupportedCardVersion
 }
+
+export enum ContainerFitStatus {
+    FullyInContainer,
+    Overflowing,
+    FullyOutOfContainer
+}

--- a/source/nodejs/adaptivecards/src/utils.ts
+++ b/source/nodejs/adaptivecards/src/utils.ts
@@ -239,8 +239,7 @@ function findNextCharacter(html: string, currIdx: number): number {
     return currIdx;
 }
 
-export function getFitStatus(element: HTMLElement,
-                             containerEnd: number): Enums.ContainerFitStatus {
+export function getFitStatus(element: HTMLElement, containerEnd: number): Enums.ContainerFitStatus {
     var start = element.offsetTop;
     var end = start + element.clientHeight;
 

--- a/source/nodejs/adaptivecards/src/utils.ts
+++ b/source/nodejs/adaptivecards/src/utils.ts
@@ -242,7 +242,7 @@ function findNextCharacter(html: string, currIdx: number): number {
 export function getFitStatus(element: HTMLElement,
                              containerEnd: number): Enums.ContainerFitStatus {
     var start = element.offsetTop;
-    var end = start + element.offsetHeight;
+    var end = start + element.clientHeight;
 
     if (end <= containerEnd) {
         return Enums.ContainerFitStatus.FullyInContainer;

--- a/source/nodejs/adaptivecards/src/utils.ts
+++ b/source/nodejs/adaptivecards/src/utils.ts
@@ -238,3 +238,19 @@ function findNextCharacter(html: string, currIdx: number): number {
 
     return currIdx;
 }
+
+export function getFitStatus(element: HTMLElement,
+                             containerEnd: number): Enums.ContainerFitStatus {
+    var start = element.offsetTop;
+    var end = start + element.offsetHeight;
+
+    if (end <= containerEnd) {
+        return Enums.ContainerFitStatus.FullyInContainer;
+    }
+    else if (start < containerEnd) {
+        return Enums.ContainerFitStatus.Overflowing;
+    }
+    else {
+        return Enums.ContainerFitStatus.FullyOutOfContainer;
+    }
+}


### PR DESCRIPTION
Updates the TypeScript renderer to enable automatically truncating content that overflows the bottom of a fixed height card. The truncation logic is triggered in the `updateLayout()` method of the `AdaptiveCard` class, though it could be easily moved to the base container class if we ever want to be able to handle content overflows on any container, not just the bottom of the card. (This isn't really necessary at the moment since there's no notion of fixed height containers yet).

The default behavior for when an element overflows the bottom of the card is to hide the entire element. Two new methods are added to the `CardElement` class (`truncateOverflows()` and `undoOverflowTruncation()`) for elements that want to override this behavior (e.g. for TextBlocks, these methods are overridden so that text content can be partially clipped).

**Example:**

![capture](https://user-images.githubusercontent.com/3249032/33582640-0c008582-d90b-11e7-9aae-64bb0f8ffd95.PNG)

Everything is hidden behind the `AdaptiveCard.useAdvancedCardBottomTruncation` flag (defaults to false, since this should only be enabled for fixed height cards).

This addresses #517.