### PR TITLE
fixed Txt Blck empty string and hyphen issue

### DIFF
--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/MarkDownUnitTest.cpp
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/MarkDownUnitTest.cpp
@@ -8,6 +8,15 @@ using namespace std;
 
 namespace AdaptiveCardsSharedModelUnitTest
 {
+    TEST_CLASS(MarkDownBasicSanityTest)
+    {
+        TEST_METHOD(CanHandleEmptyStringTest)
+        {
+            MarkDownParser parser("");
+            Assert::AreEqual<string>("<p></p>", parser.TransformToHtml());
+        }
+    };
+
     TEST_CLASS(EmphasisLeftDelimterTest)
     {
         TEST_METHOD(LeftDelimiterTest)
@@ -457,6 +466,11 @@ namespace AdaptiveCardsSharedModelUnitTest
         {
             MarkDownParser parser("- my list\rHello");
             Assert::AreEqual<string>("<ul><li>my list\rHello</li></ul>", parser.TransformToHtml());
+        }
+        TEST_METHOD(InvalidListStringReturnedUnchangedTest)
+        {
+            MarkDownParser parser("023-34-567");
+            Assert::AreEqual<string>("<p>023-34-567</p>", parser.TransformToHtml());
         }
     };
     TEST_CLASS(OrderedListTest)

--- a/source/shared/cpp/ObjectModel/MarkDownBlockParser.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownBlockParser.cpp
@@ -601,7 +601,6 @@ void ListParser::Match(std::stringstream &stream)
         {
             // if incorrect syntax, capture what was thrown as a new token.
             m_parsedResult.AddNewTokenToParsedResult('-');
-            stream.get();
         }
     }
 }

--- a/source/shared/cpp/ObjectModel/MarkDownParser.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownParser.cpp
@@ -12,6 +12,10 @@ MarkDownParser::MarkDownParser(const std::string &txt) : m_text(txt)
 // transforms string to html
 std::string MarkDownParser::TransformToHtml()
 {
+    if (m_text.empty())
+    {
+        return "<p></p>";
+    }
     // begin parsing html blocks
     ParseBlock();
 


### PR DESCRIPTION
Fixed the following issues.
- When empty string is presented, MD doesn't handle it properly 
    - it will now return "\<p\>\</p\>"
- When hyphen is present in the middle of string, MD eats up chars when
hyphen is not part of list marker.
