### PR TITLE
Fix single line text overflow when Markdown isn't used

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -622,6 +622,7 @@ export class TextBlock extends CardElement {
             }
             else {
                 element.style.whiteSpace = "nowrap";
+                element.style.textOverflow = "ellipsis";
             }
 
             if (AdaptiveCard.useAdvancedTextBlockTruncation


### PR DESCRIPTION
Fixes an issue in the TypeScript renderer where single-line TextBlocks (with `wrap: false`) wouldn't truncate properly if Markdown wasn't used:

![capture](https://user-images.githubusercontent.com/3249032/35070280-97707c32-fb91-11e7-97ea-d999e0d2b266.PNG)

The issue occurred because the only place where `text-overflow: ellipsis` got added to TextBlocks was hidden behind a check for `if (element.firstElementChild instanceof HTMLElement)`.