### PR TITLE
Unsupported strings should return default values

### DIFF
--- a/source/shared/cpp/ObjectModel/Enums.cpp
+++ b/source/shared/cpp/ObjectModel/Enums.cpp
@@ -597,7 +597,7 @@ CardElementType CardElementTypeFromString(const std::string& elementType)
 
     if (cardElementTypeNameToEnum.find(elementType) == cardElementTypeNameToEnum.end())
     {
-        throw std::out_of_range("Invalid CardElementType: " + elementType);
+        return CardElementType::Unsupported;
     }
 
     return cardElementTypeNameToEnum[elementType];
@@ -623,7 +623,7 @@ ActionType ActionTypeFromString(const std::string& actionType)
 
     if (actionTypeNameToEnum.find(actionType) == actionTypeNameToEnum.end())
     {
-        throw std::out_of_range("Invalid ActionType: " + actionType);
+        return ActionType::Unsupported;
     }
 
     return actionTypeNameToEnum[actionType];
@@ -648,7 +648,7 @@ HorizontalAlignment HorizontalAlignmentFromString(const std::string& alignment)
 
     if (horizontalAlignmentNameToEnum.find(alignment) == horizontalAlignmentNameToEnum.end())
     {
-        throw std::out_of_range("Invalid HorizontalAlignment: " + alignment);
+        return HorizontalAlignment::Left;
     }
 
     return horizontalAlignmentNameToEnum[alignment];
@@ -673,7 +673,7 @@ ForegroundColor ForegroundColorFromString(const std::string& color)
 
     if (colorNameToEnum.find(color) == colorNameToEnum.end())
     {
-        throw std::out_of_range("Invalid ForegroundColor: " + color);
+        return ForegroundColor::Default;
     }
 
     return colorNameToEnum[color];
@@ -698,7 +698,7 @@ TextWeight TextWeightFromString(const std::string& weight)
 
     if (textWeightNameToEnum.find(weight) == textWeightNameToEnum.end())
     {
-        throw std::out_of_range("Invalid TextWeight: " + weight);
+        return TextWeight::Default;
     }
 
     return textWeightNameToEnum[weight];
@@ -723,7 +723,7 @@ TextSize TextSizeFromString(const std::string& size)
 
     if (textSizeNameToEnum.find(size) == textSizeNameToEnum.end())
     {
-        throw std::out_of_range("Invalid TextSize: " + size);
+        return TextSize::Default;
     }
 
     return textSizeNameToEnum[size];
@@ -748,7 +748,7 @@ ImageSize ImageSizeFromString(const std::string& size)
 
     if (imageSizeNameToEnum.find(size) == imageSizeNameToEnum.end())
     {
-        throw std::out_of_range("Invalid ImageSize: " + size);
+        return ImageSize::Auto;
     }
 
     return imageSizeNameToEnum[size];
@@ -773,7 +773,7 @@ Spacing SpacingFromString(const std::string& spacing)
 
     if (spacingNameToEnum.find(spacing) == spacingNameToEnum.end())
     {
-        throw std::out_of_range("Invalid Spacing: " + spacing);
+        return Spacing::Default;
     }
 
     return spacingNameToEnum[spacing];
@@ -798,7 +798,7 @@ SeparatorThickness SeparatorThicknessFromString(const std::string& thickness)
 
     if (separatorThicknessNameToEnum.find(thickness) == separatorThicknessNameToEnum.end())
     {
-        throw std::out_of_range("Invalid SeparatorThickness: " + thickness);
+        return SeparatorThickness::Default;
     }
 
     return separatorThicknessNameToEnum[thickness];
@@ -823,7 +823,7 @@ ImageStyle ImageStyleFromString(const std::string& style)
 
     if (imageStyleNameToEnum.find(style) == imageStyleNameToEnum.end())
     {
-        throw std::out_of_range("Invalid ImageStyle: " + style);
+        return ImageStyle::Default;
     }
 
     return imageStyleNameToEnum[style];
@@ -848,7 +848,7 @@ ActionsOrientation ActionsOrientationFromString(const std::string& orientation)
 
     if (actionsOrientationNameToEnum.find(orientation) == actionsOrientationNameToEnum.end())
     {
-        throw std::out_of_range("Invalid ActionsOrientation: " + orientation);
+        return ActionsOrientation::Horizontal;
     }
     return actionsOrientationNameToEnum[orientation];
 }
@@ -872,7 +872,7 @@ ActionMode ActionModeFromString(const std::string& mode)
 
     if (actionModeNameToEnum.find(mode) == actionModeNameToEnum.end())
     {
-        throw std::out_of_range("Invalid ActionMode: " + mode);
+        return ActionMode::Inline;
     }
     return actionModeNameToEnum[mode];
 }
@@ -895,7 +895,7 @@ ChoiceSetStyle ChoiceSetStyleFromString(const std::string & style)
 
     if (choiceSetStyleNameToEnum.find(style) == choiceSetStyleNameToEnum.end())
     {
-        throw std::out_of_range("Invalid ChoiceSetStyle: " + style);
+        return ChoiceSetStyle::Compact;
     }
     return choiceSetStyleNameToEnum[style];
 }
@@ -919,7 +919,7 @@ TextInputStyle TextInputStyleFromString(const std::string & style)
 
     if (textInputStyleNameToEnum.find(style) == textInputStyleNameToEnum.end())
     {
-        throw std::out_of_range("Invalid TextInputStyle: " + style);
+        return TextInputStyle::Text;
     }
     return textInputStyleNameToEnum[style];
 }
@@ -943,7 +943,7 @@ ContainerStyle ContainerStyleFromString(const std::string & style)
 
     if (containerStyleNameToEnum.find(style) == containerStyleNameToEnum.end())
     {
-        throw std::out_of_range("Invalid ContainerStyle: " + style);
+        return ContainerStyle::Default;
     }
     return containerStyleNameToEnum[style];
 }
@@ -967,7 +967,7 @@ ActionAlignment ActionAlignmentFromString(const std::string & alignment)
 
     if (actionAlignmentNameToEnum.find(alignment) == actionAlignmentNameToEnum.end())
     {
-        throw std::out_of_range("Invalid ActionAlignment: " + alignment);
+        return ActionAlignment::Left;
     }
     return actionAlignmentNameToEnum[alignment];
 }


### PR DESCRIPTION
Changes exception throwing for returning the default value when a string cant be mapped to an enum value