### PR TITLE
Turn on automatic cppcore guidelines checking

### DIFF
--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModel/AdaptiveCardsSharedModel.vcxproj
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModel/AdaptiveCardsSharedModel.vcxproj
@@ -69,7 +69,18 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <CodeAnalysisRuleSet>CppCoreCheckRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <CodeAnalysisRuleSet>CppCoreCheckRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <CodeAnalysisRuleSet>CppCoreCheckRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <CodeAnalysisRuleSet>CppCoreCheckRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <WarningLevel>Level4</WarningLevel>

--- a/source/shared/cpp/ObjectModel/DateTimePreparser.cpp
+++ b/source/shared/cpp/ObjectModel/DateTimePreparser.cpp
@@ -164,7 +164,7 @@ void DateTimePreparser::ParseDateTime(std::string const &in)
                 // converts to seconds
                 hours *= 3600;
                 minutes *= 60;
-                offset = hours + minutes;
+                offset = (time_t)hours + (time_t)minutes;
 
                 wchar_t zone = matches[TimeZone].str()[0];
                 // time zone offset calculation 
@@ -191,7 +191,7 @@ void DateTimePreparser::ParseDateTime(std::string const &in)
             wcsftime(tzOffsetBuff, 6, L"%z", &parsedTm);
             std::wstring localTimeZoneOffsetStr(tzOffsetBuff);
             int nTzOffset = std::stoi(localTimeZoneOffsetStr);
-            offset += ((nTzOffset / 100) * 3600 + (nTzOffset % 100) * 60);
+            offset += ((time_t)(nTzOffset / 100) * 3600 + (time_t)(nTzOffset % 100) * 60);
             // add offset to utc
             utc += offset;
             struct tm result{};

--- a/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.cpp
@@ -20,48 +20,48 @@ std::string MarkDownStringHtmlGenerator::GenerateHtmlString()
 
 //     left and right emphasis tokens are match if
 //     1. they are same types
-//     2. neither of the emphasis tokens are both left and right emphasis tokens, and 
-//        if either or both of them are, then their sum is not multiple of 3 
-bool MarkDownEmphasisHtmlGenerator::IsMatch(std::shared_ptr<MarkDownEmphasisHtmlGenerator> &emphasisToken)
+//     2. neither of the emphasis tokens are both left and right emphasis tokens, and
+//        if either or both of them are, then their sum is not multiple of 3
+bool MarkDownEmphasisHtmlGenerator::IsMatch(const MarkDownEmphasisHtmlGenerator &emphasisToken)
 {
-    if (this->type == emphasisToken->type)
+    if (this->type == emphasisToken.type)
     {
-        // rule #9 & #10, sum of delimiter count can't be multiple of 3 
-        return !((this->IsLeftAndRightEmphasis() || emphasisToken->IsLeftAndRightEmphasis()) &&
-            (((this->m_numberOfUnusedDelimiters + emphasisToken->m_numberOfUnusedDelimiters) % 3) == 0));
+        // rule #9 & #10, sum of delimiter count can't be multiple of 3
+        return !((this->IsLeftAndRightEmphasis() || emphasisToken.IsLeftAndRightEmphasis()) &&
+            (((this->m_numberOfUnusedDelimiters + emphasisToken.m_numberOfUnusedDelimiters) % 3) == 0));
     }
     return false;
 }
 
-bool MarkDownEmphasisHtmlGenerator::IsSameType(std::shared_ptr<MarkDownEmphasisHtmlGenerator> &token)
+bool MarkDownEmphasisHtmlGenerator::IsSameType(const MarkDownEmphasisHtmlGenerator &token)
 {
-    return this->type == token->type;
+    return this->type == token.type;
 }
 
 // adjust number of emphasis counts after maching is done
-int MarkDownEmphasisHtmlGenerator::AdjustEmphasisCounts(int leftOver, std::shared_ptr<MarkDownEmphasisHtmlGenerator> rightToken)
+int MarkDownEmphasisHtmlGenerator::AdjustEmphasisCounts(int leftOver, MarkDownEmphasisHtmlGenerator &rightToken)
 {
     int delimiterCount = 0;
     if (leftOver >= 0)
     {
         delimiterCount = this->m_numberOfUnusedDelimiters - leftOver;
         this->m_numberOfUnusedDelimiters = leftOver;
-        rightToken->m_numberOfUnusedDelimiters = 0;
+        rightToken.m_numberOfUnusedDelimiters = 0;
     }
     else
     {
         delimiterCount = this->m_numberOfUnusedDelimiters;
-        rightToken->m_numberOfUnusedDelimiters = leftOver * (-1);
+        rightToken.m_numberOfUnusedDelimiters = leftOver * (-1);
         this->m_numberOfUnusedDelimiters = 0;
     }
     return delimiterCount;
 }
 
 // generate bold and emphasis html tags
-bool MarkDownEmphasisHtmlGenerator::GenerateTags(std::shared_ptr<MarkDownEmphasisHtmlGenerator> &token)
+bool MarkDownEmphasisHtmlGenerator::GenerateTags(MarkDownEmphasisHtmlGenerator &token)
 {
     int delimiterCount = 0, leftOver = 0;
-    leftOver = this->m_numberOfUnusedDelimiters - token->m_numberOfUnusedDelimiters;
+    leftOver = this->m_numberOfUnusedDelimiters - token.m_numberOfUnusedDelimiters;
     delimiterCount = this->AdjustEmphasisCounts(leftOver, token);
     bool hasHtmlTags = (delimiterCount > 0);
 
@@ -69,14 +69,14 @@ bool MarkDownEmphasisHtmlGenerator::GenerateTags(std::shared_ptr<MarkDownEmphasi
     if (delimiterCount % 2)
     {
         this->PushItalicTag();
-        token->PushItalicTag();
+        token.PushItalicTag();
     }
 
     // strong emphasis found
     for (int i = 0; i < delimiterCount / 2; i++)
     {
         this->PushBoldTag();
-        token->PushBoldTag();
+        token.PushBoldTag();
     }
     return hasHtmlTags;
 }
@@ -130,13 +130,13 @@ void MarkDownRightEmphasisHtmlGenerator::PushBoldTag()
 
 std::string MarkDownRightEmphasisHtmlGenerator::GenerateHtmlString()
 {
-    // append tags; 
+    // append tags;
     for (auto itr = m_tags.begin(); itr != m_tags.end(); itr++)
     {
         html << *itr;
     }
 
-    // if there are unused emphasis, append them 
+    // if there are unused emphasis, append them
     if (m_numberOfUnusedDelimiters)
     {
         unsigned long startIdx = static_cast<unsigned long>(m_token.size()) - m_numberOfUnusedDelimiters;

--- a/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.h
+++ b/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.h
@@ -18,11 +18,11 @@ enum DelimiterType
     Asterisk,
 };
 
-// this class knows how to generate html string of their types 
-// - MarkDownStringHtmlGenerator 
+// this class knows how to generate html string of their types
+// - MarkDownStringHtmlGenerator
 //   it is the most basic form,
 //   it simply retains and return text as string
-// - MarkDownEmphasisHtmlGenerator 
+// - MarkDownEmphasisHtmlGenerator
 //   it knows how to handle bold and italic html
 //   tags and apply those to its text when asked to generate html string
 // - MarkDownListHtmlGenerator
@@ -45,7 +45,7 @@ class MarkDownHtmlGenerator
         void MakeItTail() { m_isTail = true; }
         virtual bool IsNewLine() { return false; }
         virtual std::string GenerateHtmlString() = 0;
-        virtual MarkDownBlockType GetBlockType() const { return ContainerBlock; }; 
+        virtual MarkDownBlockType GetBlockType() const { return ContainerBlock; };
     protected:
         std::string m_token;
         std::ostringstream html;
@@ -53,64 +53,64 @@ class MarkDownHtmlGenerator
         bool m_isTail = false;
 };
 
-// - MarkDownStringHtmlGenerator 
+// - MarkDownStringHtmlGenerator
 //   it is the most basic form,
 //   it simply retains and return text as string
 class MarkDownStringHtmlGenerator : public MarkDownHtmlGenerator
-{ 
+{
     public:
         MarkDownStringHtmlGenerator(std::string &token) : MarkDownHtmlGenerator(token){};
         std::string GenerateHtmlString();
 };
 
-// - MarkDownNewLineHtmlGenerator 
+// - MarkDownNewLineHtmlGenerator
 //   it contains new line chars
-class MarkDownNewLineHtmlGenerator : public MarkDownStringHtmlGenerator 
-{ 
+class MarkDownNewLineHtmlGenerator : public MarkDownStringHtmlGenerator
+{
     public:
         MarkDownNewLineHtmlGenerator(std::string &token) : MarkDownStringHtmlGenerator(token){};
         bool IsNewLine() { return true; }
 };
 
-// - MarkDownEmphasisHtmlGenerator 
+// - MarkDownEmphasisHtmlGenerator
 //   it knows how to handle bold and italic html
 //   tags and apply those to its text when asked to generate html string
 class MarkDownEmphasisHtmlGenerator : public MarkDownHtmlGenerator
 {
     public:
-        MarkDownEmphasisHtmlGenerator(std::string &token, 
+        MarkDownEmphasisHtmlGenerator(std::string &token,
                 int sizeOfEmphasisDelimiterRun,
                 DelimiterType type
-                ) : MarkDownHtmlGenerator(token), 
+                ) : MarkDownHtmlGenerator(token),
         m_numberOfUnusedDelimiters(sizeOfEmphasisDelimiterRun), type(type){};
 
-        MarkDownEmphasisHtmlGenerator(std::string &token, 
+        MarkDownEmphasisHtmlGenerator(std::string &token,
                 int sizeOfEmphasisDelimiterRun,
                 DelimiterType type,
                 std::vector<std::string> &tags
-                ) : MarkDownHtmlGenerator(token), 
+                ) : MarkDownHtmlGenerator(token),
         m_numberOfUnusedDelimiters(sizeOfEmphasisDelimiterRun), type(type), m_tags(tags){};
 
         virtual bool IsRightEmphasis() const { return false; }
         virtual bool IsLeftEmphasis() const  { return false; }
         virtual bool IsLeftAndRightEmphasis() const { return false; }
-        virtual void PushItalicTag(); 
-        virtual void PushBoldTag(); 
+        virtual void PushItalicTag();
+        virtual void PushBoldTag();
 
-        bool IsMatch(std::shared_ptr<MarkDownEmphasisHtmlGenerator> &token);
-        bool IsSameType(std::shared_ptr<MarkDownEmphasisHtmlGenerator> &token);
+        bool IsMatch(const MarkDownEmphasisHtmlGenerator &token);
+        bool IsSameType(const MarkDownEmphasisHtmlGenerator &token);
         bool IsDone() const { return m_numberOfUnusedDelimiters == 0; }
         int GetNumberOfUnusedDelimiters() const { return m_numberOfUnusedDelimiters; };
-        bool GenerateTags(std::shared_ptr<MarkDownEmphasisHtmlGenerator> &token);
+        bool GenerateTags(MarkDownEmphasisHtmlGenerator &token);
         void ReverseDirectionType() { m_directionType = !m_directionType; };
     protected:
-        enum 
+        enum
         {
             Left = 0,
             Right = 1,
         };
 
-        int AdjustEmphasisCounts(int leftOver, std::shared_ptr<MarkDownEmphasisHtmlGenerator> rightToken);
+        int AdjustEmphasisCounts(int leftOver, MarkDownEmphasisHtmlGenerator &rightToken);
         int m_numberOfUnusedDelimiters;
         int m_directionType = Right;
         DelimiterType type;
@@ -118,79 +118,79 @@ class MarkDownEmphasisHtmlGenerator : public MarkDownHtmlGenerator
 
 };
 
-// - MarkDownLeftEmphasisHtmlGenerator 
+// - MarkDownLeftEmphasisHtmlGenerator
 //   it knows how to generates opening italic and bold html tags
-class MarkDownLeftEmphasisHtmlGenerator : public MarkDownEmphasisHtmlGenerator 
+class MarkDownLeftEmphasisHtmlGenerator : public MarkDownEmphasisHtmlGenerator
 {
     public:
-        MarkDownLeftEmphasisHtmlGenerator (std::string &token, 
+        MarkDownLeftEmphasisHtmlGenerator (std::string &token,
                 int sizeOfEmphasisDelimiterRun,
-                DelimiterType type) : MarkDownEmphasisHtmlGenerator(token, 
+                DelimiterType type) : MarkDownEmphasisHtmlGenerator(token,
                     sizeOfEmphasisDelimiterRun, type){};
-        
-        MarkDownLeftEmphasisHtmlGenerator(std::string &token, 
+
+        MarkDownLeftEmphasisHtmlGenerator(std::string &token,
                 int sizeOfEmphasisDelimiterRun,
-                DelimiterType type, std::vector<std::string> &tags) : MarkDownEmphasisHtmlGenerator(token, 
+                DelimiterType type, std::vector<std::string> &tags) : MarkDownEmphasisHtmlGenerator(token,
                     sizeOfEmphasisDelimiterRun, type, tags){};
 
         bool IsLeftEmphasis() const  { return true; }
         std::string GenerateHtmlString();
 };
 
-// - MarkDownRightEmphasisHtmlGenerator 
+// - MarkDownRightEmphasisHtmlGenerator
 //   it knows how to generates closing italic and bold html tags
-class MarkDownRightEmphasisHtmlGenerator : public MarkDownEmphasisHtmlGenerator 
+class MarkDownRightEmphasisHtmlGenerator : public MarkDownEmphasisHtmlGenerator
 {
     public:
-        MarkDownRightEmphasisHtmlGenerator(std::string &token, 
+        MarkDownRightEmphasisHtmlGenerator(std::string &token,
                 int sizeOfEmphasisDelimiterRun,
-                DelimiterType type) : MarkDownEmphasisHtmlGenerator(token, 
+                DelimiterType type) : MarkDownEmphasisHtmlGenerator(token,
                     sizeOfEmphasisDelimiterRun, type){};
 
         void GenerateTags(std::shared_ptr<MarkDownEmphasisHtmlGenerator> &token);
         bool IsRightEmphasis() const { return true; }
         std::string GenerateHtmlString();
-        void PushItalicTag(); 
-        void PushBoldTag(); 
+        void PushItalicTag();
+        void PushBoldTag();
 };
 
-// - MarkDownLeftAndRightEmphasisHtmlGenerator 
+// - MarkDownLeftAndRightEmphasisHtmlGenerator
 //   it can have both directions, and its final direction is determined at the later stage
-class MarkDownLeftAndRightEmphasisHtmlGenerator : public MarkDownRightEmphasisHtmlGenerator 
+class MarkDownLeftAndRightEmphasisHtmlGenerator : public MarkDownRightEmphasisHtmlGenerator
 {
     public:
-        MarkDownLeftAndRightEmphasisHtmlGenerator(std::string &token, 
+        MarkDownLeftAndRightEmphasisHtmlGenerator(std::string &token,
                 int sizeOfEmphasisDelimiterRun,
-                DelimiterType type) : MarkDownRightEmphasisHtmlGenerator(token, 
+                DelimiterType type) : MarkDownRightEmphasisHtmlGenerator(token,
                     sizeOfEmphasisDelimiterRun, type) {};
         bool IsRightEmphasis() const { return m_directionType == Right; }
         bool IsLeftEmphasis() const  { return m_directionType == Left; }
         bool IsLeftAndRightEmphasis() const { return true; };
-        void PushItalicTag(); 
-        void PushBoldTag(); 
+        void PushItalicTag();
+        void PushBoldTag();
 };
 
 // - MarkDownListHtmlGenerator
 //   it functions simmilary as MarkDownStringHtmlGenerator, but its GetBlockType() returns
 //   UnorderedList type, this is used in generating html block tags <ul>
-class MarkDownListHtmlGenerator : public MarkDownStringHtmlGenerator 
+class MarkDownListHtmlGenerator : public MarkDownStringHtmlGenerator
 {
     public:
         MarkDownListHtmlGenerator(std::string &token) : MarkDownStringHtmlGenerator(token) {};
         std::string GenerateHtmlString();
-        MarkDownBlockType GetBlockType() const { return UnorderedList; }; 
+        MarkDownBlockType GetBlockType() const { return UnorderedList; };
 };
 
 // - MarkDownUnorderedListHtmlGenerator
 //   it functions simmilary as MarkDownStringHtmlGenerator, but its GetBlockType() returns
 //   OrderedList type, this is used in generating html block tags <ol>
-class MarkDownOrderedListHtmlGenerator : public MarkDownStringHtmlGenerator 
+class MarkDownOrderedListHtmlGenerator : public MarkDownStringHtmlGenerator
 {
     public:
-        MarkDownOrderedListHtmlGenerator(std::string &token, std::string &number_string) : 
+        MarkDownOrderedListHtmlGenerator(std::string &token, std::string &number_string) :
             MarkDownStringHtmlGenerator(token), m_numberString(number_string) {};
         std::string GenerateHtmlString();
-        MarkDownBlockType GetBlockType() const { return OrderedList; }; 
+        MarkDownBlockType GetBlockType() const { return OrderedList; };
     private:
         std::string m_numberString;
 };

--- a/source/shared/cpp/ObjectModel/MarkDownParsedResult.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownParsedResult.cpp
@@ -18,9 +18,9 @@ void MarkDownParsedResult::AddBlockTags()
     m_codeGenTokens.back()->MakeItTail();
 }
 
-void MarkDownParsedResult::MarkTags(const std::shared_ptr<MarkDownHtmlGenerator> &x)
-{ 
-    if (m_codeGenTokens.back()->GetBlockType() != x->GetBlockType())
+void MarkDownParsedResult::MarkTags(MarkDownHtmlGenerator &x)
+{
+    if (m_codeGenTokens.back()->GetBlockType() != x.GetBlockType())
     {
         if (m_codeGenTokens.back()->IsNewLine())
         {
@@ -31,7 +31,7 @@ void MarkDownParsedResult::MarkTags(const std::shared_ptr<MarkDownHtmlGenerator>
         {
             m_codeGenTokens.back()->MakeItTail();
         }
-        x->MakeItHead();
+        x.MakeItHead();
     }
 }
 // append caller's parsed result to callee's parsed result
@@ -40,7 +40,7 @@ void MarkDownParsedResult::AppendParseResult(MarkDownParsedResult &x)
     if (!m_codeGenTokens.empty() && !x.m_codeGenTokens.empty())
     {
         // check if two different block types, then add closing tag followed by the opening tag of new type
-        MarkTags(x.m_codeGenTokens.front());
+        MarkTags(*(x.m_codeGenTokens.front()));
     }
     m_codeGenTokens.splice(m_codeGenTokens.end(), x.m_codeGenTokens);
     m_emphasisLookUpTable.splice(m_emphasisLookUpTable.end(), x.m_emphasisLookUpTable);
@@ -48,23 +48,23 @@ void MarkDownParsedResult::AppendParseResult(MarkDownParsedResult &x)
 }
 
 // append MarkDownHtmlGenerator object to callee's prased result
-void MarkDownParsedResult::AppendToTokens(const std::shared_ptr<MarkDownHtmlGenerator> &x) 
+void MarkDownParsedResult::AppendToTokens(const std::shared_ptr<MarkDownHtmlGenerator> &x)
 {
-    if (!m_codeGenTokens.empty()) 
+    if (!m_codeGenTokens.empty())
     {
         // check if two different block types, then add closing tag followed by the opening tag of new type
-        MarkTags(x);
+        MarkTags(*(x));
     }
     m_codeGenTokens.push_back(x);
 }
 
-void MarkDownParsedResult::AppendToLookUpTable(const std::shared_ptr<MarkDownEmphasisHtmlGenerator> &x) 
+void MarkDownParsedResult::AppendToLookUpTable(const std::shared_ptr<MarkDownEmphasisHtmlGenerator> &x)
 {
     m_emphasisLookUpTable.push_back(x);
 }
 
 void MarkDownParsedResult::PopFront()
-{ 
+{
     m_codeGenTokens.pop_front();
 }
 
@@ -105,13 +105,13 @@ void MarkDownParsedResult::AddNewLineTokenToParsedResult(char ch)
     AppendToTokens(htmlToken);
 }
 
-std::string MarkDownParsedResult::GenerateHtmlString() 
-{ 
-    // process tags 
-    std::ostringstream html; 
+std::string MarkDownParsedResult::GenerateHtmlString()
+{
+    // process tags
+    std::ostringstream html;
 
-    for (auto itr = m_codeGenTokens.begin(); itr != m_codeGenTokens.end(); itr++) 
-    { 
+    for (auto itr = m_codeGenTokens.begin(); itr != m_codeGenTokens.end(); itr++)
+    {
         html << (*itr)->GenerateHtmlString();
     }
 
@@ -128,7 +128,7 @@ std::string MarkDownParsedResult::GenerateHtmlString()
 // it builds tokens of vectors
 // each time emphasis tokens are found, they are also added into a lookup table.
 // the look up table stores index of the corresponding token in the token vectors, and
-// emphasis count and its types that are used in html generation 
+// emphasis count and its types that are used in html generation
 // add comments -> what it does: generating  n supported features + 1 tokens --> capture them in token class
 void MarkDownParsedResult::MatchLeftAndRightEmphasises()
 {
@@ -138,7 +138,7 @@ void MarkDownParsedResult::MatchLeftAndRightEmphasises()
     while (!(currentEmphasis == m_emphasisLookUpTable.end()))
     {
         // keep exploring left until right token is found
-        if ((*currentEmphasis)->IsLeftEmphasis() || 
+        if ((*currentEmphasis)->IsLeftEmphasis() ||
             ((*currentEmphasis)->IsLeftAndRightEmphasis() && leftEmphasisToExplore.empty()))
         {
             if ((*currentEmphasis)->IsLeftAndRightEmphasis() && (*currentEmphasis)->IsRightEmphasis())
@@ -159,32 +159,32 @@ void MarkDownParsedResult::MatchLeftAndRightEmphasises()
             // check if matches are found
             //     mataches are found with left and right emphasis tokens if
             //     1. they are same types
-            //     2. neigher of the emphasis tokens are both left and right emphasis tokens, and 
-            //        if either or both of them are, then their sum is not multipe of 3 
-            //        
+            //     2. neigher of the emphasis tokens are both left and right emphasis tokens, and
+            //        if either or both of them are, then their sum is not multipe of 3
+            //
             //     if matches are not found
-            //     1. search left emphasis tokens first for match because of rule 14 matches on the left side is preferred 
+            //     1. search left emphasis tokens first for match because of rule 14 matches on the left side is preferred
             //        if match is found set left emphasis as the new left emphasis token and proceed to token processing
             //        any non-matching left emphasis will be poped, in this way it always move forward
-            //        if still no match is found, 
+            //        if still no match is found,
             //     2. search right
             //        if the right emphasis can be left empahs search matching right emphasis tokens using the right emphasis
             //        as left emphasis
             //        else
             //        use current left emphasis to search, and pop current right emphasis
-            if (!(*currentLeftEmphasis)->IsMatch(*currentEmphasis))
+            if (!(*currentLeftEmphasis)->IsMatch(*(*currentEmphasis)))
             {
                 std::vector<std::list<std::shared_ptr<MarkDownEmphasisHtmlGenerator>>::iterator> store;
                 bool isFound = false;
                 // search first if matching left emphasis can be found with the right delim
                 // if match found, set the new left emphasis token as current token, and
-                // process tokens and as of the result, any left emphasis tokens that were searched and not matching 
+                // process tokens and as of the result, any left emphasis tokens that were searched and not matching
                 // will be no longer considerred in tag processing
                 // pop until matching delim is found
                 while (!leftEmphasisToExplore.empty() && !isFound)
                 {
                     auto leftToken = leftEmphasisToExplore.back();
-                    if ((*leftToken)->IsMatch(*currentEmphasis))
+                    if ((*leftToken)->IsMatch(*(*currentEmphasis)))
                     {
                         currentLeftEmphasis = leftToken;
                         isFound = true;
@@ -196,12 +196,12 @@ void MarkDownParsedResult::MatchLeftAndRightEmphasises()
                     }
                 }
 
-                // if no match found from the left and the right emphasis is both left and right, 
+                // if no match found from the left and the right emphasis is both left and right,
                 // and the sum of their emphasises counts is divisible by 3,
-                // use current right emphasis as 
+                // use current right emphasis as
                 // left emphasis, make the right emphasis, as current left
                 // emphasis and start searching from there.
-                // during the search if no match found, 
+                // during the search if no match found,
                 // this emphasis tokens will be dropped
                 if (!isFound)
                 {
@@ -213,7 +213,7 @@ void MarkDownParsedResult::MatchLeftAndRightEmphasises()
                     }
 
                     // check for the reason why we had to backtrack
-                    if ((*leftEmphasisToExplore.back())->IsSameType(*currentEmphasis))
+                    if ((*leftEmphasisToExplore.back())->IsSameType(*(*currentEmphasis)))
                     {
                         //right emphasis becomes left emphasis
                         /// create new left empahsis html generator from right
@@ -229,7 +229,7 @@ void MarkDownParsedResult::MatchLeftAndRightEmphasises()
                 }
             }
             // check which one has leftover delims
-            m_isHTMLTagsAdded = (*currentLeftEmphasis)->GenerateTags(*currentEmphasis) || m_isHTMLTagsAdded;
+            m_isHTMLTagsAdded = (*currentLeftEmphasis)->GenerateTags(*(*currentEmphasis)) || m_isHTMLTagsAdded;
 
             // all right delims used, move to next
             if ((*currentEmphasis)->IsDone())
@@ -239,12 +239,12 @@ void MarkDownParsedResult::MatchLeftAndRightEmphasises()
 
             // all left or right delims used, pop
             if ((*currentLeftEmphasis)->IsDone())
-            { 
+            {
                 leftEmphasisToExplore.pop_back();
             }
         }
         else
-        { 
+        {
             currentEmphasis++;
         }
     }

--- a/source/shared/cpp/ObjectModel/MarkDownParsedResult.h
+++ b/source/shared/cpp/ObjectModel/MarkDownParsedResult.h
@@ -5,42 +5,51 @@
 #include <list>
 
 AdaptiveSharedNamespaceStart
-    // Holds Parsing Result of MarkDown String
-    class MarkDownParsedResult
-    {
-        public:
-        MarkDownParsedResult() : m_isHTMLTagsAdded(false) {};
-        // Translate Intermediate Parsing Result to a form that can be
-        // written to html string
-        void Translate();
-        void AddBlockTags();
-        // Write to html string
-        std::string GenerateHtmlString(); 
-        // Append contents of the given parsing result object
-        void AppendParseResult(MarkDownParsedResult &);
-        // Append html code gen object to parse result
-        void AppendToTokens(const std::shared_ptr<MarkDownHtmlGenerator> &); 
-        // Append emphasis html code gen object to parse result
-        void AppendToLookUpTable(const std::shared_ptr<MarkDownEmphasisHtmlGenerator> &); 
-        // Take a char and convert it html code gen and append it to the result
-        // It is used to store MarkDown keywords such as '[', ']', '(', ')'
-        void AddNewTokenToParsedResult(char ch);
-        // Take string and convert it html code gen and append it to the result
-        void AddNewTokenToParsedResult(std::string &word);
-        // Take a new line char and convert it html code gen and append it to the result
-        // It is used to store MarkDown keywords such as '\r', '\n'
-        void AddNewLineTokenToParsedResult(char ch);
-        void PopFront();
-        void PopBack();
-        void Clear();
-        bool HasHtmlTags();
-        void FoundHtmlTags();
-        private:
-        void MarkTags(const std::shared_ptr<MarkDownHtmlGenerator> &);
-        std::list<std::shared_ptr<MarkDownHtmlGenerator>> m_codeGenTokens;
-        std::list<std::shared_ptr<MarkDownEmphasisHtmlGenerator>> m_emphasisLookUpTable;
-        bool m_isHTMLTagsAdded;
-        // take m_emphasisLookUpTable and matches left and right emphasises
-        void MatchLeftAndRightEmphasises();
-    };
+// Holds Parsing Result of MarkDown String
+class MarkDownParsedResult
+{
+public:
+    MarkDownParsedResult() : m_isHTMLTagsAdded(false) {};
+
+    // Translate Intermediate Parsing Result to a form that can be written to html string
+    void Translate();
+    void AddBlockTags();
+
+    // Write to html string
+    std::string GenerateHtmlString();
+
+    // Append contents of the given parsing result object
+    void AppendParseResult(MarkDownParsedResult &);
+
+    // Append html code gen object to parse result
+    void AppendToTokens(const std::shared_ptr<MarkDownHtmlGenerator> &);
+
+    // Append emphasis html code gen object to parse result
+    void AppendToLookUpTable(const std::shared_ptr<MarkDownEmphasisHtmlGenerator> &);
+
+    // Take a char and convert it html code gen and append it to the result. used to store MarkDown keywords such as
+    // '[', ']', '(', ')'
+    void AddNewTokenToParsedResult(char ch);
+
+    // Take string and convert it html code gen and append it to the result
+    void AddNewTokenToParsedResult(std::string &word);
+
+    // Take a new line char and convert it html code gen and append it to the result It is used to store MarkDown
+    // keywords such as '\r', '\n'
+    void AddNewLineTokenToParsedResult(char ch);
+    void PopFront();
+    void PopBack();
+    void Clear();
+    bool HasHtmlTags();
+    void FoundHtmlTags();
+
+private:
+    void MarkTags(MarkDownHtmlGenerator &);
+    std::list<std::shared_ptr<MarkDownHtmlGenerator>> m_codeGenTokens;
+    std::list<std::shared_ptr<MarkDownEmphasisHtmlGenerator>> m_emphasisLookUpTable;
+    bool m_isHTMLTagsAdded;
+
+    // take m_emphasisLookUpTable and matches left and right emphasises
+    void MatchLeftAndRightEmphasises();
+};
 AdaptiveSharedNamespaceEnd

--- a/source/shared/cpp/ObjectModel/jsoncpp.cpp
+++ b/source/shared/cpp/ObjectModel/jsoncpp.cpp
@@ -74,6 +74,8 @@ license you like.
 
 #include "pch.h"
 
+#pragma warning(disable: ALL_CPPCORECHECK_WARNINGS)
+
 #include "json/json.h"
 
 #ifndef JSON_IS_AMALGAMATION

--- a/source/shared/cpp/ObjectModel/pch.h
+++ b/source/shared/cpp/ObjectModel/pch.h
@@ -5,7 +5,7 @@
 #endif
 
 #ifndef AdaptiveSharedNamespaceStart
-#define AdaptiveSharedNamespaceStart namespace AdaptiveCards { 
+#define AdaptiveSharedNamespaceStart namespace AdaptiveCards {
 #define AdaptiveSharedNamespace AdaptiveCards
 #define AdaptiveSharedNamespaceEnd }
 #endif
@@ -22,3 +22,12 @@
 #include <unordered_set>
 #include <fstream>
 #include <locale>
+
+#ifndef __ANDROID__
+#include <CppCoreCheck\warnings.h>
+#pragma warning(disable: ALL_CPPCORECHECK_WARNINGS)
+#pragma warning(default: CPPCORECHECK_STYLE_WARNINGS)
+#pragma warning(default: CPPCORECHECK_CONCURRENCY_WARNINGS)
+#pragma warning(default: CPPCORECHECK_ARITHMETIC_WARNINGS)
+#pragma warning(default: CPPCORECHECK_UNIQUE_POINTER_WARNINGS)
+#endif

--- a/source/shared/cpp/ObjectModel/pch.h
+++ b/source/shared/cpp/ObjectModel/pch.h
@@ -23,7 +23,7 @@
 #include <fstream>
 #include <locale>
 
-#ifndef __ANDROID__
+#if !defined(__ANDROID__) && !defined(__APPLE__)
 #include <CppCoreCheck\warnings.h>
 #pragma warning(disable: ALL_CPPCORECHECK_WARNINGS)
 #pragma warning(default: CPPCORECHECK_STYLE_WARNINGS)


### PR DESCRIPTION
In this change, we enable automatic checking of a subset of cppcore guidelines checks. As we make further progress, we can turn on further checks by adding them to the list in `pch.h`.