### PR TITLE
[UWP] Fix break when language is not specified

### DIFF
--- a/source/uwp/Renderer/lib/AdaptiveTextBlock.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTextBlock.cpp
@@ -190,8 +190,11 @@ AdaptiveNamespaceStart
         textBlock->SetText(text);
 
         std::string language;
-        RETURN_IF_FAILED(HStringToUTF8(m_language.Get(), language));
-        textBlock->SetLanguage(language);
+        if (!(WindowsIsStringEmpty(m_language.Get())))
+        {
+            RETURN_IF_FAILED(HStringToUTF8(m_language.Get(), language));
+            textBlock->SetLanguage(language);
+        }
 
         sharedTextBlock = textBlock;
         return S_OK;

--- a/source/uwp/Renderer/lib/Util.cpp
+++ b/source/uwp/Renderer/lib/Util.cpp
@@ -739,20 +739,6 @@ std::wstring StringToWstring(const std::string& in)
 
 std::string WstringToString(const std::wstring& input)
 {
-    // Different platforms and compilers use different sizes for wchar_t, 
-    // in Windows the size for wchar_t is 2 bytes (https://docs.microsoft.com/en-us/cpp/cpp/char-wchar-t-char16-t-char32-t)
-    // while Android and iOS have a wchar_t size of 4 bytes
-    #pragma warning( push )
-    #pragma warning( disable : 4127)
-    if (sizeof(wchar_t) == 2)
-    #pragma warning( pop )
-    {
-        std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t> utfConverter;
-        return utfConverter.to_bytes(input);
-    }
-    else
-    {
-        std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> utfConverter;
-        return utfConverter.to_bytes(input);
-    }
+    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t> utfConverter;
+    return utfConverter.to_bytes(input);
 }


### PR DESCRIPTION
The GetSharedModel failed when retrieving the language when it was empty (I wonder if some other modules may fail because of the same)


Bug: https://github.com/Microsoft/AdaptiveCards/issues/1407