### PR TITLE
iOS: Support borderColor/borderThickness for Container

### DIFF
--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/resources/sample.json
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/resources/sample.json
@@ -29,6 +29,7 @@
     "default": {
       "backgroundColor": "#00000000",
       "borderColor": "#FF232323",
+      "borderThickness": "1",
       "fontColors": {
         "default": {
           "normal": "#333333",

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/resources/sample.json
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/resources/sample.json
@@ -28,8 +28,6 @@
   "containerStyles": {
     "default": {
       "backgroundColor": "#00000000",
-      "borderColor": "#FF232323",
-      "borderThickness": "1",
       "fontColors": {
         "default": {
           "normal": "#333333",
@@ -55,6 +53,8 @@
     },
     "emphasis": {
       "backgroundColor": "#08000000",
+      "borderColor": "#FF232323",
+      "borderThickness": "1",
       "fontColors": {
         "default": {
           "normal": "#333333",

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/resources/sample.json
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/resources/sample.json
@@ -69,7 +69,7 @@
             },
             "backgroundColor": "#08000000",
             "borderColor": "#FF000000",
-            "borderThickness": "2"
+            "borderThickness": 2
               }
     },
     "spacing": {

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/resources/sample.json
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/resources/sample.json
@@ -28,7 +28,7 @@
   "containerStyles": {
     "default": {
       "backgroundColor": "#00000000",
-      "borderColor": "#00232323",
+      "borderColor": "#FF232323",
       "fontColors": {
         "default": {
           "normal": "#333333",

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/resources/sample.json
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/resources/sample.json
@@ -102,7 +102,7 @@
     },
     "imageSet": {
         "imageSize": "Medium",
-        "maxImageHeight": "maxImageHeight"
+        "maxImageHeight": 999
     },
     "factSet": {
         "title": {

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/resources/sample.json
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/resources/sample.json
@@ -28,6 +28,7 @@
   "containerStyles": {
     "default": {
       "backgroundColor": "#00000000",
+      "borderColor": "#00232323",
       "fontColors": {
         "default": {
           "normal": "#333333",

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentStackView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentStackView.mm
@@ -79,11 +79,6 @@ using namespace AdaptiveCards;
                     alpha:((num & 0xFF000000) >> 24) / 255.0];
 }
 
-+ (CGFloat)borderWidthFromString:(const std::string&)thicknessString
-{
-    return std::stof(thicknessString);
-}
-
 - (ContainerStyleDefinition&)paletteForHostConfig:(std::shared_ptr<HostConfig> const &)config
 {
     return (_style == ContainerStyle::Emphasis)
@@ -107,7 +102,7 @@ using namespace AdaptiveCards;
 
 - (void)setBorderThicknessWithHostConfig:(std::shared_ptr<HostConfig> const &)config
 {
-    const CGFloat borderWidth = [[self class] borderWidthFromString:[self paletteForHostConfig:config].borderThickness];
+    const CGFloat borderWidth = [self paletteForHostConfig:config].borderThickness;
 
     [[self layer] setBorderWidth:borderWidth];
 }

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentStackView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentStackView.mm
@@ -24,6 +24,7 @@ using namespace AdaptiveCards;
         _style = style;
         [self setBackgroundColorWithHostConfig:config];
         [self setBorderColorWithHostConfig:config];
+        [self setBorderThicknessWithHostConfig:config];
     }
     return self;
 }
@@ -68,25 +69,37 @@ using namespace AdaptiveCards;
                     alpha:((num & 0xFF000000) >> 24) / 255.0];
 }
 
-+ (ContainerStyleDefinition&)paletteForStyle:(ContainerStyle&)style hostConfig:(std::shared_ptr<HostConfig> const &)config
++ (CGFloat)borderWidthFromString:(const std::string&)thicknessString
 {
-    return (style == ContainerStyle::Emphasis)
+    return std::stof(thicknessString);
+}
+
+- (ContainerStyleDefinition&)paletteForHostConfig:(std::shared_ptr<HostConfig> const &)config
+{
+    return (_style == ContainerStyle::Emphasis)
         ? config->containerStyles.emphasisPalette
         : config->containerStyles.defaultPalette;
 }
 
 - (void)setBackgroundColorWithHostConfig:(std::shared_ptr<HostConfig> const &)config
 {
-    UIColor *color = [[self class] colorFromString:[[self class] paletteForStyle:_style hostConfig:config].backgroundColor];
+    UIColor *color = [[self class] colorFromString:[self paletteForHostConfig:config].backgroundColor];
 
     self.backgroundColor = color;
 }
 
 - (void)setBorderColorWithHostConfig:(std::shared_ptr<HostConfig> const &)config
 {
-    UIColor *color = [[self class] colorFromString:[[self class] paletteForStyle:_style hostConfig:config].borderColor];
+    UIColor *color = [[self class] colorFromString:[self paletteForHostConfig:config].borderColor];
 
     [[self layer] setBorderColor:[color CGColor]];
+}
+
+- (void)setBorderThicknessWithHostConfig:(std::shared_ptr<HostConfig> const &)config
+{
+    const CGFloat borderWidth = [[self class] borderWidthFromString:[self paletteForHostConfig:config].borderThickness];
+
+    [[self layer] setBorderWidth:borderWidth];
 }
 
 - (void)config

--- a/source/shared/cpp/ObjectModel/HostConfig.cpp
+++ b/source/shared/cpp/ObjectModel/HostConfig.cpp
@@ -252,11 +252,14 @@ ContainerStyleDefinition AdaptiveCards::ContainerStyleDefinition::Deserialize(co
 {
     ContainerStyleDefinition result;
 
-    std::string backgroundColor = ParseUtil::GetString(json, AdaptiveCardSchemaKey::BackgroundColor);
+    const std::string backgroundColor = ParseUtil::GetString(json, AdaptiveCardSchemaKey::BackgroundColor);
     result.backgroundColor = backgroundColor == "" ? defaultValue.backgroundColor : backgroundColor;
 
-    std::string borderColor = ParseUtil::GetString(json, AdaptiveCardSchemaKey::BorderColor);
+    const std::string borderColor = ParseUtil::GetString(json, AdaptiveCardSchemaKey::BorderColor);
     result.borderColor = borderColor == "" ? defaultValue.borderColor : borderColor;
+
+    const std::string borderThickness = ParseUtil::GetString(json, AdaptiveCardSchemaKey::BorderThickness);
+    result.borderThickness = borderThickness == "" ? defaultValue.borderThickness : borderThickness;
 
     result.foregroundColors = ParseUtil::ExtractJsonValueAndMergeWithDefault<ColorsConfig>(
         json, AdaptiveCardSchemaKey::ForegroundColors, defaultValue.foregroundColors, ColorsConfig::Deserialize);

--- a/source/shared/cpp/ObjectModel/HostConfig.cpp
+++ b/source/shared/cpp/ObjectModel/HostConfig.cpp
@@ -255,6 +255,9 @@ ContainerStyleDefinition AdaptiveCards::ContainerStyleDefinition::Deserialize(co
     std::string backgroundColor = ParseUtil::GetString(json, AdaptiveCardSchemaKey::BackgroundColor);
     result.backgroundColor = backgroundColor == "" ? defaultValue.backgroundColor : backgroundColor;
 
+    std::string borderColor = ParseUtil::GetString(json, AdaptiveCardSchemaKey::BorderColor);
+    result.borderColor = borderColor == "" ? defaultValue.borderColor : borderColor;
+
     result.foregroundColors = ParseUtil::ExtractJsonValueAndMergeWithDefault<ColorsConfig>(
         json, AdaptiveCardSchemaKey::ForegroundColors, defaultValue.foregroundColors, ColorsConfig::Deserialize);
 

--- a/source/shared/cpp/ObjectModel/HostConfig.cpp
+++ b/source/shared/cpp/ObjectModel/HostConfig.cpp
@@ -258,8 +258,7 @@ ContainerStyleDefinition AdaptiveCards::ContainerStyleDefinition::Deserialize(co
     const std::string borderColor = ParseUtil::GetString(json, AdaptiveCardSchemaKey::BorderColor);
     result.borderColor = borderColor == "" ? defaultValue.borderColor : borderColor;
 
-    const std::string borderThickness = ParseUtil::GetString(json, AdaptiveCardSchemaKey::BorderThickness);
-    result.borderThickness = borderThickness == "" ? defaultValue.borderThickness : borderThickness;
+    result.borderThickness = ParseUtil::GetInt(json, AdaptiveCardSchemaKey::BorderThickness, defaultValue.borderThickness);
 
     result.foregroundColors = ParseUtil::ExtractJsonValueAndMergeWithDefault<ColorsConfig>(
         json, AdaptiveCardSchemaKey::ForegroundColors, defaultValue.foregroundColors, ColorsConfig::Deserialize);

--- a/source/shared/cpp/ObjectModel/HostConfig.h
+++ b/source/shared/cpp/ObjectModel/HostConfig.h
@@ -124,6 +124,7 @@ struct ContainerStyleDefinition
 {
     std::string backgroundColor = "#FFFFFFFF";
     std::string borderColor = "#FF7F7F7F7F";
+    std::string borderThickness = "1";
     ColorsConfig foregroundColors;
 
     static ContainerStyleDefinition Deserialize(const Json::Value& json, const ContainerStyleDefinition& defaultValue);
@@ -133,7 +134,7 @@ struct ContainerStylesDefinition
 {
     ContainerStyleDefinition defaultPalette;
     ContainerStyleDefinition emphasisPalette = 
-    { "#08000000", "#08000000",
+    { "#08000000", "#08000000", "1",
         {
             { "#FF000000", "#B2000000" },   //defaultColor
             { "#FF0000FF", "#B20000FF" },   //accent

--- a/source/shared/cpp/ObjectModel/HostConfig.h
+++ b/source/shared/cpp/ObjectModel/HostConfig.h
@@ -123,6 +123,7 @@ struct FactSetConfig
 struct ContainerStyleDefinition
 {
     std::string backgroundColor = "#FFFFFFFF";
+    std::string borderColor = "#FF7F7F7F7F";
     ColorsConfig foregroundColors;
 
     static ContainerStyleDefinition Deserialize(const Json::Value& json, const ContainerStyleDefinition& defaultValue);
@@ -132,7 +133,7 @@ struct ContainerStylesDefinition
 {
     ContainerStyleDefinition defaultPalette;
     ContainerStyleDefinition emphasisPalette = 
-    { "#08000000",
+    { "#08000000", "#08000000",
         {
             { "#FF000000", "#B2000000" },   //defaultColor
             { "#FF0000FF", "#B20000FF" },   //accent

--- a/source/shared/cpp/ObjectModel/HostConfig.h
+++ b/source/shared/cpp/ObjectModel/HostConfig.h
@@ -124,7 +124,7 @@ struct ContainerStyleDefinition
 {
     std::string backgroundColor = "#FFFFFFFF";
     std::string borderColor = "#FF7F7F7F7F";
-    std::string borderThickness = "1";
+    std::string borderThickness = "0";
     ColorsConfig foregroundColors;
 
     static ContainerStyleDefinition Deserialize(const Json::Value& json, const ContainerStyleDefinition& defaultValue);
@@ -134,7 +134,7 @@ struct ContainerStylesDefinition
 {
     ContainerStyleDefinition defaultPalette;
     ContainerStyleDefinition emphasisPalette = 
-    { "#08000000", "#08000000", "1",
+    { "#08000000", "#08000000", "0",
         {
             { "#FF000000", "#B2000000" },   //defaultColor
             { "#FF0000FF", "#B20000FF" },   //accent

--- a/source/shared/cpp/ObjectModel/HostConfig.h
+++ b/source/shared/cpp/ObjectModel/HostConfig.h
@@ -124,7 +124,7 @@ struct ContainerStyleDefinition
 {
     std::string backgroundColor = "#FFFFFFFF";
     std::string borderColor = "#FF7F7F7F7F"; // CAUTION: Experimental feature for iOS. Not in v1 schema, subject to change.
-    std::string borderThickness = "0"; // CAUTION: Experimental feature for iOS. Not in v1 schema, subject to change.
+    unsigned int borderThickness = 0; // CAUTION: Experimental feature for iOS. Not in v1 schema, subject to change.
     ColorsConfig foregroundColors;
 
     static ContainerStyleDefinition Deserialize(const Json::Value& json, const ContainerStyleDefinition& defaultValue);
@@ -134,7 +134,7 @@ struct ContainerStylesDefinition
 {
     ContainerStyleDefinition defaultPalette;
     ContainerStyleDefinition emphasisPalette = 
-    { "#08000000", "#08000000", "0",
+    { "#08000000", "#08000000", 0,
         {
             { "#FF000000", "#B2000000" },   //defaultColor
             { "#FF0000FF", "#B20000FF" },   //accent

--- a/source/shared/cpp/ObjectModel/HostConfig.h
+++ b/source/shared/cpp/ObjectModel/HostConfig.h
@@ -123,8 +123,8 @@ struct FactSetConfig
 struct ContainerStyleDefinition
 {
     std::string backgroundColor = "#FFFFFFFF";
-    std::string borderColor = "#FF7F7F7F7F";
-    std::string borderThickness = "0";
+    std::string borderColor = "#FF7F7F7F7F"; // CAUTION: Experimental feature for iOS. Not in v1 schema, subject to change.
+    std::string borderThickness = "0"; // CAUTION: Experimental feature for iOS. Not in v1 schema, subject to change.
     ColorsConfig foregroundColors;
 
     static ContainerStyleDefinition Deserialize(const Json::Value& json, const ContainerStyleDefinition& defaultValue);


### PR DESCRIPTION
## Defect
NYI. We have schema for borderColor/borderThickness, but have not made it on iOS.

## Fix
Parse from JSON and apply when rendering Container elements.

## Tests
Using iOS Visualizer, verify:
- The default style (without borderColor/Thickness) has no border
- The emphasis style (with borderColor/Thickness) has border.
