### PR TITLE
Removal of HSTRING variables inside UWP renderer

### DIFF
--- a/source/nodejs/adaptivecards/README.md
+++ b/source/nodejs/adaptivecards/README.md
@@ -8,11 +8,11 @@ Adaptive Cards are a new way for developers to exchange card content in a common
 
 Break outside the box of templated cards. Adaptive Cards let you describe your content as you see fit and deliver it beautifully wherever your customers are.
 
-The simple open card format enables an ecosystem of shared tooling, seamless integration between producers and consumers, and native cross-platorm performance on any device.
+The simple open card format enables an ecosystem of shared tooling, seamless integration between producers and consumers, and native cross-platform performance on any device.
 
 ## Get Started
 
-### Check out the [full documenation](https://docs.microsoft.com/en-us/adaptive-cards/display/libraries/htmlclient) for more
+### Check out the [full documentation](https://docs.microsoft.com/en-us/adaptive-cards/display/libraries/htmlclient) for more
 
 ## Install
 

--- a/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj
+++ b/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj
@@ -114,9 +114,11 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="lib\AdaptiveActionElement.h" />
     <ClInclude Include="lib\AdaptiveActionInvoker.h" />
     <ClInclude Include="lib\AdaptiveActionParserRegistration.h" />
     <ClInclude Include="lib\AdaptiveActionsConfig.h" />
+    <ClInclude Include="lib\AdaptiveCardElement.h" />
     <ClInclude Include="lib\AdaptiveChoiceSetInputRenderer.h" />
     <ClInclude Include="lib\AdaptiveColumnRenderer.h" />
     <ClInclude Include="lib\AdaptiveColumnSetRenderer.h" />
@@ -139,6 +141,7 @@
     <ClInclude Include="lib\AdaptiveImageRenderer.h" />
     <ClInclude Include="lib\AdaptiveImageSetRenderer.h" />
     <ClInclude Include="lib\AdaptiveImageSizesConfig.h" />
+    <ClInclude Include="lib\AdaptiveInputElement.h" />
     <ClInclude Include="lib\AdaptiveInputs.h" />
     <ClInclude Include="lib\AdaptiveNumberInputRenderer.h" />
     <ClInclude Include="lib\AdaptiveRenderArgs.h" />
@@ -199,9 +202,11 @@
     <ClCompile Include="lib\pch.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="lib\AdaptiveActionElement.cpp" />
     <ClCompile Include="lib\AdaptiveActionInvoker.cpp" />
     <ClCompile Include="lib\AdaptiveActionParserRegistration.cpp" />
     <ClCompile Include="lib\AdaptiveActionsConfig.cpp" />
+    <ClCompile Include="lib\AdaptiveCardElement.cpp" />
     <ClCompile Include="lib\AdaptiveChoiceSetInputRenderer.cpp" />
     <ClCompile Include="lib\AdaptiveColumnRenderer.cpp" />
     <ClCompile Include="lib\AdaptiveColumnSetRenderer.cpp" />
@@ -224,6 +229,7 @@
     <ClCompile Include="lib\AdaptiveImageRenderer.cpp" />
     <ClCompile Include="lib\AdaptiveImageSetRenderer.cpp" />
     <ClCompile Include="lib\AdaptiveImageSizesConfig.cpp" />
+    <ClCompile Include="lib\AdaptiveInputElement.cpp" />
     <ClCompile Include="lib\AdaptiveInputs.cpp" />
     <ClCompile Include="lib\AdaptiveNumberInputRenderer.cpp" />
     <ClCompile Include="lib\AdaptiveRenderArgs.cpp" />

--- a/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj.filters
+++ b/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj.filters
@@ -78,6 +78,9 @@
     <ClCompile Include="lib\HtmlHelpers.cpp" />
     <ClCompile Include="lib\InputValue.cpp" />
     <ClCompile Include="lib\pch.cpp" />
+    <ClCompile Include="lib\AdaptiveCardElement.cpp" />
+    <ClCompile Include="lib\AdaptiveInputElement.cpp" />
+    <ClCompile Include="lib\AdaptiveActionElement.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="lib\AdaptiveCard.h" />
@@ -163,6 +166,9 @@
     <ClInclude Include="lib\DateTimeParser.h" />
     <ClInclude Include="lib\HtmlHelpers.h" />
     <ClInclude Include="lib\InputValue.h" />
+    <ClInclude Include="lib\AdaptiveCardElement.h" />
+    <ClInclude Include="lib\AdaptiveInputElement.h" />
+    <ClInclude Include="lib\AdaptiveActionElement.h" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="idl\AdaptiveCards.Rendering.Uwp.idl" />

--- a/source/uwp/Renderer/lib/AdaptiveActionElement.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveActionElement.cpp
@@ -1,0 +1,82 @@
+#include "pch.h"
+#include "AdaptiveActionElement.h"
+
+using namespace Microsoft::WRL;
+using namespace Microsoft::WRL::Wrappers;
+using namespace ABI::AdaptiveCards::Rendering::Uwp;
+using namespace ABI::Windows::Foundation::Collections;
+using namespace ABI::Windows::UI::Xaml;
+using namespace ABI::Windows::UI::Xaml::Controls;
+
+namespace AdaptiveCards { namespace Rendering { namespace Uwp
+{
+    HRESULT AdaptiveActionElementBase::InitializeBaseElement(std::shared_ptr<AdaptiveCards::BaseActionElement>& sharedModel)
+    {
+        RETURN_IF_FAILED(UTF8ToHString(sharedModel->GetId(), m_id.GetAddressOf()));
+        RETURN_IF_FAILED(UTF8ToHString(sharedModel->GetTitle(), m_title.GetAddressOf()));
+
+        RETURN_IF_FAILED(JsonCppToJsonObject(sharedModel->GetAdditionalProperties(), &m_additionalProperties));
+        RETURN_IF_FAILED(UTF8ToHString(sharedModel->GetElementTypeString(), m_typeString.GetAddressOf()));
+        return S_OK;
+    }
+
+    IFACEMETHODIMP AdaptiveActionElementBase::get_Title(HSTRING* title)
+    {
+        return m_title.CopyTo(title);
+    }
+
+    IFACEMETHODIMP AdaptiveActionElementBase::put_Title(HSTRING title)
+    {
+        return m_title.Set(title);
+    }
+
+    IFACEMETHODIMP AdaptiveActionElementBase::get_Id(HSTRING* id)
+    {
+        return m_id.CopyTo(id);
+    }
+
+    IFACEMETHODIMP AdaptiveActionElementBase::put_Id(HSTRING id)
+    {
+        return m_id.Set(id);
+    }
+
+    IFACEMETHODIMP AdaptiveActionElementBase::get_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject** result)
+    {
+        return m_additionalProperties.CopyTo(result);
+    }
+
+    IFACEMETHODIMP AdaptiveActionElementBase::put_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject* jsonObject)
+    {
+        m_additionalProperties = jsonObject;
+        return S_OK;
+    }
+
+    IFACEMETHODIMP AdaptiveActionElementBase::get_ActionTypeString(HSTRING* type)
+    {
+        return m_typeString.CopyTo(type);
+    }
+
+    IFACEMETHODIMP AdaptiveActionElementBase::ToJson(ABI::Windows::Data::Json::IJsonObject** result)
+    {
+        std::shared_ptr<AdaptiveCards::BaseActionElement> sharedModel;
+        RETURN_IF_FAILED(GetSharedModel(sharedModel));
+
+        return StringToJsonObject(sharedModel->Serialize(), result);
+    }
+
+    HRESULT AdaptiveActionElementBase::SetSharedElementProperties(
+        std::shared_ptr<AdaptiveCards::BaseActionElement> sharedCardElement)
+    {
+        sharedCardElement->SetId(HStringToUTF8(m_id.Get()));
+        sharedCardElement->SetTitle(HStringToUTF8(m_title.Get()));
+
+        if (m_additionalProperties != nullptr)
+        {
+            Json::Value jsonCpp;
+            RETURN_IF_FAILED(JsonObjectToJsonCpp(m_additionalProperties.Get(), &jsonCpp));
+            sharedCardElement->SetAdditionalProperties(jsonCpp);
+        }
+
+        return S_OK;
+    }
+}}}

--- a/source/uwp/Renderer/lib/AdaptiveActionElement.h
+++ b/source/uwp/Renderer/lib/AdaptiveActionElement.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "AdaptiveCards.Rendering.Uwp.h"
+#include "Enums.h"
+
+namespace AdaptiveCards { namespace Rendering { namespace Uwp
+{
+    class DECLSPEC_UUID("8CFF4A73-2DE3-4BB2-8179-971A8A19F7DE") AdaptiveActionElementBase : public IUnknown
+    {
+    protected:
+
+        HRESULT InitializeBaseElement(std::shared_ptr<AdaptiveCards::BaseActionElement>& sharedModel);
+
+        IFACEMETHODIMP get_ActionTypeString(_Out_ HSTRING* value);
+
+        IFACEMETHODIMP get_Title(_Out_ HSTRING* title);
+        IFACEMETHODIMP put_Title(_In_ HSTRING title);
+
+        IFACEMETHODIMP get_Id(_Out_ HSTRING* id);
+        IFACEMETHODIMP put_Id(_In_ HSTRING id);
+
+        IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
+        IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value);
+
+        IFACEMETHODIMP ToJson(ABI::Windows::Data::Json::IJsonObject** result);
+
+        HRESULT SetSharedElementProperties(std::shared_ptr<AdaptiveCards::BaseActionElement> sharedCardElement);
+
+        virtual HRESULT GetSharedModel(std::shared_ptr<BaseActionElement>& sharedModel) = 0;
+
+    private:
+        Microsoft::WRL::Wrappers::HString m_id;
+        Microsoft::WRL::Wrappers::HString m_title;
+        Microsoft::WRL::ComPtr<ABI::Windows::Data::Json::IJsonObject> m_additionalProperties;
+        Microsoft::WRL::Wrappers::HString m_typeString;
+    };
+}}}

--- a/source/uwp/Renderer/lib/AdaptiveActionParserRegistration.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveActionParserRegistration.cpp
@@ -5,6 +5,7 @@
 #include "Util.h"
 
 using namespace Microsoft::WRL;
+using namespace Microsoft::WRL::Wrappers;
 using namespace ABI::AdaptiveCards::Rendering::Uwp;
 using namespace ABI::Windows::UI;
 
@@ -80,11 +81,11 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     {
         std::string type = ParseUtil::GetTypeAsString(value);
 
-        HSTRING typeAsHstring;
-        THROW_IF_FAILED(UTF8ToHString(type, &typeAsHstring));
+        HString typeAsHstring;
+        THROW_IF_FAILED(UTF8ToHString(type, typeAsHstring.GetAddressOf()));
 
         ComPtr<IAdaptiveActionParser> parser;
-        THROW_IF_FAILED(m_parserRegistration->Get(typeAsHstring, &parser));
+        THROW_IF_FAILED(m_parserRegistration->Get(typeAsHstring.Get(), &parser));
 
         ComPtr<ABI::Windows::Data::Json::IJsonObject>jsonObject;
         THROW_IF_FAILED(JsonCppToJsonObject(value, &jsonObject));

--- a/source/uwp/Renderer/lib/AdaptiveCard.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveCard.cpp
@@ -140,19 +140,19 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveCard::RuntimeClassInitialize(std::shared_ptr<::AdaptiveCards::AdaptiveCard> sharedAdaptiveCard)
+        HRESULT AdaptiveCard::RuntimeClassInitialize(std::shared_ptr<::AdaptiveCards::AdaptiveCard> sharedAdaptiveCard)
     {
         m_body = Microsoft::WRL::Make<Vector<IAdaptiveCardElement*>>();
         if (m_body == nullptr)
         {
             return E_FAIL;
         }
-        
+
         m_actions = Microsoft::WRL::Make<Vector<IAdaptiveActionElement*>>();
         if (m_actions == nullptr)
         {
             return E_FAIL;
-        }        
+        }
 
         RETURN_IF_FAILED(GenerateContainedElementsProjection(sharedAdaptiveCard->GetBody(), m_body.Get()));
         RETURN_IF_FAILED(GenerateActionsProjection(sharedAdaptiveCard->GetActions(), m_actions.Get()));
@@ -168,11 +168,10 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
             HStringReference(RuntimeClass_Windows_Foundation_Uri).Get(),
             &uriActivationFactory));
 
-        HSTRING imageUri;
-        RETURN_IF_FAILED(UTF8ToHString(sharedAdaptiveCard->GetBackgroundImage(), &imageUri));
-        if (imageUri != nullptr)
+        std::wstring imageUri = StringToWstring(sharedAdaptiveCard->GetBackgroundImage());
+        if (!imageUri.empty())
         {
-            RETURN_IF_FAILED(uriActivationFactory->CreateUri(imageUri, m_backgroundImage.GetAddressOf()));
+            RETURN_IF_FAILED(uriActivationFactory->CreateUri(HStringReference(imageUri.c_str()).Get(), m_backgroundImage.GetAddressOf()));
         }
 
         return S_OK;

--- a/source/uwp/Renderer/lib/AdaptiveCard.h
+++ b/source/uwp/Renderer/lib/AdaptiveCard.h
@@ -41,7 +41,7 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
 
         IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
 
-        HRESULT GetSharedModel(_In_ std::shared_ptr<AdaptiveCards::AdaptiveCard>& sharedModel);
+        HRESULT GetSharedModel(std::shared_ptr<AdaptiveCards::AdaptiveCard>& sharedModel);
 
         // ITypePeek method
         void *PeekAt(REFIID riid) override

--- a/source/uwp/Renderer/lib/AdaptiveCardElement.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveCardElement.cpp
@@ -1,0 +1,97 @@
+#include "pch.h"
+#include "AdaptiveCardElement.h"
+
+using namespace Microsoft::WRL;
+using namespace Microsoft::WRL::Wrappers;
+using namespace ABI::AdaptiveCards::Rendering::Uwp;
+using namespace ABI::Windows::Foundation::Collections;
+using namespace ABI::Windows::UI::Xaml;
+using namespace ABI::Windows::UI::Xaml::Controls;
+
+namespace AdaptiveCards { namespace Rendering { namespace Uwp
+{
+    HRESULT AdaptiveCardElementBase::InitializeBaseElement(std::shared_ptr<AdaptiveCards::BaseCardElement>& sharedModel)
+    {
+        m_spacing = static_cast<ABI::AdaptiveCards::Rendering::Uwp::Spacing>(sharedModel->GetSpacing());
+        m_separator = sharedModel->GetSeparator();
+        RETURN_IF_FAILED(UTF8ToHString(sharedModel->GetId(), m_id.GetAddressOf()));
+        RETURN_IF_FAILED(JsonCppToJsonObject(sharedModel->GetAdditionalProperties(), &m_additionalProperties));
+        RETURN_IF_FAILED(UTF8ToHString(sharedModel->GetElementTypeString(), m_typeString.GetAddressOf()));
+        return S_OK;
+    }
+
+    IFACEMETHODIMP AdaptiveCardElementBase::get_Spacing(_Out_ ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing)
+    {
+        *spacing = m_spacing;
+        return S_OK;
+    }
+
+    IFACEMETHODIMP AdaptiveCardElementBase::put_Spacing(_In_ ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing)
+    {
+        m_spacing = spacing;
+        return S_OK;
+    }
+
+    IFACEMETHODIMP AdaptiveCardElementBase::get_Separator(boolean* separator)
+    {
+        *separator = m_separator;
+        return S_OK;
+    }
+
+    IFACEMETHODIMP AdaptiveCardElementBase::put_Separator(boolean separator)
+    {
+        m_separator = separator;
+        return S_OK;
+    }
+
+    IFACEMETHODIMP AdaptiveCardElementBase::get_Id(HSTRING* id)
+    {
+        return m_id.CopyTo(id);
+    }
+
+    IFACEMETHODIMP AdaptiveCardElementBase::put_Id(HSTRING id)
+    {
+        return m_id.Set(id);
+    }
+
+    IFACEMETHODIMP AdaptiveCardElementBase::get_ElementTypeString(HSTRING* type)
+    {
+        return m_typeString.CopyTo(type);
+    }
+
+    IFACEMETHODIMP AdaptiveCardElementBase::get_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject** result)
+    {
+        return m_additionalProperties.CopyTo(result);
+    }
+
+    IFACEMETHODIMP AdaptiveCardElementBase::put_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject* jsonObject)
+    {
+        m_additionalProperties = jsonObject;
+        return S_OK;
+    }
+
+    IFACEMETHODIMP AdaptiveCardElementBase::ToJson(ABI::Windows::Data::Json::IJsonObject** result)
+    {
+        std::shared_ptr<AdaptiveCards::BaseCardElement> sharedModel;
+        RETURN_IF_FAILED(GetSharedModel(sharedModel));
+
+        return StringToJsonObject(sharedModel->Serialize(), result);
+    }
+
+    HRESULT AdaptiveCardElementBase::SetSharedElementProperties(
+        std::shared_ptr<AdaptiveCards::BaseCardElement> sharedCardElement)
+    {
+        sharedCardElement->SetId(HStringToUTF8(m_id.Get()));
+        sharedCardElement->SetSeparator(m_separator);
+        sharedCardElement->SetSpacing(static_cast<AdaptiveCards::Spacing>(m_spacing));
+
+        if (m_additionalProperties != nullptr)
+        {
+            Json::Value jsonCpp;
+            RETURN_IF_FAILED(JsonObjectToJsonCpp(m_additionalProperties.Get(), &jsonCpp));
+            sharedCardElement->SetAdditionalProperties(jsonCpp);
+        }
+
+        return S_OK;
+    }
+}}}

--- a/source/uwp/Renderer/lib/AdaptiveCardElement.h
+++ b/source/uwp/Renderer/lib/AdaptiveCardElement.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "AdaptiveCards.Rendering.Uwp.h"
+#include "Enums.h"
+
+namespace AdaptiveCards { namespace Rendering { namespace Uwp
+{
+    class DECLSPEC_UUID("49496982-18E7-48A8-9D16-99E389BE9133") AdaptiveCardElementBase : public IUnknown
+    {
+    protected:
+
+        HRESULT InitializeBaseElement(std::shared_ptr<AdaptiveCards::BaseCardElement>& sharedModel);
+
+        IFACEMETHODIMP get_Spacing(_Out_ ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing);
+        IFACEMETHODIMP put_Spacing(_In_ ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing);
+        
+        IFACEMETHODIMP get_Separator(boolean* separator);
+        IFACEMETHODIMP put_Separator(boolean separator);
+
+        IFACEMETHODIMP get_Id(HSTRING* id);
+        IFACEMETHODIMP put_Id(HSTRING id);
+
+        IFACEMETHODIMP get_ElementTypeString(HSTRING* type);
+
+        IFACEMETHODIMP get_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject** result);
+        IFACEMETHODIMP put_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject* jsonObject);
+
+        IFACEMETHODIMP ToJson(ABI::Windows::Data::Json::IJsonObject** result);
+
+        HRESULT SetSharedElementProperties(std::shared_ptr<AdaptiveCards::BaseCardElement> sharedCardElement);
+
+        virtual HRESULT GetSharedModel(std::shared_ptr<BaseCardElement>& sharedModel) = 0;
+
+    private:
+        boolean m_separator;
+        Microsoft::WRL::Wrappers::HString m_id;
+        ABI::AdaptiveCards::Rendering::Uwp::Spacing m_spacing;
+        Microsoft::WRL::ComPtr<ABI::Windows::Data::Json::IJsonObject> m_additionalProperties;
+        Microsoft::WRL::Wrappers::HString m_typeString;
+    };
+}}}

--- a/source/uwp/Renderer/lib/AdaptiveCardRendererComponent.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveCardRendererComponent.cpp
@@ -196,9 +196,9 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
             IJsonObject* adaptiveJson,
             IRenderedAdaptiveCard** result)
     {
-        HSTRING adaptiveJsonAsHstring;
-        RETURN_IF_FAILED(JsonObjectToHString(adaptiveJson, &adaptiveJsonAsHstring));
-        return RenderAdaptiveCardFromJsonString(adaptiveJsonAsHstring, result);
+        HString adaptiveJsonAsHstring;
+        RETURN_IF_FAILED(JsonObjectToHString(adaptiveJson, adaptiveJsonAsHstring.GetAddressOf()));
+        return RenderAdaptiveCardFromJsonString(adaptiveJsonAsHstring.Get(), result);
     }
 
     _Use_decl_annotations_

--- a/source/uwp/Renderer/lib/AdaptiveChoiceInput.h
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceInput.h
@@ -27,7 +27,7 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
 
         IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveCards::Rendering::Uwp::ElementType* elementType);
 
-        HRESULT GetSharedModel(_In_ std::shared_ptr<AdaptiveCards::ChoiceInput>& sharedModel);
+        HRESULT GetSharedModel(std::shared_ptr<AdaptiveCards::ChoiceInput>& sharedModel);
 
         // ITypePeek method
         void *PeekAt(REFIID riid) override

--- a/source/uwp/Renderer/lib/AdaptiveChoiceSetInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceSetInput.cpp
@@ -26,7 +26,7 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     } CATCH_RETURN;
 
     _Use_decl_annotations_
-    HRESULT AdaptiveChoiceSetInput::RuntimeClassInitialize(const std::shared_ptr<AdaptiveCards::ChoiceSetInput>& sharedChoiceSetInput)
+    HRESULT AdaptiveChoiceSetInput::RuntimeClassInitialize(const std::shared_ptr<AdaptiveCards::ChoiceSetInput>& sharedChoiceSetInput) try
     {
         if (sharedChoiceSetInput == nullptr)
         {
@@ -35,18 +35,13 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
 
         GenerateInputChoicesProjection(sharedChoiceSetInput->GetChoices(), m_choices.Get());
 
-        m_isRequired = sharedChoiceSetInput->GetIsRequired();
         m_isMultiSelect = sharedChoiceSetInput->GetIsMultiSelect();
         m_choiceSetStyle = static_cast<ABI::AdaptiveCards::Rendering::Uwp::ChoiceSetStyle>(sharedChoiceSetInput->GetChoiceSetStyle());
         RETURN_IF_FAILED(UTF8ToHString(sharedChoiceSetInput->GetValue(), m_value.GetAddressOf()));
 
-        m_spacing = static_cast<ABI::AdaptiveCards::Rendering::Uwp::Spacing>(sharedChoiceSetInput->GetSpacing());
-        m_separator = sharedChoiceSetInput->GetSeparator();
-        RETURN_IF_FAILED(UTF8ToHString(sharedChoiceSetInput->GetId(), m_id.GetAddressOf()));
-        RETURN_IF_FAILED(JsonCppToJsonObject(sharedChoiceSetInput->GetAdditionalProperties(), &m_additionalProperties));
-
+        InitializeBaseElement(std::static_pointer_cast<BaseInputElement>(sharedChoiceSetInput));
         return S_OK;
-    }
+    } CATCH_RETURN;
 
     _Use_decl_annotations_
     HRESULT AdaptiveChoiceSetInput::get_IsMultiSelect(boolean* isMultiSelect)
@@ -59,20 +54,6 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     HRESULT AdaptiveChoiceSetInput::put_IsMultiSelect(boolean isMultiSelect)
     {
         m_isMultiSelect = isMultiSelect;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveChoiceSetInput::get_IsRequired(boolean* isRequired)
-    {
-        *isRequired = m_isRequired;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveChoiceSetInput::put_IsRequired(boolean isRequired)
-    {
-        m_isRequired = isRequired;
         return S_OK;
     }
 
@@ -97,15 +78,17 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveChoiceSetInput::get_Id(HSTRING* id)
+    HRESULT AdaptiveChoiceSetInput::get_Value(HSTRING * value)
     {
-        return m_id.CopyTo(id);
+        m_value.CopyTo(value);
+        return S_OK;
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveChoiceSetInput::put_Id(HSTRING id)
+    HRESULT AdaptiveChoiceSetInput::put_Value(HSTRING value)
     {
-        return m_id.Set(id);
+        m_value.Set(value);
+        return S_OK;
     }
 
     _Use_decl_annotations_
@@ -116,73 +99,14 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveChoiceSetInput::get_Spacing(ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing)
-    {
-        *spacing = m_spacing;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveChoiceSetInput::put_Spacing(ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing)
-    {
-        m_spacing = spacing;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveChoiceSetInput::get_Separator(boolean* separator)
-    {
-        *separator = m_separator;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveChoiceSetInput::put_Separator(boolean separator)
-    {
-        m_separator = separator;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveChoiceSetInput::get_ElementTypeString(HSTRING* type)
-    {
-        ElementType typeEnum;
-        RETURN_IF_FAILED(get_ElementType(&typeEnum));
-        return ProjectedElementTypeToHString(typeEnum, type);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveChoiceSetInput::get_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject** result)
-    {
-        return m_additionalProperties.CopyTo(result);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveChoiceSetInput::put_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject* jsonObject)
-    {
-        m_additionalProperties = jsonObject;
-        return S_OK;
-    }    
-    
-    _Use_decl_annotations_
-    HRESULT AdaptiveChoiceSetInput::ToJson(ABI::Windows::Data::Json::IJsonObject** result)
-    {
-        std::shared_ptr<AdaptiveCards::ChoiceSetInput> sharedModel;
-        RETURN_IF_FAILED(GetSharedModel(sharedModel));
-
-        return StringToJsonObject(sharedModel->Serialize(), result);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveChoiceSetInput::GetSharedModel(std::shared_ptr<AdaptiveCards::ChoiceSetInput>& sharedModel) try
+    HRESULT AdaptiveChoiceSetInput::GetSharedModel(std::shared_ptr<AdaptiveCards::BaseCardElement>& sharedModel) try
     {
         std::shared_ptr<AdaptiveCards::ChoiceSetInput> choiceSet = std::make_shared<AdaptiveCards::ChoiceSetInput>();
 
-        RETURN_IF_FAILED(SetSharedElementProperties(this, std::dynamic_pointer_cast<AdaptiveCards::BaseCardElement>(choiceSet)));
+        RETURN_IF_FAILED(SetSharedElementProperties(std::static_pointer_cast<AdaptiveCards::BaseInputElement>(choiceSet)));
 
         choiceSet->SetChoiceSetStyle(static_cast<AdaptiveCards::ChoiceSetStyle>(m_choiceSetStyle));
         choiceSet->SetIsMultiSelect(m_isMultiSelect);
-        choiceSet->SetIsRequired(m_isRequired);
 
         RETURN_IF_FAILED(GenerateSharedChoices(m_choices.Get(), choiceSet->GetChoices()));
 
@@ -190,15 +114,4 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         return S_OK;
     } CATCH_RETURN;
 
-    HRESULT AdaptiveChoiceSetInput::get_Value(HSTRING * value)
-    {
-        m_value.CopyTo(value);
-        return S_OK;
-    }
-
-    HRESULT AdaptiveChoiceSetInput::put_Value(HSTRING value)
-    {
-        m_value.Set(value);
-        return S_OK;
-    }
 }}}

--- a/source/uwp/Renderer/lib/AdaptiveChoiceSetInput.h
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceSetInput.h
@@ -4,6 +4,7 @@
 #include "ChoiceSetInput.h"
 #include "Enums.h"
 #include <windows.foundation.h>
+#include "AdaptiveInputElement.h"
 
 namespace AdaptiveCards { namespace Rendering { namespace Uwp
 {
@@ -13,7 +14,8 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveChoiceSetInput,
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveInputElement,
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement,
-            Microsoft::WRL::CloakedIid<ITypePeek>>
+            Microsoft::WRL::CloakedIid<ITypePeek>,
+            Microsoft::WRL::CloakedIid<AdaptiveCards::Rendering::Uwp::AdaptiveInputElementBase>>
     {
         InspectableClass(RuntimeClass_AdaptiveCards_Rendering_Uwp_AdaptiveChoiceSetInput, BaseTrust)
 
@@ -37,29 +39,29 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         IFACEMETHODIMP get_Choices(_COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveChoiceInput*>** columns);
 
         // IAdaptiveInputElement
-        IFACEMETHODIMP get_IsRequired(_Out_ boolean* isRequired);
-        IFACEMETHODIMP put_IsRequired(_In_ boolean isRequired);
+        IFACEMETHODIMP get_IsRequired(_Out_ boolean* isRequired) { return AdaptiveInputElementBase::get_IsRequired(isRequired); }
+        IFACEMETHODIMP put_IsRequired(_In_ boolean isRequired) { return AdaptiveInputElementBase::put_IsRequired(isRequired); }
 
         // IAdaptiveCardElement
         IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveCards::Rendering::Uwp::ElementType* elementType);
 
-        IFACEMETHODIMP get_Spacing(_Out_ ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing);
-        IFACEMETHODIMP put_Spacing(_In_ ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing);
+        IFACEMETHODIMP get_Spacing(_Out_ ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing) { return AdaptiveCardElementBase::get_Spacing(spacing); }
+        IFACEMETHODIMP put_Spacing(_In_ ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing) { return AdaptiveCardElementBase::put_Spacing(spacing); }
 
-        IFACEMETHODIMP get_Separator(_Out_ boolean* separator);
-        IFACEMETHODIMP put_Separator(_In_ boolean separator);
-        
-        IFACEMETHODIMP get_Id(_Out_ HSTRING* id);
-        IFACEMETHODIMP put_Id(_In_ HSTRING id);
+        IFACEMETHODIMP get_Separator(_Out_ boolean* separator) { return AdaptiveCardElementBase::get_Separator(separator); }
+        IFACEMETHODIMP put_Separator(_In_ boolean separator) { return AdaptiveCardElementBase::put_Separator(separator); }
 
-        IFACEMETHODIMP get_ElementTypeString(_Out_ HSTRING* value);
+        IFACEMETHODIMP get_Id(_Out_ HSTRING* id) { return AdaptiveCardElementBase::get_Id(id); }
+        IFACEMETHODIMP put_Id(_In_ HSTRING id) { return AdaptiveCardElementBase::put_Id(id); }
 
-        IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
+        IFACEMETHODIMP get_ElementTypeString(_Out_ HSTRING* value) { return AdaptiveCardElementBase::get_ElementTypeString(value); }
 
-        IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
-        IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value);
+        IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveCardElementBase::get_AdditionalProperties(result); }
+        IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value) { return AdaptiveCardElementBase::put_AdditionalProperties(value); }
 
-        HRESULT GetSharedModel(_In_ std::shared_ptr<AdaptiveCards::ChoiceSetInput>& sharedModel);
+        IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveCardElementBase::ToJson(result); }
+
+        virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveCards::BaseCardElement>& sharedModel) override;
 
         // ITypePeek method
         void *PeekAt(REFIID riid) override
@@ -69,15 +71,9 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
 
     private:
         Microsoft::WRL::ComPtr<ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveChoiceInput*>> m_choices;
-        boolean m_isRequired;
         boolean m_isMultiSelect;
         ABI::AdaptiveCards::Rendering::Uwp::ChoiceSetStyle m_choiceSetStyle;
         Microsoft::WRL::Wrappers::HString m_value;
-
-        boolean m_separator;
-        Microsoft::WRL::Wrappers::HString m_id;
-        ABI::AdaptiveCards::Rendering::Uwp::Spacing m_spacing;
-        Microsoft::WRL::ComPtr<ABI::Windows::Data::Json::IJsonObject> m_additionalProperties;
     };
 
     ActivatableClass(AdaptiveChoiceSetInput);

--- a/source/uwp/Renderer/lib/AdaptiveColumn.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveColumn.cpp
@@ -26,7 +26,7 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     } CATCH_RETURN;
 
     _Use_decl_annotations_
-    HRESULT AdaptiveColumn::RuntimeClassInitialize(const std::shared_ptr<AdaptiveCards::Column>& sharedColumn)
+    HRESULT AdaptiveColumn::RuntimeClassInitialize(const std::shared_ptr<AdaptiveCards::Column>& sharedColumn) try
     {
         GenerateContainedElementsProjection(sharedColumn->GetItems(), m_items.Get());
         GenerateActionProjection(sharedColumn->GetSelectAction(), &m_selectAction);
@@ -34,12 +34,9 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         m_style = static_cast<ABI::AdaptiveCards::Rendering::Uwp::ContainerStyle>(sharedColumn->GetStyle());
         RETURN_IF_FAILED(UTF8ToHString(sharedColumn->GetWidth(), m_width.GetAddressOf()));
 
-        m_spacing = static_cast<ABI::AdaptiveCards::Rendering::Uwp::Spacing>(sharedColumn->GetSpacing());
-        m_separator = sharedColumn->GetSeparator();
-        RETURN_IF_FAILED(UTF8ToHString(sharedColumn->GetId(), m_id.GetAddressOf()));
-        RETURN_IF_FAILED(JsonCppToJsonObject(sharedColumn->GetAdditionalProperties(), &m_additionalProperties));
+        InitializeBaseElement(std::static_pointer_cast<BaseCardElement>(sharedColumn));
         return S_OK;
-    }
+    } CATCH_RETURN;
 
     _Use_decl_annotations_
     HRESULT AdaptiveColumn::get_Width(HSTRING* width)
@@ -94,81 +91,10 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveColumn::get_Spacing(ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing)
-    {
-        *spacing = m_spacing;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveColumn::put_Spacing(ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing)
-    {
-        m_spacing = spacing;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveColumn::get_Separator(boolean* separator)
-    {
-        *separator = m_separator;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveColumn::put_Separator(boolean separator)
-    {
-        m_separator = separator;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveColumn::get_Id(HSTRING* id)
-    {
-        return m_id.CopyTo(id);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveColumn::put_Id(HSTRING id)
-    {
-        return m_id.Set(id);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveColumn::get_ElementTypeString(HSTRING* type)
-    {
-        ElementType typeEnum;
-        RETURN_IF_FAILED(get_ElementType(&typeEnum));
-        return ProjectedElementTypeToHString(typeEnum, type);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveColumn::get_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject** result)
-    {
-        return m_additionalProperties.CopyTo(result);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveColumn::put_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject* jsonObject)
-    {
-        m_additionalProperties = jsonObject;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveColumn::ToJson(ABI::Windows::Data::Json::IJsonObject** result)
-    {
-        std::shared_ptr<AdaptiveCards::Column> sharedModel;
-        RETURN_IF_FAILED(GetSharedModel(sharedModel));
-
-        return StringToJsonObject(sharedModel->Serialize(), result);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveColumn::GetSharedModel(std::shared_ptr<AdaptiveCards::Column>& sharedModel) try
+    HRESULT AdaptiveColumn::GetSharedModel(std::shared_ptr<AdaptiveCards::BaseCardElement>& sharedModel) try
     {
         std::shared_ptr<AdaptiveCards::Column> column = std::make_shared<AdaptiveCards::Column>();
-
-        RETURN_IF_FAILED(SetSharedElementProperties(this, std::dynamic_pointer_cast<AdaptiveCards::BaseCardElement>(column)));
+        RETURN_IF_FAILED(SetSharedElementProperties(std::static_pointer_cast<AdaptiveCards::BaseCardElement>(column)));
 
         column->SetStyle(static_cast<AdaptiveCards::ContainerStyle>(m_style));
         column->SetWidth(HStringToUTF8(m_width.Get()));

--- a/source/uwp/Renderer/lib/AdaptiveColumn.h
+++ b/source/uwp/Renderer/lib/AdaptiveColumn.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "AdaptiveCards.Rendering.Uwp.h"
+#include "AdaptiveCardElement.h"
 #include "Enums.h"
 #include "Column.h"
 #include <windows.foundation.h>
@@ -12,7 +13,8 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveColumn,
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement,
-            Microsoft::WRL::CloakedIid<ITypePeek>>
+            Microsoft::WRL::CloakedIid<ITypePeek>,
+            Microsoft::WRL::CloakedIid<AdaptiveCards::Rendering::Uwp::AdaptiveCardElementBase>>
     {
         InspectableClass(RuntimeClass_AdaptiveCards_Rendering_Uwp_AdaptiveColumn, BaseTrust)
 
@@ -36,23 +38,23 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         // IAdaptiveCardElement
         IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveCards::Rendering::Uwp::ElementType* elementType);
 
-        IFACEMETHODIMP get_Spacing(_Out_ ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing);
-        IFACEMETHODIMP put_Spacing(_In_ ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing);
+        IFACEMETHODIMP get_Spacing(_Out_ ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing) { return AdaptiveCardElementBase::get_Spacing(spacing); }
+        IFACEMETHODIMP put_Spacing(_In_ ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing) { return AdaptiveCardElementBase::put_Spacing(spacing); }
 
-        IFACEMETHODIMP get_Separator(_Out_ boolean* separator);
-        IFACEMETHODIMP put_Separator(_In_ boolean separator);
+        IFACEMETHODIMP get_Separator(_Out_ boolean* separator) { return AdaptiveCardElementBase::get_Separator(separator); }
+        IFACEMETHODIMP put_Separator(_In_ boolean separator) { return AdaptiveCardElementBase::put_Separator(separator); }
 
-        IFACEMETHODIMP get_Id(_Out_ HSTRING* id);
-        IFACEMETHODIMP put_Id(_In_ HSTRING id);
+        IFACEMETHODIMP get_Id(_Out_ HSTRING* id) { return AdaptiveCardElementBase::get_Id(id); }
+        IFACEMETHODIMP put_Id(_In_ HSTRING id) { return AdaptiveCardElementBase::put_Id(id); }
 
-        IFACEMETHODIMP get_ElementTypeString(_Out_ HSTRING* value);
+        IFACEMETHODIMP get_ElementTypeString(_Out_ HSTRING* value) { return AdaptiveCardElementBase::get_ElementTypeString(value); }
 
-        IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
-        IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value);
+        IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveCardElementBase::get_AdditionalProperties(result); }
+        IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value) { return AdaptiveCardElementBase::put_AdditionalProperties(value); }
 
-        IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
+        IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveCardElementBase::ToJson(result); }
 
-        HRESULT GetSharedModel(_In_ std::shared_ptr<AdaptiveCards::Column>& sharedModel);
+        virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveCards::BaseCardElement>& sharedModel) override;
 
         // ITypePeek method
         void *PeekAt(REFIID riid) override
@@ -67,11 +69,6 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
 
         Microsoft::WRL::Wrappers::HString m_width; 
         ABI::AdaptiveCards::Rendering::Uwp::ContainerStyle m_style;
-
-        boolean m_separator;
-        Microsoft::WRL::Wrappers::HString m_id;
-        ABI::AdaptiveCards::Rendering::Uwp::Spacing m_spacing;
-        Microsoft::WRL::ComPtr<ABI::Windows::Data::Json::IJsonObject> m_additionalProperties;
     };
 
     ActivatableClass(AdaptiveColumn);

--- a/source/uwp/Renderer/lib/AdaptiveColumnSet.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveColumnSet.cpp
@@ -28,7 +28,7 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     } CATCH_RETURN;
 
     _Use_decl_annotations_
-    HRESULT AdaptiveColumnSet::RuntimeClassInitialize(const std::shared_ptr<AdaptiveCards::ColumnSet>& sharedColumnSet)
+    HRESULT AdaptiveColumnSet::RuntimeClassInitialize(const std::shared_ptr<AdaptiveCards::ColumnSet>& sharedColumnSet) try
     {
         if (sharedColumnSet == nullptr)
         {
@@ -38,13 +38,10 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         GenerateColumnsProjection(sharedColumnSet->GetColumns(), m_columns.Get());
         GenerateActionProjection(sharedColumnSet->GetSelectAction(), &m_selectAction);
 
-        m_spacing = static_cast<ABI::AdaptiveCards::Rendering::Uwp::Spacing>(sharedColumnSet->GetSpacing());
-        m_separator = sharedColumnSet->GetSeparator();
-        RETURN_IF_FAILED(UTF8ToHString(sharedColumnSet->GetId(), m_id.GetAddressOf()));
-        RETURN_IF_FAILED(JsonCppToJsonObject(sharedColumnSet->GetAdditionalProperties(), &m_additionalProperties));
+        InitializeBaseElement(std::static_pointer_cast<BaseCardElement>(sharedColumnSet));
 
         return S_OK;
-    }
+    } CATCH_RETURN;
 
     _Use_decl_annotations_
     IFACEMETHODIMP AdaptiveColumnSet::get_Columns(IVector<IAdaptiveColumn*>** columns)
@@ -73,81 +70,10 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveColumnSet::get_Spacing(ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing)
-    {
-        *spacing = m_spacing;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveColumnSet::put_Spacing(ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing)
-    {
-        m_spacing = spacing;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveColumnSet::get_Separator(boolean* separator)
-    {
-        *separator = m_separator;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveColumnSet::put_Separator(boolean separator)
-    {
-        m_separator = separator;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveColumnSet::get_Id(HSTRING* id)
-    {
-        return m_id.CopyTo(id);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveColumnSet::put_Id(HSTRING id)
-    {
-        return m_id.Set(id);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveColumnSet::get_ElementTypeString(HSTRING* type)
-    {
-        ElementType typeEnum;
-        RETURN_IF_FAILED(get_ElementType(&typeEnum));
-        return ProjectedElementTypeToHString(typeEnum, type);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveColumnSet::get_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject** result)
-    {
-        return m_additionalProperties.CopyTo(result);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveColumnSet::put_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject* jsonObject)
-    {
-        m_additionalProperties = jsonObject;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveColumnSet::ToJson(ABI::Windows::Data::Json::IJsonObject** result)
-    {
-        std::shared_ptr<AdaptiveCards::ColumnSet> sharedModel;
-        RETURN_IF_FAILED(GetSharedModel(sharedModel));
-
-        return StringToJsonObject(sharedModel->Serialize(), result);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveColumnSet::GetSharedModel(std::shared_ptr<AdaptiveCards::ColumnSet>& sharedModel) try
+    HRESULT AdaptiveColumnSet::GetSharedModel(std::shared_ptr<AdaptiveCards::BaseCardElement>& sharedModel) try
     {
         std::shared_ptr<AdaptiveCards::ColumnSet> columnSet = std::make_shared<AdaptiveCards::ColumnSet>();
-
-        RETURN_IF_FAILED(SetSharedElementProperties(this, std::dynamic_pointer_cast<AdaptiveCards::BaseCardElement>(columnSet)));
+        RETURN_IF_FAILED(SetSharedElementProperties(std::static_pointer_cast<AdaptiveCards::BaseCardElement>(columnSet)));
 
         if (m_selectAction != nullptr)
         {
@@ -158,9 +84,16 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
 
         XamlHelpers::IterateOverVector<IAdaptiveColumn>(m_columns.Get(), [&](IAdaptiveColumn* column)
         {
-            std::shared_ptr<Column> sharedColumn = std::make_shared<Column>();
             ComPtr<AdaptiveCards::Rendering::Uwp::AdaptiveColumn> columnImpl = PeekInnards<AdaptiveCards::Rendering::Uwp::AdaptiveColumn>(column);
-            RETURN_IF_FAILED(columnImpl->GetSharedModel(sharedColumn));
+
+            std::shared_ptr<BaseCardElement> sharedColumnBaseElement;
+            RETURN_IF_FAILED(columnImpl->GetSharedModel(sharedColumnBaseElement));
+
+            std::shared_ptr<AdaptiveCards::Column> sharedColumn = std::dynamic_pointer_cast<AdaptiveCards::Column>(sharedColumnBaseElement);
+            if (sharedColumn == nullptr)
+            {
+                return E_UNEXPECTED;
+            }
 
             columnSet->GetColumns().push_back(sharedColumn);
 

--- a/source/uwp/Renderer/lib/AdaptiveColumnSet.h
+++ b/source/uwp/Renderer/lib/AdaptiveColumnSet.h
@@ -4,6 +4,7 @@
 #include "Enums.h"
 #include "ColumnSet.h"
 #include <windows.foundation.h>
+#include "AdaptiveCardElement.h"
 
 namespace AdaptiveCards { namespace Rendering { namespace Uwp
 {
@@ -12,7 +13,8 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveColumnSet,
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement,
-            Microsoft::WRL::CloakedIid<ITypePeek>>
+            Microsoft::WRL::CloakedIid<ITypePeek>,
+            Microsoft::WRL::CloakedIid<AdaptiveCards::Rendering::Uwp::AdaptiveCardElementBase>>
     {
         InspectableClass(RuntimeClass_AdaptiveCards_Rendering_Uwp_AdaptiveColumnSet, BaseTrust)
 
@@ -30,23 +32,23 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         // IAdaptiveCardElement
         IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveCards::Rendering::Uwp::ElementType* elementType);
 
-        IFACEMETHODIMP get_Spacing(_Out_ ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing);
-        IFACEMETHODIMP put_Spacing(_In_ ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing);
+        IFACEMETHODIMP get_Spacing(_Out_ ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing) { return AdaptiveCardElementBase::get_Spacing(spacing); }
+        IFACEMETHODIMP put_Spacing(_In_ ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing) { return AdaptiveCardElementBase::put_Spacing(spacing); }
 
-        IFACEMETHODIMP get_Separator(_Out_ boolean* separator);
-        IFACEMETHODIMP put_Separator(_In_ boolean separator);
+        IFACEMETHODIMP get_Separator(_Out_ boolean* separator) { return AdaptiveCardElementBase::get_Separator(separator); }
+        IFACEMETHODIMP put_Separator(_In_ boolean separator) { return AdaptiveCardElementBase::put_Separator(separator); }
 
-        IFACEMETHODIMP get_Id(_Out_ HSTRING* id);
-        IFACEMETHODIMP put_Id(_In_ HSTRING id);
+        IFACEMETHODIMP get_Id(_Out_ HSTRING* id) { return AdaptiveCardElementBase::get_Id(id); }
+        IFACEMETHODIMP put_Id(_In_ HSTRING id) { return AdaptiveCardElementBase::put_Id(id); }
 
-        IFACEMETHODIMP get_ElementTypeString(_Out_ HSTRING* value);
+        IFACEMETHODIMP get_ElementTypeString(_Out_ HSTRING* value) { return AdaptiveCardElementBase::get_ElementTypeString(value); }
 
-        IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
-        IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value);
+        IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveCardElementBase::get_AdditionalProperties(result); }
+        IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value) { return AdaptiveCardElementBase::put_AdditionalProperties(value); }
 
-        IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
+        IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveCardElementBase::ToJson(result); }
 
-        HRESULT GetSharedModel(_In_ std::shared_ptr<AdaptiveCards::ColumnSet>& sharedModel);
+        virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveCards::BaseCardElement>& sharedModel) override;
 
         // ITypePeek method
         void *PeekAt(REFIID riid) override
@@ -58,11 +60,6 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
 
         Microsoft::WRL::ComPtr<ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveColumn*>> m_columns;
         Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveActionElement> m_selectAction;
-
-        boolean m_separator;
-        Microsoft::WRL::Wrappers::HString m_id;
-        ABI::AdaptiveCards::Rendering::Uwp::Spacing m_spacing;
-        Microsoft::WRL::ComPtr<ABI::Windows::Data::Json::IJsonObject> m_additionalProperties;
     };
 
     ActivatableClass(AdaptiveColumnSet);

--- a/source/uwp/Renderer/lib/AdaptiveContainer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveContainer.cpp
@@ -26,7 +26,7 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     } CATCH_RETURN;
 
     _Use_decl_annotations_
-    HRESULT AdaptiveContainer::RuntimeClassInitialize(const std::shared_ptr<AdaptiveCards::Container>& sharedContainer)
+    HRESULT AdaptiveContainer::RuntimeClassInitialize(const std::shared_ptr<AdaptiveCards::Container>& sharedContainer) try
     {
         if (sharedContainer == nullptr)
         {
@@ -37,13 +37,9 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         GenerateActionProjection(sharedContainer->GetSelectAction(), &m_selectAction);
         m_style = static_cast<ABI::AdaptiveCards::Rendering::Uwp::ContainerStyle>(sharedContainer->GetStyle());
         
-        m_spacing = static_cast<ABI::AdaptiveCards::Rendering::Uwp::Spacing>(sharedContainer->GetSpacing());
-        m_separator = sharedContainer->GetSeparator();
-        RETURN_IF_FAILED(UTF8ToHString(sharedContainer->GetId(), m_id.GetAddressOf()));
-        RETURN_IF_FAILED(JsonCppToJsonObject(sharedContainer->GetAdditionalProperties(), &m_additionalProperties));
-
+        InitializeBaseElement(std::static_pointer_cast<BaseCardElement>(sharedContainer));
         return S_OK;
-    }
+    } CATCH_RETURN;
 
     _Use_decl_annotations_
     HRESULT AdaptiveContainer::get_Items(IVector<IAdaptiveCardElement*>** items)
@@ -86,81 +82,10 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveContainer::get_Spacing(ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing)
-    {
-        *spacing = m_spacing;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveContainer::put_Spacing(ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing)
-    {
-        m_spacing = spacing;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveContainer::get_Separator(boolean* separator)
-    {
-        *separator = m_separator;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveContainer::put_Separator(boolean separator)
-    {
-        m_separator = separator;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveContainer::get_Id(HSTRING* id)
-    {
-        return m_id.CopyTo(id);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveContainer::put_Id(HSTRING id)
-    {
-        return m_id.Set(id);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveContainer::get_ElementTypeString(HSTRING* type)
-    {
-        ElementType typeEnum;
-        RETURN_IF_FAILED(get_ElementType(&typeEnum));
-        return ProjectedElementTypeToHString(typeEnum, type);
-    }
-
-    _Use_decl_annotations_
-        HRESULT AdaptiveContainer::get_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject** result)
-    {
-        return m_additionalProperties.CopyTo(result);
-    }
-
-    _Use_decl_annotations_
-        HRESULT AdaptiveContainer::put_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject* jsonObject)
-    {
-        m_additionalProperties = jsonObject;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveContainer::ToJson(ABI::Windows::Data::Json::IJsonObject** result)
-    {
-        std::shared_ptr<AdaptiveCards::Container> sharedModel;
-        RETURN_IF_FAILED(GetSharedModel(sharedModel));
-
-        return StringToJsonObject(sharedModel->Serialize(), result);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveContainer::GetSharedModel(std::shared_ptr<AdaptiveCards::Container>& sharedModel) try
+    HRESULT AdaptiveContainer::GetSharedModel(std::shared_ptr<AdaptiveCards::BaseCardElement>& sharedModel) try
     {
         std::shared_ptr<AdaptiveCards::Container> container = std::make_shared<AdaptiveCards::Container>();
-
-        RETURN_IF_FAILED(SetSharedElementProperties(this, std::dynamic_pointer_cast<AdaptiveCards::BaseCardElement>(container)));
+        RETURN_IF_FAILED(SetSharedElementProperties(std::static_pointer_cast<AdaptiveCards::BaseCardElement>(container)));
 
         if (m_selectAction != nullptr)
         {

--- a/source/uwp/Renderer/lib/AdaptiveContainer.h
+++ b/source/uwp/Renderer/lib/AdaptiveContainer.h
@@ -4,6 +4,7 @@
 #include "Enums.h"
 #include "Container.h"
 #include <windows.foundation.h>
+#include "AdaptiveCardElement.h"
 
 namespace AdaptiveCards { namespace Rendering { namespace Uwp
 {
@@ -12,7 +13,8 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveContainer,
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement,
-            Microsoft::WRL::CloakedIid<ITypePeek>>
+            Microsoft::WRL::CloakedIid<ITypePeek>,
+            Microsoft::WRL::CloakedIid<AdaptiveCards::Rendering::Uwp::AdaptiveCardElementBase>>
     {
         InspectableClass(RuntimeClass_AdaptiveCards_Rendering_Uwp_AdaptiveContainer, BaseTrust)
 
@@ -33,23 +35,23 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         // IAdaptiveCardElement
         IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveCards::Rendering::Uwp::ElementType* elementType);
 
-        IFACEMETHODIMP get_Spacing(_Out_ ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing);
-        IFACEMETHODIMP put_Spacing(_In_ ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing);
+        IFACEMETHODIMP get_Spacing(_Out_ ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing) { return AdaptiveCardElementBase::get_Spacing(spacing); }
+        IFACEMETHODIMP put_Spacing(_In_ ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing) { return AdaptiveCardElementBase::put_Spacing(spacing); }
 
-        IFACEMETHODIMP get_Separator(_Out_ boolean* separator);
-        IFACEMETHODIMP put_Separator(_In_ boolean separator);
+        IFACEMETHODIMP get_Separator(_Out_ boolean* separator) { return AdaptiveCardElementBase::get_Separator(separator); }
+        IFACEMETHODIMP put_Separator(_In_ boolean separator) { return AdaptiveCardElementBase::put_Separator(separator); }
 
-        IFACEMETHODIMP get_Id(_Out_ HSTRING* id);
-        IFACEMETHODIMP put_Id(_In_ HSTRING id);
+        IFACEMETHODIMP get_Id(_Out_ HSTRING* id) { return AdaptiveCardElementBase::get_Id(id); }
+        IFACEMETHODIMP put_Id(_In_ HSTRING id) { return AdaptiveCardElementBase::put_Id(id); }
 
-        IFACEMETHODIMP get_ElementTypeString(_Out_ HSTRING* value);
+        IFACEMETHODIMP get_ElementTypeString(_Out_ HSTRING* value) { return AdaptiveCardElementBase::get_ElementTypeString(value); }
 
-        IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
+        IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveCardElementBase::get_AdditionalProperties(result); }
+        IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value) { return AdaptiveCardElementBase::put_AdditionalProperties(value); }
 
-        IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
-        IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value);
+        IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveCardElementBase::ToJson(result); }
 
-        HRESULT GetSharedModel(_In_ std::shared_ptr<AdaptiveCards::Container>& sharedModel);
+        virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveCards::BaseCardElement>& sharedModel) override;
 
         // ITypePeek method
         void *PeekAt(REFIID riid) override
@@ -61,11 +63,6 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         Microsoft::WRL::ComPtr<ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement*>> m_items;
         Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveActionElement> m_selectAction;
         ABI::AdaptiveCards::Rendering::Uwp::ContainerStyle m_style;
-
-        boolean m_separator;
-        Microsoft::WRL::Wrappers::HString m_id;
-        ABI::AdaptiveCards::Rendering::Uwp::Spacing m_spacing;
-        Microsoft::WRL::ComPtr<ABI::Windows::Data::Json::IJsonObject> m_additionalProperties;
     };
 
     ActivatableClass(AdaptiveContainer);

--- a/source/uwp/Renderer/lib/AdaptiveDateInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveDateInput.cpp
@@ -31,12 +31,7 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         RETURN_IF_FAILED(UTF8ToHString(sharedDateInput->GetPlaceholder(), m_placeholder.GetAddressOf()));
         RETURN_IF_FAILED(UTF8ToHString(sharedDateInput->GetValue(), m_value.GetAddressOf()));
 
-        m_isRequired = sharedDateInput->GetIsRequired();
-        m_spacing = static_cast<ABI::AdaptiveCards::Rendering::Uwp::Spacing>(sharedDateInput->GetSpacing());
-        m_separator = sharedDateInput->GetSeparator();
-        RETURN_IF_FAILED(UTF8ToHString(sharedDateInput->GetId(), m_id.GetAddressOf()));
-        RETURN_IF_FAILED(JsonCppToJsonObject(sharedDateInput->GetAdditionalProperties(), &m_additionalProperties));
-
+        InitializeBaseElement(std::static_pointer_cast<BaseInputElement>(sharedDateInput));
         return S_OK;
     }CATCH_RETURN;
 
@@ -89,18 +84,6 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveDateInput::get_Id(HSTRING* id)
-    {
-        return m_id.CopyTo(id);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveDateInput::put_Id(HSTRING id)
-    {
-        return m_id.Set(id);
-    }
-
-    _Use_decl_annotations_
     HRESULT AdaptiveDateInput::get_ElementType(ElementType* elementType)
     {
         *elementType = ElementType::DateInput;
@@ -108,84 +91,11 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveDateInput::get_Spacing(ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing)
-    {
-        *spacing = m_spacing;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveDateInput::put_Spacing(ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing)
-    {
-        m_spacing = spacing;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveDateInput::get_Separator(boolean* separator)
-    {
-        *separator = m_separator;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveDateInput::put_Separator(boolean separator)
-    {
-        m_separator = separator;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveDateInput::get_IsRequired(boolean* isRequired)
-    {
-        *isRequired = m_isRequired;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveDateInput::put_IsRequired(boolean isRequired)
-    {
-        m_isRequired = isRequired;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveDateInput::get_ElementTypeString(HSTRING* type)
-    {
-        ElementType typeEnum;
-        RETURN_IF_FAILED(get_ElementType(&typeEnum));
-        return ProjectedElementTypeToHString(typeEnum, type);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveDateInput::get_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject** result)
-    {
-        return m_additionalProperties.CopyTo(result);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveDateInput::put_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject* jsonObject)
-    {
-        m_additionalProperties = jsonObject;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveDateInput::ToJson(ABI::Windows::Data::Json::IJsonObject** result)
-    {
-        std::shared_ptr<AdaptiveCards::DateInput> sharedDateInput = std::make_shared<AdaptiveCards::DateInput>();
-        GetSharedModel(sharedDateInput);
-
-        return StringToJsonObject(sharedDateInput->Serialize(), result);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveDateInput::GetSharedModel(std::shared_ptr<AdaptiveCards::DateInput>& sharedModel) try
+    HRESULT AdaptiveDateInput::GetSharedModel(std::shared_ptr<AdaptiveCards::BaseCardElement>& sharedModel) try
     { 
         std::shared_ptr<AdaptiveCards::DateInput> dateInput = std::make_shared<AdaptiveCards::DateInput>();
 
-        RETURN_IF_FAILED(SetSharedElementProperties(this, std::dynamic_pointer_cast<AdaptiveCards::BaseCardElement>(dateInput)));
-        dateInput->SetIsRequired(m_isRequired);
+        RETURN_IF_FAILED(SetSharedElementProperties(std::static_pointer_cast<AdaptiveCards::BaseInputElement>(dateInput)));
 
         std::string max;
         RETURN_IF_FAILED(HStringToUTF8(m_max.Get(), max));
@@ -202,6 +112,8 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         std::string value;
         RETURN_IF_FAILED(HStringToUTF8(m_value.Get(), value));
         dateInput->SetValue(value);
+
+        sharedModel = dateInput;
 
         return S_OK;
     }CATCH_RETURN;

--- a/source/uwp/Renderer/lib/AdaptiveDateInput.h
+++ b/source/uwp/Renderer/lib/AdaptiveDateInput.h
@@ -3,6 +3,7 @@
 #include "AdaptiveCards.Rendering.Uwp.h"
 #include "DateInput.h"
 #include "Enums.h"
+#include "AdaptiveInputElement.h"
 
 namespace AdaptiveCards { namespace Rendering { namespace Uwp
 {
@@ -12,7 +13,8 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveDateInput,
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveInputElement,
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement,
-            Microsoft::WRL::CloakedIid<ITypePeek>>
+            Microsoft::WRL::CloakedIid<ITypePeek>,
+            Microsoft::WRL::CloakedIid<AdaptiveCards::Rendering::Uwp::AdaptiveInputElementBase>>
     {
         InspectableClass(RuntimeClass_AdaptiveCards_Rendering_Uwp_AdaptiveDateInput, BaseTrust)
 
@@ -34,29 +36,29 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         IFACEMETHODIMP put_Value(_In_ HSTRING value);
 
         // IAdaptiveInputElement
-        IFACEMETHODIMP get_IsRequired(_Out_ boolean* isRequired);
-        IFACEMETHODIMP put_IsRequired(_In_ boolean isRequired);
+        IFACEMETHODIMP get_IsRequired(_Out_ boolean* isRequired) { return AdaptiveInputElementBase::get_IsRequired(isRequired); }
+        IFACEMETHODIMP put_IsRequired(_In_ boolean isRequired) { return AdaptiveInputElementBase::put_IsRequired(isRequired); }
 
         // IAdaptiveCardElement
         IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveCards::Rendering::Uwp::ElementType* elementType);
 
-        IFACEMETHODIMP get_Id(_Out_ HSTRING* id);
-        IFACEMETHODIMP put_Id(_In_ HSTRING id);
+        IFACEMETHODIMP get_Spacing(_Out_ ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing) { return AdaptiveCardElementBase::get_Spacing(spacing); }
+        IFACEMETHODIMP put_Spacing(_In_ ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing) { return AdaptiveCardElementBase::put_Spacing(spacing); }
 
-        IFACEMETHODIMP get_Spacing(_Out_ ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing);
-        IFACEMETHODIMP put_Spacing(_In_ ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing);
+        IFACEMETHODIMP get_Separator(_Out_ boolean* separator) { return AdaptiveCardElementBase::get_Separator(separator); }
+        IFACEMETHODIMP put_Separator(_In_ boolean separator) { return AdaptiveCardElementBase::put_Separator(separator); }
 
-        IFACEMETHODIMP get_Separator(_Out_ boolean* separator);
-        IFACEMETHODIMP put_Separator(_In_ boolean separator);
+        IFACEMETHODIMP get_Id(_Out_ HSTRING* id) { return AdaptiveCardElementBase::get_Id(id); }
+        IFACEMETHODIMP put_Id(_In_ HSTRING id) { return AdaptiveCardElementBase::put_Id(id); }
 
-        IFACEMETHODIMP get_ElementTypeString(_Out_ HSTRING* value);
+        IFACEMETHODIMP get_ElementTypeString(_Out_ HSTRING* value) { return AdaptiveCardElementBase::get_ElementTypeString(value); }
 
-        IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
-        IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value);
+        IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveCardElementBase::get_AdditionalProperties(result); }
+        IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value) { return AdaptiveCardElementBase::put_AdditionalProperties(value); }
 
-        IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
+        IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveCardElementBase::ToJson(result); }
 
-        HRESULT GetSharedModel(_In_ std::shared_ptr<AdaptiveCards::DateInput>& sharedModel);
+        virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveCards::BaseCardElement>& sharedModel) override;
 
         // ITypePeek method
         void *PeekAt(REFIID riid) override
@@ -69,12 +71,6 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         Microsoft::WRL::Wrappers::HString m_min;
         Microsoft::WRL::Wrappers::HString m_placeholder;
         Microsoft::WRL::Wrappers::HString m_value;
-
-        boolean m_isRequired;
-        boolean m_separator;
-        Microsoft::WRL::Wrappers::HString m_id;
-        ABI::AdaptiveCards::Rendering::Uwp::Spacing m_spacing;
-        Microsoft::WRL::ComPtr<ABI::Windows::Data::Json::IJsonObject> m_additionalProperties;
     };
 
     ActivatableClass(AdaptiveDateInput);

--- a/source/uwp/Renderer/lib/AdaptiveElementParserRegistration.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveElementParserRegistration.cpp
@@ -5,6 +5,7 @@
 #include "Util.h"
 
 using namespace Microsoft::WRL;
+using namespace Microsoft::WRL::Wrappers;
 using namespace ABI::AdaptiveCards::Rendering::Uwp;
 using namespace ABI::Windows::UI;
 
@@ -80,11 +81,11 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     {
         std::string type = ParseUtil::GetTypeAsString(value);
 
-        HSTRING typeAsHstring;
-        THROW_IF_FAILED(UTF8ToHString(type, &typeAsHstring));
+        HString typeAsHstring;
+        THROW_IF_FAILED(UTF8ToHString(type, typeAsHstring.GetAddressOf()));
 
         ComPtr<IAdaptiveElementParser> parser;
-        THROW_IF_FAILED(m_parserRegistration->Get(typeAsHstring, &parser));
+        THROW_IF_FAILED(m_parserRegistration->Get(typeAsHstring.Get(), &parser));
 
         ComPtr<ABI::Windows::Data::Json::IJsonObject>jsonObject;
         THROW_IF_FAILED(JsonCppToJsonObject(value, &jsonObject));

--- a/source/uwp/Renderer/lib/AdaptiveFact.h
+++ b/source/uwp/Renderer/lib/AdaptiveFact.h
@@ -27,7 +27,7 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
 
         IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveCards::Rendering::Uwp::ElementType* elementType);
 
-        HRESULT GetSharedModel(_In_ std::shared_ptr<AdaptiveCards::Fact>& sharedModel);
+        HRESULT GetSharedModel(std::shared_ptr<AdaptiveCards::Fact>& sharedModel);
 
         // ITypePeek method
         void *PeekAt(REFIID riid) override

--- a/source/uwp/Renderer/lib/AdaptiveFactSet.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveFactSet.cpp
@@ -26,7 +26,7 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     } CATCH_RETURN;
 
     _Use_decl_annotations_
-    HRESULT AdaptiveFactSet::RuntimeClassInitialize(const std::shared_ptr<AdaptiveCards::FactSet>& sharedFactSet)
+    HRESULT AdaptiveFactSet::RuntimeClassInitialize(const std::shared_ptr<AdaptiveCards::FactSet>& sharedFactSet) try
     {
         if (sharedFactSet == nullptr)
         {
@@ -35,13 +35,9 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
 
         GenerateFactsProjection(sharedFactSet->GetFacts(), m_facts.Get());
         
-        m_spacing = static_cast<ABI::AdaptiveCards::Rendering::Uwp::Spacing>(sharedFactSet->GetSpacing());
-        m_separator = sharedFactSet->GetSeparator();
-        RETURN_IF_FAILED(UTF8ToHString(sharedFactSet->GetId(), m_id.GetAddressOf()));
-        RETURN_IF_FAILED(JsonCppToJsonObject(sharedFactSet->GetAdditionalProperties(), &m_additionalProperties));
-
+        InitializeBaseElement(std::static_pointer_cast<BaseCardElement>(sharedFactSet));
         return S_OK;
-    }
+    } CATCH_RETURN;
 
     _Use_decl_annotations_
     IFACEMETHODIMP AdaptiveFactSet::get_Facts(IVector<IAdaptiveFact*>** facts)
@@ -57,81 +53,11 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveFactSet::get_Spacing(ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing)
-    {
-        *spacing = m_spacing;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveFactSet::put_Spacing(ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing)
-    {
-        m_spacing = spacing;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveFactSet::get_Separator(boolean* separator)
-    {
-        *separator = m_separator;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveFactSet::put_Separator(boolean separator)
-    {
-        m_separator = separator;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveFactSet::get_Id(HSTRING* id)
-    {
-        return m_id.CopyTo(id);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveFactSet::put_Id(HSTRING id)
-    {
-        return m_id.Set(id);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveFactSet::get_ElementTypeString(HSTRING* type)
-    {
-        ElementType typeEnum;
-        RETURN_IF_FAILED(get_ElementType(&typeEnum));
-        return ProjectedElementTypeToHString(typeEnum, type);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveFactSet::get_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject** result)
-    {
-        return m_additionalProperties.CopyTo(result);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveFactSet::put_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject* jsonObject)
-    {
-        m_additionalProperties = jsonObject;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveFactSet::ToJson(ABI::Windows::Data::Json::IJsonObject** result)
-    {
-        std::shared_ptr<AdaptiveCards::FactSet> sharedModel;
-        RETURN_IF_FAILED(GetSharedModel(sharedModel));
-
-        return StringToJsonObject(sharedModel->Serialize(), result);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveFactSet::GetSharedModel(std::shared_ptr<AdaptiveCards::FactSet>& sharedModel) try
+    HRESULT AdaptiveFactSet::GetSharedModel(std::shared_ptr<AdaptiveCards::BaseCardElement>& sharedModel) try
     {
         std::shared_ptr<AdaptiveCards::FactSet> factSet = std::make_shared<AdaptiveCards::FactSet>();
 
-        RETURN_IF_FAILED(SetSharedElementProperties(this, std::dynamic_pointer_cast<AdaptiveCards::BaseCardElement>(factSet)));
+        RETURN_IF_FAILED(SetSharedElementProperties(std::static_pointer_cast<AdaptiveCards::BaseCardElement>(factSet)));
         RETURN_IF_FAILED(GenerateSharedFacts(m_facts.Get(), factSet->GetFacts()));
 
         sharedModel = factSet;

--- a/source/uwp/Renderer/lib/AdaptiveFactSet.h
+++ b/source/uwp/Renderer/lib/AdaptiveFactSet.h
@@ -4,6 +4,7 @@
 #include "Enums.h"
 #include "FactSet.h"
 #include <windows.foundation.h>
+#include "AdaptiveCardElement.h"
 
 namespace AdaptiveCards { namespace Rendering { namespace Uwp
 {
@@ -12,7 +13,8 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveFactSet,
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement,
-            Microsoft::WRL::CloakedIid<ITypePeek>>
+            Microsoft::WRL::CloakedIid<ITypePeek>,
+            Microsoft::WRL::CloakedIid<AdaptiveCards::Rendering::Uwp::AdaptiveCardElementBase>>
     {
         InspectableClass(RuntimeClass_AdaptiveCards_Rendering_Uwp_AdaptiveFactSet, BaseTrust)
 
@@ -28,23 +30,23 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         // IAdaptiveCardElement
         IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveCards::Rendering::Uwp::ElementType* elementType);
 
-        IFACEMETHODIMP get_Spacing(_Out_ ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing);
-        IFACEMETHODIMP put_Spacing(_In_ ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing);
+        IFACEMETHODIMP get_Spacing(_Out_ ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing) { return AdaptiveCardElementBase::get_Spacing(spacing); }
+        IFACEMETHODIMP put_Spacing(_In_ ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing) { return AdaptiveCardElementBase::put_Spacing(spacing); }
 
-        IFACEMETHODIMP get_Separator(_Out_ boolean* separator);
-        IFACEMETHODIMP put_Separator(_In_ boolean separator);
+        IFACEMETHODIMP get_Separator(_Out_ boolean* separator) { return AdaptiveCardElementBase::get_Separator(separator); }
+        IFACEMETHODIMP put_Separator(_In_ boolean separator) { return AdaptiveCardElementBase::put_Separator(separator); }
 
-        IFACEMETHODIMP get_Id(_Out_ HSTRING* id);
-        IFACEMETHODIMP put_Id(_In_ HSTRING id);
+        IFACEMETHODIMP get_Id(_Out_ HSTRING* id) { return AdaptiveCardElementBase::get_Id(id); }
+        IFACEMETHODIMP put_Id(_In_ HSTRING id) { return AdaptiveCardElementBase::put_Id(id); }
 
-        IFACEMETHODIMP get_ElementTypeString(_Out_ HSTRING* value);
+        IFACEMETHODIMP get_ElementTypeString(_Out_ HSTRING* value) { return AdaptiveCardElementBase::get_ElementTypeString(value); }
 
-        IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
-        IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value);
+        IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveCardElementBase::get_AdditionalProperties(result); }
+        IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value) { return AdaptiveCardElementBase::put_AdditionalProperties(value); }
 
-        IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
+        IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveCardElementBase::ToJson(result); }
 
-        HRESULT GetSharedModel(_In_ std::shared_ptr<AdaptiveCards::FactSet>& sharedModel);
+        virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveCards::BaseCardElement>& sharedModel) override;
 
         // ITypePeek method
         void *PeekAt(REFIID riid) override
@@ -54,11 +56,6 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
 
     private:
         Microsoft::WRL::ComPtr<ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveFact*>> m_facts;
-
-        boolean m_separator;
-        Microsoft::WRL::Wrappers::HString m_id;
-        ABI::AdaptiveCards::Rendering::Uwp::Spacing m_spacing;
-        Microsoft::WRL::ComPtr<ABI::Windows::Data::Json::IJsonObject> m_additionalProperties;
     };
 
     ActivatableClass(AdaptiveFactSet);

--- a/source/uwp/Renderer/lib/AdaptiveImage.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImage.cpp
@@ -48,11 +48,7 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
 
         GenerateActionProjection(sharedImage->GetSelectAction(), &m_selectAction);
 
-        m_spacing = static_cast<ABI::AdaptiveCards::Rendering::Uwp::Spacing>(sharedImage->GetSpacing());
-        m_separator = sharedImage->GetSeparator();
-        RETURN_IF_FAILED(UTF8ToHString(sharedImage->GetId(), m_id.GetAddressOf()));
-        RETURN_IF_FAILED(JsonCppToJsonObject(sharedImage->GetAdditionalProperties(), &m_additionalProperties));
-
+        InitializeBaseElement(std::static_pointer_cast<BaseCardElement>(sharedImage));
         return S_OK;
     } CATCH_RETURN;
 
@@ -131,67 +127,6 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveImage::get_Spacing(ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing)
-    {
-        *spacing = m_spacing;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveImage::put_Spacing(ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing)
-    {
-        m_spacing = spacing;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveImage::get_Separator(boolean* separator)
-    {
-        *separator = m_separator;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveImage::put_Separator(boolean separator)
-    {
-        m_separator = separator;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveImage::get_Id(HSTRING* id)
-    {
-        return m_id.CopyTo(id);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveImage::put_Id(HSTRING id)
-    {
-        return m_id.Set(id);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveImage::get_ElementTypeString(HSTRING* type)
-    {
-        ElementType typeEnum;
-        RETURN_IF_FAILED(get_ElementType(&typeEnum));
-        return ProjectedElementTypeToHString(typeEnum, type);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveImage::get_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject** result)
-    {
-        return m_additionalProperties.CopyTo(result);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveImage::put_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject* jsonObject)
-    {
-        m_additionalProperties = jsonObject;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
     HRESULT AdaptiveImage::get_SelectAction(IAdaptiveActionElement** action)
     {
         return m_selectAction.CopyTo(action);
@@ -205,20 +140,11 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveImage::ToJson(ABI::Windows::Data::Json::IJsonObject** result)
-    {
-        std::shared_ptr<AdaptiveCards::Image> image;
-        RETURN_IF_FAILED(GetSharedModel(image));
-
-        return StringToJsonObject(image->Serialize(), result);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveImage::GetSharedModel(std::shared_ptr<AdaptiveCards::Image>& sharedImage) try
+    HRESULT AdaptiveImage::GetSharedModel(std::shared_ptr<AdaptiveCards::BaseCardElement>& sharedImage) try
     {
         std::shared_ptr<AdaptiveCards::Image> image = std::make_shared<AdaptiveCards::Image>();
 
-        RETURN_IF_FAILED(SetSharedElementProperties(this, std::dynamic_pointer_cast<AdaptiveCards::BaseCardElement>(image)));
+        RETURN_IF_FAILED(SetSharedElementProperties(std::static_pointer_cast<AdaptiveCards::BaseCardElement>(image)));
 
         if (m_selectAction != nullptr)
         {

--- a/source/uwp/Renderer/lib/AdaptiveImage.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImage.cpp
@@ -34,11 +34,11 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         RETURN_IF_FAILED(GetActivationFactory(
             HStringReference(RuntimeClass_Windows_Foundation_Uri).Get(),
             &uriActivationFactory));
-        HSTRING imageUri;
-        RETURN_IF_FAILED(UTF8ToHString(sharedImage->GetUrl(), &imageUri));
-        if (imageUri != nullptr)
+        
+        std::wstring imageUri = StringToWstring(sharedImage->GetUrl());
+        if (!imageUri.empty())
         {
-            RETURN_IF_FAILED(uriActivationFactory->CreateUri(imageUri, m_url.GetAddressOf()));
+            RETURN_IF_FAILED(uriActivationFactory->CreateUri(HStringReference(imageUri.c_str()).Get(), m_url.GetAddressOf()));
         }
 
         m_imageStyle = static_cast<ABI::AdaptiveCards::Rendering::Uwp::ImageStyle>(sharedImage->GetImageStyle());

--- a/source/uwp/Renderer/lib/AdaptiveImage.h
+++ b/source/uwp/Renderer/lib/AdaptiveImage.h
@@ -4,6 +4,7 @@
 #include "Enums.h"
 #include "Image.h"
 #include <windows.foundation.h>
+#include "AdaptiveCardElement.h"
 
 namespace AdaptiveCards { namespace Rendering { namespace Uwp
 {
@@ -12,7 +13,8 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveImage,
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement,
-            Microsoft::WRL::CloakedIid<ITypePeek>>
+            Microsoft::WRL::CloakedIid<ITypePeek>,
+            Microsoft::WRL::CloakedIid<AdaptiveCards::Rendering::Uwp::AdaptiveCardElementBase>>
     {
         InspectableClass(RuntimeClass_AdaptiveCards_Rendering_Uwp_AdaptiveImage, BaseTrust)
 
@@ -43,23 +45,23 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         // IAdaptiveCardElement
         IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveCards::Rendering::Uwp::ElementType* elementType);
 
-        IFACEMETHODIMP get_Spacing(_Out_ ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing);
-        IFACEMETHODIMP put_Spacing(_In_ ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing);
+        IFACEMETHODIMP get_Spacing(_Out_ ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing) { return AdaptiveCardElementBase::get_Spacing(spacing); }
+        IFACEMETHODIMP put_Spacing(_In_ ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing) { return AdaptiveCardElementBase::put_Spacing(spacing); }
 
-        IFACEMETHODIMP get_Separator(_Out_ boolean* separator);
-        IFACEMETHODIMP put_Separator(_In_ boolean separator);
+        IFACEMETHODIMP get_Separator(_Out_ boolean* separator) { return AdaptiveCardElementBase::get_Separator(separator); }
+        IFACEMETHODIMP put_Separator(_In_ boolean separator) { return AdaptiveCardElementBase::put_Separator(separator); }
 
-        IFACEMETHODIMP get_Id(_Out_ HSTRING* id);
-        IFACEMETHODIMP put_Id(_In_ HSTRING id);
+        IFACEMETHODIMP get_Id(_Out_ HSTRING* id) { return AdaptiveCardElementBase::get_Id(id); }
+        IFACEMETHODIMP put_Id(_In_ HSTRING id) { return AdaptiveCardElementBase::put_Id(id); }
 
-        IFACEMETHODIMP get_ElementTypeString(_Out_ HSTRING* value);
+        IFACEMETHODIMP get_ElementTypeString(_Out_ HSTRING* value) { return AdaptiveCardElementBase::get_ElementTypeString(value); }
 
-        IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
-        IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value);
+        IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveCardElementBase::get_AdditionalProperties(result); }
+        IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value) { return AdaptiveCardElementBase::put_AdditionalProperties(value); }
 
-        IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
+        IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveCardElementBase::ToJson(result); }
 
-        HRESULT GetSharedModel(_In_ std::shared_ptr<AdaptiveCards::Image>& sharedModel);
+        virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveCards::BaseCardElement>& sharedModel) override;
 
         // ITypePeek method
         void *PeekAt(REFIID riid) override
@@ -74,11 +76,6 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         Microsoft::WRL::Wrappers::HString m_altText;
         ABI::AdaptiveCards::Rendering::Uwp::HAlignment m_horizontalAlignment;
         Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveActionElement> m_selectAction;
-
-        boolean m_separator;
-        Microsoft::WRL::Wrappers::HString m_id;
-        ABI::AdaptiveCards::Rendering::Uwp::Spacing m_spacing;
-        Microsoft::WRL::ComPtr<ABI::Windows::Data::Json::IJsonObject> m_additionalProperties;
     };
 
     ActivatableClass(AdaptiveImage);

--- a/source/uwp/Renderer/lib/AdaptiveImageSet.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImageSet.cpp
@@ -26,7 +26,7 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     } CATCH_RETURN;
 
     _Use_decl_annotations_
-    HRESULT AdaptiveImageSet::RuntimeClassInitialize(const std::shared_ptr<AdaptiveCards::ImageSet>& sharedImageSet)
+    HRESULT AdaptiveImageSet::RuntimeClassInitialize(const std::shared_ptr<AdaptiveCards::ImageSet>& sharedImageSet) try
     {
         if (sharedImageSet == nullptr)
         {
@@ -36,14 +36,10 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         GenerateImagesProjection(sharedImageSet->GetImages(), m_images.Get());
 
         m_imageSize = static_cast<ABI::AdaptiveCards::Rendering::Uwp::ImageSize>(sharedImageSet->GetImageSize());
-
-        m_spacing = static_cast<ABI::AdaptiveCards::Rendering::Uwp::Spacing>(sharedImageSet->GetSpacing());
-        m_separator = sharedImageSet->GetSeparator();
-        RETURN_IF_FAILED(UTF8ToHString(sharedImageSet->GetId(), m_id.GetAddressOf()));
-        RETURN_IF_FAILED(JsonCppToJsonObject(sharedImageSet->GetAdditionalProperties(), &m_additionalProperties));
-
+        
+        InitializeBaseElement(std::static_pointer_cast<BaseCardElement>(sharedImageSet));
         return S_OK;
-    }
+    } CATCH_RETURN;
 
     _Use_decl_annotations_
         IFACEMETHODIMP AdaptiveImageSet::get_Images(IVector<IAdaptiveImage*>** images)
@@ -73,81 +69,11 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveImageSet::get_Spacing(ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing)
-    {
-        *spacing = m_spacing;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveImageSet::put_Spacing(ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing)
-    {
-        m_spacing = spacing;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveImageSet::get_Separator(boolean* separator)
-    {
-        *separator = m_separator;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveImageSet::put_Separator(boolean separator)
-    {
-        m_separator = separator;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveImageSet::get_Id(HSTRING* id)
-    {
-        return m_id.CopyTo(id);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveImageSet::put_Id(HSTRING id)
-    {
-        return m_id.Set(id);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveImageSet::get_ElementTypeString(HSTRING* type)
-    {
-        ElementType typeEnum;
-        RETURN_IF_FAILED(get_ElementType(&typeEnum));
-        return ProjectedElementTypeToHString(typeEnum, type);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveImageSet::get_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject** result)
-    {
-        return m_additionalProperties.CopyTo(result);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveImageSet::put_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject* jsonObject)
-    {
-        m_additionalProperties = jsonObject;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveImageSet::ToJson(ABI::Windows::Data::Json::IJsonObject** result)
-    {
-        std::shared_ptr<AdaptiveCards::ImageSet> sharedModel;
-        RETURN_IF_FAILED(GetSharedModel(sharedModel));
-
-        return StringToJsonObject(sharedModel->Serialize(), result);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveImageSet::GetSharedModel(std::shared_ptr<AdaptiveCards::ImageSet>& sharedModel) try
+    HRESULT AdaptiveImageSet::GetSharedModel(std::shared_ptr<AdaptiveCards::BaseCardElement>& sharedModel) try
     {
         std::shared_ptr<AdaptiveCards::ImageSet> imageSet = std::make_shared<AdaptiveCards::ImageSet>();
 
-        RETURN_IF_FAILED(SetSharedElementProperties(this, std::dynamic_pointer_cast<AdaptiveCards::BaseCardElement>(imageSet)));
+        RETURN_IF_FAILED(SetSharedElementProperties(std::static_pointer_cast<AdaptiveCards::BaseCardElement>(imageSet)));
 
         imageSet->SetImageSize(static_cast<AdaptiveCards::ImageSize>(m_imageSize));
 

--- a/source/uwp/Renderer/lib/AdaptiveImageSet.h
+++ b/source/uwp/Renderer/lib/AdaptiveImageSet.h
@@ -4,6 +4,7 @@
 #include "Enums.h"
 #include "ImageSet.h"
 #include <windows.foundation.h>
+#include "AdaptiveCardElement.h"
 
 namespace AdaptiveCards { namespace Rendering { namespace Uwp
 {
@@ -12,7 +13,8 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
         ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveImageSet,
         ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement,
-        Microsoft::WRL::CloakedIid<ITypePeek>>
+        Microsoft::WRL::CloakedIid<ITypePeek>,
+        Microsoft::WRL::CloakedIid<AdaptiveCards::Rendering::Uwp::AdaptiveCardElementBase>>
     {
         InspectableClass(RuntimeClass_AdaptiveCards_Rendering_Uwp_AdaptiveImageSet, BaseTrust)
 
@@ -31,23 +33,23 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         // IAdaptiveCardElement
         IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveCards::Rendering::Uwp::ElementType* elementType);
 
-        IFACEMETHODIMP get_Spacing(_Out_ ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing);
-        IFACEMETHODIMP put_Spacing(_In_ ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing);
+        IFACEMETHODIMP get_Spacing(_Out_ ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing) { return AdaptiveCardElementBase::get_Spacing(spacing); }
+        IFACEMETHODIMP put_Spacing(_In_ ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing) { return AdaptiveCardElementBase::put_Spacing(spacing); }
 
-        IFACEMETHODIMP get_Separator(_Out_ boolean* separator);
-        IFACEMETHODIMP put_Separator(_In_ boolean separator);
+        IFACEMETHODIMP get_Separator(_Out_ boolean* separator) { return AdaptiveCardElementBase::get_Separator(separator); }
+        IFACEMETHODIMP put_Separator(_In_ boolean separator) { return AdaptiveCardElementBase::put_Separator(separator); }
 
-        IFACEMETHODIMP get_Id(_Out_ HSTRING* id);
-        IFACEMETHODIMP put_Id(_In_ HSTRING id);
+        IFACEMETHODIMP get_Id(_Out_ HSTRING* id) { return AdaptiveCardElementBase::get_Id(id); }
+        IFACEMETHODIMP put_Id(_In_ HSTRING id) { return AdaptiveCardElementBase::put_Id(id); }
 
-        IFACEMETHODIMP get_ElementTypeString(_Out_ HSTRING* value);
+        IFACEMETHODIMP get_ElementTypeString(_Out_ HSTRING* value) { return AdaptiveCardElementBase::get_ElementTypeString(value); }
 
-        IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
-        IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value);
+        IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveCardElementBase::get_AdditionalProperties(result); }
+        IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value) { return AdaptiveCardElementBase::put_AdditionalProperties(value); }
 
-        IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
+        IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveCardElementBase::ToJson(result); }
 
-        HRESULT GetSharedModel(_In_ std::shared_ptr<AdaptiveCards::ImageSet>& sharedModel);
+        virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveCards::BaseCardElement>& sharedModel) override;
 
         // ITypePeek method
         void *PeekAt(REFIID riid) override
@@ -58,11 +60,6 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     private:
         Microsoft::WRL::ComPtr<ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveImage*>> m_images;
         ABI::AdaptiveCards::Rendering::Uwp::ImageSize m_imageSize;
-
-        boolean m_separator;
-        Microsoft::WRL::Wrappers::HString m_id;
-        ABI::AdaptiveCards::Rendering::Uwp::Spacing m_spacing;
-        Microsoft::WRL::ComPtr<ABI::Windows::Data::Json::IJsonObject> m_additionalProperties;
     };
 
     ActivatableClass(AdaptiveImageSet);

--- a/source/uwp/Renderer/lib/AdaptiveInputElement.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveInputElement.cpp
@@ -1,0 +1,41 @@
+#include "pch.h"
+#include "AdaptiveInputElement.h"
+
+using namespace Microsoft::WRL;
+using namespace Microsoft::WRL::Wrappers;
+using namespace ABI::AdaptiveCards::Rendering::Uwp;
+using namespace ABI::Windows::Foundation::Collections;
+using namespace ABI::Windows::UI::Xaml;
+using namespace ABI::Windows::UI::Xaml::Controls;
+
+namespace AdaptiveCards { namespace Rendering { namespace Uwp
+{
+    HRESULT AdaptiveInputElementBase::InitializeBaseElement(std::shared_ptr<AdaptiveCards::BaseInputElement>& sharedModel)
+    {
+        AdaptiveCardElementBase::InitializeBaseElement(std::static_pointer_cast<AdaptiveCards::BaseCardElement>(sharedModel));
+        m_isRequired = sharedModel->GetIsRequired();
+        return S_OK;
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveInputElementBase::get_IsRequired(boolean* isRequired)
+    {
+        *isRequired = m_isRequired;
+        return S_OK;
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveInputElementBase::put_IsRequired(boolean isRequired)
+    {
+        m_isRequired = isRequired;
+        return S_OK;
+    }
+
+    HRESULT AdaptiveInputElementBase::SetSharedElementProperties(
+        std::shared_ptr<AdaptiveCards::BaseInputElement> sharedCardElement)
+    {
+        AdaptiveCardElementBase::SetSharedElementProperties(sharedCardElement);
+        sharedCardElement->SetIsRequired(m_isRequired);
+        return S_OK;
+    }
+}}}

--- a/source/uwp/Renderer/lib/AdaptiveInputElement.h
+++ b/source/uwp/Renderer/lib/AdaptiveInputElement.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "AdaptiveCards.Rendering.Uwp.h"
+#include "Enums.h"
+#include "BaseInputElement.h"
+#include "AdaptiveCardElement.h"
+
+namespace AdaptiveCards { namespace Rendering { namespace Uwp
+{
+    class DECLSPEC_UUID("E2E42BA6-A0AE-4B01-B161-29AF2F2B302B") AdaptiveInputElementBase : public AdaptiveCardElementBase
+    {
+    protected:
+
+        HRESULT InitializeBaseElement(std::shared_ptr<AdaptiveCards::BaseInputElement>& sharedModel);
+
+        IFACEMETHODIMP get_IsRequired(_Out_ boolean* isRequired);
+        IFACEMETHODIMP put_IsRequired(_In_ boolean isRequired);
+
+        HRESULT SetSharedElementProperties(std::shared_ptr<AdaptiveCards::BaseInputElement> sharedCardElement);
+
+    private:
+        boolean m_isRequired;
+    };
+}}}

--- a/source/uwp/Renderer/lib/AdaptiveNumberInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveNumberInput.cpp
@@ -32,11 +32,7 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         m_value = sharedNumberInput->GetValue();
         RETURN_IF_FAILED(UTF8ToHString(sharedNumberInput->GetPlaceholder(), m_placeholder.GetAddressOf()));
 
-        m_isRequired = sharedNumberInput->GetIsRequired();
-        m_spacing = static_cast<ABI::AdaptiveCards::Rendering::Uwp::Spacing>(sharedNumberInput->GetSpacing());
-        m_separator = sharedNumberInput->GetSeparator();
-        RETURN_IF_FAILED(UTF8ToHString(sharedNumberInput->GetId(), m_id.GetAddressOf()));
-        RETURN_IF_FAILED(JsonCppToJsonObject(sharedNumberInput->GetAdditionalProperties(), &m_additionalProperties));
+        InitializeBaseElement(std::static_pointer_cast<BaseInputElement>(sharedNumberInput));
         return S_OK;
     } CATCH_RETURN;
 
@@ -93,18 +89,6 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         m_min = min;
         return S_OK;
     }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveNumberInput::get_Id(HSTRING* id)
-    {
-        return m_id.CopyTo(id);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveNumberInput::put_Id(HSTRING id)
-    {
-        return m_id.Set(id);
-    }
     
     _Use_decl_annotations_
     HRESULT AdaptiveNumberInput::get_ElementType(ElementType* elementType)
@@ -113,85 +97,11 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         return S_OK;
     }
 
-    _Use_decl_annotations_
-    HRESULT AdaptiveNumberInput::get_Spacing(ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing)
-    {
-        *spacing = m_spacing;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveNumberInput::put_Spacing(ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing)
-    {
-        m_spacing = spacing;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveNumberInput::get_Separator(boolean* separator)
-    {
-        *separator = m_separator;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveNumberInput::put_Separator(boolean separator)
-    {
-        m_separator = separator;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveNumberInput::get_IsRequired(boolean* isRequired)
-    {
-        *isRequired = m_isRequired;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveNumberInput::put_IsRequired(boolean isRequired)
-    {
-        m_isRequired = isRequired;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveNumberInput::get_ElementTypeString(HSTRING* type)
-    {
-        ElementType typeEnum;
-        RETURN_IF_FAILED(get_ElementType(&typeEnum));
-        return ProjectedElementTypeToHString(typeEnum, type);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveNumberInput::get_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject** result)
-    {
-        return m_additionalProperties.CopyTo(result);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveNumberInput::put_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject* jsonObject)
-    {
-        m_additionalProperties = jsonObject;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveNumberInput::ToJson(ABI::Windows::Data::Json::IJsonObject** result)
-    {
-        std::shared_ptr<AdaptiveCards::NumberInput> sharedNumberInput = std::make_shared<AdaptiveCards::NumberInput>();
-        GetSharedModel(sharedNumberInput);
-
-        return StringToJsonObject(sharedNumberInput->Serialize(), result);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveNumberInput::GetSharedModel(std::shared_ptr<AdaptiveCards::NumberInput>& sharedModel) try
+    HRESULT AdaptiveNumberInput::GetSharedModel(std::shared_ptr<AdaptiveCards::BaseCardElement>& sharedModel) try
     {
         std::shared_ptr<AdaptiveCards::NumberInput> numberInput = std::make_shared<AdaptiveCards::NumberInput>();
 
-        RETURN_IF_FAILED(SetSharedElementProperties(this, std::dynamic_pointer_cast<AdaptiveCards::BaseCardElement>(numberInput)));
-        numberInput->SetIsRequired(m_isRequired);
+        RETURN_IF_FAILED(SetSharedElementProperties(std::static_pointer_cast<AdaptiveCards::BaseInputElement>(numberInput)));
 
         numberInput->SetMin(m_min);
         numberInput->SetMax(m_max);
@@ -201,6 +111,7 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         RETURN_IF_FAILED(HStringToUTF8(m_placeholder.Get(), placeholder));
         numberInput->SetPlaceholder(placeholder);
 
+        sharedModel = numberInput;
         return S_OK;
     }CATCH_RETURN;
 }}}

--- a/source/uwp/Renderer/lib/AdaptiveNumberInput.h
+++ b/source/uwp/Renderer/lib/AdaptiveNumberInput.h
@@ -3,6 +3,7 @@
 #include "AdaptiveCards.Rendering.Uwp.h"
 #include "Enums.h"
 #include "NumberInput.h"
+#include "AdaptiveInputElement.h"
 
 namespace AdaptiveCards { namespace Rendering { namespace Uwp
 {
@@ -12,7 +13,8 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveNumberInput,
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveInputElement,
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement,
-            Microsoft::WRL::CloakedIid<ITypePeek>>
+            Microsoft::WRL::CloakedIid<ITypePeek>,
+            Microsoft::WRL::CloakedIid<AdaptiveCards::Rendering::Uwp::AdaptiveInputElementBase>>
     {
         InspectableClass(RuntimeClass_AdaptiveCards_Rendering_Uwp_AdaptiveNumberInput, BaseTrust)
 
@@ -34,29 +36,29 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         IFACEMETHODIMP put_Min(_In_ INT32 value);
 
         // IAdaptiveInputElement
-        IFACEMETHODIMP get_IsRequired(_Out_ boolean* isRequired);
-        IFACEMETHODIMP put_IsRequired(_In_ boolean isRequired);
+        IFACEMETHODIMP get_IsRequired(_Out_ boolean* isRequired) { return AdaptiveInputElementBase::get_IsRequired(isRequired); }
+        IFACEMETHODIMP put_IsRequired(_In_ boolean isRequired) { return AdaptiveInputElementBase::put_IsRequired(isRequired); }
 
         // IAdaptiveCardElement
         IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveCards::Rendering::Uwp::ElementType* elementType);
 
-        IFACEMETHODIMP get_Id(_Out_ HSTRING* id);
-        IFACEMETHODIMP put_Id(_In_ HSTRING id);
+        IFACEMETHODIMP get_Spacing(_Out_ ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing) { return AdaptiveCardElementBase::get_Spacing(spacing); }
+        IFACEMETHODIMP put_Spacing(_In_ ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing) { return AdaptiveCardElementBase::put_Spacing(spacing); }
 
-        IFACEMETHODIMP get_Spacing(_Out_ ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing);
-        IFACEMETHODIMP put_Spacing(_In_ ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing);
+        IFACEMETHODIMP get_Separator(_Out_ boolean* separator) { return AdaptiveCardElementBase::get_Separator(separator); }
+        IFACEMETHODIMP put_Separator(_In_ boolean separator) { return AdaptiveCardElementBase::put_Separator(separator); }
 
-        IFACEMETHODIMP get_Separator(_Out_ boolean* separator);
-        IFACEMETHODIMP put_Separator(_In_ boolean separator);
+        IFACEMETHODIMP get_Id(_Out_ HSTRING* id) { return AdaptiveCardElementBase::get_Id(id); }
+        IFACEMETHODIMP put_Id(_In_ HSTRING id) { return AdaptiveCardElementBase::put_Id(id); }
 
-        IFACEMETHODIMP get_ElementTypeString(_Out_ HSTRING* value);
+        IFACEMETHODIMP get_ElementTypeString(_Out_ HSTRING* value) { return AdaptiveCardElementBase::get_ElementTypeString(value); }
 
-        IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
-        IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value);
+        IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveCardElementBase::get_AdditionalProperties(result); }
+        IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value) { return AdaptiveCardElementBase::put_AdditionalProperties(value); }
 
-        IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
+        IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveCardElementBase::ToJson(result); }
 
-        HRESULT GetSharedModel(_In_ std::shared_ptr<AdaptiveCards::NumberInput>& sharedModel);
+        virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveCards::BaseCardElement>& sharedModel) override;
 
         // ITypePeek method
         void *PeekAt(REFIID riid) override
@@ -69,12 +71,6 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         INT32 m_min;
         INT32 m_value;
         Microsoft::WRL::Wrappers::HString m_placeholder;
-
-        boolean m_isRequired;
-        boolean m_separator;
-        Microsoft::WRL::Wrappers::HString m_id;
-        ABI::AdaptiveCards::Rendering::Uwp::Spacing m_spacing;
-        Microsoft::WRL::ComPtr<ABI::Windows::Data::Json::IJsonObject> m_additionalProperties;
     };
 
     ActivatableClass(AdaptiveNumberInput);

--- a/source/uwp/Renderer/lib/AdaptiveOpenUrlAction.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveOpenUrlAction.cpp
@@ -11,69 +11,43 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
 {
     HRESULT AdaptiveOpenUrlAction::RuntimeClassInitialize() noexcept try
     {
-        m_sharedOpenUrlAction = std::make_shared<OpenUrlAction>();
-        return S_OK;
+        std::shared_ptr<AdaptiveCards::OpenUrlAction> openUrlAction = std::make_shared<AdaptiveCards::OpenUrlAction>();
+        return RuntimeClassInitialize(openUrlAction);
     } CATCH_RETURN;
 
     _Use_decl_annotations_
-    HRESULT AdaptiveOpenUrlAction::RuntimeClassInitialize(const std::shared_ptr<AdaptiveCards::OpenUrlAction>& sharedOpenUrlAction)
+    HRESULT AdaptiveOpenUrlAction::RuntimeClassInitialize(const std::shared_ptr<AdaptiveCards::OpenUrlAction>& sharedOpenUrlAction) try
     {
         if (sharedOpenUrlAction == nullptr)
         {
             return E_INVALIDARG;
         }
 
-        m_sharedOpenUrlAction = sharedOpenUrlAction;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveOpenUrlAction::get_Title(HSTRING* title)
-    {
-        return UTF8ToHString(m_sharedOpenUrlAction->GetTitle(), title);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveOpenUrlAction::put_Title(HSTRING title)
-    {
-        std::string out;
-        RETURN_IF_FAILED(HStringToUTF8(title, out));
-        m_sharedOpenUrlAction->SetTitle(out);
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveOpenUrlAction::get_Url(IUriRuntimeClass** url)
-    {
-        *url = nullptr;
-
         ComPtr<IUriRuntimeClassFactory> uriActivationFactory;
         RETURN_IF_FAILED(GetActivationFactory(
             HStringReference(RuntimeClass_Windows_Foundation_Uri).Get(),
             &uriActivationFactory));
-
         HSTRING imageUri;
-        RETURN_IF_FAILED(UTF8ToHString(m_sharedOpenUrlAction->GetUrl(), &imageUri));
-        RETURN_IF_FAILED(uriActivationFactory->CreateUri(imageUri, url));
+        RETURN_IF_FAILED(UTF8ToHString(sharedOpenUrlAction->GetUrl(), &imageUri));
+        if (imageUri != nullptr)
+        {
+            RETURN_IF_FAILED(uriActivationFactory->CreateUri(imageUri, m_url.GetAddressOf()));
+        }
 
+        InitializeBaseElement(std::static_pointer_cast<AdaptiveCards::BaseActionElement>(sharedOpenUrlAction));
         return S_OK;
+    } CATCH_RETURN;
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveOpenUrlAction::get_Url(IUriRuntimeClass** url)
+    {
+        return m_url.CopyTo(url);
     }
 
     _Use_decl_annotations_
     HRESULT AdaptiveOpenUrlAction::put_Url(IUriRuntimeClass* url) try
     {
-        if (url == nullptr)
-        {
-            return E_INVALIDARG;
-        }
-
-        HString urlTemp;
-        url->get_AbsoluteUri(urlTemp.GetAddressOf());
-
-        std::string urlString;
-        RETURN_IF_FAILED(HStringToUTF8(urlTemp.Get(), urlString));
-        m_sharedOpenUrlAction->SetUrl(urlString);
-
+        m_url = url;
         return S_OK;
     } CATCH_RETURN;
 
@@ -85,53 +59,22 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveOpenUrlAction::get_Id(HSTRING* id)
+    HRESULT AdaptiveOpenUrlAction::GetSharedModel(std::shared_ptr<AdaptiveCards::BaseActionElement>& sharedModel) try
     {
-        return UTF8ToHString(m_sharedOpenUrlAction->GetId(), id);
-    }
+        std::shared_ptr<AdaptiveCards::OpenUrlAction> openUrlAction = std::make_shared<AdaptiveCards::OpenUrlAction>();
+        RETURN_IF_FAILED(SetSharedElementProperties(std::static_pointer_cast<AdaptiveCards::BaseActionElement>(openUrlAction)));
 
-    _Use_decl_annotations_
-    HRESULT AdaptiveOpenUrlAction::put_Id(HSTRING id)
-    {
-        std::string out;
-        RETURN_IF_FAILED(HStringToUTF8(id, out));
-        m_sharedOpenUrlAction->SetId(out);
+        if (m_url != nullptr)
+        {
+            HString urlTemp;
+            m_url->get_AbsoluteUri(urlTemp.GetAddressOf());
+
+            std::string urlString;
+            RETURN_IF_FAILED(HStringToUTF8(urlTemp.Get(), urlString));
+            openUrlAction->SetUrl(urlString);
+        }
+
+        sharedModel = openUrlAction;
         return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveOpenUrlAction::get_ActionTypeString(HSTRING* type)
-    {
-        ::ActionType typeEnum;
-        RETURN_IF_FAILED(get_ActionType(&typeEnum));
-        return ProjectedActionTypeToHString(typeEnum, type);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveOpenUrlAction::get_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject** result)
-    {
-        return JsonCppToJsonObject(m_sharedOpenUrlAction->GetAdditionalProperties(), result);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveOpenUrlAction::put_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject* jsonObject)
-    {
-        Json::Value jsonCpp;
-        RETURN_IF_FAILED(JsonObjectToJsonCpp(jsonObject, &jsonCpp));
-        m_sharedOpenUrlAction->SetAdditionalProperties(jsonCpp);
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveOpenUrlAction::ToJson(ABI::Windows::Data::Json::IJsonObject** result)
-    {
-        return StringToJsonObject(m_sharedOpenUrlAction->Serialize(), result);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveOpenUrlAction::GetSharedModel(std::shared_ptr<AdaptiveCards::OpenUrlAction>& sharedModel)
-    {
-        sharedModel = m_sharedOpenUrlAction;
-        return S_OK;
-    }
+    } CATCH_RETURN;
 }}}

--- a/source/uwp/Renderer/lib/AdaptiveOpenUrlAction.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveOpenUrlAction.cpp
@@ -27,12 +27,8 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         RETURN_IF_FAILED(GetActivationFactory(
             HStringReference(RuntimeClass_Windows_Foundation_Uri).Get(),
             &uriActivationFactory));
-        HSTRING imageUri;
-        RETURN_IF_FAILED(UTF8ToHString(sharedOpenUrlAction->GetUrl(), &imageUri));
-        if (imageUri != nullptr)
-        {
-            RETURN_IF_FAILED(uriActivationFactory->CreateUri(imageUri, m_url.GetAddressOf()));
-        }
+        std::wstring imageUri = StringToWstring(sharedOpenUrlAction->GetUrl());
+        RETURN_IF_FAILED(uriActivationFactory->CreateUri(HStringReference(imageUri.c_str()).Get(), m_url.GetAddressOf()));
 
         InitializeBaseElement(std::static_pointer_cast<AdaptiveCards::BaseActionElement>(sharedOpenUrlAction));
         return S_OK;

--- a/source/uwp/Renderer/lib/AdaptiveOpenUrlAction.h
+++ b/source/uwp/Renderer/lib/AdaptiveOpenUrlAction.h
@@ -3,6 +3,7 @@
 #include "AdaptiveCards.Rendering.Uwp.h"
 #include "Enums.h"
 #include "OpenUrlAction.h"
+#include "AdaptiveActionElement.h"
 
 namespace AdaptiveCards { namespace Rendering { namespace Uwp
 {
@@ -11,7 +12,8 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveOpenUrlAction,
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveActionElement,
-            Microsoft::WRL::CloakedIid<ITypePeek>>
+            Microsoft::WRL::CloakedIid<ITypePeek>,
+            Microsoft::WRL::CloakedIid<AdaptiveCards::Rendering::Uwp::AdaptiveActionElementBase>>
     {
         InspectableClass(RuntimeClass_AdaptiveCards_Rendering_Uwp_AdaptiveOpenUrlAction, BaseTrust)
 
@@ -25,20 +27,20 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
 
         // IAdaptiveActionElement
         IFACEMETHODIMP get_ActionType(_Out_ ABI::AdaptiveCards::Rendering::Uwp::ActionType* actionType);
-        IFACEMETHODIMP get_ActionTypeString(_Out_ HSTRING* value);
+        IFACEMETHODIMP get_ActionTypeString(_Out_ HSTRING* value) { return AdaptiveActionElementBase::get_ActionTypeString(value); }
 
-        IFACEMETHODIMP get_Title(_Out_ HSTRING* title);
-        IFACEMETHODIMP put_Title(_In_ HSTRING title);
+        IFACEMETHODIMP get_Title(_Out_ HSTRING* title) { return AdaptiveActionElementBase::get_Title(title); }
+        IFACEMETHODIMP put_Title(_In_ HSTRING title) { return AdaptiveActionElementBase::put_Title(title); }
 
-        IFACEMETHODIMP get_Id(_Out_ HSTRING* id);
-        IFACEMETHODIMP put_Id(_In_ HSTRING id);
+        IFACEMETHODIMP get_Id(_Out_ HSTRING* id) { return AdaptiveActionElementBase::get_Id(id); }
+        IFACEMETHODIMP put_Id(_In_ HSTRING id) { return AdaptiveActionElementBase::put_Id(id); }
 
-        IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
-        IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value);
+        IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveActionElementBase::get_AdditionalProperties(result); }
+        IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value) { return AdaptiveActionElementBase::put_AdditionalProperties(value); }
 
-        IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
+        IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveActionElementBase::ToJson(result); }
 
-        HRESULT GetSharedModel(_In_ std::shared_ptr<AdaptiveCards::OpenUrlAction>& sharedModel);
+        virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveCards::BaseActionElement>& sharedModel) override;
 
         // ITypePeek method
         void *PeekAt(REFIID riid) override
@@ -47,7 +49,7 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         }
 
     private:
-        std::shared_ptr<AdaptiveCards::OpenUrlAction> m_sharedOpenUrlAction;
+        Microsoft::WRL::ComPtr<ABI::Windows::Foundation::IUriRuntimeClass> m_url;
     };
 
     ActivatableClass(AdaptiveOpenUrlAction);

--- a/source/uwp/Renderer/lib/AdaptiveShowCardAction.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveShowCardAction.cpp
@@ -15,7 +15,7 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     } CATCH_RETURN;
 
     _Use_decl_annotations_
-    HRESULT AdaptiveShowCardAction::RuntimeClassInitialize(const std::shared_ptr<AdaptiveCards::ShowCardAction>& sharedShowCardAction)
+    HRESULT AdaptiveShowCardAction::RuntimeClassInitialize(const std::shared_ptr<AdaptiveCards::ShowCardAction>& sharedShowCardAction) try
     {
         if (sharedShowCardAction == nullptr)
         {
@@ -23,12 +23,10 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         }
 
         RETURN_IF_FAILED(MakeAndInitialize<AdaptiveCard>(&m_card, sharedShowCardAction->GetCard()));
-        RETURN_IF_FAILED(UTF8ToHString(sharedShowCardAction->GetId(), m_id.GetAddressOf()));
-        RETURN_IF_FAILED(UTF8ToHString(sharedShowCardAction->GetTitle(), m_title.GetAddressOf()));
-        RETURN_IF_FAILED(JsonCppToJsonObject(sharedShowCardAction->GetAdditionalProperties(), &m_additionalProperties));
 
+        InitializeBaseElement(std::static_pointer_cast<AdaptiveCards::BaseActionElement>(sharedShowCardAction));
         return S_OK;
-    }
+    } CATCH_RETURN;
 
     IFACEMETHODIMP AdaptiveShowCardAction::get_Card(ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCard** card)
     {
@@ -42,18 +40,6 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveShowCardAction::get_Title(HSTRING* title)
-    {
-        return m_title.CopyTo(title);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveShowCardAction::put_Title(HSTRING title)
-    {
-        return m_title.Set(title);
-    }
-
-    _Use_decl_annotations_
     HRESULT AdaptiveShowCardAction::get_ActionType(ABI::AdaptiveCards::Rendering::Uwp::ActionType* actionType)
     {
         *actionType = ABI::AdaptiveCards::Rendering::Uwp::ActionType::ShowCard;
@@ -61,61 +47,13 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveShowCardAction::get_Id(HSTRING* id)
-    {
-        return m_id.CopyTo(id);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveShowCardAction::put_Id(HSTRING id)
-    {
-        return m_id.Set(id);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveShowCardAction::get_ActionTypeString(HSTRING* type)
-    {
-        ::ActionType typeEnum;
-        RETURN_IF_FAILED(get_ActionType(&typeEnum));
-        return ProjectedActionTypeToHString(typeEnum, type);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveShowCardAction::get_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject** result)
-    {
-        return m_additionalProperties.CopyTo(result);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveShowCardAction::put_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject* jsonObject)
-    {
-        m_additionalProperties = jsonObject;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveShowCardAction::ToJson(ABI::Windows::Data::Json::IJsonObject** result)
-    {
-        std::shared_ptr<AdaptiveCards::ShowCardAction> sharedModel;
-        RETURN_IF_FAILED(GetSharedModel(sharedModel));
-
-        return StringToJsonObject(sharedModel->Serialize(), result);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveShowCardAction::GetSharedModel(std::shared_ptr<AdaptiveCards::ShowCardAction>& sharedModel)
+    HRESULT AdaptiveShowCardAction::GetSharedModel(std::shared_ptr<AdaptiveCards::BaseActionElement>& sharedModel) try
     {
         std::shared_ptr<AdaptiveCards::ShowCardAction> showCardAction = std::make_shared<AdaptiveCards::ShowCardAction>();
-
-        showCardAction->SetId(HStringToUTF8(m_id.Get()));
-        showCardAction->SetTitle(HStringToUTF8(m_title.Get()));
-
-        Json::Value jsonValue;
-        JsonObjectToJsonCpp(m_additionalProperties.Get(), &jsonValue);
-        showCardAction->SetAdditionalProperties(jsonValue);
+        RETURN_IF_FAILED(SetSharedElementProperties(std::static_pointer_cast<AdaptiveCards::BaseActionElement>(showCardAction)));
 
         ComPtr<AdaptiveCards::Rendering::Uwp::AdaptiveCard> card = PeekInnards<AdaptiveCards::Rendering::Uwp::AdaptiveCard>(m_card);
-        
+
         std::shared_ptr<AdaptiveCards::AdaptiveCard> sharedCard;
         RETURN_IF_FAILED(card->GetSharedModel(sharedCard));
 
@@ -123,5 +61,5 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         
         sharedModel = showCardAction;
         return S_OK;
-    }
+    } CATCH_RETURN;
 }}}

--- a/source/uwp/Renderer/lib/AdaptiveShowCardAction.h
+++ b/source/uwp/Renderer/lib/AdaptiveShowCardAction.h
@@ -3,6 +3,7 @@
 #include "AdaptiveCards.Rendering.Uwp.h"
 #include "Enums.h"
 #include "ShowCardAction.h"
+#include "AdaptiveActionElement.h"
 
 namespace AdaptiveCards { namespace Rendering { namespace Uwp
 {
@@ -11,7 +12,8 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveShowCardAction,
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveActionElement,
-            Microsoft::WRL::CloakedIid<ITypePeek>>
+            Microsoft::WRL::CloakedIid<ITypePeek>,
+            Microsoft::WRL::CloakedIid<AdaptiveCards::Rendering::Uwp::AdaptiveActionElementBase>>
     {
         InspectableClass(RuntimeClass_AdaptiveCards_Rendering_Uwp_AdaptiveShowCardAction, BaseTrust)
 
@@ -25,20 +27,20 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
 
         // IAdaptiveActionElement
         IFACEMETHODIMP get_ActionType(_Out_ ABI::AdaptiveCards::Rendering::Uwp::ActionType* actionType);
-        IFACEMETHODIMP get_ActionTypeString(_Out_ HSTRING* value);
+        IFACEMETHODIMP get_ActionTypeString(_Out_ HSTRING* value) {return AdaptiveActionElementBase::get_ActionTypeString(value);}
 
-        IFACEMETHODIMP get_Title(_Out_ HSTRING* title);
-        IFACEMETHODIMP put_Title(_In_ HSTRING title);
+        IFACEMETHODIMP get_Title(_Out_ HSTRING* title) { return AdaptiveActionElementBase::get_Title(title); }
+        IFACEMETHODIMP put_Title(_In_ HSTRING title) { return AdaptiveActionElementBase::put_Title(title); }
 
-        IFACEMETHODIMP get_Id(_Out_ HSTRING* id);
-        IFACEMETHODIMP put_Id(_In_ HSTRING id);
+        IFACEMETHODIMP get_Id(_Out_ HSTRING* id) { return AdaptiveActionElementBase::get_Id(id); }
+        IFACEMETHODIMP put_Id(_In_ HSTRING id) { return AdaptiveActionElementBase::put_Id(id); }
 
-        IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
-        IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value);
+        IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveActionElementBase::get_AdditionalProperties(result); }
+        IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value) { return AdaptiveActionElementBase::put_AdditionalProperties(value); }
 
-        IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
+        IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveActionElementBase::ToJson(result); }
 
-        HRESULT GetSharedModel(_In_ std::shared_ptr<AdaptiveCards::ShowCardAction>& sharedModel);
+        virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveCards::BaseActionElement>& sharedModel) override;
 
         // ITypePeek method
         void *PeekAt(REFIID riid) override
@@ -49,11 +51,6 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     private:
         
         Microsoft::WRL::ComPtr<ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCard> m_card;
-
-        Microsoft::WRL::Wrappers::HString m_id;
-        Microsoft::WRL::Wrappers::HString m_title;
-        Microsoft::WRL::ComPtr<ABI::Windows::Data::Json::IJsonObject> m_additionalProperties;
-
     };
 
     ActivatableClass(AdaptiveShowCardAction);

--- a/source/uwp/Renderer/lib/AdaptiveSubmitAction.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveSubmitAction.cpp
@@ -10,36 +10,22 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
 {
     HRESULT AdaptiveSubmitAction::RuntimeClassInitialize() noexcept try
     {
-        m_sharedSubmitAction = std::make_shared<SubmitAction>();
-        return S_OK;
+        std::shared_ptr<AdaptiveCards::SubmitAction> submitAction = std::make_shared<AdaptiveCards::SubmitAction>();
+        return RuntimeClassInitialize(submitAction);
     } CATCH_RETURN;
 
     _Use_decl_annotations_
-    HRESULT AdaptiveSubmitAction::RuntimeClassInitialize(const std::shared_ptr<AdaptiveCards::SubmitAction>& sharedSubmitAction)
+    HRESULT AdaptiveSubmitAction::RuntimeClassInitialize(const std::shared_ptr<AdaptiveCards::SubmitAction>& sharedSubmitAction) try
     {
         if (sharedSubmitAction == nullptr)
         {
             return E_INVALIDARG;
         }
 
-        m_sharedSubmitAction = sharedSubmitAction;
+        RETURN_IF_FAILED(StringToJsonValue(sharedSubmitAction->GetDataJson(), &m_dataJson));
+        InitializeBaseElement(std::static_pointer_cast<AdaptiveCards::BaseActionElement>(sharedSubmitAction));
         return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveSubmitAction::get_Title(HSTRING* title)
-    {
-        return UTF8ToHString(m_sharedSubmitAction->GetTitle(), title);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveSubmitAction::put_Title(HSTRING title)
-    {
-        std::string out;
-        RETURN_IF_FAILED(HStringToUTF8(title, out));
-        m_sharedSubmitAction->SetTitle(out);
-        return S_OK;
-    }
+    } CATCH_RETURN;
 
     _Use_decl_annotations_
     HRESULT AdaptiveSubmitAction::get_ActionType(ABI::AdaptiveCards::Rendering::Uwp::ActionType* actionType)
@@ -51,66 +37,27 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     _Use_decl_annotations_
     HRESULT AdaptiveSubmitAction::get_DataJson(IJsonValue** data)
     {
-        return StringToJsonValue(m_sharedSubmitAction->GetDataJson(), data);
+        return m_dataJson.CopyTo(data);
     }
 
     _Use_decl_annotations_
     HRESULT AdaptiveSubmitAction::put_DataJson(IJsonValue* data)
     {
+        m_dataJson = data;
+        return S_OK;
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveSubmitAction::GetSharedModel(std::shared_ptr<AdaptiveCards::BaseActionElement>& sharedModel) try
+    {
+        std::shared_ptr<AdaptiveCards::SubmitAction> submitAction = std::make_shared<AdaptiveCards::SubmitAction>();
+        RETURN_IF_FAILED(SetSharedElementProperties(std::static_pointer_cast<AdaptiveCards::BaseActionElement>(submitAction)));
+
         std::string jsonAsString;
-        RETURN_IF_FAILED(JsonValueToString(data, jsonAsString));
-        m_sharedSubmitAction->SetDataJson(jsonAsString);
+        RETURN_IF_FAILED(JsonValueToString(m_dataJson.Get(), jsonAsString));
+        submitAction->SetDataJson(jsonAsString);
+
+        sharedModel = submitAction;
         return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveSubmitAction::get_Id(HSTRING* id)
-    {
-        return UTF8ToHString(m_sharedSubmitAction->GetId(), id);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveSubmitAction::put_Id(HSTRING id)
-    {
-        std::string out;
-        RETURN_IF_FAILED(HStringToUTF8(id, out));
-        m_sharedSubmitAction->SetId(out);
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveSubmitAction::get_ActionTypeString(HSTRING* type)
-    {
-        ::ActionType typeEnum;
-        RETURN_IF_FAILED(get_ActionType(&typeEnum));
-        return ProjectedActionTypeToHString(typeEnum, type);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveSubmitAction::get_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject** result)
-    {
-        return JsonCppToJsonObject(m_sharedSubmitAction->GetAdditionalProperties(), result);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveSubmitAction::put_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject* jsonObject)
-    {
-        Json::Value jsonCpp;
-        RETURN_IF_FAILED(JsonObjectToJsonCpp(jsonObject, &jsonCpp));
-        m_sharedSubmitAction->SetAdditionalProperties(jsonCpp);
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveSubmitAction::ToJson(ABI::Windows::Data::Json::IJsonObject** result)
-    {
-        return StringToJsonObject(m_sharedSubmitAction->Serialize(), result);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveSubmitAction::GetSharedModel(std::shared_ptr<AdaptiveCards::SubmitAction>& sharedModel)
-    {
-        sharedModel = m_sharedSubmitAction;
-        return S_OK;
-    }
+    }CATCH_RETURN;
 }}}

--- a/source/uwp/Renderer/lib/AdaptiveSubmitAction.h
+++ b/source/uwp/Renderer/lib/AdaptiveSubmitAction.h
@@ -3,6 +3,7 @@
 #include "AdaptiveCards.Rendering.Uwp.h"
 #include "Enums.h"
 #include "SubmitAction.h"
+#include "AdaptiveActionElement.h"
 
 namespace AdaptiveCards { namespace Rendering { namespace Uwp
 {
@@ -11,7 +12,8 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveSubmitAction,
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveActionElement,
-            Microsoft::WRL::CloakedIid<ITypePeek>>
+            Microsoft::WRL::CloakedIid<ITypePeek>,
+            Microsoft::WRL::CloakedIid<AdaptiveCards::Rendering::Uwp::AdaptiveActionElementBase>>
     {
         InspectableClass(RuntimeClass_AdaptiveCards_Rendering_Uwp_AdaptiveSubmitAction, BaseTrust)
 
@@ -19,25 +21,26 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         HRESULT RuntimeClassInitialize() noexcept;
         HRESULT RuntimeClassInitialize(_In_ const std::shared_ptr<AdaptiveCards::SubmitAction>& sharedSubmitAction);
 
-        // IAdaptiveActionElement
-        IFACEMETHODIMP get_ActionType(_Out_ ABI::AdaptiveCards::Rendering::Uwp::ActionType* actionType);
-        IFACEMETHODIMP get_ActionTypeString(_Out_ HSTRING* value);
-
-        IFACEMETHODIMP get_Title(_Out_ HSTRING* title);
-        IFACEMETHODIMP put_Title(_In_ HSTRING title);
-
-        IFACEMETHODIMP get_Id(_Out_ HSTRING* id);
-        IFACEMETHODIMP put_Id(_In_ HSTRING id);
-
+        // IAdaptiveSubmitAction
         IFACEMETHODIMP get_DataJson(_Out_ ABI::Windows::Data::Json::IJsonValue** data);
         IFACEMETHODIMP put_DataJson(_In_ ABI::Windows::Data::Json::IJsonValue* data);
 
-        IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
-        IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value);
+        // IAdaptiveActionElement
+        IFACEMETHODIMP get_ActionType(_Out_ ABI::AdaptiveCards::Rendering::Uwp::ActionType* actionType);
+        IFACEMETHODIMP get_ActionTypeString(_Out_ HSTRING* value) { return AdaptiveActionElementBase::get_ActionTypeString(value); }
 
-        IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
+        IFACEMETHODIMP get_Title(_Out_ HSTRING* title) { return AdaptiveActionElementBase::get_Title(title); }
+        IFACEMETHODIMP put_Title(_In_ HSTRING title) { return AdaptiveActionElementBase::put_Title(title); }
 
-        HRESULT GetSharedModel(_In_ std::shared_ptr<AdaptiveCards::SubmitAction>& sharedModel);
+        IFACEMETHODIMP get_Id(_Out_ HSTRING* id) { return AdaptiveActionElementBase::get_Id(id); }
+        IFACEMETHODIMP put_Id(_In_ HSTRING id) { return AdaptiveActionElementBase::put_Id(id); }
+
+        IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveActionElementBase::get_AdditionalProperties(result); }
+        IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value) { return AdaptiveActionElementBase::put_AdditionalProperties(value); }
+
+        IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveActionElementBase::ToJson(result); }
+
+        virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveCards::BaseActionElement>& sharedModel) override;
 
         // ITypePeek method
         void *PeekAt(REFIID riid) override
@@ -46,7 +49,7 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         }
 
     private:
-        std::shared_ptr<AdaptiveCards::SubmitAction> m_sharedSubmitAction;
+        Microsoft::WRL::ComPtr<ABI::Windows::Data::Json::IJsonValue> m_dataJson;
     };
 
     ActivatableClass(AdaptiveSubmitAction);

--- a/source/uwp/Renderer/lib/AdaptiveTextBlock.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTextBlock.cpp
@@ -39,10 +39,7 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         RETURN_IF_FAILED(UTF8ToHString(sharedTextBlock->GetText(), m_text.GetAddressOf()));
         RETURN_IF_FAILED(UTF8ToHString(sharedTextBlock->GetLanguage(), m_language.GetAddressOf()));
 
-        m_spacing = static_cast<ABI::AdaptiveCards::Rendering::Uwp::Spacing>(sharedTextBlock->GetSpacing());
-        m_separator = sharedTextBlock->GetSeparator();
-        RETURN_IF_FAILED(UTF8ToHString(sharedTextBlock->GetId(), m_id.GetAddressOf()));
-        RETURN_IF_FAILED(JsonCppToJsonObject(sharedTextBlock->GetAdditionalProperties(), &m_additionalProperties));
+        InitializeBaseElement(std::static_pointer_cast<BaseCardElement>(sharedTextBlock));
         return S_OK;
     } CATCH_RETURN;
 
@@ -176,81 +173,11 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveTextBlock::get_Spacing(ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing)
-    {
-        *spacing = m_spacing;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTextBlock::put_Spacing(ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing)
-    {
-        m_spacing = spacing;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTextBlock::get_Separator(boolean* separator)
-    {
-        *separator = m_separator;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTextBlock::put_Separator(boolean separator)
-    {
-        m_separator = separator;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTextBlock::get_Id(HSTRING* id)
-    {
-        return m_id.CopyTo(id);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTextBlock::put_Id(HSTRING id)
-    {
-        return m_id.Set(id);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTextBlock::get_ElementTypeString(HSTRING* type)
-    {
-        ElementType typeEnum;
-        RETURN_IF_FAILED(get_ElementType(&typeEnum));
-        return ProjectedElementTypeToHString(typeEnum, type);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTextBlock::get_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject** result)
-    {
-        return m_additionalProperties.CopyTo(result);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTextBlock::put_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject* jsonObject)
-    {
-        m_additionalProperties = jsonObject;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTextBlock::ToJson(ABI::Windows::Data::Json::IJsonObject** result)
-    {
-        std::shared_ptr<AdaptiveCards::TextBlock> textBlock = std::make_shared<AdaptiveCards::TextBlock>();
-        GetSharedModel(textBlock);
-
-        return StringToJsonObject(textBlock->Serialize(), result);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTextBlock::GetSharedModel(std::shared_ptr<AdaptiveCards::TextBlock>& sharedTextBlock) try
+    HRESULT AdaptiveTextBlock::GetSharedModel(std::shared_ptr<AdaptiveCards::BaseCardElement>& sharedTextBlock) try
     {
         std::shared_ptr<AdaptiveCards::TextBlock> textBlock = std::make_shared<AdaptiveCards::TextBlock>();
 
-        RETURN_IF_FAILED(SetSharedElementProperties(this, std::dynamic_pointer_cast<AdaptiveCards::BaseCardElement>(textBlock)));
+        RETURN_IF_FAILED(SetSharedElementProperties(std::static_pointer_cast<AdaptiveCards::BaseCardElement>(textBlock)));
 
         textBlock->SetWrap(m_wrap);
         textBlock->SetIsSubtle(m_subtle);
@@ -268,6 +195,7 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         RETURN_IF_FAILED(HStringToUTF8(m_language.Get(), language));
         textBlock->SetLanguage(language);
 
+        sharedTextBlock = textBlock;
         return S_OK;
     } CATCH_RETURN;
 }}}

--- a/source/uwp/Renderer/lib/AdaptiveTextBlock.h
+++ b/source/uwp/Renderer/lib/AdaptiveTextBlock.h
@@ -3,6 +3,7 @@
 #include "AdaptiveCards.Rendering.Uwp.h"
 #include "Enums.h"
 #include "TextBlock.h"
+#include "AdaptiveCardElement.h"
 
 namespace AdaptiveCards { namespace Rendering { namespace Uwp
 {
@@ -11,7 +12,8 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveTextBlock,
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement,
-            Microsoft::WRL::CloakedIid<ITypePeek>>
+            Microsoft::WRL::CloakedIid<ITypePeek>,
+            Microsoft::WRL::CloakedIid<AdaptiveCards::Rendering::Uwp::AdaptiveCardElementBase>>
     {
         InspectableClass(RuntimeClass_AdaptiveCards_Rendering_Uwp_AdaptiveTextBlock, BaseTrust)
 
@@ -50,23 +52,23 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         // IAdaptiveCardElement
         IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveCards::Rendering::Uwp::ElementType* elementType);
 
-        IFACEMETHODIMP get_Spacing(_Out_ ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing);
-        IFACEMETHODIMP put_Spacing(_In_ ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing);
+        IFACEMETHODIMP get_Spacing(_Out_ ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing) { return AdaptiveCardElementBase::get_Spacing(spacing); }
+        IFACEMETHODIMP put_Spacing(_In_ ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing) { return AdaptiveCardElementBase::put_Spacing(spacing); }
 
-        IFACEMETHODIMP get_Separator(_Out_ boolean* separator);
-        IFACEMETHODIMP put_Separator(_In_ boolean separator);
+        IFACEMETHODIMP get_Separator(_Out_ boolean* separator) { return AdaptiveCardElementBase::get_Separator(separator); }
+        IFACEMETHODIMP put_Separator(_In_ boolean separator) { return AdaptiveCardElementBase::put_Separator(separator); }
 
-        IFACEMETHODIMP get_Id(_Out_ HSTRING* id);
-        IFACEMETHODIMP put_Id(_In_ HSTRING id);
+        IFACEMETHODIMP get_Id(_Out_ HSTRING* id) { return AdaptiveCardElementBase::get_Id(id); }
+        IFACEMETHODIMP put_Id(_In_ HSTRING id) { return AdaptiveCardElementBase::put_Id(id); }
 
-        IFACEMETHODIMP get_ElementTypeString(_Out_ HSTRING* value);
+        IFACEMETHODIMP get_ElementTypeString(_Out_ HSTRING* value) { return AdaptiveCardElementBase::get_ElementTypeString(value); }
 
-        IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
-        IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value);
+        IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveCardElementBase::get_AdditionalProperties(result); }
+        IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value) { return AdaptiveCardElementBase::put_AdditionalProperties(value); }
 
-        IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
+        IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveCardElementBase::ToJson(result); }
 
-        HRESULT GetSharedModel(_In_ std::shared_ptr<AdaptiveCards::TextBlock>& sharedModel);
+        virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveCards::BaseCardElement>& sharedModel) override;
 
         // ITypePeek method
         void *PeekAt(REFIID riid) override
@@ -84,12 +86,6 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         ABI::AdaptiveCards::Rendering::Uwp::TextWeight m_textWeight;
         ABI::AdaptiveCards::Rendering::Uwp::ForegroundColor m_foregroundColor;
         ABI::AdaptiveCards::Rendering::Uwp::HAlignment m_horizontalAlignment;
-
-        boolean m_isRequired;
-        boolean m_separator;
-        Microsoft::WRL::Wrappers::HString m_id;
-        ABI::AdaptiveCards::Rendering::Uwp::Spacing m_spacing;
-        Microsoft::WRL::ComPtr<ABI::Windows::Data::Json::IJsonObject> m_additionalProperties;
     };
 
     ActivatableClass(AdaptiveTextBlock);

--- a/source/uwp/Renderer/lib/AdaptiveTextInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTextInput.cpp
@@ -20,7 +20,7 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     } CATCH_RETURN;
 
     _Use_decl_annotations_
-    HRESULT AdaptiveTextInput::RuntimeClassInitialize(const std::shared_ptr<AdaptiveCards::TextInput>& sharedTextInput)
+    HRESULT AdaptiveTextInput::RuntimeClassInitialize(const std::shared_ptr<AdaptiveCards::TextInput>& sharedTextInput) try
     {
         if (sharedTextInput == nullptr)
         {
@@ -33,14 +33,10 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         m_isMultiline = sharedTextInput->GetIsMultiline();
         m_textInputStyle = static_cast<ABI::AdaptiveCards::Rendering::Uwp::TextInputStyle>(sharedTextInput->GetTextInputStyle());
 
-        m_isRequired = sharedTextInput->GetIsRequired();
-        m_spacing = static_cast<ABI::AdaptiveCards::Rendering::Uwp::Spacing>(sharedTextInput->GetSpacing());
-        m_separator = sharedTextInput->GetSeparator();
-        RETURN_IF_FAILED(UTF8ToHString(sharedTextInput->GetId(), m_id.GetAddressOf()));
-        RETURN_IF_FAILED(JsonCppToJsonObject(sharedTextInput->GetAdditionalProperties(), &m_additionalProperties));
+        InitializeBaseElement(std::static_pointer_cast<BaseInputElement>(sharedTextInput));
 
         return S_OK;
-    }
+    } CATCH_RETURN;
 
     _Use_decl_annotations_
     HRESULT AdaptiveTextInput::get_Placeholder(HSTRING* placeholder)
@@ -107,18 +103,6 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveTextInput::get_Id(HSTRING* id)
-    {
-        return m_id.CopyTo(id);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTextInput::put_Id(HSTRING id)
-    {
-        return m_id.Set(id);
-    }
-
-    _Use_decl_annotations_
     HRESULT AdaptiveTextInput::get_ElementType(ElementType* elementType)
     {
         *elementType = ElementType::TextInput;
@@ -126,84 +110,11 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveTextInput::get_Spacing(ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing)
-    {
-        *spacing = m_spacing;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTextInput::put_Spacing(ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing)
-    {
-        m_spacing = spacing;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTextInput::get_Separator(boolean* separator)
-    {
-        *separator = m_separator;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTextInput::put_Separator(boolean separator)
-    {
-        m_separator = separator;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTextInput::get_IsRequired(boolean* isRequired)
-    {
-        *isRequired = m_isRequired;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTextInput::put_IsRequired(boolean isRequired)
-    {
-        m_isRequired = isRequired;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTextInput::get_ElementTypeString(HSTRING* type)
-    {
-        ElementType typeEnum;
-        RETURN_IF_FAILED(get_ElementType(&typeEnum));
-        return ProjectedElementTypeToHString(typeEnum, type);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTextInput::get_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject** result)
-    {
-        return m_additionalProperties.CopyTo(result);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTextInput::put_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject* jsonObject)
-    {
-        m_additionalProperties = jsonObject;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTextInput::ToJson(ABI::Windows::Data::Json::IJsonObject** result)
-    {
-        std::shared_ptr<AdaptiveCards::TextInput> sharedTextInput = std::make_shared<AdaptiveCards::TextInput>();
-        GetSharedModel(sharedTextInput);
-
-        return StringToJsonObject(sharedTextInput->Serialize(), result);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTextInput::GetSharedModel(std::shared_ptr<AdaptiveCards::TextInput>& sharedModel) try
+    HRESULT AdaptiveTextInput::GetSharedModel(std::shared_ptr<AdaptiveCards::BaseCardElement>& sharedModel) try
     {
         std::shared_ptr<AdaptiveCards::TextInput> textInput = std::make_shared<AdaptiveCards::TextInput>();
 
-        RETURN_IF_FAILED(SetSharedElementProperties(this, std::dynamic_pointer_cast<AdaptiveCards::BaseCardElement>(textInput)));
-        textInput->SetIsRequired(m_isRequired);
+        RETURN_IF_FAILED(SetSharedElementProperties(std::static_pointer_cast<AdaptiveCards::BaseInputElement>(textInput)));
         
         textInput->SetMaxLength(m_maxLength);
         textInput->SetIsMultiline(m_isMultiline);
@@ -216,6 +127,8 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         std::string value;
         RETURN_IF_FAILED(HStringToUTF8(m_value.Get(), value));
         textInput->SetValue(value);
+
+        sharedModel = textInput;
 
         return S_OK;
     }CATCH_RETURN;

--- a/source/uwp/Renderer/lib/AdaptiveTextInput.h
+++ b/source/uwp/Renderer/lib/AdaptiveTextInput.h
@@ -3,6 +3,7 @@
 #include "AdaptiveCards.Rendering.Uwp.h"
 #include "Enums.h"
 #include "TextInput.h"
+#include "AdaptiveInputElement.h"
 
 namespace AdaptiveCards { namespace Rendering { namespace Uwp
 {
@@ -12,7 +13,8 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveTextInput,
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveInputElement,
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement,
-            Microsoft::WRL::CloakedIid<ITypePeek>>
+            Microsoft::WRL::CloakedIid<ITypePeek>,
+            Microsoft::WRL::CloakedIid<AdaptiveCards::Rendering::Uwp::AdaptiveInputElementBase>>
     {
         InspectableClass(RuntimeClass_AdaptiveCards_Rendering_Uwp_AdaptiveTextInput, BaseTrust)
 
@@ -37,29 +39,29 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         IFACEMETHODIMP put_TextInputStyle(_In_ ABI::AdaptiveCards::Rendering::Uwp::TextInputStyle textInputStyle);
 
         // IAdaptiveInputElement
-        IFACEMETHODIMP get_IsRequired(_Out_ boolean* isRequired);
-        IFACEMETHODIMP put_IsRequired(_In_ boolean isRequired);
+        IFACEMETHODIMP get_IsRequired(_Out_ boolean* isRequired) { return AdaptiveInputElementBase::get_IsRequired(isRequired); }
+        IFACEMETHODIMP put_IsRequired(_In_ boolean isRequired) { return AdaptiveInputElementBase::put_IsRequired(isRequired); }
 
         // IAdaptiveCardElement
         IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveCards::Rendering::Uwp::ElementType* elementType);
 
-        IFACEMETHODIMP get_Id(_Out_ HSTRING* id);
-        IFACEMETHODIMP put_Id(_In_ HSTRING id);
+        IFACEMETHODIMP get_Spacing(_Out_ ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing) { return AdaptiveCardElementBase::get_Spacing(spacing); }
+        IFACEMETHODIMP put_Spacing(_In_ ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing) { return AdaptiveCardElementBase::put_Spacing(spacing); }
 
-        IFACEMETHODIMP get_Spacing(_Out_ ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing);
-        IFACEMETHODIMP put_Spacing(_In_ ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing);
+        IFACEMETHODIMP get_Separator(_Out_ boolean* separator) { return AdaptiveCardElementBase::get_Separator(separator); }
+        IFACEMETHODIMP put_Separator(_In_ boolean separator) { return AdaptiveCardElementBase::put_Separator(separator); }
 
-        IFACEMETHODIMP get_Separator(_Out_ boolean* separator);
-        IFACEMETHODIMP put_Separator(_In_ boolean separator);
+        IFACEMETHODIMP get_Id(_Out_ HSTRING* id) { return AdaptiveCardElementBase::get_Id(id); }
+        IFACEMETHODIMP put_Id(_In_ HSTRING id) { return AdaptiveCardElementBase::put_Id(id); }
 
-        IFACEMETHODIMP get_ElementTypeString(_Out_ HSTRING* value);
+        IFACEMETHODIMP get_ElementTypeString(_Out_ HSTRING* value) { return AdaptiveCardElementBase::get_ElementTypeString(value); }
 
-        IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
-        IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value);
+        IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveCardElementBase::get_AdditionalProperties(result); }
+        IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value) { return AdaptiveCardElementBase::put_AdditionalProperties(value); }
 
-        IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
+        IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveCardElementBase::ToJson(result); }
 
-        HRESULT GetSharedModel(_In_ std::shared_ptr<AdaptiveCards::TextInput>& sharedModel);
+        virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveCards::BaseCardElement>& sharedModel) override;
 
         // ITypePeek method
         void *PeekAt(REFIID riid) override
@@ -73,12 +75,6 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         UINT32 m_maxLength;
         boolean m_isMultiline;
         ABI::AdaptiveCards::Rendering::Uwp::TextInputStyle m_textInputStyle;
-
-        boolean m_isRequired;
-        boolean m_separator;
-        Microsoft::WRL::Wrappers::HString m_id;
-        ABI::AdaptiveCards::Rendering::Uwp::Spacing m_spacing;
-        Microsoft::WRL::ComPtr<ABI::Windows::Data::Json::IJsonObject> m_additionalProperties;
     };
 
     ActivatableClass(AdaptiveTextInput);

--- a/source/uwp/Renderer/lib/AdaptiveTimeInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTimeInput.cpp
@@ -32,12 +32,7 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         RETURN_IF_FAILED(UTF8ToHString(sharedTimeInput->GetPlaceholder(), m_placeholder.GetAddressOf()));
         RETURN_IF_FAILED(UTF8ToHString(sharedTimeInput->GetValue(), m_value.GetAddressOf()));
 
-        m_isRequired = sharedTimeInput->GetIsRequired();
-        m_spacing = static_cast<ABI::AdaptiveCards::Rendering::Uwp::Spacing>(sharedTimeInput->GetSpacing());
-        m_separator = sharedTimeInput->GetSeparator();
-        RETURN_IF_FAILED(UTF8ToHString(sharedTimeInput->GetId(), m_id.GetAddressOf()));
-        RETURN_IF_FAILED(JsonCppToJsonObject(sharedTimeInput->GetAdditionalProperties(), &m_additionalProperties));
-        RETURN_IF_FAILED(JsonCppToJsonObject(sharedTimeInput->GetAdditionalProperties(), &m_additionalProperties));
+        InitializeBaseElement(std::static_pointer_cast<BaseInputElement>(sharedTimeInput));
 
         return S_OK;
     }CATCH_RETURN;
@@ -91,18 +86,6 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveTimeInput::get_Id(HSTRING* id)
-    {
-        return m_id.CopyTo(id);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTimeInput::put_Id(HSTRING id)
-    {
-        return m_id.Set(id);
-    }
-
-    _Use_decl_annotations_
     HRESULT AdaptiveTimeInput::get_ElementType(ElementType* elementType)
     {
         *elementType = ElementType::TimeInput;
@@ -110,84 +93,11 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveTimeInput::get_Spacing(ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing)
-    {
-        *spacing = m_spacing;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTimeInput::put_Spacing(ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing)
-    {
-        m_spacing = spacing;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTimeInput::get_Separator(boolean* separator)
-    {
-        *separator = m_separator;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTimeInput::put_Separator(boolean separator)
-    {
-        m_separator = separator;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTimeInput::get_IsRequired(boolean* isRequired)
-    {
-        *isRequired = m_isRequired;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTimeInput::put_IsRequired(boolean isRequired)
-    {
-        m_isRequired = isRequired;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTimeInput::get_ElementTypeString(HSTRING* type)
-    {
-        ElementType typeEnum;
-        RETURN_IF_FAILED(get_ElementType(&typeEnum));
-        return ProjectedElementTypeToHString(typeEnum, type);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTimeInput::get_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject** result)
-    {
-        return m_additionalProperties.CopyTo(result);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTimeInput::put_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject* jsonObject)
-    {
-        m_additionalProperties = jsonObject;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTimeInput::ToJson(ABI::Windows::Data::Json::IJsonObject** result)
-    {
-        std::shared_ptr<AdaptiveCards::TimeInput> sharedTimeInput = std::make_shared<AdaptiveCards::TimeInput>();
-        GetSharedModel(sharedTimeInput);
-
-        return StringToJsonObject(sharedTimeInput->Serialize(), result);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTimeInput::GetSharedModel(std::shared_ptr<AdaptiveCards::TimeInput>& sharedModel) try
+    HRESULT AdaptiveTimeInput::GetSharedModel(std::shared_ptr<AdaptiveCards::BaseCardElement>& sharedModel) try
     {
         std::shared_ptr<AdaptiveCards::TimeInput> timeInput = std::make_shared<AdaptiveCards::TimeInput>();
 
-        RETURN_IF_FAILED(SetSharedElementProperties(this, std::dynamic_pointer_cast<AdaptiveCards::BaseCardElement>(timeInput)));
-        timeInput->SetIsRequired(m_isRequired);
+        RETURN_IF_FAILED(SetSharedElementProperties(std::static_pointer_cast<AdaptiveCards::BaseInputElement>(timeInput)));
 
         std::string max;
         RETURN_IF_FAILED(HStringToUTF8(m_max.Get(), max));
@@ -204,6 +114,8 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         std::string value;
         RETURN_IF_FAILED(HStringToUTF8(m_value.Get(), value));
         timeInput->SetValue(value);
+
+        sharedModel = timeInput;
 
         return S_OK;
     }CATCH_RETURN;

--- a/source/uwp/Renderer/lib/AdaptiveTimeInput.h
+++ b/source/uwp/Renderer/lib/AdaptiveTimeInput.h
@@ -3,6 +3,7 @@
 #include "AdaptiveCards.Rendering.Uwp.h"
 #include "Enums.h"
 #include "TimeInput.h"
+#include "AdaptiveInputElement.h"
 
 namespace AdaptiveCards { namespace Rendering { namespace Uwp
 {
@@ -12,7 +13,8 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveTimeInput,
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveInputElement,
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement,
-            Microsoft::WRL::CloakedIid<ITypePeek>>
+            Microsoft::WRL::CloakedIid<ITypePeek>,
+            Microsoft::WRL::CloakedIid<AdaptiveCards::Rendering::Uwp::AdaptiveInputElementBase>>
     {
         InspectableClass(RuntimeClass_AdaptiveCards_Rendering_Uwp_AdaptiveTimeInput, BaseTrust)
 
@@ -34,29 +36,29 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         IFACEMETHODIMP put_Value(_In_ HSTRING value);
 
         // IAdaptiveInputElement
-        IFACEMETHODIMP get_IsRequired(_Out_ boolean* isRequired);
-        IFACEMETHODIMP put_IsRequired(_In_ boolean isRequired);
+        IFACEMETHODIMP get_IsRequired(_Out_ boolean* isRequired) { return AdaptiveInputElementBase::get_IsRequired(isRequired); }
+        IFACEMETHODIMP put_IsRequired(_In_ boolean isRequired) { return AdaptiveInputElementBase::put_IsRequired(isRequired); }
 
         // IAdaptiveCardElement
         IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveCards::Rendering::Uwp::ElementType* elementType);
 
-        IFACEMETHODIMP get_Id(_Out_ HSTRING* id);
-        IFACEMETHODIMP put_Id(_In_ HSTRING id);
+        IFACEMETHODIMP get_Spacing(_Out_ ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing) { return AdaptiveCardElementBase::get_Spacing(spacing); }
+        IFACEMETHODIMP put_Spacing(_In_ ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing) { return AdaptiveCardElementBase::put_Spacing(spacing); }
 
-        IFACEMETHODIMP get_Spacing(_Out_ ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing);
-        IFACEMETHODIMP put_Spacing(_In_ ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing);
+        IFACEMETHODIMP get_Separator(_Out_ boolean* separator) { return AdaptiveCardElementBase::get_Separator(separator); }
+        IFACEMETHODIMP put_Separator(_In_ boolean separator) { return AdaptiveCardElementBase::put_Separator(separator); }
 
-        IFACEMETHODIMP get_Separator(_Out_ boolean* separator);
-        IFACEMETHODIMP put_Separator(_In_ boolean separator);
+        IFACEMETHODIMP get_Id(_Out_ HSTRING* id) { return AdaptiveCardElementBase::get_Id(id); }
+        IFACEMETHODIMP put_Id(_In_ HSTRING id) { return AdaptiveCardElementBase::put_Id(id); }
 
-        IFACEMETHODIMP get_ElementTypeString(_Out_ HSTRING* value);
+        IFACEMETHODIMP get_ElementTypeString(_Out_ HSTRING* value) { return AdaptiveCardElementBase::get_ElementTypeString(value); }
 
-        IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
-        IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value);
+        IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveCardElementBase::get_AdditionalProperties(result); }
+        IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value) { return AdaptiveCardElementBase::put_AdditionalProperties(value); }
 
-        IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
+        IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveCardElementBase::ToJson(result); }
 
-        HRESULT GetSharedModel(_In_ std::shared_ptr<AdaptiveCards::TimeInput>& sharedModel);
+        virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveCards::BaseCardElement>& sharedModel) override;
 
         // ITypePeek method
         void *PeekAt(REFIID riid) override
@@ -69,12 +71,6 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         Microsoft::WRL::Wrappers::HString m_min;
         Microsoft::WRL::Wrappers::HString m_placeholder;
         Microsoft::WRL::Wrappers::HString m_value;
-
-        boolean m_isRequired;
-        boolean m_separator;
-        Microsoft::WRL::Wrappers::HString m_id;
-        ABI::AdaptiveCards::Rendering::Uwp::Spacing m_spacing;
-        Microsoft::WRL::ComPtr<ABI::Windows::Data::Json::IJsonObject> m_additionalProperties;
     };
 
     ActivatableClass(AdaptiveTimeInput);

--- a/source/uwp/Renderer/lib/AdaptiveToggleInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveToggleInput.cpp
@@ -32,11 +32,7 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         RETURN_IF_FAILED(UTF8ToHString(sharedToggleInput->GetValueOn(), m_valueOn.GetAddressOf()));
         RETURN_IF_FAILED(UTF8ToHString(sharedToggleInput->GetValueOff(), m_valueOff.GetAddressOf()));
 
-        m_isRequired = sharedToggleInput->GetIsRequired();
-        m_spacing = static_cast<ABI::AdaptiveCards::Rendering::Uwp::Spacing>(sharedToggleInput->GetSpacing());
-        m_separator = sharedToggleInput->GetSeparator();
-        RETURN_IF_FAILED(UTF8ToHString(sharedToggleInput->GetId(), m_id.GetAddressOf()));
-        RETURN_IF_FAILED(JsonCppToJsonObject(sharedToggleInput->GetAdditionalProperties(), &m_additionalProperties));
+        InitializeBaseElement(std::static_pointer_cast<BaseInputElement>(sharedToggleInput));
         return S_OK;
     }CATCH_RETURN;
 
@@ -89,18 +85,6 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveToggleInput::get_Id(HSTRING* id)
-    {
-        return m_id.CopyTo(id);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveToggleInput::put_Id(HSTRING id)
-    {
-        return m_id.Set(id);
-    }
-
-    _Use_decl_annotations_
     HRESULT AdaptiveToggleInput::get_ElementType(ElementType* elementType)
     {
         *elementType = ElementType::ToggleInput;
@@ -108,84 +92,11 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveToggleInput::get_Spacing(ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing)
-    {
-        *spacing = m_spacing;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveToggleInput::put_Spacing(ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing)
-    {
-        m_spacing = spacing;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveToggleInput::get_Separator(boolean* separator)
-    {
-        *separator = m_separator;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveToggleInput::put_Separator(boolean separator)
-    {
-        m_separator = separator;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveToggleInput::get_IsRequired(boolean* isRequired)
-    {
-        *isRequired = m_isRequired;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveToggleInput::put_IsRequired(boolean isRequired)
-    {
-        m_isRequired = isRequired;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveToggleInput::get_ElementTypeString(HSTRING* type)
-    {
-        ElementType typeEnum;
-        RETURN_IF_FAILED(get_ElementType(&typeEnum));
-        return ProjectedElementTypeToHString(typeEnum, type);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveToggleInput::get_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject** result)
-    {
-        return m_additionalProperties.CopyTo(result);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveToggleInput::put_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject* jsonObject)
-    {
-        m_additionalProperties = jsonObject;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveToggleInput::ToJson(ABI::Windows::Data::Json::IJsonObject** result)
-    {
-        std::shared_ptr<AdaptiveCards::ToggleInput> sharedToggleInput = std::make_shared<AdaptiveCards::ToggleInput>();
-        GetSharedModel(sharedToggleInput);
-
-        return StringToJsonObject(sharedToggleInput->Serialize(), result);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveToggleInput::GetSharedModel(std::shared_ptr<AdaptiveCards::ToggleInput>& sharedModel) try
+    HRESULT AdaptiveToggleInput::GetSharedModel(std::shared_ptr<AdaptiveCards::BaseCardElement>& sharedModel) try
     {
         std::shared_ptr<AdaptiveCards::ToggleInput> toggleInput = std::make_shared<AdaptiveCards::ToggleInput>();
 
-        RETURN_IF_FAILED(SetSharedElementProperties(this, std::dynamic_pointer_cast<AdaptiveCards::BaseCardElement>(toggleInput)));
-        toggleInput->SetIsRequired(m_isRequired);
+        RETURN_IF_FAILED(SetSharedElementProperties(std::static_pointer_cast<AdaptiveCards::BaseInputElement>(toggleInput)));
 
         std::string title;
         RETURN_IF_FAILED(HStringToUTF8(m_title.Get(), title));
@@ -202,6 +113,8 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         std::string valueOff;
         RETURN_IF_FAILED(HStringToUTF8(m_valueOff.Get(), valueOff));
         toggleInput->SetValueOff(valueOff);
+
+        sharedModel = toggleInput;
 
         return S_OK;
     }CATCH_RETURN;

--- a/source/uwp/Renderer/lib/AdaptiveToggleInput.h
+++ b/source/uwp/Renderer/lib/AdaptiveToggleInput.h
@@ -3,6 +3,7 @@
 #include "AdaptiveCards.Rendering.Uwp.h"
 #include "Enums.h"
 #include "ToggleInput.h"
+#include "AdaptiveInputElement.h"
 
 namespace AdaptiveCards { namespace Rendering { namespace Uwp
 {
@@ -12,7 +13,8 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveToggleInput,
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveInputElement,
             ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement,
-            Microsoft::WRL::CloakedIid<ITypePeek>>
+            Microsoft::WRL::CloakedIid<ITypePeek>,
+            Microsoft::WRL::CloakedIid<AdaptiveCards::Rendering::Uwp::AdaptiveInputElementBase>>
     {
         InspectableClass(RuntimeClass_AdaptiveCards_Rendering_Uwp_AdaptiveToggleInput, BaseTrust)
 
@@ -34,29 +36,29 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         IFACEMETHODIMP put_ValueOn(_In_ HSTRING value);
 
         // IAdaptiveInputElement
-        IFACEMETHODIMP get_IsRequired(_Out_ boolean* isRequired);
-        IFACEMETHODIMP put_IsRequired(_In_ boolean isRequired);
+        IFACEMETHODIMP get_IsRequired(_Out_ boolean* isRequired) { return AdaptiveInputElementBase::get_IsRequired(isRequired); }
+        IFACEMETHODIMP put_IsRequired(_In_ boolean isRequired) { return AdaptiveInputElementBase::put_IsRequired(isRequired); }
 
         // IAdaptiveCardElement
         IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveCards::Rendering::Uwp::ElementType* elementType);
 
-        IFACEMETHODIMP get_Id(_Out_ HSTRING* id);
-        IFACEMETHODIMP put_Id(_In_ HSTRING id);
+        IFACEMETHODIMP get_Spacing(_Out_ ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing) { return AdaptiveCardElementBase::get_Spacing(spacing); }
+        IFACEMETHODIMP put_Spacing(_In_ ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing) { return AdaptiveCardElementBase::put_Spacing(spacing); }
 
-        IFACEMETHODIMP get_Spacing(_Out_ ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing);
-        IFACEMETHODIMP put_Spacing(_In_ ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing);
+        IFACEMETHODIMP get_Separator(_Out_ boolean* separator) { return AdaptiveCardElementBase::get_Separator(separator); }
+        IFACEMETHODIMP put_Separator(_In_ boolean separator) { return AdaptiveCardElementBase::put_Separator(separator); }
 
-        IFACEMETHODIMP get_Separator(_Out_ boolean* separator);
-        IFACEMETHODIMP put_Separator(_In_ boolean separator);
+        IFACEMETHODIMP get_Id(_Out_ HSTRING* id) { return AdaptiveCardElementBase::get_Id(id); }
+        IFACEMETHODIMP put_Id(_In_ HSTRING id) { return AdaptiveCardElementBase::put_Id(id); }
 
-        IFACEMETHODIMP get_ElementTypeString(_Out_ HSTRING* value);
+        IFACEMETHODIMP get_ElementTypeString(_Out_ HSTRING* value) { return AdaptiveCardElementBase::get_ElementTypeString(value); }
 
-        IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
-        IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value);
+        IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveCardElementBase::get_AdditionalProperties(result); }
+        IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value) { return AdaptiveCardElementBase::put_AdditionalProperties(value); }
 
-        IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
+        IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveCardElementBase::ToJson(result); }
 
-        HRESULT GetSharedModel(_In_ std::shared_ptr<AdaptiveCards::ToggleInput>& sharedModel);
+        virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveCards::BaseCardElement>& sharedModel) override;
 
         // ITypePeek method
         void *PeekAt(REFIID riid) override
@@ -69,12 +71,6 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         Microsoft::WRL::Wrappers::HString m_value;
         Microsoft::WRL::Wrappers::HString m_valueOn;
         Microsoft::WRL::Wrappers::HString m_valueOff;
-
-        boolean m_isRequired;
-        boolean m_separator;
-        Microsoft::WRL::Wrappers::HString m_id;
-        ABI::AdaptiveCards::Rendering::Uwp::Spacing m_spacing;
-        Microsoft::WRL::ComPtr<ABI::Windows::Data::Json::IJsonObject> m_additionalProperties;
     };
 
     ActivatableClass(AdaptiveToggleInput);

--- a/source/uwp/Renderer/lib/Util.cpp
+++ b/source/uwp/Renderer/lib/Util.cpp
@@ -85,41 +85,12 @@ bool Boolify(const boolean value)
     return value > 0 ? true : false;
 }
 
-HRESULT SetSharedElementProperties(
-    ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement * adaptiveCardElement,
-    std::shared_ptr<AdaptiveCards::BaseCardElement> sharedCardElement)
-{
-    HString id;
-    RETURN_IF_FAILED(adaptiveCardElement->get_Id(id.GetAddressOf()));
-    sharedCardElement->SetId(HStringToUTF8(id.Get()));
-
-    boolean separator;
-    RETURN_IF_FAILED(adaptiveCardElement->get_Separator(&separator));
-    sharedCardElement->SetSeparator(separator);
-
-    ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing;
-    RETURN_IF_FAILED(adaptiveCardElement->get_Spacing(&spacing));
-    sharedCardElement->SetSpacing(static_cast<AdaptiveCards::Spacing>(spacing));
-
-    ComPtr<IJsonObject> additionalProperties;
-    RETURN_IF_FAILED(adaptiveCardElement->get_AdditionalProperties(&additionalProperties));
-
-    if (additionalProperties != nullptr)
-    {
-        Json::Value jsonCpp;
-        RETURN_IF_FAILED(JsonObjectToJsonCpp(additionalProperties.Get(), &jsonCpp));
-        sharedCardElement->SetAdditionalProperties(jsonCpp);
-    }
-
-    return S_OK;
-}
-
-template <typename TSharedBaseType, typename TSharedType, typename TAdaptiveBaseType, typename TAdaptiveType>
+template <typename TSharedBaseType, typename TAdaptiveBaseType, typename TAdaptiveType>
 std::shared_ptr<TSharedBaseType> GetSharedModel(TAdaptiveBaseType * item)
 {
     ComPtr<TAdaptiveType> adaptiveElement = PeekInnards<TAdaptiveType>(item);
 
-    std::shared_ptr<TSharedType> sharedModelElement;
+    std::shared_ptr<TSharedBaseType> sharedModelElement;
     if (adaptiveElement && SUCCEEDED(adaptiveElement->GetSharedModel(sharedModelElement)))
         return sharedModelElement;
     else
@@ -141,40 +112,40 @@ HRESULT GenerateSharedElements(
         switch (elementType)
         {
             case ABI::AdaptiveCards::Rendering::Uwp::ElementType::ChoiceSetInput:
-                baseCardElement = GetSharedModel<AdaptiveCards::BaseCardElement, AdaptiveCards::ChoiceSetInput, ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement, AdaptiveCards::Rendering::Uwp::AdaptiveChoiceSetInput>(item);
+                baseCardElement = GetSharedModel<AdaptiveCards::BaseCardElement, ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement, AdaptiveCards::Rendering::Uwp::AdaptiveChoiceSetInput>(item);
                 break;
             case ABI::AdaptiveCards::Rendering::Uwp::ElementType::ColumnSet:
-                baseCardElement = GetSharedModel<AdaptiveCards::BaseCardElement, AdaptiveCards::ColumnSet, ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement, AdaptiveCards::Rendering::Uwp::AdaptiveColumnSet>(item);
+                baseCardElement = GetSharedModel<AdaptiveCards::BaseCardElement, ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement, AdaptiveCards::Rendering::Uwp::AdaptiveColumnSet>(item);
                 break;
             case ABI::AdaptiveCards::Rendering::Uwp::ElementType::Container:
-                baseCardElement = GetSharedModel<AdaptiveCards::BaseCardElement, AdaptiveCards::Container, ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement, AdaptiveCards::Rendering::Uwp::AdaptiveContainer>(item);
+                baseCardElement = GetSharedModel<AdaptiveCards::BaseCardElement, ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement, AdaptiveCards::Rendering::Uwp::AdaptiveContainer>(item);
                 break;
             case ABI::AdaptiveCards::Rendering::Uwp::ElementType::DateInput:
-                baseCardElement = GetSharedModel<AdaptiveCards::BaseCardElement, AdaptiveCards::DateInput, ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement, AdaptiveCards::Rendering::Uwp::AdaptiveDateInput>(item);
+                baseCardElement = GetSharedModel<AdaptiveCards::BaseCardElement, ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement, AdaptiveCards::Rendering::Uwp::AdaptiveDateInput>(item);
                 break;
             case ABI::AdaptiveCards::Rendering::Uwp::ElementType::FactSet:
-                baseCardElement = GetSharedModel<AdaptiveCards::BaseCardElement, AdaptiveCards::FactSet, ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement, AdaptiveCards::Rendering::Uwp::AdaptiveFactSet>(item);
+                baseCardElement = GetSharedModel<AdaptiveCards::BaseCardElement, ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement, AdaptiveCards::Rendering::Uwp::AdaptiveFactSet>(item);
                 break;
             case ABI::AdaptiveCards::Rendering::Uwp::ElementType::Image:
-                baseCardElement = GetSharedModel<AdaptiveCards::BaseCardElement, AdaptiveCards::Image, ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement, AdaptiveCards::Rendering::Uwp::AdaptiveImage>(item);
+                baseCardElement = GetSharedModel<AdaptiveCards::BaseCardElement, ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement, AdaptiveCards::Rendering::Uwp::AdaptiveImage>(item);
                 break;
             case ABI::AdaptiveCards::Rendering::Uwp::ElementType::ImageSet:
-                baseCardElement = GetSharedModel<AdaptiveCards::BaseCardElement, AdaptiveCards::ImageSet, ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement, AdaptiveCards::Rendering::Uwp::AdaptiveImageSet>(item);
+                baseCardElement = GetSharedModel<AdaptiveCards::BaseCardElement, ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement, AdaptiveCards::Rendering::Uwp::AdaptiveImageSet>(item);
                 break;
             case ABI::AdaptiveCards::Rendering::Uwp::ElementType::NumberInput:
-                baseCardElement = GetSharedModel<AdaptiveCards::BaseCardElement, AdaptiveCards::NumberInput, ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement, AdaptiveCards::Rendering::Uwp::AdaptiveNumberInput>(item);
+                baseCardElement = GetSharedModel<AdaptiveCards::BaseCardElement, ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement, AdaptiveCards::Rendering::Uwp::AdaptiveNumberInput>(item);
                 break;
             case ABI::AdaptiveCards::Rendering::Uwp::ElementType::TextBlock:
-                baseCardElement = GetSharedModel<AdaptiveCards::BaseCardElement, AdaptiveCards::TextBlock, ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement, AdaptiveCards::Rendering::Uwp::AdaptiveTextBlock>(item);
+                baseCardElement = GetSharedModel<AdaptiveCards::BaseCardElement, ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement, AdaptiveCards::Rendering::Uwp::AdaptiveTextBlock>(item);
                 break;
             case ABI::AdaptiveCards::Rendering::Uwp::ElementType::TextInput:
-                baseCardElement = GetSharedModel<AdaptiveCards::BaseCardElement, AdaptiveCards::TextInput, ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement, AdaptiveCards::Rendering::Uwp::AdaptiveTextInput>(item);
+                baseCardElement = GetSharedModel<AdaptiveCards::BaseCardElement, ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement, AdaptiveCards::Rendering::Uwp::AdaptiveTextInput>(item);
                 break;
             case ABI::AdaptiveCards::Rendering::Uwp::ElementType::TimeInput:
-                baseCardElement = GetSharedModel<AdaptiveCards::BaseCardElement, AdaptiveCards::TimeInput, ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement, AdaptiveCards::Rendering::Uwp::AdaptiveTimeInput>(item);
+                baseCardElement = GetSharedModel<AdaptiveCards::BaseCardElement, ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement, AdaptiveCards::Rendering::Uwp::AdaptiveTimeInput>(item);
                 break;
             case ABI::AdaptiveCards::Rendering::Uwp::ElementType::ToggleInput:
-                baseCardElement = GetSharedModel<AdaptiveCards::BaseCardElement, AdaptiveCards::ToggleInput, ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement, AdaptiveCards::Rendering::Uwp::AdaptiveToggleInput>(item);
+                baseCardElement = GetSharedModel<AdaptiveCards::BaseCardElement, ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement, AdaptiveCards::Rendering::Uwp::AdaptiveToggleInput>(item);
                 break;
             case ABI::AdaptiveCards::Rendering::Uwp::ElementType::Custom:
                 baseCardElement = std::make_shared<CustomElementWrapper>(item);
@@ -203,13 +174,13 @@ HRESULT GenerateSharedAction(
     switch (actionType)
     {
         case ABI::AdaptiveCards::Rendering::Uwp::ActionType::OpenUrl:
-            sharedAction = GetSharedModel<AdaptiveCards::BaseActionElement, AdaptiveCards::OpenUrlAction, ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveActionElement, AdaptiveCards::Rendering::Uwp::AdaptiveOpenUrlAction>(action);
+            sharedAction = GetSharedModel<AdaptiveCards::BaseActionElement, ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveActionElement, AdaptiveCards::Rendering::Uwp::AdaptiveOpenUrlAction>(action);
             break;
         case ABI::AdaptiveCards::Rendering::Uwp::ActionType::ShowCard:
-            sharedAction = GetSharedModel<AdaptiveCards::BaseActionElement, AdaptiveCards::ShowCardAction, ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveActionElement, AdaptiveCards::Rendering::Uwp::AdaptiveShowCardAction>(action);
+            sharedAction = GetSharedModel<AdaptiveCards::BaseActionElement, ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveActionElement, AdaptiveCards::Rendering::Uwp::AdaptiveShowCardAction>(action);
             break;
         case ABI::AdaptiveCards::Rendering::Uwp::ActionType::Submit:
-            sharedAction = GetSharedModel<AdaptiveCards::BaseActionElement, AdaptiveCards::SubmitAction, ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveActionElement, AdaptiveCards::Rendering::Uwp::AdaptiveSubmitAction>(action);
+            sharedAction = GetSharedModel<AdaptiveCards::BaseActionElement, ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveActionElement, AdaptiveCards::Rendering::Uwp::AdaptiveSubmitAction>(action);
             break;
         case ABI::AdaptiveCards::Rendering::Uwp::ActionType::Custom:
             sharedAction = std::make_shared<CustomActionWrapper>(action);
@@ -248,7 +219,7 @@ HRESULT GenerateSharedImages(
         ComPtr<ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement> imageAsElement;
         localImage.As(&imageAsElement);
 
-        std::shared_ptr<AdaptiveCards::BaseCardElement> sharedImage = GetSharedModel<AdaptiveCards::BaseCardElement, AdaptiveCards::Image, ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement, AdaptiveCards::Rendering::Uwp::AdaptiveImage>(imageAsElement.Get());
+        std::shared_ptr<AdaptiveCards::BaseCardElement> sharedImage = GetSharedModel<AdaptiveCards::BaseCardElement,ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement, AdaptiveCards::Rendering::Uwp::AdaptiveImage>(imageAsElement.Get());
         containedElements.push_back(std::dynamic_pointer_cast<AdaptiveCards::Image>(sharedImage));
 
         return S_OK;

--- a/source/uwp/Renderer/lib/Util.cpp
+++ b/source/uwp/Renderer/lib/Util.cpp
@@ -621,9 +621,8 @@ HRESULT GetBackgroundColorFromStyle(
 
 HRESULT StringToJsonObject(const string inputString, IJsonObject** result)
 {
-    HSTRING asHstring;
-    RETURN_IF_FAILED(UTF8ToHString(inputString, &asHstring));
-    return HStringToJsonObject(asHstring, result);
+    std::wstring asWstring = StringToWstring(inputString);
+    return HStringToJsonObject(HStringReference(asWstring.c_str()).Get(), result);
 }
 
 HRESULT HStringToJsonObject(const HSTRING& inputHString, IJsonObject** result)
@@ -644,9 +643,9 @@ HRESULT HStringToJsonObject(const HSTRING& inputHString, IJsonObject** result)
 
 HRESULT JsonObjectToString(IJsonObject* inputJson, string& result)
 {
-    HSTRING asHstring;
-    RETURN_IF_FAILED(JsonObjectToHString(inputJson, &asHstring));
-    return HStringToUTF8(asHstring, result);
+    HString asHstring;
+    RETURN_IF_FAILED(JsonObjectToHString(inputJson, asHstring.GetAddressOf()));
+    return HStringToUTF8(asHstring.Get(), result);
 }
 
 HRESULT JsonObjectToHString(IJsonObject* inputJson, HSTRING* result)
@@ -663,9 +662,8 @@ HRESULT JsonObjectToHString(IJsonObject* inputJson, HSTRING* result)
 
 HRESULT StringToJsonValue(const string inputString, IJsonValue** result)
 {
-    HSTRING asHstring;
-    RETURN_IF_FAILED(UTF8ToHString(inputString, &asHstring));
-    return HStringToJsonValue(asHstring, result);
+    std::wstring asWstring = StringToWstring(inputString);
+    return HStringToJsonValue(HStringReference(asWstring.c_str()).Get(), result);
 }
 
 HRESULT HStringToJsonValue(const HSTRING& inputHString, IJsonValue** result)
@@ -687,9 +685,9 @@ HRESULT HStringToJsonValue(const HSTRING& inputHString, IJsonValue** result)
 
 HRESULT JsonValueToString(IJsonValue* inputValue, string& result)
 {
-    HSTRING asHstring;
-    RETURN_IF_FAILED(JsonValueToHString(inputValue, &asHstring));
-    return HStringToUTF8(asHstring, result);
+    HString asHstring;
+    RETURN_IF_FAILED(JsonValueToHString(inputValue, asHstring.GetAddressOf()));
+    return HStringToUTF8(asHstring.Get(), result);
 }
 
 HRESULT JsonValueToHString(IJsonValue* inputJsonValue, HSTRING* result)

--- a/source/uwp/Renderer/lib/Util.h
+++ b/source/uwp/Renderer/lib/Util.h
@@ -49,10 +49,6 @@ HRESULT GetSpacingSizeFromSpacing(
     ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing,
     UINT* spacingSize) noexcept;
 
-HRESULT SetSharedElementProperties(
-    ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement * adaptiveCardElement,
-    std::shared_ptr<AdaptiveCards::BaseCardElement> sharedCardElement);
-
 HRESULT GenerateSharedElements(
     ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement*>* items,
     std::vector<std::shared_ptr<AdaptiveCards::BaseCardElement>>& containedElements);

--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -452,14 +452,14 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
         IAdaptiveCardResourceResolvers* resolvers)
     {
         // Get the image url scheme
-        HSTRING schemeName;
-        THROW_IF_FAILED(imageUri->get_SchemeName(&schemeName));
+        HString schemeName;
+        THROW_IF_FAILED(imageUri->get_SchemeName(schemeName.GetAddressOf()));
 
         // Get the resolver for the image
         ComPtr<IAdaptiveCardResourceResolver> resolver;
         if (resolvers != nullptr)
         {
-            THROW_IF_FAILED(resolvers->Get(schemeName, &resolver));
+            THROW_IF_FAILED(resolvers->Get(schemeName.Get(), &resolver));
             // If we have a resolver
             if (resolver != nullptr)
             {

--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -266,8 +266,11 @@ namespace AdaptiveCards { namespace Rendering { namespace Uwp
             ComPtr<IResourceDictionary> strongDictionary = resourceDictionary;
             ComPtr<IInspectable> dictionaryValue;
             ComPtr<IMap<IInspectable*, IInspectable*>> resourceDictionaryMap;
+
+            boolean hasKey{};
             if (SUCCEEDED(strongDictionary.As(&resourceDictionaryMap)) &&
-                SUCCEEDED(resourceDictionaryMap->Lookup(resourceKey.Get(), dictionaryValue.GetAddressOf())))
+                SUCCEEDED(resourceDictionaryMap->HasKey(resourceKey.Get(), &hasKey)) &&
+                hasKey && SUCCEEDED(resourceDictionaryMap->Lookup(resourceKey.Get(), dictionaryValue.GetAddressOf())))
             {
                 ComPtr<T> resourceToReturn;
                 if (SUCCEEDED(dictionaryValue.As(&resourceToReturn)))


### PR DESCRIPTION
Replaces the existing HSTRING variable inside the renderers for HString and HStringReference objects. Fix for issue https://github.com/Microsoft/AdaptiveCards/issues/853