### PR TITLE
iOS: Do not call render at viewDidLoad

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRViewController.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRViewController.mm
@@ -45,7 +45,7 @@ using namespace AdaptiveCards;
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    self.view = [[[ACRView alloc] init:_adaptiveCard hostconfig:_hostConfig widthConstraint:_guideFrame.size.width] render];
+    self.view = [[ACRView alloc] init:_adaptiveCard hostconfig:_hostConfig widthConstraint:_guideFrame.size.width];
     ((ACRView *)self.view).acrActionDelegate = _delegate;
 }
 


### PR DESCRIPTION
## Defect
We wrongly called the render method in viewDidLoad. This resulted in double rendering of the same adaptive card, and multiple unnecessary calls to viewLoadElements.

This reproduces with renderAsViewController.

## Fix
Do not call render in viewDidLoad.

## Tests
Using a custom app, renderAsViewC renders the adaptive card with no dupulication.
Using the Visualizer app, adaptive cards are rendered as previous.
