### PR TITLE
 Don't create the xml document if there's no html

### DIFF
--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/MarkDownUnitTest.cpp
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/MarkDownUnitTest.cpp
@@ -14,6 +14,7 @@ namespace AdaptiveCardsSharedModelUnitTest
         {
             MarkDownParser parser("");
             Assert::AreEqual<string>("<p></p>", parser.TransformToHtml());
+            Assert::AreEqual<bool>(false, parser.HasHtmlTags());
         }
     };
 
@@ -33,11 +34,13 @@ namespace AdaptiveCardsSharedModelUnitTest
         {
             MarkDownParser parser("* foo bar*");
             Assert::AreEqual<string>("<p>* foo bar*</p>", parser.TransformToHtml());
+            Assert::AreEqual<bool>(false, parser.HasHtmlTags());
         }
         TEST_METHOD(UnderscoreLeftDelimiterFalseCaseWithSpaceTest)
         {
             MarkDownParser parser("_ foo bar_");
             Assert::AreEqual<string>("<p>_ foo bar_</p>", parser.TransformToHtml());
+            Assert::AreEqual<bool>(false, parser.HasHtmlTags());
         }
         TEST_METHOD(LeftDelimiterFalseCaseWithAlphaNumericInfrontAndPuntuationBehind)
         {
@@ -354,42 +357,49 @@ namespace AdaptiveCardsSharedModelUnitTest
         {
             MarkDownParser parser("[hello(www.naver.com)"); 
             Assert::AreEqual<string>("<p>[hello(www.naver.com)</p>", parser.TransformToHtml());
+            Assert::AreEqual<bool>(parser.HasHtmlTags(), false);
         }
 
         TEST_METHOD(InvalidLinkTestWithInvalidEmphasis)
         {
             MarkDownParser parser("*[*hello(www.naver.com)"); 
             Assert::AreEqual<string>("<p>*[*hello(www.naver.com)</p>", parser.TransformToHtml());
+            Assert::AreEqual<bool>(parser.HasHtmlTags(), false);
         }
 
         TEST_METHOD(InvalidLinkTestWithValidEmphasis)
         {
             MarkDownParser parser("*[*hello(www.naver.com)*"); 
             Assert::AreEqual<string>("<p>*[<em>hello(www.naver.com)</em></p>", parser.TransformToHtml());
+            Assert::AreEqual<bool>(parser.HasHtmlTags(), true);
         }
 
         TEST_METHOD(ValidLinkTestWithUnMatchingBracketsWithChars)
         {
             MarkDownParser parser("[a[b[hello](www.naver.com)"); 
             Assert::AreEqual<string>("<p>[a[b<a href=\"www.naver.com\">hello</a></p>", parser.TransformToHtml());
+            Assert::AreEqual<bool>(true, parser.HasHtmlTags());
         }
 
         TEST_METHOD(ValidLinkTestWithUnMatchingBracketsWithCharsAndParenthesis)
         {
             MarkDownParser parser("[[a[b[h(ello](www.naver.com)"); 
             Assert::AreEqual<string>("<p>[[a[b<a href=\"www.naver.com\">h(ello</a></p>", parser.TransformToHtml());
+            Assert::AreEqual<bool>(true, parser.HasHtmlTags());
         }
 
         TEST_METHOD(InvalidCharsBetweenLinkTextAndDestination)
         {
             MarkDownParser parser("[hello]a(www.naver.com)");
             Assert::AreEqual<string>("<p>[hello]a(www.naver.com)</p>", parser.TransformToHtml());
+            Assert::AreEqual<bool>(false, parser.HasHtmlTags());
         }
 
         TEST_METHOD(OutSideEmphasisAndLinkTest)
         {
             MarkDownParser parser("*[hello](www.naver.com)*"); 
             Assert::AreEqual<string>("<p><em><a href=\"www.naver.com\">hello</a></em></p>", parser.TransformToHtml());
+            Assert::AreEqual<bool>(true, parser.HasHtmlTags());
         }
 
         TEST_METHOD(EmphasisAndLinkTextTest)
@@ -456,6 +466,7 @@ namespace AdaptiveCardsSharedModelUnitTest
         {
             MarkDownParser parser("Hello\r- my list");
             Assert::AreEqual<string>("<p>Hello</p><ul><li>my list</li></ul>", parser.TransformToHtml());
+            Assert::AreEqual<bool>(true, parser.HasHtmlTags());
         }
         TEST_METHOD(ListFollowedByPtagedBlockElementTest)
         {
@@ -471,6 +482,7 @@ namespace AdaptiveCardsSharedModelUnitTest
         {
             MarkDownParser parser("023-34-567");
             Assert::AreEqual<string>("<p>023-34-567</p>", parser.TransformToHtml());
+            Assert::AreEqual<bool>(false, parser.HasHtmlTags());
         }
     };
     TEST_CLASS(OrderedListTest)
@@ -489,6 +501,7 @@ namespace AdaptiveCardsSharedModelUnitTest
         {
             MarkDownParser parser("1. hello world - hello hello");
             Assert::AreEqual<string>("<ol start=\"1\"><li>hello world - hello hello</li></ol>", parser.TransformToHtml());
+            Assert::AreEqual<bool>(true, parser.HasHtmlTags());
         }
         TEST_METHOD(MultipleListWithHyphenTests)
         {
@@ -509,6 +522,7 @@ namespace AdaptiveCardsSharedModelUnitTest
         {
             MarkDownParser parser("Hello\r1. my list");
             Assert::AreEqual<string>("<p>Hello</p><ol start=\"1\"><li>my list</li></ol>", parser.TransformToHtml());
+            Assert::AreEqual<bool>(true, parser.HasHtmlTags());
         }
         TEST_METHOD(ListFollowedByPtagedBlockElementTest)
         {

--- a/source/shared/cpp/ObjectModel/MarkDownBlockParser.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownBlockParser.cpp
@@ -471,6 +471,7 @@ void LinkParser::CaptureLinkToken()
         std::make_shared<MarkDownStringHtmlGenerator>(html_string);
 
     m_parsedResult.Clear();
+    m_parsedResult.FoundHtmlTags();
     m_parsedResult.AppendToTokens(codeGen);
 }
 
@@ -621,6 +622,7 @@ void ListParser::CaptureListToken()
         std::make_shared<MarkDownListHtmlGenerator>(html_string);
 
     m_parsedResult.Clear();
+    m_parsedResult.FoundHtmlTags();
     m_parsedResult.AppendToTokens(codeGen);
 }
 
@@ -674,5 +676,6 @@ void OrderedListParser::CaptureOrderedListToken(std::string &number_string)
         std::make_shared<MarkDownOrderedListHtmlGenerator>(html_string, number_string);
 
     m_parsedResult.Clear();
+    m_parsedResult.FoundHtmlTags();
     m_parsedResult.AppendToTokens(codeGen);
 }

--- a/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.cpp
@@ -58,11 +58,12 @@ int MarkDownEmphasisHtmlGenerator::AdjustEmphasisCounts(int leftOver, std::share
 }
 
 // generate bold and emphasis html tags
-void MarkDownEmphasisHtmlGenerator::GenerateTags(std::shared_ptr<MarkDownEmphasisHtmlGenerator> &token)
+bool MarkDownEmphasisHtmlGenerator::GenerateTags(std::shared_ptr<MarkDownEmphasisHtmlGenerator> &token)
 {
     int delimiterCount = 0, leftOver = 0;
     leftOver = this->m_numberOfUnusedDelimiters - token->m_numberOfUnusedDelimiters;
     delimiterCount = this->AdjustEmphasisCounts(leftOver, token);
+    bool hasHtmlTags = (delimiterCount > 0);
 
     // emphasis found
     if (delimiterCount % 2)
@@ -77,6 +78,7 @@ void MarkDownEmphasisHtmlGenerator::GenerateTags(std::shared_ptr<MarkDownEmphasi
         this->PushBoldTag();
         token->PushBoldTag();
     }
+    return hasHtmlTags;
 }
 
 void MarkDownEmphasisHtmlGenerator::PushItalicTag()

--- a/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.h
+++ b/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.h
@@ -101,7 +101,7 @@ class MarkDownEmphasisHtmlGenerator : public MarkDownHtmlGenerator
         bool IsSameType(std::shared_ptr<MarkDownEmphasisHtmlGenerator> &token);
         bool IsDone() const { return m_numberOfUnusedDelimiters == 0; }
         int GetNumberOfUnusedDelimiters() const { return m_numberOfUnusedDelimiters; };
-        void GenerateTags(std::shared_ptr<MarkDownEmphasisHtmlGenerator> &token);
+        bool GenerateTags(std::shared_ptr<MarkDownEmphasisHtmlGenerator> &token);
         void ReverseDirectionType() { m_directionType = !m_directionType; };
     protected:
         enum 

--- a/source/shared/cpp/ObjectModel/MarkDownParsedResult.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownParsedResult.cpp
@@ -44,6 +44,7 @@ void MarkDownParsedResult::AppendParseResult(MarkDownParsedResult &x)
     }
     m_codeGenTokens.splice(m_codeGenTokens.end(), x.m_codeGenTokens);
     m_emphasisLookUpTable.splice(m_emphasisLookUpTable.end(), x.m_emphasisLookUpTable);
+    m_isHTMLTagsAdded = m_isHTMLTagsAdded || x.HasHtmlTags();
 }
 
 // append MarkDownHtmlGenerator object to callee's prased result
@@ -228,7 +229,7 @@ void MarkDownParsedResult::MatchLeftAndRightEmphasises()
                 }
             }
             // check which one has leftover delims
-            (*currentLeftEmphasis)->GenerateTags(*currentEmphasis);
+            m_isHTMLTagsAdded = m_isHTMLTagsAdded | (*currentLeftEmphasis)->GenerateTags(*currentEmphasis);
 
             // all right delims used, move to next
             if ((*currentEmphasis)->IsDone())
@@ -247,4 +248,14 @@ void MarkDownParsedResult::MatchLeftAndRightEmphasises()
             currentEmphasis++;
         }
     }
+}
+
+bool MarkDownParsedResult::HasHtmlTags()
+{
+    return m_isHTMLTagsAdded;
+}
+
+void MarkDownParsedResult::FoundHtmlTags()
+{
+    m_isHTMLTagsAdded = true;
 }

--- a/source/shared/cpp/ObjectModel/MarkDownParsedResult.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownParsedResult.cpp
@@ -229,7 +229,7 @@ void MarkDownParsedResult::MatchLeftAndRightEmphasises()
                 }
             }
             // check which one has leftover delims
-            m_isHTMLTagsAdded = m_isHTMLTagsAdded || (*currentLeftEmphasis)->GenerateTags(*currentEmphasis);
+            m_isHTMLTagsAdded = (*currentLeftEmphasis)->GenerateTags(*currentEmphasis) || m_isHTMLTagsAdded;
 
             // all right delims used, move to next
             if ((*currentEmphasis)->IsDone())

--- a/source/shared/cpp/ObjectModel/MarkDownParsedResult.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownParsedResult.cpp
@@ -229,7 +229,7 @@ void MarkDownParsedResult::MatchLeftAndRightEmphasises()
                 }
             }
             // check which one has leftover delims
-            m_isHTMLTagsAdded = m_isHTMLTagsAdded | (*currentLeftEmphasis)->GenerateTags(*currentEmphasis);
+            m_isHTMLTagsAdded = m_isHTMLTagsAdded || (*currentLeftEmphasis)->GenerateTags(*currentEmphasis);
 
             // all right delims used, move to next
             if ((*currentEmphasis)->IsDone())

--- a/source/shared/cpp/ObjectModel/MarkDownParsedResult.h
+++ b/source/shared/cpp/ObjectModel/MarkDownParsedResult.h
@@ -9,6 +9,7 @@ AdaptiveSharedNamespaceStart
     class MarkDownParsedResult
     {
         public:
+        MarkDownParsedResult() : m_isHTMLTagsAdded(false) {};
         // Translate Intermediate Parsing Result to a form that can be
         // written to html string
         void Translate();
@@ -32,10 +33,13 @@ AdaptiveSharedNamespaceStart
         void PopFront();
         void PopBack();
         void Clear();
+        bool HasHtmlTags();
+        void FoundHtmlTags();
         private:
         void MarkTags(const std::shared_ptr<MarkDownHtmlGenerator> &);
         std::list<std::shared_ptr<MarkDownHtmlGenerator>> m_codeGenTokens;
         std::list<std::shared_ptr<MarkDownEmphasisHtmlGenerator>> m_emphasisLookUpTable;
+        bool m_isHTMLTagsAdded;
         // take m_emphasisLookUpTable and matches left and right emphasises
         void MatchLeftAndRightEmphasises();
     };

--- a/source/shared/cpp/ObjectModel/MarkDownParser.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownParser.cpp
@@ -6,7 +6,7 @@
 
 using namespace AdaptiveSharedNamespace;
 
-MarkDownParser::MarkDownParser(const std::string &txt) : m_text(txt)
+MarkDownParser::MarkDownParser(const std::string &txt) : m_text(txt), m_hasHTMLTag(false)
 {
 }
 
@@ -27,9 +27,14 @@ std::string MarkDownParser::TransformToHtml()
     //add block tags such as <p> <ul>
     m_parsedResult.AddBlockTags();
 
+    m_hasHTMLTag = m_parsedResult.HasHtmlTags();
     return m_parsedResult.GenerateHtmlString();
 }
 
+bool MarkDownParser::HasHtmlTags()
+{
+    return m_hasHTMLTag;
+}
 // MarkDown is consisted of Blocks, this methods parses blocks
 void MarkDownParser::ParseBlock()
 {

--- a/source/shared/cpp/ObjectModel/MarkDownParser.h
+++ b/source/shared/cpp/ObjectModel/MarkDownParser.h
@@ -17,10 +17,13 @@ public:
 
     std::string TransformToHtml();
 
+    bool HasHtmlTags();
+
 private:
     void ParseBlock();
     std::string EscapeText();
     std::string m_text;
     MarkDownParsedResult m_parsedResult;
+    bool m_hasHTMLTag;
 };
 AdaptiveSharedNamespaceEnd

--- a/source/uwp/Renderer/lib/HtmlHelpers.h
+++ b/source/uwp/Renderer/lib/HtmlHelpers.h
@@ -11,3 +11,10 @@ HRESULT AddTextInlines(
     BOOL isBold,
     BOOL isItalic,
     ABI::Windows::Foundation::Collections::IVector<ABI::Windows::UI::Xaml::Documents::Inline*>* inlines);
+
+HRESULT AddSingleTextInline(
+    ABI::AdaptiveNamespace::IAdaptiveRenderContext* renderContext,
+    HSTRING string,
+    bool isBold,
+    bool isItalic,
+    ABI::Windows::Foundation::Collections::IVector<ABI::Windows::UI::Xaml::Documents::Inline*>* inlines);


### PR DESCRIPTION
Profiling showed significant time spent in msxml. Updated code to not create the xml document if the text doesn't have markdown in it. Thanks to Joseph for the update to the markdown parser to allow me to detect this. Change results in ~15% improvement in renderer performance.