### PR TITLE
Cpp improvements

### DIFF
--- a/source/shared/cpp/ObjectModel/ActionParserRegistration.cpp
+++ b/source/shared/cpp/ObjectModel/ActionParserRegistration.cpp
@@ -20,7 +20,7 @@ AdaptiveSharedNamespaceStart
         });
     }
 
-    void ActionParserRegistration::AddParser(std::string elementType, std::shared_ptr<ActionElementParser> parser)
+    void ActionParserRegistration::AddParser(std::string const &elementType, std::shared_ptr<ActionElementParser> parser)
     {
         if (m_knownElements.find(elementType) == m_knownElements.end())
         {
@@ -32,19 +32,15 @@ AdaptiveSharedNamespaceStart
         }
     }
 
-    void ActionParserRegistration::RemoveParser(std::string elementType)
+    void ActionParserRegistration::RemoveParser(std::string const &elementType)
     {
-        if (m_knownElements.find(elementType) == m_knownElements.end())
+        if (m_knownElements.find(elementType) != m_knownElements.end())
         {
             ActionParserRegistration::m_cardElementParsers.erase(elementType);
         }
-        else
-        {
-            throw AdaptiveCardParseException(ErrorStatusCode::UnsupportedParserOverride, "Overriding known action parsers is unsupported");
-        }
     }
 
-    std::shared_ptr<ActionElementParser> ActionParserRegistration::GetParser(std::string elementType)
+    std::shared_ptr<ActionElementParser> ActionParserRegistration::GetParser(std::string const &elementType)
     {
         auto parser = m_cardElementParsers.find(elementType);
         if (parser != ActionParserRegistration::m_cardElementParsers.end())

--- a/source/shared/cpp/ObjectModel/ActionParserRegistration.h
+++ b/source/shared/cpp/ObjectModel/ActionParserRegistration.h
@@ -24,9 +24,9 @@ AdaptiveSharedNamespaceStart
 
         ActionParserRegistration();
 
-        void AddParser(std::string elementType, std::shared_ptr<AdaptiveSharedNamespace::ActionElementParser> parser);
-        void RemoveParser(std::string elementType);
-        std::shared_ptr<AdaptiveSharedNamespace::ActionElementParser> GetParser(std::string elementType);
+        void AddParser(std::string const &elementType, std::shared_ptr<AdaptiveSharedNamespace::ActionElementParser> parser);
+        void RemoveParser(std::string const &elementType);
+        std::shared_ptr<AdaptiveSharedNamespace::ActionElementParser> GetParser(std::string const &elementType);
 
     private:
         std::unordered_set<std::string> m_knownElements;

--- a/source/shared/cpp/ObjectModel/AdaptiveCardParseException.cpp
+++ b/source/shared/cpp/ObjectModel/AdaptiveCardParseException.cpp
@@ -3,7 +3,7 @@
 
 using namespace AdaptiveSharedNamespace;
 
-AdaptiveCardParseException::AdaptiveCardParseException(const ErrorStatusCode statusCode, const std::string & message) : m_statusCode(statusCode), m_message(message)
+AdaptiveCardParseException::AdaptiveCardParseException(ErrorStatusCode statusCode, const std::string & message) : m_statusCode(statusCode), m_message(message)
 {
 }
 
@@ -16,7 +16,7 @@ const char* AdaptiveCardParseException::what() const throw()
     return m_message.c_str();
 }
 
-const ErrorStatusCode AdaptiveCardParseException::GetStatusCode() const
+ErrorStatusCode AdaptiveCardParseException::GetStatusCode() const
 {
     return m_statusCode;
 }

--- a/source/shared/cpp/ObjectModel/AdaptiveCardParseException.h
+++ b/source/shared/cpp/ObjectModel/AdaptiveCardParseException.h
@@ -8,11 +8,11 @@ AdaptiveSharedNamespaceStart
 class AdaptiveCardParseException : public std::exception
 {
 public:
-    AdaptiveCardParseException(const AdaptiveSharedNamespace::ErrorStatusCode statusCode, const std::string& message);
+    AdaptiveCardParseException(AdaptiveSharedNamespace::ErrorStatusCode statusCode, const std::string& message);
     ~AdaptiveCardParseException();
 
     virtual const char* what() const throw();
-    const AdaptiveSharedNamespace::ErrorStatusCode GetStatusCode() const;
+    AdaptiveSharedNamespace::ErrorStatusCode GetStatusCode() const;
     const std::string& GetReason() const;
 
 private:

--- a/source/shared/cpp/ObjectModel/AdaptiveCardParseWarning.cpp
+++ b/source/shared/cpp/ObjectModel/AdaptiveCardParseWarning.cpp
@@ -11,7 +11,7 @@ AdaptiveCardParseWarning::~AdaptiveCardParseWarning()
 {
 }
 
-const WarningStatusCode AdaptiveCardParseWarning::GetStatusCode() const
+WarningStatusCode AdaptiveCardParseWarning::GetStatusCode() const
 {
     return m_statusCode;
 }

--- a/source/shared/cpp/ObjectModel/AdaptiveCardParseWarning.h
+++ b/source/shared/cpp/ObjectModel/AdaptiveCardParseWarning.h
@@ -8,10 +8,10 @@ AdaptiveSharedNamespaceStart
 class AdaptiveCardParseWarning
 {
 public:
-    AdaptiveCardParseWarning(const AdaptiveSharedNamespace::WarningStatusCode statusCode, const std::string& message);
+    AdaptiveCardParseWarning(AdaptiveSharedNamespace::WarningStatusCode statusCode, const std::string& message);
     ~AdaptiveCardParseWarning();
 
-    const AdaptiveSharedNamespace::WarningStatusCode GetStatusCode() const;
+    AdaptiveSharedNamespace::WarningStatusCode GetStatusCode() const;
     const std::string& GetReason() const;
 
 private:

--- a/source/shared/cpp/ObjectModel/BaseActionElement.cpp
+++ b/source/shared/cpp/ObjectModel/BaseActionElement.cpp
@@ -20,7 +20,7 @@ std::string BaseActionElement::GetElementTypeString() const
     return m_typeString;
 }
 
-void BaseActionElement::SetElementTypeString(const std::string value)
+void BaseActionElement::SetElementTypeString(const std::string &value)
 {
     m_typeString = value;
 }
@@ -30,7 +30,7 @@ std::string BaseActionElement::GetTitle() const
     return m_title;
 }
 
-void BaseActionElement::SetTitle(const std::string value)
+void BaseActionElement::SetTitle(const std::string &value)
 {
     m_title = value;
 }
@@ -40,7 +40,7 @@ std::string BaseActionElement::GetId() const
     return m_id;
 }
 
-void BaseActionElement::SetId(const std::string value)
+void BaseActionElement::SetId(const std::string &value)
 {
     m_id = value;
 }
@@ -60,13 +60,13 @@ const ActionType BaseActionElement::GetElementType() const
     return m_type;
 }
 
-std::string BaseActionElement::Serialize()
+std::string BaseActionElement::Serialize() const
 {
     Json::FastWriter writer;
     return writer.write(SerializeToJsonValue());
 }
 
-Json::Value BaseActionElement::SerializeToJsonValue()
+Json::Value BaseActionElement::SerializeToJsonValue() const
 {
     Json::Value root = GetAdditionalProperties();
     root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Type)] = ActionTypeToString(m_type);
@@ -81,12 +81,12 @@ Json::Value BaseActionElement::SerializeToJsonValue()
     return root;
 }
 
-Json::Value BaseActionElement::GetAdditionalProperties()
+Json::Value BaseActionElement::GetAdditionalProperties() const
 {
     return m_additionalProperties;
 }
 
-void BaseActionElement::SetAdditionalProperties(Json::Value value)
+void BaseActionElement::SetAdditionalProperties(Json::Value const &value)
 {
     m_additionalProperties = value;
 }

--- a/source/shared/cpp/ObjectModel/BaseActionElement.h
+++ b/source/shared/cpp/ObjectModel/BaseActionElement.h
@@ -14,27 +14,27 @@ public:
     virtual ~BaseActionElement();
 
     virtual std::string GetElementTypeString() const;
-    virtual void SetElementTypeString(const std::string value);
+    virtual void SetElementTypeString(const std::string &value);
 
     virtual std::string GetTitle() const;
-    virtual void SetTitle(const std::string value);
+    virtual void SetTitle(const std::string &value);
 
     virtual std::string GetId() const;
-    virtual void SetId(const std::string value);
+    virtual void SetId(const std::string &value);
 
     virtual std::string GetIconUrl() const;
     virtual void SetIconUrl(const std::string& value);
 
     virtual const ActionType GetElementType() const;
 
-    std::string Serialize();
-    virtual Json::Value SerializeToJsonValue();
+    std::string Serialize() const;
+    virtual Json::Value SerializeToJsonValue() const;
 
     template <typename T>
     static std::shared_ptr<T> Deserialize(const Json::Value& json);
 
-    Json::Value GetAdditionalProperties();
-    void SetAdditionalProperties(Json::Value additionalProperties);
+    Json::Value GetAdditionalProperties() const;
+    void SetAdditionalProperties(Json::Value const &additionalProperties);
 
     virtual void GetResourceUris(std::vector<std::string>& resourceUris);
 

--- a/source/shared/cpp/ObjectModel/BaseCardElement.cpp
+++ b/source/shared/cpp/ObjectModel/BaseCardElement.cpp
@@ -13,14 +13,14 @@ BaseCardElement::BaseCardElement(
     bool separator) :
     m_type(type),
     m_spacing(spacing),
-    m_separator(separator),
-    m_typeString(CardElementTypeToString(type))
+    m_typeString(CardElementTypeToString(type)),
+    m_separator(separator)
 {
     PopulateKnownPropertiesSet();
 }
 
 BaseCardElement::BaseCardElement(CardElementType type) :
-    m_separator(false), m_type(type), m_spacing(Spacing::Default), m_typeString(CardElementTypeToString(type))
+    m_type(type), m_spacing(Spacing::Default), m_typeString(CardElementTypeToString(type)), m_separator(false)
 {
     PopulateKnownPropertiesSet();
 }
@@ -41,7 +41,7 @@ std::string BaseCardElement::GetElementTypeString() const
     return m_typeString;
 }
 
-void BaseCardElement::SetElementTypeString(const std::string value)
+void BaseCardElement::SetElementTypeString(const std::string &value)
 {
     m_typeString = value;
 }
@@ -71,7 +71,7 @@ std::string BaseCardElement::GetId() const
     return m_id;
 }
 
-void BaseCardElement::SetId(const std::string value)
+void BaseCardElement::SetId(const std::string &value)
 {
     m_id = value;
 }
@@ -81,13 +81,13 @@ const CardElementType BaseCardElement::GetElementType() const
     return m_type;
 }
 
-std::string BaseCardElement::Serialize()
+std::string BaseCardElement::Serialize() const
 {
     Json::FastWriter writer;
     return writer.write(SerializeToJsonValue());
 }
 
-Json::Value BaseCardElement::SerializeToJsonValue()
+Json::Value BaseCardElement::SerializeToJsonValue() const
  {
     Json::Value root = GetAdditionalProperties();
     root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Type)] = CardElementTypeToString(GetElementType());
@@ -110,7 +110,7 @@ Json::Value BaseCardElement::SerializeToJsonValue()
     return root;
 }
 
-Json::Value BaseCardElement::SerializeSelectAction(const std::shared_ptr<BaseActionElement> selectAction)
+Json::Value BaseCardElement::SerializeSelectAction(const std::shared_ptr<BaseActionElement> selectAction) 
 {
     if (selectAction != nullptr)
     {
@@ -119,12 +119,12 @@ Json::Value BaseCardElement::SerializeSelectAction(const std::shared_ptr<BaseAct
     return Json::Value();
 }
 
-Json::Value BaseCardElement::GetAdditionalProperties()
+Json::Value BaseCardElement::GetAdditionalProperties() const
 {
     return m_additionalProperties;
 }
 
-void BaseCardElement::SetAdditionalProperties(Json::Value value)
+void BaseCardElement::SetAdditionalProperties(Json::Value const &value)
 {
     m_additionalProperties = value;
 }

--- a/source/shared/cpp/ObjectModel/BaseCardElement.h
+++ b/source/shared/cpp/ObjectModel/BaseCardElement.h
@@ -18,7 +18,7 @@ public:
     virtual ~BaseCardElement();
 
     virtual std::string GetElementTypeString() const;
-    virtual void SetElementTypeString(const std::string value);
+    virtual void SetElementTypeString(const std::string &value);
 
     virtual bool GetSeparator() const;
     virtual void SetSeparator(const bool value);
@@ -27,18 +27,18 @@ public:
     virtual void SetSpacing(const Spacing value);
 
     virtual std::string GetId() const;
-    virtual void SetId(const std::string value);
+    virtual void SetId(const std::string &value);
 
     virtual const CardElementType GetElementType() const;
 
-    std::string Serialize();
-    virtual Json::Value SerializeToJsonValue();
+    std::string Serialize() const;
+    virtual Json::Value SerializeToJsonValue() const;
 
     template <typename T>
     static std::shared_ptr<T> Deserialize(const Json::Value& json);
 
-    Json::Value GetAdditionalProperties();
-    void SetAdditionalProperties(Json::Value additionalProperties);
+    Json::Value GetAdditionalProperties() const;
+    void SetAdditionalProperties(const Json::Value &additionalProperties);
 
     virtual void GetResourceUris(std::vector<std::string>& resourceUris);
 

--- a/source/shared/cpp/ObjectModel/BaseInputElement.cpp
+++ b/source/shared/cpp/ObjectModel/BaseInputElement.cpp
@@ -19,7 +19,7 @@ std::string BaseInputElement::GetId() const
     return m_id;
 }
 
-void BaseInputElement::SetId(const std::string value)
+void BaseInputElement::SetId(const std::string &value)
 {
     m_id = value;
 }
@@ -34,7 +34,7 @@ void BaseInputElement::SetIsRequired(const bool value)
     m_isRequired = value;
 }
 
-Json::Value BaseInputElement::SerializeToJsonValue()
+Json::Value BaseInputElement::SerializeToJsonValue() const
 {
     Json::Value root = BaseCardElement::SerializeToJsonValue();
 

--- a/source/shared/cpp/ObjectModel/BaseInputElement.h
+++ b/source/shared/cpp/ObjectModel/BaseInputElement.h
@@ -14,7 +14,7 @@ public:
     BaseInputElement(CardElementType type, Spacing spacing, bool separator);
 
     std::string GetId() const override;
-    void SetId(const std::string value) override;
+    virtual void SetId(const std::string &value) override;
 
     template <typename T>
     static std::shared_ptr<T> Deserialize(const Json::Value& json);
@@ -22,7 +22,7 @@ public:
     bool GetIsRequired() const;
     void SetIsRequired(const bool isRequired);
 
-    virtual Json::Value SerializeToJsonValue() override;
+    virtual Json::Value SerializeToJsonValue() const override;
 
 private:
     std::string m_id;

--- a/source/shared/cpp/ObjectModel/ChoiceInput.cpp
+++ b/source/shared/cpp/ObjectModel/ChoiceInput.cpp
@@ -51,7 +51,7 @@ std::string ChoiceInput::GetTitle() const
     return m_title;
 }
 
-void ChoiceInput::SetTitle(const std::string title)
+void ChoiceInput::SetTitle(const std::string &title)
 {
     m_title = title;
 }
@@ -61,7 +61,7 @@ std::string ChoiceInput::GetValue() const
     return m_value;
 }
 
-void ChoiceInput::SetValue(const std::string value)
+void ChoiceInput::SetValue(const std::string &value)
 {
     m_value = value;
 }

--- a/source/shared/cpp/ObjectModel/ChoiceInput.h
+++ b/source/shared/cpp/ObjectModel/ChoiceInput.h
@@ -15,10 +15,10 @@ public:
     Json::Value SerializeToJsonValue();
 
     std::string GetTitle() const;
-    void SetTitle(const std::string value);
+    void SetTitle(const std::string &value);
 
     std::string GetValue() const;
-    void SetValue(const std::string value);
+    void SetValue(const std::string &value);
 
     static std::shared_ptr<ChoiceInput> Deserialize(
         std::shared_ptr<ElementParserRegistration> elementParserRegistration,

--- a/source/shared/cpp/ObjectModel/ChoiceSetInput.cpp
+++ b/source/shared/cpp/ObjectModel/ChoiceSetInput.cpp
@@ -20,7 +20,7 @@ std::vector<std::shared_ptr<ChoiceInput>>& ChoiceSetInput::GetChoices()
     return m_choices;
 }
 
-Json::Value ChoiceSetInput::SerializeToJsonValue()
+Json::Value ChoiceSetInput::SerializeToJsonValue() const
 {
     Json::Value root = BaseInputElement::SerializeToJsonValue();
 
@@ -71,7 +71,7 @@ std::string ChoiceSetInput::GetValue() const
     return m_value;
 }
 
-void ChoiceSetInput::SetValue(std::string value)
+void ChoiceSetInput::SetValue(std::string const &value)
 {
     m_value = value;
 }

--- a/source/shared/cpp/ObjectModel/ChoiceSetInput.h
+++ b/source/shared/cpp/ObjectModel/ChoiceSetInput.h
@@ -14,7 +14,7 @@ friend class ChoiceSetInputParser;
 public:
     ChoiceSetInput();
 
-    virtual Json::Value SerializeToJsonValue() override;
+    virtual Json::Value SerializeToJsonValue() const override;
 
     bool GetIsMultiSelect() const;
     void SetIsMultiSelect(const bool isMultiSelect);
@@ -26,7 +26,7 @@ public:
     const std::vector<std::shared_ptr<ChoiceInput>>& GetChoices() const;
 
     std::string GetValue() const;
-    void SetValue(std::string value);
+    void SetValue(const std::string &value);
 
 private:
     void PopulateKnownPropertiesSet();

--- a/source/shared/cpp/ObjectModel/Column.cpp
+++ b/source/shared/cpp/ObjectModel/Column.cpp
@@ -15,7 +15,7 @@ std::string Column::GetWidth() const
     return m_width;
 }
 
-void Column::SetWidth(const std::string value)
+void Column::SetWidth(const std::string &value)
 {
     m_width = ParseUtil::ToLowercase(value);
 }
@@ -51,13 +51,13 @@ std::vector<std::shared_ptr<BaseCardElement>>& Column::GetItems()
     return m_items;
 }
 
-std::string Column::Serialize()
+std::string Column::Serialize() const
 {
     Json::FastWriter writer;
     return writer.write(SerializeToJsonValue());
 }
 
-Json::Value Column::SerializeToJsonValue()
+Json::Value Column::SerializeToJsonValue() const
 {
     Json::Value root = BaseCardElement::SerializeToJsonValue();
 

--- a/source/shared/cpp/ObjectModel/Column.h
+++ b/source/shared/cpp/ObjectModel/Column.h
@@ -11,8 +11,8 @@ class Column : public BaseCardElement
 public:
     Column();
 
-    virtual std::string Serialize();
-    virtual Json::Value SerializeToJsonValue();
+    virtual std::string Serialize() const;
+    virtual Json::Value SerializeToJsonValue() const override;
 
     static std::shared_ptr<Column> Deserialize(
         std::shared_ptr<ElementParserRegistration> elementParserRegistration,
@@ -25,7 +25,7 @@ public:
         const std::string& jsonString);
 
     std::string GetWidth() const;
-    void SetWidth(const std::string value);
+    void SetWidth(const std::string &value);
 
     // explicit width takes precedence over relative width 
     int GetPixelWidth() const;

--- a/source/shared/cpp/ObjectModel/ColumnSet.cpp
+++ b/source/shared/cpp/ObjectModel/ColumnSet.cpp
@@ -39,11 +39,11 @@ void ColumnSet::SetLanguage(const std::string& language)
     }
 }
 
-Json::Value ColumnSet::SerializeToJsonValue()
+Json::Value ColumnSet::SerializeToJsonValue() const
 {
     Json::Value root = BaseCardElement::SerializeToJsonValue();
 
-    std::string propertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Columns);
+    std::string const &propertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Columns);
     root[propertyName] = Json::Value(Json::arrayValue);
     for (const auto& column : m_columns)
     {

--- a/source/shared/cpp/ObjectModel/ColumnSet.h
+++ b/source/shared/cpp/ObjectModel/ColumnSet.h
@@ -13,7 +13,7 @@ friend class ColumnSetParser;
 public:
     ColumnSet();
 
-    virtual Json::Value SerializeToJsonValue() override;
+    virtual Json::Value SerializeToJsonValue() const override;
 
     std::vector<std::shared_ptr<Column>>& GetColumns();
     const std::vector<std::shared_ptr<Column>>& GetColumns() const;

--- a/source/shared/cpp/ObjectModel/Container.cpp
+++ b/source/shared/cpp/ObjectModel/Container.cpp
@@ -46,7 +46,7 @@ void Container::SetLanguage(const std::string& value)
     PropagateLanguage(value, m_items);
 }
 
-Json::Value Container::SerializeToJsonValue()
+Json::Value Container::SerializeToJsonValue() const
 {
     Json::Value root = BaseCardElement::SerializeToJsonValue();
 
@@ -55,7 +55,7 @@ Json::Value Container::SerializeToJsonValue()
         root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Style)] = ContainerStyleToString(m_style);
     }
 
-    std::string itemsPropertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Items);
+    std::string const &itemsPropertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Items);
     root[itemsPropertyName] = Json::Value(Json::arrayValue);
     for (const auto& cardElement : m_items)
     {

--- a/source/shared/cpp/ObjectModel/Container.h
+++ b/source/shared/cpp/ObjectModel/Container.h
@@ -13,7 +13,7 @@ friend class ContainerParser;
 public:
     Container();
 
-    virtual Json::Value SerializeToJsonValue() override;
+    virtual Json::Value SerializeToJsonValue() const override;
 
     std::vector<std::shared_ptr<BaseCardElement>>& GetItems();
     const std::vector<std::shared_ptr<BaseCardElement>>& GetItems() const;

--- a/source/shared/cpp/ObjectModel/DateInput.cpp
+++ b/source/shared/cpp/ObjectModel/DateInput.cpp
@@ -10,7 +10,7 @@ DateInput::DateInput() :
     PopulateKnownPropertiesSet();
 }
 
-Json::Value DateInput::SerializeToJsonValue()
+Json::Value DateInput::SerializeToJsonValue() const
 {
     Json::Value root = BaseInputElement::SerializeToJsonValue();
 
@@ -42,7 +42,7 @@ std::string DateInput::GetMax() const
     return m_max;
 }
 
-void DateInput::SetMax(const std::string value)
+void DateInput::SetMax(const std::string &value)
 {
     m_max = value;
 }
@@ -52,7 +52,7 @@ std::string DateInput::GetMin() const
     return m_min;
 }
 
-void DateInput::SetMin(const std::string value)
+void DateInput::SetMin(const std::string &value)
 {
     m_min = value;
 }
@@ -62,7 +62,7 @@ std::string DateInput::GetPlaceholder() const
     return m_placeholder;
 }
 
-void DateInput::SetPlaceholder(const std::string value)
+void DateInput::SetPlaceholder(const std::string &value)
 {
     m_placeholder = value;
 }
@@ -72,7 +72,7 @@ std::string DateInput::GetValue() const
     return m_value;
 }
 
-void DateInput::SetValue(const std::string value)
+void DateInput::SetValue(const std::string &value)
 {
     m_value = value;
 }

--- a/source/shared/cpp/ObjectModel/DateInput.h
+++ b/source/shared/cpp/ObjectModel/DateInput.h
@@ -11,19 +11,19 @@ class DateInput : public BaseInputElement
 public:
     DateInput();
 
-    virtual Json::Value SerializeToJsonValue() override;
+    virtual Json::Value SerializeToJsonValue() const override;
 
     std::string GetMax() const;
-    void SetMax(const std::string value);
+    void SetMax(const std::string &value);
 
     std::string GetMin() const;
-    void SetMin(const std::string value);
+    void SetMin(const std::string &value);
 
     std::string GetPlaceholder() const;
-    void SetPlaceholder(const std::string value);
+    void SetPlaceholder(const std::string &value);
 
     std::string GetValue() const;
-    void SetValue(const std::string value);
+    void SetValue(const std::string &value);
 
 private:
     void PopulateKnownPropertiesSet();

--- a/source/shared/cpp/ObjectModel/DateTimePreparsedToken.cpp
+++ b/source/shared/cpp/ObjectModel/DateTimePreparsedToken.cpp
@@ -7,11 +7,11 @@ DateTimePreparsedToken::DateTimePreparsedToken() : m_text(""), m_format(DateTime
 {
 }
 
-DateTimePreparsedToken::DateTimePreparsedToken(std::string text, DateTimePreparsedTokenFormat format) : m_text(text), m_format(format)
+DateTimePreparsedToken::DateTimePreparsedToken(std::string const &text, DateTimePreparsedTokenFormat format) : m_text(text), m_format(format)
 {
 }
 
-DateTimePreparsedToken::DateTimePreparsedToken(std::string text, struct tm date, DateTimePreparsedTokenFormat format) :
+DateTimePreparsedToken::DateTimePreparsedToken(std::string const &text, struct tm date, DateTimePreparsedTokenFormat format) :
     m_text(text), m_date(date), m_format(format)
 {
 }

--- a/source/shared/cpp/ObjectModel/DateTimePreparsedToken.h
+++ b/source/shared/cpp/ObjectModel/DateTimePreparsedToken.h
@@ -8,8 +8,8 @@ AdaptiveSharedNamespaceStart
     {
     public:
         DateTimePreparsedToken();
-        DateTimePreparsedToken(std::string text, DateTimePreparsedTokenFormat format);
-        DateTimePreparsedToken(std::string text, struct tm date, DateTimePreparsedTokenFormat format);
+        DateTimePreparsedToken(std::string const &text, DateTimePreparsedTokenFormat format);
+        DateTimePreparsedToken(std::string const &text, struct tm date, DateTimePreparsedTokenFormat format);
 
         std::string GetText() const;
         DateTimePreparsedTokenFormat GetFormat() const;

--- a/source/shared/cpp/ObjectModel/DateTimePreparser.cpp
+++ b/source/shared/cpp/ObjectModel/DateTimePreparser.cpp
@@ -25,7 +25,7 @@ DateTimePreparser::DateTimePreparser() :
 {
 }
 
-DateTimePreparser::DateTimePreparser(std::string in)
+DateTimePreparser::DateTimePreparser(std::string const &in)
 {
     ParseDateTime(in);
 }
@@ -35,12 +35,12 @@ std::vector<std::shared_ptr<DateTimePreparsedToken>> DateTimePreparser::GetTextT
     return m_textTokenCollection;
 }
 
-bool DateTimePreparser::HasDateTokens()
+bool DateTimePreparser::HasDateTokens() const
 {
     return m_hasDateTokens;
 }
 
-void DateTimePreparser::AddTextToken(std::string text, DateTimePreparsedTokenFormat format)
+void DateTimePreparser::AddTextToken(std::string const &text, DateTimePreparsedTokenFormat format)
 {
     if (!text.empty())
     {
@@ -48,13 +48,13 @@ void DateTimePreparser::AddTextToken(std::string text, DateTimePreparsedTokenFor
     }
 }
 
-void DateTimePreparser::AddDateToken(std::string text, struct tm date, DateTimePreparsedTokenFormat format)
+void DateTimePreparser::AddDateToken(std::string const &text, struct tm date, DateTimePreparsedTokenFormat format)
 {
     m_textTokenCollection.emplace_back(std::make_shared<DateTimePreparsedToken>(text, date, format));
     m_hasDateTokens = true;
 }
 
-std::string DateTimePreparser::Concatenate()
+std::string DateTimePreparser::Concatenate() const
 {
     std::string formedString;
     for (const auto& piece : m_textTokenCollection)
@@ -89,7 +89,7 @@ bool DateTimePreparser::IsValidTimeAndDate(const struct tm &parsedTm, int hours,
     return false;
 }
 
-void DateTimePreparser::ParseDateTime(std::string in)
+void DateTimePreparser::ParseDateTime(std::string const &in)
 {
     std::vector<DateTimePreparsedToken> sections;
 

--- a/source/shared/cpp/ObjectModel/DateTimePreparser.h
+++ b/source/shared/cpp/ObjectModel/DateTimePreparser.h
@@ -10,16 +10,16 @@ AdaptiveSharedNamespaceStart
     {
     public:
         DateTimePreparser();
-        DateTimePreparser(std::string in);
+        DateTimePreparser(std::string const &in);
         std::vector<std::shared_ptr<DateTimePreparsedToken>> GetTextTokens() const;
-        bool HasDateTokens();
+        bool HasDateTokens() const;
 
     private:
-        void AddTextToken(std::string text, DateTimePreparsedTokenFormat format);
-        void AddDateToken(std::string text, struct tm date, DateTimePreparsedTokenFormat format);
-        std::string Concatenate();
+        void AddTextToken(std::string const &text, DateTimePreparsedTokenFormat format);
+        void AddDateToken(std::string const &text, struct tm date, DateTimePreparsedTokenFormat format);
+        std::string Concatenate() const;
         static bool IsValidTimeAndDate(const struct tm &parsedTm, int hours, int minutes);
-        void ParseDateTime(std::string in);        
+        void ParseDateTime(std::string const &in);        
 
         std::vector<std::shared_ptr<DateTimePreparsedToken>> m_textTokenCollection;
         bool m_hasDateTokens;

--- a/source/shared/cpp/ObjectModel/ElementParserRegistration.cpp
+++ b/source/shared/cpp/ObjectModel/ElementParserRegistration.cpp
@@ -64,10 +64,14 @@ AdaptiveSharedNamespaceStart
 
     void ElementParserRegistration::RemoveParser(std::string const &elementType)
     {
-        if (m_knownElements.find(elementType) != m_knownElements.end())
+        if (m_knownElements.find(elementType) == m_knownElements.end())
         {
             ElementParserRegistration::m_cardElementParsers.erase(elementType);
         }
+	else
+	{
+		throw AdaptiveCardParseException(ErrorStatusCode::UnsupportedParserOverride, "Overriding known element parsers is unsupported");
+	}
     }
 
     std::shared_ptr<BaseCardElementParser> ElementParserRegistration::GetParser(std::string const &elementType)

--- a/source/shared/cpp/ObjectModel/ElementParserRegistration.cpp
+++ b/source/shared/cpp/ObjectModel/ElementParserRegistration.cpp
@@ -50,7 +50,7 @@ AdaptiveSharedNamespaceStart
         });
     }
 
-    void ElementParserRegistration::AddParser(std::string elementType, std::shared_ptr<BaseCardElementParser> parser)
+    void ElementParserRegistration::AddParser(std::string const &elementType, std::shared_ptr<BaseCardElementParser> parser)
     {
         if (m_knownElements.find(elementType) == m_knownElements.end())
         {
@@ -62,19 +62,15 @@ AdaptiveSharedNamespaceStart
         }
     }
 
-    void ElementParserRegistration::RemoveParser(std::string elementType)
+    void ElementParserRegistration::RemoveParser(std::string const &elementType)
     {
-        if (m_knownElements.find(elementType) == m_knownElements.end())
+        if (m_knownElements.find(elementType) != m_knownElements.end())
         {
             ElementParserRegistration::m_cardElementParsers.erase(elementType);
         }
-        else
-        {
-            throw AdaptiveCardParseException(ErrorStatusCode::UnsupportedParserOverride, "Overriding known element parsers is unsupported");
-        }
     }
 
-    std::shared_ptr<BaseCardElementParser> ElementParserRegistration::GetParser(std::string elementType)
+    std::shared_ptr<BaseCardElementParser> ElementParserRegistration::GetParser(std::string const &elementType)
     {
         auto parser = m_cardElementParsers.find(elementType);
         if (parser != ElementParserRegistration::m_cardElementParsers.end())

--- a/source/shared/cpp/ObjectModel/ElementParserRegistration.cpp
+++ b/source/shared/cpp/ObjectModel/ElementParserRegistration.cpp
@@ -68,10 +68,10 @@ AdaptiveSharedNamespaceStart
         {
             ElementParserRegistration::m_cardElementParsers.erase(elementType);
         }
-	else
-	{
-		throw AdaptiveCardParseException(ErrorStatusCode::UnsupportedParserOverride, "Overriding known element parsers is unsupported");
-	}
+        else
+        {
+            throw AdaptiveCardParseException(ErrorStatusCode::UnsupportedParserOverride, "Overriding known element parsers is unsupported");
+        }
     }
 
     std::shared_ptr<BaseCardElementParser> ElementParserRegistration::GetParser(std::string const &elementType)

--- a/source/shared/cpp/ObjectModel/ElementParserRegistration.h
+++ b/source/shared/cpp/ObjectModel/ElementParserRegistration.h
@@ -24,9 +24,9 @@ AdaptiveSharedNamespaceStart
 
         ElementParserRegistration();
 
-        void AddParser(std::string elementType, std::shared_ptr<AdaptiveSharedNamespace::BaseCardElementParser> parser);
-        void RemoveParser(std::string elementType);
-        std::shared_ptr<AdaptiveSharedNamespace::BaseCardElementParser> GetParser(std::string elementType);
+        void AddParser(std::string const &elementType, std::shared_ptr<AdaptiveSharedNamespace::BaseCardElementParser> parser);
+        void RemoveParser(std::string const &elementType);
+        std::shared_ptr<AdaptiveSharedNamespace::BaseCardElementParser> GetParser(std::string const &elementType);
 
     private:
         std::unordered_set<std::string> m_knownElements;

--- a/source/shared/cpp/ObjectModel/Enums.h
+++ b/source/shared/cpp/ObjectModel/Enums.h
@@ -27,7 +27,7 @@ struct CaseInsensitiveEqualTo {
 
 struct CaseInsensitiveHash {
     size_t operator() (const std::string& keyval) const {
-        return std::accumulate(keyval.begin(), keyval.end(), size_t{ 0 }, [](size_t acc, char c) { return acc + static_cast<size_t>(std::tolower(c)); });
+        return std::accumulate(keyval.begin(), keyval.end(), size_t{ 0 }, [](size_t acc, char c) { return acc + static_cast<size_t>(std::toupper(c)); });
     }
 };
 

--- a/source/shared/cpp/ObjectModel/Fact.cpp
+++ b/source/shared/cpp/ObjectModel/Fact.cpp
@@ -8,7 +8,7 @@ Fact::Fact()
 {
 }
 
-Fact::Fact(std::string title, std::string value) : 
+Fact::Fact(std::string const &title, std::string const &value) : 
     m_title(title), m_value(value)
 {
 }
@@ -53,7 +53,7 @@ std::string Fact::GetTitle() const
     return m_title;
 }
 
-void Fact::SetTitle(const std::string value)
+void Fact::SetTitle(const std::string &value)
 {
     m_title = value;
 }
@@ -63,7 +63,7 @@ std::string Fact::GetValue() const
     return m_value;
 }
 
-void Fact::SetValue(const std::string value)
+void Fact::SetValue(const std::string &value)
 {
     m_value = value;
 }

--- a/source/shared/cpp/ObjectModel/Fact.h
+++ b/source/shared/cpp/ObjectModel/Fact.h
@@ -10,16 +10,16 @@ class Fact
 {
 public:
     Fact();
-    Fact(std::string title, std::string value);
+    Fact(std::string const &title, std::string const &value);
 
     std::string Serialize();
     Json::Value SerializeToJsonValue();
 
     std::string GetTitle() const;
-    void SetTitle(const std::string value);
+    void SetTitle(const std::string &value);
 
     std::string GetValue() const;
-    void SetValue(const std::string value);
+    void SetValue(const std::string &value);
 
     static std::shared_ptr<Fact> Deserialize(
         std::shared_ptr<ElementParserRegistration> elementParserRegistration,

--- a/source/shared/cpp/ObjectModel/FactSet.cpp
+++ b/source/shared/cpp/ObjectModel/FactSet.cpp
@@ -20,7 +20,7 @@ std::vector<std::shared_ptr<Fact>>& FactSet::GetFacts()
     return m_facts;
 }
 
-Json::Value FactSet::SerializeToJsonValue()
+Json::Value FactSet::SerializeToJsonValue() const
 {
     Json::Value root = BaseCardElement::SerializeToJsonValue();
 

--- a/source/shared/cpp/ObjectModel/FactSet.h
+++ b/source/shared/cpp/ObjectModel/FactSet.h
@@ -14,7 +14,7 @@ friend class FactSetParser;
 public:
     FactSet();
 
-    virtual Json::Value SerializeToJsonValue() override;
+    virtual Json::Value SerializeToJsonValue() const override;
 
     std::vector<std::shared_ptr<Fact>>& GetFacts();
     const std::vector<std::shared_ptr<Fact>>& GetFacts() const;

--- a/source/shared/cpp/ObjectModel/Image.cpp
+++ b/source/shared/cpp/ObjectModel/Image.cpp
@@ -16,7 +16,7 @@ Image::Image() :
     PopulateKnownPropertiesSet();
 }
 
-Json::Value Image::SerializeToJsonValue()
+Json::Value Image::SerializeToJsonValue() const
 {
     const char pixelstring[] = "px";
 
@@ -80,7 +80,7 @@ std::string Image::GetUrl() const
     return m_url;
 }
 
-void Image::SetUrl(const std::string value)
+void Image::SetUrl(const std::string &value)
 {
     m_url = value;
 }
@@ -110,7 +110,7 @@ std::string Image::GetAltText() const
     return m_altText;
 }
 
-void Image::SetAltText(const std::string value)
+void Image::SetAltText(const std::string &value)
 {
     m_altText = value;
 }

--- a/source/shared/cpp/ObjectModel/Image.h
+++ b/source/shared/cpp/ObjectModel/Image.h
@@ -12,10 +12,10 @@ class Image : public BaseCardElement
 public:
     Image();
 
-    virtual Json::Value SerializeToJsonValue() override;
+    virtual Json::Value SerializeToJsonValue() const override;
 
     std::string GetUrl() const;
-    void SetUrl(const std::string value);
+    void SetUrl(const std::string &value);
 
     ImageStyle GetImageStyle() const;
     void SetImageStyle(const ImageStyle value);
@@ -24,7 +24,7 @@ public:
     void SetImageSize(const ImageSize value);
 
     std::string GetAltText() const;
-    void SetAltText(const std::string value);
+    void SetAltText(const std::string &value);
 
     HorizontalAlignment GetHorizontalAlignment() const;
     void SetHorizontalAlignment(const HorizontalAlignment value);

--- a/source/shared/cpp/ObjectModel/ImageSet.cpp
+++ b/source/shared/cpp/ObjectModel/ImageSet.cpp
@@ -32,7 +32,7 @@ std::vector<std::shared_ptr<Image>>& ImageSet::GetImages()
     return m_images;
 }
 
-Json::Value ImageSet::SerializeToJsonValue()
+Json::Value ImageSet::SerializeToJsonValue() const
 {
     Json::Value root = BaseCardElement::SerializeToJsonValue();
 
@@ -41,7 +41,7 @@ Json::Value ImageSet::SerializeToJsonValue()
         root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::ImageSize)] = ImageSizeToString(GetImageSize());
     }
 
-    std::string itemsPropertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Images);
+    std::string const &itemsPropertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Images);
     root[itemsPropertyName] = Json::Value(Json::arrayValue);
     for (const auto& image : m_images)
     {

--- a/source/shared/cpp/ObjectModel/ImageSet.h
+++ b/source/shared/cpp/ObjectModel/ImageSet.h
@@ -13,7 +13,7 @@ friend class ImageSetParser;
 public:
     ImageSet();
 
-    virtual Json::Value SerializeToJsonValue() override;
+    virtual Json::Value SerializeToJsonValue() const override;
 
     ImageSize GetImageSize() const;
     void SetImageSize(const ImageSize value);

--- a/source/shared/cpp/ObjectModel/NumberInput.cpp
+++ b/source/shared/cpp/ObjectModel/NumberInput.cpp
@@ -6,14 +6,14 @@ using namespace AdaptiveSharedNamespace;
 
 NumberInput::NumberInput() :
     BaseInputElement(CardElementType::NumberInput),
-    m_min(std::numeric_limits<int>::min()),
+    m_value(0),
     m_max(std::numeric_limits<int>::max()),
-    m_value(0)
+    m_min(std::numeric_limits<int>::min())
 {
     PopulateKnownPropertiesSet();
 }
 
-Json::Value NumberInput::SerializeToJsonValue()
+Json::Value NumberInput::SerializeToJsonValue() const
 {
     Json::Value root = BaseInputElement::SerializeToJsonValue();
 
@@ -45,7 +45,7 @@ std::string NumberInput::GetPlaceholder() const
     return m_placeholder;
 }
 
-void NumberInput::SetPlaceholder(const std::string value)
+void NumberInput::SetPlaceholder(const std::string &value)
 {
     m_placeholder = value;
 }

--- a/source/shared/cpp/ObjectModel/NumberInput.h
+++ b/source/shared/cpp/ObjectModel/NumberInput.h
@@ -11,10 +11,10 @@ class NumberInput : public BaseInputElement
 public:
     NumberInput();
 
-    virtual Json::Value SerializeToJsonValue() override;
+    virtual Json::Value SerializeToJsonValue() const override;
 
     std::string GetPlaceholder() const;
-    void SetPlaceholder(const std::string value);
+    void SetPlaceholder(const std::string &value);
 
     int GetValue() const;
     void SetValue(const int value);

--- a/source/shared/cpp/ObjectModel/OpenUrlAction.cpp
+++ b/source/shared/cpp/ObjectModel/OpenUrlAction.cpp
@@ -9,7 +9,7 @@ OpenUrlAction::OpenUrlAction() : BaseActionElement(ActionType::OpenUrl)
     PopulateKnownPropertiesSet();
 }
 
-Json::Value OpenUrlAction::SerializeToJsonValue()
+Json::Value OpenUrlAction::SerializeToJsonValue() const
 {
     Json::Value root = BaseActionElement::SerializeToJsonValue();
 
@@ -23,7 +23,7 @@ std::string OpenUrlAction::GetUrl() const
     return m_url;
 }
 
-void OpenUrlAction::SetUrl(const std::string value)
+void OpenUrlAction::SetUrl(const std::string &value)
 {
     m_url = value;
 }

--- a/source/shared/cpp/ObjectModel/OpenUrlAction.h
+++ b/source/shared/cpp/ObjectModel/OpenUrlAction.h
@@ -11,10 +11,10 @@ class OpenUrlAction : public BaseActionElement
 public:
     OpenUrlAction();
 
-    virtual Json::Value SerializeToJsonValue() override;
+    virtual Json::Value SerializeToJsonValue() const override;
 
     std::string GetUrl() const;
-    void SetUrl(const std::string value);
+    void SetUrl(const std::string &value);
 
 private:
     void PopulateKnownPropertiesSet();

--- a/source/shared/cpp/ObjectModel/ParseResult.cpp
+++ b/source/shared/cpp/ObjectModel/ParseResult.cpp
@@ -13,12 +13,12 @@ ParseResult::ParseResult(
 {
 }
 
-std::shared_ptr<AdaptiveCard> ParseResult::GetAdaptiveCard()
+std::shared_ptr<AdaptiveCard> ParseResult::GetAdaptiveCard() const
 {
     return m_adaptiveCard;
 }
 
-std::vector<std::shared_ptr<AdaptiveCardParseWarning>> ParseResult::GetWarnings()
+std::vector<std::shared_ptr<AdaptiveCardParseWarning>> ParseResult::GetWarnings() const
 {
     return m_warnings;
 }

--- a/source/shared/cpp/ObjectModel/ParseResult.h
+++ b/source/shared/cpp/ObjectModel/ParseResult.h
@@ -13,8 +13,8 @@ AdaptiveSharedNamespaceStart
             std::shared_ptr<AdaptiveCard> adaptiveCard,
             std::vector<std::shared_ptr<AdaptiveCardParseWarning>> warnings);
 
-        std::shared_ptr<AdaptiveCard> GetAdaptiveCard();
-        std::vector<std::shared_ptr<AdaptiveCardParseWarning>> GetWarnings();
+        std::shared_ptr<AdaptiveCard> GetAdaptiveCard() const;
+        std::vector<std::shared_ptr<AdaptiveCardParseWarning>> GetWarnings() const;
 
     private:
         std::shared_ptr<AdaptiveCard> m_adaptiveCard;

--- a/source/shared/cpp/ObjectModel/ParseUtil.cpp
+++ b/source/shared/cpp/ObjectModel/ParseUtil.cpp
@@ -280,7 +280,7 @@ Json::Value ParseUtil::GetArray(
     return elementArray;
 }
 
-Json::Value ParseUtil::GetJsonValueFromString(const std::string jsonString)
+Json::Value ParseUtil::GetJsonValueFromString(const std::string &jsonString)
 {
     Json::Reader reader;
     Json::Value jsonValue;
@@ -302,10 +302,12 @@ Json::Value ParseUtil::ExtractJsonValue(const Json::Value& json, AdaptiveCardSch
     return propertyValue;
 }
 
-std::string ParseUtil::ToLowercase(std::string value)
+std::string ParseUtil::ToLowercase(std::string const &value)
 {
-    std::transform(value.begin(), value.end(), value.begin(), [](char c) { return std::tolower(c, std::locale()); });
-    return value;
+    std::string new_value;
+    new_value.resize(value.size());
+    std::transform(value.begin(), value.end(), new_value.begin(), [](char c) { return std::tolower(c, std::locale()); });
+    return new_value;
 }
 
 std::vector<std::shared_ptr<BaseCardElement>> ParseUtil::GetElementCollection(

--- a/source/shared/cpp/ObjectModel/ParseUtil.h
+++ b/source/shared/cpp/ObjectModel/ParseUtil.h
@@ -47,7 +47,7 @@ public:
 
     static Json::Value GetArray(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired = false);
 
-    static Json::Value GetJsonValueFromString(const std::string jsonString);
+    static Json::Value GetJsonValueFromString(const std::string &jsonString);
 
     static Json::Value ExtractJsonValue(const Json::Value& jsonRoot, AdaptiveCardSchemaKey key, bool isRequired = false);
 
@@ -106,7 +106,7 @@ public:
     // throws if the key is missing or the value mapped to the key is the wrong type
     static void ExpectKeyAndValueType(const Json::Value& json, const char* expectedKey, std::function<void(const Json::Value&)> throwIfWrongType);
 
-    static std::string ToLowercase(const std::string value);
+    static std::string ToLowercase(const std::string &value);
 
 private:
     ParseUtil();
@@ -121,7 +121,7 @@ T ParseUtil::GetEnumValue(const Json::Value& json, AdaptiveCardSchemaKey key, T 
     try
     {
         const std::string propertyName = AdaptiveCardSchemaKeyToString(key);
-        auto propertyValue = json.get(propertyName, Json::Value());
+        auto const &propertyValue = json.get(propertyName, Json::Value());
         if (propertyValue.empty())
         {
             if (isRequired)

--- a/source/shared/cpp/ObjectModel/Separator.cpp
+++ b/source/shared/cpp/ObjectModel/Separator.cpp
@@ -4,7 +4,7 @@
 
 using namespace AdaptiveSharedNamespace;
 
-Separator::Separator()
+Separator::Separator(): m_thickness(SeparatorThickness::Default), m_color(ForegroundColor::Default)
 {
 }
 

--- a/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
+++ b/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
@@ -8,37 +8,37 @@
 
 using namespace AdaptiveSharedNamespace;
 
-AdaptiveCard::AdaptiveCard()
+AdaptiveCard::AdaptiveCard(): m_style(ContainerStyle::None)
 {
 }
 
-AdaptiveCard::AdaptiveCard(std::string version,
-    std::string fallbackText,
-    std::string backgroundImage,
+AdaptiveCard::AdaptiveCard(std::string const &version,
+    std::string const &fallbackText,
+    std::string const &backgroundImage,
     ContainerStyle style,
-    std::string speak,
-    std::string language) :
+    std::string const &speak,
+    std::string const &language) :
     m_version(version),
     m_fallbackText(fallbackText),
     m_backgroundImage(backgroundImage),
-    m_style(style),
     m_speak(speak),
+    m_style(style),
     m_language(language)
 {
 }
 
-AdaptiveCard::AdaptiveCard(std::string version,
-    std::string fallbackText,
-    std::string backgroundImage,
+AdaptiveCard::AdaptiveCard(std::string const &version,
+    std::string const &fallbackText,
+    std::string const &backgroundImage,
     ContainerStyle style,
-    std::string speak,
-    std::string language,
+    std::string const &speak,
+    std::string const &language,
     std::vector<std::shared_ptr<BaseCardElement>>& body, std::vector<std::shared_ptr<BaseActionElement>>& actions) :
     m_version(version),
     m_fallbackText(fallbackText),
     m_backgroundImage(backgroundImage),
-    m_style(style),
     m_speak(speak),
+    m_style(style),
     m_language(language),
     m_body(body),
     m_actions(actions)
@@ -162,7 +162,7 @@ std::shared_ptr<ParseResult> AdaptiveCard::DeserializeFromString(
     return AdaptiveCard::Deserialize(ParseUtil::GetJsonValueFromString(jsonString), rendererVersion, elementParserRegistration, actionParserRegistration);
 }
 
-Json::Value AdaptiveCard::SerializeToJsonValue()
+Json::Value AdaptiveCard::SerializeToJsonValue() const
 {
     Json::Value root;
     root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Type)] = CardElementTypeToString(CardElementType::AdaptiveCard);
@@ -227,7 +227,7 @@ std::shared_ptr<AdaptiveCard> AdaptiveCard::MakeFallbackTextCard(
     return fallbackCard;
 }
 
-std::string AdaptiveCard::Serialize()
+std::string AdaptiveCard::Serialize() const
 {
     Json::FastWriter writer;
     return writer.write(SerializeToJsonValue());
@@ -238,7 +238,7 @@ std::string AdaptiveCard::GetVersion() const
     return m_version;
 }
 
-void AdaptiveCard::SetVersion(const std::string value)
+void AdaptiveCard::SetVersion(const std::string &value)
 {
     m_version = value;
 }
@@ -248,7 +248,7 @@ std::string AdaptiveCard::GetFallbackText() const
     return m_fallbackText;
 }
 
-void AdaptiveCard::SetFallbackText(const std::string value)
+void AdaptiveCard::SetFallbackText(const std::string &value)
 {
     m_fallbackText = value;
 }
@@ -258,7 +258,7 @@ std::string AdaptiveCard::GetBackgroundImage() const
     return m_backgroundImage;
 }
 
-void AdaptiveCard::SetBackgroundImage(const std::string value)
+void AdaptiveCard::SetBackgroundImage(const std::string &value)
 {
     m_backgroundImage = value;
 }
@@ -268,7 +268,7 @@ std::string AdaptiveCard::GetSpeak() const
     return m_speak;
 }
 
-void AdaptiveCard::SetSpeak(const std::string value)
+void AdaptiveCard::SetSpeak(const std::string &value)
 {
     m_speak = value;
 }
@@ -317,7 +317,17 @@ std::vector<std::shared_ptr<BaseCardElement>>& AdaptiveCard::GetBody()
     return m_body;
 }
 
+const std::vector<std::shared_ptr<BaseCardElement>>& AdaptiveCard::GetBody() const
+{
+    return m_body;
+}
+
 std::vector<std::shared_ptr<BaseActionElement>>& AdaptiveCard::GetActions()
+{
+    return m_actions;
+}
+
+const std::vector<std::shared_ptr<BaseActionElement>>& AdaptiveCard::GetActions() const
 {
     return m_actions;
 }

--- a/source/shared/cpp/ObjectModel/SharedAdaptiveCard.h
+++ b/source/shared/cpp/ObjectModel/SharedAdaptiveCard.h
@@ -14,30 +14,30 @@ class AdaptiveCard
 public:
     AdaptiveCard();
     AdaptiveCard(
-        std::string version,
-        std::string fallbackText,
-        std::string backgroundImage,
+        std::string const &version,
+        std::string const &fallbackText,
+        std::string const &backgroundImage,
         ContainerStyle style,
-        std::string speak,
-        std::string language);
+        std::string const &speak,
+        std::string const &language);
     AdaptiveCard(
-        std::string version,
-        std::string fallbackText,
-        std::string backgroundImage,
+        std::string const &version,
+        std::string const &fallbackText,
+        std::string const &backgroundImage,
         ContainerStyle style,
-        std::string speak,
-        std::string language,
+        std::string const &speak,
+        std::string const &language,
         std::vector<std::shared_ptr<BaseCardElement>>& body,
         std::vector<std::shared_ptr<BaseActionElement>>& actions);
 
     std::string GetVersion() const;
-    void SetVersion(const std::string value);
+    void SetVersion(const std::string &value);
     std::string GetFallbackText() const;
-    void SetFallbackText(const std::string value);
+    void SetFallbackText(const std::string &value);
     std::string GetBackgroundImage() const;
-    void SetBackgroundImage(const std::string value);
+    void SetBackgroundImage(const std::string &value);
     std::string GetSpeak() const;
-    void SetSpeak(const std::string value);
+    void SetSpeak(const std::string &value);
     ContainerStyle GetStyle() const;
     void SetStyle(const ContainerStyle value);
     std::string GetLanguage() const;
@@ -47,7 +47,9 @@ public:
     void SetSelectAction(const std::shared_ptr<BaseActionElement> action);
 
     std::vector<std::shared_ptr<BaseCardElement>>& GetBody();
+    const std::vector<std::shared_ptr<BaseCardElement>>& GetBody() const;
     std::vector<std::shared_ptr<BaseActionElement>>& GetActions();
+    const std::vector<std::shared_ptr<BaseActionElement>>& GetActions() const;
 
     std::vector<std::string> GetResourceUris();
 
@@ -90,8 +92,8 @@ public:
         const std::string& language);
 
 #endif // __ANDROID__
-    Json::Value SerializeToJsonValue();
-    std::string Serialize();
+    Json::Value SerializeToJsonValue() const;
+    std::string Serialize() const;
 
 private:
     std::string m_version;

--- a/source/shared/cpp/ObjectModel/ShowCardAction.cpp
+++ b/source/shared/cpp/ObjectModel/ShowCardAction.cpp
@@ -10,7 +10,7 @@ ShowCardAction::ShowCardAction() : BaseActionElement(ActionType::ShowCard)
     PopulateKnownPropertiesSet();
 }
 
-Json::Value ShowCardAction::SerializeToJsonValue()
+Json::Value ShowCardAction::SerializeToJsonValue() const
 {
     Json::Value root = BaseActionElement::SerializeToJsonValue();
 

--- a/source/shared/cpp/ObjectModel/ShowCardAction.h
+++ b/source/shared/cpp/ObjectModel/ShowCardAction.h
@@ -12,7 +12,7 @@ class ShowCardAction : public BaseActionElement
 public:
     ShowCardAction();
 
-    virtual Json::Value SerializeToJsonValue() override;
+    virtual Json::Value SerializeToJsonValue() const override;
 
     std::shared_ptr<AdaptiveSharedNamespace::AdaptiveCard> GetCard() const;
     void SetCard(const std::shared_ptr<AdaptiveSharedNamespace::AdaptiveCard>);

--- a/source/shared/cpp/ObjectModel/SubmitAction.cpp
+++ b/source/shared/cpp/ObjectModel/SubmitAction.cpp
@@ -14,12 +14,12 @@ std::string SubmitAction::GetDataJson() const
     return m_dataJson;
 }
 
-void SubmitAction::SetDataJson(const std::string value)
+void SubmitAction::SetDataJson(const std::string &value)
 {
     m_dataJson = value;
 }
 
-Json::Value SubmitAction::SerializeToJsonValue()
+Json::Value SubmitAction::SerializeToJsonValue() const
 {
     Json::Value root = BaseActionElement::SerializeToJsonValue();
 

--- a/source/shared/cpp/ObjectModel/SubmitAction.h
+++ b/source/shared/cpp/ObjectModel/SubmitAction.h
@@ -12,9 +12,9 @@ public:
     SubmitAction();
 
     std::string GetDataJson() const;
-    void SetDataJson(const std::string value);
+    void SetDataJson(const std::string &value);
 
-    virtual Json::Value SerializeToJsonValue() override;
+    virtual Json::Value SerializeToJsonValue() const override;
 
 private:
     void PopulateKnownPropertiesSet();

--- a/source/shared/cpp/ObjectModel/TextBlock.cpp
+++ b/source/shared/cpp/ObjectModel/TextBlock.cpp
@@ -16,14 +16,14 @@ TextBlock::TextBlock() :
     m_textColor(ForegroundColor::Default),
     m_isSubtle(false),
     m_wrap(false),
-    m_hAlignment(HorizontalAlignment::Left),
     m_maxLines(0),
+    m_hAlignment(HorizontalAlignment::Left),
     m_language()
 {
     PopulateKnownPropertiesSet();
 }
 
-Json::Value TextBlock::SerializeToJsonValue()
+Json::Value TextBlock::SerializeToJsonValue() const
 {
     Json::Value root = BaseCardElement::SerializeToJsonValue();
 
@@ -73,7 +73,7 @@ std::string TextBlock::GetText() const
     return m_text;
 }
 
-void TextBlock::SetText(const std::string value)
+void TextBlock::SetText(const std::string &value)
 {
     m_text = value;
 }

--- a/source/shared/cpp/ObjectModel/TextBlock.h
+++ b/source/shared/cpp/ObjectModel/TextBlock.h
@@ -13,10 +13,10 @@ class TextBlock : public BaseCardElement
 public:
     TextBlock();
 
-    virtual Json::Value SerializeToJsonValue() override;
+    virtual Json::Value SerializeToJsonValue() const override;
 
     std::string GetText() const;
-    void SetText(const std::string value);
+    void SetText(const std::string &value);
     DateTimePreparser GetTextForDateParsing() const;
 
     TextSize GetTextSize() const;

--- a/source/shared/cpp/ObjectModel/TextInput.cpp
+++ b/source/shared/cpp/ObjectModel/TextInput.cpp
@@ -7,12 +7,13 @@ using namespace AdaptiveSharedNamespace;
 TextInput::TextInput() :
     BaseInputElement(CardElementType::TextInput),
     m_isMultiline(false),
-    m_maxLength(0)
+    m_maxLength(0),
+    m_style(TextInputStyle::Text)
 {
     PopulateKnownPropertiesSet();
 }
 
-Json::Value TextInput::SerializeToJsonValue()
+Json::Value TextInput::SerializeToJsonValue() const
 {
     Json::Value root = BaseInputElement::SerializeToJsonValue();
 
@@ -49,7 +50,7 @@ std::string TextInput::GetPlaceholder() const
     return m_placeholder;
 }
 
-void TextInput::SetPlaceholder(const std::string value)
+void TextInput::SetPlaceholder(const std::string &value)
 {
     m_placeholder = value;
 }
@@ -59,7 +60,7 @@ std::string TextInput::GetValue() const
     return m_value;
 }
 
-void TextInput::SetValue(const std::string value)
+void TextInput::SetValue(const std::string &value)
 {
     m_value = value;
 }

--- a/source/shared/cpp/ObjectModel/TextInput.h
+++ b/source/shared/cpp/ObjectModel/TextInput.h
@@ -11,13 +11,13 @@ class TextInput : public BaseInputElement
 public:
     TextInput();
 
-    virtual Json::Value SerializeToJsonValue() override;
+    virtual Json::Value SerializeToJsonValue() const override;
 
     std::string GetPlaceholder() const;
-    void SetPlaceholder(const std::string value);
+    void SetPlaceholder(const std::string &value);
 
     std::string GetValue() const;
-    void SetValue(const std::string value);
+    void SetValue(const std::string &value);
 
     bool GetIsMultiline() const;
     void SetIsMultiline(const bool value);

--- a/source/shared/cpp/ObjectModel/TimeInput.cpp
+++ b/source/shared/cpp/ObjectModel/TimeInput.cpp
@@ -10,7 +10,7 @@ TimeInput::TimeInput() :
     PopulateKnownPropertiesSet();
 }
 
-Json::Value TimeInput::SerializeToJsonValue()
+Json::Value TimeInput::SerializeToJsonValue() const
 {
     Json::Value root = BaseInputElement::SerializeToJsonValue();
 
@@ -42,7 +42,7 @@ std::string TimeInput::GetMax() const
     return m_max;
 }
 
-void TimeInput::SetMax(const std::string value)
+void TimeInput::SetMax(const std::string &value)
 {
     m_max = value;
 }
@@ -52,7 +52,7 @@ std::string TimeInput::GetMin() const
     return m_min;
 }
 
-void TimeInput::SetMin(const std::string value)
+void TimeInput::SetMin(const std::string &value)
 {
     m_min = value;
 }
@@ -62,7 +62,7 @@ std::string TimeInput::GetPlaceholder() const
     return m_placeholder;
 }
 
-void TimeInput::SetPlaceholder(const std::string value)
+void TimeInput::SetPlaceholder(const std::string &value)
 {
     m_placeholder = value;
 }
@@ -72,7 +72,7 @@ std::string TimeInput::GetValue() const
     return m_value;
 }
 
-void TimeInput::SetValue(const std::string value)
+void TimeInput::SetValue(const std::string &value)
 {
     m_value = value;
 }

--- a/source/shared/cpp/ObjectModel/TimeInput.h
+++ b/source/shared/cpp/ObjectModel/TimeInput.h
@@ -11,19 +11,19 @@ class TimeInput : public BaseInputElement
 public:
     TimeInput();
 
-    virtual Json::Value SerializeToJsonValue() override;
+    virtual Json::Value SerializeToJsonValue() const override;
 
     std::string GetMax() const;
-    void SetMax(const std::string value);
+    void SetMax(const std::string &value);
 
     std::string GetMin() const;
-    void SetMin(const std::string value);
+    void SetMin(const std::string &value);
 
     std::string GetPlaceholder() const;
-    void SetPlaceholder(const std::string value);
+    void SetPlaceholder(const std::string &value);
 
     std::string GetValue() const;
-    void SetValue(const std::string value);
+    void SetValue(const std::string &value);
 
 private:
     void PopulateKnownPropertiesSet();

--- a/source/shared/cpp/ObjectModel/ToggleInput.cpp
+++ b/source/shared/cpp/ObjectModel/ToggleInput.cpp
@@ -6,13 +6,13 @@ using namespace AdaptiveSharedNamespace;
 
 ToggleInput::ToggleInput() :
     BaseInputElement(CardElementType::ToggleInput),
-    m_valueOn("true"),
-    m_valueOff("false")
+    m_valueOff("false"),
+    m_valueOn("true")
 {
     PopulateKnownPropertiesSet();
 }
 
-Json::Value ToggleInput::SerializeToJsonValue()
+Json::Value ToggleInput::SerializeToJsonValue() const
 {
     Json::Value root = BaseInputElement::SerializeToJsonValue();
 
@@ -41,7 +41,7 @@ std::string ToggleInput::GetTitle() const
     return m_title;
 }
 
-void ToggleInput::SetTitle(const std::string value)
+void ToggleInput::SetTitle(const std::string &value)
 {
     m_title = value;
 }
@@ -51,11 +51,11 @@ std::string ToggleInput::GetValue() const
     return m_value;
 }
 
-void ToggleInput::SetValue(const std::string value)
+void ToggleInput::SetValue(const std::string &value)
 {
     m_value = value;
 }
-void ToggleInput::SetValueOff(const std::string valueOff)
+void ToggleInput::SetValueOff(const std::string &valueOff)
 {
     m_valueOff = valueOff;
 }
@@ -70,7 +70,7 @@ std::string ToggleInput::GetValueOn() const
     return m_valueOn;
 }
 
-void ToggleInput::SetValueOn(const std::string valueOn)
+void ToggleInput::SetValueOn(const std::string &valueOn)
 {
     m_valueOn = valueOn;
 }

--- a/source/shared/cpp/ObjectModel/ToggleInput.h
+++ b/source/shared/cpp/ObjectModel/ToggleInput.h
@@ -11,19 +11,19 @@ class ToggleInput : public BaseInputElement
 public:
     ToggleInput();
 
-    virtual Json::Value SerializeToJsonValue() override;
+    virtual Json::Value SerializeToJsonValue() const override;
 
     std::string GetTitle() const;
-    void SetTitle(const std::string value);
+    void SetTitle(const std::string &value);
 
     std::string GetValue() const;
-    void SetValue(const std::string value);
+    void SetValue(const std::string &value);
 
     std::string GetValueOff() const;
-    void SetValueOff(const std::string value);
+    void SetValueOff(const std::string &value);
 
     std::string GetValueOn() const;
-    void SetValueOn(const std::string value);
+    void SetValueOn(const std::string &value);
 
 private:
     void PopulateKnownPropertiesSet();


### PR DESCRIPTION
You are making a beautiful thing happen, truly thankful for that. Please consider this collaboration.

- ~~Bug fix: RemoveParser was backwards (unlikely to be called ever, yet...)~~ (my bad, the code wasn't backwards but the check was legit -whether the parser was for a "known"/standard element).

- Bug fixes: many empty constructors would forget to initialize enum members.

- Semantic fix: it's customary to use toupper (not tolower) when computing case-insensitive things. In English it makes no difference, but in languages like Greek, the lower case symbol will depend of the position of the letter within the word (not true for uppercase).

- Performance improvement: a majority of strings were being passed in by copy or const copy; made to pass-in by const ref (of course not for the parser work).

Additionally, a suggestion on parsing; you may be too young or too far from compiler teams to know Bison or lexx/yacc, but there are better ways to construct these machine states without so much manual work.
