### PR TITLE
iOS: Notify rendering completion

### DIFF
--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ViewController.m
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ViewController.m
@@ -233,9 +233,9 @@
     NSLog(@"Http Request fetched: %@", request);    
 }
 
-- (void)didCompleteRendering
+- (void)didLoadElements
 {
-    NSLog(@"didCompleteRendering");
+    NSLog(@"didLoadElements");
 }
 
 - (void)registerForKeyboardNotifications

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ViewController.m
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ViewController.m
@@ -233,6 +233,11 @@
     NSLog(@"Http Request fetched: %@", request);    
 }
 
+- (void)didCompleteRendering
+{
+    NSLog(@"didCompleteRendering");
+}
+
 - (void)registerForKeyboardNotifications
 {
     [[NSNotificationCenter defaultCenter] addObserver:self

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionDelegate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionDelegate.h
@@ -7,11 +7,15 @@
 
 #import <Foundation/Foundation.h>
 
-@protocol ACRActionDelegate
+@protocol ACRActionDelegate <NSObject>
 
 - (void)didFetchUserResponses:(NSData *)json error:(NSError *)error;
 
 - (void)didFetchUserResponses:(NSData *)json data:(NSString *)data error:(NSError *)error;
 
 - (void)didFetchHttpRequest:(NSURLRequest *)urlRequest;
+
+@optional
+- (void)didCompleteRendering;
+
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionDelegate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionDelegate.h
@@ -16,6 +16,6 @@
 - (void)didFetchHttpRequest:(NSURLRequest *)urlRequest;
 
 @optional
-- (void)didCompleteRendering;
+- (void)didLoadElements;
 
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRViewController.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRViewController.mm
@@ -75,7 +75,7 @@ using namespace AdaptiveCards;
 
     [self render];
 
-    [self callDidCompleteRenderingIfNeeded];
+    [self callDidLoadElementsIfNeeded];
 }
 
 - (void)render
@@ -191,21 +191,21 @@ using namespace AdaptiveCards;
 
     _asyncRenderedElements.remove(elem.get());
 
-    [self callDidCompleteRenderingIfNeeded];
+    [self callDidLoadElementsIfNeeded];
 }
 
-- (void)callDidCompleteRenderingIfNeeded
+- (void)callDidLoadElementsIfNeeded
 {
     if (_asyncRenderedElements.size() == 0)
     {
 #if DEBUG
-        NSLog(@"Call didCompleteRendering");
+        NSLog(@"Call didLoadElements");
 #endif
 
-        // Call back app with didCompleteRendering
-        if ([[self acrActionDelegate] respondsToSelector:@selector(didCompleteRendering)])
+        // Call back app with didLoadElements
+        if ([[self acrActionDelegate] respondsToSelector:@selector(didLoadElements)])
         {
-            [[self acrActionDelegate] didCompleteRendering];
+            [[self acrActionDelegate] didLoadElements];
         }
     }
 }


### PR DESCRIPTION
This is to notify app of the rendering completion of an adaptive card. Using this, app can show the card only after it gets fully available.

## Issue
TextBlock rendering is a heavy task in iOS. It gives noticeable delay for users in hundreds milliseconds. We do render TextBlock elements async (which alone is good), but it is slow enough for users to notice they are being rendered. It looks messy so you may want to hide it while rendering is in progress. 

## Change
Provided didLoadElements, a new optional method in ACRActionDelegate.

When app implements this, we notify rendering complete by calling this back to app. Then app can handle to show/hide the adaptive card which has just been rendered completely.

The new method applies to not only TextBlock/Image/ImageSet but all other elements (which are rendered synchronously). We call didLoadElements at viewDidLoad when there are no TextBlock elements which are being rendered async. Otherwise, we let all TextBlock/Image/ImageSet elements render and call didLoadElements at the last element which completed rendering.

Updated the Visualizer code so the method is called with a NSLog call.

## Tests
Using iOS Visualizer, verify didLoadElements is called - log line will be added on debug console.
Tested all existing JSON in iOS Visualizer and confirmed didLoadElements is called in all the cases.
