### PR TITLE
Fixed column overflows issue

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRImageRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRImageRenderer.mm
@@ -192,6 +192,8 @@
                                            withSuperview:wrappingview
                                                   toView:view]];
 
+    [wrappingview setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
+    [wrappingview setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisVertical];
     std::shared_ptr<BaseActionElement> selectAction = imgElem->GetSelectAction();
     // instantiate and add tap gesture recognizer
     UILongPressGestureRecognizer * gestureRecognizer =

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRSeparator.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRSeparator.mm
@@ -24,7 +24,7 @@ using namespace AdaptiveCards;
 
 - (instancetype)initWithFrame:(CGRect)frame
 {
-    self = [super initWithFrame:CGRectMake(0,0,0,0)];
+    self = [super initWithFrame:frame];
     if(self)
     {
         width  = frame.size.width;
@@ -141,9 +141,8 @@ using namespace AdaptiveCards;
         {
             superview = ((ACRContentStackView *) view).stackView;
         }
-
-        separator = [[ACRSeparator alloc] init];
-        unsigned int spacing = [separator getSpacing:requestedSpacing hostConfig:config];
+        unsigned int spacing = [ACRSeparator getSpacing:requestedSpacing hostConfig:config];
+        separator = [[ACRSeparator alloc] initWithFrame:CGRectMake(0, 0, spacing, spacing)];
         if(separator)
         {
             // Shared model has not implemented support
@@ -169,8 +168,7 @@ using namespace AdaptiveCards;
     }
 }
 
-- (unsigned int)getSpacing:(Spacing)spacing
-                           hostConfig:(std::shared_ptr<HostConfig> const &)config
++ (unsigned int)getSpacing:(Spacing)spacing hostConfig:(std::shared_ptr<HostConfig> const &)config
 {
     switch (spacing)
     {

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextBlockRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextBlockRenderer.mm
@@ -79,9 +79,7 @@ rootViewController:(UIViewController *)vc
         lab.numberOfLines = 1;
     }
 
-    CGSize intrinsicSz = [lab intrinsicContentSize];
-
-    ACRContentHoldingUIView *wrappingview = [[ACRContentHoldingUIView alloc] initWithFrame:CGRectMake(0, 0, intrinsicSz.width, intrinsicSz.height)];
+    ACRContentHoldingUIView *wrappingview = [[ACRContentHoldingUIView alloc] init];
 
     [wrappingview addSubview:lab];
 


### PR DESCRIPTION
- column overflows if the width is set to "auto"
this is expected behavior, but this should not cause other UI elements to be compressed.
- updated compression resistance to UIImageView.
- separator gets correct spacing value read from host config
- removed unnecessary system call from TextBlockRenderer.