### PR TITLE
Fix for not including .map files in mpm output (issue #1492)

### DIFF
--- a/source/nodejs/adaptivecards/.npmignore
+++ b/source/nodejs/adaptivecards/.npmignore
@@ -1,0 +1,7 @@
+/src
+/scss
+/dist/*.map
+/lib/*.map
+/*.html
+/*.json
+/*.js

--- a/source/nodejs/adaptivecards/package.json
+++ b/source/nodejs/adaptivecards/package.json
@@ -14,10 +14,6 @@
   ],
   "main": "lib/adaptivecards.js",
   "types": "lib/adaptivecards.d.ts",
-  "files": [
-    "lib",
-    "dist"
-  ],
   "scripts": {
     "test": "jest --forceExit --runInBand",
     "clean": "rimraf build lib dist",


### PR DESCRIPTION
Adds an `.npmignore` files to exclude files from npm publishing, including `.map` files and removed the `files` element from package.json (which overrides settings in `.npmignore`)