### PR TITLE
iOS: Fix crash on TextBlock rendering

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRViewController.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRViewController.mm
@@ -241,11 +241,13 @@ using namespace AdaptiveCards;
                         // Convert html string to NSMutableAttributedString, NSAttributedString knows how to apply html tags
                         NSData *htmlData = [parsedString dataUsingEncoding:NSUTF16StringEncoding];
                         NSDictionary *options = @{NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType};
-                        // Initializing NSMutableAttributedString for HTML rendering is very slow
-                        NSMutableAttributedString *content = [[NSMutableAttributedString alloc] initWithData:htmlData options:options documentAttributes:nil error:nil];
 
-                         dispatch_async(dispatch_get_main_queue(),
-                             ^{ __block ACRUILabel *lab = nil; // generate key for text map from TextBlock element's id
+                        dispatch_async(dispatch_get_main_queue(),
+                             ^{
+                                  // Initializing NSMutableAttributedString for HTML rendering is very slow
+                                  NSMutableAttributedString *content = [[NSMutableAttributedString alloc] initWithData:htmlData options:options documentAttributes:nil error:nil];
+
+                                  __block ACRUILabel *lab = nil; // generate key for text map from TextBlock element's id
                                   NSString *key = [NSString stringWithCString:txtElem->GetId().c_str() encoding:[NSString defaultCStringEncoding]];
                                   // syncronize access to text map
                                   dispatch_sync(_serial_text_queue,


### PR DESCRIPTION
## Defect
We make NSMutableAttributedString call in background thread. It may cause crash because NSMutableAttributedString is not thread-safe.

https://stackoverflow.com/questions/37029891/ios-crash-nsmutableattributedstring
https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/AttributedStrings/Tasks/CreatingAttributedStrings.html

Actually, we see a crash frequently on an iPhone X device.

## Fix
Moved the NSMutableAttributedString to main thread.

## Tests
iOS Visualizer works fine, render the test templates.
