### PR TITLE
Icon for Actions support in iOS

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionOpenURLRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionOpenURLRenderer.mm
@@ -32,8 +32,9 @@
     std::shared_ptr<OpenUrlAction> action = std::dynamic_pointer_cast<OpenUrlAction>(elem);
 
     NSString *title  = [NSString stringWithCString:action->GetTitle().c_str() encoding:NSUTF8StringEncoding];
+    NSString *iconUrl = [NSString stringWithCString:action->GetUrl().c_str() encoding:(NSUTF8StringEncoding)];
     
-    UIButton *button = [UIButton acr_renderButton:rootView title:title andHostConfig:config];
+    UIButton *button = [UIButton acr_renderButton:rootView title:title iconUrl:iconUrl andHostConfig:config];
 
     ACRAggregateTarget *target = [[ACRAggregateTarget alloc] initWithActionElement:acoElem rootView:(ACRView *)rootView];
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionOpenURLRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionOpenURLRenderer.mm
@@ -27,14 +27,13 @@
          baseActionElement:(ACOBaseActionElement *)acoElem
                 hostConfig:(ACOHostConfig *)acoConfig;
 {
-    std::shared_ptr<HostConfig> config = [acoConfig getHostConfig];
     std::shared_ptr<BaseActionElement> elem = [acoElem element];
     std::shared_ptr<OpenUrlAction> action = std::dynamic_pointer_cast<OpenUrlAction>(elem);
 
     NSString *title  = [NSString stringWithCString:action->GetTitle().c_str() encoding:NSUTF8StringEncoding];
     NSString *iconUrl = [NSString stringWithCString:action->GetUrl().c_str() encoding:(NSUTF8StringEncoding)];
     
-    UIButton *button = [UIButton rootView:rootView baseActionElement:acoElem title:title iconUrl:iconUrl andHostConfig:config];
+    UIButton *button = [UIButton rootView:rootView baseActionElement:acoElem title:title iconUrl:iconUrl andHostConfig:acoConfig];
 
     ACRAggregateTarget *target = [[ACRAggregateTarget alloc] initWithActionElement:acoElem rootView:(ACRView *)rootView];
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionOpenURLRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionOpenURLRenderer.mm
@@ -34,7 +34,7 @@
     NSString *title  = [NSString stringWithCString:action->GetTitle().c_str() encoding:NSUTF8StringEncoding];
     NSString *iconUrl = [NSString stringWithCString:action->GetUrl().c_str() encoding:(NSUTF8StringEncoding)];
     
-    UIButton *button = [UIButton acr_renderButton:rootView title:title iconUrl:iconUrl andHostConfig:config];
+    UIButton *button = [UIButton rootView:rootView baseActionElement:acoElem title:title iconUrl:iconUrl andHostConfig:config];
 
     ACRAggregateTarget *target = [[ACRAggregateTarget alloc] initWithActionElement:acoElem rootView:(ACRView *)rootView];
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionShowCardRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionShowCardRenderer.mm
@@ -33,7 +33,7 @@
     NSString *title  = [NSString stringWithCString:action->GetTitle().c_str() encoding:NSUTF8StringEncoding];
     NSString *iconUrl = [NSString stringWithCString:action->GetIconUrl().c_str() encoding:NSUTF8StringEncoding];
     
-    UIButton *button = [UIButton rootView:rootView baseActionElement:acoElem title:title iconUrl:iconUrl andHostConfig:[acoConfig getHostConfig]];
+    UIButton *button = [UIButton rootView:rootView baseActionElement:acoElem title:title iconUrl:iconUrl andHostConfig:acoConfig];
 
     ACRShowCardTarget *target = [[ACRShowCardTarget alloc] initWithAdaptiveCard:action->GetCard()
                                                                          config:acoConfig

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionShowCardRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionShowCardRenderer.mm
@@ -33,7 +33,7 @@
     NSString *title  = [NSString stringWithCString:action->GetTitle().c_str() encoding:NSUTF8StringEncoding];
     NSString *iconUrl = [NSString stringWithCString:action->GetIconUrl().c_str() encoding:NSUTF8StringEncoding];
     
-    UIButton *button = [UIButton acr_renderButton:rootView title:title iconUrl:iconUrl andHostConfig:[acoConfig getHostConfig]];
+    UIButton *button = [UIButton rootView:rootView baseActionElement:acoElem title:title iconUrl:iconUrl andHostConfig:[acoConfig getHostConfig]];
 
     ACRShowCardTarget *target = [[ACRShowCardTarget alloc] initWithAdaptiveCard:action->GetCard()
                                                                          config:acoConfig

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionShowCardRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionShowCardRenderer.mm
@@ -30,9 +30,10 @@
     std::shared_ptr<BaseActionElement> elem = [acoElem element];
     std::shared_ptr<ShowCardAction> action = std::dynamic_pointer_cast<ShowCardAction>(elem);
 
-    NSString *title  = [NSString stringWithCString:action->GetTitle().c_str()
-                                          encoding:NSUTF8StringEncoding];
-    UIButton *button = [UIButton acr_renderButton:rootView title:title andHostConfig:[acoConfig getHostConfig]];
+    NSString *title  = [NSString stringWithCString:action->GetTitle().c_str() encoding:NSUTF8StringEncoding];
+    NSString *iconUrl = [NSString stringWithCString:action->GetIconUrl().c_str() encoding:NSUTF8StringEncoding];
+    
+    UIButton *button = [UIButton acr_renderButton:rootView title:title iconUrl:iconUrl andHostConfig:[acoConfig getHostConfig]];
 
     ACRShowCardTarget *target = [[ACRShowCardTarget alloc] initWithAdaptiveCard:action->GetCard()
                                                                          config:acoConfig

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionSubmitRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionSubmitRenderer.mm
@@ -27,13 +27,12 @@
          baseActionElement:(ACOBaseActionElement *)acoElem
                 hostConfig:(ACOHostConfig *)acoConfig;
 {
-    std::shared_ptr<HostConfig> config = [acoConfig getHostConfig];
     std::shared_ptr<BaseActionElement> elem = [acoElem element];
     std::shared_ptr<SubmitAction> action = std::dynamic_pointer_cast<SubmitAction>(elem);
 
     NSString *title = [NSString stringWithCString:action->GetTitle().c_str() encoding:NSUTF8StringEncoding];
     NSString *iconUrl = [NSString stringWithCString:action->GetIconUrl().c_str() encoding:NSUTF8StringEncoding];
-    UIButton *button = [UIButton rootView:view baseActionElement:acoElem title:title iconUrl:iconUrl andHostConfig:config];
+    UIButton *button = [UIButton rootView:view baseActionElement:acoElem title:title iconUrl:iconUrl andHostConfig:acoConfig];
 
     ACRAggregateTarget *target = [[ACRAggregateTarget alloc] initWithActionElement:acoElem rootView:(ACRView*)view];
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionSubmitRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionSubmitRenderer.mm
@@ -31,9 +31,9 @@
     std::shared_ptr<BaseActionElement> elem = [acoElem element];
     std::shared_ptr<SubmitAction> action = std::dynamic_pointer_cast<SubmitAction>(elem);
 
-    NSString *title = [NSString stringWithCString:action->GetTitle().c_str()
-                                        encoding:NSUTF8StringEncoding];
-    UIButton *button = [UIButton acr_renderButton:view title:title andHostConfig:config];
+    NSString *title = [NSString stringWithCString:action->GetTitle().c_str() encoding:NSUTF8StringEncoding];
+    NSString *iconUrl = [NSString stringWithCString:action->GetIconUrl().c_str() encoding:NSUTF8StringEncoding];
+    UIButton *button = [UIButton acr_renderButton:view title:title iconUrl:iconUrl andHostConfig:config];
 
     ACRAggregateTarget *target = [[ACRAggregateTarget alloc] initWithActionElement:acoElem rootView:(ACRView*)view];
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionSubmitRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionSubmitRenderer.mm
@@ -33,7 +33,7 @@
 
     NSString *title = [NSString stringWithCString:action->GetTitle().c_str() encoding:NSUTF8StringEncoding];
     NSString *iconUrl = [NSString stringWithCString:action->GetIconUrl().c_str() encoding:NSUTF8StringEncoding];
-    UIButton *button = [UIButton acr_renderButton:view title:title iconUrl:iconUrl andHostConfig:config];
+    UIButton *button = [UIButton rootView:view baseActionElement:acoElem title:title iconUrl:iconUrl andHostConfig:config];
 
     ACRAggregateTarget *target = [[ACRAggregateTarget alloc] initWithActionElement:acoElem rootView:(ACRView*)view];
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.h
@@ -15,5 +15,5 @@
      baseActionElement:(ACOBaseActionElement *)acoAction
                  title:(NSString *)title
                iconUrl:(NSString *)iconUrl
-         andHostConfig:(std::shared_ptr<AdaptiveCards::HostConfig> const &)config;
+         andHostConfig:(ACOHostConfig *)config;
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.h
@@ -13,5 +13,8 @@
 @interface UIButton(ACRButton)
 + (UIButton *)acr_renderButton:(ACRView *)view
                          title:(NSString *)title
+                       iconUrl:(NSString *)iconUrl
                  andHostConfig:(std::shared_ptr<AdaptiveCards::HostConfig> const &)config;
+
++ (UIImage *)scaleImage:(UIImage *)image toSize:(CGSize)newSize;
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.h
@@ -11,10 +11,9 @@
 #import "ACRView.h"
 
 @interface UIButton(ACRButton)
-+ (UIButton *)acr_renderButton:(ACRView *)view
-                         title:(NSString *)title
-                       iconUrl:(NSString *)iconUrl
-                 andHostConfig:(std::shared_ptr<AdaptiveCards::HostConfig> const &)config;
-
-+ (UIImage *)scaleImage:(UIImage *)image toSize:(CGSize)newSize;
++ (UIButton *)rootView:(ACRView *)rootView
+     baseActionElement:(ACOBaseActionElement *)acoAction
+                 title:(NSString *)title
+               iconUrl:(NSString *)iconUrl
+         andHostConfig:(std::shared_ptr<AdaptiveCards::HostConfig> const &)config;
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.mm
@@ -14,7 +14,7 @@
      baseActionElement:(ACOBaseActionElement *)acoAction
                  title:(NSString *)title
                iconUrl:(NSString *)iconUrl
-         andHostConfig:(std::shared_ptr<AdaptiveCards::HostConfig> const &)config;
+         andHostConfig:(ACOHostConfig *)config;
 {
     UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
     [button setTitle:title forState:UIControlStateNormal];
@@ -29,7 +29,8 @@
     [button setContentEdgeInsets:UIEdgeInsetsMake(5,5,5,5)];
     
     std::shared_ptr<AdaptiveCards::BaseActionElement> action = [acoAction element];
-    if( [iconUrl length] != 0 ){
+    if([iconUrl length] != 0)
+    {
         NSMutableDictionary *actionsViewMap = [rootView getActionsMap];
         __block UIImageView *imgView = nil;
         // Generate key for ImageViewMap
@@ -37,41 +38,25 @@
         // Syncronize access to imageViewMap
         dispatch_sync([rootView getSerialQueue], ^{
             // if imageView is available, get it, otherwise cache UIButton, so it can be used once images are ready
-            if(actionsViewMap[key] && [actionsViewMap[key] isKindOfClass:[UIImageView class]]) {
+            if(actionsViewMap[key] && [actionsViewMap[key] isKindOfClass:[UIImageView class]])
+            {
                 imgView = actionsViewMap[key];
             }
-            else {
+            else
+            {
                 actionsViewMap[key] = button;
             }
         });
         
-        if(imgView){
-            // Format the image so it fits in the button and is placed where it must be placed
-            CGSize contentSize = [button.titleLabel intrinsicContentSize];
-            double imageHeight = contentSize.height;
-            CGSize originalImageSize = [imgView intrinsicContentSize];
-            double scaleRatio = imageHeight / originalImageSize.height;
-            double imageWidth = scaleRatio * originalImageSize.width;
-            
-            IconPlacement iconPlacement = config->actions.iconPlacement;
-            if( iconPlacement == AdaptiveCards::IconPlacement::AboveTitle ){
-                [imgView setFrame:CGRectMake( (button.frame.size.width - imageWidth) / 2, 5, imageWidth, imageHeight)];
-                [button setTitleEdgeInsets:UIEdgeInsetsMake(imageHeight, 5, -imageHeight, 5)];
-                [button setContentEdgeInsets:UIEdgeInsetsMake(5, 5, 5 + imageHeight, 5)];
-            } else {
-                int iconPadding = config->spacing.defaultSpacing;
-                [button setTitleEdgeInsets:UIEdgeInsetsMake(5, (iconPadding + imageWidth), 5, 0)];
-                double titleOriginX = button.titleLabel.frame.origin.x;
-                [imgView setFrame:CGRectMake( titleOriginX - (iconPadding + imageWidth) / 2, 5, imageWidth, imageHeight)];
-            }
-            [button addSubview:imgView];
+        if(imgView)
+        {          
+            [ACRView setImageView:imgView inButton:button withConfig:config];
             
             // remove postfix added for imageMap access
             std::string id = action->GetId();
             std::size_t idx = id.find_last_of('_');
             action->SetId(id.substr(0, idx));
         }
-        
     }
     
     return button;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.mm
@@ -10,9 +10,10 @@
 @implementation UIButton(ACRButton)
 + (UIButton* )acr_renderButton:(UIView *)view
                          title:(NSString *)title
+                       iconUrl:(NSString *)iconUrl
                  andHostConfig:(std::shared_ptr<AdaptiveCards::HostConfig> const &)config;
 {
-    UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
+    UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
     [button setTitle:title forState:UIControlStateNormal];
     [button setTitleColor:UIColor.whiteColor forState:UIControlStateNormal];
     [button setBackgroundColor:[UIColor colorWithRed:0.0
@@ -21,9 +22,48 @@
                                                alpha:1.0]];
 
     CGSize contentSize = [button.titleLabel intrinsicContentSize];
-    button.frame = CGRectMake(0, 0, contentSize.width, contentSize.height);
-    button.contentEdgeInsets = UIEdgeInsetsMake(5,5,5,5);
+    [button setFrame:CGRectMake(0, 0, contentSize.width, contentSize.height)];
+    [button setContentEdgeInsets:UIEdgeInsetsMake(5,5,5,5)];
+    
+    if( [iconUrl length] != 0 ){
+        // Format the image so it looks pretty
+        NSData *imageData = [[NSData alloc] initWithContentsOfURL: [NSURL URLWithString: @"https://i.imgur.com/95qFPCV.jpg"]];
+        UIImage *image = [UIImage imageWithData: imageData];
 
+        double imageHeight = contentSize.height;
+        CGSize originalImageSize = [image size];
+        double scaleRatio = imageHeight / originalImageSize.height;
+        double imageWidth = scaleRatio * originalImageSize.width;
+        
+        UIImage *scaledImage = [self scaleImage:image toSize:CGSizeMake(imageWidth, imageHeight)];
+        [button setImage:scaledImage forState:UIControlStateNormal];
+        
+        AdaptiveCards::IconPlacement iconPlacement = config->actions.iconPlacement;
+        if( iconPlacement == AdaptiveCards::IconPlacement::AboveTitle ){
+            // Changes the insets for image, title and contents so the icon is rendered above the title
+            CGFloat totalHeight = (imageHeight + contentSize.height);
+            [button setImageEdgeInsets:UIEdgeInsetsMake(-(totalHeight - 2 * imageHeight), 0.0f, 0.0f, -contentSize.width)];
+            [button setTitleEdgeInsets:UIEdgeInsetsMake(imageHeight, -imageWidth, - (totalHeight - contentSize.height), 0.0f)];
+            [button setContentEdgeInsets:UIEdgeInsetsMake(5, 5, 5 + imageHeight, 5)];
+        } else {
+            // The icons are drawn to the left of the title by default, so we only set the padding to the right for the image
+            int iconPadding = config->spacing.defaultSpacing;
+            [button setImageEdgeInsets:UIEdgeInsetsMake(0, 0, 0, iconPadding)];
+        }
+        
+    }
+    
     return button;
+}
+
++ (UIImage*)scaleImage:(UIImage *)image toSize:(CGSize)newSize {
+    //UIGraphicsBeginImageContext(newSize);
+    // In next line, pass 0.0 to use the current device's pixel scaling factor (and thus account for Retina resolution).
+    // Pass 1.0 to force exact pixel size.
+    UIGraphicsBeginImageContextWithOptions(newSize, NO, 0.0);
+    [image drawInRect:CGRectMake(0, 0, newSize.width, newSize.height)];
+    UIImage *scaledImage = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    return scaledImage;
 }
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.mm
@@ -5,13 +5,16 @@
 //  Copyright © 2017 Microsoft. All rights reserved.
 //
 
+#import "ACOBaseActionElementPrivate.h"
 #import "ACRButton.h"
+#import "ACRView.h"
 
 @implementation UIButton(ACRButton)
-+ (UIButton* )acr_renderButton:(UIView *)view
-                         title:(NSString *)title
-                       iconUrl:(NSString *)iconUrl
-                 andHostConfig:(std::shared_ptr<AdaptiveCards::HostConfig> const &)config;
++ (UIButton* )rootView:(ACRView *)rootView
+     baseActionElement:(ACOBaseActionElement *)acoAction
+                 title:(NSString *)title
+               iconUrl:(NSString *)iconUrl
+         andHostConfig:(std::shared_ptr<AdaptiveCards::HostConfig> const &)config;
 {
     UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
     [button setTitle:title forState:UIControlStateNormal];
@@ -25,45 +28,55 @@
     [button setFrame:CGRectMake(0, 0, contentSize.width, contentSize.height)];
     [button setContentEdgeInsets:UIEdgeInsetsMake(5,5,5,5)];
     
+    std::shared_ptr<AdaptiveCards::BaseActionElement> action = [acoAction element];
+    
     if( [iconUrl length] != 0 ){
-        // Format the image so it looks pretty
-        NSData *imageData = [[NSData alloc] initWithContentsOfURL: [NSURL URLWithString: @"https://i.imgur.com/95qFPCV.jpg"]];
-        UIImage *image = [UIImage imageWithData: imageData];
-
-        double imageHeight = contentSize.height;
-        CGSize originalImageSize = [image size];
-        double scaleRatio = imageHeight / originalImageSize.height;
-        double imageWidth = scaleRatio * originalImageSize.width;
+        NSMutableDictionary *actionsViewMap = [rootView getActionsMap];
+        __block UIImage *img = nil;
+        // Generate key for ImageViewMap
+        NSString *key = [NSString stringWithCString:action->GetId().c_str() encoding:[NSString defaultCStringEncoding]];
+        // Syncronize access to imageViewMap
+        dispatch_sync([rootView getSerialQueue], ^{
+            // if image is available, get it, otherwise cache UIButton, so it can be used once images are ready
+            if(actionsViewMap[key] && [actionsViewMap[key] isKindOfClass:[UIImage class]]) {
+                img = actionsViewMap[key];
+            }
+            else {
+                actionsViewMap[key] = button;
+            }
+        });
         
-        UIImage *scaledImage = [self scaleImage:image toSize:CGSizeMake(imageWidth, imageHeight)];
-        [button setImage:scaledImage forState:UIControlStateNormal];
-        
-        AdaptiveCards::IconPlacement iconPlacement = config->actions.iconPlacement;
-        if( iconPlacement == AdaptiveCards::IconPlacement::AboveTitle ){
-            // Changes the insets for image, title and contents so the icon is rendered above the title
-            CGFloat totalHeight = (imageHeight + contentSize.height);
-            [button setImageEdgeInsets:UIEdgeInsetsMake(-(totalHeight - 2 * imageHeight), 0.0f, 0.0f, -contentSize.width)];
-            [button setTitleEdgeInsets:UIEdgeInsetsMake(imageHeight, -imageWidth, - (totalHeight - contentSize.height), 0.0f)];
-            [button setContentEdgeInsets:UIEdgeInsetsMake(5, 5, 5 + imageHeight, 5)];
-        } else {
-            // The icons are drawn to the left of the title by default, so we only set the padding to the right for the image
-            int iconPadding = config->spacing.defaultSpacing;
-            [button setImageEdgeInsets:UIEdgeInsetsMake(0, 0, 0, iconPadding)];
+        if(img){
+            // Format the image so it fits in the button and is placed where it must be placed
+            double imageHeight = contentSize.height;
+            CGSize originalImageSize = [img size];
+            double scaleRatio = imageHeight / originalImageSize.height;
+            double imageWidth = scaleRatio * originalImageSize.width;
+            
+            UIImage *scaledImage = [rootView scaleImage:img toSize:CGSizeMake(imageWidth, imageHeight)];
+            [button setImage:scaledImage forState:UIControlStateNormal];
+            
+            AdaptiveCards::IconPlacement iconPlacement = config->actions.iconPlacement;
+            if( iconPlacement == AdaptiveCards::IconPlacement::AboveTitle ){
+                // Changes the insets for image, title and contents so the icon is rendered above the title
+                CGFloat totalHeight = (imageHeight + contentSize.height);
+                [button setImageEdgeInsets:UIEdgeInsetsMake(-(totalHeight - 2 * imageHeight), 0.0f, 0.0f, -contentSize.width)];
+                [button setTitleEdgeInsets:UIEdgeInsetsMake(imageHeight, -imageWidth, - (totalHeight - contentSize.height), 0.0f)];
+                [button setContentEdgeInsets:UIEdgeInsetsMake(5, 5, 5 + imageHeight, 5)];
+            } else {
+                // The icons are drawn to the left of the title by default, so we only set the padding to the right for the image
+                int iconPadding = config->spacing.defaultSpacing;
+                [button setImageEdgeInsets:UIEdgeInsetsMake(0, 0, 0, iconPadding)];
+            }
+            
+            // remove postfix added for imageMap access
+            std::string id = action->GetId();
+            std::size_t idx = id.find_last_of('_');
+            action->SetId(id.substr(0, idx));
         }
         
     }
     
     return button;
-}
-
-+ (UIImage*)scaleImage:(UIImage *)image toSize:(CGSize)newSize {
-    //UIGraphicsBeginImageContext(newSize);
-    // In next line, pass 0.0 to use the current device's pixel scaling factor (and thus account for Retina resolution).
-    // Pass 1.0 to force exact pixel size.
-    UIGraphicsBeginImageContextWithOptions(newSize, NO, 0.0);
-    [image drawInRect:CGRectMake(0, 0, newSize.width, newSize.height)];
-    UIImage *scaledImage = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
-    return scaledImage;
 }
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.mm
@@ -48,26 +48,26 @@
         
         if(img){
             // Format the image so it fits in the button and is placed where it must be placed
+            CGSize contentSize = [button.titleLabel intrinsicContentSize];
             double imageHeight = contentSize.height;
             CGSize originalImageSize = [img size];
             double scaleRatio = imageHeight / originalImageSize.height;
             double imageWidth = scaleRatio * originalImageSize.width;
             
-            UIImage *scaledImage = [rootView scaleImage:img toSize:CGSizeMake(imageWidth, imageHeight)];
-            [button setImage:scaledImage forState:UIControlStateNormal];
+            UIImageView *imageView = [[UIImageView alloc] initWithImage:img];
             
-            AdaptiveCards::IconPlacement iconPlacement = config->actions.iconPlacement;
+            IconPlacement iconPlacement = config->actions.iconPlacement;
             if( iconPlacement == AdaptiveCards::IconPlacement::AboveTitle ){
-                // Changes the insets for image, title and contents so the icon is rendered above the title
-                CGFloat totalHeight = (imageHeight + contentSize.height);
-                [button setImageEdgeInsets:UIEdgeInsetsMake(-(totalHeight - 2 * imageHeight), 0.0f, 0.0f, -contentSize.width)];
-                [button setTitleEdgeInsets:UIEdgeInsetsMake(imageHeight, -imageWidth, - (totalHeight - contentSize.height), 0.0f)];
+                [imageView setFrame:CGRectMake( (button.frame.size.width - imageWidth) / 2, 5, imageWidth, imageHeight)];
+                [button setTitleEdgeInsets:UIEdgeInsetsMake(imageHeight, 5, -imageHeight, 5)];
                 [button setContentEdgeInsets:UIEdgeInsetsMake(5, 5, 5 + imageHeight, 5)];
             } else {
-                // The icons are drawn to the left of the title by default, so we only set the padding to the right for the image
                 int iconPadding = config->spacing.defaultSpacing;
-                [button setImageEdgeInsets:UIEdgeInsetsMake(0, 0, 0, iconPadding)];
+                [button setTitleEdgeInsets:UIEdgeInsetsMake(5, (iconPadding + imageWidth), 5, 0)];
+                double titleOriginX = button.titleLabel.frame.origin.x;
+                [imageView setFrame:CGRectMake( titleOriginX - (iconPadding + imageWidth) / 2, 5, imageWidth, imageHeight)];
             }
+            [button addSubview:imageView];
             
             // remove postfix added for imageMap access
             std::string id = action->GetId();

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.mm
@@ -29,45 +29,42 @@
     [button setContentEdgeInsets:UIEdgeInsetsMake(5,5,5,5)];
     
     std::shared_ptr<AdaptiveCards::BaseActionElement> action = [acoAction element];
-    
     if( [iconUrl length] != 0 ){
         NSMutableDictionary *actionsViewMap = [rootView getActionsMap];
-        __block UIImage *img = nil;
+        __block UIImageView *imgView = nil;
         // Generate key for ImageViewMap
         NSString *key = [NSString stringWithCString:action->GetId().c_str() encoding:[NSString defaultCStringEncoding]];
         // Syncronize access to imageViewMap
         dispatch_sync([rootView getSerialQueue], ^{
-            // if image is available, get it, otherwise cache UIButton, so it can be used once images are ready
-            if(actionsViewMap[key] && [actionsViewMap[key] isKindOfClass:[UIImage class]]) {
-                img = actionsViewMap[key];
+            // if imageView is available, get it, otherwise cache UIButton, so it can be used once images are ready
+            if(actionsViewMap[key] && [actionsViewMap[key] isKindOfClass:[UIImageView class]]) {
+                imgView = actionsViewMap[key];
             }
             else {
                 actionsViewMap[key] = button;
             }
         });
         
-        if(img){
+        if(imgView){
             // Format the image so it fits in the button and is placed where it must be placed
             CGSize contentSize = [button.titleLabel intrinsicContentSize];
             double imageHeight = contentSize.height;
-            CGSize originalImageSize = [img size];
+            CGSize originalImageSize = [imgView intrinsicContentSize];
             double scaleRatio = imageHeight / originalImageSize.height;
             double imageWidth = scaleRatio * originalImageSize.width;
             
-            UIImageView *imageView = [[UIImageView alloc] initWithImage:img];
-            
             IconPlacement iconPlacement = config->actions.iconPlacement;
             if( iconPlacement == AdaptiveCards::IconPlacement::AboveTitle ){
-                [imageView setFrame:CGRectMake( (button.frame.size.width - imageWidth) / 2, 5, imageWidth, imageHeight)];
+                [imgView setFrame:CGRectMake( (button.frame.size.width - imageWidth) / 2, 5, imageWidth, imageHeight)];
                 [button setTitleEdgeInsets:UIEdgeInsetsMake(imageHeight, 5, -imageHeight, 5)];
                 [button setContentEdgeInsets:UIEdgeInsetsMake(5, 5, 5 + imageHeight, 5)];
             } else {
                 int iconPadding = config->spacing.defaultSpacing;
                 [button setTitleEdgeInsets:UIEdgeInsetsMake(5, (iconPadding + imageWidth), 5, 0)];
                 double titleOriginX = button.titleLabel.frame.origin.x;
-                [imageView setFrame:CGRectMake( titleOriginX - (iconPadding + imageWidth) / 2, 5, imageWidth, imageHeight)];
+                [imgView setFrame:CGRectMake( titleOriginX - (iconPadding + imageWidth) / 2, 5, imageWidth, imageHeight)];
             }
-            [button addSubview:imageView];
+            [button addSubview:imgView];
             
             // remove postfix added for imageMap access
             std::string id = action->GetId();

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRenderer.mm
@@ -62,13 +62,11 @@ using namespace AdaptiveCards;
                          hostconfig:(ACOHostConfig *)config
 {
     std::vector<std::shared_ptr<BaseCardElement>> body = adaptiveCard->GetBody();
-
     ACRColumnView *verticalView = containingView;
-
+    
     if(!body.empty())
     {
         [rootView addTasksToConcurrentQueue:body];
-
         ACRContainerStyle style = ([config getHostConfig]->adaptiveCard.allowCustomStyle)? (ACRContainerStyle)adaptiveCard->GetStyle() : ACRDefault;
         style = (style == ACRNone)? ACRDefault : style;
         [verticalView setStyle:style];
@@ -78,11 +76,13 @@ using namespace AdaptiveCards;
         [[rootView card] setInputs:inputs];
 
         std::vector<std::shared_ptr<BaseActionElement>> actions = adaptiveCard->GetActions();
+        [rootView addActionsToConcurrentQueue:actions];
 
         [ACRSeparator renderActionsSeparator:verticalView hostConfig:[config getHostConfig]];
         // renders buttons and their associated actions
         [ACRRenderer renderButton:rootView inputs:inputs superview:verticalView actionElems:actions hostConfig:config];
     }
+    
     return verticalView;
 }
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.h
@@ -31,6 +31,4 @@
 - (ACOAdaptiveCard *)card;
 
 - (UIView *)render;
-
-- (UIImage*) scaleImage:(UIImage*)image toSize:(CGSize)size;
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.h
@@ -24,9 +24,13 @@
 
 - (NSMutableDictionary *)getTextMap;
 
+- (NSMutableDictionary *)getActionsMap;
+
 - (dispatch_queue_t)getSerialTextQueue;
 
 - (ACOAdaptiveCard *)card;
 
 - (UIView *)render;
+
+- (UIImage*) scaleImage:(UIImage*)image toSize:(CGSize)size;
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.h
@@ -31,4 +31,6 @@
 - (ACOAdaptiveCard *)card;
 
 - (UIView *)render;
+
++ (void) setImageView:(UIImageView*)imageView inButton:(UIButton*)button withConfig:(ACOHostConfig *)config;
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm
@@ -30,10 +30,11 @@ using namespace AdaptiveCards;
     ACOHostConfig *_hostConfig;
     NSMutableDictionary *_imageViewMap;
     NSMutableDictionary *_textMap;
+    NSMutableDictionary *_actionsMap;
     dispatch_queue_t _serial_queue;
     dispatch_queue_t _serial_text_queue;
     int _serialNumber;
-    std::list<const BaseCardElement*> _asyncRenderedElements;
+    std::list<const void*> _asyncRenderedElements;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -44,6 +45,7 @@ using namespace AdaptiveCards;
         _hostConfig = [[ACOHostConfig alloc] initWithConfig:cHostConfig];
         _imageViewMap = [[NSMutableDictionary alloc] init];
         _textMap = [[NSMutableDictionary alloc] init];
+        _actionsMap = [[NSMutableDictionary alloc] init];
         _serial_queue = dispatch_queue_create("io.adaptiveCards.serial_queue", DISPATCH_QUEUE_SERIAL);
         _serial_text_queue = dispatch_queue_create("io.adaptiveCards.serial_text_queue", DISPATCH_QUEUE_SERIAL);
         _serialNumber = 0;
@@ -117,12 +119,12 @@ using namespace AdaptiveCards;
     return newView;
 }
 
-- (void)addToAsyncRenderingList:(std::shared_ptr<BaseCardElement> const &)elem
+- (void)addToAsyncRenderingList:(std::shared_ptr<void> const &)elem
 {
     _asyncRenderedElements.push_back(elem.get());
 }
 
-- (void)removeFromAsyncRenderingListAndNotifyIfNeeded:(std::shared_ptr<BaseCardElement> const &)elem
+- (void)removeFromAsyncRenderingListAndNotifyIfNeeded:(std::shared_ptr<void> const &)elem
 {
     _asyncRenderedElements.remove(elem.get());
 
@@ -287,6 +289,21 @@ using namespace AdaptiveCards;
     }
 }
 
+// Walk through the actions found and process them concurrently
+- (void)addActionsToConcurrentQueue:(std::vector<std::shared_ptr<BaseActionElement>> const &)actions
+{
+    // Move this to a different function
+    for(auto &action : actions)
+    {
+        std::string iconUrl = action->GetIconUrl();
+        if(!iconUrl.empty())
+        {
+            [self tagBaseActionElement:action];
+            [self processActionWithIconConcurrently:action];
+        }
+    }
+}
+
 - (void)processImageConcurrently:(std::shared_ptr<Image> const &)imageElem
 {
     [self addToAsyncRenderingList:imageElem];
@@ -357,12 +374,93 @@ using namespace AdaptiveCards;
              }
     );
 }
+
+- (void)processActionWithIconConcurrently:(std::shared_ptr<BaseActionElement> const &)action
+{
+    [self addToAsyncRenderingList:action];
+    
+    /// generate a string key to uniquely identify Image
+    if(!(action->GetIconUrl().empty()))
+    {
+        // run image downloading and processing on global queue which is concurrent and different from main queue
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0),
+            ^{
+                NSString *urlStr = [NSString stringWithCString:action->GetIconUrl().c_str() encoding:[NSString defaultCStringEncoding]];
+                // generate key for imageMap from image element's id
+                NSString *key = [NSString stringWithCString:action->GetId().c_str() encoding:[NSString defaultCStringEncoding]];
+                NSURL *url = [NSURL URLWithString:urlStr];
+                
+                // download image
+                UIImage *img = [UIImage imageWithData:[NSData dataWithContentsOfURL:url]];
+                
+                // UITask can't be run on global queue, add task to main queue
+                dispatch_async(dispatch_get_main_queue(),
+                    ^{
+                        __block UIButton *button = nil;
+                        // syncronize access to image map
+                        dispatch_sync(_serial_queue,
+                            ^{
+                                if(!_actionsMap[key]) {// UIButton is not ready, cache UIImage
+                                    _actionsMap[key] = img;
+                                } else {// UIButton ready, get view
+                                    button = _actionsMap[key];
+                                }
+                            });
+                        
+                        // if view is available, set image to it, and continue image processing
+                        if(button)
+                        {
+                            // Format the image so it fits in the button and is placed where it must be placed
+                            CGSize contentSize = [button.titleLabel intrinsicContentSize];
+                            double imageHeight = contentSize.height;
+                            CGSize originalImageSize = [img size];
+                            double scaleRatio = imageHeight / originalImageSize.height;
+                            double imageWidth = scaleRatio * originalImageSize.width;
+                            
+                            UIImage *scaledImage = [self scaleImage:img toSize:CGSizeMake(imageWidth, imageHeight)];
+                            [button setImage:scaledImage forState:UIControlStateNormal];
+                            
+                            IconPlacement iconPlacement = [_hostConfig getHostConfig]->actions.iconPlacement;
+                            if( iconPlacement == AdaptiveCards::IconPlacement::AboveTitle ){
+                                // Changes the insets for image, title and contents so the icon is rendered above the title
+                                CGFloat totalHeight = (imageHeight + contentSize.height);
+                                [button setImageEdgeInsets:UIEdgeInsetsMake(-(totalHeight - 2 * imageHeight), 0.0f, 0.0f, -contentSize.width)];
+                                [button setTitleEdgeInsets:UIEdgeInsetsMake(imageHeight, -imageWidth, - (totalHeight - contentSize.height), 0.0f)];
+                                [button setContentEdgeInsets:UIEdgeInsetsMake(5, 5, 5 + imageHeight, 5)];
+                            } else {
+                                // The icons are drawn to the left of the title by default, so we only set the padding to the right for the image
+                                int iconPadding = [_hostConfig getHostConfig]->spacing.defaultSpacing;
+                                [button setImageEdgeInsets:UIEdgeInsetsMake(0, 0, 0, iconPadding)];
+                            }
+                            
+                            // remove tag
+                            std::string id = action->GetId();
+                            std::size_t idx = id.find_last_of('_');
+                            action->SetId(id.substr(0, idx));
+                        }
+                                          
+                        [self removeFromAsyncRenderingListAndNotifyIfNeeded:action];
+                    });
+                }
+            );
+    }
+}
+
 // add postfix to existing BaseCardElement ID to be used as key
 -(void)tagBaseCardElement:(std::shared_ptr<BaseCardElement> const &)elem
 {
     std::string serial_number_as_string = std::to_string(_serialNumber);
     // concat a newly generated key to a existing id, the key will be removed after use
     elem->SetId(elem->GetId() + "_" + serial_number_as_string);
+    ++_serialNumber;
+}
+
+// add postfix to existing BaseCardElement ID to be used as key
+-(void)tagBaseActionElement:(std::shared_ptr<BaseActionElement> const &)action
+{
+    std::string serial_number_as_string = std::to_string(_serialNumber);
+    // concat a newly generated key to a existing id, the key will be removed after use
+    action->SetId(action->GetId() + "_" + serial_number_as_string);
     ++_serialNumber;
 }
 
@@ -385,8 +483,24 @@ using namespace AdaptiveCards;
     return _textMap;
 }
 
+- (NSMutableDictionary *)getActionsMap
+{
+    return _actionsMap;
+}
+
 - (ACOAdaptiveCard *)card
 {
     return _adaptiveCard;
+}
+
+- (UIImage*)scaleImage:(UIImage *)image toSize:(CGSize)newSize {
+    //UIGraphicsBeginImageContext(newSize);
+    // In next line, pass 0.0 to use the current device's pixel scaling factor (and thus account for Retina resolution).
+    // Pass 1.0 to force exact pixel size.
+    UIGraphicsBeginImageContextWithOptions(newSize, NO, 0.0);
+    [image drawInRect:CGRectMake(0, 0, newSize.width, newSize.height)];
+    UIImage *scaledImage = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    return scaledImage;
 }
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm
@@ -379,15 +379,17 @@ using namespace AdaptiveCards;
 {
     [self addToAsyncRenderingList:action];
     
+    std::shared_ptr<BaseActionElement> act = action;
+    
     /// generate a string key to uniquely identify Image
-    if(!(action->GetIconUrl().empty()))
+    if(!(act->GetIconUrl().empty()))
     {
         // run image downloading and processing on global queue which is concurrent and different from main queue
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0),
             ^{
-                NSString *urlStr = [NSString stringWithCString:action->GetIconUrl().c_str() encoding:[NSString defaultCStringEncoding]];
+                NSString *urlStr = [NSString stringWithCString:act->GetIconUrl().c_str() encoding:[NSString defaultCStringEncoding]];
                 // generate key for imageMap from image element's id
-                NSString *key = [NSString stringWithCString:action->GetId().c_str() encoding:[NSString defaultCStringEncoding]];
+                NSString *key = [NSString stringWithCString:act->GetId().c_str() encoding:[NSString defaultCStringEncoding]];
                 NSURL *url = [NSURL URLWithString:urlStr];
                 
                 // download image
@@ -434,12 +436,12 @@ using namespace AdaptiveCards;
                             }
                             
                             // remove tag
-                            std::string id = action->GetId();
+                            std::string id = act->GetId();
                             std::size_t idx = id.find_last_of('_');
-                            action->SetId(id.substr(0, idx));
+                            act->SetId(id.substr(0, idx));
                         }
                                           
-                        [self removeFromAsyncRenderingListAndNotifyIfNeeded:action];
+                        [self removeFromAsyncRenderingListAndNotifyIfNeeded:act];
                     });
                 }
             );

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm
@@ -419,21 +419,20 @@ using namespace AdaptiveCards;
                             double scaleRatio = imageHeight / originalImageSize.height;
                             double imageWidth = scaleRatio * originalImageSize.width;
                             
-                            UIImage *scaledImage = [self scaleImage:img toSize:CGSizeMake(imageWidth, imageHeight)];
-                            [button setImage:scaledImage forState:UIControlStateNormal];
-                            
+                            UIImageView *imageView = [[UIImageView alloc] initWithImage:img];
+                           
                             IconPlacement iconPlacement = [_hostConfig getHostConfig]->actions.iconPlacement;
                             if( iconPlacement == AdaptiveCards::IconPlacement::AboveTitle ){
-                                // Changes the insets for image, title and contents so the icon is rendered above the title
-                                CGFloat totalHeight = (imageHeight + contentSize.height);
-                                [button setImageEdgeInsets:UIEdgeInsetsMake(-(totalHeight - 2 * imageHeight), 0.0f, 0.0f, -contentSize.width)];
-                                [button setTitleEdgeInsets:UIEdgeInsetsMake(imageHeight, -imageWidth, - (totalHeight - contentSize.height), 0.0f)];
+                                [imageView setFrame:CGRectMake( (button.frame.size.width - imageWidth) / 2, 5, imageWidth, imageHeight)];
+                                [button setTitleEdgeInsets:UIEdgeInsetsMake(imageHeight, 5, -imageHeight, 5)];
                                 [button setContentEdgeInsets:UIEdgeInsetsMake(5, 5, 5 + imageHeight, 5)];
                             } else {
-                                // The icons are drawn to the left of the title by default, so we only set the padding to the right for the image
                                 int iconPadding = [_hostConfig getHostConfig]->spacing.defaultSpacing;
-                                [button setImageEdgeInsets:UIEdgeInsetsMake(0, 0, 0, iconPadding)];
+                                [button setTitleEdgeInsets:UIEdgeInsetsMake(5, (iconPadding + imageWidth), 5, 0)];
+                                double titleOriginX = button.titleLabel.frame.origin.x;
+                                [imageView setFrame:CGRectMake( titleOriginX - (iconPadding + imageWidth) / 2, 5, imageWidth, imageHeight)];
                             }
+                            [button addSubview:imageView];
                             
                             // remove tag
                             std::string id = act->GetId();
@@ -493,16 +492,5 @@ using namespace AdaptiveCards;
 - (ACOAdaptiveCard *)card
 {
     return _adaptiveCard;
-}
-
-- (UIImage*)scaleImage:(UIImage *)image toSize:(CGSize)newSize {
-    //UIGraphicsBeginImageContext(newSize);
-    // In next line, pass 0.0 to use the current device's pixel scaling factor (and thus account for Retina resolution).
-    // Pass 1.0 to force exact pixel size.
-    UIGraphicsBeginImageContextWithOptions(newSize, NO, 0.0);
-    [image drawInRect:CGRectMake(0, 0, newSize.width, newSize.height)];
-    UIImage *scaledImage = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
-    return scaledImage;
 }
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm
@@ -394,6 +394,7 @@ using namespace AdaptiveCards;
                 
                 // download image
                 UIImage *img = [UIImage imageWithData:[NSData dataWithContentsOfURL:url]];
+                UIImageView *imageView = [[UIImageView alloc] initWithImage:img];
                 
                 // UITask can't be run on global queue, add task to main queue
                 dispatch_async(dispatch_get_main_queue(),
@@ -402,8 +403,8 @@ using namespace AdaptiveCards;
                         // syncronize access to image map
                         dispatch_sync(_serial_queue,
                             ^{
-                                if(!_actionsMap[key]) {// UIButton is not ready, cache UIImage
-                                    _actionsMap[key] = img;
+                                if(!_actionsMap[key]) {// UIButton is not ready, cache UIImageView
+                                    _actionsMap[key] = imageView;
                                 } else {// UIButton ready, get view
                                     button = _actionsMap[key];
                                 }
@@ -418,8 +419,6 @@ using namespace AdaptiveCards;
                             CGSize originalImageSize = [img size];
                             double scaleRatio = imageHeight / originalImageSize.height;
                             double imageWidth = scaleRatio * originalImageSize.width;
-                            
-                            UIImageView *imageView = [[UIImageView alloc] initWithImage:img];
                            
                             IconPlacement iconPlacement = [_hostConfig getHostConfig]->actions.iconPlacement;
                             if( iconPlacement == AdaptiveCards::IconPlacement::AboveTitle ){

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm
@@ -403,9 +403,12 @@ using namespace AdaptiveCards;
                         // syncronize access to image map
                         dispatch_sync(_serial_queue,
                             ^{
-                                if(!_actionsMap[key]) {// UIButton is not ready, cache UIImageView
+                                if(!_actionsMap[key]) // UIButton is not ready, cache UIImageView
+                                {
                                     _actionsMap[key] = imageView;
-                                } else {// UIButton ready, get view
+                                }
+                                else // UIButton ready, get view
+                                {
                                     button = _actionsMap[key];
                                 }
                             });
@@ -413,25 +416,7 @@ using namespace AdaptiveCards;
                         // if view is available, set image to it, and continue image processing
                         if(button)
                         {
-                            // Format the image so it fits in the button and is placed where it must be placed
-                            CGSize contentSize = [button.titleLabel intrinsicContentSize];
-                            double imageHeight = contentSize.height;
-                            CGSize originalImageSize = [img size];
-                            double scaleRatio = imageHeight / originalImageSize.height;
-                            double imageWidth = scaleRatio * originalImageSize.width;
-                           
-                            IconPlacement iconPlacement = [_hostConfig getHostConfig]->actions.iconPlacement;
-                            if( iconPlacement == AdaptiveCards::IconPlacement::AboveTitle ){
-                                [imageView setFrame:CGRectMake( (button.frame.size.width - imageWidth) / 2, 5, imageWidth, imageHeight)];
-                                [button setTitleEdgeInsets:UIEdgeInsetsMake(imageHeight, 5, -imageHeight, 5)];
-                                [button setContentEdgeInsets:UIEdgeInsetsMake(5, 5, 5 + imageHeight, 5)];
-                            } else {
-                                int iconPadding = [_hostConfig getHostConfig]->spacing.defaultSpacing;
-                                [button setTitleEdgeInsets:UIEdgeInsetsMake(5, (iconPadding + imageWidth), 5, 0)];
-                                double titleOriginX = button.titleLabel.frame.origin.x;
-                                [imageView setFrame:CGRectMake( titleOriginX - (iconPadding + imageWidth) / 2, 5, imageWidth, imageHeight)];
-                            }
-                            [button addSubview:imageView];
+                            [ACRView setImageView:imageView inButton:button withConfig:_hostConfig];
                             
                             // remove tag
                             std::string id = act->GetId();
@@ -491,5 +476,31 @@ using namespace AdaptiveCards;
 - (ACOAdaptiveCard *)card
 {
     return _adaptiveCard;
+}
+
++ (void)setImageView:(UIImageView*)imageView inButton:(UIButton*)button withConfig:(ACOHostConfig *)config
+{
+    // Format the image so it fits in the button and is placed where it must be placed
+    CGSize contentSize = [button.titleLabel intrinsicContentSize];
+    double imageHeight = contentSize.height;
+    CGSize originalImageSize = [imageView intrinsicContentSize];
+    double scaleRatio = imageHeight / originalImageSize.height;
+    double imageWidth = scaleRatio * originalImageSize.width;
+    
+    IconPlacement iconPlacement = [config getHostConfig]->actions.iconPlacement;
+    if(iconPlacement == AdaptiveCards::IconPlacement::AboveTitle)
+    {
+        [imageView setFrame:CGRectMake( (button.frame.size.width - imageWidth) / 2, 5, imageWidth, imageHeight)];
+        [button setTitleEdgeInsets:UIEdgeInsetsMake(imageHeight, 5, -imageHeight, 5)];
+        [button setContentEdgeInsets:UIEdgeInsetsMake(5, 5, 5 + imageHeight, 5)];
+    }
+    else
+    {
+        int iconPadding = [config getHostConfig]->spacing.defaultSpacing;
+        [button setTitleEdgeInsets:UIEdgeInsetsMake(5, (iconPadding + imageWidth), 5, 0)];
+        double titleOriginX = button.titleLabel.frame.origin.x;
+        [imageView setFrame:CGRectMake( titleOriginX - (iconPadding + imageWidth) / 2, 5, imageWidth, imageHeight)];
+    }
+    [button addSubview:imageView];
 }
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRViewPrivate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRViewPrivate.h
@@ -14,4 +14,6 @@
 // Walk through adaptive cards elements and if images are found, download and process images concurrently and on different thread
 // from main thread, so images process won't block UI thread.
 - (void) addTasksToConcurrentQueue:(std::vector<std::shared_ptr<BaseCardElement>> const &) body;
+// Different method to just handle the actions so they wont be processed multiple times
+- (void) addActionsToConcurrentQueue:(std::vector<std::shared_ptr<BaseActionElement>> const &) actions;
 @end


### PR DESCRIPTION
Adds support for rendering actions that include an icon above or left of the title. 

Issue: https://github.com/Microsoft/AdaptiveCards/issues/1279

Original thread: https://github.com/Microsoft/AdaptiveCards/issues/389