### PR TITLE
[Android] Fix to time preparsing returning invalid value

### DIFF
--- a/source/shared/cpp/ObjectModel/DateTimePreparser.cpp
+++ b/source/shared/cpp/ObjectModel/DateTimePreparser.cpp
@@ -186,10 +186,10 @@ void DateTimePreparser::ParseDateTime(std::string const &in)
                 AddTextToken(matches[0], DateTimePreparsedTokenFormat::RegularString);
             }
 
-            wchar_t tzOffsetBuff[6]{};
+            char tzOffsetBuff[6]{};
             // gets local time zone offset
-            wcsftime(tzOffsetBuff, 6, L"%z", &parsedTm);
-            std::wstring localTimeZoneOffsetStr(tzOffsetBuff);
+            strftime(tzOffsetBuff, 6, "%z", &parsedTm);
+            std::string localTimeZoneOffsetStr(tzOffsetBuff);
             int nTzOffset = std::stoi(localTimeZoneOffsetStr);
             offset += ((nTzOffset / 100) * 3600 + (nTzOffset % 100) * 60);
             // add offset to utc


### PR DESCRIPTION
This is the fix to this https://github.com/Microsoft/AdaptiveCards/issues/1371

It looks like the method wcsftime didn't work in SDK 19 always returning a "%" which in turn messed the string to integer conversion and made the program crash, I changed the function to strftime which is the same function, with the only difference that the former uses single byte chars