### PR TITLE
Honour preexpandSingleShowCardAction and weight of fact title from HostConfig

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -2309,7 +2309,7 @@ class ActionCollection {
 
         var forbiddenActionTypes = this._owner.getForbiddenActionTypes();
 
-        if (AdaptiveCard.preExpandSingleShowCardAction && maxActions == 1 && this.items[0] instanceof ShowCardAction && isActionAllowed(this.items[i], forbiddenActionTypes)) {
+        if (this._owner.hostConfig.actions.preExpandSingleShowCardAction && maxActions == 1 && this.items[0] instanceof ShowCardAction && isActionAllowed(this.items[i], forbiddenActionTypes)) {
             this.showActionCard(<ShowCardAction>this.items[0], true);
             this._renderedActionCount = 1;
         }
@@ -3803,7 +3803,6 @@ export class AdaptiveCard extends ContainerWithActions {
     private static currentVersion: Version = new Version(1, 0);
 
     static useAutomaticContainerBleeding: boolean = false;
-    static preExpandSingleShowCardAction: boolean = false;
     static useAdvancedTextBlockTruncation: boolean = true;
     static useAdvancedCardBottomTruncation: boolean = false;
     static useMarkdownInRadioButtonAndCheckbox: boolean = true;

--- a/source/nodejs/adaptivecards/src/host-config.ts
+++ b/source/nodejs/adaptivecards/src/host-config.ts
@@ -73,13 +73,13 @@ export class FactTextDefinition {
 
 export class FactTitleDefinition extends FactTextDefinition {
     maxWidth?: number = 150;
-    weight: Enums.TextWeight = Enums.TextWeight.Bolder;
 
     constructor(obj?: any) {
         super(obj);
 
         if (obj) {
             this.maxWidth = obj["maxWidth"] != null ? obj["maxWidth"] : this.maxWidth;
+			this.weight = Utils.parseHostConfigEnum(Enums.TextWeight, obj["weight"], Enums.TextWeight.Bolder);
         }
     }
 }


### PR DESCRIPTION
This Pull Request has changes for below two items:
1)PreExpandSingleShowCardAction taken from HostConfig is not currently used. Made changes to use value taken from HostConfig.
2)Weight of FactTitle is always bolder because it overrides the value from HostConfig. Made changes to start consuming value from HostConfig