### PR TITLE
iOS: Show image with higher resolution

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRImageRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRImageRenderer.mm
@@ -137,6 +137,20 @@
     CGSize cgsize = [ACRImageRenderer getImageSize:imgElem->GetImageSize() withHostConfig:config];
     UIImageView *view = [[UIImageView alloc]
                          initWithFrame:CGRectMake(0, 0, cgsize.width, cgsize.height)];
+    [view addConstraint:[NSLayoutConstraint constraintWithItem:view
+                                                     attribute:NSLayoutAttributeWidth
+                                                     relatedBy:NSLayoutRelationEqual
+                                                        toItem:nil
+                                                     attribute:NSLayoutAttributeNotAnAttribute
+                                                    multiplier:1.0
+                                                      constant:cgsize.width]];
+    [view addConstraint:[NSLayoutConstraint constraintWithItem:view
+                                                     attribute:NSLayoutAttributeHeight
+                                                     relatedBy:NSLayoutRelationEqual
+                                                        toItem:nil
+                                                     attribute:NSLayoutAttributeNotAnAttribute
+                                                    multiplier:1.0
+                                                      constant:cgsize.height]];
 
     NSMutableDictionary *imageViewMap = [(ACRViewController *)vc getImageMap];
     __block UIImage *img = nil;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRImageRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRImageRenderer.mm
@@ -137,20 +137,24 @@
     CGSize cgsize = [ACRImageRenderer getImageSize:imgElem->GetImageSize() withHostConfig:config];
     UIImageView *view = [[UIImageView alloc]
                          initWithFrame:CGRectMake(0, 0, cgsize.width, cgsize.height)];
-    [view addConstraint:[NSLayoutConstraint constraintWithItem:view
-                                                     attribute:NSLayoutAttributeWidth
-                                                     relatedBy:NSLayoutRelationEqual
-                                                        toItem:nil
-                                                     attribute:NSLayoutAttributeNotAnAttribute
-                                                    multiplier:1.0
-                                                      constant:cgsize.width]];
-    [view addConstraint:[NSLayoutConstraint constraintWithItem:view
-                                                     attribute:NSLayoutAttributeHeight
-                                                     relatedBy:NSLayoutRelationEqual
-                                                        toItem:nil
-                                                     attribute:NSLayoutAttributeNotAnAttribute
-                                                    multiplier:1.0
-                                                      constant:cgsize.height]];
+    
+    // Add width/height constraints so image is resized accordingly
+    [view addConstraints:@[
+                           [NSLayoutConstraint constraintWithItem:view
+                                                        attribute:NSLayoutAttributeWidth
+                                                        relatedBy:NSLayoutRelationEqual
+                                                           toItem:nil
+                                                        attribute:NSLayoutAttributeNotAnAttribute
+                                                       multiplier:1.0
+                                                         constant:cgsize.width],
+                           [NSLayoutConstraint constraintWithItem:view
+                                                        attribute:NSLayoutAttributeHeight
+                                                        relatedBy:NSLayoutRelationEqual
+                                                           toItem:nil
+                                                        attribute:NSLayoutAttributeNotAnAttribute
+                                                       multiplier:1.0
+                                                         constant:cgsize.height]
+                           ]];
 
     NSMutableDictionary *imageViewMap = [(ACRViewController *)vc getImageMap];
     __block UIImage *img = nil;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRViewController.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRViewController.mm
@@ -311,10 +311,12 @@ using namespace AdaptiveCards;
              UIImage *img = [UIImage imageWithData:[NSData dataWithContentsOfURL:url]];
              CGSize cgsize = [ACRImageRenderer getImageSize:imgElem->GetImageSize() withHostConfig:_hostConfig];
              // scale image
+/*
              UIGraphicsBeginImageContext(cgsize);
              [img drawInRect:(CGRectMake(0, 0, cgsize.width, cgsize.height))];
              img = UIGraphicsGetImageFromCurrentImageContext();
              UIGraphicsEndImageContext();
+*/
              // UITask can't be run on global queue, add task to main queue
              dispatch_async(dispatch_get_main_queue(),
                  ^{

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRViewController.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRViewController.mm
@@ -310,13 +310,7 @@ using namespace AdaptiveCards;
              // download image
              UIImage *img = [UIImage imageWithData:[NSData dataWithContentsOfURL:url]];
              CGSize cgsize = [ACRImageRenderer getImageSize:imgElem->GetImageSize() withHostConfig:_hostConfig];
-             // scale image
-/*
-             UIGraphicsBeginImageContext(cgsize);
-             [img drawInRect:(CGRectMake(0, 0, cgsize.width, cgsize.height))];
-             img = UIGraphicsGetImageFromCurrentImageContext();
-             UIGraphicsEndImageContext();
-*/
+
              // UITask can't be run on global queue, add task to main queue
              dispatch_async(dispatch_get_main_queue(),
                  ^{


### PR DESCRIPTION
## Defect
We did down-sample the image to exactly fit the width/height of the container frame. However, this is bad for retina display where we can show image beautifully with higher resolution (x2 or x3) in the same visible size.

## Fix
Stop downsampling and let UIImageView resize as appropriate. This way images are rendered beautifully respecting the resolution of the original image.

Added constraints for width/height so UIImageView is fit to the intended size of the frame.

## Tests
Using iOS Visualizer, test all templates and see images are clearer, and that width/height are retained.