### PR TITLE
Implement GetResourceUris at the UWP layer

### DIFF
--- a/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
+++ b/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
@@ -418,7 +418,6 @@ AdaptiveNamespaceStart
         interface Windows.Foundation.Collections.IVector<IAdaptiveWarning*>;
         interface Windows.Foundation.Collections.IObservableVector<IAdaptiveCardElement*>;
         interface Windows.Foundation.Collections.IObservableVector<IAdaptiveColumn*>;
-        interface Windows.Foundation.Collections.IObservableVector<IAdaptiveColumn*>;
         interface Windows.Foundation.IAsyncOperation<RenderedAdaptiveCard*>;
     }
 
@@ -450,6 +449,15 @@ AdaptiveNamespaceStart
         [propput] HRESULT AdditionalProperties([in] Windows.Data.Json.JsonObject* json);
 
         HRESULT ToJson([out, retval] Windows.Data.Json.JsonObject** value);
+    };
+
+    [
+        uuid(7BEB71E7-2401-4B40-95AC-DCA3A06FAB37),
+        version(NTDDI_WIN10_RS1),
+    ]
+    interface IAdaptiveElementWithRemoteResources : IInspectable
+    {
+        HRESULT GetResourceUris([out, retval] Windows.Foundation.Collections.IVectorView<Windows.Foundation.Uri*>** result);
     };
 
     [
@@ -580,6 +588,8 @@ AdaptiveNamespaceStart
         [propput] HRESULT SelectAction([in] IAdaptiveActionElement* value);
 
         HRESULT ToJson([out, retval] Windows.Data.Json.JsonObject** value);
+
+        HRESULT GetResourceUris([out, retval] Windows.Foundation.Collections.IVectorView<Windows.Foundation.Uri*>** result);
     };
 
     [

--- a/source/uwp/Renderer/lib/AdaptiveCard.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveCard.cpp
@@ -307,4 +307,34 @@ AdaptiveNamespaceStart
         sharedModel = adaptiveCard;
         return S_OK;
     }
+
+    _Use_decl_annotations_
+    HRESULT AdaptiveCard::GetResourceUris(_COM_Outptr_ ABI::Windows::Foundation::Collections::IVectorView<ABI::Windows::Foundation::Uri*>** uris)
+    {
+        std::shared_ptr<AdaptiveCards::AdaptiveCard> sharedModel;
+        GetSharedModel(sharedModel);
+
+        std::vector<std::string> resourceUriStrings = sharedModel->GetResourceUris();
+
+        ComPtr<IUriRuntimeClassFactory> uriActivationFactory;
+        RETURN_IF_FAILED(GetActivationFactory(
+            HStringReference(RuntimeClass_Windows_Foundation_Uri).Get(),
+            &uriActivationFactory));
+
+        ComPtr<ABI::Windows::Foundation::Collections::IVector<ABI::Windows::Foundation::Uri*>> resourceUris = Make<Vector<Uri*>>();
+        for (auto resourceUriString : resourceUriStrings)
+        {
+            HString resourceUriHString;
+            RETURN_IF_FAILED(UTF8ToHString(resourceUriString, resourceUriHString.GetAddressOf()));
+         
+            ComPtr<IUriRuntimeClass> resourceUri;
+            RETURN_IF_FAILED(uriActivationFactory->CreateUri(resourceUriHString.Get(), resourceUri.GetAddressOf()));
+
+            RETURN_IF_FAILED(resourceUris->Append(resourceUri.Get()));
+        }
+
+        RETURN_IF_FAILED(resourceUris->GetView(uris));
+
+        return S_OK;
+    }
 AdaptiveNamespaceEnd

--- a/source/uwp/Renderer/lib/AdaptiveCard.h
+++ b/source/uwp/Renderer/lib/AdaptiveCard.h
@@ -43,6 +43,8 @@ AdaptiveNamespaceStart
 
         IFACEMETHODIMP ToJson(_Out_ ABI::Windows::Data::Json::IJsonObject** result);
 
+        IFACEMETHODIMP GetResourceUris(_COM_Outptr_ ABI::Windows::Foundation::Collections::IVectorView<ABI::Windows::Foundation::Uri*>** uris);
+
         HRESULT GetSharedModel(std::shared_ptr<AdaptiveSharedNamespace::AdaptiveCard>& sharedModel);
 
         // ITypePeek method

--- a/source/uwp/Renderer/lib/CustomActionWrapper.cpp
+++ b/source/uwp/Renderer/lib/CustomActionWrapper.cpp
@@ -50,4 +50,12 @@ HRESULT CustomActionWrapper::GetWrappedElement(ABI::AdaptiveNamespace::IAdaptive
     return m_actionElement.CopyTo(actionElement);
 }
 
+void CustomActionWrapper::GetResourceUris(std::vector<std::string>& resourceUris)
+{
+    ComPtr<ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveElementWithRemoteResources> remoteResources;
+    if (SUCCEEDED(m_actionElement.As(&remoteResources)))
+    {
+        RemoteResourceElementToUriStringVector(remoteResources.Get(), resourceUris);
+    }
+}
 AdaptiveNamespaceEnd

--- a/source/uwp/Renderer/lib/CustomActionWrapper.h
+++ b/source/uwp/Renderer/lib/CustomActionWrapper.h
@@ -22,6 +22,8 @@ AdaptiveNamespaceStart
 
         HRESULT GetWrappedElement(ABI::AdaptiveNamespace::IAdaptiveActionElement** actionElement);
 
+        virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
+
     private:
         Microsoft::WRL::ComPtr<ABI::AdaptiveNamespace::IAdaptiveActionElement> m_actionElement;
     };

--- a/source/uwp/Renderer/lib/CustomElementWrapper.cpp
+++ b/source/uwp/Renderer/lib/CustomElementWrapper.cpp
@@ -56,6 +56,15 @@ AdaptiveNamespaceStart
         return jsonCppValue;
     }
 
+    void CustomElementWrapper::GetResourceUris(std::vector<std::string>& resourceUris)
+    {
+        ComPtr<ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveElementWithRemoteResources> remoteResources;
+        if (SUCCEEDED(m_cardElement.As(&remoteResources)))
+        {
+            RemoteResourceElementToUriStringVector(remoteResources.Get(), resourceUris);
+        }
+    }
+
     HRESULT CustomElementWrapper::GetWrappedElement(ABI::AdaptiveNamespace::IAdaptiveCardElement** cardElement)
     {
         return m_cardElement.CopyTo(cardElement);

--- a/source/uwp/Renderer/lib/CustomElementWrapper.h
+++ b/source/uwp/Renderer/lib/CustomElementWrapper.h
@@ -23,6 +23,8 @@ AdaptiveNamespaceStart
 
         virtual Json::Value SerializeToJsonValue() override;
 
+        virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
+
         HRESULT GetWrappedElement(ABI::AdaptiveNamespace::IAdaptiveCardElement** cardElement);
 
     private:

--- a/source/uwp/Renderer/lib/Util.h
+++ b/source/uwp/Renderer/lib/Util.h
@@ -154,3 +154,7 @@ template<typename T, typename R> Microsoft::WRL::ComPtr<T> PeekInnards(R r)
     }
     return inner;
 }
+
+void RemoteResourceElementToUriStringVector(
+    ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveElementWithRemoteResources* remoteResources,
+    std::vector<std::string>& resourceUris);

--- a/source/uwp/Renderer/lib/Vector.h
+++ b/source/uwp/Renderer/lib/Vector.h
@@ -1,263 +1,684 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT License. 
+
 #pragma once
 
-#include "AdaptiveCards.Rendering.Uwp.h"
-#include <windows.foundation.collections.h>
-#include <wrl.h>
+#include "winstring.h"
+#include <algorithm>
+#include <assert.h>
+#include <iterator>
+#include <mutex>
+#include <typeindex>
+#include <unordered_map>
 
-using namespace ABI::Windows::Foundation::Collections;
-using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;
 
-AdaptiveNamespaceStart
-    template <typename T>
-    struct Wrap
+//Helpers for error handling.  General strategy is that errors are always
+//reported as exceptions (so we don't need to special case any STL usage).
+
+//Methods that need to return HRESULTs wrap their body inside an
+//ExceptionBoundary.
+
+//Generally all errors are reported with an associated HRESULT.  These are
+//represented as an HResultException.  Use ExceptionBoundary() to catch
+//exceptions and translate them to HRESULTs.
+
+//As the constructor is protected, only ThrowHR() can be used to throw an
+//HResultException.  This provides future flexibility in case we some day
+//want to throw more varied types of exception.
+
+class HResultException
+{
+    HRESULT m_Hr;
+
+protected:
+    explicit HResultException(HRESULT hr)
+        : m_Hr(hr)
+    {}
+
+public:
+    HRESULT GetHr() const
     {
-        typename typedef T type;
-        static const T& MakeWrap(const T& t)
-        {
-            return t;
-        }
-        static const T& Unwrap(const T& t)
-        {
-            return t;
-        }
+        return m_Hr;
+    }
+
+    __declspec(noreturn)
+        friend void ThrowHR(HRESULT);
+};
+
+//
+// Throws an exception for the given HRESULT.
+//
+__declspec(noreturn) __declspec(noinline)
+inline void ThrowHR(HRESULT hr)
+{
+    throw HResultException(hr);
+}
+
+//
+// Throws the appropriate exception for the given HRESULT, attaching a custom error message
+// string. To avoid leaks, the message string should be owned by an RAII wrapper such as
+// WinString. We don't take this parameter directly as a WinString to break what would
+// otherwise be a circular dependency (WinString uses ErrorHandling.h in its implementation).
+//
+__declspec(noreturn) __declspec(noinline)
+inline void ThrowHR(HRESULT hr, HSTRING message)
+{
+    RoOriginateError(hr, message);
+
+    ThrowHR(hr);
+}
+
+__declspec(noreturn) __declspec(noinline)
+inline void ThrowHR(HRESULT hr, wchar_t const* message)
+{
+    using ::Microsoft::WRL::Wrappers::HStringReference;
+
+    ThrowHR(hr, HStringReference(message).Get());
+}
+
+//
+// Throws if the HR fails.  This is the workhorse helper for converting calls to
+// functions that return HRESULTs to exceptions. eg:
+//
+//    ThrowIfFailed(myObj->MethodThatReturnsHRESULT());
+//
+inline void ThrowIfFailed(HRESULT hr)
+{
+    if (FAILED(hr))
+        ThrowHR(hr);
+}
+
+//
+// Throws if the given pointer is null.
+//
+template<typename T>
+inline void ThrowIfNullPointer(T* ptr, HRESULT hrToThrow)
+{
+    if (ptr == nullptr)
+        ThrowHR(hrToThrow);
+}
+
+template<typename T>
+inline void ThrowIfNegative(T value)
+{
+    if (value < 0)
+        ThrowHR(E_INVALIDARG);
+}
+
+inline void ThrowIfZeroOrNegative(uint32_t n)
+{
+    if (n <= 0)
+    {
+        ThrowHR(E_INVALIDARG);
+    }
+}
+
+//
+// Checks that a given pointer argument is valid (ie non-null).  This is
+// expected to be used at the beginning of methods to validate pointer
+// parameters that are marked as [in].
+//
+template<typename T>
+inline void CheckInPointer(T* ptr)
+{
+    ThrowIfNullPointer(ptr, E_INVALIDARG);
+}
+
+//
+// Checks that a given output pointer parameter is valid (ie non-null), and sets
+// it to null.  This is expected to be used at the beginning of methods to
+// validate out pointer parameters that are marked as [out].
+//
+template<typename T>
+inline void CheckAndClearOutPointer(T** ptr)
+{
+    CheckInPointer(ptr);
+    *ptr = nullptr;
+}
+
+//
+// WRL's Make<>() function returns an empty ComPtr on failure rather than
+// throwing an exception.  This checks the result and throws bad_alloc.
+//
+// Note: generally we use exceptions inside constructors to report errors.
+// Therefore the only way that Make() will return an error is if an allocation
+// fails.
+//
+__declspec(noreturn) __declspec(noinline)
+inline void ThrowBadAlloc()
+{
+    throw std::bad_alloc();
+}
+
+inline void CheckMakeResult(bool result)
+{
+    if (!result)
+        ThrowBadAlloc();
+}
+
+//
+// Converts exceptions in the callable code into HRESULTs.
+//
+__declspec(noinline)
+inline HRESULT ThrownExceptionToHResult()
+{
+    try
+    {
+        throw;
+    }
+    catch (HResultException const& e)
+    {
+        return e.GetHr();
+    }
+    catch (std::bad_alloc const&)
+    {
+        return E_OUTOFMEMORY;
+    }
+    catch (...)
+    {
+        return E_UNEXPECTED;
+    }
+}
+
+template<typename CALLABLE>
+HRESULT ExceptionBoundary(CALLABLE&& fn)
+{
+    try
+    {
+        fn();
+        return S_OK;
+    }
+    catch (...)
+    {
+        return ThrownExceptionToHResult();
+    }
+}
+
+// Element traits describe how to store and manipulate the values inside a collection.
+// This default implementation is for value types. The same template is specialized with
+// more interesting versions for reference counted pointer types and strings.
+template<typename T>
+struct ElementTraits
+{
+    typedef T ElementType;
+
+    static ElementType Wrap(T const& value)
+    {
+        return value;
+    }
+
+    static void Unwrap(ElementType const& value, _Out_ T* result)
+    {
+        *result = value;
+    }
+
+    static bool Equals(T const& value1, T const& value2)
+    {
+        return value1 == value2;
+    }
+};
+
+// Specialized element traits for reference counted pointer types.
+template<typename T>
+struct ElementTraits<T*>
+{
+    typedef Microsoft::WRL::ComPtr<T> ElementType;
+
+    static ElementType Wrap(T* value)
+    {
+        return Microsoft::WRL::ComPtr<T>(value);
+    }
+
+    static void Unwrap(ElementType const& value, _Out_ T** result)
+    {
+        ThrowIfFailed(value.CopyTo(result));
+    }
+
+    static bool Equals(Microsoft::WRL::ComPtr<T> const& value1, T* value2)
+    {
+        return value1.Get() == value2;
+    }
+};
+
+
+// Specialized element traits for strings.
+template<>
+struct ElementTraits<HSTRING>
+{
+    typedef HString ElementType;
+
+    static ElementType Wrap(HSTRING const& value)
+    {
+        HString hstringValue;
+        hstringValue.Set(value);
+        return hstringValue;
+    }
+
+    static void Unwrap(ElementType const& value, _Out_ HSTRING* result)
+    {
+        value.CopyTo(result);
+    }
+
+    static bool Equals(HSTRING const& value1, HSTRING const& value2)
+    {
+        int compareResult;
+        ThrowIfFailed(WindowsCompareStringOrdinal(value1, value2, &compareResult));
+        return compareResult == 0;
+    }
+};
+
+
+// Vector traits describe how the collection itself is implemented.
+// This default version just uses an STL vector.
+template<typename T>
+struct DefaultVectorTraits : public ElementTraits<T>
+{
+    typedef std::vector<ElementType> InternalVectorType;
+
+
+    static unsigned GetSize(InternalVectorType const& vector)
+    {
+        return (unsigned)vector.size();
     };
 
-    template <>
-    struct Wrap<HSTRING>
+
+    static ElementType GetAt(InternalVectorType const& vector, unsigned index)
     {
-        typedef std::string type;
-        static std::string MakeWrap(const HSTRING& t)
+        if (index >= vector.size())
+            ThrowHR(E_BOUNDS);
+
+        return vector[index];
+    }
+
+
+    static void SetAt(InternalVectorType& vector, unsigned index, T const& item)
+    {
+        if (index >= vector.size())
+            ThrowHR(E_BOUNDS);
+
+        vector[index] = Wrap(item);
+    }
+
+
+    static void InsertAt(InternalVectorType& vector, unsigned index, T const& item)
+    {
+        if (index > vector.size())
+            ThrowHR(E_BOUNDS);
+
+        vector.insert(vector.begin() + index, Wrap(item));
+    }
+
+
+    static void RemoveAt(InternalVectorType& vector, unsigned index)
+    {
+        if (index >= vector.size())
+            ThrowHR(E_BOUNDS);
+
+        vector.erase(vector.begin() + index);
+    }
+
+
+    static void Append(InternalVectorType& vector, T const& item)
+    {
+        vector.push_back(Wrap(item));
+    }
+
+
+    static void Clear(InternalVectorType& vector)
+    {
+        vector.clear();
+    }
+};
+
+
+// Implements the WinRT IVector interface.
+template<typename T, template<typename T_abi> class Traits = DefaultVectorTraits>
+class Vector : public Microsoft::WRL::RuntimeClass<
+    ABI::Windows::Foundation::Collections::IVector<T>,
+    ABI::Windows::Foundation::Collections::IIterable<T>>
+{
+    InspectableClass(IVector<T>::z_get_rc_name_impl(), BaseTrust);
+
+public:
+    // T_abi is often the same as T, but if T is a runtime class, T_abi will be the corresponding interface.
+    typedef typename ABI::Windows::Foundation::Internal::GetAbiType<typename RuntimeClass::IVector::T_complex>::type T_abi;
+
+    // Specialize our traits class to use the ABI version of the type.
+    typedef Traits<T_abi> Traits;
+
+private:
+    // Fields.
+    typename Traits::InternalVectorType mVector;
+
+    bool isFixedSize;
+    bool isChanged;
+
+
+public:
+    // Constructs an empty vector.
+    Vector()
+        : isFixedSize(false),
+        isChanged(false)
+    { }
+
+
+    // Constructs a vector of the specified size.
+    template<typename... Args>
+    Vector(bool isFixedSize, Args&&... args)
+        : mVector(std::forward<Args>(args)...),
+        isFixedSize(isFixedSize),
+        isChanged(false)
+    { }
+
+
+    // Checks whether this vector is fixed or resizable.
+    bool IsFixedSize() const
+    {
+        return isFixedSize;
+    }
+
+
+    // Checks whether the contents of the vector have changed since the last call to SetChanged(false).
+    bool IsChanged() const
+    {
+        return isChanged;
+    }
+
+
+    // Sets or clears the IsChanged flag.
+    void SetChanged(bool changed)
+    {
+        isChanged = changed;
+    }
+
+
+    // Expose direct access to the internal STL collection. This lets C++ owners
+    // bypass the ExceptionBoundary overhead of the public WinRT API surface.
+    typename Traits::InternalVectorType& InternalVector()
+    {
+        return mVector;
+    }
+
+
+    virtual HRESULT STDMETHODCALLTYPE get_Size(_Out_ unsigned *size)
+    {
+        return ExceptionBoundary([&]
         {
-            std::string wrappedValue;
-            HStringToUTF8(t, wrappedValue);
-            return wrappedValue;
-        }
-        static HSTRING Unwrap(const std::string& t)
-        {
-            HSTRING retvalue;
-            UTF8ToHString(t, &retvalue);
-            return retvalue;
-        }
+            CheckInPointer(size);
+
+            *size = Traits::GetSize(mVector);
+        });
     };
 
 
-    template <typename T>
-    struct Wrap<T*>
+    virtual HRESULT STDMETHODCALLTYPE GetAt(_In_opt_ unsigned index, _Out_ T_abi *item)
     {
-        typename typedef ComPtr<T> type;
-        static ComPtr<T> MakeWrap(T* t)
+        return ExceptionBoundary([&]
         {
-            ComPtr<T> ptr(t);
-            return ptr;
-        }
-        static T* Unwrap(ComPtr<T> t)
-        {
-            ComPtr<T> ptr(t);
-            return t.Detach();
-        }
-    };
+            CheckInPointer(item);
+            ZeroMemory(item, sizeof(*item));
 
-    template <class T>
-    class Iterator : public RuntimeClass<IIterator<T>>
+            Traits::Unwrap(Traits::GetAt(mVector, index), item);
+        });
+    }
+
+
+    virtual HRESULT STDMETHODCALLTYPE IndexOf(_In_opt_ T_abi value, _Out_ unsigned *index, _Out_ boolean *found)
     {
-        AdaptiveRuntimeStringClass(Iterator)
-
-    private:
-        typedef typename std::vector<typename Wrap<T>::type> WrappedVector;
-        typedef typename std::vector<typename Wrap<T>::type>::iterator WrappedVectorIterator;
-
-    public:
-        Iterator() {} 
-
-        HRESULT Init(const std::shared_ptr<WrappedVector>& vec) try
+        return ExceptionBoundary([&]
         {
-            m_wrappedVector = vec;
+            CheckInPointer(index);
+            CheckInPointer(found);
 
-            m_iterator = m_wrappedVector->begin();
-            if (m_iterator != m_wrappedVector->end())
-            {
-                m_currentElement = Wrap<T>::Unwrap(*m_iterator);
-                m_hasCurrentElement = true;
-            }
-            else
-            {
-                m_hasCurrentElement = false;
-            }
-            return S_OK;
-        }CATCH_RETURN;
-
-    public:
-        STDMETHODIMP get_Current(T *current) try
-        {
-            if (m_iterator != m_wrappedVector->end())
-            {
-                m_hasCurrentElement = true;
-                m_currentElement = Wrap<T>::Unwrap(*m_iterator);
-                *current = m_currentElement;
-            }
-            else
-            {
-                m_hasCurrentElement = false;
-            }
-            return S_OK;
-        } CATCH_RETURN;
-
-        STDMETHODIMP get_HasCurrent(boolean *hasCurrent)
-        {
-            *hasCurrent = m_hasCurrentElement;
-            return S_OK;
-        }
-
-        STDMETHODIMP MoveNext(boolean *hasCurrent) try
-        {
-            if (m_iterator != m_wrappedVector->end())
-            {
-                ++m_iterator;
-                if (m_iterator == m_wrappedVector->end())
-                {
-                    *hasCurrent = false;
-                    m_hasCurrentElement = false;
-                }
-                else
-                {
-                    *hasCurrent = true;
-                    m_hasCurrentElement = true;
-                }
-            }
-            else
-            {
-                *hasCurrent = false;
-                m_hasCurrentElement = false;
-            }
-            return S_OK;
-        } CATCH_RETURN;
-
-
-    private:
-        std::shared_ptr<WrappedVector> m_wrappedVector;
-        WrappedVectorIterator m_iterator;
-        T m_currentElement;
-        boolean m_hasCurrentElement = false;
-    };
-
-    template <typename T>
-    class Vector : public RuntimeClass<IVector<T>,
-        IIterable<T>,
-        Microsoft::WRL::FtmBase>
-    {
-        AdaptiveRuntimeStringClass(Vector)
-
-    private:
-        typedef typename std::vector<typename Wrap<T>::type> WrappedVector;
-        typedef typename VectorChangedEventHandler<T> WFC_Handler;
-
-    public:
-        Vector() 
-        {
-            m_wrappedVector = std::make_shared<WrappedVector>();
-        }
-
-    public:
-        STDMETHODIMP GetAt(unsigned int index, T* item) try
-        {
-            if (index >= m_wrappedVector->size())
-            {
-                return E_INVALIDARG;
-            }
-            *item = Wrap<T>::Unwrap((*m_wrappedVector)[index]);
-            return S_OK;
-        } CATCH_RETURN;
-
-        STDMETHODIMP get_Size(unsigned int* size) try
-        {
-            *size = static_cast<unsigned int>(m_wrappedVector->size());
-            return S_OK;
-        } CATCH_RETURN;
-
-        STDMETHODIMP GetView(IVectorView<T>** view)
-        {
-            *view = nullptr;
-            return E_NOTIMPL;
-        }
-
-        STDMETHODIMP IndexOf(T value, unsigned int* index, boolean* found) try
-        {
             *index = 0;
             *found = false;
 
-            unsigned foundIndex = 0;
-            for (auto& entry : *m_wrappedVector)
+            auto size = Traits::GetSize(mVector);
+
+            for (unsigned i = 0; i < size; i++)
             {
-                const T& unwrappedEntry = Wrap<T>::Unwrap(entry);
-                if (unwrappedEntry == value)
+                if (Traits::Equals(Traits::GetAt(mVector, i), value))
                 {
+                    *index = i;
                     *found = true;
-                    *index = foundIndex;
                     break;
                 }
-                foundIndex++;
             }
+        });
+    }
 
-            return S_OK;
-        } CATCH_RETURN;
 
-        STDMETHODIMP SetAt(unsigned int index, T item) try
+    virtual HRESULT STDMETHODCALLTYPE SetAt(_In_ unsigned index, _In_opt_ T_abi item)
+    {
+        return ExceptionBoundary([&]
         {
-            if (index >= m_wrappedVector->size())
+            Traits::SetAt(mVector, index, item);
+            isChanged = true;
+        });
+    }
+
+
+    virtual HRESULT STDMETHODCALLTYPE InsertAt(_In_ unsigned index, _In_opt_ T_abi item)
+    {
+        return ExceptionBoundary([&]
+        {
+            if (isFixedSize)
+                ThrowHR(E_NOTIMPL);
+
+            Traits::InsertAt(mVector, index, item);
+            isChanged = true;
+        });
+    }
+
+
+    virtual HRESULT STDMETHODCALLTYPE RemoveAt(_In_ unsigned index)
+    {
+        return ExceptionBoundary([&]
+        {
+            if (isFixedSize)
+                ThrowHR(E_NOTIMPL);
+
+            Traits::RemoveAt(mVector, index);
+            isChanged = true;
+        });
+    }
+
+
+    virtual HRESULT STDMETHODCALLTYPE Append(_In_opt_ T_abi item)
+    {
+        return ExceptionBoundary([&]
+        {
+            if (isFixedSize)
+                ThrowHR(E_NOTIMPL);
+
+            Traits::Append(mVector, item);
+            isChanged = true;
+        });
+    }
+
+
+    virtual HRESULT STDMETHODCALLTYPE RemoveAtEnd()
+    {
+        return ExceptionBoundary([&]
+        {
+            if (isFixedSize)
+                ThrowHR(E_NOTIMPL);
+
+            Traits::RemoveAt(mVector, Traits::GetSize(mVector) - 1);
+            isChanged = true;
+        });
+    }
+
+
+    virtual HRESULT STDMETHODCALLTYPE Clear()
+    {
+        return ExceptionBoundary([&]
+        {
+            if (isFixedSize)
+                ThrowHR(E_NOTIMPL);
+
+            Traits::Clear(mVector);
+            isChanged = true;
+        });
+    }
+
+
+    virtual HRESULT STDMETHODCALLTYPE ReplaceAll(_In_ unsigned count, _In_reads_(count) T_abi *value)
+    {
+        return ExceptionBoundary([&]
+        {
+            CheckInPointer(value);
+
+            if (count == Traits::GetSize(mVector))
             {
-                return E_INVALIDARG;
+                for (unsigned i = 0; i < count; i++)
+                {
+                    Traits::SetAt(mVector, i, value[i]);
+                }
             }
-            (*m_wrappedVector)[index] = Wrap<T>::MakeWrap(item);
-            return S_OK;
-        } CATCH_RETURN;
-
-        STDMETHODIMP InsertAt(unsigned int index, T item) try
-        {
-            m_wrappedVector->insert(m_wrappedVector->begin() + index, Wrap<T>::MakeWrap(item));
-            return S_OK;
-        } CATCH_RETURN;
-
-        STDMETHODIMP RemoveAt(unsigned int index) try
-        {
-            if (index >= m_wrappedVector->size())
+            else
             {
-                return E_INVALIDARG;
+                if (isFixedSize)
+                    ThrowHR(E_NOTIMPL);
+
+                Traits::Clear(mVector);
+
+                for (unsigned i = 0; i < count; i++)
+                {
+                    Traits::Append(mVector, value[i]);
+                }
             }
-            m_wrappedVector->erase(m_wrappedVector->begin() + index);
-            return S_OK;
-        } CATCH_RETURN;
 
-        STDMETHODIMP Append(T item) try
+            isChanged = true;
+        });
+    }
+
+
+    virtual HRESULT STDMETHODCALLTYPE GetView(_Outptr_result_maybenull_ ABI::Windows::Foundation::Collections::IVectorView<T> **view)
+    {
+        return ExceptionBoundary([&]
         {
-            m_wrappedVector->push_back(Wrap<T>::MakeWrap(item));
-            return S_OK;
-        } CATCH_RETURN;
+            CheckAndClearOutPointer(view);
 
-        STDMETHODIMP RemoveAtEnd() try
+            auto vectorView = Microsoft::WRL::Make<VectorView<T, Vector>>(this);
+            CheckMakeResult(vectorView);
+
+            *view = vectorView.Detach();
+        });
+    }
+
+
+    virtual HRESULT STDMETHODCALLTYPE First(_Outptr_result_maybenull_ ABI::Windows::Foundation::Collections::IIterator<T> **first)
+    {
+        return ExceptionBoundary([&]
         {
-            if (!m_wrappedVector->empty())
-            {
-                m_wrappedVector->pop_back();
-            }
-            return S_OK;
-        } CATCH_RETURN;
+            CheckAndClearOutPointer(first);
 
-        STDMETHODIMP Clear() try
-        {
-            m_wrappedVector->clear();
-            return S_OK;
-        } CATCH_RETURN;
+            auto iterator = Microsoft::WRL::Make<VectorIterator<T, Vector>>(this);
+            CheckMakeResult(iterator);
 
-        STDMETHODIMP First(IIterator<T> **first) try
-        {
-            ComPtr<Iterator<T>> p = Make<Iterator<T>>();
-            p->Init(m_wrappedVector);
-            *first = p.Detach();
-            return S_OK;
-        } CATCH_RETURN;
+            *first = iterator.Detach();
+        });
+    }
+};
 
-    private:
-        std::shared_ptr<WrappedVector> m_wrappedVector;
+
+// Implements the WinRT IVectorView interface.
+template<typename T, typename TVector>
+class VectorView : public Microsoft::WRL::RuntimeClass<ABI::Windows::Foundation::Collections::IVectorView<T>,
+    ABI::Windows::Foundation::Collections::IIterable<T>>
+{
+    InspectableClass(IVectorView<T>::z_get_rc_name_impl(), BaseTrust);
+
+    // Fields.
+    Microsoft::WRL::ComPtr<TVector> mVector;
+
+
+public:
+    // Constructor wraps around an existing Vector<T>.
+    VectorView(TVector* vector)
+        : mVector(vector)
+    { }
+
+
+    virtual HRESULT STDMETHODCALLTYPE get_Size(_Out_ unsigned *size)
+    {
+        return mVector->get_Size(size);
     };
-AdaptiveNamespaceEnd
+
+
+    virtual HRESULT STDMETHODCALLTYPE GetAt(_In_opt_ unsigned index, _Out_ typename TVector::T_abi *item)
+    {
+        return mVector->GetAt(index, item);
+    }
+
+
+    virtual HRESULT STDMETHODCALLTYPE IndexOf(_In_opt_ typename TVector::T_abi value, _Out_ unsigned *index, _Out_ boolean *found)
+    {
+        return mVector->IndexOf(value, index, found);
+    }
+
+
+    virtual HRESULT STDMETHODCALLTYPE First(_Outptr_result_maybenull_ ABI::Windows::Foundation::Collections::IIterator<T> **first)
+    {
+        return mVector->First(first);
+    }
+};
+
+
+// Implements the WinRT IIterator interface.
+template<typename T, typename TVector>
+class VectorIterator : public Microsoft::WRL::RuntimeClass<ABI::Windows::Foundation::Collections::IIterator<T>>
+{
+    InspectableClass(IIterator<T>::z_get_rc_name_impl(), BaseTrust);
+
+    // Fields.
+    Microsoft::WRL::ComPtr<TVector> mVector;
+    unsigned mPosition;
+
+
+public:
+    // Constructor wraps around an existing Vector<T>.
+    VectorIterator(TVector* vector)
+        : mVector(vector),
+        mPosition(0)
+    { }
+
+
+    virtual HRESULT STDMETHODCALLTYPE get_Current(_Out_ typename TVector::T_abi *current)
+    {
+        return mVector->GetAt(mPosition, current);
+    }
+
+
+    virtual HRESULT STDMETHODCALLTYPE get_HasCurrent(_Out_ boolean *hasCurrent)
+    {
+        return ExceptionBoundary([&]
+        {
+            CheckInPointer(hasCurrent);
+
+            *hasCurrent = (mPosition < TVector::Traits::GetSize(mVector->InternalVector()));
+        });
+    }
+
+
+    virtual HRESULT STDMETHODCALLTYPE MoveNext(_Out_ boolean *hasCurrent)
+    {
+        return ExceptionBoundary([&]
+        {
+            CheckInPointer(hasCurrent);
+
+            auto size = TVector::Traits::GetSize(mVector->InternalVector());
+
+            if (mPosition >= size)
+            {
+                ThrowHR(E_BOUNDS);
+            }
+
+            mPosition++;
+            *hasCurrent = (mPosition < size);
+        });
+    }
+};


### PR DESCRIPTION
Implemented AdaptiveCard.GetResourceUris. This included replacing our implementation of vector in Vector.h with the version from Win2D in order to support vectors of runtime classes.

Vector code taken from:
https://github.com/Microsoft/Win2D/blob/master/winrt/inc/Vector.h

Implements #1322