### PR TITLE
[UWP] Add height property to element properties

### DIFF
--- a/samples/v1.0/Elements/ColumnSet.VerticalStretch.json
+++ b/samples/v1.0/Elements/ColumnSet.VerticalStretch.json
@@ -1,0 +1,46 @@
+{
+	"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+	"type": "AdaptiveCard",
+	"height": "stretch",
+	"version": "1.0",
+	"body": [
+		{
+			"type": "ColumnSet",
+			"columns": [
+				{
+					"width": 1,
+					"items": [
+						{
+							"type": "TextBlock",
+							"text": "The left column has a very, very long text which makes it very tall. Because it is tall, the right column is also very tall. The right column contains two TextBlocks; one is displaying at the top of the column, while the other one is displayed at the bottom. That is achieved by setting the first TextBlock's **height** property to **stretch**.",
+							"wrap": true
+						},
+						{
+							"type": "TextBlock",
+							"text": "Ok",
+							"wrap": true
+						}
+					]
+				},
+				{
+					"width": 1,
+					"spacing": "large",
+					"separator": true,
+					"items": [
+						{
+							"type": "TextBlock",
+							"height": "stretch",
+							"text": "First TextBlock displayed at the top",
+							"wrap": true
+						},
+						{
+							"type": "TextBlock",
+							"text": "Second TextBlock displayed at the bottom",
+							"wrap": true
+						}
+					]
+				}
+			]
+		}
+	]
+}

--- a/source/shared/cpp/ObjectModel/BaseCardElement.cpp
+++ b/source/shared/cpp/ObjectModel/BaseCardElement.cpp
@@ -66,6 +66,16 @@ void BaseCardElement::SetSpacing(const Spacing value)
     m_spacing = value;
 }
 
+Height BaseCardElement::GetHeight() const
+{
+    return m_height;
+}
+
+void BaseCardElement::SetHeight(const Height value)
+{
+    m_height = value;
+}
+
 std::string BaseCardElement::GetId() const
 {
     return m_id;
@@ -94,6 +104,7 @@ Json::Value BaseCardElement::SerializeToJsonValue()
     root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Spacing)] = SpacingToString(GetSpacing());
     root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Separator)] = GetSeparator();
     root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Id)] = GetId();
+    root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Height)] = Height::SerializeToString(GetHeight());
 
     /* Issue #629 to make separator an object
     Json::Value jsonSeparator;
@@ -102,7 +113,6 @@ Json::Value BaseCardElement::SerializeToJsonValue()
 
     root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Separator)] = jsonSeparator;
     */
-
     return root;
 }
 

--- a/source/shared/cpp/ObjectModel/BaseCardElement.cpp
+++ b/source/shared/cpp/ObjectModel/BaseCardElement.cpp
@@ -104,7 +104,7 @@ Json::Value BaseCardElement::SerializeToJsonValue()
     root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Spacing)] = SpacingToString(GetSpacing());
     root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Separator)] = GetSeparator();
     root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Id)] = GetId();
-    root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Height)] = Height::SerializeToString(GetHeight());
+    root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Height)] = HeightTypeToString(GetHeight().GetHeightType());
 
     /* Issue #629 to make separator an object
     Json::Value jsonSeparator;

--- a/source/shared/cpp/ObjectModel/BaseCardElement.h
+++ b/source/shared/cpp/ObjectModel/BaseCardElement.h
@@ -2,6 +2,7 @@
 
 #include "pch.h"
 #include "Enums.h"
+#include "Height.h"
 #include "json/json.h"
 #include "BaseActionElement.h"
 #include "ParseUtil.h"
@@ -27,6 +28,9 @@ public:
 
     virtual bool GetSeparator() const;
     virtual void SetSeparator(const bool value);
+
+    Height GetHeight() const;
+    void SetHeight(const Height value);
 
     virtual Spacing GetSpacing() const;
     virtual void SetSpacing(const Spacing value);
@@ -65,6 +69,7 @@ private:
     //std::shared_ptr<Separator> m_separator; Issue #629 to make separator an object
     bool m_separator;
     Json::Value m_additionalProperties;
+    Height m_height;
 };
 
 template <typename T>
@@ -79,6 +84,8 @@ std::shared_ptr<T> BaseCardElement::Deserialize(const Json::Value& json)
             ParseUtil::GetEnumValue<Spacing>(json, AdaptiveCardSchemaKey::Spacing, Spacing::Default, SpacingFromString)); 
     baseCardElement->SetSeparator(ParseUtil::GetBool(json, AdaptiveCardSchemaKey::Separator, false));
     baseCardElement->SetId(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Id));
+    baseCardElement->SetHeight(
+        ParseUtil::ExtractJsonValueAndMergeWithDefault<Height>(json, AdaptiveCardSchemaKey::Height, Height(), Height::Deserialize));
   
     /* Issue #629 to make separator an object
     Json::Value separatorJson = json.get(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Separator), Json::Value());

--- a/source/shared/cpp/ObjectModel/BaseCardElement.h
+++ b/source/shared/cpp/ObjectModel/BaseCardElement.h
@@ -84,9 +84,10 @@ std::shared_ptr<T> BaseCardElement::Deserialize(const Json::Value& json)
             ParseUtil::GetEnumValue<Spacing>(json, AdaptiveCardSchemaKey::Spacing, Spacing::Default, SpacingFromString)); 
     baseCardElement->SetSeparator(ParseUtil::GetBool(json, AdaptiveCardSchemaKey::Separator, false));
     baseCardElement->SetId(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Id));
-    baseCardElement->SetHeight(
-        ParseUtil::ExtractJsonValueAndMergeWithDefault<Height>(json, AdaptiveCardSchemaKey::Height, Height(), Height::Deserialize));
-  
+
+    baseCardElement->SetHeight(Height::Deserialize(json));
+    // baseCardElement->SetHeight(ParseUtil::ExtractJsonValueAndMergeWithDefault<Height>(json, AdaptiveCardSchemaKey::Height, Height(), Height::Deserialize));
+
     /* Issue #629 to make separator an object
     Json::Value separatorJson = json.get(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Separator), Json::Value());
     if (!separatorJson.empty())

--- a/source/shared/cpp/ObjectModel/Column.cpp
+++ b/source/shared/cpp/ObjectModel/Column.cpp
@@ -13,10 +13,10 @@ Column::Column() : BaseCardElement(CardElementType::Column), m_width("Auto")
 Column::Column(
     Spacing spacing,
     bool separation,
-    std::string size,
+    std::string width,
     ContainerStyle style,
     std::vector<std::shared_ptr<BaseCardElement>>& items) :
-    BaseCardElement(CardElementType::Column, spacing, separation), m_width(size), m_style(style), m_items(items)
+    BaseCardElement(CardElementType::Column, spacing, separation), m_width(width), m_style(style), m_items(items)
 {
     PopulateKnownPropertiesSet();
 }

--- a/source/shared/cpp/ObjectModel/Column.h
+++ b/source/shared/cpp/ObjectModel/Column.h
@@ -10,8 +10,8 @@ class Column : public BaseCardElement
 {
 public:
     Column();
-    Column(Spacing spacing, bool separation, std::string size, ContainerStyle style);
-    Column(Spacing spacing, bool separation, std::string size, ContainerStyle style, std::vector<std::shared_ptr<BaseCardElement>>& items);
+    Column(Spacing spacing, bool separation, std::string width, ContainerStyle style);
+    Column(Spacing spacing, bool separation, std::string width, ContainerStyle style, std::vector<std::shared_ptr<BaseCardElement>>& items);
 
     virtual std::string Serialize();
     virtual Json::Value SerializeToJsonValue();
@@ -45,6 +45,7 @@ private:
 
     std::string m_width;
     std::vector<std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>> m_items;
+    static const std::unordered_map<CardElementType, std::function<std::shared_ptr<BaseCardElement>(const Json::Value&)>, EnumHash> CardElementParsers; // I dont know what this is used for
     std::shared_ptr<BaseActionElement> m_selectAction;
     ContainerStyle m_style;
 };

--- a/source/shared/cpp/ObjectModel/Enums.cpp
+++ b/source/shared/cpp/ObjectModel/Enums.cpp
@@ -54,6 +54,7 @@ void GetAdaptiveCardSchemaKeyEnumMappings(
         { AdaptiveCardSchemaKey::FontSizes, "fontSizes" },
         { AdaptiveCardSchemaKey::FontWeights, "fontWeights" },
         { AdaptiveCardSchemaKey::Good, "good" },
+        { AdaptiveCardSchemaKey::Height, "height" },
         { AdaptiveCardSchemaKey::HorizontalAlignment, "horizontalAlignment" },
         { AdaptiveCardSchemaKey::IconPlacement, "iconPlacement" },
         { AdaptiveCardSchemaKey::IconUrl, "iconUrl" },
@@ -198,6 +199,30 @@ void GetActionTypeEnumMappings(
     if (actionTypeNameToEnumOut != nullptr)
     {
         *actionTypeNameToEnumOut = actionTypeNameToEnum;
+    }
+}
+
+void GetHeightTypeEnumMappings(
+    std::unordered_map<HeightType, std::string, EnumHash> * heightTypeEnumToNameOut,
+    std::unordered_map<std::string, HeightType, CaseInsensitiveHash, CaseInsensitiveEqualTo> * heightTypeNameToEnumOut)
+{
+    static std::unordered_map<HeightType, std::string, EnumHash> HeightTypeEnumToName =
+    {
+        { HeightType::Auto, "Auto" },
+        { HeightType::Stretch, "Stretch" }
+    };
+
+    static std::unordered_map<std::string, HeightType, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+        HeightTypeNameToEnum = GenerateStringToEnumMap<HeightType>(HeightTypeEnumToName);
+
+    if (heightTypeEnumToNameOut != nullptr)
+    {
+        *heightTypeEnumToNameOut = HeightTypeEnumToName;
+    }
+
+    if (heightTypeNameToEnumOut != nullptr)
+    {
+        *heightTypeNameToEnumOut = HeightTypeNameToEnum;
     }
 }
 
@@ -651,6 +676,32 @@ ActionType ActionTypeFromString(const std::string& actionType)
     }
 
     return actionTypeNameToEnum[actionType];
+}
+
+const std::string HeightTypeToString(HeightType heightType)
+{
+    std::unordered_map<HeightType, std::string, EnumHash> heightTypeEnumToName;
+    GetHeightTypeEnumMappings(&heightTypeEnumToName, nullptr);
+
+    if (heightTypeEnumToName.find(heightType) == heightTypeEnumToName.end())
+    {
+        throw std::out_of_range("Invalid HeightType type");
+    }
+
+    return heightTypeEnumToName[heightType];
+}
+
+HeightType HeightTypeFromString(const std::string& heightType)
+{
+    std::unordered_map<std::string, HeightType, CaseInsensitiveHash, CaseInsensitiveEqualTo> heightTypeNameToEnum;
+    GetHeightTypeEnumMappings(nullptr, &heightTypeNameToEnum);
+
+    if (heightTypeNameToEnum.find(heightType) == heightTypeNameToEnum.end())
+    {
+        return HeightType::Auto;
+    }
+
+    return heightTypeNameToEnum[heightType];
 }
 
 const std::string HorizontalAlignmentToString(HorizontalAlignment alignment)

--- a/source/shared/cpp/ObjectModel/Enums.cpp
+++ b/source/shared/cpp/ObjectModel/Enums.cpp
@@ -206,23 +206,23 @@ void GetHeightTypeEnumMappings(
     std::unordered_map<HeightType, std::string, EnumHash> * heightTypeEnumToNameOut,
     std::unordered_map<std::string, HeightType, CaseInsensitiveHash, CaseInsensitiveEqualTo> * heightTypeNameToEnumOut)
 {
-    static std::unordered_map<HeightType, std::string, EnumHash> HeightTypeEnumToName =
+    static std::unordered_map<HeightType, std::string, EnumHash> heightTypeEnumToName =
     {
         { HeightType::Auto, "Auto" },
         { HeightType::Stretch, "Stretch" }
     };
 
     static std::unordered_map<std::string, HeightType, CaseInsensitiveHash, CaseInsensitiveEqualTo>
-        HeightTypeNameToEnum = GenerateStringToEnumMap<HeightType>(HeightTypeEnumToName);
+        heightTypeNameToEnum = GenerateStringToEnumMap<HeightType>(heightTypeEnumToName);
 
     if (heightTypeEnumToNameOut != nullptr)
     {
-        *heightTypeEnumToNameOut = HeightTypeEnumToName;
+        *heightTypeEnumToNameOut = heightTypeEnumToName;
     }
 
     if (heightTypeNameToEnumOut != nullptr)
     {
-        *heightTypeNameToEnumOut = HeightTypeNameToEnum;
+        *heightTypeNameToEnumOut = heightTypeNameToEnum;
     }
 }
 

--- a/source/shared/cpp/ObjectModel/Enums.h
+++ b/source/shared/cpp/ObjectModel/Enums.h
@@ -79,6 +79,7 @@ enum class AdaptiveCardSchemaKey
     FontSizes,
     FontWeights,
     Good,
+    Height,
     HorizontalAlignment,
     IconPlacement,
     IconUrl,
@@ -314,6 +315,12 @@ enum class IconPlacement
     LeftOfTitle
 };
 
+enum class HeightType
+{
+    Auto = 0,
+    Stretch
+};
+
 const std::string AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey type);
 AdaptiveCardSchemaKey AdaptiveCardSchemaKeyFromString(const std::string& type);
 
@@ -322,6 +329,9 @@ CardElementType CardElementTypeFromString(const std::string& elementType);
 
 const std::string ActionTypeToString(ActionType actionType);
 ActionType ActionTypeFromString(const std::string& actionType);
+
+const std::string HeightTypeToString(HeightType heightType);
+HeightType HeightTypeFromString(const std::string& heightType);
 
 const std::string HorizontalAlignmentToString(HorizontalAlignment alignment);
 HorizontalAlignment HorizontalAlignmentFromString(const std::string& alignment);

--- a/source/shared/cpp/ObjectModel/Height.cpp
+++ b/source/shared/cpp/ObjectModel/Height.cpp
@@ -2,17 +2,46 @@
 #include "Height.h"
 #include "ParseUtil.h"
 
-using namespace AdaptiveCards;
+using namespace AdaptiveSharedNamespace;
 
-Height Height::Deserialize(const Json::Value& json, const Height& defaultValue)
+Height::Height() : m_heightType(HeightType::Auto) { }
+
+Height::Height(HeightType heightType) : m_heightType(heightType) { }
+
+HeightType Height::GetHeightType()
 {
-    Height result;
-    ParseUtil::ThrowIfNotJsonObject(json);
-    result.heightType = HeightTypeFromString(json.asString());
-    return result;
+    return m_heightType;
 }
 
-std::string Height::SerializeToString(const Height& defaultValue)
+void Height::SetHeightType(HeightType value)
 {
-    return HeightTypeToString(defaultValue.heightType);
+    m_heightType = value;
+}
+
+Height Height::Deserialize(
+    const Json::Value& json)
+{
+    HeightType heightType = ParseUtil::GetEnumValue<HeightType>(json, AdaptiveCardSchemaKey::Height, HeightType::Auto, HeightTypeFromString, false /* isRequired */);
+    Height height(heightType);
+    return height;
+}
+
+std::shared_ptr<Height> Height::DeserializeFromString(
+    const std::string& jsonString)
+{
+    return std::make_shared<Height>(Height::Deserialize(ParseUtil::GetJsonValueFromString(jsonString)));
+}
+
+std::string Height::Serialize()
+{
+    Json::FastWriter writer;
+    return writer.write(SerializeToJsonValue());
+}
+
+Json::Value Height::SerializeToJsonValue()
+{
+    Json::Value root;
+    root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Height)] = HeightTypeToString(GetHeightType());
+
+    return root;
 }

--- a/source/shared/cpp/ObjectModel/Height.cpp
+++ b/source/shared/cpp/ObjectModel/Height.cpp
@@ -1,0 +1,18 @@
+#include "pch.h"
+#include "Height.h"
+#include "ParseUtil.h"
+
+using namespace AdaptiveCards;
+
+Height Height::Deserialize(const Json::Value& json, const Height& defaultValue)
+{
+    Height result;
+    ParseUtil::ThrowIfNotJsonObject(json);
+    result.heightType = HeightTypeFromString(json.asString());
+    return result;
+}
+
+std::string Height::SerializeToString(const Height& defaultValue)
+{
+    return HeightTypeToString(defaultValue.heightType);
+}

--- a/source/shared/cpp/ObjectModel/Height.h
+++ b/source/shared/cpp/ObjectModel/Height.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "pch.h"
+#include "Enums.h"
+#include "json/json.h"
+
+namespace AdaptiveCards
+{
+struct Height
+{
+    // Height is a struct rather than an enum since in the future it's possible that we'll have
+    // heights of pixel heights, or star-based heights. So following a similar pattern to XAML GridLength.
+    HeightType heightType = HeightType::Auto;
+
+    static Height Deserialize(const Json::Value& json, const Height& defaultValue);
+    static std::string SerializeToString(const Height& defaultValue);
+};
+}

--- a/source/shared/cpp/ObjectModel/Height.h
+++ b/source/shared/cpp/ObjectModel/Height.h
@@ -4,15 +4,29 @@
 #include "Enums.h"
 #include "json/json.h"
 
-namespace AdaptiveCards
+AdaptiveSharedNamespaceStart
+class Height
 {
-struct Height
-{
+public:
+    Height();
+    Height(HeightType heightType);
+
+    HeightType GetHeightType();
+    void SetHeightType(HeightType value);
+
+    std::string Serialize();
+
+    Json::Value SerializeToJsonValue();
+
+    static Height Deserialize(
+        const Json::Value& root);
+
+    static std::shared_ptr<Height> DeserializeFromString(
+        const std::string& jsonString);
+
+private:
     // Height is a struct rather than an enum since in the future it's possible that we'll have
     // heights of pixel heights, or star-based heights. So following a similar pattern to XAML GridLength.
-    HeightType heightType = HeightType::Auto;
-
-    static Height Deserialize(const Json::Value& json, const Height& defaultValue);
-    static std::string SerializeToString(const Height& defaultValue);
+    HeightType m_heightType;
 };
-}
+AdaptiveSharedNamespaceEnd

--- a/source/uwp/ObjectModelProjection/ObjectModelProjection.vcxproj
+++ b/source/uwp/ObjectModelProjection/ObjectModelProjection.vcxproj
@@ -43,6 +43,7 @@
     <ClCompile Include="..\..\shared\cpp\ObjectModel\ColumnSet.cpp" />
     <ClCompile Include="..\..\shared\cpp\ObjectModel\Fact.cpp" />
     <ClCompile Include="..\..\shared\cpp\ObjectModel\FactSet.cpp" />
+    <ClCompile Include="..\..\shared\cpp\ObjectModel\Height.cpp" />
     <ClCompile Include="..\..\shared\cpp\ObjectModel\Image.cpp" />
     <ClCompile Include="..\..\shared\cpp\ObjectModel\ImageSet.cpp" />
     <ClCompile Include="..\..\shared\cpp\ObjectModel\DateInput.cpp" />
@@ -84,6 +85,7 @@
     <ClInclude Include="..\..\shared\cpp\ObjectModel\ElementParserRegistration.h" />
     <ClInclude Include="..\..\shared\cpp\ObjectModel\Fact.h" />
     <ClInclude Include="..\..\shared\cpp\ObjectModel\FactSet.h" />
+    <ClInclude Include="..\..\shared\cpp\ObjectModel\Height.h" />
     <ClInclude Include="..\..\shared\cpp\ObjectModel\HostConfig.h" />
     <ClInclude Include="..\..\shared\cpp\ObjectModel\Image.h" />
     <ClInclude Include="..\..\shared\cpp\ObjectModel\ImageSet.h" />

--- a/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj
+++ b/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj
@@ -173,6 +173,7 @@
     <ClInclude Include="lib\AdaptiveFact.h" />
     <ClInclude Include="lib\AdaptiveFactSet.h" />
     <ClInclude Include="lib\AdaptiveFactSetConfig.h" />
+    <ClInclude Include="lib\AdaptiveHeight.h" />
     <ClInclude Include="lib\AdaptiveHostConfig.h" />
     <ClInclude Include="lib\AdaptiveImage.h" />
     <ClInclude Include="lib\AdaptiveImageSet.h" />
@@ -261,6 +262,7 @@
     <ClCompile Include="lib\AdaptiveFact.cpp" />
     <ClCompile Include="lib\AdaptiveFactSet.cpp" />
     <ClCompile Include="lib\AdaptiveFactSetConfig.cpp" />
+    <ClCompile Include="lib\AdaptiveHeight.cpp" />
     <ClCompile Include="lib\AdaptiveHostConfig.cpp" />
     <ClCompile Include="lib\AdaptiveImage.cpp" />
     <ClCompile Include="lib\AdaptiveImageSet.cpp" />

--- a/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
+++ b/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
@@ -83,6 +83,7 @@ AdaptiveNamespaceStart
     runtimeclass AdaptiveDateInputRenderer;
     runtimeclass AdaptiveElementRendererRegistration;
     runtimeclass AdaptiveFactSetRenderer;
+    runtimeclass AdaptiveHeight;
     runtimeclass AdaptiveImageRenderer;
     runtimeclass AdaptiveImageSetRenderer;
     runtimeclass AdaptiveNumberInputRenderer;
@@ -142,6 +143,7 @@ AdaptiveNamespaceStart
     interface IRenderedAdaptiveCard;
     interface IAdaptiveInputs;
     interface IAdaptiveActionEventArgs;
+    interface IAdaptiveHeight;
 
     interface IAdaptiveElementParserRegistration;
     interface IAdaptiveElementParserRegistrationStatics;
@@ -407,6 +409,17 @@ AdaptiveNamespaceStart
         LeftOfTitle
     } IconPlacement;
 
+    [version(NTDDI_WIN10_RS1)]
+#ifdef ADAPTIVE_CARDS_WINDOWS
+    [contract(InternalContract, 1)]
+    [internal]
+#endif
+    typedef [v1_enum] enum HeightType
+    {
+        Auto = 0,
+        Stretch
+    } HeightType;
+
     declare
     {
         interface Windows.Foundation.Collections.IVector<IAdaptiveCardElement*>;
@@ -436,6 +449,9 @@ AdaptiveNamespaceStart
     {
         [propget] HRESULT ElementType([out, retval] ElementType* value);
         [propget] HRESULT ElementTypeString([out, retval] HSTRING* value);
+
+        [propget] HRESULT Height([out, retval] AdaptiveHeight** value);
+        [propput] HRESULT Height([in] AdaptiveHeight* value);
 
         [propget] HRESULT Spacing([out, retval] Spacing* value);
         [propput] HRESULT Spacing([in] Spacing value);
@@ -2526,7 +2542,7 @@ AdaptiveNamespaceStart
         HRESULT AddError([in] ErrorStatusCode statusCode, [in] HSTRING message);
         HRESULT AddWarning([in] WarningStatusCode statusCode, [in] HSTRING message);
     };
-
+    
     [
         version(NTDDI_WIN10_RS1),
         activatable(NTDDI_WIN10_RS1),
@@ -2539,6 +2555,37 @@ AdaptiveNamespaceStart
     runtimeclass AdaptiveRenderContext
     {
         [default] interface IAdaptiveRenderContext;
+    };
+
+    [
+        version(NTDDI_WIN10_RS1),
+        exclusiveto(AdaptiveHeight),
+#ifdef ADAPTIVE_CARDS_WINDOWS
+        uuid(d37a48d6-6cd8-11e7-907b-a6006ad3dba0),
+        contract(InternalContract, 1),
+        internal
+#else
+        uuid(2b6520f1-c000-4b6c-925f-8b2cbeba0156)
+#endif        
+    ]
+    interface IAdaptiveHeight : IInspectable
+    {
+        [propget] HRESULT HeightType([out, retval] HeightType* value);
+        [propput] HRESULT HeightType([in] HeightType value);
+    };
+
+    [
+        version(NTDDI_WIN10_RS1),
+        activatable(NTDDI_WIN10_RS1),
+#ifdef ADAPTIVE_CARDS_WINDOWS
+        contract(InternalContract, 1),
+        internal,
+        activatable(InternalContract, 1)
+#endif        
+    ]
+    runtimeclass AdaptiveHeight
+    {
+        [default] interface IAdaptiveHeight;
     };
 
     [

--- a/source/uwp/Renderer/idl/AdaptiveCards.XamlCardRenderer.idl
+++ b/source/uwp/Renderer/idl/AdaptiveCards.XamlCardRenderer.idl
@@ -695,8 +695,8 @@ namespace AdaptiveCards
         ]
         interface IAdaptiveColumn : IInspectable
         {
-            [propget] HRESULT Size([out, retval] HSTRING* value);
-            [propput] HRESULT Size([in] HSTRING value);
+            [propget] HRESULT Width([out, retval] HSTRING* value);
+            [propput] HRESULT Width([in] HSTRING value);
 
             [propget] HRESULT Items([out, retval] Windows.Foundation.Collections.IVector<IAdaptiveCardElement*>** value);
         };

--- a/source/uwp/Renderer/idl/AdaptiveCards.XamlCardRenderer.idl
+++ b/source/uwp/Renderer/idl/AdaptiveCards.XamlCardRenderer.idl
@@ -1,0 +1,1645 @@
+#include <sdkddkver.h>
+
+import "inspectable.idl";
+import "Windows.Foundation.idl";
+import "Windows.UI.Xaml.idl";
+
+namespace AdaptiveCards
+{
+    namespace XamlCardRenderer
+    {
+        runtimeclass XamlCardRenderer;
+
+        runtimeclass AdaptiveTextBlock;
+        runtimeclass AdaptiveCard;
+        runtimeclass AdaptiveImage;
+        runtimeclass AdaptiveImageSet;
+        runtimeclass AdaptiveContainer;
+        runtimeclass AdaptiveColumn;
+        runtimeclass AdaptiveColumnSet;
+        runtimeclass AdaptiveFact;
+        runtimeclass AdaptiveFactSet;
+        runtimeclass AdaptiveChoiceInput;
+        runtimeclass AdaptiveChoiceSetInput;
+        runtimeclass AdaptiveDateInput;
+        runtimeclass AdaptiveNumberInput;
+        runtimeclass AdaptiveTextInput;
+        runtimeclass AdaptiveTimeInput;
+        runtimeclass AdaptiveToggleInput;
+        runtimeclass AdaptiveHeight;
+
+        runtimeclass AdaptiveSpacingDefinition;
+        runtimeclass AdaptiveFontSizesConfig;
+        runtimeclass AdaptiveColorsConfig;
+        runtimeclass AdaptiveColorConfig;
+        runtimeclass AdaptiveTextConfig;
+        runtimeclass AdaptiveSeparationConfig;
+        runtimeclass AdaptiveImageSizesConfig;
+        runtimeclass AdaptiveTextBlockConfig;
+        runtimeclass AdaptiveImageSetConfig;
+        runtimeclass AdaptiveColumnConfig;
+        runtimeclass AdaptiveContainerConfig;
+        runtimeclass AdaptiveContainerStyleConfig;
+        runtimeclass AdaptiveColumnSetConfig;
+        runtimeclass AdaptiveImageConfig;
+        runtimeclass AdaptiveCardConfig;
+        runtimeclass AdaptiveFactSetConfig;
+        runtimeclass AdaptiveShowCardActionConfig;
+        runtimeclass AdaptiveActionsConfig;
+        runtimeclass AdaptiveDateInputConfig;
+        runtimeclass AdaptiveTimeInputConfig;
+        runtimeclass AdaptiveNumberInputConfig;
+        runtimeclass AdaptiveToggleInputConfig;
+        runtimeclass AdaptiveTextInputConfig;
+        runtimeclass AdaptiveChoiceSetInputConfig;
+        runtimeclass AdaptiveHostConfig;
+        runtimeclass AdaptiveActionEventArgs;
+
+        interface IAdaptiveCardElement;
+        interface IAdaptiveActionElement;
+        interface IAdaptiveTextBlock;
+        interface IAdaptiveCard;
+        interface IAdaptiveImage;
+        interface IAdaptiveImageSet;
+        interface IAdaptiveContainer;
+        interface IAdaptiveColumn;
+        interface IAdaptiveColumnSet;
+        interface IAdaptiveFact;
+        interface IAdaptiveFactSet;
+        interface IAdaptiveChoiceInput;
+        interface IAdaptiveChoiceSetInput;
+        interface IAdaptiveDateInput;
+        interface IAdaptiveTextInput;
+        interface IAdaptiveNumberInput;
+        interface IAdaptiveTimeInput;
+        interface IAdaptiveToggleInput;
+        interface IAdaptiveHeight;
+
+        interface IAdaptiveSpacingDefinition;
+        interface IAdaptiveFontSizesConfig;
+        interface IAdaptiveColorConfig;
+        interface IAdaptiveColorsConfig;
+        interface IAdaptiveTextConfig;
+        interface IAdaptiveSeparationConfig;
+        interface IAdaptiveImageSizesConfig;
+        interface IAdaptiveTextBlockConfig;
+        interface IAdaptiveImageSetConfig;
+        interface IAdaptiveColumnConfig;
+        interface IAdaptiveContainerStyleConfig;
+        interface IAdaptiveContainerConfig;
+        interface IAdaptiveColumnSetConfig;
+        interface IAdaptiveImageConfig;
+        interface IAdaptiveCardConfig;
+        interface IAdaptiveFactSetConfig;
+        interface IAdaptiveShowCardActionConfig;
+        interface IAdaptiveActionsConfig;
+        interface IAdaptiveDateInputConfig;
+        interface IAdaptiveTimeInputConfig;
+        interface IAdaptiveNumberInputConfig;
+        interface IAdaptiveToggleInputConfig;
+        interface IAdaptiveTextInputConfig;
+        interface IAdaptiveChoiceSetInputConfig;
+        interface IAdaptiveHostConfig;
+        interface IAdaptiveActionEventArgs;
+
+        [version(NTDDI_WIN10_RS1)]
+        typedef [v1_enum] enum HeightType
+        {
+            Auto = 0,
+            Stretch
+        } HeightType;
+
+        [version(NTDDI_WIN10_RS1)]
+        typedef [v1_enum] enum TextSize
+        {
+            Small = 0,
+            Normal,
+            Medium,
+            Large,
+            ExtraLarge
+        } TextSize;
+
+        [version(NTDDI_WIN10_RS1)]
+        typedef [v1_enum] enum TextWeight
+        {
+            Lighter = 0,
+            Normal,
+            Bolder
+        } TextWeight;
+
+        [version(NTDDI_WIN10_RS1)]
+        typedef [v1_enum] enum TextColor
+        {
+            Default = 0,
+            Dark,
+            Light,
+            Accent,
+            Good,
+            Warning,
+            Attention
+        } TextColor;
+
+        [version(NTDDI_WIN10_RS1)]
+        typedef [v1_enum] enum HAlignment
+        {
+            Left = 0,
+            Center,
+            Right
+        } HAlignment;
+
+        [version(NTDDI_WIN10_RS1)]
+        typedef [v1_enum] enum ElementType
+        {
+            Unsupported = 0,
+            AdaptiveCard,
+            TextBlock,
+            Image,
+            Container,
+            Column,
+            ColumnSet,
+            FactSet,
+            Fact,
+            ImageSet,
+            ChoiceInput,
+            ChoiceSetInput,
+            DateInput,
+            NumberInput,
+            TextInput,
+            TimeInput,
+            ToggleInput,
+        } ElementType;
+
+        [version(NTDDI_WIN10_RS1)]
+        typedef [v1_enum] enum ActionType
+        {
+            Unsupported = 0, 
+            ShowCard,
+            Submit,
+            Http,
+            OpenUrl
+        } ActionType;
+
+        [version(NTDDI_WIN10_RS1)]
+        typedef [v1_enum] enum ImageStyle {
+            Normal = 0,
+            Person
+        } ImageStyle;
+
+        [version(NTDDI_WIN10_RS1)]
+        typedef [v1_enum] enum ImageSize {
+            Default = 0,
+            Auto,
+            Stretch,
+            Small,
+            Medium,
+            Large
+        } ImageSize;
+
+        [version(NTDDI_WIN10_RS1)]
+        typedef [v1_enum] enum SeparationStyle {
+            Default = 0,
+            None,
+            Strong,
+        } SeparationStyle;
+
+        [version(NTDDI_WIN10_RS1)]
+        typedef [v1_enum] enum ActionsOrientation {
+            Vertical = 0,
+            Horizontal
+        } ActionsOrientation;
+
+        [version(NTDDI_WIN10_RS1)]
+        typedef [v1_enum] enum ActionAlignment {
+            Left = 0,
+            Center,
+            Right,
+            Stretch,
+        } ActionAlignment;
+
+        [version(NTDDI_WIN10_RS1)]
+        typedef [v1_enum] enum ActionMode {
+            InlineEdgeToEdge = 0,
+            Inline,
+            Popup
+        } ActionMode;
+
+        [version(NTDDI_WIN10_RS1)]
+        typedef [v1_enum] enum ChoiceSetStyle {
+            Compact = 0,
+            Expanded
+        } ChoiceSetStyle;
+
+        [version(NTDDI_WIN10_RS1)]
+        typedef [v1_enum] enum TextInputStyle {
+            Text = 0,
+            Tel,
+            Url,
+            Email,
+        } TextInputStyle;
+
+        [version(NTDDI_WIN10_RS1)]
+        typedef [v1_enum] enum ContainerStyle {
+            Normal = 0,
+            Emphasis
+        } ContainerStyle;
+
+        declare
+        {
+            interface Windows.Foundation.Collections.IVector<IAdaptiveCardElement*>;
+            interface Windows.Foundation.Collections.IVector<IAdaptiveActionElement*>;
+            interface Windows.Foundation.Collections.IVector<IAdaptiveColumn*>;
+            interface Windows.Foundation.Collections.IVector<IAdaptiveFact*>;
+            interface Windows.Foundation.Collections.IVector<IAdaptiveChoiceInput*>;
+            interface Windows.Foundation.Collections.IObservableVector<IAdaptiveCardElement*>;
+            interface Windows.Foundation.Collections.IObservableVector<IAdaptiveColumn*>;
+            interface Windows.Foundation.Collections.IObservableVector<IAdaptiveColumn*>;
+            interface Windows.Foundation.IAsyncOperation<Windows.UI.Xaml.UIElement*>;
+            interface Windows.Foundation.IReference<Windows.UI.Text.FontWeight>;
+        }
+
+        [
+            uuid(74D69C2F-7F1C-47FD-A319-F4B4E7F72EE9),
+            version(NTDDI_WIN10_RS1)
+        ]
+        interface IAdaptiveCardElement : IInspectable
+        {
+            [propget] HRESULT ElementType([out, retval] ElementType* value);
+
+            [propget] HRESULT Height([out, retval] AdaptiveHeight** value);
+            [propput] HRESULT Height([in] AdaptiveHeight* value);
+
+            [propget] HRESULT Speak([out, retval] HSTRING* value);
+            [propput] HRESULT Speak([in] HSTRING value);
+
+            [propget] HRESULT Separation([out, retval] SeparationStyle* value);
+            [propput] HRESULT Separation([in] SeparationStyle value);
+        };
+
+        [
+            uuid(f3b844da-2d6a-4003-8a57-4e5541fcd078),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveTextBlock)
+        ]
+        interface IAdaptiveTextBlock : IInspectable
+        {
+            [propget] HRESULT Size([out, retval] TextSize* value);
+            [propput] HRESULT Size([in] TextSize value);
+
+            [propget] HRESULT Weight([out, retval] TextWeight* value);
+            [propput] HRESULT Weight([in] TextWeight value);
+
+            [propget] HRESULT Color([out, retval] TextColor* value);
+            [propput] HRESULT Color([in] TextColor value);
+
+            [propget] HRESULT Text([out, retval] HSTRING* value);
+            [propput] HRESULT Text([in] HSTRING value);
+
+            [propget] HRESULT IsSubtle([out, retval] boolean* value);
+            [propput] HRESULT IsSubtle([in] boolean value);
+
+            [propget] HRESULT Wrap([out, retval] boolean* value);
+            [propput] HRESULT Wrap([in] boolean value);
+
+            [propget] HRESULT HorizontalAlignment([out, retval] HAlignment* value);
+            [propput] HRESULT HorizontalAlignment([in] HAlignment value);
+
+            [propget] HRESULT MaxLines([out, retval] UINT32 *value);
+            [propput] HRESULT MaxLines([in] UINT32 value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveTextBlock
+        {
+            [default] interface IAdaptiveTextBlock;
+            interface IAdaptiveCardElement;
+        };
+
+        [
+            uuid(9F68A612-9DCB-4710-8121-A116BD33B69B),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveCard),
+        ]
+        interface IAdaptiveCard : IInspectable
+        {
+            [propget] HRESULT Body([out, retval] Windows.Foundation.Collections.IVector<IAdaptiveCardElement*>** value);
+
+            [propget] HRESULT Actions([out, retval] Windows.Foundation.Collections.IVector<IAdaptiveActionElement*>** value);
+
+            [propget] HRESULT ElementType([out, retval] ElementType* value);
+
+            [propget] HRESULT Version([out, retval] HSTRING* value);
+            [propput] HRESULT Version([in] HSTRING value);
+
+            [propget] HRESULT MinVersion([out, retval] HSTRING* value);
+            [propput] HRESULT MinVersion([in] HSTRING value);
+
+            [propget] HRESULT FallbackText([out, retval] HSTRING* value);
+            [propput] HRESULT FallbackText([in] HSTRING value);
+
+            [propget] HRESULT BackgroundImageUrl([out, retval] Windows.Foundation.Uri** value);
+            [propput] HRESULT BackgroundImageUrl([in] Windows.Foundation.Uri* value);
+
+            HRESULT ToJsonString([out, retval] HSTRING* value);
+        };
+
+        [
+            uuid(C312AD20-DFE3-4418-819F-E3CB7A0CD2FE),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveCard),
+        ]
+        interface IAdaptiveCardStatics : IInspectable
+        {
+            HRESULT CreateCardFromJson([in] HSTRING adaptiveJson, [out, retval] AdaptiveCard** card);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1),
+            static(IAdaptiveCardStatics, NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveCard
+        {
+            [default] interface IAdaptiveCard;
+        }
+
+        [
+            uuid(16452a2e-1152-47f3-90bd-6e4148b09669),
+            version(NTDDI_WIN10_RS1),
+        ]
+        interface IAdaptiveImage : IInspectable
+        {
+            [propget] HRESULT Url([out, retval] Windows.Foundation.Uri** value);
+            [propput] HRESULT Url([in] Windows.Foundation.Uri* value);
+
+            [propget] HRESULT Style([out, retval] ImageStyle* value);
+            [propput] HRESULT Style([in] ImageStyle value);
+
+            [propget] HRESULT Size([out, retval] ImageSize* value);
+            [propput] HRESULT Size([in] ImageSize value);
+
+            [propget] HRESULT HorizontalAlignment([out, retval] HAlignment* value);
+            [propput] HRESULT HorizontalAlignment([in] HAlignment value);
+
+            [propget] HRESULT AltText([out, retval] HSTRING* value);
+            [propput] HRESULT AltText([in] HSTRING value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveImage
+        {
+            [default] interface IAdaptiveImage;
+            interface IAdaptiveCardElement;
+        };
+
+        [
+            uuid(f618bd35-8fe3-46bd-8988-cdf5607314d1),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveImageSet)
+        ]
+        interface IAdaptiveImageSet : IInspectable
+        {
+            [propget] HRESULT Images([out, retval] Windows.Foundation.Collections.IVector<IAdaptiveImage*>** value);
+
+            [propget] HRESULT ImageSize([out, retval] ImageSize* value);
+            [propput] HRESULT ImageSize([in] ImageSize value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveImageSet
+        {
+            [default] interface IAdaptiveImageSet;
+            interface IAdaptiveCardElement;
+        };
+
+        [
+            uuid(9b10f5ef-26e8-4d65-ba76-b986b5e90586),
+            version(NTDDI_WIN10_RS1),
+        ]
+        interface IAdaptiveInputElement : IInspectable
+        {
+            [propget] HRESULT Id([out, retval] HSTRING* value);
+            [propput] HRESULT Id([in] HSTRING value);
+
+            [propget] HRESULT IsRequired([out, retval] boolean* value);
+            [propput] HRESULT IsRequired([in] boolean value);
+        };
+
+        [
+            uuid(99797dfe-d39c-43a4-9f2b-d457cc358e1e),
+            version(NTDDI_WIN10_RS1)
+        ]
+        interface IAdaptiveChoiceInput : IInspectable
+        {
+            [propget] HRESULT ElementType([out, retval] ElementType* value);
+
+            [propget] HRESULT Speak([out, retval] HSTRING* value);
+            [propput] HRESULT Speak([in] HSTRING value);
+
+            [propget] HRESULT Title([out, retval] HSTRING* value);
+            [propput] HRESULT Title([in] HSTRING value);
+
+            [propget] HRESULT Value([out, retval] HSTRING* value);
+            [propput] HRESULT Value([in] HSTRING value);
+            
+            [propget] HRESULT IsSelected([out, retval] boolean* value);
+            [propput] HRESULT IsSelected([in] boolean value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveChoiceInput
+        {
+            [default] interface IAdaptiveChoiceInput;
+        };
+
+        [
+            uuid(ce0735ef-f983-4a5e-bdad-f5eb7f962faa),
+            version(NTDDI_WIN10_RS1)
+        ]
+        interface IAdaptiveChoiceSetInput : IInspectable
+        {
+            [propget] HRESULT IsMultiSelect([out, retval] boolean* value);
+            [propput] HRESULT IsMultiSelect([in] boolean value);
+
+            [propget] HRESULT ChoiceSetStyle([out, retval] ChoiceSetStyle* value);
+            [propput] HRESULT ChoiceSetStyle([in] ChoiceSetStyle value);
+
+            [propget] HRESULT Choices([out, retval] Windows.Foundation.Collections.IVector<IAdaptiveChoiceInput*>** value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveChoiceSetInput
+        {
+            [default] interface IAdaptiveChoiceSetInput;
+            interface IAdaptiveInputElement;
+            interface IAdaptiveCardElement;
+        };
+
+        [
+            uuid(359e2cc5-9b8d-40bf-bbb2-2d3494d30991),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveDateInput)
+        ]
+        interface IAdaptiveDateInput : IInspectable
+        {
+            [propget] HRESULT Max([out, retval] HSTRING* value);
+            [propput] HRESULT Max([in] HSTRING value);
+
+            [propget] HRESULT Min([out, retval] HSTRING* value);
+            [propput] HRESULT Min([in] HSTRING value);
+
+            [propget] HRESULT Placeholder([out, retval] HSTRING* value);
+            [propput] HRESULT Placeholder([in] HSTRING value);
+
+            [propget] HRESULT Value([out, retval] HSTRING* value);
+            [propput] HRESULT Value([in] HSTRING value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveDateInput
+        {
+            [default] interface IAdaptiveDateInput;
+            interface IAdaptiveInputElement;
+            interface IAdaptiveCardElement;
+        };
+
+        [
+            uuid(3bd0868c-5fbd-4341-91ff-4b07eb2bd54c),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveNumberInput)
+        ]
+        interface IAdaptiveNumberInput : IInspectable
+        {
+            [propget] HRESULT Max([out, retval] INT32 *value);
+            [propput] HRESULT Max([in] INT32 value);
+
+            [propget] HRESULT Min([out, retval] INT32 *value);
+            [propput] HRESULT Min([in] INT32 value);
+
+            [propget] HRESULT Placeholder([out, retval] HSTRING* value);
+            [propput] HRESULT Placeholder([in] HSTRING value);
+
+            [propget] HRESULT Value([out, retval] INT32* value);
+            [propput] HRESULT Value([in] INT32 value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveNumberInput
+        {
+            [default] interface IAdaptiveNumberInput;
+            interface IAdaptiveInputElement;
+            interface IAdaptiveCardElement;
+        };
+
+        [
+            uuid(ab30772b-172d-4595-bcd2-01001df19d1e),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveTextInput)
+        ]
+        interface IAdaptiveTextInput : IInspectable
+        {
+            [propget] HRESULT IsMultiline([out, retval] boolean* value);
+            [propput] HRESULT IsMultiline([in] boolean value);
+
+            [propget] HRESULT MaxLength([out, retval] UINT32 *value);
+            [propput] HRESULT MaxLength([in] UINT32 value);
+
+            [propget] HRESULT Placeholder([out, retval] HSTRING* value);
+            [propput] HRESULT Placeholder([in] HSTRING value);
+
+            [propget] HRESULT Value([out, retval] HSTRING* value);
+            [propput] HRESULT Value([in] HSTRING value);
+
+            [propget] HRESULT TextInputStyle([out, retval] TextInputStyle* value);
+            [propput] HRESULT TextInputStyle([in] TextInputStyle value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveTextInput
+        {
+            [default] interface IAdaptiveTextInput;
+            interface IAdaptiveInputElement;
+            interface IAdaptiveCardElement;
+        };
+
+        [
+            uuid(1ee90aff-93e8-4292-ac49-39d4c3289cd9),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveTimeInput)
+        ]
+        interface IAdaptiveTimeInput : IInspectable
+        {
+            [propget] HRESULT Max([out, retval] HSTRING* value);
+            [propput] HRESULT Max([in] HSTRING value);
+
+            [propget] HRESULT Min([out, retval] HSTRING* value);
+            [propput] HRESULT Min([in] HSTRING value);
+
+            [propget] HRESULT Placeholder([out, retval] HSTRING* value);
+            [propput] HRESULT Placeholder([in] HSTRING value);
+
+            [propget] HRESULT Value([out, retval] HSTRING* value);
+            [propput] HRESULT Value([in] HSTRING value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveTimeInput
+        {
+            [default] interface IAdaptiveTimeInput;
+            interface IAdaptiveInputElement;
+            interface IAdaptiveCardElement;
+        };
+
+        [
+            uuid(e8af72a5-597c-4a19-b9c2-1a597db1c79a),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveToggleInput)
+        ]
+        interface IAdaptiveToggleInput : IInspectable
+        {
+            [propget] HRESULT Title([out, retval] HSTRING* value);
+            [propput] HRESULT Title([in] HSTRING value);
+
+            [propget] HRESULT Value([out, retval] HSTRING* value);
+            [propput] HRESULT Value([in] HSTRING value);
+
+            [propget] HRESULT ValueOff([out, retval] HSTRING* value);
+            [propput] HRESULT ValueOff([in] HSTRING value);
+
+            [propget] HRESULT ValueOn([out, retval] HSTRING* value);
+            [propput] HRESULT ValueOn([in] HSTRING value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveToggleInput
+        {
+            [default] interface IAdaptiveToggleInput;
+            interface IAdaptiveInputElement;
+            interface IAdaptiveCardElement;
+        };
+
+        [
+            uuid(d37a48d6-6cd8-11e7-907b-a6006ad3dba0),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveHeight)
+        ]
+        interface IAdaptiveHeight : IInspectable
+        {
+            [propget] HRESULT HeightType([out, retval] HeightType* value);
+            [propput] HRESULT HeightType([in] HeightType value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveHeight
+        {
+            [default] interface IAdaptiveHeight;
+        };
+
+        [
+            uuid(ba90da3f-556c-4e3a-9d01-11f2ce78dcd7),
+            version(NTDDI_WIN10_RS1)
+        ]
+        interface IAdaptiveContainer : IInspectable
+        {
+            [propget] HRESULT Style([out, retval] ContainerStyle* value);
+            [propput] HRESULT Style([in] ContainerStyle value);
+
+            [propget] HRESULT Items([out, retval] Windows.Foundation.Collections.IVector<IAdaptiveCardElement*>** value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveContainer
+        {
+            [default] interface IAdaptiveContainer;
+            interface IAdaptiveCardElement;
+        };
+
+        [
+            uuid(91e03800-d239-43bc-b5fb-2ccfe0cc7fcb),
+            version(NTDDI_WIN10_RS1)
+        ]
+        interface IAdaptiveColumn : IInspectable
+        {
+            [propget] HRESULT Size([out, retval] HSTRING* value);
+            [propput] HRESULT Size([in] HSTRING value);
+
+            [propget] HRESULT Items([out, retval] Windows.Foundation.Collections.IVector<IAdaptiveCardElement*>** value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveColumn
+        {
+            [default] interface IAdaptiveColumn;
+            interface IAdaptiveCardElement;
+        };
+
+        [
+            uuid(4e3e1cd1-906b-4718-96ea-0a6e16bf0199),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveColumnSet)
+        ]
+        interface IAdaptiveColumnSet : IInspectable
+        {
+            [propget] HRESULT Columns([out, retval] Windows.Foundation.Collections.IVector<IAdaptiveColumn*>** value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveColumnSet
+        {
+            [default] interface IAdaptiveColumnSet;
+            interface IAdaptiveCardElement;
+        };
+
+
+        [
+            uuid(5c19aa31-03aa-4148-a529-75b855ba045b),
+            version(NTDDI_WIN10_RS1)
+        ]
+        interface IAdaptiveFact : IInspectable
+        {
+            [propget] HRESULT ElementType([out, retval] ElementType* value);
+
+            [propget] HRESULT Speak([out, retval] HSTRING* value);
+            [propput] HRESULT Speak([in] HSTRING value);
+
+            [propget] HRESULT Title([out, retval] HSTRING* value);
+            [propput] HRESULT Title([in] HSTRING value);
+
+            [propget] HRESULT Value([out, retval] HSTRING* value);
+            [propput] HRESULT Value([in] HSTRING value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveFact
+        {
+            [default] interface IAdaptiveFact;
+        };
+
+        [
+            uuid(05457b99-8090-4937-a637-b469f8edc74f),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveFactSet)
+        ]
+        interface IAdaptiveFactSet : IInspectable
+        {
+            [propget] HRESULT Facts([out, retval] Windows.Foundation.Collections.IVector<IAdaptiveFact*>** value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveFactSet
+        {
+            [default] interface IAdaptiveFactSet;
+            interface IAdaptiveCardElement;
+        };
+
+        [flags]
+        [version(NTDDI_WIN10_RS1)]
+        typedef [v1_enum] enum RenderOptions
+        {
+            None = 0x0,
+            SupportsActionBar = 0x1,
+            SupportsInlineActions = 0x2,
+        }RenderOptions;
+
+        [
+            uuid(DB7C7BB8-C313-440A-A421-B52620107F8B),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(XamlCardRenderer),
+        ]
+        interface IXamlCardRenderer : IInspectable
+        {
+            HRESULT SetRenderOptions([in] RenderOptions options);
+            HRESULT SetOverrideStyles([in] Windows.UI.Xaml.ResourceDictionary* overrideDictionary);
+            HRESULT SetHostConfig([in] AdaptiveHostConfig* hostConfig);
+
+            HRESULT RenderCardAsXaml([in] AdaptiveCard* adaptiveCard, [out, retval] Windows.UI.Xaml.UIElement** result);
+            HRESULT RenderCardAsXamlAsync([in] AdaptiveCard* adaptiveCard, [out, retval] Windows.Foundation.IAsyncOperation<Windows.UI.Xaml.UIElement*>** result);
+
+            HRESULT RenderAdaptiveJsonAsXaml([in] HSTRING adaptiveJson, [out, retval] Windows.UI.Xaml.UIElement** result);
+            HRESULT RenderAdaptiveJsonAsXamlAsync([in] HSTRING adaptiveJson, [out, retval] Windows.Foundation.IAsyncOperation<Windows.UI.Xaml.UIElement*>** result);
+
+            [eventadd] HRESULT Action([in] Windows.Foundation.TypedEventHandler<XamlCardRenderer*, AdaptiveActionEventArgs*>* pHandler, [out][retval] EventRegistrationToken* pToken);
+            [eventremove] HRESULT Action([in] EventRegistrationToken token);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1),
+        ]
+        runtimeclass XamlCardRenderer
+        {
+            [default] interface IXamlCardRenderer;
+        };
+
+        [
+            uuid(6853cff8-60ee-4270-9cd2-23b25cd8703f),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveActionEventArgs)
+        ]
+        interface IAdaptiveActionEventArgs : IInspectable
+        {
+            [propget] HRESULT Action([out, retval] IAdaptiveActionElement** action);
+            [propget] HRESULT Inputs([out, retval] HSTRING* value);
+        }
+
+        [
+            version(NTDDI_WIN10_RS1),
+        ]
+        runtimeclass AdaptiveActionEventArgs
+        {
+            [default] interface IAdaptiveActionEventArgs;
+        };
+
+        [
+            uuid(c49685af-df56-49ea-8fce-ce302788edc5),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveSpacingDefinition)
+        ]
+        interface IAdaptiveSpacingDefinition : IInspectable
+        {
+            [propget] HRESULT Left([out, retval] UINT32 *value);
+            [propput] HRESULT Left([in] UINT32 value);
+
+            [propget] HRESULT Right([out, retval] UINT32 *value);
+            [propput] HRESULT Right([in] UINT32 value);
+
+            [propget] HRESULT Bottom([out, retval] UINT32 *value);
+            [propput] HRESULT Bottom([in] UINT32 value);
+
+            [propget] HRESULT Top([out, retval] UINT32 *value);
+            [propput] HRESULT Top([in] UINT32 value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveSpacingDefinition
+        {
+            [default] interface IAdaptiveSpacingDefinition;
+        };
+
+        [
+            uuid(ebca0eab-b08b-4087-9c42-4667ec6ab0e0),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveFontSizesConfig)
+        ]
+        interface IAdaptiveFontSizesConfig : IInspectable
+        {
+            [propget] HRESULT Small([out, retval] UINT32 *value);
+            [propput] HRESULT Small([in] UINT32 value);
+
+            [propget] HRESULT Normal([out, retval] UINT32 *value);
+            [propput] HRESULT Normal([in] UINT32 value);
+
+            [propget] HRESULT Medium([out, retval] UINT32 *value);
+            [propput] HRESULT Medium([in] UINT32 value);
+
+            [propget] HRESULT Large([out, retval] UINT32 *value);
+            [propput] HRESULT Large([in] UINT32 value);
+
+            [propget] HRESULT ExtraLarge([out, retval] UINT32 *value);
+            [propput] HRESULT ExtraLarge([in] UINT32 value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveFontSizesConfig
+        {
+            [default] interface IAdaptiveFontSizesConfig;
+        };
+
+        [
+            uuid(421149d7-65e9-4ec9-b70b-802ba7d6cf98),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveColorConfig)
+        ]
+        interface IAdaptiveColorConfig : IInspectable
+        {
+            [propget] HRESULT Normal([out][retval] Windows.UI.Color* value);
+            [propput] HRESULT Normal([in] Windows.UI.Color value);
+
+            [propget] HRESULT Subtle([out][retval] Windows.UI.Color* value);
+            [propput] HRESULT Subtle([in] Windows.UI.Color value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveColorConfig
+        {
+            [default] interface IAdaptiveColorConfig;
+        };
+
+        [
+            uuid(1ade7d94-f0ae-4301-a9e2-b1f9c065916f),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveColorsConfig)
+        ]
+        interface IAdaptiveColorsConfig : IInspectable
+        {
+            [propget] HRESULT Default([out][retval] AdaptiveColorConfig** value);
+            [propput] HRESULT Default([in] AdaptiveColorConfig* value);
+
+            [propget] HRESULT Accent([out][retval] AdaptiveColorConfig** value);
+            [propput] HRESULT Accent([in] AdaptiveColorConfig* value);
+
+            [propget] HRESULT Dark([out][retval] AdaptiveColorConfig** value);
+            [propput] HRESULT Dark([in] AdaptiveColorConfig* value);
+
+            [propget] HRESULT Light([out][retval] AdaptiveColorConfig** value);
+            [propput] HRESULT Light([in] AdaptiveColorConfig* value);
+
+            [propget] HRESULT Good([out][retval] AdaptiveColorConfig** value);
+            [propput] HRESULT Good([in] AdaptiveColorConfig* value);
+
+            [propget] HRESULT Warning([out][retval] AdaptiveColorConfig** value);
+            [propput] HRESULT Warning([in] AdaptiveColorConfig* value);
+
+            [propget] HRESULT Attention([out][retval] AdaptiveColorConfig** value);
+            [propput] HRESULT Attention([in] AdaptiveColorConfig* value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveColorsConfig
+        {
+            [default] interface IAdaptiveColorsConfig;
+        };
+
+        [
+            uuid(d730ba59-1f48-4dc6-8375-17f364f6086a),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveTextConfig)
+        ]
+        interface IAdaptiveTextConfig : IInspectable
+        {
+            [propget] HRESULT Weight([out, retval] TextWeight* value);
+            [propput] HRESULT Weight([in] TextWeight value);
+
+            [propget] HRESULT Size([out, retval] TextSize* value);
+            [propput] HRESULT Size([in] TextSize value);
+
+            [propget] HRESULT Color([out, retval] TextColor* value);
+            [propput] HRESULT Color([in] TextColor value);
+ 
+            [propget] HRESULT IsSubtle([out, retval] boolean* value);
+            [propput] HRESULT IsSubtle([in] boolean value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveTextConfig
+        {
+            [default] interface IAdaptiveTextConfig;
+        };
+
+        [
+            uuid(88e10cbc-0d67-42e3-bfcc-fd2ddb31dadd),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveSeparationConfig)
+        ]
+        interface IAdaptiveSeparationConfig : IInspectable
+        {
+            [propget] HRESULT Spacing([out, retval] UINT32 *value);
+            [propput] HRESULT Spacing([in] UINT32 value);
+
+            [propget] HRESULT LineThickness([out, retval] UINT32 *value);
+            [propput] HRESULT LineThickness([in] UINT32 value);
+
+            [propget] HRESULT LineColor([out, retval] Windows.UI.Color* value);
+            [propput] HRESULT LineColor([in] Windows.UI.Color value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveSeparationConfig
+        {
+            [default] interface IAdaptiveSeparationConfig;
+        };
+
+        [
+            uuid(ce5cd318-502c-4017-a076-4f8cdbb0316d),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveImageSizesConfig)
+        ]
+        interface IAdaptiveImageSizesConfig : IInspectable
+        {
+            [propget] HRESULT Small([out, retval] UINT32 *value);
+            [propput] HRESULT Small([in] UINT32 value);
+
+            [propget] HRESULT Medium([out, retval] UINT32 *value);
+            [propput] HRESULT Medium([in] UINT32 value);
+
+            [propget] HRESULT Large([out, retval] UINT32 *value);
+            [propput] HRESULT Large([in] UINT32 value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveImageSizesConfig
+        {
+            [default] interface IAdaptiveImageSizesConfig;
+        };
+
+        [
+            uuid(51417beb-2bbc-44e5-8210-6f61414cca6f),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveTextBlockConfig)
+        ]
+        interface IAdaptiveTextBlockConfig : IInspectable
+        {
+            [propget] HRESULT SmallSeparation([out, retval] AdaptiveSeparationConfig** value);
+            [propput] HRESULT SmallSeparation([in] AdaptiveSeparationConfig* value);
+
+            [propget] HRESULT NormalSeparation([out, retval] AdaptiveSeparationConfig** value);
+            [propput] HRESULT NormalSeparation([in] AdaptiveSeparationConfig* value);
+
+            [propget] HRESULT MediumSeparation([out, retval] AdaptiveSeparationConfig** value);
+            [propput] HRESULT MediumSeparation([in] AdaptiveSeparationConfig* value);
+
+            [propget] HRESULT LargeSeparation([out, retval] AdaptiveSeparationConfig** value);
+            [propput] HRESULT LargeSeparation([in] AdaptiveSeparationConfig* value);
+
+            [propget] HRESULT ExtraLargeSeparation([out, retval] AdaptiveSeparationConfig** value);
+            [propput] HRESULT ExtraLargeSeparation([in] AdaptiveSeparationConfig* value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveTextBlockConfig
+        {
+            [default] interface IAdaptiveTextBlockConfig;
+        };
+        
+        [
+            uuid(29685cc3-027f-4da8-9659-6d3a53c34d88),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveImageSetConfig)
+        ]
+        interface IAdaptiveImageSetConfig : IInspectable
+        {
+            [propget] HRESULT ImageSize([out, retval] ImageSize* value);
+            [propput] HRESULT ImageSize([in] ImageSize value);
+
+            [propget] HRESULT Separation([out, retval] AdaptiveSeparationConfig** value);
+            [propput] HRESULT Separation([in] AdaptiveSeparationConfig* value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveImageSetConfig
+        {
+            [default] interface IAdaptiveImageSetConfig;
+        };
+
+        [
+            uuid(0103c3c1-aa6e-4fb4-ab38-9c0ff1a6a00f),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveColumnConfig)
+        ]
+        interface IAdaptiveColumnConfig : IInspectable
+        {
+            [propget] HRESULT Separation([out, retval] AdaptiveSeparationConfig **value);
+            [propput] HRESULT Separation([in] AdaptiveSeparationConfig *value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveColumnConfig
+        {
+            [default] interface IAdaptiveColumnConfig;
+        };
+
+        [
+            uuid(51b57d16-6155-4bbe-bf1a-516382ac9e81),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveContainerStyleConfig)
+        ]
+        interface IAdaptiveContainerStyleConfig : IInspectable
+        {
+            [propget] HRESULT BackgroundColor([out][retval] Windows.UI.Color* value);
+            [propput] HRESULT BackgroundColor([in] Windows.UI.Color value);
+
+            [propget] HRESULT BorderColor([out][retval] Windows.UI.Color* value);
+            [propput] HRESULT BorderColor([in] Windows.UI.Color value);
+
+            [propget] HRESULT Padding([out, retval] AdaptiveSpacingDefinition** value);
+            [propput] HRESULT Padding([in] AdaptiveSpacingDefinition* value);
+
+            [propget] HRESULT BorderThickness([out, retval] AdaptiveSpacingDefinition** value);
+            [propput] HRESULT BorderThickness([in] AdaptiveSpacingDefinition* value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveContainerStyleConfig
+        {
+            [default] interface IAdaptiveContainerStyleConfig;
+        };
+
+        [
+            uuid(740419b1-29de-435d-b8da-e34f1bd5afee),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveContainerConfig)
+        ]
+        interface IAdaptiveContainerConfig : IInspectable
+        {
+            [propget] HRESULT Separation([out, retval] AdaptiveSeparationConfig** value);
+            [propput] HRESULT Separation([in] AdaptiveSeparationConfig* value);
+
+            [propget] HRESULT Normal([out, retval] AdaptiveContainerStyleConfig** value);
+            [propput] HRESULT Normal([in] AdaptiveContainerStyleConfig* value);
+
+            [propget] HRESULT Emphasis([out, retval] AdaptiveContainerStyleConfig** value);
+            [propput] HRESULT Emphasis([in] AdaptiveContainerStyleConfig* value);
+
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveContainerConfig
+        {
+            [default] interface IAdaptiveContainerConfig;
+        };
+
+        [
+            uuid(cc83d315-b819-4980-97b1-cf950e760fc4),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveColumnSetConfig)
+        ]
+        interface IAdaptiveColumnSetConfig : IInspectable
+        {
+            [propget] HRESULT Separation([out, retval] AdaptiveSeparationConfig** value);
+            [propput] HRESULT Separation([in] AdaptiveSeparationConfig* value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveColumnSetConfig
+        {
+            [default] interface IAdaptiveColumnSetConfig;
+        };
+
+        [
+            uuid(4b8664ce-92d4-4093-af07-0d46712ac09b),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveImageConfig)
+        ]
+        interface IAdaptiveImageConfig : IInspectable
+        {
+            [propget] HRESULT Separation([out, retval] AdaptiveSeparationConfig** value);
+            [propput] HRESULT Separation([in] AdaptiveSeparationConfig* value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveImageConfig
+        {
+            [default] interface IAdaptiveImageConfig;
+        };
+
+        [
+            uuid(9363ea9c-9f73-4e7d-8d6e-0559ac52b314),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveCardConfig)
+        ]
+        interface IAdaptiveCardConfig : IInspectable
+        {
+            [propget] HRESULT Padding([out, retval] AdaptiveSpacingDefinition** value);
+            [propput] HRESULT Padding([in] AdaptiveSpacingDefinition* value);
+
+            [propget] HRESULT BackgroundColor([out][retval] Windows.UI.Color* value);
+            [propput] HRESULT BackgroundColor([in] Windows.UI.Color value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveCardConfig
+        {
+            [default] interface IAdaptiveCardConfig;
+        };
+
+        [
+            uuid(9949ed60-fbc0-49fd-80d4-29fb1184854d),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveFactSetConfig)
+        ]
+        interface IAdaptiveFactSetConfig : IInspectable
+        {
+            [propget] HRESULT Title([out, retval] AdaptiveTextConfig** value);
+            [propput] HRESULT Title([in] AdaptiveTextConfig* value);
+
+            [propget] HRESULT Value([out, retval] AdaptiveTextConfig** value);
+            [propput] HRESULT Value([in] AdaptiveTextConfig* value);
+
+            [propget] HRESULT Spacing([out][retval] UINT32* value);
+            [propput] HRESULT Spacing([in] UINT32 value);
+
+            [propget] HRESULT Separation([out, retval] AdaptiveSeparationConfig** value);
+            [propput] HRESULT Separation([in] AdaptiveSeparationConfig* value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveFactSetConfig
+        {
+            [default] interface IAdaptiveFactSetConfig;
+        };
+
+        [
+            uuid(eacabf24-288c-4307-bd5a-5888a00da918),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveShowCardActionConfig)
+        ]
+        interface IAdaptiveShowCardActionConfig : IInspectable
+        {
+            [propget] HRESULT ActionMode([out, retval] ActionMode *value);
+            [propput] HRESULT ActionMode([in] ActionMode value);
+
+            [propget] HRESULT BackgroundColor([out][retval] Windows.UI.Color* value);
+            [propput] HRESULT BackgroundColor([in] Windows.UI.Color value);
+
+            [propget] HRESULT Padding([out, retval] AdaptiveSpacingDefinition** value);
+            [propput] HRESULT Padding([in] AdaptiveSpacingDefinition* value);
+
+            [propget] HRESULT InlineTopMargin([out, retval] UINT32 *value);
+            [propput] HRESULT InlineTopMargin([in] UINT32 value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveShowCardActionConfig
+        {
+            [default] interface IAdaptiveShowCardActionConfig;
+        };
+
+        [
+            uuid(c01e7195-0c83-4fed-9911-3845bdb8ebc6),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveActionsConfig)
+        ]
+        interface IAdaptiveActionsConfig : IInspectable
+        {
+            [propget] HRESULT ShowCard([out, retval] AdaptiveShowCardActionConfig** value);
+            [propput] HRESULT ShowCard([in] AdaptiveShowCardActionConfig* value);
+
+            [propget] HRESULT ActionsOrientation([out][retval] ActionsOrientation* value);
+            [propput] HRESULT ActionsOrientation([in] ActionsOrientation value);
+
+            [propget] HRESULT ActionAlignment([out, retval] ActionAlignment* value);
+            [propput] HRESULT ActionAlignment([in] ActionAlignment value);
+
+            [propget] HRESULT ButtonSpacing([out][retval] UINT32* value);
+            [propput] HRESULT ButtonSpacing([in] UINT32 value);
+
+            [propget] HRESULT MaxActions([out][retval] UINT32* value);
+            [propput] HRESULT MaxActions([in] UINT32 value);
+
+            [propget] HRESULT Separation([out, retval] AdaptiveSeparationConfig** value);
+            [propput] HRESULT Separation([in] AdaptiveSeparationConfig* value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveActionsConfig
+        {
+            [default] interface IAdaptiveActionsConfig;
+        };
+
+        [
+            uuid(11213517-1e67-49df-a471-13dc0b2a3e5c),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveDateInputConfig)
+        ]
+        interface IAdaptiveDateInputConfig : IInspectable
+        {
+            [propget] HRESULT Separation([out, retval] AdaptiveSeparationConfig** value);
+            [propput] HRESULT Separation([in] AdaptiveSeparationConfig* value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveDateInputConfig
+        {
+            [default] interface IAdaptiveDateInputConfig;
+        };
+
+        [
+            uuid(0a53b7db-e8d8-41a5-94ad-d0992ba2879e),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveTimeInputConfig)
+        ]
+        interface IAdaptiveTimeInputConfig : IInspectable
+        {
+            [propget] HRESULT Separation([out, retval] AdaptiveSeparationConfig** value);
+            [propput] HRESULT Separation([in] AdaptiveSeparationConfig* value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveTimeInputConfig
+        {
+            [default] interface IAdaptiveTimeInputConfig;
+        };
+
+        [
+            uuid(f0a43896-35e3-4d61-9057-c19da8dafa07),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveNumberInputConfig)
+        ]
+        interface IAdaptiveNumberInputConfig : IInspectable
+        {
+            [propget] HRESULT Separation([out, retval] AdaptiveSeparationConfig** value);
+            [propput] HRESULT Separation([in] AdaptiveSeparationConfig* value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveNumberInputConfig
+        {
+            [default] interface IAdaptiveNumberInputConfig;
+        };
+
+        [
+            uuid(78a7b94a-559a-4aec-8d34-6a88189460b3),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveToggleInputConfig)
+        ]
+        interface IAdaptiveToggleInputConfig : IInspectable
+        {
+            [propget] HRESULT Separation([out, retval] AdaptiveSeparationConfig** value);
+            [propput] HRESULT Separation([in] AdaptiveSeparationConfig* value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveToggleInputConfig
+        {
+            [default] interface IAdaptiveToggleInputConfig;
+        };
+
+        [
+            uuid(b9b3fccc-2d5a-4a15-9e72-b8f6e8d479e9),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveTextInputConfig)
+        ]
+        interface IAdaptiveTextInputConfig : IInspectable
+        {
+            [propget] HRESULT Separation([out, retval] AdaptiveSeparationConfig** value);
+            [propput] HRESULT Separation([in] AdaptiveSeparationConfig* value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveTextInputConfig
+        {
+            [default] interface IAdaptiveTextInputConfig;
+        };
+
+        [
+            uuid(0df8b226-303c-46a7-9c4b-0b4154bb9c7d),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveChoiceSetInputConfig)
+        ]
+        interface IAdaptiveChoiceSetInputConfig : IInspectable
+        {
+            [propget] HRESULT Separation([out, retval] AdaptiveSeparationConfig** value);
+            [propput] HRESULT Separation([in] AdaptiveSeparationConfig* value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveChoiceSetInputConfig
+        {
+            [default] interface IAdaptiveChoiceSetInputConfig;
+        };
+
+        [
+            uuid(85ef9ddc-4599-4ab6-adf1-1e04238601a5),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveHostConfig)
+        ]
+        interface IAdaptiveHostConfig : IInspectable
+        {
+            [propget] HRESULT FontFamily([out, retval] HSTRING* value);
+            [propput] HRESULT FontFamily([in] HSTRING value);
+
+            [propget] HRESULT FontSizes([out, retval] AdaptiveFontSizesConfig** value);
+            [propput] HRESULT FontSizes([in] AdaptiveFontSizesConfig* value);
+
+            [propget] HRESULT SupportsInteractivity([out, retval] boolean* value);
+            [propput] HRESULT SupportsInteractivity([in] boolean value);
+
+            [propget] HRESULT Colors([out, retval] AdaptiveColorsConfig** value);
+            [propput] HRESULT Colors([in] AdaptiveColorsConfig* value);
+
+            [propget] HRESULT ImageSizes([out, retval] AdaptiveImageSizesConfig** value);
+            [propput] HRESULT ImageSizes([in] AdaptiveImageSizesConfig* value);
+
+            [propget] HRESULT MaxActions([out, retval] UINT32 *value);
+            [propput] HRESULT MaxActions([in] UINT32 value);
+
+            [propget] HRESULT StrongSeparation([out, retval] AdaptiveSeparationConfig** value);
+            [propput] HRESULT StrongSeparation([in] AdaptiveSeparationConfig* value);
+
+            [propget] HRESULT AdaptiveCard([out, retval] AdaptiveCardConfig** value);
+            [propput] HRESULT AdaptiveCard([in] AdaptiveCardConfig* value);
+
+            [propget] HRESULT ImageSet([out, retval] AdaptiveImageSetConfig** value);
+            [propput] HRESULT ImageSet([in] AdaptiveImageSetConfig* value);
+
+            [propget] HRESULT Image([out, retval] AdaptiveImageConfig** value);
+            [propput] HRESULT Image([in] AdaptiveImageConfig* value);
+
+            [propget] HRESULT FactSet([out, retval] AdaptiveFactSetConfig** value);
+            [propput] HRESULT FactSet([in] AdaptiveFactSetConfig* value);
+
+            [propget] HRESULT Column([out, retval] AdaptiveColumnConfig** value);
+            [propput] HRESULT Column([in] AdaptiveColumnConfig* value);
+
+            [propget] HRESULT Container([out, retval] AdaptiveContainerConfig** value);
+            [propput] HRESULT Container([in] AdaptiveContainerConfig* value);
+
+            [propget] HRESULT ColumnSet([out, retval] AdaptiveColumnSetConfig** value);
+            [propput] HRESULT ColumnSet([in] AdaptiveColumnSetConfig* value);
+
+            [propget] HRESULT TextBlock([out, retval] AdaptiveTextBlockConfig** value);
+            [propput] HRESULT TextBlock([in] AdaptiveTextBlockConfig* value);
+
+            [propget] HRESULT DateInput([out, retval] AdaptiveDateInputConfig** value);
+            [propput] HRESULT DateInput([in] AdaptiveDateInputConfig* value);
+
+            [propget] HRESULT TimeInput([out, retval] AdaptiveTimeInputConfig** value);
+            [propput] HRESULT TimeInput([in] AdaptiveTimeInputConfig* value);
+
+            [propget] HRESULT NumberInput([out, retval] AdaptiveNumberInputConfig** value);
+            [propput] HRESULT NumberInput([in] AdaptiveNumberInputConfig* value);
+
+            [propget] HRESULT ToggleInput([out, retval] AdaptiveToggleInputConfig** value);
+            [propput] HRESULT ToggleInput([in] AdaptiveToggleInputConfig* value);
+
+            [propget] HRESULT TextInput([out, retval] AdaptiveTextInputConfig** value);
+            [propput] HRESULT TextInput([in] AdaptiveTextInputConfig* value);
+
+            [propget] HRESULT ChoiceSetInput([out, retval] AdaptiveChoiceSetInputConfig** value);
+            [propput] HRESULT ChoiceSetInput([in] AdaptiveChoiceSetInputConfig* value);
+
+            [propget] HRESULT Actions([out, retval] AdaptiveActionsConfig** value);
+            [propput] HRESULT Actions([in] AdaptiveActionsConfig* value);
+        };
+
+        [
+            uuid(b90caf09-4257-4b00-a9d0-8c3cc4f8b76e),
+            version(NTDDI_WIN10_RS1),
+            exclusiveto(AdaptiveHostConfig),
+        ]
+        interface IAdaptiveHostConfigStatics : IInspectable
+        {
+            HRESULT CreateHostConfigFromJson([in] HSTRING hostConfigJson, [out, retval] AdaptiveHostConfig** config);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1),
+            static(IAdaptiveHostConfigStatics, NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveHostConfig
+        {
+            [default] interface IAdaptiveHostConfig;
+        };
+
+        [
+            uuid(f0076852-de82-4cc6-8cb3-26cf6ab3c196),
+            version(NTDDI_WIN10_RS1),
+        ]
+        interface IAdaptiveActionElement : IInspectable
+        {
+            [propget] HRESULT ActionType([out, retval] ActionType* value);
+
+            [propget] HRESULT Title([out, retval] HSTRING* value);
+            [propput] HRESULT Title([in] HSTRING value);
+
+            [propget] HRESULT Speak([out, retval] HSTRING* value);
+            [propput] HRESULT Speak([in] HSTRING value);
+        };
+
+        [
+            uuid(3d2b3b79-af79-46c5-9657-d862f2dee109),
+            version(NTDDI_WIN10_RS1),
+        ]
+        interface IAdaptiveHttpAction : IInspectable
+        {
+            [propput] HRESULT Url([in] Windows.Foundation.Uri* value);
+            [propget] HRESULT Url([out, retval] Windows.Foundation.Uri** value);
+
+            [propget] HRESULT Method([out, retval] HSTRING* value);
+            [propput] HRESULT Method([in] HSTRING value);
+
+            [propget] HRESULT Body([out, retval] HSTRING* value);
+            [propput] HRESULT Body([in] HSTRING value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveHttpAction
+        {
+            [default] interface IAdaptiveHttpAction;
+            interface IAdaptiveActionElement;
+        };
+
+        [
+            uuid(d70a58cb-4d51-4f96-bb6b-2698eced32ff),
+            version(NTDDI_WIN10_RS1),
+        ]
+        interface IAdaptiveOpenUrlAction : IInspectable
+        {
+            [propput] HRESULT Url([in] Windows.Foundation.Uri* value);
+            [propget] HRESULT Url([out, retval] Windows.Foundation.Uri** value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveOpenUrlAction
+        {
+            [default] interface IAdaptiveOpenUrlAction;
+            interface IAdaptiveActionElement;
+        };
+
+        [
+            uuid(435ea974-33c7-43b0-a6ac-8137c1b7bb44),
+            version(NTDDI_WIN10_RS1),
+        ]
+        interface IAdaptiveShowCardAction : IInspectable
+        {
+            [propget] HRESULT Card([out, retval] AdaptiveCard** value);
+            [propput] HRESULT Card([in] AdaptiveCard* value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveShowCardAction
+        {
+            [default] interface IAdaptiveShowCardAction;
+            interface IAdaptiveActionElement;
+        };
+
+        [
+            uuid(97b9b3a3-657b-4d38-a136-154cc8da19a9),
+            version(NTDDI_WIN10_RS1),
+        ]
+        interface IAdaptiveSubmitAction : IInspectable
+        {
+            [propget] HRESULT DataJson([out, retval] HSTRING* value);
+            [propput] HRESULT DataJson([in] HSTRING value);
+        };
+
+        [
+            version(NTDDI_WIN10_RS1),
+            activatable(NTDDI_WIN10_RS1)
+        ]
+        runtimeclass AdaptiveSubmitAction
+        {
+            [default] interface IAdaptiveSubmitAction;
+            interface IAdaptiveActionElement;
+        };
+    }
+}

--- a/source/uwp/Renderer/lib/AdaptiveCardElement.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveCardElement.cpp
@@ -16,6 +16,8 @@ AdaptiveNamespaceStart
         RETURN_IF_FAILED(UTF8ToHString(sharedModel->GetId(), m_id.GetAddressOf()));
         RETURN_IF_FAILED(JsonCppToJsonObject(sharedModel->GetAdditionalProperties(), &m_additionalProperties));
         RETURN_IF_FAILED(UTF8ToHString(sharedModel->GetElementTypeString(), m_typeString.GetAddressOf()));
+        RETURN_IF_FAILED(MakeAndInitialize<AdaptiveHeight>(&m_height, sharedModel->GetHeight()));
+
         return S_OK;
     }
 
@@ -69,6 +71,17 @@ AdaptiveNamespaceStart
         return S_OK;
     }
 
+    IFACEMETHODIMP AdaptiveCardElementBase::get_Height(ABI::AdaptiveNamespace::IAdaptiveHeight** height)
+    {
+        return m_height.CopyTo(height);
+    }
+
+    IFACEMETHODIMP AdaptiveCardElementBase::put_Height(ABI::AdaptiveNamespace::IAdaptiveHeight* height)
+    {
+        m_height = height;
+        return S_OK;
+    }
+
     IFACEMETHODIMP AdaptiveCardElementBase::ToJson(ABI::Windows::Data::Json::IJsonObject** result)
     {
         std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement> sharedModel;
@@ -89,6 +102,13 @@ AdaptiveNamespaceStart
             Json::Value jsonCpp;
             RETURN_IF_FAILED(JsonObjectToJsonCpp(m_additionalProperties.Get(), &jsonCpp));
             sharedCardElement->SetAdditionalProperties(jsonCpp);
+        }
+
+        if (m_height != nullptr)
+        {
+            ABI::AdaptiveNamespace::HeightType heightType;
+            m_height->get_HeightType(&heightType);
+            sharedCardElement->SetHeight(Height(static_cast<AdaptiveSharedNamespace::HeightType>(heightType)));
         }
 
         return S_OK;

--- a/source/uwp/Renderer/lib/AdaptiveCardElement.h
+++ b/source/uwp/Renderer/lib/AdaptiveCardElement.h
@@ -2,6 +2,7 @@
 
 #include "AdaptiveCards.Rendering.Uwp.h"
 #include "Enums.h"
+#include "AdaptiveHeight.h"
 
 AdaptiveNamespaceStart
     class DECLSPEC_UUID("49496982-18E7-48A8-9D16-99E389BE9133") AdaptiveCardElementBase : public IUnknown
@@ -24,6 +25,9 @@ AdaptiveNamespaceStart
         IFACEMETHODIMP get_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject** result);
         IFACEMETHODIMP put_AdditionalProperties(ABI::Windows::Data::Json::IJsonObject* jsonObject);
 
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height);
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height);
+
         IFACEMETHODIMP ToJson(ABI::Windows::Data::Json::IJsonObject** result);
 
         HRESULT SetSharedElementProperties(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement> sharedCardElement);
@@ -36,5 +40,6 @@ AdaptiveNamespaceStart
         ABI::AdaptiveNamespace::Spacing m_spacing;
         Microsoft::WRL::ComPtr<ABI::Windows::Data::Json::IJsonObject> m_additionalProperties;
         Microsoft::WRL::Wrappers::HString m_typeString;
+        Microsoft::WRL::ComPtr<ABI::AdaptiveNamespace::IAdaptiveHeight> m_height;
     };
 AdaptiveNamespaceEnd

--- a/source/uwp/Renderer/lib/AdaptiveChoiceSetInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceSetInput.cpp
@@ -98,20 +98,6 @@ AdaptiveNamespaceStart
         return S_OK;
     }
 
-    _Use_decl_annotations_
-    HRESULT AdaptiveChoiceSetInput::get_Height(IAdaptiveHeight** height)
-    {
-        std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement> sharedChoiceSetInput;
-        RETURN_IF_FAILED(GetSharedModel(sharedChoiceSetInput));
-        return MakeAndInitialize<AdaptiveHeight>(height, sharedChoiceSetInput->GetHeight());
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveChoiceSetInput::put_Height(IAdaptiveHeight* height)
-    {
-        return E_NOTIMPL;
-    }
-
     HRESULT AdaptiveChoiceSetInput::GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) try
     {
         std::shared_ptr<AdaptiveSharedNamespace::ChoiceSetInput> choiceSet = std::make_shared<AdaptiveSharedNamespace::ChoiceSetInput>();

--- a/source/uwp/Renderer/lib/AdaptiveChoiceSetInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceSetInput.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "AdaptiveHeight.h"
 #include "AdaptiveChoiceSetInput.h"
 
 #include "Util.h"
@@ -95,6 +96,20 @@ AdaptiveNamespaceStart
     {
         *elementType = ElementType::ChoiceSetInput;
         return S_OK;
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveChoiceSetInput::get_Height(IAdaptiveHeight** height)
+    {
+        std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement> sharedChoiceSetInput;
+        RETURN_IF_FAILED(GetSharedModel(sharedChoiceSetInput));
+        return MakeAndInitialize<AdaptiveHeight>(height, sharedChoiceSetInput->GetHeight());
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveChoiceSetInput::put_Height(IAdaptiveHeight* height)
+    {
+        return E_NOTIMPL;
     }
 
     HRESULT AdaptiveChoiceSetInput::GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) try

--- a/source/uwp/Renderer/lib/AdaptiveChoiceSetInput.h
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceSetInput.h
@@ -47,6 +47,9 @@ AdaptiveNamespaceStart
         IFACEMETHODIMP get_Spacing(_Out_ ABI::AdaptiveNamespace::Spacing* spacing) { return AdaptiveCardElementBase::get_Spacing(spacing); }
         IFACEMETHODIMP put_Spacing(_In_ ABI::AdaptiveNamespace::Spacing spacing) { return AdaptiveCardElementBase::put_Spacing(spacing); }
 
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height);
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height);
+
         IFACEMETHODIMP get_Separator(_Out_ boolean* separator) { return AdaptiveCardElementBase::get_Separator(separator); }
         IFACEMETHODIMP put_Separator(_In_ boolean separator) { return AdaptiveCardElementBase::put_Separator(separator); }
 

--- a/source/uwp/Renderer/lib/AdaptiveChoiceSetInput.h
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceSetInput.h
@@ -47,8 +47,8 @@ AdaptiveNamespaceStart
         IFACEMETHODIMP get_Spacing(_Out_ ABI::AdaptiveNamespace::Spacing* spacing) { return AdaptiveCardElementBase::get_Spacing(spacing); }
         IFACEMETHODIMP put_Spacing(_In_ ABI::AdaptiveNamespace::Spacing spacing) { return AdaptiveCardElementBase::put_Spacing(spacing); }
 
-        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height);
-        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height);
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height) { return AdaptiveCardElementBase::get_Height(height); }
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height) { return AdaptiveCardElementBase::put_Height(height); }
 
         IFACEMETHODIMP get_Separator(_Out_ boolean* separator) { return AdaptiveCardElementBase::get_Separator(separator); }
         IFACEMETHODIMP put_Separator(_In_ boolean separator) { return AdaptiveCardElementBase::put_Separator(separator); }

--- a/source/uwp/Renderer/lib/AdaptiveColumn.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveColumn.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "AdaptiveHeight.h"
 #include "AdaptiveColumn.h"
 
 #include "Util.h"
@@ -67,6 +68,19 @@ AdaptiveNamespaceStart
     HRESULT AdaptiveColumn::get_Items(IVector<IAdaptiveCardElement*>** items)
     {
         return m_items.CopyTo(items);
+    }
+
+    HRESULT AdaptiveColumn::get_Height(IAdaptiveHeight** height)
+    {
+        std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement> sharedColumn;
+        RETURN_IF_FAILED(GetSharedModel(sharedColumn));
+        return MakeAndInitialize<AdaptiveHeight>(height, sharedColumn->GetHeight());
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveColumn::put_Height(IAdaptiveHeight* height)
+    {
+        return E_NOTIMPL;
     }
 
     _Use_decl_annotations_

--- a/source/uwp/Renderer/lib/AdaptiveColumn.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveColumn.cpp
@@ -70,19 +70,6 @@ AdaptiveNamespaceStart
         return m_items.CopyTo(items);
     }
 
-    HRESULT AdaptiveColumn::get_Height(IAdaptiveHeight** height)
-    {
-        std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement> sharedColumn;
-        RETURN_IF_FAILED(GetSharedModel(sharedColumn));
-        return MakeAndInitialize<AdaptiveHeight>(height, sharedColumn->GetHeight());
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveColumn::put_Height(IAdaptiveHeight* height)
-    {
-        return E_NOTIMPL;
-    }
-
     _Use_decl_annotations_
     HRESULT AdaptiveColumn::get_SelectAction(IAdaptiveActionElement** action)
     {

--- a/source/uwp/Renderer/lib/AdaptiveColumn.h
+++ b/source/uwp/Renderer/lib/AdaptiveColumn.h
@@ -55,6 +55,9 @@ AdaptiveNamespaceStart
 
         virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) override;
 
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height);
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height);
+
         // ITypePeek method
         void *PeekAt(REFIID riid) override
         {

--- a/source/uwp/Renderer/lib/AdaptiveColumn.h
+++ b/source/uwp/Renderer/lib/AdaptiveColumn.h
@@ -55,8 +55,8 @@ AdaptiveNamespaceStart
 
         virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) override;
 
-        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height);
-        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height);
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height) { return AdaptiveCardElementBase::get_Height(height); }
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height) { return AdaptiveCardElementBase::put_Height(height); }
 
         // ITypePeek method
         void *PeekAt(REFIID riid) override

--- a/source/uwp/Renderer/lib/AdaptiveColumnSet.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveColumnSet.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "AdaptiveHeight.h"
 #include "AdaptiveColumnSet.h"
 
 #include "Util.h"
@@ -52,6 +53,20 @@ AdaptiveNamespaceStart
     IFACEMETHODIMP AdaptiveColumnSet::get_SelectAction(IAdaptiveActionElement** action)
     {
         return m_selectAction.CopyTo(action);
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveColumnSet::get_Height(IAdaptiveHeight** height)
+    {
+        std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement> sharedColumnSet;
+        RETURN_IF_FAILED(GetSharedModel(sharedColumnSet));
+        return MakeAndInitialize<AdaptiveHeight>(height, sharedColumnSet->GetHeight());
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveColumnSet::put_Height(IAdaptiveHeight* height)
+    {
+        return E_NOTIMPL;
     }
 
     _Use_decl_annotations_

--- a/source/uwp/Renderer/lib/AdaptiveColumnSet.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveColumnSet.cpp
@@ -56,20 +56,6 @@ AdaptiveNamespaceStart
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveColumnSet::get_Height(IAdaptiveHeight** height)
-    {
-        std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement> sharedColumnSet;
-        RETURN_IF_FAILED(GetSharedModel(sharedColumnSet));
-        return MakeAndInitialize<AdaptiveHeight>(height, sharedColumnSet->GetHeight());
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveColumnSet::put_Height(IAdaptiveHeight* height)
-    {
-        return E_NOTIMPL;
-    }
-
-    _Use_decl_annotations_
     IFACEMETHODIMP AdaptiveColumnSet::put_SelectAction(IAdaptiveActionElement* action)
     {
         m_selectAction = action;

--- a/source/uwp/Renderer/lib/AdaptiveColumnSet.h
+++ b/source/uwp/Renderer/lib/AdaptiveColumnSet.h
@@ -49,6 +49,9 @@ AdaptiveNamespaceStart
 
         virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) override;
 
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height);
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height);
+
         // ITypePeek method
         void *PeekAt(REFIID riid) override
         {

--- a/source/uwp/Renderer/lib/AdaptiveColumnSet.h
+++ b/source/uwp/Renderer/lib/AdaptiveColumnSet.h
@@ -49,8 +49,8 @@ AdaptiveNamespaceStart
 
         virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) override;
 
-        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height);
-        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height);
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height) { return AdaptiveCardElementBase::get_Height(height); }
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height) { return AdaptiveCardElementBase::put_Height(height); }
 
         // ITypePeek method
         void *PeekAt(REFIID riid) override

--- a/source/uwp/Renderer/lib/AdaptiveContainer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveContainer.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "AdaptiveHeight.h"
 #include "AdaptiveContainer.h"
 
 #include "Util.h"
@@ -57,6 +58,19 @@ AdaptiveNamespaceStart
     {
         m_selectAction = action;
         return S_OK;
+    }
+
+    HRESULT AdaptiveContainer::get_Height(IAdaptiveHeight** height)
+    {
+        std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement> sharedContainer;
+        RETURN_IF_FAILED(GetSharedModel(sharedContainer));
+        return MakeAndInitialize<AdaptiveHeight>(height, sharedContainer->GetHeight());
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveContainer::put_Height(IAdaptiveHeight* height)
+    {
+        return E_NOTIMPL;
     }
 
     _Use_decl_annotations_

--- a/source/uwp/Renderer/lib/AdaptiveContainer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveContainer.cpp
@@ -60,19 +60,6 @@ AdaptiveNamespaceStart
         return S_OK;
     }
 
-    HRESULT AdaptiveContainer::get_Height(IAdaptiveHeight** height)
-    {
-        std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement> sharedContainer;
-        RETURN_IF_FAILED(GetSharedModel(sharedContainer));
-        return MakeAndInitialize<AdaptiveHeight>(height, sharedContainer->GetHeight());
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveContainer::put_Height(IAdaptiveHeight* height)
-    {
-        return E_NOTIMPL;
-    }
-
     _Use_decl_annotations_
     HRESULT AdaptiveContainer::get_ElementType(ElementType* elementType)
     {

--- a/source/uwp/Renderer/lib/AdaptiveContainer.h
+++ b/source/uwp/Renderer/lib/AdaptiveContainer.h
@@ -52,8 +52,8 @@ AdaptiveNamespaceStart
 
         virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) override;
 
-        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height);
-        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height);
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height) { return AdaptiveCardElementBase::get_Height(height); }
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height) { return AdaptiveCardElementBase::put_Height(height); }
 
         // ITypePeek method
         void *PeekAt(REFIID riid) override

--- a/source/uwp/Renderer/lib/AdaptiveContainer.h
+++ b/source/uwp/Renderer/lib/AdaptiveContainer.h
@@ -52,6 +52,9 @@ AdaptiveNamespaceStart
 
         virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) override;
 
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height);
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height);
+
         // ITypePeek method
         void *PeekAt(REFIID riid) override
         {

--- a/source/uwp/Renderer/lib/AdaptiveDateInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveDateInput.cpp
@@ -90,20 +90,6 @@ AdaptiveNamespaceStart
         return S_OK;
     }
 
-    _Use_decl_annotations_
-        HRESULT AdaptiveDateInput::get_Height(IAdaptiveHeight** height)
-    {
-        std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement> sharedDateInput;
-        RETURN_IF_FAILED(GetSharedModel(sharedDateInput));
-        return MakeAndInitialize<AdaptiveHeight>(height, sharedDateInput->GetHeight());
-    }
-
-    _Use_decl_annotations_
-        HRESULT AdaptiveDateInput::put_Height(IAdaptiveHeight* height)
-    {
-        return E_NOTIMPL;
-    }
-
     HRESULT AdaptiveDateInput::GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) try
     {
         std::shared_ptr<AdaptiveSharedNamespace::DateInput> dateInput = std::make_shared<AdaptiveSharedNamespace::DateInput>();

--- a/source/uwp/Renderer/lib/AdaptiveDateInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveDateInput.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "AdaptiveHeight.h"
 #include "AdaptiveDateInput.h"
 #include "Util.h"
 #include <windows.foundation.collections.h>
@@ -89,10 +90,23 @@ AdaptiveNamespaceStart
         return S_OK;
     }
 
-    HRESULT AdaptiveDateInput::GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) try
-    { 
-        std::shared_ptr<AdaptiveSharedNamespace::DateInput> dateInput = std::make_shared<AdaptiveSharedNamespace::DateInput>();
+    _Use_decl_annotations_
+        HRESULT AdaptiveDateInput::get_Height(IAdaptiveHeight** height)
+    {
+        std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement> sharedDateInput;
+        RETURN_IF_FAILED(GetSharedModel(sharedDateInput));
+        return MakeAndInitialize<AdaptiveHeight>(height, sharedDateInput->GetHeight());
+    }
 
+    _Use_decl_annotations_
+        HRESULT AdaptiveDateInput::put_Height(IAdaptiveHeight* height)
+    {
+        return E_NOTIMPL;
+    }
+
+    HRESULT AdaptiveDateInput::GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) try
+    {
+        std::shared_ptr<AdaptiveSharedNamespace::DateInput> dateInput = std::make_shared<AdaptiveSharedNamespace::DateInput>();
         RETURN_IF_FAILED(SetSharedElementProperties(std::static_pointer_cast<AdaptiveSharedNamespace::BaseInputElement>(dateInput)));
 
         std::string max;

--- a/source/uwp/Renderer/lib/AdaptiveDateInput.h
+++ b/source/uwp/Renderer/lib/AdaptiveDateInput.h
@@ -59,8 +59,8 @@ AdaptiveNamespaceStart
 
         virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) override;
 
-        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height);
-        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height);
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height) { return AdaptiveCardElementBase::get_Height(height); }
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height) { return AdaptiveCardElementBase::put_Height(height); }
 
         // ITypePeek method
         void *PeekAt(REFIID riid) override

--- a/source/uwp/Renderer/lib/AdaptiveDateInput.h
+++ b/source/uwp/Renderer/lib/AdaptiveDateInput.h
@@ -59,6 +59,9 @@ AdaptiveNamespaceStart
 
         virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) override;
 
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height);
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height);
+
         // ITypePeek method
         void *PeekAt(REFIID riid) override
         {

--- a/source/uwp/Renderer/lib/AdaptiveFact.h
+++ b/source/uwp/Renderer/lib/AdaptiveFact.h
@@ -18,11 +18,11 @@ AdaptiveNamespaceStart
         HRESULT RuntimeClassInitialize(_In_ const std::shared_ptr<AdaptiveSharedNamespace::Fact>& sharedFact);
 
         // IAdaptiveFact
-        IFACEMETHODIMP get_Title(_In_ HSTRING* title);
-        IFACEMETHODIMP put_Title(_Out_ HSTRING title);
+        IFACEMETHODIMP get_Title(_Out_ HSTRING* title);
+        IFACEMETHODIMP put_Title(_In_ HSTRING title);
 
-        IFACEMETHODIMP get_Value(_In_ HSTRING* value);
-        IFACEMETHODIMP put_Value(_Out_ HSTRING value);
+        IFACEMETHODIMP get_Value(_Out_ HSTRING* value);
+        IFACEMETHODIMP put_Value(_In_ HSTRING value);
 
         IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveNamespace::ElementType* elementType);
 

--- a/source/uwp/Renderer/lib/AdaptiveFactSet.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveFactSet.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "AdaptiveHeight.h"
 #include "AdaptiveFactSet.h"
 
 #include "Util.h"
@@ -49,6 +50,20 @@ AdaptiveNamespaceStart
     {
         *elementType = ElementType::FactSet;
         return S_OK;
+    }
+
+    _Use_decl_annotations_
+        HRESULT AdaptiveFactSet::get_Height(IAdaptiveHeight** height)
+    {
+        std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement> sharedFactSet;
+        RETURN_IF_FAILED(GetSharedModel(sharedFactSet));
+        return MakeAndInitialize<AdaptiveHeight>(height, sharedFactSet->GetHeight());
+    }
+
+    _Use_decl_annotations_
+        HRESULT AdaptiveFactSet::put_Height(IAdaptiveHeight* height)
+    {
+        return E_NOTIMPL;
     }
 
     HRESULT AdaptiveFactSet::GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) try

--- a/source/uwp/Renderer/lib/AdaptiveFactSet.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveFactSet.cpp
@@ -52,20 +52,6 @@ AdaptiveNamespaceStart
         return S_OK;
     }
 
-    _Use_decl_annotations_
-        HRESULT AdaptiveFactSet::get_Height(IAdaptiveHeight** height)
-    {
-        std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement> sharedFactSet;
-        RETURN_IF_FAILED(GetSharedModel(sharedFactSet));
-        return MakeAndInitialize<AdaptiveHeight>(height, sharedFactSet->GetHeight());
-    }
-
-    _Use_decl_annotations_
-        HRESULT AdaptiveFactSet::put_Height(IAdaptiveHeight* height)
-    {
-        return E_NOTIMPL;
-    }
-
     HRESULT AdaptiveFactSet::GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) try
     {
         std::shared_ptr<AdaptiveSharedNamespace::FactSet> factSet = std::make_shared<AdaptiveSharedNamespace::FactSet>();

--- a/source/uwp/Renderer/lib/AdaptiveFactSet.h
+++ b/source/uwp/Renderer/lib/AdaptiveFactSet.h
@@ -32,6 +32,9 @@ AdaptiveNamespaceStart
         IFACEMETHODIMP get_Spacing(_Out_ ABI::AdaptiveNamespace::Spacing* spacing) { return AdaptiveCardElementBase::get_Spacing(spacing); }
         IFACEMETHODIMP put_Spacing(_In_ ABI::AdaptiveNamespace::Spacing spacing) { return AdaptiveCardElementBase::put_Spacing(spacing); }
 
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height);
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height);
+
         IFACEMETHODIMP get_Separator(_Out_ boolean* separator) { return AdaptiveCardElementBase::get_Separator(separator); }
         IFACEMETHODIMP put_Separator(_In_ boolean separator) { return AdaptiveCardElementBase::put_Separator(separator); }
 

--- a/source/uwp/Renderer/lib/AdaptiveFactSet.h
+++ b/source/uwp/Renderer/lib/AdaptiveFactSet.h
@@ -32,8 +32,8 @@ AdaptiveNamespaceStart
         IFACEMETHODIMP get_Spacing(_Out_ ABI::AdaptiveNamespace::Spacing* spacing) { return AdaptiveCardElementBase::get_Spacing(spacing); }
         IFACEMETHODIMP put_Spacing(_In_ ABI::AdaptiveNamespace::Spacing spacing) { return AdaptiveCardElementBase::put_Spacing(spacing); }
 
-        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height);
-        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height);
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height) { return AdaptiveCardElementBase::get_Height(height); }
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height) { return AdaptiveCardElementBase::put_Height(height); }
 
         IFACEMETHODIMP get_Separator(_Out_ boolean* separator) { return AdaptiveCardElementBase::get_Separator(separator); }
         IFACEMETHODIMP put_Separator(_In_ boolean separator) { return AdaptiveCardElementBase::put_Separator(separator); }

--- a/source/uwp/Renderer/lib/AdaptiveHeight.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveHeight.cpp
@@ -19,14 +19,20 @@ AdaptiveNamespaceStart
     _Use_decl_annotations_
     HRESULT AdaptiveHeight::get_HeightType(ABI::AdaptiveNamespace::HeightType* heightType)
     {
-        *heightType = static_cast<ABI::AdaptiveNamespace::HeightType>(m_sharedHeight.heightType);
+        *heightType = static_cast<ABI::AdaptiveNamespace::HeightType>(m_sharedHeight.GetHeightType());
         return S_OK;
     }
 
     _Use_decl_annotations_
     HRESULT AdaptiveHeight::put_HeightType(ABI::AdaptiveNamespace::HeightType heightType)
     {
-        m_sharedHeight.heightType = static_cast<AdaptiveCards::HeightType>(heightType);
+        m_sharedHeight.SetHeightType(static_cast<AdaptiveCards::HeightType>(heightType));
+        return S_OK;
+    }
+
+    HRESULT AdaptiveHeight::GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::Height>& sharedModel)
+    {
+        sharedModel = std::make_shared<Height>(m_sharedHeight);
         return S_OK;
     }
 AdaptiveNamespaceEnd

--- a/source/uwp/Renderer/lib/AdaptiveHeight.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveHeight.cpp
@@ -1,0 +1,32 @@
+#include "pch.h"
+#include "AdaptiveHeight.h"
+
+using namespace Microsoft::WRL;
+using namespace ABI::AdaptiveNamespace;
+
+AdaptiveNamespaceStart
+    HRESULT AdaptiveHeight::RuntimeClassInitialize() noexcept try
+    {
+        return S_OK;
+    } CATCH_RETURN;
+
+    HRESULT AdaptiveHeight::RuntimeClassInitialize(Height Height) noexcept
+    {
+        m_sharedHeight = Height;
+        return S_OK;
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveHeight::get_HeightType(ABI::AdaptiveNamespace::HeightType* heightType)
+    {
+        *heightType = static_cast<ABI::AdaptiveNamespace::HeightType>(m_sharedHeight.heightType);
+        return S_OK;
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveHeight::put_HeightType(ABI::AdaptiveNamespace::HeightType heightType)
+    {
+        m_sharedHeight.heightType = static_cast<AdaptiveCards::HeightType>(heightType);
+        return S_OK;
+    }
+AdaptiveNamespaceEnd

--- a/source/uwp/Renderer/lib/AdaptiveHeight.h
+++ b/source/uwp/Renderer/lib/AdaptiveHeight.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "AdaptiveCards.Rendering.Uwp.h"
+#include "Enums.h"
+#include "Height.h"
+
+AdaptiveNamespaceStart
+    class AdaptiveHeight :
+        public Microsoft::WRL::RuntimeClass<
+            Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
+            ABI::AdaptiveNamespace::IAdaptiveHeight>
+    {
+        AdaptiveRuntime(AdaptiveHeight);
+
+    public:
+        HRESULT RuntimeClassInitialize() noexcept;
+        HRESULT RuntimeClassInitialize(Height height) noexcept;
+
+        IFACEMETHODIMP get_HeightType(_Out_ ABI::AdaptiveNamespace::HeightType* heightType);
+        IFACEMETHODIMP put_HeightType(_In_ ABI::AdaptiveNamespace::HeightType heightType);
+
+    private:
+        Height m_sharedHeight;
+    };
+
+    ActivatableClass(AdaptiveHeight);
+AdaptiveNamespaceEnd

--- a/source/uwp/Renderer/lib/AdaptiveHeight.h
+++ b/source/uwp/Renderer/lib/AdaptiveHeight.h
@@ -5,10 +5,11 @@
 #include "Height.h"
 
 AdaptiveNamespaceStart
-    class AdaptiveHeight :
+    class DECLSPEC_UUID("502edea9-72fd-4856-a89e-54565181bed9") AdaptiveHeight :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
-            ABI::AdaptiveNamespace::IAdaptiveHeight>
+            ABI::AdaptiveNamespace::IAdaptiveHeight>,
+            Microsoft::WRL::CloakedIid<ITypePeek>
     {
         AdaptiveRuntime(AdaptiveHeight);
 
@@ -18,6 +19,14 @@ AdaptiveNamespaceStart
 
         IFACEMETHODIMP get_HeightType(_Out_ ABI::AdaptiveNamespace::HeightType* heightType);
         IFACEMETHODIMP put_HeightType(_In_ ABI::AdaptiveNamespace::HeightType heightType);
+
+        HRESULT GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::Height>& sharedModel);
+
+        // ITypePeek method
+        void *PeekAt(REFIID riid) override
+        {
+            return PeekHelper(riid, this);
+        }
 
     private:
         Height m_sharedHeight;

--- a/source/uwp/Renderer/lib/AdaptiveImage.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImage.cpp
@@ -111,21 +111,7 @@ AdaptiveNamespaceStart
         *alignment = m_horizontalAlignment;
         return S_OK;
     }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveImage::get_Height(IAdaptiveHeight** height)
-    {
-        std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement> sharedImage;
-        RETURN_IF_FAILED(GetSharedModel(sharedImage));
-        return MakeAndInitialize<AdaptiveHeight>(height, sharedImage->GetHeight());
-    }
-
-    _Use_decl_annotations_
-        HRESULT AdaptiveImage::put_Height(IAdaptiveHeight* height)
-    {
-        return E_NOTIMPL;
-    }
-    
+   
     _Use_decl_annotations_
     HRESULT AdaptiveImage::put_HorizontalAlignment(ABI::AdaptiveNamespace::HAlignment alignment)
     {

--- a/source/uwp/Renderer/lib/AdaptiveImage.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImage.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "AdaptiveHeight.h"
 #include "AdaptiveImage.h"
 
 #include "Util.h"
@@ -111,6 +112,20 @@ AdaptiveNamespaceStart
         return S_OK;
     }
 
+    _Use_decl_annotations_
+    HRESULT AdaptiveImage::get_Height(IAdaptiveHeight** height)
+    {
+        std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement> sharedImage;
+        RETURN_IF_FAILED(GetSharedModel(sharedImage));
+        return MakeAndInitialize<AdaptiveHeight>(height, sharedImage->GetHeight());
+    }
+
+    _Use_decl_annotations_
+        HRESULT AdaptiveImage::put_Height(IAdaptiveHeight* height)
+    {
+        return E_NOTIMPL;
+    }
+    
     _Use_decl_annotations_
     HRESULT AdaptiveImage::put_HorizontalAlignment(ABI::AdaptiveNamespace::HAlignment alignment)
     {

--- a/source/uwp/Renderer/lib/AdaptiveImage.h
+++ b/source/uwp/Renderer/lib/AdaptiveImage.h
@@ -62,6 +62,9 @@ AdaptiveNamespaceStart
 
         virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) override;
 
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height);
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height);
+
         // ITypePeek method
         void *PeekAt(REFIID riid) override
         {

--- a/source/uwp/Renderer/lib/AdaptiveImage.h
+++ b/source/uwp/Renderer/lib/AdaptiveImage.h
@@ -62,8 +62,8 @@ AdaptiveNamespaceStart
 
         virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) override;
 
-        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height);
-        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height);
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height) { return AdaptiveCardElementBase::get_Height(height); }
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height) { return AdaptiveCardElementBase::put_Height(height); }
 
         // ITypePeek method
         void *PeekAt(REFIID riid) override

--- a/source/uwp/Renderer/lib/AdaptiveImageSet.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImageSet.cpp
@@ -67,20 +67,6 @@ AdaptiveNamespaceStart
         *elementType = ElementType::ImageSet;
         return S_OK;
     }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveImageSet::get_Height(IAdaptiveHeight** height)
-    {
-        std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement> sharedImageSet;
-        RETURN_IF_FAILED(GetSharedModel(sharedImageSet));
-        return MakeAndInitialize<AdaptiveHeight>(height, sharedImageSet->GetHeight());
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveImageSet::put_Height(IAdaptiveHeight* height)
-    {
-        return E_NOTIMPL;
-    }
    
     _Use_decl_annotations_
     HRESULT AdaptiveImageSet::GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) try

--- a/source/uwp/Renderer/lib/AdaptiveImageSet.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImageSet.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "AdaptiveHeight.h"
 #include "AdaptiveImageSet.h"
 
 #include "Util.h"
@@ -67,6 +68,21 @@ AdaptiveNamespaceStart
         return S_OK;
     }
 
+    _Use_decl_annotations_
+    HRESULT AdaptiveImageSet::get_Height(IAdaptiveHeight** height)
+    {
+        std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement> sharedImageSet;
+        RETURN_IF_FAILED(GetSharedModel(sharedImageSet));
+        return MakeAndInitialize<AdaptiveHeight>(height, sharedImageSet->GetHeight());
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveImageSet::put_Height(IAdaptiveHeight* height)
+    {
+        return E_NOTIMPL;
+    }
+   
+    _Use_decl_annotations_
     HRESULT AdaptiveImageSet::GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) try
     {
         std::shared_ptr<AdaptiveSharedNamespace::ImageSet> imageSet = std::make_shared<AdaptiveSharedNamespace::ImageSet>();

--- a/source/uwp/Renderer/lib/AdaptiveImageSet.h
+++ b/source/uwp/Renderer/lib/AdaptiveImageSet.h
@@ -43,6 +43,9 @@ AdaptiveNamespaceStart
 
         IFACEMETHODIMP get_ElementTypeString(_Out_ HSTRING* value) { return AdaptiveCardElementBase::get_ElementTypeString(value); }
 
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height);
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height);
+
         IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveCardElementBase::get_AdditionalProperties(result); }
         IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value) { return AdaptiveCardElementBase::put_AdditionalProperties(value); }
 

--- a/source/uwp/Renderer/lib/AdaptiveImageSet.h
+++ b/source/uwp/Renderer/lib/AdaptiveImageSet.h
@@ -43,8 +43,8 @@ AdaptiveNamespaceStart
 
         IFACEMETHODIMP get_ElementTypeString(_Out_ HSTRING* value) { return AdaptiveCardElementBase::get_ElementTypeString(value); }
 
-        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height);
-        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height);
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height) { return AdaptiveCardElementBase::get_Height(height); }
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height) { return AdaptiveCardElementBase::put_Height(height); }
 
         IFACEMETHODIMP get_AdditionalProperties(_Out_ ABI::Windows::Data::Json::IJsonObject** result) { return AdaptiveCardElementBase::get_AdditionalProperties(result); }
         IFACEMETHODIMP put_AdditionalProperties(_In_ ABI::Windows::Data::Json::IJsonObject* value) { return AdaptiveCardElementBase::put_AdditionalProperties(value); }

--- a/source/uwp/Renderer/lib/AdaptiveNumberInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveNumberInput.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "AdaptiveHeight.h"
 #include "AdaptiveNumberInput.h"
 
 #include "Util.h"
@@ -96,6 +97,21 @@ AdaptiveNamespaceStart
         return S_OK;
     }
 
+    _Use_decl_annotations_
+    HRESULT AdaptiveNumberInput::get_Height(IAdaptiveHeight** height)
+    {
+        std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement> sharedNumberInput;
+        RETURN_IF_FAILED(GetSharedModel(sharedNumberInput));
+        return MakeAndInitialize<AdaptiveHeight>(height, sharedNumberInput->GetHeight());
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveNumberInput::put_Height(IAdaptiveHeight* height)
+    {
+        return E_NOTIMPL;
+    }
+
+    _Use_decl_annotations_
     HRESULT AdaptiveNumberInput::GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) try
     {
         std::shared_ptr<AdaptiveSharedNamespace::NumberInput> numberInput = std::make_shared<AdaptiveSharedNamespace::NumberInput>();

--- a/source/uwp/Renderer/lib/AdaptiveNumberInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveNumberInput.cpp
@@ -98,20 +98,6 @@ AdaptiveNamespaceStart
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveNumberInput::get_Height(IAdaptiveHeight** height)
-    {
-        std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement> sharedNumberInput;
-        RETURN_IF_FAILED(GetSharedModel(sharedNumberInput));
-        return MakeAndInitialize<AdaptiveHeight>(height, sharedNumberInput->GetHeight());
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveNumberInput::put_Height(IAdaptiveHeight* height)
-    {
-        return E_NOTIMPL;
-    }
-
-    _Use_decl_annotations_
     HRESULT AdaptiveNumberInput::GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) try
     {
         std::shared_ptr<AdaptiveSharedNamespace::NumberInput> numberInput = std::make_shared<AdaptiveSharedNamespace::NumberInput>();

--- a/source/uwp/Renderer/lib/AdaptiveNumberInput.h
+++ b/source/uwp/Renderer/lib/AdaptiveNumberInput.h
@@ -59,8 +59,8 @@ AdaptiveNamespaceStart
 
         virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) override;
 
-        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height);
-        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height);
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height) { return AdaptiveCardElementBase::get_Height(height); }
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height) { return AdaptiveCardElementBase::put_Height(height); }
 
         // ITypePeek method
         void *PeekAt(REFIID riid) override

--- a/source/uwp/Renderer/lib/AdaptiveNumberInput.h
+++ b/source/uwp/Renderer/lib/AdaptiveNumberInput.h
@@ -59,6 +59,9 @@ AdaptiveNamespaceStart
 
         virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) override;
 
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height);
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height);
+
         // ITypePeek method
         void *PeekAt(REFIID riid) override
         {

--- a/source/uwp/Renderer/lib/AdaptiveTextBlock.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTextBlock.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "AdaptiveHeight.h"
 #include "AdaptiveTextBlock.h"
 #include "Util.h"
 #include "DateTimeParser.h"
@@ -163,6 +164,20 @@ AdaptiveNamespaceStart
     {
         return m_language.Set(language);
     }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveTextBlock::get_Height(IAdaptiveHeight** height)
+    {
+        std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement> sharedTextBlock;
+        RETURN_IF_FAILED(GetSharedModel(sharedTextBlock));
+        return MakeAndInitialize<AdaptiveHeight>(height, sharedTextBlock->GetHeight());
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveTextBlock::put_Height(IAdaptiveHeight* height)
+    {
+        return E_NOTIMPL;
+    }  
 
     _Use_decl_annotations_
     HRESULT AdaptiveTextBlock::get_ElementType(ElementType* elementType)

--- a/source/uwp/Renderer/lib/AdaptiveTextBlock.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTextBlock.cpp
@@ -166,20 +166,6 @@ AdaptiveNamespaceStart
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveTextBlock::get_Height(IAdaptiveHeight** height)
-    {
-        std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement> sharedTextBlock;
-        RETURN_IF_FAILED(GetSharedModel(sharedTextBlock));
-        return MakeAndInitialize<AdaptiveHeight>(height, sharedTextBlock->GetHeight());
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTextBlock::put_Height(IAdaptiveHeight* height)
-    {
-        return E_NOTIMPL;
-    }  
-
-    _Use_decl_annotations_
     HRESULT AdaptiveTextBlock::get_ElementType(ElementType* elementType)
     {
         *elementType = ElementType::TextBlock;
@@ -205,8 +191,12 @@ AdaptiveNamespaceStart
         textBlock->SetText(text);
 
         std::string language;
-        RETURN_IF_FAILED(HStringToUTF8(m_language.Get(), language));
-        textBlock->SetLanguage(language);
+        //  If the language was not specified the conversion fails, just keep the language as an empty string
+        if (!(WindowsIsStringEmpty(m_language.Get())))
+        {
+            RETURN_IF_FAILED(HStringToUTF8(m_language.Get(), language));
+            textBlock->SetLanguage(language);
+        }
 
         sharedTextBlock = textBlock;
         return S_OK;

--- a/source/uwp/Renderer/lib/AdaptiveTextBlock.h
+++ b/source/uwp/Renderer/lib/AdaptiveTextBlock.h
@@ -69,6 +69,9 @@ AdaptiveNamespaceStart
 
         virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) override;
 
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height);
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height);
+
         // ITypePeek method
         void *PeekAt(REFIID riid) override
         {

--- a/source/uwp/Renderer/lib/AdaptiveTextBlock.h
+++ b/source/uwp/Renderer/lib/AdaptiveTextBlock.h
@@ -69,8 +69,8 @@ AdaptiveNamespaceStart
 
         virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) override;
 
-        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height);
-        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height);
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height) { return AdaptiveCardElementBase::get_Height(height); }
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height) { return AdaptiveCardElementBase::put_Height(height); }
 
         // ITypePeek method
         void *PeekAt(REFIID riid) override

--- a/source/uwp/Renderer/lib/AdaptiveTextInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTextInput.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "AdaptiveHeight.h"
 #include "AdaptiveTextInput.h"
 
 #include "Util.h"
@@ -106,6 +107,20 @@ AdaptiveNamespaceStart
     {
         *elementType = ElementType::TextInput;
         return S_OK;
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveTextInput::get_Height(IAdaptiveHeight** height)
+    {
+        std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement> sharedTextInput;
+        RETURN_IF_FAILED(GetSharedModel(sharedTextInput));
+        return MakeAndInitialize<AdaptiveHeight>(height, sharedTextInput->GetHeight());
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveTextInput::put_Height(IAdaptiveHeight* height)
+    {
+        return E_NOTIMPL;
     }
 
     HRESULT AdaptiveTextInput::GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) try

--- a/source/uwp/Renderer/lib/AdaptiveTextInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTextInput.cpp
@@ -109,20 +109,6 @@ AdaptiveNamespaceStart
         return S_OK;
     }
 
-    _Use_decl_annotations_
-    HRESULT AdaptiveTextInput::get_Height(IAdaptiveHeight** height)
-    {
-        std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement> sharedTextInput;
-        RETURN_IF_FAILED(GetSharedModel(sharedTextInput));
-        return MakeAndInitialize<AdaptiveHeight>(height, sharedTextInput->GetHeight());
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTextInput::put_Height(IAdaptiveHeight* height)
-    {
-        return E_NOTIMPL;
-    }
-
     HRESULT AdaptiveTextInput::GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) try
     {
         std::shared_ptr<AdaptiveSharedNamespace::TextInput> textInput = std::make_shared<AdaptiveSharedNamespace::TextInput>();

--- a/source/uwp/Renderer/lib/AdaptiveTextInput.h
+++ b/source/uwp/Renderer/lib/AdaptiveTextInput.h
@@ -62,6 +62,9 @@ AdaptiveNamespaceStart
 
         virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) override;
 
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height);
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height);
+
         // ITypePeek method
         void *PeekAt(REFIID riid) override
         {

--- a/source/uwp/Renderer/lib/AdaptiveTextInput.h
+++ b/source/uwp/Renderer/lib/AdaptiveTextInput.h
@@ -62,9 +62,9 @@ AdaptiveNamespaceStart
 
         virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) override;
 
-        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height);
-        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height);
-
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height) { return AdaptiveCardElementBase::get_Height(height); }
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height) { return AdaptiveCardElementBase::put_Height(height); }
+        
         // ITypePeek method
         void *PeekAt(REFIID riid) override
         {

--- a/source/uwp/Renderer/lib/AdaptiveTimeInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTimeInput.cpp
@@ -93,20 +93,6 @@ AdaptiveNamespaceStart
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveTimeInput::get_Height(IAdaptiveHeight** height)
-    {
-        std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement> sharedTimeInput;
-        RETURN_IF_FAILED(GetSharedModel(sharedTimeInput));
-        return MakeAndInitialize<AdaptiveHeight>(height, sharedTimeInput->GetHeight());
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveTimeInput::put_Height(IAdaptiveHeight* height)
-    {
-        return E_NOTIMPL;
-    }
-
-    _Use_decl_annotations_
     HRESULT AdaptiveTimeInput::GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) try
     {
         std::shared_ptr<AdaptiveSharedNamespace::TimeInput> timeInput = std::make_shared<AdaptiveSharedNamespace::TimeInput>();

--- a/source/uwp/Renderer/lib/AdaptiveTimeInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTimeInput.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "AdaptiveHeight.h"
 #include "AdaptiveTimeInput.h"
 
 #include "Util.h"
@@ -91,6 +92,21 @@ AdaptiveNamespaceStart
         return S_OK;
     }
 
+    _Use_decl_annotations_
+    HRESULT AdaptiveTimeInput::get_Height(IAdaptiveHeight** height)
+    {
+        std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement> sharedTimeInput;
+        RETURN_IF_FAILED(GetSharedModel(sharedTimeInput));
+        return MakeAndInitialize<AdaptiveHeight>(height, sharedTimeInput->GetHeight());
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveTimeInput::put_Height(IAdaptiveHeight* height)
+    {
+        return E_NOTIMPL;
+    }
+
+    _Use_decl_annotations_
     HRESULT AdaptiveTimeInput::GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) try
     {
         std::shared_ptr<AdaptiveSharedNamespace::TimeInput> timeInput = std::make_shared<AdaptiveSharedNamespace::TimeInput>();

--- a/source/uwp/Renderer/lib/AdaptiveTimeInput.h
+++ b/source/uwp/Renderer/lib/AdaptiveTimeInput.h
@@ -59,8 +59,8 @@ AdaptiveNamespaceStart
 
         virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) override;
 
-        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height);
-        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height);
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height) { return AdaptiveCardElementBase::get_Height(height); }
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height) { return AdaptiveCardElementBase::put_Height(height); }
 
         // ITypePeek method
         void *PeekAt(REFIID riid) override

--- a/source/uwp/Renderer/lib/AdaptiveTimeInput.h
+++ b/source/uwp/Renderer/lib/AdaptiveTimeInput.h
@@ -59,6 +59,9 @@ AdaptiveNamespaceStart
 
         virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) override;
 
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height);
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height);
+
         // ITypePeek method
         void *PeekAt(REFIID riid) override
         {

--- a/source/uwp/Renderer/lib/AdaptiveToggleInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveToggleInput.cpp
@@ -92,20 +92,6 @@ AdaptiveNamespaceStart
     }
 
     _Use_decl_annotations_
-    HRESULT AdaptiveToggleInput::get_Height(IAdaptiveHeight** height)
-    {
-        std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement> sharedToggleInput;
-        RETURN_IF_FAILED(GetSharedModel(sharedToggleInput));
-        return MakeAndInitialize<AdaptiveHeight>(height, sharedToggleInput->GetHeight());
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveToggleInput::put_Height(IAdaptiveHeight* height)
-    {
-        return E_NOTIMPL;
-    }
-
-    _Use_decl_annotations_
     HRESULT AdaptiveToggleInput::GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) try
     {
         std::shared_ptr<AdaptiveSharedNamespace::ToggleInput> toggleInput = std::make_shared<AdaptiveSharedNamespace::ToggleInput>();

--- a/source/uwp/Renderer/lib/AdaptiveToggleInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveToggleInput.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "AdaptiveHeight.h"
 #include "AdaptiveToggleInput.h"
 
 #include "Util.h"
@@ -90,6 +91,21 @@ AdaptiveNamespaceStart
         return S_OK;
     }
 
+    _Use_decl_annotations_
+    HRESULT AdaptiveToggleInput::get_Height(IAdaptiveHeight** height)
+    {
+        std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement> sharedToggleInput;
+        RETURN_IF_FAILED(GetSharedModel(sharedToggleInput));
+        return MakeAndInitialize<AdaptiveHeight>(height, sharedToggleInput->GetHeight());
+    }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveToggleInput::put_Height(IAdaptiveHeight* height)
+    {
+        return E_NOTIMPL;
+    }
+
+    _Use_decl_annotations_
     HRESULT AdaptiveToggleInput::GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) try
     {
         std::shared_ptr<AdaptiveSharedNamespace::ToggleInput> toggleInput = std::make_shared<AdaptiveSharedNamespace::ToggleInput>();

--- a/source/uwp/Renderer/lib/AdaptiveToggleInput.h
+++ b/source/uwp/Renderer/lib/AdaptiveToggleInput.h
@@ -59,8 +59,8 @@ AdaptiveNamespaceStart
 
         virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) override;
 
-        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height);
-        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height);
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height) { return AdaptiveCardElementBase::get_Height(height); }
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height) { return AdaptiveCardElementBase::put_Height(height); }
 
         // ITypePeek method
         void *PeekAt(REFIID riid) override

--- a/source/uwp/Renderer/lib/AdaptiveToggleInput.h
+++ b/source/uwp/Renderer/lib/AdaptiveToggleInput.h
@@ -59,6 +59,9 @@ AdaptiveNamespaceStart
 
         virtual HRESULT GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel) override;
 
+        IFACEMETHODIMP get_Height(_Out_ ABI::AdaptiveNamespace::IAdaptiveHeight** height);
+        IFACEMETHODIMP put_Height(_In_ ABI::AdaptiveNamespace::IAdaptiveHeight* height);
+
         // ITypePeek method
         void *PeekAt(REFIID riid) override
         {

--- a/source/uwp/Renderer/lib/WholeItemsPanel.h
+++ b/source/uwp/Renderer/lib/WholeItemsPanel.h
@@ -4,8 +4,10 @@
 #include <windows.ui.xaml.shapes.h>
 
 AdaptiveNamespaceStart
-    class WholeItemsPanel : public Microsoft::WRL::RuntimeClass<ABI::AdaptiveNamespace::IWholeItemsPanel,
+    class DECLSPEC_UUID("32934D77-6248-4915-BD2A-8F52EF6C8322") WholeItemsPanel : public Microsoft::WRL::RuntimeClass<
+        ABI::AdaptiveNamespace::IWholeItemsPanel,
         ABI::Windows::UI::Xaml::IFrameworkElementOverrides,
+        Microsoft::WRL::CloakedIid<ITypePeek>,
         Microsoft::WRL::ComposableBase<ABI::Windows::UI::Xaml::Controls::IPanelFactory>>
     {
         AdaptiveRuntimeStringClass(WholeItemsPanel)
@@ -35,9 +37,21 @@ AdaptiveNamespaceStart
             virtual HRESULT STDMETHODCALLTYPE IsAllContentClippedOut(__RPC__out boolean* pResult);
             virtual HRESULT STDMETHODCALLTYPE IsTruncated(__RPC__out boolean* pResult);
 
+            void AddElementToStretchablesList(_In_ ABI::Windows::UI::Xaml::IUIElement* element);
+            bool IsUIElementInStretchableList(_In_ ABI::Windows::UI::Xaml::IUIElement* element);
+
+            // ITypePeek method
+            void *PeekAt(REFIID riid) override
+            {
+                return PeekHelper(riid, this);
+            }
+
     private:
-        unsigned int m_visibleCount = 0;
-        unsigned int m_measuredCount = 0;
+        unsigned int m_visibleCount{};
+        unsigned int m_measuredCount{};
+
+        unsigned int m_accessKeyCount{};
+        std::set<std::string> m_stretchableItems;
 
         // true if this represents the mainPanel.
         // Some rules such as images vertical stretching only apply for this panel

--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -1879,13 +1879,13 @@ AdaptiveNamespaceStart
             }
             else if (isStretchResult == 0 || !adaptiveColumnWidth.IsValid() || (widthAsDouble <= 0))
             {
-                // If stretch specified, or column size invalid or set to non-positive, use stretch with default of 1
+                // If stretch specified, or column width invalid or set to non-positive, use stretch with default of 1
                 columnWidth.GridUnitType = GridUnitType::GridUnitType_Star;
                 columnWidth.Value = 1;
             }
             else
             {
-                // If user specified specific valid size, use that star size
+                // If user specified specific valid width, use that star width
                 columnWidth.GridUnitType = GridUnitType::GridUnitType_Star;
                 columnWidth.Value = _wtof(adaptiveColumnWidth.GetRawBuffer(nullptr));
             }

--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -670,6 +670,22 @@ AdaptiveNamespaceStart
                 ComPtr<IUIElement> newControl;
                 elementRenderer->Render(element, renderContext, renderArgs, &newControl);
                 XamlHelpers::AppendXamlElementToPanel(newControl.Get(), parentPanel);
+
+                /*
+                IAdaptiveHeight* elementHeight;
+                THROW_IF_FAILED(element->get_Height(&elementHeight));
+                ABI::AdaptiveCards::XamlCardRenderer::HeightType heightType;
+                THROW_IF_FAILED(elementHeight->get_HeightType(&heightType));
+                if (heightType == ABI::AdaptiveCards::XamlCardRenderer::HeightType::Stretch)
+                {
+                    XamlHelpers::AddRow(newControl.Get(), parentGrid, {1, GridUnitType::GridUnitType_Star});
+                }
+                else
+                {
+                    XamlHelpers::AddRow(newControl.Get(), parentGrid, {1, GridUnitType::GridUnitType_Auto});
+                }
+                */
+
                 childCreatedCallback(newControl.Get());
             }
             else
@@ -1073,6 +1089,10 @@ AdaptiveNamespaceStart
         // Buttons go into body panel, show cards go into outer panel so they're not inside the padding
         XamlHelpers::AppendXamlElementToPanel(actionsPanel.Get(), bodyPanel);
         XamlHelpers::AppendXamlElementToPanel(showCardsStackPanel.Get(), parentPanel);
+        // XamlHelpers::AddRow(actionsPanel.Get(), parentGrid, { 1, GridUnitType::GridUnitType_Auto });
+
+        // TODO: EdgeToEdge show cards should not go in "parentPanel", which has margins applied to it from the adaptive card options
+        // XamlHelpers::AddRow(showCardsStackPanel.Get(), parentGrid, { 1, GridUnitType::GridUnitType_Auto });
     }
 
     _Use_decl_annotations_

--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -667,24 +667,16 @@ AdaptiveNamespaceStart
                         XamlHelpers::AppendXamlElementToPanel(separator.Get(), parentPanel);
                     }
                 }
+
                 ComPtr<IUIElement> newControl;
                 elementRenderer->Render(element, renderContext, renderArgs, &newControl);
-                XamlHelpers::AppendXamlElementToPanel(newControl.Get(), parentPanel);
 
-                /*
-                IAdaptiveHeight* elementHeight;
-                THROW_IF_FAILED(element->get_Height(&elementHeight));
-                ABI::AdaptiveCards::XamlCardRenderer::HeightType heightType;
+                ComPtr<IAdaptiveHeight> elementHeight;
+                THROW_IF_FAILED(element->get_Height(elementHeight.GetAddressOf()));
+                ABI::AdaptiveNamespace::HeightType heightType;
                 THROW_IF_FAILED(elementHeight->get_HeightType(&heightType));
-                if (heightType == ABI::AdaptiveCards::XamlCardRenderer::HeightType::Stretch)
-                {
-                    XamlHelpers::AddRow(newControl.Get(), parentGrid, {1, GridUnitType::GridUnitType_Star});
-                }
-                else
-                {
-                    XamlHelpers::AddRow(newControl.Get(), parentGrid, {1, GridUnitType::GridUnitType_Auto});
-                }
-                */
+                
+                XamlHelpers::AppendXamlElementToPanel(newControl.Get(), parentPanel, heightType);
 
                 childCreatedCallback(newControl.Get());
             }
@@ -1797,6 +1789,9 @@ AdaptiveNamespaceStart
         ComPtr<IAdaptiveColumnSet> adaptiveColumnSet;
         THROW_IF_FAILED(cardElement.As(&adaptiveColumnSet));
 
+        ComPtr<WholeItemsPanel> gridContainer;
+        THROW_IF_FAILED(MakeAndInitialize<WholeItemsPanel>(&gridContainer));
+
         ComPtr<IGrid> xamlGrid = XamlHelpers::CreateXamlClass<IGrid>(HStringReference(RuntimeClass_Windows_UI_Xaml_Controls_Grid));
         ComPtr<IGridStatics> gridStatics;
         THROW_IF_FAILED(GetActivationFactory(HStringReference(RuntimeClass_Windows_UI_Xaml_Controls_Grid).Get(), &gridStatics));
@@ -1821,7 +1816,8 @@ AdaptiveNamespaceStart
         ComPtr<IAdaptiveHostConfig> hostConfig;
         THROW_IF_FAILED(renderContext->get_HostConfig(&hostConfig));
 
-        XamlHelpers::IterateOverVector<IAdaptiveColumn>(columns.Get(), [xamlGrid, gridStatics, &currentColumn, renderContext, renderArgs, columnRenderer, hostConfig](IAdaptiveColumn* column)
+        double maxColumnHeight{};
+        XamlHelpers::IterateOverVector<IAdaptiveColumn>(columns.Get(), [xamlGrid, gridStatics, &currentColumn, renderContext, renderArgs, columnRenderer, hostConfig, &maxColumnHeight](IAdaptiveColumn* column)
         {
             ComPtr<IAdaptiveCardElement> columnAsCardElement;
             ComPtr<IAdaptiveColumn> localColumn(column);
@@ -1909,7 +1905,30 @@ AdaptiveNamespaceStart
 
             // Finally add the column container to the grid
             XamlHelpers::AppendXamlElementToPanel(xamlColumn.Get(), gridAsPanel.Get());
+
+            Size columnSize;
+            THROW_IF_FAILED(xamlColumn->get_DesiredSize(&columnSize));
+            maxColumnHeight = max(maxColumnHeight, columnSize.Height);
         });
+
+        // Iterate over all the columns and asign the height for each column
+        ComPtr<IPanel> gridAsPanel;
+        THROW_IF_FAILED(xamlGrid.As(&gridAsPanel));
+        ComPtr<IVector<UIElement*>> panelChildren;
+        THROW_IF_FAILED(gridAsPanel->get_Children(panelChildren.ReleaseAndGetAddressOf()));
+        unsigned int childrenLength{};
+        THROW_IF_FAILED(panelChildren->get_Size(&childrenLength));
+
+        for (unsigned int i{}; i < childrenLength; ++i)
+        {
+            ComPtr<IUIElement> column;
+            THROW_IF_FAILED(panelChildren->GetAt(i, column.GetAddressOf()));
+
+            Size columnSize;
+            THROW_IF_FAILED(column->get_DesiredSize(&columnSize));
+            columnSize.Height = static_cast<float>(maxColumnHeight);
+            THROW_IF_FAILED(column->Measure(columnSize));
+        }
 
         ComPtr<IFrameworkElement> columnSetAsFrameworkElement;
         THROW_IF_FAILED(xamlGrid.As(&columnSetAsFrameworkElement));
@@ -1918,10 +1937,16 @@ AdaptiveNamespaceStart
         ComPtr<IAdaptiveActionElement> selectAction;
         THROW_IF_FAILED(adaptiveColumnSet->get_SelectAction(&selectAction));
 
+        ComPtr<IPanel> gridContainerAsPanel;
+        THROW_IF_FAILED(gridContainer.As(&gridContainerAsPanel));
+        ComPtr<IUIElement> gridContainerAsUIElement;
+        THROW_IF_FAILED(gridContainer.As(&gridContainerAsUIElement));
+
         ComPtr<IUIElement> gridAsUIElement;
         THROW_IF_FAILED(xamlGrid.As(&gridAsUIElement));
 
-        HandleSelectAction(adaptiveCardElement, selectAction.Get(), renderContext, gridAsUIElement.Get(), SupportsInteractivity(hostConfig.Get()), true, columnSetControl);
+        XamlHelpers::AppendXamlElementToPanel(xamlGrid.Get(), gridContainerAsPanel.Get());
+        HandleSelectAction(adaptiveCardElement, selectAction.Get(), renderContext, gridContainerAsUIElement.Get(), SupportsInteractivity(hostConfig.Get()), true, columnSetControl);
     }
 
     _Use_decl_annotations_
@@ -1951,13 +1976,23 @@ AdaptiveNamespaceStart
         THROW_IF_FAILED(columnDefinitions->Append(titleColumn.Get()));
         THROW_IF_FAILED(columnDefinitions->Append(valueColumn.Get()));
 
+        GridLength factSetGridHeight = factSetGridLength;
+        ComPtr<IAdaptiveHeight> height;
+        THROW_IF_FAILED(cardElement->get_Height(height.GetAddressOf()));
+        ABI::AdaptiveNamespace::HeightType heightType;
+        THROW_IF_FAILED(height->get_HeightType(&heightType));
+        if (heightType == ABI::AdaptiveNamespace::HeightType::Stretch)
+        {
+            factSetGridHeight = {1, GridUnitType::GridUnitType_Star};
+        }
+
         ComPtr<IVector<IAdaptiveFact*>> facts;
         THROW_IF_FAILED(adaptiveFactSet->get_Facts(&facts));
         int currentFact = 0;
-        XamlHelpers::IterateOverVector<IAdaptiveFact>(facts.Get(), [xamlGrid, gridStatics, factSetGridLength, &currentFact, renderContext, renderArgs](IAdaptiveFact* fact)
+        XamlHelpers::IterateOverVector<IAdaptiveFact>(facts.Get(), [xamlGrid, gridStatics, factSetGridHeight, &currentFact, renderContext, renderArgs](IAdaptiveFact* fact)
         {
             ComPtr<IRowDefinition> factRow = XamlHelpers::CreateXamlClass<IRowDefinition>(HStringReference(RuntimeClass_Windows_UI_Xaml_Controls_RowDefinition));
-            THROW_IF_FAILED(factRow->put_Height(factSetGridLength));
+            THROW_IF_FAILED(factRow->put_Height(factSetGridHeight));
 
             ComPtr<IVector<RowDefinition*>> rowDefinitions;
             THROW_IF_FAILED(xamlGrid->get_RowDefinitions(&rowDefinitions));
@@ -2089,6 +2124,8 @@ AdaptiveNamespaceStart
                 UINT32 maxImageHeight;
                 THROW_IF_FAILED(imageSetConfig->get_MaxImageHeight(&maxImageHeight));
                 THROW_IF_FAILED(imageAsFrameworkElement->put_MaxHeight(maxImageHeight));
+
+                
 
                 ComPtr<IPanel> gridAsPanel;
                 THROW_IF_FAILED(xamlGrid.As(&gridAsPanel));

--- a/source/uwp/Renderer/lib/XamlBuilder.h
+++ b/source/uwp/Renderer/lib/XamlBuilder.h
@@ -139,6 +139,7 @@ AdaptiveNamespaceStart
             _In_ ABI::Windows::Foundation::IUriRuntimeClass* uri,
             _Inout_ ABI::AdaptiveNamespace::IAdaptiveRenderContext* renderContext,
             _In_ ABI::AdaptiveNamespace::IAdaptiveRenderArgs* renderArgs);
+
         template<typename T>
         void SetImageSource(T* destination, ABI::Windows::UI::Xaml::Media::IImageSource* imageSource);
         template<typename T>
@@ -150,6 +151,14 @@ AdaptiveNamespaceStart
         void PopulateImageFromUrlAsync(_In_ ABI::Windows::Foundation::IUriRuntimeClass* imageUrl, T* imageControl);
         void FireAllImagesLoaded();
         void FireImagesLoadingHadError();
+        // Keeping it alive cause I dont know what this is
+        /*
+        void BuildPanelChildren(
+            _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCardElement*>* children,
+            _In_ ABI::Windows::UI::Xaml::Controls::IGrid* parentGrid,
+            std::shared_ptr<std::vector<InputItem>> inputElements,
+            _In_ std::function<void(ABI::Windows::UI::Xaml::IUIElement* child)> childCreatedCallback);
+        */
         void BuildShowCard(
             AdaptiveNamespace::AdaptiveCardRenderer* renderer,
             ABI::AdaptiveNamespace::IAdaptiveShowCardActionConfig* showCardActionConfig,
@@ -172,7 +181,14 @@ AdaptiveNamespaceStart
             _In_ bool insertSeparator,
             _Inout_ AdaptiveNamespace::AdaptiveRenderContext* renderContext,
             ABI::AdaptiveNamespace::ContainerStyle containerStyle);
-
+        
+        // I think this class is not used anymore, I think they changed the name for separator
+        /*
+        void GetSeparationConfigForElement(
+            _In_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveCardElement* element,
+            _In_ ABI::AdaptiveCards::XamlCardRenderer::SeparationStyle separation,
+            _COM_Outptr_result_maybenull_ ABI::AdaptiveCards::XamlCardRenderer::IAdaptiveSeparationConfig** separationConfig);
+            */
         static Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IUIElement> CreateSeparator(
             _Inout_  ABI::AdaptiveNamespace::IAdaptiveRenderContext* renderContext,
             UINT spacing, UINT separatorThickness, ABI::Windows::UI::Color separatorColor, bool isHorizontal = true);

--- a/source/uwp/Renderer/lib/XamlHelpers.h
+++ b/source/uwp/Renderer/lib/XamlHelpers.h
@@ -124,5 +124,34 @@ AdaptiveNamespaceStart
             THROW_IF_FAILED(content->put_Text(contentString));
             THROW_IF_FAILED(contentControl->put_Content(content.Get()));
         }
+
+        template<typename T>
+        static void AddRow(
+            T* item,
+            ABI::Windows::UI::Xaml::Controls::IGrid* grid,
+            ABI::Windows::UI::Xaml::GridLength rowHeight)
+        {
+            ComPtr<ABI::Windows::UI::Xaml::Controls::IGrid> localGrid(grid);
+
+            ComPtr<IVector<RowDefinition*>> rowDefinitions;
+            THROW_IF_FAILED(localGrid->get_RowDefinitions(&rowDefinitions));
+
+            unsigned int rowIndex;
+            THROW_IF_FAILED(rowDefinitions->get_Size(&rowIndex));
+            ComPtr<IGridStatics> gridStatics;
+            THROW_IF_FAILED(GetActivationFactory(HStringReference(RuntimeClass_Windows_UI_Xaml_Controls_Grid).Get(), &gridStatics));
+            Microsoft::WRL::ComPtr<T> localItem(item);
+            ComPtr<IFrameworkElement> localItemAsFrameworkElement;
+            THROW_IF_FAILED(localItem.As(&localItemAsFrameworkElement));
+            gridStatics->SetRow(localItemAsFrameworkElement.Get(), rowIndex);
+
+            ComPtr<IRowDefinition> rowDefinition = XamlHelpers::CreateXamlClass<IRowDefinition>(HStringReference(RuntimeClass_Windows_UI_Xaml_Controls_RowDefinition));
+            THROW_IF_FAILED(rowDefinition->put_Height(rowHeight));
+            THROW_IF_FAILED(rowDefinitions->Append(rowDefinition.Get()));
+
+            ComPtr<ABI::Windows::UI::Xaml::Controls::IPanel> localPanel;
+            THROW_IF_FAILED(localGrid.As(&localPanel));
+            XamlHelpers::AppendXamlElementToPanel(item, localPanel.Get());
+        }
     };
 AdaptiveNamespaceEnd

--- a/source/uwp/Renderer/lib/XamlHelpers.h
+++ b/source/uwp/Renderer/lib/XamlHelpers.h
@@ -51,7 +51,9 @@ AdaptiveNamespaceStart
         template<typename T>
         static void AppendXamlElementToPanel(
             T* xamlElement,
-            ABI::Windows::UI::Xaml::Controls::IPanel* panel)
+            ABI::Windows::UI::Xaml::Controls::IPanel* panel,
+            ABI::AdaptiveNamespace::HeightType heightType = ABI::AdaptiveNamespace::HeightType::Auto
+            )
         {
             if (!xamlElement)
             {
@@ -67,6 +69,17 @@ AdaptiveNamespaceStart
             THROW_IF_FAILED(panel->get_Children(panelChildren.ReleaseAndGetAddressOf()));
 
             THROW_IF_FAILED(panelChildren->Append(elementToAppend.Get()));
+
+            if (heightType == ABI::AdaptiveNamespace::HeightType::Stretch)
+            {
+                ComPtr<IPanel> spPanel(panel);
+                ComPtr<IWholeItemsPanel> wholeItemsPanel;
+                if (SUCCEEDED(spPanel.As(&wholeItemsPanel)))
+                {
+                    ComPtr<WholeItemsPanel> panel = PeekInnards<WholeItemsPanel>(wholeItemsPanel);
+                    panel->AddElementToStretchablesList(elementToAppend.Get());
+                }
+            }
         }
 
         template<typename T>


### PR DESCRIPTION
Adds the height property so elements may stretch over an empty space in the card height. As we don't have a property to define. 

Issue: https://github.com/Microsoft/AdaptiveCards/issues/1295 
