### PR TITLE
Add the google source to properly download gradle on a build machine

### DIFF
--- a/source/android/build.gradle
+++ b/source/android/build.gradle
@@ -2,6 +2,7 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {


### PR DESCRIPTION
Fixing our android builds on our build servers.