### PR TITLE
Fix to respect font-family in host config

### DIFF
--- a/source/shared/cpp/ObjectModel/HostConfig.cpp
+++ b/source/shared/cpp/ObjectModel/HostConfig.cpp
@@ -13,7 +13,7 @@ HostConfig HostConfig::Deserialize(const Json::Value& json)
 {
     HostConfig result;
     std::string fontFamily = ParseUtil::GetString(json, AdaptiveCardSchemaKey::FontFamily);
-    result.fontFamily = fontFamily == "" ? fontFamily : result.fontFamily;
+    result.fontFamily = fontFamily != "" ? fontFamily : result.fontFamily;
 
     result.supportsInteractivity = ParseUtil::GetBool(
         json, AdaptiveCardSchemaKey::SupportsInteractivity, result.supportsInteractivity);


### PR DESCRIPTION
## Defect
We had a wrong condition check on when to fall back to default value for font-family. As a result we ignore the font family given in the host config.

## Fix
Corrected the condition check to respect host config or fall back to default.

## Tests
Using iOS Visualizer, verify that font changes per host config.