### PR TITLE
Make the markdown parsing interface consistent in terms of parameters…

### DIFF
--- a/source/shared/cpp/ObjectModel/MarkDownBlockParser.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownBlockParser.cpp
@@ -23,13 +23,13 @@ void MarkDownBlockParser::ParseBlock(std::stringstream &stream)
     case ']': case ')':
     {
         // add these char as token to code gen list
-        m_parsedResult.AddNewTokenToParsedResult(static_cast<char>(stream.get()));
+        m_parsedResult.AddNewTokenToParsedResult(stream.get());
         break;
     }
     case '\n': case '\r':
     {
         // add new line char as token to code gen list
-        m_parsedResult.AddNewLineTokenToParsedResult(static_cast<char>(stream.get()));
+        m_parsedResult.AddNewLineTokenToParsedResult(stream.get());
         break;
     }
     // handles list block
@@ -85,11 +85,11 @@ EmphasisParser::EmphasisState EmphasisParser::MatchText(EmphasisParser &parser, 
         return EmphasisState::Captured;
     }
 
-    if (parser.IsMarkDownDelimiter(static_cast<char>(stream.peek())))
+    if (parser.IsMarkDownDelimiter(stream.peek()))
     {
         // encounterred first emphasis delimiter
         parser.CaptureCurrentCollectedStringAsRegularToken();
-        DelimiterType emphasisType = EmphasisParser::GetDelimiterTypeForCharAtCurrentPosition(static_cast<char>(stream.peek()));
+        DelimiterType emphasisType = EmphasisParser::GetDelimiterTypeForCharAtCurrentPosition(stream.peek());
         // get previous character and update the look behind if it was captured before 
         if (stream.tellg())
         {
@@ -98,13 +98,13 @@ EmphasisParser::EmphasisState EmphasisParser::MatchText(EmphasisParser &parser, 
         }
 
         parser.UpdateCurrentEmphasisRunState(emphasisType);
-        token += static_cast<char>(stream.get());
+        token += stream.get();
         return EmphasisState::Emphasis;
     }
     else
     {
         parser.UpdateLookBehind(stream.peek());
-        token += static_cast<char>(stream.get());
+        token += stream.get();
         return EmphasisState::Text;
     }
 }
@@ -121,15 +121,15 @@ EmphasisParser::EmphasisState EmphasisParser::MatchEmphasis(EmphasisParser &pars
     }
 
     /// if another emphasis delimiter is encounterred, it is delimiter run
-    if (parser.IsMarkDownDelimiter(static_cast<char>(stream.peek())))
+    if (parser.IsMarkDownDelimiter(stream.peek()))
     {
-        DelimiterType emphasisType = EmphasisParser::GetDelimiterTypeForCharAtCurrentPosition(static_cast<char>(stream.peek()));
+        DelimiterType emphasisType = EmphasisParser::GetDelimiterTypeForCharAtCurrentPosition((stream.peek()));
         if (parser.IsEmphasisDelimiterRun(emphasisType))
         {
             parser.UpdateCurrentEmphasisRunState(emphasisType);
         }
 
-        token += static_cast<char>(stream.get());
+        token += stream.get();
     }
     /// delimiter run is ended, capture the current accumulated token as emphasis
     else
@@ -144,7 +144,7 @@ EmphasisParser::EmphasisState EmphasisParser::MatchEmphasis(EmphasisParser &pars
 
         parser.ResetCurrentEmphasisState();
         parser.UpdateLookBehind(stream.peek());
-        token += static_cast<char>(stream.get());
+        token += stream.get();
         return EmphasisState::Text;
     }
     return EmphasisState::Emphasis;
@@ -166,7 +166,7 @@ void EmphasisParser::Flush(int ch, std::string& currentToken)
     currentToken.clear();
 }
 
-bool EmphasisParser::IsMarkDownDelimiter(char ch)
+bool EmphasisParser::IsMarkDownDelimiter(int ch)
 {
     return ((ch == '*' || ch == '_') && (m_lookBehind != Escape));
 }
@@ -201,7 +201,7 @@ void EmphasisParser::UpdateCurrentEmphasisRunState(DelimiterType emphasisType)
 
 bool EmphasisParser::IsRightEmphasisDelimiter(int ch)
 {
-    if ((isspace(ch) || (ch == EOF)) &&
+    if ((std::isspace(ch) || (ch == EOF)) &&
         (m_lookBehind != WhiteSpace) &&
         (m_checkLookAhead || m_checkIntraWord || m_currentDelimiterType == Asterisk))
     {
@@ -331,7 +331,7 @@ bool LinkParser::MatchAtLinkInit(std::stringstream &lookahead)
 {
     if (lookahead.peek() == '[')
     {
-        m_linkTextParsedResult.AddNewTokenToParsedResult(static_cast<char>(lookahead.get()));
+        m_linkTextParsedResult.AddNewTokenToParsedResult(lookahead.get());
         return true;
     }
 
@@ -345,7 +345,7 @@ bool LinkParser::MatchAtLinkTextRun(std::stringstream &lookahead)
 {
     if (lookahead.peek() == ']')
     {
-        m_linkTextParsedResult.AddNewTokenToParsedResult(static_cast<char>(lookahead.get()));
+        m_linkTextParsedResult.AddNewTokenToParsedResult(lookahead.get());
         return true;
     }
     else
@@ -364,7 +364,7 @@ bool LinkParser::MatchAtLinkTextRun(std::stringstream &lookahead)
             if (lookahead.peek() == ']')
             {
                 // move code gen objects to link text list to further process it 
-                m_linkTextParsedResult.AddNewTokenToParsedResult(static_cast<char>(lookahead.get()));
+                m_linkTextParsedResult.AddNewTokenToParsedResult(lookahead.get());
                 return true;
             }
 
@@ -379,7 +379,7 @@ bool LinkParser::MatchAtLinkTextEnd(std::stringstream &lookahead)
 {
     if (lookahead.peek() == '(')
     {
-        m_linkTextParsedResult.AddNewTokenToParsedResult(static_cast<char>(lookahead.get()));
+        m_linkTextParsedResult.AddNewTokenToParsedResult(lookahead.get());
         return true;
     }
 
@@ -517,7 +517,7 @@ bool ListParser::MatchNewOrderedListItem(std::stringstream &stream, std::string 
 {
     do
     {
-        number_string += static_cast<char>(stream.get());
+        number_string += stream.get();
     } while (isdigit(stream.peek()));
 
     if (stream.peek() == '.')
@@ -558,7 +558,7 @@ void ListParser::ParseSubBlocks(std::stringstream &stream)
                 break;
             }
 
-            m_parsedResult.AddNewTokenToParsedResult(static_cast<char>(newLineChar));
+            m_parsedResult.AddNewTokenToParsedResult(newLineChar);
         }
         ParseBlock(stream);
     }
@@ -632,7 +632,7 @@ void OrderedListParser::Match(std::stringstream &stream)
     {
         do
         {
-            number_string += static_cast<char>(stream.get());
+            number_string += stream.get();
         } while (isdigit(stream.peek()));
 
         if (IsDot(stream.peek()))

--- a/source/shared/cpp/ObjectModel/MarkDownBlockParser.h
+++ b/source/shared/cpp/ObjectModel/MarkDownBlockParser.h
@@ -41,7 +41,7 @@ namespace AdaptiveCards
         // and causes the emphasis parsing to terminate
         void Flush(int ch, std::string& currentToken);
         // check if given character is * or _
-        bool IsMarkDownDelimiter(char ch);
+        bool IsMarkDownDelimiter(int ch);
         void CaptureCurrentCollectedStringAsRegularToken(std::string&currentToken); 
         void CaptureCurrentCollectedStringAsRegularToken();
         void UpdateCurrentEmphasisRunState(DelimiterType emphasisType);
@@ -63,7 +63,7 @@ namespace AdaptiveCards
         bool TryCapturingLeftEmphasisToken(int ch, std::string &currentToken);
         void CaptureEmphasisToken(int ch, std::string &currentToken);
         void UpdateLookBehind(int ch);
-        static DelimiterType GetDelimiterTypeForCharAtCurrentPosition(char ch) { return (ch == '*')? Asterisk : Underscore; };
+        static DelimiterType GetDelimiterTypeForCharAtCurrentPosition(int ch) { return (ch == '*')? Asterisk : Underscore; };
 
         typedef EmphasisState (* MatchWithChar)(EmphasisParser&, std::stringstream &, std::string &);
         // Callback function that handles the Text State


### PR DESCRIPTION
… being processed.

Keep the character representation as an int throughout the markdown parser.

This was noticed when investigating #1154.