### PR TITLE
Adding support for precompiled headers for UWP projects

### DIFF
--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModel/AdaptiveCardsSharedModel.vcxproj
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModel/AdaptiveCardsSharedModel.vcxproj
@@ -75,6 +75,8 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -82,6 +84,8 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -91,6 +95,8 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -104,6 +110,8 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -111,6 +119,10 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\ObjectModel\pch.cpp">
+      <PrecompiledHeader>Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="..\..\ObjectModel\ActionParserRegistration.cpp" />
     <ClCompile Include="..\..\ObjectModel\ActionParserRegistration.cpp" />
     <ClCompile Include="..\..\ObjectModel\AdaptiveCardParseException.cpp" />
     <ClCompile Include="..\..\ObjectModel\AdaptiveCardParseWarning.cpp" />

--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModel/AdaptiveCardsSharedModel.vcxproj.filters
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModel/AdaptiveCardsSharedModel.vcxproj.filters
@@ -15,6 +15,9 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\ObjectModel\pch.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\ObjectModel\AdaptiveCardParseException.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/source/shared/cpp/ObjectModel/ActionParserRegistration.cpp
+++ b/source/shared/cpp/ObjectModel/ActionParserRegistration.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "ActionParserRegistration.h"
 #include "OpenUrlAction.h"
 #include "ShowCardAction.h"

--- a/source/shared/cpp/ObjectModel/AdaptiveCardParseException.cpp
+++ b/source/shared/cpp/ObjectModel/AdaptiveCardParseException.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "AdaptiveCardParseException.h"
 
 using namespace AdaptiveCards;

--- a/source/shared/cpp/ObjectModel/AdaptiveCardParseWarning.cpp
+++ b/source/shared/cpp/ObjectModel/AdaptiveCardParseWarning.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "AdaptiveCardParseWarning.h"
 
 using namespace AdaptiveCards;

--- a/source/shared/cpp/ObjectModel/BaseActionElement.cpp
+++ b/source/shared/cpp/ObjectModel/BaseActionElement.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "BaseActionElement.h"
 #include "ParseUtil.h"
 

--- a/source/shared/cpp/ObjectModel/BaseCardElement.cpp
+++ b/source/shared/cpp/ObjectModel/BaseCardElement.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "BaseCardElement.h"
 #include "ShowCardAction.h"
 #include "OpenUrlAction.h"

--- a/source/shared/cpp/ObjectModel/BaseInputElement.cpp
+++ b/source/shared/cpp/ObjectModel/BaseInputElement.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "BaseInputElement.h"
 #include "ParseUtil.h"
 

--- a/source/shared/cpp/ObjectModel/ChoiceInput.cpp
+++ b/source/shared/cpp/ObjectModel/ChoiceInput.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "ChoiceInput.h"
 #include "ParseUtil.h"
 #include "Enums.h"

--- a/source/shared/cpp/ObjectModel/ChoiceSetInput.cpp
+++ b/source/shared/cpp/ObjectModel/ChoiceSetInput.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "ChoiceInput.h"
 #include "ChoiceSetInput.h"
 #include "ParseUtil.h"

--- a/source/shared/cpp/ObjectModel/Column.cpp
+++ b/source/shared/cpp/ObjectModel/Column.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "ChoiceSetInput.h"
 #include "Column.h"
 #include "Util.h"

--- a/source/shared/cpp/ObjectModel/ColumnSet.cpp
+++ b/source/shared/cpp/ObjectModel/ColumnSet.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "ColumnSet.h"
 #include "ParseUtil.h"
 #include "Image.h"

--- a/source/shared/cpp/ObjectModel/Container.cpp
+++ b/source/shared/cpp/ObjectModel/Container.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "Container.h"
 #include "TextBlock.h"
 #include "ColumnSet.h"

--- a/source/shared/cpp/ObjectModel/DateInput.cpp
+++ b/source/shared/cpp/ObjectModel/DateInput.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "DateInput.h"
 #include "ParseUtil.h"
 

--- a/source/shared/cpp/ObjectModel/DateTimePreparsedToken.cpp
+++ b/source/shared/cpp/ObjectModel/DateTimePreparsedToken.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "DateTimePreparsedToken.h"
 
 using namespace AdaptiveCards;

--- a/source/shared/cpp/ObjectModel/DateTimePreparser.cpp
+++ b/source/shared/cpp/ObjectModel/DateTimePreparser.cpp
@@ -1,3 +1,5 @@
+#include "pch.h"
+
 #if defined(__ANDROID__) || (__APPLE__) || (__linux__)
 #define LOCALTIME(X,Y) (nullptr == localtime_r(Y, X))
 #else
@@ -6,7 +8,6 @@
 
 #include "DateTimePreparsedToken.h"
 
-#include "pch.h"
 #include "BaseCardElement.h"
 #include "Enums.h"
 #include <time.h>

--- a/source/shared/cpp/ObjectModel/ElementParserRegistration.cpp
+++ b/source/shared/cpp/ObjectModel/ElementParserRegistration.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "ElementParserRegistration.h"
 #include "ChoiceSetInput.h"
 #include "ColumnSet.h"

--- a/source/shared/cpp/ObjectModel/Enums.cpp
+++ b/source/shared/cpp/ObjectModel/Enums.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "Enums.h"
 
 namespace AdaptiveCards

--- a/source/shared/cpp/ObjectModel/Fact.cpp
+++ b/source/shared/cpp/ObjectModel/Fact.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "Fact.h"
 #include "ParseUtil.h"
 

--- a/source/shared/cpp/ObjectModel/FactSet.cpp
+++ b/source/shared/cpp/ObjectModel/FactSet.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "FactSet.h"
 #include "ParseUtil.h"
 #include "Fact.h"

--- a/source/shared/cpp/ObjectModel/Image.cpp
+++ b/source/shared/cpp/ObjectModel/Image.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "Image.h"
 #include "ParseUtil.h"
 

--- a/source/shared/cpp/ObjectModel/ImageSet.cpp
+++ b/source/shared/cpp/ObjectModel/ImageSet.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "ImageSet.h"
 #include "ParseUtil.h"
 #include "Image.h"

--- a/source/shared/cpp/ObjectModel/MarkDownBlockParser.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownBlockParser.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include <iostream>
 #include "MarkDownBlockParser.h"
 

--- a/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "MarkDownHtmlGenerator.h"
 
 using namespace AdaptiveCards;

--- a/source/shared/cpp/ObjectModel/MarkDownParsedResult.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownParsedResult.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "MarkDownParsedResult.h"
 
 using namespace AdaptiveCards;

--- a/source/shared/cpp/ObjectModel/MarkDownParser.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownParser.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include <vector>
 #include <iomanip>
 #include <iostream>

--- a/source/shared/cpp/ObjectModel/NumberInput.cpp
+++ b/source/shared/cpp/ObjectModel/NumberInput.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "NumberInput.h"
 #include "ParseUtil.h"
 

--- a/source/shared/cpp/ObjectModel/OpenUrlAction.cpp
+++ b/source/shared/cpp/ObjectModel/OpenUrlAction.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "OpenUrlAction.h"
 #include "ParseUtil.h"
 

--- a/source/shared/cpp/ObjectModel/ParseResult.cpp
+++ b/source/shared/cpp/ObjectModel/ParseResult.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "ParseResult.h"
 #include "ParseResult.h"
 #include "SharedAdaptiveCard.h"

--- a/source/shared/cpp/ObjectModel/ParseUtil.cpp
+++ b/source/shared/cpp/ObjectModel/ParseUtil.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "ParseUtil.h"
 #include "AdaptiveCardParseException.h"
 #include "ElementParserRegistration.h"

--- a/source/shared/cpp/ObjectModel/Separator.cpp
+++ b/source/shared/cpp/ObjectModel/Separator.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "Separator.h"
 #include "ParseUtil.h"
 

--- a/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
+++ b/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "SharedAdaptiveCard.h"
 #include "ParseUtil.h"
 #include "Util.h"

--- a/source/shared/cpp/ObjectModel/ShowCardAction.cpp
+++ b/source/shared/cpp/ObjectModel/ShowCardAction.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "SharedAdaptiveCard.h"
 #include "ParseUtil.h"
 #include "ShowCardAction.h"

--- a/source/shared/cpp/ObjectModel/SubmitAction.cpp
+++ b/source/shared/cpp/ObjectModel/SubmitAction.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "ParseUtil.h"
 #include "SubmitAction.h"
 

--- a/source/shared/cpp/ObjectModel/TextBlock.cpp
+++ b/source/shared/cpp/ObjectModel/TextBlock.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include <iomanip>
 #include <regex>
 #include <iostream>

--- a/source/shared/cpp/ObjectModel/TextInput.cpp
+++ b/source/shared/cpp/ObjectModel/TextInput.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "ParseUtil.h"
 #include "TextInput.h"
 

--- a/source/shared/cpp/ObjectModel/TimeInput.cpp
+++ b/source/shared/cpp/ObjectModel/TimeInput.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "ParseUtil.h"
 #include "TimeInput.h"
 

--- a/source/shared/cpp/ObjectModel/ToggleInput.cpp
+++ b/source/shared/cpp/ObjectModel/ToggleInput.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "ToggleInput.h"
 #include "ParseUtil.h"
 

--- a/source/shared/cpp/ObjectModel/UnknownElement.cpp
+++ b/source/shared/cpp/ObjectModel/UnknownElement.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include <iomanip>
 #include <regex>
 #include <iostream>

--- a/source/shared/cpp/ObjectModel/Util.cpp
+++ b/source/shared/cpp/ObjectModel/Util.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "Util.h"
 #include "ColumnSet.h"
 #include "Container.h"

--- a/source/shared/cpp/ObjectModel/jsoncpp.cpp
+++ b/source/shared/cpp/ObjectModel/jsoncpp.cpp
@@ -72,6 +72,7 @@ license you like.
 
 
 
+#include "pch.h"
 
 #include "json/json.h"
 

--- a/source/shared/cpp/ObjectModel/pch.cpp
+++ b/source/shared/cpp/ObjectModel/pch.cpp
@@ -1,0 +1,1 @@
+#include "pch.h"

--- a/source/uwp/ObjectModelProjection/ObjectModelProjection.vcxproj
+++ b/source/uwp/ObjectModelProjection/ObjectModelProjection.vcxproj
@@ -27,6 +27,9 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\shared\cpp\ObjectModel\pch.cpp">
+      <PrecompiledHeader>Create</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="..\..\shared\cpp\ObjectModel\ActionParserRegistration.cpp" />
     <ClCompile Include="..\..\shared\cpp\ObjectModel\AdaptiveCardParseException.cpp" />
     <ClCompile Include="..\..\shared\cpp\ObjectModel\AdaptiveCardParseWarning.cpp" />
@@ -154,7 +157,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
       <CompileAsWinRT>false</CompileAsWinRT>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\shared\cpp\ObjectModel;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/source/uwp/ObjectModelProjection/ObjectModelProjection.vcxproj.filters
+++ b/source/uwp/ObjectModelProjection/ObjectModelProjection.vcxproj.filters
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
+    <ClCompile Include="..\..\shared\cpp\ObjectModel\pch.cpp" />
     <ClCompile Include="..\..\shared\cpp\ObjectModel\Container.cpp" />
     <ClCompile Include="..\..\shared\cpp\ObjectModel\Enums.cpp" />
     <ClCompile Include="..\..\shared\cpp\ObjectModel\TextBlock.cpp" />

--- a/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj
+++ b/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj
@@ -65,7 +65,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
       <PreprocessorDefinitions>_WINRT_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalUsingDirectories>
@@ -196,6 +196,9 @@
     <ClInclude Include="lib\Vector.h" />
     <ClInclude Include="lib\WholeItemsPanel.h" />
     <ClInclude Include="lib\XamlBuilder.h" />
+    <ClCompile Include="lib\pch.cpp">
+      <PrecompiledHeader>Create</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="lib\AdaptiveActionInvoker.cpp" />
     <ClCompile Include="lib\AdaptiveActionParserRegistration.cpp" />
     <ClCompile Include="lib\AdaptiveActionsConfig.cpp" />

--- a/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj.filters
+++ b/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj.filters
@@ -77,6 +77,7 @@
     <ClCompile Include="lib\DateTimeParser.cpp" />
     <ClCompile Include="lib\HtmlHelpers.cpp" />
     <ClCompile Include="lib\InputValue.cpp" />
+    <ClCompile Include="lib\pch.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="lib\AdaptiveCard.h" />

--- a/source/uwp/Renderer/dll/dll.cpp
+++ b/source/uwp/Renderer/dll/dll.cpp
@@ -1,6 +1,7 @@
 //
 //    Copyright (C) Microsoft.  All rights reserved.
 //
+#include "pch.h"
 #include <windows.h>
 #include <wrl.h>
 #include <wrl\wrappers\corewrappers.h>

--- a/source/uwp/Renderer/lib/DateTimeParser.cpp
+++ b/source/uwp/Renderer/lib/DateTimeParser.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "DateTimeParser.h"
 #include "Util.h"
 #include <iomanip>
@@ -52,4 +53,3 @@ std::string DateTimeParser::GenerateString(DateTimePreparser text)
 
     return WstringToString(parsedostr.str());
 }
-

--- a/source/uwp/Renderer/lib/pch.cpp
+++ b/source/uwp/Renderer/lib/pch.cpp
@@ -1,0 +1,4 @@
+//
+//    Copyright (C) Microsoft.  All rights reserved.
+//
+#include "pch.h"

--- a/source/uwp/Renderer/lib/pch.h
+++ b/source/uwp/Renderer/lib/pch.h
@@ -18,3 +18,5 @@
 
 #include "ErrorHandling.h"
 #include "Util.h"
+
+#include "AdaptiveCards.Rendering.Uwp.h"


### PR DESCRIPTION
Using precompiled headers was not enabled in the UWP build. This was slowing down building the code tremendously. The improvements that I noticed were significant when building the whole project:


| Computer | Before PCH | After PCH |
|-----|-----|----|
| **Microsoft SurfaceBook** i7 2 cores (4 virtual CPUs) | 13 minutes | < 4 minutes |
| **HP Z440** i7 6 cores (12 virtual CPUs) | 3:35 minutes | 1:37 minutes |

