### PR TITLE
Bug: ImageSetConfig - max image height

### DIFF
--- a/source/nodejs/adaptivecards/src/__tests__/host-config/image_set_config.spec.ts
+++ b/source/nodejs/adaptivecards/src/__tests__/host-config/image_set_config.spec.ts
@@ -1,0 +1,12 @@
+import {ImageSetConfig} from "../../host-config";
+
+test('ImageSetConfig should parse valid json', ()=>{
+    const imageSizeJson = {
+        imageSize: 10,
+        maxImageHeight: 50
+    }
+    const imageSetConfig = new ImageSetConfig(imageSizeJson);
+
+    expect(imageSetConfig.imageSize).toEqual(10);
+    expect(imageSetConfig.maxImageHeight).toEqual(50);
+})

--- a/source/nodejs/adaptivecards/src/host-config.ts
+++ b/source/nodejs/adaptivecards/src/host-config.ts
@@ -31,7 +31,7 @@ export class ImageSetConfig {
     constructor(obj?: any) {
         if (obj) {
             this.imageSize = obj["imageSize"] != null ? obj["imageSize"] : this.imageSize;
-            this.maxImageHeight = Utils.getValueOrDefault<number>("maxImageHeight", 100);
+            this.maxImageHeight = Utils.getValueOrDefault<number>(obj["maxImageHeight"], 100);
         }
     }
 


### PR DESCRIPTION
Fixes an issue with TypeScript ImageSetConfig json parsing logic where maxImageHeight property wouldn't parse correctly because of typo. 

## Current behaviour
```javascript
    var imageSizeJson = {
        imageSize: 10,
        maxImageHeight: 50
    }
    var imageSetConfig = new ImageSetConfig(imageSizeJson);
    // imageSetConfig.maxImageHeight === "maxImageHeight" - it should be 50 instead
```
## Behaviour after fix
```javascript
    var imageSizeJson = {
        imageSize: 10,
        maxImageHeight: 50
    }
    var imageSetConfig = new ImageSetConfig(imageSizeJson);
    // imageSetConfig.maxImageHeight === 50
```
#1130