### PR TITLE
Make items not required for containers

### DIFF
--- a/source/shared/cpp/ObjectModel/Container.cpp
+++ b/source/shared/cpp/ObjectModel/Container.cpp
@@ -95,7 +95,7 @@ std::shared_ptr<BaseCardElement> ContainerParser::Deserialize(
         ParseUtil::GetEnumValue<ContainerStyle>(value, AdaptiveCardSchemaKey::Style, ContainerStyle::None, ContainerStyleFromString));
 
     // Parse Items
-    auto cardElements = ParseUtil::GetElementCollection(elementParserRegistration, actionParserRegistration, value, AdaptiveCardSchemaKey::Items, true);
+    auto cardElements = ParseUtil::GetElementCollection(elementParserRegistration, actionParserRegistration, value, AdaptiveCardSchemaKey::Items, false);
     container->m_items = std::move(cardElements);
 
     container->SetSelectAction(BaseCardElement::DeserializeSelectAction(elementParserRegistration, actionParserRegistration, value, AdaptiveCardSchemaKey::SelectAction));


### PR DESCRIPTION
Per discussion with Matt, update the code to make the items collection not required in a container. This fixes #1168.