### PR TITLE
Add missing null check to UWP test app

### DIFF
--- a/source/uwp/AdaptiveCardTestApp/ViewModels/TestResultViewModel.cs
+++ b/source/uwp/AdaptiveCardTestApp/ViewModels/TestResultViewModel.cs
@@ -44,7 +44,7 @@ namespace AdaptiveCardTestApp.ViewModels
 
         public bool DidHostConfigChange => _oldHostConfigHash != null && _oldHostConfigHash != HostConfigFile.Hash;
         public bool DidCardPayloadChange => _oldCardHash != null && _oldCardHash != CardFile.Hash;
-        public bool DidRoundtrippedJsonChange => ExpectedRoundtrippedJsonModel.Hash != RoundtrippedJsonModel.Hash;
+        public bool DidRoundtrippedJsonChange => ExpectedRoundtrippedJsonModel != null && ExpectedRoundtrippedJsonModel.Hash != RoundtrippedJsonModel.Hash;
 
         private StorageFolder _expectedFolder;
         private StorageFolder _sourceHostConfigsFolder;


### PR DESCRIPTION
Missing null check in the comparison of roundtripped json hashed led to issues where test results were not displayed correctly.