### PR TITLE
iOS: Respect font weight to render text in lighter weight

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRFactSetRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRFactSetRenderer.mm
@@ -44,7 +44,7 @@
                                                             [ACRTextBlockRenderer getTextBlockColor:txtConfig.color
                                                                                         colorsConfig:colorConfig
                                                                                        subtleOption:txtConfig.isSubtle],
-                                                            NSStrokeWidthAttributeName:[ACRTextBlockRenderer getTextBlockTextWeight:txtConfig.weight
+                                                            NSStrokeWidthAttributeName:[ACRTextBlockRenderer getTextStrokeWidthForWeight:txtConfig.weight
                                                                                                                      withHostConfig:config]}];
     NSMutableParagraphStyle *para = [[NSMutableParagraphStyle alloc] init];
     [content addAttributes:@{NSParagraphStyleAttributeName:para} range:NSMakeRange(0,1)];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextBlockRenderer.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextBlockRenderer.h
@@ -12,8 +12,10 @@
 
 + (ACRTextBlockRenderer *)getInstance;
 
-+ (NSNumber *)getTextBlockTextWeight:(TextWeight)weight
++ (NSNumber *)getTextStrokeWidthForWeight:(TextWeight)weight
                       withHostConfig:(std::shared_ptr<HostConfig> const &)config;
++ (int)getTextBlockFontWeight:(TextWeight)weight
+               withHostConfig:(std::shared_ptr<HostConfig> const &)config;
 + (int)getTextBlockTextSize:(TextSize)txtSz
              withHostConfig:(std::shared_ptr<HostConfig> const &)config;
 + (UIColor *)getTextBlockColor:(ForegroundColor)txtClr

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextBlockRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextBlockRenderer.mm
@@ -65,7 +65,7 @@ rootViewController:(UIViewController *)vc
                                                                          config->containerStyles.defaultPalette.foregroundColors;
 
         // Add paragraph style, text color, text weight as attributes to a NSMutableAttributedString, content.
-        [content addAttributes:@{NSParagraphStyleAttributeName:paragraphStyle, NSForegroundColorAttributeName:[ACRTextBlockRenderer getTextBlockColor:txtBlck->GetTextColor() colorsConfig:colorConfig subtleOption:txtBlck->GetIsSubtle()], NSStrokeWidthAttributeName:[ACRTextBlockRenderer getTextBlockTextWeight:txtBlck->GetTextWeight() withHostConfig:config]} range:NSMakeRange(0, content.length - 1)];
+        [content addAttributes:@{NSParagraphStyleAttributeName:paragraphStyle, NSForegroundColorAttributeName:[ACRTextBlockRenderer getTextBlockColor:txtBlck->GetTextColor() colorsConfig:colorConfig subtleOption:txtBlck->GetIsSubtle()], NSStrokeWidthAttributeName:[ACRTextBlockRenderer getTextStrokeWidthForWeight:txtBlck->GetTextWeight() withHostConfig:config]} range:NSMakeRange(0, content.length - 1)];
         lab.attributedText = content;
 
         std::string id = txtBlck->GetId();
@@ -183,7 +183,7 @@ rootViewController:(UIViewController *)vc
     }
 }
 
-+ (NSNumber *)getTextBlockTextWeight:(TextWeight)weight
++ (NSNumber *)getTextStrokeWidthForWeight:(TextWeight)weight
                       withHostConfig:(std::shared_ptr<HostConfig> const &)config
 {
     switch (weight) {
@@ -193,6 +193,20 @@ rootViewController:(UIViewController *)vc
             return @1;
         case TextWeight::Bolder:
             return @-2;
+    }
+}
+
++ (int)getTextBlockFontWeight:(TextWeight)weight
+               withHostConfig:(std::shared_ptr<HostConfig> const &)config
+{
+    switch (weight) {
+        default:
+        case TextWeight::Default:
+            return config->fontWeights.defaultWeight;
+        case TextWeight::Lighter:
+            return config->fontWeights.lighterWeight;
+        case TextWeight::Bolder:
+            return config->fontWeights.bolderWeight;
     }
 }
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRViewController.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRViewController.mm
@@ -191,8 +191,11 @@ using namespace AdaptiveCards;
 
                         // Font and text size are applied as CSS style by appending it to the html string
                         NSString *fontFamily = [NSString stringWithCString:_hostConfig->fontFamily.c_str() encoding:NSUTF8StringEncoding];
-                        parsedString = [parsedString stringByAppendingString:[NSString stringWithFormat:@"<style>body{font-family: '%@'; font-size:%dpx; font-weight: 600;}</style>",
-                                                                              fontFamily, [ACRTextBlockRenderer getTextBlockTextSize:txtElem->GetTextSize() withHostConfig:_hostConfig]]];
+                        const int fontWeight = [ACRTextBlockRenderer getTextBlockFontWeight:txtElem->GetTextWeight() withHostConfig:_hostConfig];
+                        parsedString = [parsedString stringByAppendingString:[NSString stringWithFormat:@"<style>body{font-family: '%@'; font-size:%dpx; font-weight: %d;}</style>",
+                                                                              fontFamily,
+                                                                              [ACRTextBlockRenderer getTextBlockTextSize:txtElem->GetTextSize() withHostConfig:_hostConfig],
+                                                                              fontWeight]];
                         // Convert html string to NSMutableAttributedString, NSAttributedString knows how to apply html tags
                         NSData *htmlData = [parsedString dataUsingEncoding:NSUTF16StringEncoding];
                         NSDictionary *options = @{NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType};
@@ -226,7 +229,11 @@ using namespace AdaptiveCards;
                                       ColorsConfig &colorConfig = (style == ContainerStyle::Emphasis)? _hostConfig->containerStyles.emphasisPalette.foregroundColors:
                                                                                                              _hostConfig->containerStyles.defaultPalette.foregroundColors;
                                       // Add paragraph style, text color, text weight as attributes to a NSMutableAttributedString, content.
-                                      [content addAttributes:@{NSParagraphStyleAttributeName:paragraphStyle, NSForegroundColorAttributeName:[ACRTextBlockRenderer getTextBlockColor:txtElem->GetTextColor() colorsConfig:colorConfig subtleOption:txtElem->GetIsSubtle()], NSStrokeWidthAttributeName:[ACRTextBlockRenderer getTextStrokeWidthForWeight:txtElem->GetTextWeight() withHostConfig:_hostConfig]} range:NSMakeRange(0, content.length - 1)];
+                                      [content addAttributes:@{
+                                                               NSParagraphStyleAttributeName:paragraphStyle,
+                                                               NSForegroundColorAttributeName:[ACRTextBlockRenderer getTextBlockColor:txtElem->GetTextColor() colorsConfig:colorConfig subtleOption:txtElem->GetIsSubtle()],
+                                                               }
+                                                       range:NSMakeRange(0, content.length - 1)];
                                       lab.attributedText = content;
                                       // remove tag
                                       std::string id = txtElem->GetId();

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRViewController.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRViewController.mm
@@ -191,7 +191,7 @@ using namespace AdaptiveCards;
 
                         // Font and text size are applied as CSS style by appending it to the html string
                         NSString *fontFamily = [NSString stringWithCString:_hostConfig->fontFamily.c_str() encoding:NSUTF8StringEncoding];
-                        parsedString = [parsedString stringByAppendingString:[NSString stringWithFormat:@"<style>body{font-family: '%@'; font-size:%dpx;}</style>",
+                        parsedString = [parsedString stringByAppendingString:[NSString stringWithFormat:@"<style>body{font-family: '%@'; font-size:%dpx; font-weight: 600;}</style>",
                                                                               fontFamily, [ACRTextBlockRenderer getTextBlockTextSize:txtElem->GetTextSize() withHostConfig:_hostConfig]]];
                         // Convert html string to NSMutableAttributedString, NSAttributedString knows how to apply html tags
                         NSData *htmlData = [parsedString dataUsingEncoding:NSUTF16StringEncoding];
@@ -226,7 +226,7 @@ using namespace AdaptiveCards;
                                       ColorsConfig &colorConfig = (style == ContainerStyle::Emphasis)? _hostConfig->containerStyles.emphasisPalette.foregroundColors:
                                                                                                              _hostConfig->containerStyles.defaultPalette.foregroundColors;
                                       // Add paragraph style, text color, text weight as attributes to a NSMutableAttributedString, content.
-                                      [content addAttributes:@{NSParagraphStyleAttributeName:paragraphStyle, NSForegroundColorAttributeName:[ACRTextBlockRenderer getTextBlockColor:txtElem->GetTextColor() colorsConfig:colorConfig subtleOption:txtElem->GetIsSubtle()], NSStrokeWidthAttributeName:[ACRTextBlockRenderer getTextBlockTextWeight:txtElem->GetTextWeight() withHostConfig:_hostConfig]} range:NSMakeRange(0, content.length - 1)];
+                                      [content addAttributes:@{NSParagraphStyleAttributeName:paragraphStyle, NSForegroundColorAttributeName:[ACRTextBlockRenderer getTextBlockColor:txtElem->GetTextColor() colorsConfig:colorConfig subtleOption:txtElem->GetIsSubtle()], NSStrokeWidthAttributeName:[ACRTextBlockRenderer getTextStrokeWidthForWeight:txtElem->GetTextWeight() withHostConfig:_hostConfig]} range:NSMakeRange(0, content.length - 1)];
                                       lab.attributedText = content;
                                       // remove tag
                                       std::string id = txtElem->GetId();


### PR DESCRIPTION
## Defect
We specified stroke width with such a value as 1, 0, or -2 to change thickness of the text. This works to make font thicker, but does not make it thinner.

Also that way does not really respect the font weight you specify in host config with a granular value like 200, 400, or 600.

## Fix
Specify font weight for real.

Note that I did not change the existing helper to tell the stroke width except for renaming of function name for clarity.

## Tests
Using iOS Visualizer, check TextBlock.Weight template (and all other TextBlock ones and more) and see text looks good with appropriate weight.
- lighter weight
- default weight
- bolder weight