### PR TITLE
Reduce calls to expensive locale functions

### DIFF
--- a/source/android/adaptivecards/src/main/cpp/objectmodel_wrap.cpp
+++ b/source/android/adaptivecards/src/main/cpp/objectmodel_wrap.cpp
@@ -14956,70 +14956,17 @@ SWIGEXPORT jlong JNICALL Java_io_adaptivecards_objectmodel_AdaptiveCardObjectMod
 }
 
 
-SWIGEXPORT void JNICALL Java_io_adaptivecards_objectmodel_AdaptiveCardObjectModelJNI_DateTimePreparser_1AddTextToken(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jstring jarg2, jint jarg3) {
+SWIGEXPORT jboolean JNICALL Java_io_adaptivecards_objectmodel_AdaptiveCardObjectModelJNI_DateTimePreparser_1HasDateTokens(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
+  jboolean jresult = 0 ;
   AdaptiveCards::DateTimePreparser *arg1 = (AdaptiveCards::DateTimePreparser *) 0 ;
-  std::string arg2 ;
-  AdaptiveCards::DateTimePreparsedTokenFormat arg3 ;
+  bool result;
   
   (void)jenv;
   (void)jcls;
   (void)jarg1_;
   arg1 = *(AdaptiveCards::DateTimePreparser **)&jarg1; 
-  if(!jarg2) {
-    SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null string");
-    return ;
-  } 
-  const char *arg2_pstr = (const char *)jenv->GetStringUTFChars(jarg2, 0); 
-  if (!arg2_pstr) return ;
-  (&arg2)->assign(arg2_pstr);
-  jenv->ReleaseStringUTFChars(jarg2, arg2_pstr); 
-  arg3 = (AdaptiveCards::DateTimePreparsedTokenFormat)jarg3; 
-  (arg1)->AddTextToken(arg2,arg3);
-}
-
-
-SWIGEXPORT void JNICALL Java_io_adaptivecards_objectmodel_AdaptiveCardObjectModelJNI_DateTimePreparser_1AddDateToken(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jstring jarg2, jlong jarg3, jobject jarg3_, jint jarg4) {
-  AdaptiveCards::DateTimePreparser *arg1 = (AdaptiveCards::DateTimePreparser *) 0 ;
-  std::string arg2 ;
-  tm arg3 ;
-  AdaptiveCards::DateTimePreparsedTokenFormat arg4 ;
-  tm *argp3 ;
-  
-  (void)jenv;
-  (void)jcls;
-  (void)jarg1_;
-  (void)jarg3_;
-  arg1 = *(AdaptiveCards::DateTimePreparser **)&jarg1; 
-  if(!jarg2) {
-    SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null string");
-    return ;
-  } 
-  const char *arg2_pstr = (const char *)jenv->GetStringUTFChars(jarg2, 0); 
-  if (!arg2_pstr) return ;
-  (&arg2)->assign(arg2_pstr);
-  jenv->ReleaseStringUTFChars(jarg2, arg2_pstr); 
-  argp3 = *(tm **)&jarg3; 
-  if (!argp3) {
-    SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "Attempt to dereference null tm");
-    return ;
-  }
-  arg3 = *argp3; 
-  arg4 = (AdaptiveCards::DateTimePreparsedTokenFormat)jarg4; 
-  (arg1)->AddDateToken(arg2,arg3,arg4);
-}
-
-
-SWIGEXPORT jstring JNICALL Java_io_adaptivecards_objectmodel_AdaptiveCardObjectModelJNI_DateTimePreparser_1Concatenate(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
-  jstring jresult = 0 ;
-  AdaptiveCards::DateTimePreparser *arg1 = (AdaptiveCards::DateTimePreparser *) 0 ;
-  std::string result;
-  
-  (void)jenv;
-  (void)jcls;
-  (void)jarg1_;
-  arg1 = *(AdaptiveCards::DateTimePreparser **)&jarg1; 
-  result = (arg1)->Concatenate();
-  jresult = jenv->NewStringUTF((&result)->c_str()); 
+  result = (bool)(arg1)->HasDateTokens();
+  jresult = (jboolean)result; 
   return jresult;
 }
 

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/objectmodel/AdaptiveCardObjectModelJNI.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/objectmodel/AdaptiveCardObjectModelJNI.java
@@ -748,9 +748,7 @@ public class AdaptiveCardObjectModelJNI {
   public final static native long new_DateTimePreparser__SWIG_0();
   public final static native long new_DateTimePreparser__SWIG_1(String jarg1);
   public final static native long DateTimePreparser_GetTextTokens(long jarg1, DateTimePreparser jarg1_);
-  public final static native void DateTimePreparser_AddTextToken(long jarg1, DateTimePreparser jarg1_, String jarg2, int jarg3);
-  public final static native void DateTimePreparser_AddDateToken(long jarg1, DateTimePreparser jarg1_, String jarg2, long jarg3, CTime jarg3_, int jarg4);
-  public final static native String DateTimePreparser_Concatenate(long jarg1, DateTimePreparser jarg1_);
+  public final static native boolean DateTimePreparser_HasDateTokens(long jarg1, DateTimePreparser jarg1_);
   public final static native void delete_DateTimePreparser(long jarg1);
   public final static native long new_TextBlock__SWIG_0();
   public final static native long new_TextBlock__SWIG_1(int jarg1, boolean jarg2, String jarg3, int jarg4, int jarg5, int jarg6, boolean jarg7, boolean jarg8, int jarg9, int jarg10, String jarg11);

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/objectmodel/DateTimePreparser.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/objectmodel/DateTimePreparser.java
@@ -47,16 +47,8 @@ public class DateTimePreparser {
     return new DateTimePreparsedTokenVector(AdaptiveCardObjectModelJNI.DateTimePreparser_GetTextTokens(swigCPtr, this), true);
   }
 
-  public void AddTextToken(String text, DateTimePreparsedTokenFormat format) {
-    AdaptiveCardObjectModelJNI.DateTimePreparser_AddTextToken(swigCPtr, this, text, format.swigValue());
-  }
-
-  public void AddDateToken(String text, CTime date, DateTimePreparsedTokenFormat format) {
-    AdaptiveCardObjectModelJNI.DateTimePreparser_AddDateToken(swigCPtr, this, text, CTime.getCPtr(date), date, format.swigValue());
-  }
-
-  public String Concatenate() {
-    return AdaptiveCardObjectModelJNI.DateTimePreparser_Concatenate(swigCPtr, this);
+  public boolean HasDateTokens() {
+    return AdaptiveCardObjectModelJNI.DateTimePreparser_HasDateTokens(swigCPtr, this);
   }
 
 }

--- a/source/shared/cpp/ObjectModel/DateTimePreparser.cpp
+++ b/source/shared/cpp/ObjectModel/DateTimePreparser.cpp
@@ -20,7 +20,8 @@
 
 using namespace AdaptiveSharedNamespace;
 
-DateTimePreparser::DateTimePreparser()
+DateTimePreparser::DateTimePreparser() :
+    m_hasDateTokens(false)
 {
 }
 
@@ -34,6 +35,11 @@ std::vector<std::shared_ptr<DateTimePreparsedToken>> DateTimePreparser::GetTextT
     return m_textTokenCollection;
 }
 
+bool DateTimePreparser::HasDateTokens()
+{
+    return m_hasDateTokens;
+}
+
 void DateTimePreparser::AddTextToken(std::string text, DateTimePreparsedTokenFormat format)
 {
     if (!text.empty())
@@ -45,6 +51,7 @@ void DateTimePreparser::AddTextToken(std::string text, DateTimePreparsedTokenFor
 void DateTimePreparser::AddDateToken(std::string text, struct tm date, DateTimePreparsedTokenFormat format)
 {
     m_textTokenCollection.emplace_back(std::make_shared<DateTimePreparsedToken>(text, date, format));
+    m_hasDateTokens = true;
 }
 
 std::string DateTimePreparser::Concatenate()

--- a/source/shared/cpp/ObjectModel/DateTimePreparser.h
+++ b/source/shared/cpp/ObjectModel/DateTimePreparser.h
@@ -12,14 +12,16 @@ AdaptiveSharedNamespaceStart
         DateTimePreparser();
         DateTimePreparser(std::string in);
         std::vector<std::shared_ptr<DateTimePreparsedToken>> GetTextTokens() const;
+        bool HasDateTokens();
+
+    private:
         void AddTextToken(std::string text, DateTimePreparsedTokenFormat format);
         void AddDateToken(std::string text, struct tm date, DateTimePreparsedTokenFormat format);
         std::string Concatenate();
-
-    private:
         static bool IsValidTimeAndDate(const struct tm &parsedTm, int hours, int minutes);
         void ParseDateTime(std::string in);        
 
         std::vector<std::shared_ptr<DateTimePreparsedToken>> m_textTokenCollection;
+        bool m_hasDateTokens;
     };
 AdaptiveSharedNamespaceEnd

--- a/source/uwp/Renderer/lib/DateTimeParser.cpp
+++ b/source/uwp/Renderer/lib/DateTimeParser.cpp
@@ -14,7 +14,20 @@ DateTimeParser::DateTimeParser(const std::string& language)
 std::string DateTimeParser::GenerateString(DateTimePreparser text)
 {
     std::wostringstream parsedostr;
-    bool haveSetLanguage = false;
+
+    if (text.HasDateTokens())
+    {
+        std::locale language;
+        try
+        {
+            language = std::locale(m_languageString.c_str());
+        }
+        catch (...)
+        {
+            language = std::locale("");
+        }
+        parsedostr.imbue(language);
+    }
 
     for (const auto& textSection : text.GetTextTokens())
     {
@@ -24,21 +37,6 @@ std::string DateTimeParser::GenerateString(DateTimePreparser text)
         result.tm_year = textSection->GetYear() >= 1900 ? textSection->GetYear() - 1900 : 0;
 
         DateTimePreparsedTokenFormat format = textSection->GetFormat();
-        if (format != DateTimePreparsedTokenFormat::RegularString && !haveSetLanguage)
-        {
-            std::locale language;
-            try
-            {
-                language = std::locale(m_languageString.c_str());
-            }
-            catch (...)
-            {
-                language = std::locale("");
-            }
-            parsedostr.imbue(language);
-            haveSetLanguage = true;
-        }
-
         // using the put_time function the 3 formats are locale dependent
         switch (format)
         {

--- a/source/uwp/Renderer/lib/DateTimeParser.cpp
+++ b/source/uwp/Renderer/lib/DateTimeParser.cpp
@@ -36,9 +36,8 @@ std::string DateTimeParser::GenerateString(DateTimePreparser text)
         result.tm_mon = textSection->GetMonth();
         result.tm_year = textSection->GetYear() >= 1900 ? textSection->GetYear() - 1900 : 0;
 
-        DateTimePreparsedTokenFormat format = textSection->GetFormat();
         // using the put_time function the 3 formats are locale dependent
-        switch (format)
+        switch (textSection->GetFormat())
         {
             case DateTimePreparsedTokenFormat::DateCompact:
                 parsedostr << std::put_time(&result, L"%Ex");

--- a/source/uwp/Renderer/lib/DateTimeParser.h
+++ b/source/uwp/Renderer/lib/DateTimeParser.h
@@ -12,6 +12,6 @@ AdaptiveNamespaceStart
         std::string GenerateString(DateTimePreparser text);
 
     private:
-        std::locale m_language;
+        std::string m_languageString;
     };
 AdaptiveNamespaceEnd


### PR DESCRIPTION
Profiling showed that the locale functions were taking a significant amount of time during rendering. Updated the date time parser code to not call locale functions until we actually encounter a date. This change results in a ~20-25% reduction in the overall render time.