### PR TITLE
Changes required for OS repo build

### DIFF
--- a/source/shared/cpp/ObjectModel/AdaptiveCardParseException.cpp
+++ b/source/shared/cpp/ObjectModel/AdaptiveCardParseException.cpp
@@ -20,7 +20,7 @@ const ErrorStatusCode AdaptiveCardParseException::GetStatusCode() const
     return m_statusCode;
 }
 
-const std::string& AdaptiveCardParseException::GetMessage() const
+const std::string& AdaptiveCardParseException::GetReason() const
 {
     return m_message;
 }

--- a/source/shared/cpp/ObjectModel/AdaptiveCardParseException.h
+++ b/source/shared/cpp/ObjectModel/AdaptiveCardParseException.h
@@ -14,7 +14,7 @@ public:
 
     virtual const char* what() const throw();
     const AdaptiveCards::ErrorStatusCode GetStatusCode() const;
-    const std::string& GetMessage() const;
+    const std::string& GetReason() const;
 
 private:
     const AdaptiveCards::ErrorStatusCode m_statusCode;

--- a/source/shared/cpp/ObjectModel/MarkDownBlockParser.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownBlockParser.cpp
@@ -4,61 +4,61 @@
 using namespace AdaptiveCards;
 
 // Parses according to each key words
-void MarkDownBlockParser::ParseBlock(std::stringstream &stream) 
+void MarkDownBlockParser::ParseBlock(std::stringstream &stream)
 {
     switch (stream.peek())
     {
         // parses link
-        case '[':
-        {
-            LinkParser linkParser;
-            // do syntax check of link
-            linkParser.Match(stream);
-            // append link result to the rest
-            m_parsedResult.AppendParseResult(linkParser.GetParsedResult());
-            break;
-        }
-        // handles special cases where these tokens are not encountered
-        // as not part of link
-        case ']': case ')': 
-        {
-            // add these char as token to code gen list
-            m_parsedResult.AddNewTokenToParsedResult(stream.get());
-            break;
-        }
-        case '\n': case '\r':
-        {
-            // add new line char as token to code gen list
-            m_parsedResult.AddNewLineTokenToParsedResult(stream.get());
-            break;
-        }
-        // handles list block
-        case '-':
-        {
-            ListParser listParser;
-            // do syntax check of list
-            listParser.Match(stream);
-            // append list result to the rest
-            m_parsedResult.AppendParseResult(listParser.GetParsedResult());
-            break;
-        }
-        case '0': case '1': case '2': case '3': case'4':
-        case '5': case '6': case '7': case '8': case'9':
-        {
-            OrderedListParser orderedListParser;
-            // do syntax check of list
-            orderedListParser.Match(stream);
-            // append list result to the rest
-            m_parsedResult.AppendParseResult(orderedListParser.GetParsedResult());
-            break;
-        }
-        // everything else is treated as normal text + emphasis
-        default:
-            EmphasisParser emphasisParser;
-            // do syntax check of normal text + emphasis
-            emphasisParser.Match(stream);
-            // append result to the rest
-            m_parsedResult.AppendParseResult(emphasisParser.GetParsedResult());
+    case '[':
+    {
+        LinkParser linkParser;
+        // do syntax check of link
+        linkParser.Match(stream);
+        // append link result to the rest
+        m_parsedResult.AppendParseResult(linkParser.GetParsedResult());
+        break;
+    }
+    // handles special cases where these tokens are not encountered
+    // as not part of link
+    case ']': case ')':
+    {
+        // add these char as token to code gen list
+        m_parsedResult.AddNewTokenToParsedResult(static_cast<char>(stream.get()));
+        break;
+    }
+    case '\n': case '\r':
+    {
+        // add new line char as token to code gen list
+        m_parsedResult.AddNewLineTokenToParsedResult(static_cast<char>(stream.get()));
+        break;
+    }
+    // handles list block
+    case '-':
+    {
+        ListParser listParser;
+        // do syntax check of list
+        listParser.Match(stream);
+        // append list result to the rest
+        m_parsedResult.AppendParseResult(listParser.GetParsedResult());
+        break;
+    }
+    case '0': case '1': case '2': case '3': case'4':
+    case '5': case '6': case '7': case '8': case'9':
+    {
+        OrderedListParser orderedListParser;
+        // do syntax check of list
+        orderedListParser.Match(stream);
+        // append list result to the rest
+        m_parsedResult.AppendParseResult(orderedListParser.GetParsedResult());
+        break;
+    }
+    // everything else is treated as normal text + emphasis
+    default:
+        EmphasisParser emphasisParser;
+        // do syntax check of normal text + emphasis
+        emphasisParser.Match(stream);
+        // append result to the rest
+        m_parsedResult.AppendParseResult(emphasisParser.GetParsedResult());
     }
 }
 
@@ -68,7 +68,7 @@ void MarkDownBlockParser::ParseBlock(std::stringstream &stream)
 // it moves two states, emphasis state and text state,
 // at each transition of state, one token is captured
 void EmphasisParser::Match(std::stringstream &stream)
-{ 
+{
     while (m_current_state != EmphasisState::Captured)
     {
         m_current_state = m_stateMachine[m_current_state](*this, stream, m_current_token);
@@ -85,26 +85,26 @@ EmphasisParser::EmphasisState EmphasisParser::MatchText(EmphasisParser &parser, 
         return EmphasisState::Captured;
     }
 
-    if (parser.IsMarkDownDelimiter(stream.peek()))
+    if (parser.IsMarkDownDelimiter(static_cast<char>(stream.peek())))
     {
         // encounterred first emphasis delimiter
         parser.CaptureCurrentCollectedStringAsRegularToken();
-        DelimiterType emphasisType = EmphasisParser::GetDelimiterTypeForCharAtCurrentPosition(stream.peek()); 
+        DelimiterType emphasisType = EmphasisParser::GetDelimiterTypeForCharAtCurrentPosition(static_cast<char>(stream.peek()));
         // get previous character and update the look behind if it was captured before 
         if (stream.tellg())
         {
             stream.unget();
-            parser.UpdateLookBehind(stream.get());
+            parser.UpdateLookBehind(static_cast<char>(stream.get()));
         }
 
         parser.UpdateCurrentEmphasisRunState(emphasisType);
-        token += stream.get();
+        token += static_cast<char>(stream.get());
         return EmphasisState::Emphasis;
     }
     else
-    {    
+    {
         parser.UpdateLookBehind(stream.peek());
-        token += stream.get();
+        token += static_cast<char>(stream.get());
         return EmphasisState::Text;
     }
 }
@@ -121,15 +121,15 @@ EmphasisParser::EmphasisState EmphasisParser::MatchEmphasis(EmphasisParser &pars
     }
 
     /// if another emphasis delimiter is encounterred, it is delimiter run
-    if (parser.IsMarkDownDelimiter(stream.peek()))
+    if (parser.IsMarkDownDelimiter(static_cast<char>(stream.peek())))
     {
-        DelimiterType emphasisType = EmphasisParser::GetDelimiterTypeForCharAtCurrentPosition(stream.peek());
+        DelimiterType emphasisType = EmphasisParser::GetDelimiterTypeForCharAtCurrentPosition(static_cast<char>(stream.peek()));
         if (parser.IsEmphasisDelimiterRun(emphasisType))
         {
             parser.UpdateCurrentEmphasisRunState(emphasisType);
         }
 
-        token += stream.get();
+        token += static_cast<char>(stream.get());
     }
     /// delimiter run is ended, capture the current accumulated token as emphasis
     else
@@ -139,12 +139,12 @@ EmphasisParser::EmphasisState EmphasisParser::MatchEmphasis(EmphasisParser &pars
         if (stream.peek() == '\\')
         {
             // skips escape char
-            stream.get();
+            static_cast<char>(stream.get());
         }
 
         parser.ResetCurrentEmphasisState();
         parser.UpdateLookBehind(stream.peek());
-        token += stream.get();
+        token += static_cast<char>(stream.get());
         return EmphasisState::Text;
     }
     return EmphasisState::Emphasis;
@@ -171,11 +171,11 @@ bool EmphasisParser::IsMarkDownDelimiter(char ch)
     return ((ch == '*' || ch == '_') && (m_lookBehind != Escape));
 }
 
-void EmphasisParser::CaptureCurrentCollectedStringAsRegularToken(std::string& currentToken) 
+void EmphasisParser::CaptureCurrentCollectedStringAsRegularToken(std::string& currentToken)
 {
     if (currentToken.empty())
         return;
-    std::shared_ptr<MarkDownHtmlGenerator> codeGen = 
+    std::shared_ptr<MarkDownHtmlGenerator> codeGen =
         std::make_shared<MarkDownStringHtmlGenerator>(currentToken);
 
     m_parsedResult.AppendToTokens(codeGen);
@@ -183,7 +183,7 @@ void EmphasisParser::CaptureCurrentCollectedStringAsRegularToken(std::string& cu
     currentToken.clear();
 }
 
-void EmphasisParser::CaptureCurrentCollectedStringAsRegularToken() 
+void EmphasisParser::CaptureCurrentCollectedStringAsRegularToken()
 {
     CaptureCurrentCollectedStringAsRegularToken(m_current_token);
 }
@@ -201,15 +201,15 @@ void EmphasisParser::UpdateCurrentEmphasisRunState(DelimiterType emphasisType)
 
 bool EmphasisParser::IsRightEmphasisDelimiter(int ch)
 {
-    if ((isspace(ch) || (ch == EOF)) && 
-       (m_lookBehind != WhiteSpace) && 
-       (m_checkLookAhead || m_checkIntraWord || m_currentDelimiterType == Asterisk))
-    {        
+    if ((isspace(ch) || (ch == EOF)) &&
+        (m_lookBehind != WhiteSpace) &&
+        (m_checkLookAhead || m_checkIntraWord || m_currentDelimiterType == Asterisk))
+    {
         return true;
     }
 
-    if (isalnum(ch) && 
-        m_lookBehind != WhiteSpace && 
+    if (isalnum(ch) &&
+        m_lookBehind != WhiteSpace &&
         m_lookBehind != Init)
     {
         if (!m_checkLookAhead && !m_checkIntraWord)
@@ -240,15 +240,15 @@ bool EmphasisParser::TryCapturingRightEmphasisToken(int ch, std::string &current
         if (IsLeftEmphasisDelimiter(ch))
         {
             // since it is both left and right emphasis, create one accordingly
-            codeGen = 
-                std::make_shared<MarkDownLeftAndRightEmphasisHtmlGenerator>(currentToken, m_delimiterCnts, 
-                        m_currentDelimiterType);
+            codeGen =
+                std::make_shared<MarkDownLeftAndRightEmphasisHtmlGenerator>(currentToken, m_delimiterCnts,
+                    m_currentDelimiterType);
         }
         else
         {
-            codeGen = 
-                std::make_shared<MarkDownRightEmphasisHtmlGenerator>(currentToken, m_delimiterCnts, 
-                        m_currentDelimiterType);
+            codeGen =
+                std::make_shared<MarkDownRightEmphasisHtmlGenerator>(currentToken, m_delimiterCnts,
+                    m_currentDelimiterType);
         }
 
         m_parsedResult.AppendToLookUpTable(codeGen);
@@ -267,9 +267,9 @@ bool EmphasisParser::TryCapturingLeftEmphasisToken(int ch, std::string &currentT
     // left emphasis detected, save emphasis for later reference
     if (IsLeftEmphasisDelimiter(ch))
     {
-        std::shared_ptr<MarkDownEmphasisHtmlGenerator> codeGen = 
-            std::make_shared<MarkDownLeftEmphasisHtmlGenerator>(currentToken, m_delimiterCnts, 
-                    m_currentDelimiterType);
+        std::shared_ptr<MarkDownEmphasisHtmlGenerator> codeGen =
+            std::make_shared<MarkDownLeftEmphasisHtmlGenerator>(currentToken, m_delimiterCnts,
+                m_currentDelimiterType);
 
         m_parsedResult.AppendToLookUpTable(codeGen);
 
@@ -296,13 +296,13 @@ void EmphasisParser::UpdateLookBehind(int ch)
 
     if (ispunct(ch))
     {
-        m_lookBehind = (ch == '\\')? Escape : Puntuation;
+        m_lookBehind = (ch == '\\') ? Escape : Puntuation;
     }
 }
 
 void EmphasisParser::CaptureEmphasisToken(int ch, std::string &currentToken)
 {
-    if (!TryCapturingRightEmphasisToken(ch, currentToken) && 
+    if (!TryCapturingRightEmphasisToken(ch, currentToken) &&
         !TryCapturingLeftEmphasisToken(ch, currentToken) &&
         !currentToken.empty())
     {
@@ -312,13 +312,13 @@ void EmphasisParser::CaptureEmphasisToken(int ch, std::string &currentToken)
     }
 }
 
-void LinkParser::Match(std::stringstream &stream) 
-{ 
+void LinkParser::Match(std::stringstream &stream)
+{
     // link syntax check, match keyword at each stage
-    if (MatchAtLinkInit(stream) && 
-        MatchAtLinkTextRun(stream) && 
-        MatchAtLinkTextEnd(stream) && 
-        MatchAtLinkDestinationStart(stream) && 
+    if (MatchAtLinkInit(stream) &&
+        MatchAtLinkTextRun(stream) &&
+        MatchAtLinkTextEnd(stream) &&
+        MatchAtLinkDestinationStart(stream) &&
         MatchAtLinkDestinationRun(stream))
     {
         /// Link is in correct syntax, capture it as link
@@ -330,8 +330,8 @@ void LinkParser::Match(std::stringstream &stream)
 bool LinkParser::MatchAtLinkInit(std::stringstream &lookahead)
 {
     if (lookahead.peek() == '[')
-    {    
-        m_linkTextParsedResult.AddNewTokenToParsedResult(lookahead.get());
+    {
+        m_linkTextParsedResult.AddNewTokenToParsedResult(static_cast<char>(lookahead.get()));
         return true;
     }
 
@@ -342,15 +342,15 @@ bool LinkParser::MatchAtLinkInit(std::stringstream &lookahead)
 
 // link is in form of [txt](url), this method matches txt
 bool LinkParser::MatchAtLinkTextRun(std::stringstream &lookahead)
-{ 
+{
     if (lookahead.peek() == ']')
     {
-        m_linkTextParsedResult.AddNewTokenToParsedResult(lookahead.get());
+        m_linkTextParsedResult.AddNewTokenToParsedResult(static_cast<char>(lookahead.get()));
         return true;
     }
     else
     {
-        if (lookahead.peek() =='[')
+        if (lookahead.peek() == '[')
         {
             m_parsedResult.AppendParseResult(m_linkTextParsedResult);
             return false;
@@ -364,7 +364,7 @@ bool LinkParser::MatchAtLinkTextRun(std::stringstream &lookahead)
             if (lookahead.peek() == ']')
             {
                 // move code gen objects to link text list to further process it 
-                m_linkTextParsedResult.AddNewTokenToParsedResult(lookahead.get());
+                m_linkTextParsedResult.AddNewTokenToParsedResult(static_cast<char>(lookahead.get()));
                 return true;
             }
 
@@ -378,11 +378,11 @@ bool LinkParser::MatchAtLinkTextRun(std::stringstream &lookahead)
 bool LinkParser::MatchAtLinkTextEnd(std::stringstream &lookahead)
 {
     if (lookahead.peek() == '(')
-    { 
-        m_linkTextParsedResult.AddNewTokenToParsedResult(lookahead.get());
+    {
+        m_linkTextParsedResult.AddNewTokenToParsedResult(static_cast<char>(lookahead.get()));
         return true;
-    } 
-    
+    }
+
     m_parsedResult.AppendParseResult(m_linkTextParsedResult);
     return false;
 }
@@ -398,7 +398,7 @@ bool LinkParser::MatchAtLinkDestinationStart(std::stringstream &lookahead)
     }
 
     if (lookahead.peek() == ')')
-    { 
+    {
         lookahead.get();
         return true;
     }
@@ -419,13 +419,13 @@ bool LinkParser::MatchAtLinkDestinationStart(std::stringstream &lookahead)
 bool LinkParser::MatchAtLinkDestinationRun(std::stringstream &lookahead)
 {
     if (isspace(lookahead.peek()) || iscntrl(lookahead.peek()))
-    { 
+    {
         m_parsedResult.AppendParseResult(m_linkTextParsedResult);
         return false;
     }
 
     if (lookahead.peek() == ')')
-    { 
+    {
         lookahead.get();
         return true;
     }
@@ -442,7 +442,7 @@ bool LinkParser::MatchAtLinkDestinationRun(std::stringstream &lookahead)
 // <a href=\destination\>text</a>
 void LinkParser::CaptureLinkToken()
 {
-    std::ostringstream html; 
+    std::ostringstream html;
     html << "<a href=\"";
     // process link destination
     html << m_parsedResult.GenerateHtmlString();
@@ -466,7 +466,7 @@ void LinkParser::CaptureLinkToken()
     std::string html_string = html.str();
 
     // Generate a MarkDownStringHtmlGenerator object
-    std::shared_ptr<MarkDownHtmlGenerator> codeGen = 
+    std::shared_ptr<MarkDownHtmlGenerator> codeGen =
         std::make_shared<MarkDownStringHtmlGenerator>(html_string);
 
     m_parsedResult.Clear();
@@ -479,7 +479,7 @@ bool ListParser::MatchNewListItem(std::stringstream &stream)
 {
     if (IsHyphen(stream.peek()))
     {
-        stream.get();
+        static_cast<char>(stream.get());
         if (stream.peek() == ' ')
         {
             stream.unget();
@@ -517,7 +517,7 @@ bool ListParser::MatchNewOrderedListItem(std::stringstream &stream, std::string 
 {
     do
     {
-        number_string += stream.get();
+        number_string += static_cast<char>(stream.get());
     } while (isdigit(stream.peek()));
 
     if (stream.peek() == '.')
@@ -535,11 +535,11 @@ bool ListParser::MatchNewOrderedListItem(std::stringstream &stream, std::string 
 // we do not include in the current block, we return, and have it handled by the caller
 void ListParser::ParseSubBlocks(std::stringstream &stream)
 {
-    while (!stream.eof()) 
-    { 
+    while (!stream.eof())
+    {
         if (IsNewLine(stream.peek()))
         {
-            int newLineChar = stream.get();
+            int newLineChar = static_cast<char>(stream.get());
             // check if it is the start of new block items
             if (isdigit(stream.peek()))
             {
@@ -549,7 +549,7 @@ void ListParser::ParseSubBlocks(std::stringstream &stream)
                     break;
                 }
                 else
-                { 
+                {
                     m_parsedResult.AddNewTokenToParsedResult(number_string);
                 }
             }
@@ -558,7 +558,7 @@ void ListParser::ParseSubBlocks(std::stringstream &stream)
                 break;
             }
 
-            m_parsedResult.AddNewTokenToParsedResult(newLineChar);
+            m_parsedResult.AddNewTokenToParsedResult(static_cast<char>(newLineChar));
         }
         ParseBlock(stream);
     }
@@ -574,7 +574,7 @@ bool ListParser::CompleteListParsing(std::stringstream &stream)
         // remove space
         do
         {
-            stream.get();
+            static_cast<char>(stream.get());
         } while (stream.peek() == ' ');
 
         ParseBlock(stream);
@@ -587,13 +587,13 @@ bool ListParser::CompleteListParsing(std::stringstream &stream)
 }
 
 // list marker has a form of ^-\s+ or [\r, \n]-\s+, and this method checks the syntax
-void ListParser::Match(std::stringstream &stream) 
-{ 
+void ListParser::Match(std::stringstream &stream)
+{
     // check for - of -\s+ list marker
     if (IsHyphen(stream.peek()))
     {
-        stream.get();
-        if(CompleteListParsing(stream)) 
+        static_cast<char>(stream.get());
+        if (CompleteListParsing(stream))
         {
             CaptureListToken();
         }
@@ -601,7 +601,7 @@ void ListParser::Match(std::stringstream &stream)
         {
             // if incorrect syntax, capture what was thrown as a new token.
             m_parsedResult.AddNewTokenToParsedResult('-');
-            stream.get();
+            static_cast<char>(stream.get());
         }
     }
 }
@@ -617,7 +617,7 @@ void ListParser::CaptureListToken()
     html << "</li>";
 
     std::string html_string = html.str();
-    std::shared_ptr<MarkDownListHtmlGenerator> codeGen = 
+    std::shared_ptr<MarkDownListHtmlGenerator> codeGen =
         std::make_shared<MarkDownListHtmlGenerator>(html_string);
 
     m_parsedResult.Clear();
@@ -625,21 +625,21 @@ void ListParser::CaptureListToken()
 }
 
 // ordered list marker has form of ^\d+\.\s* or [\r,\n]\d+\.\s*, and this method checks the syntax
-void OrderedListParser::Match(std::stringstream &stream) 
-{ 
+void OrderedListParser::Match(std::stringstream &stream)
+{
     // used to capture digit char
     std::string number_string = "";
     if (isdigit(stream.peek()))
     {
         do
         {
-            number_string += stream.get();
+            number_string += static_cast<char>(stream.get());
         } while (isdigit(stream.peek()));
 
         if (IsDot(stream.peek()))
         {
             // ordered list syntax check complete
-            stream.get();
+            static_cast<char>(stream.get());
             if (CompleteListParsing(stream))
             {
                 CaptureOrderedListToken(number_string);
@@ -670,7 +670,7 @@ void OrderedListParser::CaptureOrderedListToken(std::string &number_string)
     html << "</li>";
 
     std::string html_string = html.str();
-    std::shared_ptr<MarkDownOrderedListHtmlGenerator> codeGen = 
+    std::shared_ptr<MarkDownOrderedListHtmlGenerator> codeGen =
         std::make_shared<MarkDownOrderedListHtmlGenerator>(html_string, number_string);
 
     m_parsedResult.Clear();

--- a/source/shared/cpp/ObjectModel/MarkDownBlockParser.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownBlockParser.cpp
@@ -94,7 +94,7 @@ EmphasisParser::EmphasisState EmphasisParser::MatchText(EmphasisParser &parser, 
         if (stream.tellg())
         {
             stream.unget();
-            parser.UpdateLookBehind(static_cast<char>(stream.get()));
+            parser.UpdateLookBehind(stream.get());
         }
 
         parser.UpdateCurrentEmphasisRunState(emphasisType);
@@ -139,7 +139,7 @@ EmphasisParser::EmphasisState EmphasisParser::MatchEmphasis(EmphasisParser &pars
         if (stream.peek() == '\\')
         {
             // skips escape char
-            static_cast<char>(stream.get());
+            stream.get();
         }
 
         parser.ResetCurrentEmphasisState();
@@ -479,7 +479,7 @@ bool ListParser::MatchNewListItem(std::stringstream &stream)
 {
     if (IsHyphen(stream.peek()))
     {
-        static_cast<char>(stream.get());
+        stream.get();
         if (stream.peek() == ' ')
         {
             stream.unget();
@@ -539,7 +539,7 @@ void ListParser::ParseSubBlocks(std::stringstream &stream)
     {
         if (IsNewLine(stream.peek()))
         {
-            int newLineChar = static_cast<char>(stream.get());
+            int newLineChar = stream.get();
             // check if it is the start of new block items
             if (isdigit(stream.peek()))
             {
@@ -574,7 +574,7 @@ bool ListParser::CompleteListParsing(std::stringstream &stream)
         // remove space
         do
         {
-            static_cast<char>(stream.get());
+            stream.get();
         } while (stream.peek() == ' ');
 
         ParseBlock(stream);
@@ -592,7 +592,7 @@ void ListParser::Match(std::stringstream &stream)
     // check for - of -\s+ list marker
     if (IsHyphen(stream.peek()))
     {
-        static_cast<char>(stream.get());
+        stream.get();
         if (CompleteListParsing(stream))
         {
             CaptureListToken();
@@ -601,7 +601,7 @@ void ListParser::Match(std::stringstream &stream)
         {
             // if incorrect syntax, capture what was thrown as a new token.
             m_parsedResult.AddNewTokenToParsedResult('-');
-            static_cast<char>(stream.get());
+            stream.get();
         }
     }
 }
@@ -639,7 +639,7 @@ void OrderedListParser::Match(std::stringstream &stream)
         if (IsDot(stream.peek()))
         {
             // ordered list syntax check complete
-            static_cast<char>(stream.get());
+            stream.get();
             if (CompleteListParsing(stream))
             {
                 CaptureOrderedListToken(number_string);

--- a/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.cpp
@@ -4,8 +4,8 @@ using namespace AdaptiveCards;
 
 std::string MarkDownStringHtmlGenerator::GenerateHtmlString()
 {
-    if (m_isHead) 
-    {              
+    if (m_isHead)
+    {
         m_token = "<p>" + m_token;
     }
 
@@ -27,7 +27,7 @@ bool MarkDownEmphasisHtmlGenerator::IsMatch(std::shared_ptr<MarkDownEmphasisHtml
     {
         // rule #9 & #10, sum of delimiter count can't be multiple of 3 
         return !((this->IsLeftAndRightEmphasis() || emphasisToken->IsLeftAndRightEmphasis()) &&
-            (((this->m_numberOfUnusedDelimiters+ emphasisToken->m_numberOfUnusedDelimiters) % 3) == 0));
+            (((this->m_numberOfUnusedDelimiters + emphasisToken->m_numberOfUnusedDelimiters) % 3) == 0));
     }
     return false;
 }
@@ -78,32 +78,32 @@ void MarkDownEmphasisHtmlGenerator::GenerateTags(std::shared_ptr<MarkDownEmphasi
     }
 }
 
-void MarkDownEmphasisHtmlGenerator::PushItalicTag() 
+void MarkDownEmphasisHtmlGenerator::PushItalicTag()
 {
     m_tags.push_back("<em>");
 }
 
-void MarkDownEmphasisHtmlGenerator::PushBoldTag() 
+void MarkDownEmphasisHtmlGenerator::PushBoldTag()
 {
     m_tags.push_back("<strong>");
 }
 
-std::string MarkDownLeftEmphasisHtmlGenerator::GenerateHtmlString() 
+std::string MarkDownLeftEmphasisHtmlGenerator::GenerateHtmlString()
 {
     if (m_numberOfUnusedDelimiters)
     {
-        unsigned long startIdx = m_token.size() - m_numberOfUnusedDelimiters;
+        unsigned long startIdx = static_cast<unsigned long>(m_token.size()) - m_numberOfUnusedDelimiters;
         html << m_token.substr(startIdx, std::string::npos);
     }
 
     // append tags; since left delims, append it in the reverse order
     for (auto itr = m_tags.rbegin(); itr != m_tags.rend(); itr++)
-    { 
+    {
         html << *itr;
     }
 
-    if (m_isHead) 
-    {   
+    if (m_isHead)
+    {
         return "<p>" + html.str();
     }
 
@@ -115,32 +115,32 @@ std::string MarkDownLeftEmphasisHtmlGenerator::GenerateHtmlString()
     return html.str();
 }
 
-void MarkDownRightEmphasisHtmlGenerator::PushItalicTag() 
+void MarkDownRightEmphasisHtmlGenerator::PushItalicTag()
 {
     m_tags.push_back("</em>");
 }
 
-void MarkDownRightEmphasisHtmlGenerator::PushBoldTag() 
+void MarkDownRightEmphasisHtmlGenerator::PushBoldTag()
 {
     m_tags.push_back("</strong>");
 }
 
-std::string MarkDownRightEmphasisHtmlGenerator::GenerateHtmlString() 
+std::string MarkDownRightEmphasisHtmlGenerator::GenerateHtmlString()
 {
     // append tags; 
     for (auto itr = m_tags.begin(); itr != m_tags.end(); itr++)
-    { 
+    {
         html << *itr;
     }
 
     // if there are unused emphasis, append them 
     if (m_numberOfUnusedDelimiters)
     {
-        unsigned long startIdx = m_token.size() - m_numberOfUnusedDelimiters;
+        unsigned long startIdx = static_cast<unsigned long>(m_token.size()) - m_numberOfUnusedDelimiters;
         html << m_token.substr(startIdx, std::string::npos);
     }
 
-    if (m_isHead) 
+    if (m_isHead)
     {
         return "<p>" + html.str();
     }
@@ -153,7 +153,7 @@ std::string MarkDownRightEmphasisHtmlGenerator::GenerateHtmlString()
     return html.str();
 }
 
-void MarkDownLeftAndRightEmphasisHtmlGenerator::PushItalicTag() 
+void MarkDownLeftAndRightEmphasisHtmlGenerator::PushItalicTag()
 {
     if (m_directionType == Left)
     {
@@ -165,7 +165,7 @@ void MarkDownLeftAndRightEmphasisHtmlGenerator::PushItalicTag()
     }
 }
 
-void MarkDownLeftAndRightEmphasisHtmlGenerator::PushBoldTag() 
+void MarkDownLeftAndRightEmphasisHtmlGenerator::PushBoldTag()
 {
     if (m_directionType == Left)
     {
@@ -179,7 +179,7 @@ void MarkDownLeftAndRightEmphasisHtmlGenerator::PushBoldTag()
 
 std::string MarkDownListHtmlGenerator::GenerateHtmlString()
 {
-    if (m_isHead) 
+    if (m_isHead)
     {
         m_token = "<ul>" + m_token;
     }
@@ -194,7 +194,7 @@ std::string MarkDownListHtmlGenerator::GenerateHtmlString()
 
 std::string MarkDownOrderedListHtmlGenerator::GenerateHtmlString()
 {
-    if (m_isHead) 
+    if (m_isHead)
     {
         m_token = "<ol start=\"" + m_numberString + "\">" + m_token;
     }

--- a/source/uwp/Renderer/lib/AdaptiveCard.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveCard.cpp
@@ -106,7 +106,7 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
                         RETURN_IF_FAILED(adaptiveParseResult->get_Errors(&errors));
                         HString errorMessage;
                         ABI::AdaptiveCards::Rendering::Uwp::ErrorStatusCode statusCode = static_cast<ABI::AdaptiveCards::Rendering::Uwp::ErrorStatusCode>(e.GetStatusCode());
-                        RETURN_IF_FAILED(UTF8ToHString(e.GetMessage(), errorMessage.GetAddressOf()));
+                        RETURN_IF_FAILED(UTF8ToHString(e.GetReason(), errorMessage.GetAddressOf()));
                         ComPtr<IAdaptiveError> adaptiveError;
                         RETURN_IF_FAILED(MakeAndInitialize<AdaptiveError>(&adaptiveError, statusCode, errorMessage.Get()));
                         RETURN_IF_FAILED(errors->Append(adaptiveError.Get()));


### PR DESCRIPTION
The GetMessage name conflicts with an OS wide macro.
Added explicit casts to some of the markdown code.
Some auto formatting that removes trailing spaces.
