### PR TITLE
Put back RenderCardAsXamlAsync for Windows internal builds.

### DIFF
--- a/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
+++ b/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
@@ -383,7 +383,7 @@ void AdaptiveCard::SetVerticalContentAlignment(const VerticalContentAlignment va
     m_verticalContentAlignment = value;
 }
 
-std::vector<std::string> AdaptiveCards::AdaptiveCard::GetResourceUris()
+std::vector<std::string> AdaptiveCard::GetResourceUris()
 {
     auto uriVector = std::vector<std::string>();
 

--- a/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
+++ b/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
@@ -1311,6 +1311,10 @@ AdaptiveNamespaceStart
         HRESULT SetFixedDimensions([in] UINT32 desiredWidth, [in] UINT32 desiredHeight);
         HRESULT ResetFixedDimensions();
 
+#ifdef ADAPTIVE_CARDS_WINDOWS
+        HRESULT RenderCardAsXamlAsync([in] AdaptiveCard* adaptiveCard, [out, retval] Windows.Foundation.IAsyncOperation<RenderedAdaptiveCard*>** result);
+#endif
+
         HRESULT RenderAdaptiveCard([in] AdaptiveCard* adaptiveCard, [out, retval] RenderedAdaptiveCard** result);
 
         HRESULT RenderAdaptiveCardFromJsonString([in] HSTRING adaptiveJson, [out, retval] RenderedAdaptiveCard** result);

--- a/source/uwp/Renderer/lib/AdaptiveCardRendererComponent.h
+++ b/source/uwp/Renderer/lib/AdaptiveCardRendererComponent.h
@@ -28,7 +28,13 @@ AdaptiveNamespaceStart
 
         IFACEMETHODIMP RenderAdaptiveCard(_In_ ABI::AdaptiveNamespace::IAdaptiveCard* adaptiveCard,
             _COM_Outptr_ ABI::AdaptiveNamespace::IRenderedAdaptiveCard** result);
-        HRESULT RenderCardAsXamlAsync(_In_ ABI::AdaptiveNamespace::IAdaptiveCard* adaptiveCard,
+
+#ifdef ADAPTIVE_CARDS_WINDOWS
+        IFACEMETHODIMP
+#else
+        HRESULT
+#endif
+        RenderCardAsXamlAsync(_In_ ABI::AdaptiveNamespace::IAdaptiveCard* adaptiveCard,
             _COM_Outptr_ ABI::Windows::Foundation::IAsyncOperation<ABI::AdaptiveNamespace::RenderedAdaptiveCard*>** result);
 
         IFACEMETHODIMP RenderAdaptiveCardFromJsonString(_In_ HSTRING adaptiveJson,

--- a/source/uwp/Renderer/lib/CustomActionWrapper.cpp
+++ b/source/uwp/Renderer/lib/CustomActionWrapper.cpp
@@ -52,7 +52,7 @@ HRESULT CustomActionWrapper::GetWrappedElement(ABI::AdaptiveNamespace::IAdaptive
 
 void CustomActionWrapper::GetResourceUris(std::vector<std::string>& resourceUris)
 {
-    ComPtr<ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveElementWithRemoteResources> remoteResources;
+    ComPtr<ABI::AdaptiveNamespace::IAdaptiveElementWithRemoteResources> remoteResources;
     if (SUCCEEDED(m_actionElement.As(&remoteResources)))
     {
         RemoteResourceElementToUriStringVector(remoteResources.Get(), resourceUris);

--- a/source/uwp/Renderer/lib/CustomElementWrapper.cpp
+++ b/source/uwp/Renderer/lib/CustomElementWrapper.cpp
@@ -58,7 +58,7 @@ AdaptiveNamespaceStart
 
     void CustomElementWrapper::GetResourceUris(std::vector<std::string>& resourceUris)
     {
-        ComPtr<ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveElementWithRemoteResources> remoteResources;
+        ComPtr<ABI::AdaptiveNamespace::IAdaptiveElementWithRemoteResources> remoteResources;
         if (SUCCEEDED(m_cardElement.As(&remoteResources)))
         {
             RemoteResourceElementToUriStringVector(remoteResources.Get(), resourceUris);

--- a/source/uwp/Renderer/lib/Util.cpp
+++ b/source/uwp/Renderer/lib/Util.cpp
@@ -744,7 +744,7 @@ std::string WstringToString(const std::wstring& input)
 }
 
 void RemoteResourceElementToUriStringVector(
-    ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveElementWithRemoteResources* remoteResourceElement,
+    ABI::AdaptiveNamespace::IAdaptiveElementWithRemoteResources* remoteResourceElement,
     std::vector<std::string>& resourceUris)
 {
     ComPtr<ABI::Windows::Foundation::Collections::IVectorView<ABI::Windows::Foundation::Uri*>> remoteResourceUris;

--- a/source/uwp/Renderer/lib/Util.h
+++ b/source/uwp/Renderer/lib/Util.h
@@ -156,5 +156,5 @@ template<typename T, typename R> Microsoft::WRL::ComPtr<T> PeekInnards(R r)
 }
 
 void RemoteResourceElementToUriStringVector(
-    ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveElementWithRemoteResources* remoteResources,
+    ABI::AdaptiveNamespace::IAdaptiveElementWithRemoteResources* remoteResources,
     std::vector<std::string>& resourceUris);

--- a/source/uwp/Renderer/lib/WholeItemsPanel.cpp
+++ b/source/uwp/Renderer/lib/WholeItemsPanel.cpp
@@ -47,7 +47,6 @@ AdaptiveNamespaceStart
 
         const Size noVerticalLimit{ availableSize.Width, numeric_limits<float>::infinity() };
 
-        unsigned int stretchableCount{};
         m_visibleCount = count;
         for (unsigned int i{}; i < count; ++i)
         {

--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -452,7 +452,7 @@ AdaptiveNamespaceStart
     void XamlBuilder::SetImageSource(
         T* destination,
         IImageSource* imageSource,
-        ABI::Windows::UI::Xaml::Media::Stretch stretch)
+        ABI::Windows::UI::Xaml::Media::Stretch /*stretch*/)
     {
         THROW_IF_FAILED(destination->put_Source(imageSource));
     };


### PR DESCRIPTION
This doesn't affect the OSS version, but keeps the code synchronized.