### PR TITLE
Prevent RETURN_IF_FAILED from executing the same statement twice

### DIFF
--- a/source/uwp/Renderer/lib/ErrorHandling.h
+++ b/source/uwp/Renderer/lib/ErrorHandling.h
@@ -2,6 +2,6 @@
 
 #include <sal.h>
 
-#define RETURN_IF_FAILED(hr)        do { if (FAILED(hr)) { return hr;}} while (0, 0)
+#define RETURN_IF_FAILED(statement) do { HRESULT hr = statement; if (FAILED(hr)) { return hr;}} while (0, 0)
 #define THROW_IF_FAILED(hr)         do { if (FAILED(hr)) { throw new std::exception();}} while (0, 0)
 #define CATCH_RETURN catch (...) {return E_FAIL;}


### PR DESCRIPTION
While doing code analysis I noticed that our RETURN_IF_FAILED macro is wrong.

`RETURN_IF_FAILED(GetValue())` would expand to:

```cpp
if(FAILED(GetValue())
{
    return GetValue();
}
```

This could have some side effects when calling the code twice.

Also, after the change, our binary size has decreased by 22K.