### PR TITLE
Introduce `.clang-format` rules to enforce style consistency

### DIFF
--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModel/AdaptiveCardsSharedModel.vcxproj
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModel/AdaptiveCardsSharedModel.vcxproj
@@ -90,6 +90,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <TreatWarningAsError>true</TreatWarningAsError>
       <DisableSpecificWarnings>4702</DisableSpecificWarnings>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -101,6 +102,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <TreatWarningAsError>true</TreatWarningAsError>
       <DisableSpecificWarnings>4702</DisableSpecificWarnings>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -114,6 +116,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <TreatWarningAsError>true</TreatWarningAsError>
       <DisableSpecificWarnings>4702</DisableSpecificWarnings>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -131,6 +134,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <TreatWarningAsError>true</TreatWarningAsError>
       <DisableSpecificWarnings>4702</DisableSpecificWarnings>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/source/shared/cpp/ObjectModel/.clang-format
+++ b/source/shared/cpp/ObjectModel/.clang-format
@@ -4,7 +4,7 @@ AccessModifierOffset: -4
 AlignAfterOpenBracket: DontAlign
 AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
-AlignEscapedNewlines: Left
+AlignEscapedNewlines: DontAlign
 AlignOperands: false
 AlignTrailingComments: false
 AllowAllParametersOfDeclarationOnNextLine: false
@@ -45,4 +45,10 @@ SpaceAfterCStyleCast: false
 SpaceAfterTemplateKeyword: false
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
 UseTab: Never

--- a/source/shared/cpp/ObjectModel/.clang-format
+++ b/source/shared/cpp/ObjectModel/.clang-format
@@ -37,7 +37,7 @@ IndentWrappedFunctionNames: false
 KeepEmptyLinesAtTheStartOfBlocks: false
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: All
-PointerAlignment: Left
+PointerAlignment: Right
 ReflowComments: true
 SortIncludes: false
 SortUsingDeclarations: true

--- a/source/shared/cpp/ObjectModel/.clang-format
+++ b/source/shared/cpp/ObjectModel/.clang-format
@@ -1,0 +1,66 @@
+Language: Cpp
+Standard: Cpp11
+AccessModifierOffset: 0
+AlignAfterOpenBracket: DontAlign
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: false
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBraces: Allman #Custom
+#BraceWrapping:
+#  AfterClass: true
+#  AfterControlStatement: true
+#  AfterEnum: true
+#  AfterFunction: true
+#  AfterNamespace: true
+#  AfterStruct: true
+#  AfterUnion: true
+#  AfterExternBlock: true
+#  BeforeCatch: true
+#  BeforeElse: true
+#  IndentBraces: false
+#  SplitEmptyFunction: false
+#  SplitEmptyRecord: false
+#  SplitEmptyNamespace: false
+BreakBeforeBinaryOperators: None
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializers: AfterColon
+BreakStringLiterals: false
+ColumnLimit: 120
+CompactNamespaces: true
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+Cpp11BracedListStyle: true
+FixNamespaceComments: true
+IncludeBlocks: Regroup
+IndentCaseLabels: false
+IndentPPDirectives: None
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: All
+PointerAlignment: Left
+ReflowComments: true
+SortIncludes: false
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+#SpaceBeforeCtorInitializerColon: true
+#SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+#SpaceBeforeRangeBasedForLoopColon: false
+UseTab: Never

--- a/source/shared/cpp/ObjectModel/.clang-format
+++ b/source/shared/cpp/ObjectModel/.clang-format
@@ -1,6 +1,6 @@
 Language: Cpp
 Standard: Cpp11
-AccessModifierOffset: 0
+AccessModifierOffset: -4
 AlignAfterOpenBracket: DontAlign
 AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
@@ -18,22 +18,7 @@ AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: true
 BinPackArguments: true
 BinPackParameters: true
-BreakBeforeBraces: Allman #Custom
-#BraceWrapping:
-#  AfterClass: true
-#  AfterControlStatement: true
-#  AfterEnum: true
-#  AfterFunction: true
-#  AfterNamespace: true
-#  AfterStruct: true
-#  AfterUnion: true
-#  AfterExternBlock: true
-#  BeforeCatch: true
-#  BeforeElse: true
-#  IndentBraces: false
-#  SplitEmptyFunction: false
-#  SplitEmptyRecord: false
-#  SplitEmptyNamespace: false
+BreakBeforeBraces: Allman
 BreakBeforeBinaryOperators: None
 BreakBeforeInheritanceComma: false
 BreakBeforeTernaryOperators: false
@@ -59,8 +44,5 @@ SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
 SpaceAfterTemplateKeyword: false
 SpaceBeforeAssignmentOperators: true
-#SpaceBeforeCtorInitializerColon: true
-#SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
-#SpaceBeforeRangeBasedForLoopColon: false
 UseTab: Never

--- a/source/shared/cpp/ObjectModel/ActionParserRegistration.cpp
+++ b/source/shared/cpp/ObjectModel/ActionParserRegistration.cpp
@@ -4,7 +4,8 @@
 #include "ShowCardAction.h"
 #include "SubmitAction.h"
 
-AdaptiveSharedNamespaceStart
+namespace AdaptiveSharedNamespace
+{
     ActionParserRegistration::ActionParserRegistration()
     {
         m_knownElements.insert({
@@ -13,14 +14,13 @@ AdaptiveSharedNamespaceStart
             ActionTypeToString(ActionType::Submit),
         });
 
-        m_cardElementParsers.insert({
-            { ActionTypeToString(ActionType::OpenUrl), std::make_shared<OpenUrlActionParser>() },
-            { ActionTypeToString(ActionType::ShowCard), std::make_shared<ShowCardActionParser>() },
-            { ActionTypeToString(ActionType::Submit), std::make_shared<SubmitActionParser>() }
-        });
+        m_cardElementParsers.insert({{ActionTypeToString(ActionType::OpenUrl), std::make_shared<OpenUrlActionParser>()},
+            {ActionTypeToString(ActionType::ShowCard), std::make_shared<ShowCardActionParser>()},
+            {ActionTypeToString(ActionType::Submit), std::make_shared<SubmitActionParser>()}});
     }
 
-    void ActionParserRegistration::AddParser(std::string const &elementType, std::shared_ptr<ActionElementParser> parser)
+    void ActionParserRegistration::AddParser(
+        std::string const& elementType, std::shared_ptr<ActionElementParser> parser)
     {
         if (m_knownElements.find(elementType) == m_knownElements.end())
         {
@@ -28,11 +28,12 @@ AdaptiveSharedNamespaceStart
         }
         else
         {
-            throw AdaptiveCardParseException(ErrorStatusCode::UnsupportedParserOverride, "Overriding known action parsers is unsupported");
+            throw AdaptiveCardParseException(
+                ErrorStatusCode::UnsupportedParserOverride, "Overriding known action parsers is unsupported");
         }
     }
 
-    void ActionParserRegistration::RemoveParser(std::string const &elementType)
+    void ActionParserRegistration::RemoveParser(std::string const& elementType)
     {
         if (m_knownElements.find(elementType) != m_knownElements.end())
         {
@@ -40,16 +41,16 @@ AdaptiveSharedNamespaceStart
         }
     }
 
-    std::shared_ptr<ActionElementParser> ActionParserRegistration::GetParser(std::string const &elementType)
+    std::shared_ptr<ActionElementParser> ActionParserRegistration::GetParser(std::string const& elementType)
     {
         auto parser = m_cardElementParsers.find(elementType);
         if (parser != ActionParserRegistration::m_cardElementParsers.end())
         {
-            return parser->second; 
+            return parser->second;
         }
         else
         {
             return std::shared_ptr<ActionElementParser>(nullptr);
         }
     }
-AdaptiveSharedNamespaceEnd
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/ActionParserRegistration.cpp
+++ b/source/shared/cpp/ObjectModel/ActionParserRegistration.cpp
@@ -20,7 +20,7 @@ namespace AdaptiveSharedNamespace
     }
 
     void ActionParserRegistration::AddParser(
-        std::string const& elementType, std::shared_ptr<ActionElementParser> parser)
+        std::string const &elementType, std::shared_ptr<ActionElementParser> parser)
     {
         if (m_knownElements.find(elementType) == m_knownElements.end())
         {
@@ -33,7 +33,7 @@ namespace AdaptiveSharedNamespace
         }
     }
 
-    void ActionParserRegistration::RemoveParser(std::string const& elementType)
+    void ActionParserRegistration::RemoveParser(std::string const &elementType)
     {
         if (m_knownElements.find(elementType) != m_knownElements.end())
         {
@@ -41,7 +41,7 @@ namespace AdaptiveSharedNamespace
         }
     }
 
-    std::shared_ptr<ActionElementParser> ActionParserRegistration::GetParser(std::string const& elementType)
+    std::shared_ptr<ActionElementParser> ActionParserRegistration::GetParser(std::string const &elementType)
     {
         auto parser = m_cardElementParsers.find(elementType);
         if (parser != ActionParserRegistration::m_cardElementParsers.end())

--- a/source/shared/cpp/ObjectModel/ActionParserRegistration.h
+++ b/source/shared/cpp/ObjectModel/ActionParserRegistration.h
@@ -12,7 +12,7 @@ namespace AdaptiveSharedNamespace
 
     class ActionElementParser
     {
-        public:
+    public:
         virtual std::shared_ptr<BaseActionElement> Deserialize(
             std::shared_ptr<AdaptiveSharedNamespace::ElementParserRegistration> elementParserRegistration,
             std::shared_ptr<AdaptiveSharedNamespace::ActionParserRegistration> actionParserRegistration,
@@ -21,7 +21,7 @@ namespace AdaptiveSharedNamespace
 
     class ActionParserRegistration
     {
-        public:
+    public:
         ActionParserRegistration();
 
         void AddParser(
@@ -29,7 +29,7 @@ namespace AdaptiveSharedNamespace
         void RemoveParser(std::string const& elementType);
         std::shared_ptr<AdaptiveSharedNamespace::ActionElementParser> GetParser(std::string const& elementType);
 
-        private:
+    private:
         std::unordered_set<std::string> m_knownElements;
         std::unordered_map<std::string, std::shared_ptr<AdaptiveSharedNamespace::ActionElementParser>,
             CaseInsensitiveHash, CaseInsensitiveEqualTo>

--- a/source/shared/cpp/ObjectModel/ActionParserRegistration.h
+++ b/source/shared/cpp/ObjectModel/ActionParserRegistration.h
@@ -16,7 +16,7 @@ namespace AdaptiveSharedNamespace
         virtual std::shared_ptr<BaseActionElement> Deserialize(
             std::shared_ptr<AdaptiveSharedNamespace::ElementParserRegistration> elementParserRegistration,
             std::shared_ptr<AdaptiveSharedNamespace::ActionParserRegistration> actionParserRegistration,
-            const Json::Value& value) = 0;
+            const Json::Value &value) = 0;
     };
 
     class ActionParserRegistration
@@ -25,9 +25,9 @@ namespace AdaptiveSharedNamespace
         ActionParserRegistration();
 
         void AddParser(
-            std::string const& elementType, std::shared_ptr<AdaptiveSharedNamespace::ActionElementParser> parser);
-        void RemoveParser(std::string const& elementType);
-        std::shared_ptr<AdaptiveSharedNamespace::ActionElementParser> GetParser(std::string const& elementType);
+            std::string const &elementType, std::shared_ptr<AdaptiveSharedNamespace::ActionElementParser> parser);
+        void RemoveParser(std::string const &elementType);
+        std::shared_ptr<AdaptiveSharedNamespace::ActionElementParser> GetParser(std::string const &elementType);
 
     private:
         std::unordered_set<std::string> m_knownElements;

--- a/source/shared/cpp/ObjectModel/ActionParserRegistration.h
+++ b/source/shared/cpp/ObjectModel/ActionParserRegistration.h
@@ -4,14 +4,15 @@
 #include "Enums.h"
 #include "json/json.h"
 
-AdaptiveSharedNamespaceStart
+namespace AdaptiveSharedNamespace
+{
     class BaseActionElement;
     class ElementParserRegistration;
     class ActionParserRegistration;
 
     class ActionElementParser
     {
-    public:
+        public:
         virtual std::shared_ptr<BaseActionElement> Deserialize(
             std::shared_ptr<AdaptiveSharedNamespace::ElementParserRegistration> elementParserRegistration,
             std::shared_ptr<AdaptiveSharedNamespace::ActionParserRegistration> actionParserRegistration,
@@ -20,16 +21,18 @@ AdaptiveSharedNamespaceStart
 
     class ActionParserRegistration
     {
-    public:
-
+        public:
         ActionParserRegistration();
 
-        void AddParser(std::string const &elementType, std::shared_ptr<AdaptiveSharedNamespace::ActionElementParser> parser);
-        void RemoveParser(std::string const &elementType);
-        std::shared_ptr<AdaptiveSharedNamespace::ActionElementParser> GetParser(std::string const &elementType);
+        void AddParser(
+            std::string const& elementType, std::shared_ptr<AdaptiveSharedNamespace::ActionElementParser> parser);
+        void RemoveParser(std::string const& elementType);
+        std::shared_ptr<AdaptiveSharedNamespace::ActionElementParser> GetParser(std::string const& elementType);
 
-    private:
+        private:
         std::unordered_set<std::string> m_knownElements;
-        std::unordered_map<std::string, std::shared_ptr<AdaptiveSharedNamespace::ActionElementParser>, CaseInsensitiveHash, CaseInsensitiveEqualTo> m_cardElementParsers;
+        std::unordered_map<std::string, std::shared_ptr<AdaptiveSharedNamespace::ActionElementParser>,
+            CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            m_cardElementParsers;
     };
-AdaptiveSharedNamespaceEnd
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/AdaptiveCardParseException.cpp
+++ b/source/shared/cpp/ObjectModel/AdaptiveCardParseException.cpp
@@ -3,14 +3,14 @@
 
 using namespace AdaptiveSharedNamespace;
 
-AdaptiveCardParseException::AdaptiveCardParseException(ErrorStatusCode statusCode, const std::string& message) :
+AdaptiveCardParseException::AdaptiveCardParseException(ErrorStatusCode statusCode, const std::string &message) :
     m_statusCode(statusCode), m_message(message)
 {
 }
 
 AdaptiveCardParseException::~AdaptiveCardParseException() {}
 
-const char* AdaptiveCardParseException::what() const throw()
+const char *AdaptiveCardParseException::what() const throw()
 {
     return m_message.c_str();
 }
@@ -20,7 +20,7 @@ ErrorStatusCode AdaptiveCardParseException::GetStatusCode() const
     return m_statusCode;
 }
 
-const std::string& AdaptiveCardParseException::GetReason() const
+const std::string &AdaptiveCardParseException::GetReason() const
 {
     return m_message;
 }

--- a/source/shared/cpp/ObjectModel/AdaptiveCardParseException.cpp
+++ b/source/shared/cpp/ObjectModel/AdaptiveCardParseException.cpp
@@ -3,13 +3,12 @@
 
 using namespace AdaptiveSharedNamespace;
 
-AdaptiveCardParseException::AdaptiveCardParseException(ErrorStatusCode statusCode, const std::string & message) : m_statusCode(statusCode), m_message(message)
+AdaptiveCardParseException::AdaptiveCardParseException(ErrorStatusCode statusCode, const std::string& message) :
+    m_statusCode(statusCode), m_message(message)
 {
 }
 
-AdaptiveCardParseException::~AdaptiveCardParseException()
-{
-}
+AdaptiveCardParseException::~AdaptiveCardParseException() {}
 
 const char* AdaptiveCardParseException::what() const throw()
 {

--- a/source/shared/cpp/ObjectModel/AdaptiveCardParseException.h
+++ b/source/shared/cpp/ObjectModel/AdaptiveCardParseException.h
@@ -7,7 +7,7 @@ namespace AdaptiveSharedNamespace
 {
     class AdaptiveCardParseException : public std::exception
     {
-        public:
+    public:
         AdaptiveCardParseException(AdaptiveSharedNamespace::ErrorStatusCode statusCode, const std::string& message);
         ~AdaptiveCardParseException();
 
@@ -15,7 +15,7 @@ namespace AdaptiveSharedNamespace
         AdaptiveSharedNamespace::ErrorStatusCode GetStatusCode() const;
         const std::string& GetReason() const;
 
-        private:
+    private:
         const AdaptiveSharedNamespace::ErrorStatusCode m_statusCode;
         const std::string m_message;
     };

--- a/source/shared/cpp/ObjectModel/AdaptiveCardParseException.h
+++ b/source/shared/cpp/ObjectModel/AdaptiveCardParseException.h
@@ -3,21 +3,21 @@
 #include "pch.h"
 #include "Enums.h"
 
-AdaptiveSharedNamespaceStart
-
-class AdaptiveCardParseException : public std::exception
+namespace AdaptiveSharedNamespace
 {
-public:
-    AdaptiveCardParseException(AdaptiveSharedNamespace::ErrorStatusCode statusCode, const std::string& message);
-    ~AdaptiveCardParseException();
+    class AdaptiveCardParseException : public std::exception
+    {
+        public:
+        AdaptiveCardParseException(AdaptiveSharedNamespace::ErrorStatusCode statusCode, const std::string& message);
+        ~AdaptiveCardParseException();
 
-    virtual const char* what() const throw();
-    AdaptiveSharedNamespace::ErrorStatusCode GetStatusCode() const;
-    const std::string& GetReason() const;
+        virtual const char* what() const throw();
+        AdaptiveSharedNamespace::ErrorStatusCode GetStatusCode() const;
+        const std::string& GetReason() const;
 
-private:
-    const AdaptiveSharedNamespace::ErrorStatusCode m_statusCode;
-    const std::string m_message;
-};
+        private:
+        const AdaptiveSharedNamespace::ErrorStatusCode m_statusCode;
+        const std::string m_message;
+    };
 
-AdaptiveSharedNamespaceEnd
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/AdaptiveCardParseException.h
+++ b/source/shared/cpp/ObjectModel/AdaptiveCardParseException.h
@@ -8,12 +8,12 @@ namespace AdaptiveSharedNamespace
     class AdaptiveCardParseException : public std::exception
     {
     public:
-        AdaptiveCardParseException(AdaptiveSharedNamespace::ErrorStatusCode statusCode, const std::string& message);
+        AdaptiveCardParseException(AdaptiveSharedNamespace::ErrorStatusCode statusCode, const std::string &message);
         ~AdaptiveCardParseException();
 
-        virtual const char* what() const throw();
+        virtual const char *what() const throw();
         AdaptiveSharedNamespace::ErrorStatusCode GetStatusCode() const;
-        const std::string& GetReason() const;
+        const std::string &GetReason() const;
 
     private:
         const AdaptiveSharedNamespace::ErrorStatusCode m_statusCode;

--- a/source/shared/cpp/ObjectModel/AdaptiveCardParseWarning.cpp
+++ b/source/shared/cpp/ObjectModel/AdaptiveCardParseWarning.cpp
@@ -3,13 +3,12 @@
 
 using namespace AdaptiveSharedNamespace;
 
-AdaptiveCardParseWarning::AdaptiveCardParseWarning(const WarningStatusCode statusCode, const std::string & message) : m_statusCode(statusCode), m_message(message)
+AdaptiveCardParseWarning::AdaptiveCardParseWarning(const WarningStatusCode statusCode, const std::string& message) :
+    m_statusCode(statusCode), m_message(message)
 {
 }
 
-AdaptiveCardParseWarning::~AdaptiveCardParseWarning()
-{
-}
+AdaptiveCardParseWarning::~AdaptiveCardParseWarning() {}
 
 WarningStatusCode AdaptiveCardParseWarning::GetStatusCode() const
 {

--- a/source/shared/cpp/ObjectModel/AdaptiveCardParseWarning.cpp
+++ b/source/shared/cpp/ObjectModel/AdaptiveCardParseWarning.cpp
@@ -3,7 +3,7 @@
 
 using namespace AdaptiveSharedNamespace;
 
-AdaptiveCardParseWarning::AdaptiveCardParseWarning(const WarningStatusCode statusCode, const std::string& message) :
+AdaptiveCardParseWarning::AdaptiveCardParseWarning(const WarningStatusCode statusCode, const std::string &message) :
     m_statusCode(statusCode), m_message(message)
 {
 }
@@ -15,7 +15,7 @@ WarningStatusCode AdaptiveCardParseWarning::GetStatusCode() const
     return m_statusCode;
 }
 
-const std::string& AdaptiveCardParseWarning::GetReason() const
+const std::string &AdaptiveCardParseWarning::GetReason() const
 {
     return m_message;
 }

--- a/source/shared/cpp/ObjectModel/AdaptiveCardParseWarning.h
+++ b/source/shared/cpp/ObjectModel/AdaptiveCardParseWarning.h
@@ -3,21 +3,20 @@
 #include "pch.h"
 #include "Enums.h"
 
-AdaptiveSharedNamespaceStart
-
-class AdaptiveCardParseWarning
+namespace AdaptiveSharedNamespace
 {
-public:
-    AdaptiveCardParseWarning(AdaptiveSharedNamespace::WarningStatusCode statusCode, const std::string& message);
-    ~AdaptiveCardParseWarning();
+    class AdaptiveCardParseWarning
+    {
+        public:
+        AdaptiveCardParseWarning(AdaptiveSharedNamespace::WarningStatusCode statusCode, const std::string& message);
+        ~AdaptiveCardParseWarning();
 
-    AdaptiveSharedNamespace::WarningStatusCode GetStatusCode() const;
-    const std::string& GetReason() const;
+        AdaptiveSharedNamespace::WarningStatusCode GetStatusCode() const;
+        const std::string& GetReason() const;
 
-private:
-    const AdaptiveSharedNamespace::WarningStatusCode m_statusCode;
-    const std::string m_message;
-};
+        private:
+        const AdaptiveSharedNamespace::WarningStatusCode m_statusCode;
+        const std::string m_message;
+    };
 
-AdaptiveSharedNamespaceEnd
-
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/AdaptiveCardParseWarning.h
+++ b/source/shared/cpp/ObjectModel/AdaptiveCardParseWarning.h
@@ -8,11 +8,11 @@ namespace AdaptiveSharedNamespace
     class AdaptiveCardParseWarning
     {
     public:
-        AdaptiveCardParseWarning(AdaptiveSharedNamespace::WarningStatusCode statusCode, const std::string& message);
+        AdaptiveCardParseWarning(AdaptiveSharedNamespace::WarningStatusCode statusCode, const std::string &message);
         ~AdaptiveCardParseWarning();
 
         AdaptiveSharedNamespace::WarningStatusCode GetStatusCode() const;
-        const std::string& GetReason() const;
+        const std::string &GetReason() const;
 
     private:
         const AdaptiveSharedNamespace::WarningStatusCode m_statusCode;

--- a/source/shared/cpp/ObjectModel/AdaptiveCardParseWarning.h
+++ b/source/shared/cpp/ObjectModel/AdaptiveCardParseWarning.h
@@ -7,14 +7,14 @@ namespace AdaptiveSharedNamespace
 {
     class AdaptiveCardParseWarning
     {
-        public:
+    public:
         AdaptiveCardParseWarning(AdaptiveSharedNamespace::WarningStatusCode statusCode, const std::string& message);
         ~AdaptiveCardParseWarning();
 
         AdaptiveSharedNamespace::WarningStatusCode GetStatusCode() const;
         const std::string& GetReason() const;
 
-        private:
+    private:
         const AdaptiveSharedNamespace::WarningStatusCode m_statusCode;
         const std::string m_message;
     };

--- a/source/shared/cpp/ObjectModel/BaseActionElement.cpp
+++ b/source/shared/cpp/ObjectModel/BaseActionElement.cpp
@@ -17,7 +17,7 @@ std::string BaseActionElement::GetElementTypeString() const
     return m_typeString;
 }
 
-void BaseActionElement::SetElementTypeString(const std::string& value)
+void BaseActionElement::SetElementTypeString(const std::string &value)
 {
     m_typeString = value;
 }
@@ -27,7 +27,7 @@ std::string BaseActionElement::GetTitle() const
     return m_title;
 }
 
-void BaseActionElement::SetTitle(const std::string& value)
+void BaseActionElement::SetTitle(const std::string &value)
 {
     m_title = value;
 }
@@ -37,7 +37,7 @@ std::string BaseActionElement::GetId() const
     return m_id;
 }
 
-void BaseActionElement::SetId(const std::string& value)
+void BaseActionElement::SetId(const std::string &value)
 {
     m_id = value;
 }
@@ -47,7 +47,7 @@ std::string BaseActionElement::GetIconUrl() const
     return m_iconUrl;
 }
 
-void BaseActionElement::SetIconUrl(const std::string& value)
+void BaseActionElement::SetIconUrl(const std::string &value)
 {
     m_iconUrl = value;
 }
@@ -83,7 +83,7 @@ Json::Value BaseActionElement::GetAdditionalProperties() const
     return m_additionalProperties;
 }
 
-void BaseActionElement::SetAdditionalProperties(Json::Value const& value)
+void BaseActionElement::SetAdditionalProperties(Json::Value const &value)
 {
     m_additionalProperties = value;
 }
@@ -96,7 +96,7 @@ void BaseActionElement::PopulateKnownPropertiesSet()
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::IconUrl));
 }
 
-void BaseActionElement::GetResourceUris(std::vector<std::string>&)
+void BaseActionElement::GetResourceUris(std::vector<std::string> &)
 {
     return;
 }

--- a/source/shared/cpp/ObjectModel/BaseActionElement.cpp
+++ b/source/shared/cpp/ObjectModel/BaseActionElement.cpp
@@ -5,22 +5,19 @@
 
 using namespace AdaptiveSharedNamespace;
 
-BaseActionElement::BaseActionElement(ActionType type) :
-    m_type(type), m_typeString(ActionTypeToString(type))
+BaseActionElement::BaseActionElement(ActionType type) : m_type(type), m_typeString(ActionTypeToString(type))
 {
     PopulateKnownPropertiesSet();
 }
 
-BaseActionElement::~BaseActionElement()
-{
-}
+BaseActionElement::~BaseActionElement() {}
 
 std::string BaseActionElement::GetElementTypeString() const
 {
     return m_typeString;
 }
 
-void BaseActionElement::SetElementTypeString(const std::string &value)
+void BaseActionElement::SetElementTypeString(const std::string& value)
 {
     m_typeString = value;
 }
@@ -30,7 +27,7 @@ std::string BaseActionElement::GetTitle() const
     return m_title;
 }
 
-void BaseActionElement::SetTitle(const std::string &value)
+void BaseActionElement::SetTitle(const std::string& value)
 {
     m_title = value;
 }
@@ -40,7 +37,7 @@ std::string BaseActionElement::GetId() const
     return m_id;
 }
 
-void BaseActionElement::SetId(const std::string &value)
+void BaseActionElement::SetId(const std::string& value)
 {
     m_id = value;
 }
@@ -86,7 +83,7 @@ Json::Value BaseActionElement::GetAdditionalProperties() const
     return m_additionalProperties;
 }
 
-void BaseActionElement::SetAdditionalProperties(Json::Value const &value)
+void BaseActionElement::SetAdditionalProperties(Json::Value const& value)
 {
     m_additionalProperties = value;
 }

--- a/source/shared/cpp/ObjectModel/BaseActionElement.h
+++ b/source/shared/cpp/ObjectModel/BaseActionElement.h
@@ -15,16 +15,16 @@ namespace AdaptiveSharedNamespace
         virtual ~BaseActionElement();
 
         virtual std::string GetElementTypeString() const;
-        virtual void SetElementTypeString(const std::string& value);
+        virtual void SetElementTypeString(const std::string &value);
 
         virtual std::string GetTitle() const;
-        virtual void SetTitle(const std::string& value);
+        virtual void SetTitle(const std::string &value);
 
         virtual std::string GetId() const;
-        virtual void SetId(const std::string& value);
+        virtual void SetId(const std::string &value);
 
         virtual std::string GetIconUrl() const;
-        virtual void SetIconUrl(const std::string& value);
+        virtual void SetIconUrl(const std::string &value);
 
         virtual const ActionType GetElementType() const;
 
@@ -32,12 +32,12 @@ namespace AdaptiveSharedNamespace
         virtual Json::Value SerializeToJsonValue() const;
 
         template<typename T>
-        static std::shared_ptr<T> Deserialize(const Json::Value& json);
+        static std::shared_ptr<T> Deserialize(const Json::Value &json);
 
         Json::Value GetAdditionalProperties() const;
-        void SetAdditionalProperties(Json::Value const& additionalProperties);
+        void SetAdditionalProperties(Json::Value const &additionalProperties);
 
-        virtual void GetResourceUris(std::vector<std::string>& resourceUris);
+        virtual void GetResourceUris(std::vector<std::string> &resourceUris);
 
     private:
         void PopulateKnownPropertiesSet();
@@ -54,7 +54,7 @@ namespace AdaptiveSharedNamespace
     };
 
     template<typename T>
-    std::shared_ptr<T> BaseActionElement::Deserialize(const Json::Value& json)
+    std::shared_ptr<T> BaseActionElement::Deserialize(const Json::Value &json)
     {
         std::shared_ptr<T> cardElement = std::make_shared<T>();
         std::shared_ptr<BaseActionElement> baseActionElement = cardElement;

--- a/source/shared/cpp/ObjectModel/BaseActionElement.h
+++ b/source/shared/cpp/ObjectModel/BaseActionElement.h
@@ -5,75 +5,75 @@
 #include "json/json.h"
 #include "ParseUtil.h"
 
-AdaptiveSharedNamespaceStart
-class BaseActionElement
+namespace AdaptiveSharedNamespace
 {
-public:
-    BaseActionElement(ActionType type);
-
-    virtual ~BaseActionElement();
-
-    virtual std::string GetElementTypeString() const;
-    virtual void SetElementTypeString(const std::string &value);
-
-    virtual std::string GetTitle() const;
-    virtual void SetTitle(const std::string &value);
-
-    virtual std::string GetId() const;
-    virtual void SetId(const std::string &value);
-
-    virtual std::string GetIconUrl() const;
-    virtual void SetIconUrl(const std::string& value);
-
-    virtual const ActionType GetElementType() const;
-
-    std::string Serialize() const;
-    virtual Json::Value SerializeToJsonValue() const;
-
-    template <typename T>
-    static std::shared_ptr<T> Deserialize(const Json::Value& json);
-
-    Json::Value GetAdditionalProperties() const;
-    void SetAdditionalProperties(Json::Value const &additionalProperties);
-
-    virtual void GetResourceUris(std::vector<std::string>& resourceUris);
-
-private:
-    void PopulateKnownPropertiesSet();
-
-    ActionType m_type;
-    std::string m_typeString;
-    std::string m_title;
-    std::string m_id;
-    std::string m_iconUrl;
-    Json::Value m_additionalProperties;
-
-protected:
-    std::unordered_set<std::string> m_knownProperties;
-};
-
-template <typename T>
-std::shared_ptr<T> BaseActionElement::Deserialize(const Json::Value& json)
-{
-    std::shared_ptr<T> cardElement = std::make_shared<T>();
-    std::shared_ptr<BaseActionElement> baseActionElement = cardElement;
-
-    ParseUtil::ThrowIfNotJsonObject(json);
-
-    baseActionElement->SetTitle(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Title, true));
-    baseActionElement->SetId(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Id));
-    baseActionElement->SetIconUrl(ParseUtil::GetString(json, AdaptiveCardSchemaKey::IconUrl));
-
-    // Walk all properties and put any unknown ones in the additional properties json
-    for (Json::Value::const_iterator it = json.begin(); it != json.end(); it++)
+    class BaseActionElement
     {
-        std::string key = it.key().asCString();
-        if (baseActionElement->m_knownProperties.find(key) == baseActionElement->m_knownProperties.end())
-        {
-            baseActionElement->m_additionalProperties[key] = *it;
-        }
-    }
-    return cardElement;
-}
-AdaptiveSharedNamespaceEnd
+        public:
+        BaseActionElement(ActionType type);
 
+        virtual ~BaseActionElement();
+
+        virtual std::string GetElementTypeString() const;
+        virtual void SetElementTypeString(const std::string& value);
+
+        virtual std::string GetTitle() const;
+        virtual void SetTitle(const std::string& value);
+
+        virtual std::string GetId() const;
+        virtual void SetId(const std::string& value);
+
+        virtual std::string GetIconUrl() const;
+        virtual void SetIconUrl(const std::string& value);
+
+        virtual const ActionType GetElementType() const;
+
+        std::string Serialize() const;
+        virtual Json::Value SerializeToJsonValue() const;
+
+        template<typename T>
+        static std::shared_ptr<T> Deserialize(const Json::Value& json);
+
+        Json::Value GetAdditionalProperties() const;
+        void SetAdditionalProperties(Json::Value const& additionalProperties);
+
+        virtual void GetResourceUris(std::vector<std::string>& resourceUris);
+
+        private:
+        void PopulateKnownPropertiesSet();
+
+        ActionType m_type;
+        std::string m_typeString;
+        std::string m_title;
+        std::string m_id;
+        std::string m_iconUrl;
+        Json::Value m_additionalProperties;
+
+        protected:
+        std::unordered_set<std::string> m_knownProperties;
+    };
+
+    template<typename T>
+    std::shared_ptr<T> BaseActionElement::Deserialize(const Json::Value& json)
+    {
+        std::shared_ptr<T> cardElement = std::make_shared<T>();
+        std::shared_ptr<BaseActionElement> baseActionElement = cardElement;
+
+        ParseUtil::ThrowIfNotJsonObject(json);
+
+        baseActionElement->SetTitle(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Title, true));
+        baseActionElement->SetId(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Id));
+        baseActionElement->SetIconUrl(ParseUtil::GetString(json, AdaptiveCardSchemaKey::IconUrl));
+
+        // Walk all properties and put any unknown ones in the additional properties json
+        for (Json::Value::const_iterator it = json.begin(); it != json.end(); it++)
+        {
+            std::string key = it.key().asCString();
+            if (baseActionElement->m_knownProperties.find(key) == baseActionElement->m_knownProperties.end())
+            {
+                baseActionElement->m_additionalProperties[key] = *it;
+            }
+        }
+        return cardElement;
+    }
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/BaseActionElement.h
+++ b/source/shared/cpp/ObjectModel/BaseActionElement.h
@@ -9,7 +9,7 @@ namespace AdaptiveSharedNamespace
 {
     class BaseActionElement
     {
-        public:
+    public:
         BaseActionElement(ActionType type);
 
         virtual ~BaseActionElement();
@@ -39,7 +39,7 @@ namespace AdaptiveSharedNamespace
 
         virtual void GetResourceUris(std::vector<std::string>& resourceUris);
 
-        private:
+    private:
         void PopulateKnownPropertiesSet();
 
         ActionType m_type;
@@ -49,7 +49,7 @@ namespace AdaptiveSharedNamespace
         std::string m_iconUrl;
         Json::Value m_additionalProperties;
 
-        protected:
+    protected:
         std::unordered_set<std::string> m_knownProperties;
     };
 

--- a/source/shared/cpp/ObjectModel/BaseCardElement.cpp
+++ b/source/shared/cpp/ObjectModel/BaseCardElement.cpp
@@ -36,7 +36,7 @@ std::string BaseCardElement::GetElementTypeString() const
     return m_typeString;
 }
 
-void BaseCardElement::SetElementTypeString(const std::string& value)
+void BaseCardElement::SetElementTypeString(const std::string &value)
 {
     m_typeString = value;
 }
@@ -76,7 +76,7 @@ std::string BaseCardElement::GetId() const
     return m_id;
 }
 
-void BaseCardElement::SetId(const std::string& value)
+void BaseCardElement::SetId(const std::string &value)
 {
     m_id = value;
 }
@@ -134,12 +134,12 @@ Json::Value BaseCardElement::GetAdditionalProperties() const
     return m_additionalProperties;
 }
 
-void BaseCardElement::SetAdditionalProperties(Json::Value const& value)
+void BaseCardElement::SetAdditionalProperties(Json::Value const &value)
 {
     m_additionalProperties = value;
 }
 
-void BaseCardElement::GetResourceUris(std::vector<std::string>&)
+void BaseCardElement::GetResourceUris(std::vector<std::string> &)
 {
     return;
 }

--- a/source/shared/cpp/ObjectModel/BaseCardElement.cpp
+++ b/source/shared/cpp/ObjectModel/BaseCardElement.cpp
@@ -7,22 +7,16 @@
 
 using namespace AdaptiveSharedNamespace;
 
-BaseCardElement::BaseCardElement(
-    CardElementType type,
-    Spacing spacing,
-    bool separator,
-    HeightType height) :
-    m_type(type),
-    m_spacing(spacing),
-    m_typeString(CardElementTypeToString(type)),
-    m_separator(separator),
+BaseCardElement::BaseCardElement(CardElementType type, Spacing spacing, bool separator, HeightType height) :
+    m_type(type), m_spacing(spacing), m_typeString(CardElementTypeToString(type)), m_separator(separator),
     m_height(height)
 {
     PopulateKnownPropertiesSet();
 }
 
 BaseCardElement::BaseCardElement(CardElementType type) :
-    m_type(type), m_spacing(Spacing::Default), m_typeString(CardElementTypeToString(type)), m_separator(false), m_height(HeightType::Auto)
+    m_type(type), m_spacing(Spacing::Default), m_typeString(CardElementTypeToString(type)), m_separator(false),
+    m_height(HeightType::Auto)
 {
     PopulateKnownPropertiesSet();
 }
@@ -35,16 +29,14 @@ void BaseCardElement::PopulateKnownPropertiesSet()
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Height));
 }
 
-BaseCardElement::~BaseCardElement()
-{
-}
+BaseCardElement::~BaseCardElement() {}
 
 std::string BaseCardElement::GetElementTypeString() const
 {
     return m_typeString;
 }
 
-void BaseCardElement::SetElementTypeString(const std::string &value)
+void BaseCardElement::SetElementTypeString(const std::string& value)
 {
     m_typeString = value;
 }
@@ -84,7 +76,7 @@ std::string BaseCardElement::GetId() const
     return m_id;
 }
 
-void BaseCardElement::SetId(const std::string &value)
+void BaseCardElement::SetId(const std::string& value)
 {
     m_id = value;
 }
@@ -101,7 +93,7 @@ std::string BaseCardElement::Serialize() const
 }
 
 Json::Value BaseCardElement::SerializeToJsonValue() const
- {
+{
     Json::Value root = GetAdditionalProperties();
     root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Type)] = CardElementTypeToString(GetElementType());
 
@@ -128,7 +120,7 @@ Json::Value BaseCardElement::SerializeToJsonValue() const
     return root;
 }
 
-Json::Value BaseCardElement::SerializeSelectAction(const std::shared_ptr<BaseActionElement> selectAction) 
+Json::Value BaseCardElement::SerializeSelectAction(const std::shared_ptr<BaseActionElement> selectAction)
 {
     if (selectAction != nullptr)
     {
@@ -142,7 +134,7 @@ Json::Value BaseCardElement::GetAdditionalProperties() const
     return m_additionalProperties;
 }
 
-void BaseCardElement::SetAdditionalProperties(Json::Value const &value)
+void BaseCardElement::SetAdditionalProperties(Json::Value const& value)
 {
     m_additionalProperties = value;
 }

--- a/source/shared/cpp/ObjectModel/BaseCardElement.h
+++ b/source/shared/cpp/ObjectModel/BaseCardElement.h
@@ -19,7 +19,7 @@ namespace AdaptiveSharedNamespace
         virtual ~BaseCardElement();
 
         virtual std::string GetElementTypeString() const;
-        virtual void SetElementTypeString(const std::string& value);
+        virtual void SetElementTypeString(const std::string &value);
 
         virtual bool GetSeparator() const;
         virtual void SetSeparator(const bool value);
@@ -31,7 +31,7 @@ namespace AdaptiveSharedNamespace
         virtual void SetSpacing(const Spacing value);
 
         virtual std::string GetId() const;
-        virtual void SetId(const std::string& value);
+        virtual void SetId(const std::string &value);
 
         virtual const CardElementType GetElementType() const;
 
@@ -39,12 +39,12 @@ namespace AdaptiveSharedNamespace
         virtual Json::Value SerializeToJsonValue() const;
 
         template<typename T>
-        static std::shared_ptr<T> Deserialize(const Json::Value& json);
+        static std::shared_ptr<T> Deserialize(const Json::Value &json);
 
         Json::Value GetAdditionalProperties() const;
-        void SetAdditionalProperties(const Json::Value& additionalProperties);
+        void SetAdditionalProperties(const Json::Value &additionalProperties);
 
-        virtual void GetResourceUris(std::vector<std::string>& resourceUris);
+        virtual void GetResourceUris(std::vector<std::string> &resourceUris);
 
     protected:
         static Json::Value SerializeSelectAction(const std::shared_ptr<BaseActionElement> selectAction);
@@ -64,7 +64,7 @@ namespace AdaptiveSharedNamespace
     };
 
     template<typename T>
-    std::shared_ptr<T> BaseCardElement::Deserialize(const Json::Value& json)
+    std::shared_ptr<T> BaseCardElement::Deserialize(const Json::Value &json)
     {
         std::shared_ptr<T> cardElement = std::make_shared<T>();
         std::shared_ptr<BaseCardElement> baseCardElement = cardElement;

--- a/source/shared/cpp/ObjectModel/BaseCardElement.h
+++ b/source/shared/cpp/ObjectModel/BaseCardElement.h
@@ -12,7 +12,7 @@ namespace AdaptiveSharedNamespace
     class Container;
     class BaseCardElement
     {
-        public:
+    public:
         BaseCardElement(CardElementType type, Spacing spacing, bool separator, HeightType height);
         BaseCardElement(CardElementType type);
 
@@ -46,12 +46,12 @@ namespace AdaptiveSharedNamespace
 
         virtual void GetResourceUris(std::vector<std::string>& resourceUris);
 
-        protected:
+    protected:
         static Json::Value SerializeSelectAction(const std::shared_ptr<BaseActionElement> selectAction);
 
         std::unordered_set<std::string> m_knownProperties;
 
-        private:
+    private:
         void PopulateKnownPropertiesSet();
 
         CardElementType m_type;

--- a/source/shared/cpp/ObjectModel/BaseCardElement.h
+++ b/source/shared/cpp/ObjectModel/BaseCardElement.h
@@ -7,87 +7,87 @@
 #include "ParseUtil.h"
 #include "Separator.h"
 
-AdaptiveSharedNamespaceStart
-class Container;
-class BaseCardElement
+namespace AdaptiveSharedNamespace
 {
-public:
-    BaseCardElement(CardElementType type, Spacing spacing, bool separator, HeightType height);
-    BaseCardElement(CardElementType type);
-
-    virtual ~BaseCardElement();
-
-    virtual std::string GetElementTypeString() const;
-    virtual void SetElementTypeString(const std::string &value);
-
-    virtual bool GetSeparator() const;
-    virtual void SetSeparator(const bool value);
-
-    HeightType GetHeight() const;
-    void SetHeight(const HeightType value);
-
-    virtual Spacing GetSpacing() const;
-    virtual void SetSpacing(const Spacing value);
-
-    virtual std::string GetId() const;
-    virtual void SetId(const std::string &value);
-
-    virtual const CardElementType GetElementType() const;
-
-    std::string Serialize() const;
-    virtual Json::Value SerializeToJsonValue() const;
-
-    template <typename T>
-    static std::shared_ptr<T> Deserialize(const Json::Value& json);
-
-    Json::Value GetAdditionalProperties() const;
-    void SetAdditionalProperties(const Json::Value &additionalProperties);
-
-    virtual void GetResourceUris(std::vector<std::string>& resourceUris);
-
-protected:
-    static Json::Value SerializeSelectAction(const std::shared_ptr<BaseActionElement> selectAction);
-
-    std::unordered_set<std::string> m_knownProperties;
-
-private:
-    void PopulateKnownPropertiesSet();
-
-    CardElementType m_type;
-    Spacing m_spacing;
-    std::string m_id;
-    std::string m_typeString;
-    bool m_separator;
-    Json::Value m_additionalProperties;
-    HeightType m_height;
-};
-
-template <typename T>
-std::shared_ptr<T> BaseCardElement::Deserialize(const Json::Value& json)
-{
-    std::shared_ptr<T> cardElement = std::make_shared<T>();
-    std::shared_ptr<BaseCardElement> baseCardElement = cardElement;
-
-    ParseUtil::ThrowIfNotJsonObject(json);
-
-    baseCardElement->SetSpacing(
-            ParseUtil::GetEnumValue<Spacing>(json, AdaptiveCardSchemaKey::Spacing, Spacing::Default, SpacingFromString)); 
-    baseCardElement->SetSeparator(ParseUtil::GetBool(json, AdaptiveCardSchemaKey::Separator, false));
-    baseCardElement->SetId(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Id));
-    baseCardElement->SetHeight(
-        ParseUtil::GetEnumValue<HeightType>(json, AdaptiveCardSchemaKey::Height, HeightType::Auto, HeightTypeFromString));
-
-    // Walk all properties and put any unknown ones in the additional properties json
-    for (Json::Value::const_iterator it = json.begin(); it != json.end(); it++)
+    class Container;
+    class BaseCardElement
     {
-        std::string key = it.key().asCString();
-        if (baseCardElement->m_knownProperties.find(key) == baseCardElement->m_knownProperties.end())
+        public:
+        BaseCardElement(CardElementType type, Spacing spacing, bool separator, HeightType height);
+        BaseCardElement(CardElementType type);
+
+        virtual ~BaseCardElement();
+
+        virtual std::string GetElementTypeString() const;
+        virtual void SetElementTypeString(const std::string& value);
+
+        virtual bool GetSeparator() const;
+        virtual void SetSeparator(const bool value);
+
+        HeightType GetHeight() const;
+        void SetHeight(const HeightType value);
+
+        virtual Spacing GetSpacing() const;
+        virtual void SetSpacing(const Spacing value);
+
+        virtual std::string GetId() const;
+        virtual void SetId(const std::string& value);
+
+        virtual const CardElementType GetElementType() const;
+
+        std::string Serialize() const;
+        virtual Json::Value SerializeToJsonValue() const;
+
+        template<typename T>
+        static std::shared_ptr<T> Deserialize(const Json::Value& json);
+
+        Json::Value GetAdditionalProperties() const;
+        void SetAdditionalProperties(const Json::Value& additionalProperties);
+
+        virtual void GetResourceUris(std::vector<std::string>& resourceUris);
+
+        protected:
+        static Json::Value SerializeSelectAction(const std::shared_ptr<BaseActionElement> selectAction);
+
+        std::unordered_set<std::string> m_knownProperties;
+
+        private:
+        void PopulateKnownPropertiesSet();
+
+        CardElementType m_type;
+        Spacing m_spacing;
+        std::string m_id;
+        std::string m_typeString;
+        bool m_separator;
+        Json::Value m_additionalProperties;
+        HeightType m_height;
+    };
+
+    template<typename T>
+    std::shared_ptr<T> BaseCardElement::Deserialize(const Json::Value& json)
+    {
+        std::shared_ptr<T> cardElement = std::make_shared<T>();
+        std::shared_ptr<BaseCardElement> baseCardElement = cardElement;
+
+        ParseUtil::ThrowIfNotJsonObject(json);
+
+        baseCardElement->SetSpacing(ParseUtil::GetEnumValue<Spacing>(
+            json, AdaptiveCardSchemaKey::Spacing, Spacing::Default, SpacingFromString));
+        baseCardElement->SetSeparator(ParseUtil::GetBool(json, AdaptiveCardSchemaKey::Separator, false));
+        baseCardElement->SetId(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Id));
+        baseCardElement->SetHeight(ParseUtil::GetEnumValue<HeightType>(
+            json, AdaptiveCardSchemaKey::Height, HeightType::Auto, HeightTypeFromString));
+
+        // Walk all properties and put any unknown ones in the additional properties json
+        for (Json::Value::const_iterator it = json.begin(); it != json.end(); it++)
         {
-            baseCardElement->m_additionalProperties[key] = *it;
+            std::string key = it.key().asCString();
+            if (baseCardElement->m_knownProperties.find(key) == baseCardElement->m_knownProperties.end())
+            {
+                baseCardElement->m_additionalProperties[key] = *it;
+            }
         }
+
+        return cardElement;
     }
-
-    return cardElement;
-}
-AdaptiveSharedNamespaceEnd
-
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/BaseInputElement.cpp
+++ b/source/shared/cpp/ObjectModel/BaseInputElement.cpp
@@ -16,7 +16,7 @@ std::string BaseInputElement::GetId() const
     return m_id;
 }
 
-void BaseInputElement::SetId(const std::string& value)
+void BaseInputElement::SetId(const std::string &value)
 {
     m_id = value;
 }

--- a/source/shared/cpp/ObjectModel/BaseInputElement.cpp
+++ b/source/shared/cpp/ObjectModel/BaseInputElement.cpp
@@ -4,10 +4,7 @@
 
 using namespace AdaptiveSharedNamespace;
 
-BaseInputElement::BaseInputElement(CardElementType elementType) :
-    BaseCardElement(elementType)
-{
-}
+BaseInputElement::BaseInputElement(CardElementType elementType) : BaseCardElement(elementType) {}
 
 BaseInputElement::BaseInputElement(CardElementType elementType, Spacing spacing, bool separator, HeightType height) :
     BaseCardElement(elementType, spacing, separator, height)
@@ -19,7 +16,7 @@ std::string BaseInputElement::GetId() const
     return m_id;
 }
 
-void BaseInputElement::SetId(const std::string &value)
+void BaseInputElement::SetId(const std::string& value)
 {
     m_id = value;
 }

--- a/source/shared/cpp/ObjectModel/BaseInputElement.h
+++ b/source/shared/cpp/ObjectModel/BaseInputElement.h
@@ -10,7 +10,7 @@ namespace AdaptiveSharedNamespace
 {
     class BaseInputElement : public BaseCardElement
     {
-        public:
+    public:
         BaseInputElement(CardElementType elementType);
         BaseInputElement(CardElementType type, Spacing spacing, bool separator, HeightType height);
 
@@ -25,7 +25,7 @@ namespace AdaptiveSharedNamespace
 
         virtual Json::Value SerializeToJsonValue() const override;
 
-        private:
+    private:
         std::string m_id;
         bool m_isRequired;
     };

--- a/source/shared/cpp/ObjectModel/BaseInputElement.h
+++ b/source/shared/cpp/ObjectModel/BaseInputElement.h
@@ -6,39 +6,40 @@
 #include "ParseUtil.h"
 #include "BaseCardElement.h"
 
-AdaptiveSharedNamespaceStart
-class BaseInputElement : public BaseCardElement
+namespace AdaptiveSharedNamespace
 {
-public:
-    BaseInputElement(CardElementType elementType);
-    BaseInputElement(CardElementType type, Spacing spacing, bool separator, HeightType height);
+    class BaseInputElement : public BaseCardElement
+    {
+        public:
+        BaseInputElement(CardElementType elementType);
+        BaseInputElement(CardElementType type, Spacing spacing, bool separator, HeightType height);
 
-    std::string GetId() const override;
-    virtual void SetId(const std::string &value) override;
+        std::string GetId() const override;
+        virtual void SetId(const std::string& value) override;
 
-    template <typename T>
-    static std::shared_ptr<T> Deserialize(const Json::Value& json);
+        template<typename T>
+        static std::shared_ptr<T> Deserialize(const Json::Value& json);
 
-    bool GetIsRequired() const;
-    void SetIsRequired(const bool isRequired);
+        bool GetIsRequired() const;
+        void SetIsRequired(const bool isRequired);
 
-    virtual Json::Value SerializeToJsonValue() const override;
+        virtual Json::Value SerializeToJsonValue() const override;
 
-private:
-    std::string m_id;
-    bool m_isRequired;
-};
+        private:
+        std::string m_id;
+        bool m_isRequired;
+    };
 
-template <typename T>
-std::shared_ptr<T> BaseInputElement::Deserialize(const Json::Value& json)
-{
-    std::shared_ptr<T> baseInputElement = BaseCardElement::Deserialize<T>(json);
+    template<typename T>
+    std::shared_ptr<T> BaseInputElement::Deserialize(const Json::Value& json)
+    {
+        std::shared_ptr<T> baseInputElement = BaseCardElement::Deserialize<T>(json);
 
-    ParseUtil::ThrowIfNotJsonObject(json);
+        ParseUtil::ThrowIfNotJsonObject(json);
 
-    baseInputElement->SetId(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Id, true));
-    baseInputElement->SetIsRequired(ParseUtil::GetBool(json, AdaptiveCardSchemaKey::IsRequired, false));
+        baseInputElement->SetId(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Id, true));
+        baseInputElement->SetIsRequired(ParseUtil::GetBool(json, AdaptiveCardSchemaKey::IsRequired, false));
 
-    return baseInputElement;
-}
-AdaptiveSharedNamespaceEnd
+        return baseInputElement;
+    }
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/BaseInputElement.h
+++ b/source/shared/cpp/ObjectModel/BaseInputElement.h
@@ -15,10 +15,10 @@ namespace AdaptiveSharedNamespace
         BaseInputElement(CardElementType type, Spacing spacing, bool separator, HeightType height);
 
         std::string GetId() const override;
-        virtual void SetId(const std::string& value) override;
+        virtual void SetId(const std::string &value) override;
 
         template<typename T>
-        static std::shared_ptr<T> Deserialize(const Json::Value& json);
+        static std::shared_ptr<T> Deserialize(const Json::Value &json);
 
         bool GetIsRequired() const;
         void SetIsRequired(const bool isRequired);
@@ -31,7 +31,7 @@ namespace AdaptiveSharedNamespace
     };
 
     template<typename T>
-    std::shared_ptr<T> BaseInputElement::Deserialize(const Json::Value& json)
+    std::shared_ptr<T> BaseInputElement::Deserialize(const Json::Value &json)
     {
         std::shared_ptr<T> baseInputElement = BaseCardElement::Deserialize<T>(json);
 

--- a/source/shared/cpp/ObjectModel/ChoiceInput.cpp
+++ b/source/shared/cpp/ObjectModel/ChoiceInput.cpp
@@ -8,7 +8,7 @@ using namespace AdaptiveSharedNamespace;
 ChoiceInput::ChoiceInput() {}
 
 std::shared_ptr<ChoiceInput> ChoiceInput::Deserialize(
-    std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value& json)
+    std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value &json)
 {
     auto choice = std::make_shared<ChoiceInput>();
 
@@ -20,7 +20,7 @@ std::shared_ptr<ChoiceInput> ChoiceInput::Deserialize(
 
 std::shared_ptr<ChoiceInput> ChoiceInput::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString)
 {
     return ChoiceInput::Deserialize(
         elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
@@ -47,7 +47,7 @@ std::string ChoiceInput::GetTitle() const
     return m_title;
 }
 
-void ChoiceInput::SetTitle(const std::string& title)
+void ChoiceInput::SetTitle(const std::string &title)
 {
     m_title = title;
 }
@@ -57,7 +57,7 @@ std::string ChoiceInput::GetValue() const
     return m_value;
 }
 
-void ChoiceInput::SetValue(const std::string& value)
+void ChoiceInput::SetValue(const std::string &value)
 {
     m_value = value;
 }

--- a/source/shared/cpp/ObjectModel/ChoiceInput.cpp
+++ b/source/shared/cpp/ObjectModel/ChoiceInput.cpp
@@ -5,14 +5,10 @@
 
 using namespace AdaptiveSharedNamespace;
 
-ChoiceInput::ChoiceInput()
-{
-}
+ChoiceInput::ChoiceInput() {}
 
 std::shared_ptr<ChoiceInput> ChoiceInput::Deserialize(
-    std::shared_ptr<ElementParserRegistration>,
-    std::shared_ptr<ActionParserRegistration>,
-    const Json::Value& json)
+    std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value& json)
 {
     auto choice = std::make_shared<ChoiceInput>();
 
@@ -24,10 +20,10 @@ std::shared_ptr<ChoiceInput> ChoiceInput::Deserialize(
 
 std::shared_ptr<ChoiceInput> ChoiceInput::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-    const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
 {
-    return ChoiceInput::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
+    return ChoiceInput::Deserialize(
+        elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
 std::string ChoiceInput::Serialize()
@@ -51,7 +47,7 @@ std::string ChoiceInput::GetTitle() const
     return m_title;
 }
 
-void ChoiceInput::SetTitle(const std::string &title)
+void ChoiceInput::SetTitle(const std::string& title)
 {
     m_title = title;
 }
@@ -61,7 +57,7 @@ std::string ChoiceInput::GetValue() const
     return m_value;
 }
 
-void ChoiceInput::SetValue(const std::string &value)
+void ChoiceInput::SetValue(const std::string& value)
 {
     m_value = value;
 }

--- a/source/shared/cpp/ObjectModel/ChoiceInput.h
+++ b/source/shared/cpp/ObjectModel/ChoiceInput.h
@@ -9,7 +9,7 @@ namespace AdaptiveSharedNamespace
 {
     class ChoiceInput
     {
-        public:
+    public:
         ChoiceInput();
 
         std::string Serialize();
@@ -29,7 +29,7 @@ namespace AdaptiveSharedNamespace
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
             std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
 
-        private:
+    private:
         std::string m_title;
         std::string m_value;
     };

--- a/source/shared/cpp/ObjectModel/ChoiceInput.h
+++ b/source/shared/cpp/ObjectModel/ChoiceInput.h
@@ -16,18 +16,18 @@ namespace AdaptiveSharedNamespace
         Json::Value SerializeToJsonValue();
 
         std::string GetTitle() const;
-        void SetTitle(const std::string& value);
+        void SetTitle(const std::string &value);
 
         std::string GetValue() const;
-        void SetValue(const std::string& value);
+        void SetValue(const std::string &value);
 
         static std::shared_ptr<ChoiceInput> Deserialize(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &root);
 
         static std::shared_ptr<ChoiceInput> DeserializeFromString(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString);
 
     private:
         std::string m_title;

--- a/source/shared/cpp/ObjectModel/ChoiceInput.h
+++ b/source/shared/cpp/ObjectModel/ChoiceInput.h
@@ -5,33 +5,32 @@
 #include "json/json.h"
 #include "ElementParserRegistration.h"
 
-AdaptiveSharedNamespaceStart
-class ChoiceInput
+namespace AdaptiveSharedNamespace
 {
-public:
-    ChoiceInput();
+    class ChoiceInput
+    {
+        public:
+        ChoiceInput();
 
-    std::string Serialize();
-    Json::Value SerializeToJsonValue();
+        std::string Serialize();
+        Json::Value SerializeToJsonValue();
 
-    std::string GetTitle() const;
-    void SetTitle(const std::string &value);
+        std::string GetTitle() const;
+        void SetTitle(const std::string& value);
 
-    std::string GetValue() const;
-    void SetValue(const std::string &value);
+        std::string GetValue() const;
+        void SetValue(const std::string& value);
 
-    static std::shared_ptr<ChoiceInput> Deserialize(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const Json::Value& root);
+        static std::shared_ptr<ChoiceInput> Deserialize(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
 
-    static std::shared_ptr<ChoiceInput> DeserializeFromString(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const std::string& jsonString);
+        static std::shared_ptr<ChoiceInput> DeserializeFromString(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
 
-private:
-    std::string m_title;
-    std::string m_value;
-};
-AdaptiveSharedNamespaceEnd
+        private:
+        std::string m_title;
+        std::string m_value;
+    };
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/ChoiceSetInput.cpp
+++ b/source/shared/cpp/ObjectModel/ChoiceSetInput.cpp
@@ -71,26 +71,27 @@ std::string ChoiceSetInput::GetValue() const
     return m_value;
 }
 
-void ChoiceSetInput::SetValue(std::string const &value)
+void ChoiceSetInput::SetValue(std::string const& value)
 {
     m_value = value;
 }
 
 std::shared_ptr<BaseCardElement> ChoiceSetInputParser::Deserialize(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-    const Json::Value& json)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& json)
 {
     ParseUtil::ExpectTypeString(json, CardElementType::ChoiceSetInput);
 
     auto choiceSet = BaseInputElement::Deserialize<ChoiceSetInput>(json);
 
-    choiceSet->SetChoiceSetStyle(ParseUtil::GetEnumValue<ChoiceSetStyle>(json, AdaptiveCardSchemaKey::Style, ChoiceSetStyle::Compact, ChoiceSetStyleFromString));
+    choiceSet->SetChoiceSetStyle(ParseUtil::GetEnumValue<ChoiceSetStyle>(
+        json, AdaptiveCardSchemaKey::Style, ChoiceSetStyle::Compact, ChoiceSetStyleFromString));
     choiceSet->SetIsMultiSelect(ParseUtil::GetBool(json, AdaptiveCardSchemaKey::IsMultiSelect, false));
     choiceSet->SetValue(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Value, false));
 
     // Parse Choices
-    auto choices = ParseUtil::GetElementCollectionOfSingleType<ChoiceInput>(elementParserRegistration, actionParserRegistration, json, AdaptiveCardSchemaKey::Choices, ChoiceInput::Deserialize, true);
+    auto choices = ParseUtil::GetElementCollectionOfSingleType<ChoiceInput>(elementParserRegistration,
+        actionParserRegistration, json, AdaptiveCardSchemaKey::Choices, ChoiceInput::Deserialize, true);
     choiceSet->m_choices = std::move(choices);
 
     return choiceSet;
@@ -98,13 +99,13 @@ std::shared_ptr<BaseCardElement> ChoiceSetInputParser::Deserialize(
 
 std::shared_ptr<BaseCardElement> ChoiceSetInputParser::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-    const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
 {
-    return ChoiceSetInputParser::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
+    return ChoiceSetInputParser::Deserialize(
+        elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
-void ChoiceSetInput::PopulateKnownPropertiesSet() 
+void ChoiceSetInput::PopulateKnownPropertiesSet()
 {
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Choices));
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::IsMultiSelect));

--- a/source/shared/cpp/ObjectModel/ChoiceSetInput.cpp
+++ b/source/shared/cpp/ObjectModel/ChoiceSetInput.cpp
@@ -10,12 +10,12 @@ ChoiceSetInput::ChoiceSetInput() : BaseInputElement(CardElementType::ChoiceSetIn
     PopulateKnownPropertiesSet();
 }
 
-const std::vector<std::shared_ptr<ChoiceInput>>& ChoiceSetInput::GetChoices() const
+const std::vector<std::shared_ptr<ChoiceInput>> &ChoiceSetInput::GetChoices() const
 {
     return m_choices;
 }
 
-std::vector<std::shared_ptr<ChoiceInput>>& ChoiceSetInput::GetChoices()
+std::vector<std::shared_ptr<ChoiceInput>> &ChoiceSetInput::GetChoices()
 {
     return m_choices;
 }
@@ -38,7 +38,7 @@ Json::Value ChoiceSetInput::SerializeToJsonValue() const
 
     std::string propertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Choices);
     root[propertyName] = Json::Value(Json::arrayValue);
-    for (const auto& choice : m_choices)
+    for (const auto &choice : m_choices)
     {
         root[propertyName].append(choice->SerializeToJsonValue());
     }
@@ -71,14 +71,14 @@ std::string ChoiceSetInput::GetValue() const
     return m_value;
 }
 
-void ChoiceSetInput::SetValue(std::string const& value)
+void ChoiceSetInput::SetValue(std::string const &value)
 {
     m_value = value;
 }
 
 std::shared_ptr<BaseCardElement> ChoiceSetInputParser::Deserialize(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& json)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &json)
 {
     ParseUtil::ExpectTypeString(json, CardElementType::ChoiceSetInput);
 
@@ -99,7 +99,7 @@ std::shared_ptr<BaseCardElement> ChoiceSetInputParser::Deserialize(
 
 std::shared_ptr<BaseCardElement> ChoiceSetInputParser::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString)
 {
     return ChoiceSetInputParser::Deserialize(
         elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));

--- a/source/shared/cpp/ObjectModel/ChoiceSetInput.h
+++ b/source/shared/cpp/ObjectModel/ChoiceSetInput.h
@@ -24,11 +24,11 @@ namespace AdaptiveSharedNamespace
         ChoiceSetStyle GetChoiceSetStyle() const;
         void SetChoiceSetStyle(const ChoiceSetStyle choiceSetStyle);
 
-        std::vector<std::shared_ptr<ChoiceInput>>& GetChoices();
-        const std::vector<std::shared_ptr<ChoiceInput>>& GetChoices() const;
+        std::vector<std::shared_ptr<ChoiceInput>> &GetChoices();
+        const std::vector<std::shared_ptr<ChoiceInput>> &GetChoices() const;
 
         std::string GetValue() const;
-        void SetValue(const std::string& value);
+        void SetValue(const std::string &value);
 
     private:
         void PopulateKnownPropertiesSet();
@@ -45,10 +45,10 @@ namespace AdaptiveSharedNamespace
     public:
         std::shared_ptr<BaseCardElement> Deserialize(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &root);
 
         std::shared_ptr<BaseCardElement> DeserializeFromString(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString);
     };
 } // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/ChoiceSetInput.h
+++ b/source/shared/cpp/ObjectModel/ChoiceSetInput.h
@@ -13,7 +13,7 @@ namespace AdaptiveSharedNamespace
     {
         friend class ChoiceSetInputParser;
 
-        public:
+    public:
         ChoiceSetInput();
 
         virtual Json::Value SerializeToJsonValue() const override;
@@ -30,7 +30,7 @@ namespace AdaptiveSharedNamespace
         std::string GetValue() const;
         void SetValue(const std::string& value);
 
-        private:
+    private:
         void PopulateKnownPropertiesSet();
 
         std::string m_value;
@@ -42,7 +42,7 @@ namespace AdaptiveSharedNamespace
 
     class ChoiceSetInputParser : public BaseCardElementParser
     {
-        public:
+    public:
         std::shared_ptr<BaseCardElement> Deserialize(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
             std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);

--- a/source/shared/cpp/ObjectModel/ChoiceSetInput.h
+++ b/source/shared/cpp/ObjectModel/ChoiceSetInput.h
@@ -6,49 +6,49 @@
 #include "Enums.h"
 #include "ElementParserRegistration.h"
 
-AdaptiveSharedNamespaceStart
-class BaseInputElement;
-class ChoiceSetInput : public BaseInputElement
+namespace AdaptiveSharedNamespace
 {
-friend class ChoiceSetInputParser;
-public:
-    ChoiceSetInput();
+    class BaseInputElement;
+    class ChoiceSetInput : public BaseInputElement
+    {
+        friend class ChoiceSetInputParser;
 
-    virtual Json::Value SerializeToJsonValue() const override;
+        public:
+        ChoiceSetInput();
 
-    bool GetIsMultiSelect() const;
-    void SetIsMultiSelect(const bool isMultiSelect);
+        virtual Json::Value SerializeToJsonValue() const override;
 
-    ChoiceSetStyle GetChoiceSetStyle() const;
-    void SetChoiceSetStyle(const ChoiceSetStyle choiceSetStyle);
+        bool GetIsMultiSelect() const;
+        void SetIsMultiSelect(const bool isMultiSelect);
 
-    std::vector<std::shared_ptr<ChoiceInput>>& GetChoices();
-    const std::vector<std::shared_ptr<ChoiceInput>>& GetChoices() const;
+        ChoiceSetStyle GetChoiceSetStyle() const;
+        void SetChoiceSetStyle(const ChoiceSetStyle choiceSetStyle);
 
-    std::string GetValue() const;
-    void SetValue(const std::string &value);
+        std::vector<std::shared_ptr<ChoiceInput>>& GetChoices();
+        const std::vector<std::shared_ptr<ChoiceInput>>& GetChoices() const;
 
-private:
-    void PopulateKnownPropertiesSet();
+        std::string GetValue() const;
+        void SetValue(const std::string& value);
 
-    std::string m_value;
-    bool m_isMultiSelect;
-    ChoiceSetStyle m_choiceSetStyle;
+        private:
+        void PopulateKnownPropertiesSet();
 
-    std::vector<std::shared_ptr<ChoiceInput>> m_choices; 
-};
+        std::string m_value;
+        bool m_isMultiSelect;
+        ChoiceSetStyle m_choiceSetStyle;
 
-class ChoiceSetInputParser : public BaseCardElementParser
-{
-public:
-    std::shared_ptr<BaseCardElement> Deserialize(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const Json::Value& root);
-    
-    std::shared_ptr<BaseCardElement> DeserializeFromString(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const std::string& jsonString);
-};
-AdaptiveSharedNamespaceEnd
+        std::vector<std::shared_ptr<ChoiceInput>> m_choices;
+    };
+
+    class ChoiceSetInputParser : public BaseCardElementParser
+    {
+        public:
+        std::shared_ptr<BaseCardElement> Deserialize(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
+
+        std::shared_ptr<BaseCardElement> DeserializeFromString(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+    };
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/Column.cpp
+++ b/source/shared/cpp/ObjectModel/Column.cpp
@@ -5,7 +5,9 @@
 
 using namespace AdaptiveSharedNamespace;
 
-Column::Column() : BaseCardElement(CardElementType::Column), m_width("Auto"), m_pixelWidth(0), m_style(ContainerStyle::None), m_verticalContentAlignment(VerticalContentAlignment::Stretch)
+Column::Column() :
+    BaseCardElement(CardElementType::Column), m_width("Auto"), m_pixelWidth(0), m_style(ContainerStyle::None),
+    m_verticalContentAlignment(VerticalContentAlignment::Stretch)
 {
     PopulateKnownPropertiesSet();
 }
@@ -15,12 +17,12 @@ std::string Column::GetWidth() const
     return m_width;
 }
 
-void Column::SetWidth(const std::string &value)
+void Column::SetWidth(const std::string& value)
 {
     m_width = ParseUtil::ToLowercase(value);
 }
 
-// explicit width takes precedence over relative width 
+// explicit width takes precedence over relative width
 int Column::GetPixelWidth() const
 {
     return m_pixelWidth;
@@ -83,7 +85,8 @@ Json::Value Column::SerializeToJsonValue() const
 
     if (m_verticalContentAlignment != VerticalContentAlignment::Stretch)
     {
-        root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::VerticalContentAlignment)] = VerticalContentAlignmentToString(m_verticalContentAlignment);
+        root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::VerticalContentAlignment)] =
+            VerticalContentAlignmentToString(m_verticalContentAlignment);
     }
 
     std::string propertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Items);
@@ -95,16 +98,15 @@ Json::Value Column::SerializeToJsonValue() const
 
     if (m_selectAction != nullptr)
     {
-        root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::SelectAction)] = BaseCardElement::SerializeSelectAction(m_selectAction);
+        root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::SelectAction)] =
+            BaseCardElement::SerializeSelectAction(m_selectAction);
     }
 
     return root;
 }
 
-std::shared_ptr<Column> Column::Deserialize(
-    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-    const Json::Value& value)
+std::shared_ptr<Column> Column::Deserialize(std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& value)
 {
     auto column = BaseCardElement::Deserialize<Column>(value);
 
@@ -115,7 +117,7 @@ std::shared_ptr<Column> Column::Deserialize(
         columnWidth = ParseUtil::GetValueAsString(value, AdaptiveCardSchemaKey::Size);
     }
 
-    // validate user input; validation only applies to user input for explicit column width 
+    // validate user input; validation only applies to user input for explicit column width
     // the other input checks are remained unchanged
     column->SetPixelWidth(0);
     if (!columnWidth.empty() && (isdigit(columnWidth.at(0)) || ('-' == columnWidth.at(0))))
@@ -123,7 +125,7 @@ std::shared_ptr<Column> Column::Deserialize(
         const std::string unit = "px";
         std::size_t foundIndex = columnWidth.find(unit);
         /// check if width is determined explicitly
-        if (std::string::npos != foundIndex) 
+        if (std::string::npos != foundIndex)
         {
             if (columnWidth.size() == foundIndex + unit.size())
             {
@@ -132,37 +134,41 @@ std::shared_ptr<Column> Column::Deserialize(
                 ValidateUserInputForDimensionWithUnit(unit, requestedDimensions, parsedDimension);
                 column->SetPixelWidth(parsedDimension);
             }
-            else 
+            else
             {
-                throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "unit is in inproper form: " + columnWidth);
+                throw AdaptiveCardParseException(
+                    ErrorStatusCode::InvalidPropertyValue, "unit is in inproper form: " + columnWidth);
             }
         }
     }
 
     column->SetWidth(columnWidth);
 
-    column->SetStyle(
-        ParseUtil::GetEnumValue<ContainerStyle>(value, AdaptiveCardSchemaKey::Style, ContainerStyle::None, ContainerStyleFromString));
+    column->SetStyle(ParseUtil::GetEnumValue<ContainerStyle>(
+        value, AdaptiveCardSchemaKey::Style, ContainerStyle::None, ContainerStyleFromString));
 
     column->SetVerticalContentAlignment(
-        ParseUtil::GetEnumValue<VerticalContentAlignment>(value, AdaptiveCardSchemaKey::VerticalContentAlignment, VerticalContentAlignment::Stretch, VerticalContentAlignmentFromString));
+        ParseUtil::GetEnumValue<VerticalContentAlignment>(value, AdaptiveCardSchemaKey::VerticalContentAlignment,
+            VerticalContentAlignment::Stretch, VerticalContentAlignmentFromString));
 
     // Parse Items
-    auto cardElements = ParseUtil::GetElementCollection(elementParserRegistration, actionParserRegistration, value, AdaptiveCardSchemaKey::Items, false);
+    auto cardElements = ParseUtil::GetElementCollection(
+        elementParserRegistration, actionParserRegistration, value, AdaptiveCardSchemaKey::Items, false);
     column->m_items = std::move(cardElements);
 
     // Parse optional selectAction
-    column->SetSelectAction(ParseUtil::GetSelectAction(elementParserRegistration, actionParserRegistration, value, AdaptiveCardSchemaKey::SelectAction, false));
+    column->SetSelectAction(ParseUtil::GetSelectAction(
+        elementParserRegistration, actionParserRegistration, value, AdaptiveCardSchemaKey::SelectAction, false));
 
     return column;
 }
 
 std::shared_ptr<Column> Column::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-    const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
 {
-    return Column::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
+    return Column::Deserialize(
+        elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
 std::shared_ptr<BaseActionElement> Column::GetSelectAction() const
@@ -175,7 +181,7 @@ void Column::SetSelectAction(const std::shared_ptr<BaseActionElement> action)
     m_selectAction = action;
 }
 
-void Column::PopulateKnownPropertiesSet() 
+void Column::PopulateKnownPropertiesSet()
 {
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Items));
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::SelectAction));

--- a/source/shared/cpp/ObjectModel/Column.cpp
+++ b/source/shared/cpp/ObjectModel/Column.cpp
@@ -17,7 +17,7 @@ std::string Column::GetWidth() const
     return m_width;
 }
 
-void Column::SetWidth(const std::string& value)
+void Column::SetWidth(const std::string &value)
 {
     m_width = ParseUtil::ToLowercase(value);
 }
@@ -43,12 +43,12 @@ void Column::SetStyle(const ContainerStyle value)
     m_style = value;
 }
 
-const std::vector<std::shared_ptr<BaseCardElement>>& Column::GetItems() const
+const std::vector<std::shared_ptr<BaseCardElement>> &Column::GetItems() const
 {
     return m_items;
 }
 
-std::vector<std::shared_ptr<BaseCardElement>>& Column::GetItems()
+std::vector<std::shared_ptr<BaseCardElement>> &Column::GetItems()
 {
     return m_items;
 }
@@ -91,7 +91,7 @@ Json::Value Column::SerializeToJsonValue() const
 
     std::string propertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Items);
     root[propertyName] = Json::Value(Json::arrayValue);
-    for (const auto& cardElement : m_items)
+    for (const auto &cardElement : m_items)
     {
         root[propertyName].append(cardElement->SerializeToJsonValue());
     }
@@ -106,7 +106,7 @@ Json::Value Column::SerializeToJsonValue() const
 }
 
 std::shared_ptr<Column> Column::Deserialize(std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& value)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &value)
 {
     auto column = BaseCardElement::Deserialize<Column>(value);
 
@@ -165,7 +165,7 @@ std::shared_ptr<Column> Column::Deserialize(std::shared_ptr<ElementParserRegistr
 
 std::shared_ptr<Column> Column::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString)
 {
     return Column::Deserialize(
         elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
@@ -190,12 +190,12 @@ void Column::PopulateKnownPropertiesSet()
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::VerticalContentAlignment));
 }
 
-void Column::SetLanguage(const std::string& language)
+void Column::SetLanguage(const std::string &language)
 {
     PropagateLanguage(language, m_items);
 }
 
-void Column::GetResourceUris(std::vector<std::string>& resourceUris)
+void Column::GetResourceUris(std::vector<std::string> &resourceUris)
 {
     auto columnItems = GetItems();
     for (auto item : columnItems)

--- a/source/shared/cpp/ObjectModel/Column.h
+++ b/source/shared/cpp/ObjectModel/Column.h
@@ -5,56 +5,54 @@
 #include "BaseActionElement.h"
 #include "BaseCardElement.h"
 
-AdaptiveSharedNamespaceStart
-class Column : public BaseCardElement
+namespace AdaptiveSharedNamespace
 {
-public:
-    Column();
+    class Column : public BaseCardElement
+    {
+        public:
+        Column();
 
-    virtual std::string Serialize() const;
-    virtual Json::Value SerializeToJsonValue() const override;
+        virtual std::string Serialize() const;
+        virtual Json::Value SerializeToJsonValue() const override;
 
-    static std::shared_ptr<Column> Deserialize(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const Json::Value& root);
+        static std::shared_ptr<Column> Deserialize(std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
 
-    static std::shared_ptr<Column> DeserializeFromString(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const std::string& jsonString);
+        static std::shared_ptr<Column> DeserializeFromString(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
 
-    std::string GetWidth() const;
-    void SetWidth(const std::string &value);
+        std::string GetWidth() const;
+        void SetWidth(const std::string& value);
 
-    // explicit width takes precedence over relative width 
-    int GetPixelWidth() const;
-    void SetPixelWidth(const int value);
+        // explicit width takes precedence over relative width
+        int GetPixelWidth() const;
+        void SetPixelWidth(const int value);
 
-    ContainerStyle GetStyle() const;
-    void SetStyle(const ContainerStyle value);
+        ContainerStyle GetStyle() const;
+        void SetStyle(const ContainerStyle value);
 
-    std::vector<std::shared_ptr<BaseCardElement>>& GetItems();
-    const std::vector<std::shared_ptr<BaseCardElement>>& GetItems() const;
+        std::vector<std::shared_ptr<BaseCardElement>>& GetItems();
+        const std::vector<std::shared_ptr<BaseCardElement>>& GetItems() const;
 
-    std::shared_ptr<BaseActionElement> GetSelectAction() const;
-    void SetSelectAction(const std::shared_ptr<BaseActionElement> action);
+        std::shared_ptr<BaseActionElement> GetSelectAction() const;
+        void SetSelectAction(const std::shared_ptr<BaseActionElement> action);
 
-    void SetLanguage(const std::string& language);
+        void SetLanguage(const std::string& language);
 
-    VerticalContentAlignment GetVerticalContentAlignment() const;
-    void SetVerticalContentAlignment(const VerticalContentAlignment value);
+        VerticalContentAlignment GetVerticalContentAlignment() const;
+        void SetVerticalContentAlignment(const VerticalContentAlignment value);
 
-    virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
+        virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
 
-private:
-    void PopulateKnownPropertiesSet();
+        private:
+        void PopulateKnownPropertiesSet();
 
-    std::string m_width;
-    unsigned int m_pixelWidth;
-    std::vector<std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>> m_items;
-    std::shared_ptr<BaseActionElement> m_selectAction;
-    ContainerStyle m_style;
-    VerticalContentAlignment m_verticalContentAlignment;
-};
-AdaptiveSharedNamespaceEnd
+        std::string m_width;
+        unsigned int m_pixelWidth;
+        std::vector<std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>> m_items;
+        std::shared_ptr<BaseActionElement> m_selectAction;
+        ContainerStyle m_style;
+        VerticalContentAlignment m_verticalContentAlignment;
+    };
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/Column.h
+++ b/source/shared/cpp/ObjectModel/Column.h
@@ -9,7 +9,7 @@ namespace AdaptiveSharedNamespace
 {
     class Column : public BaseCardElement
     {
-        public:
+    public:
         Column();
 
         virtual std::string Serialize() const;
@@ -45,7 +45,7 @@ namespace AdaptiveSharedNamespace
 
         virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
 
-        private:
+    private:
         void PopulateKnownPropertiesSet();
 
         std::string m_width;

--- a/source/shared/cpp/ObjectModel/Column.h
+++ b/source/shared/cpp/ObjectModel/Column.h
@@ -16,14 +16,14 @@ namespace AdaptiveSharedNamespace
         virtual Json::Value SerializeToJsonValue() const override;
 
         static std::shared_ptr<Column> Deserialize(std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &root);
 
         static std::shared_ptr<Column> DeserializeFromString(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString);
 
         std::string GetWidth() const;
-        void SetWidth(const std::string& value);
+        void SetWidth(const std::string &value);
 
         // explicit width takes precedence over relative width
         int GetPixelWidth() const;
@@ -32,18 +32,18 @@ namespace AdaptiveSharedNamespace
         ContainerStyle GetStyle() const;
         void SetStyle(const ContainerStyle value);
 
-        std::vector<std::shared_ptr<BaseCardElement>>& GetItems();
-        const std::vector<std::shared_ptr<BaseCardElement>>& GetItems() const;
+        std::vector<std::shared_ptr<BaseCardElement>> &GetItems();
+        const std::vector<std::shared_ptr<BaseCardElement>> &GetItems() const;
 
         std::shared_ptr<BaseActionElement> GetSelectAction() const;
         void SetSelectAction(const std::shared_ptr<BaseActionElement> action);
 
-        void SetLanguage(const std::string& language);
+        void SetLanguage(const std::string &language);
 
         VerticalContentAlignment GetVerticalContentAlignment() const;
         void SetVerticalContentAlignment(const VerticalContentAlignment value);
 
-        virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
+        virtual void GetResourceUris(std::vector<std::string> &resourceUris) override;
 
     private:
         void PopulateKnownPropertiesSet();

--- a/source/shared/cpp/ObjectModel/ColumnSet.cpp
+++ b/source/shared/cpp/ObjectModel/ColumnSet.cpp
@@ -43,7 +43,7 @@ Json::Value ColumnSet::SerializeToJsonValue() const
 {
     Json::Value root = BaseCardElement::SerializeToJsonValue();
 
-    std::string const &propertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Columns);
+    std::string const& propertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Columns);
     root[propertyName] = Json::Value(Json::arrayValue);
     for (const auto& column : m_columns)
     {
@@ -52,7 +52,8 @@ Json::Value ColumnSet::SerializeToJsonValue() const
 
     if (m_selectAction != nullptr)
     {
-        root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::SelectAction)] = BaseCardElement::SerializeSelectAction(m_selectAction);
+        root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::SelectAction)] =
+            BaseCardElement::SerializeSelectAction(m_selectAction);
     }
 
     return root;
@@ -60,32 +61,33 @@ Json::Value ColumnSet::SerializeToJsonValue() const
 
 std::shared_ptr<BaseCardElement> ColumnSetParser::Deserialize(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-    const Json::Value& value)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& value)
 {
     ParseUtil::ExpectTypeString(value, CardElementType::ColumnSet);
 
     auto container = BaseCardElement::Deserialize<ColumnSet>(value);
 
     // Parse Columns
-    auto cardElements = ParseUtil::GetElementCollectionOfSingleType<Column>(elementParserRegistration, actionParserRegistration, value, AdaptiveCardSchemaKey::Columns, Column::Deserialize, true);
+    auto cardElements = ParseUtil::GetElementCollectionOfSingleType<Column>(elementParserRegistration,
+        actionParserRegistration, value, AdaptiveCardSchemaKey::Columns, Column::Deserialize, true);
     container->m_columns = std::move(cardElements);
 
     // Parse optional selectAction
-    container->SetSelectAction(ParseUtil::GetSelectAction(elementParserRegistration, actionParserRegistration, value, AdaptiveCardSchemaKey::SelectAction, false));
+    container->SetSelectAction(ParseUtil::GetSelectAction(
+        elementParserRegistration, actionParserRegistration, value, AdaptiveCardSchemaKey::SelectAction, false));
 
     return container;
 }
 
 std::shared_ptr<BaseCardElement> ColumnSetParser::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-    const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
 {
-    return ColumnSetParser::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
+    return ColumnSetParser::Deserialize(
+        elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
-void ColumnSet::PopulateKnownPropertiesSet() 
+void ColumnSet::PopulateKnownPropertiesSet()
 {
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Columns));
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::SelectAction));

--- a/source/shared/cpp/ObjectModel/ColumnSet.cpp
+++ b/source/shared/cpp/ObjectModel/ColumnSet.cpp
@@ -11,12 +11,12 @@ ColumnSet::ColumnSet() : BaseCardElement(CardElementType::ColumnSet)
     PopulateKnownPropertiesSet();
 }
 
-const std::vector<std::shared_ptr<Column>>& ColumnSet::GetColumns() const
+const std::vector<std::shared_ptr<Column>> &ColumnSet::GetColumns() const
 {
     return m_columns;
 }
 
-std::vector<std::shared_ptr<Column>>& ColumnSet::GetColumns()
+std::vector<std::shared_ptr<Column>> &ColumnSet::GetColumns()
 {
     return m_columns;
 }
@@ -31,9 +31,9 @@ void ColumnSet::SetSelectAction(const std::shared_ptr<BaseActionElement> action)
     m_selectAction = action;
 }
 
-void ColumnSet::SetLanguage(const std::string& language)
+void ColumnSet::SetLanguage(const std::string &language)
 {
-    for (auto& column : m_columns)
+    for (auto &column : m_columns)
     {
         column->SetLanguage(language);
     }
@@ -43,9 +43,9 @@ Json::Value ColumnSet::SerializeToJsonValue() const
 {
     Json::Value root = BaseCardElement::SerializeToJsonValue();
 
-    std::string const& propertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Columns);
+    std::string const &propertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Columns);
     root[propertyName] = Json::Value(Json::arrayValue);
-    for (const auto& column : m_columns)
+    for (const auto &column : m_columns)
     {
         root[propertyName].append(column->SerializeToJsonValue());
     }
@@ -61,7 +61,7 @@ Json::Value ColumnSet::SerializeToJsonValue() const
 
 std::shared_ptr<BaseCardElement> ColumnSetParser::Deserialize(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& value)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &value)
 {
     ParseUtil::ExpectTypeString(value, CardElementType::ColumnSet);
 
@@ -81,7 +81,7 @@ std::shared_ptr<BaseCardElement> ColumnSetParser::Deserialize(
 
 std::shared_ptr<BaseCardElement> ColumnSetParser::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString)
 {
     return ColumnSetParser::Deserialize(
         elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
@@ -93,7 +93,7 @@ void ColumnSet::PopulateKnownPropertiesSet()
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::SelectAction));
 }
 
-void ColumnSet::GetResourceUris(std::vector<std::string>& resourceUris)
+void ColumnSet::GetResourceUris(std::vector<std::string> &resourceUris)
 {
     auto columns = GetColumns();
     for (auto column : columns)

--- a/source/shared/cpp/ObjectModel/ColumnSet.h
+++ b/source/shared/cpp/ObjectModel/ColumnSet.h
@@ -17,20 +17,20 @@ namespace AdaptiveSharedNamespace
 
         virtual Json::Value SerializeToJsonValue() const override;
 
-        std::vector<std::shared_ptr<Column>>& GetColumns();
-        const std::vector<std::shared_ptr<Column>>& GetColumns() const;
+        std::vector<std::shared_ptr<Column>> &GetColumns();
+        const std::vector<std::shared_ptr<Column>> &GetColumns() const;
 
         std::shared_ptr<BaseActionElement> GetSelectAction() const;
         void SetSelectAction(const std::shared_ptr<BaseActionElement> action);
 
-        void SetLanguage(const std::string& language);
+        void SetLanguage(const std::string &language);
 
-        virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
+        virtual void GetResourceUris(std::vector<std::string> &resourceUris) override;
 
     private:
         void PopulateKnownPropertiesSet();
 
-        static const std::unordered_map<CardElementType, std::function<std::shared_ptr<Column>(const Json::Value&)>,
+        static const std::unordered_map<CardElementType, std::function<std::shared_ptr<Column>(const Json::Value &)>,
             EnumHash>
             ColumnParser;
         std::vector<std::shared_ptr<Column>> m_columns;
@@ -42,10 +42,10 @@ namespace AdaptiveSharedNamespace
     public:
         std::shared_ptr<BaseCardElement> Deserialize(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &root);
 
         std::shared_ptr<BaseCardElement> DeserializeFromString(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString);
     };
 } // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/ColumnSet.h
+++ b/source/shared/cpp/ObjectModel/ColumnSet.h
@@ -6,44 +6,46 @@
 #include "Column.h"
 #include "ElementParserRegistration.h"
 
-AdaptiveSharedNamespaceStart
-class ColumnSet : public BaseCardElement
+namespace AdaptiveSharedNamespace
 {
-friend class ColumnSetParser;
-public:
-    ColumnSet();
+    class ColumnSet : public BaseCardElement
+    {
+        friend class ColumnSetParser;
 
-    virtual Json::Value SerializeToJsonValue() const override;
+        public:
+        ColumnSet();
 
-    std::vector<std::shared_ptr<Column>>& GetColumns();
-    const std::vector<std::shared_ptr<Column>>& GetColumns() const;
+        virtual Json::Value SerializeToJsonValue() const override;
 
-    std::shared_ptr<BaseActionElement> GetSelectAction() const;
-    void SetSelectAction(const std::shared_ptr<BaseActionElement> action);
+        std::vector<std::shared_ptr<Column>>& GetColumns();
+        const std::vector<std::shared_ptr<Column>>& GetColumns() const;
 
-    void SetLanguage(const std::string& language);
+        std::shared_ptr<BaseActionElement> GetSelectAction() const;
+        void SetSelectAction(const std::shared_ptr<BaseActionElement> action);
 
-    virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
+        void SetLanguage(const std::string& language);
 
-private:
-    void PopulateKnownPropertiesSet();
+        virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
 
-    static const std::unordered_map<CardElementType, std::function<std::shared_ptr<Column>(const Json::Value&)>, EnumHash> ColumnParser;
-    std::vector<std::shared_ptr<Column>> m_columns;
-    std::shared_ptr<BaseActionElement> m_selectAction;
-};
+        private:
+        void PopulateKnownPropertiesSet();
 
-class ColumnSetParser : public BaseCardElementParser
-{
-public:
-    std::shared_ptr<BaseCardElement> Deserialize(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const Json::Value& root);
+        static const std::unordered_map<CardElementType, std::function<std::shared_ptr<Column>(const Json::Value&)>,
+            EnumHash>
+            ColumnParser;
+        std::vector<std::shared_ptr<Column>> m_columns;
+        std::shared_ptr<BaseActionElement> m_selectAction;
+    };
 
-    std::shared_ptr<BaseCardElement> DeserializeFromString(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const std::string& jsonString);
-};
-AdaptiveSharedNamespaceEnd
+    class ColumnSetParser : public BaseCardElementParser
+    {
+        public:
+        std::shared_ptr<BaseCardElement> Deserialize(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
+
+        std::shared_ptr<BaseCardElement> DeserializeFromString(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+    };
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/ColumnSet.h
+++ b/source/shared/cpp/ObjectModel/ColumnSet.h
@@ -12,7 +12,7 @@ namespace AdaptiveSharedNamespace
     {
         friend class ColumnSetParser;
 
-        public:
+    public:
         ColumnSet();
 
         virtual Json::Value SerializeToJsonValue() const override;
@@ -27,7 +27,7 @@ namespace AdaptiveSharedNamespace
 
         virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
 
-        private:
+    private:
         void PopulateKnownPropertiesSet();
 
         static const std::unordered_map<CardElementType, std::function<std::shared_ptr<Column>(const Json::Value&)>,
@@ -39,7 +39,7 @@ namespace AdaptiveSharedNamespace
 
     class ColumnSetParser : public BaseCardElementParser
     {
-        public:
+    public:
         std::shared_ptr<BaseCardElement> Deserialize(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
             std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);

--- a/source/shared/cpp/ObjectModel/Container.cpp
+++ b/source/shared/cpp/ObjectModel/Container.cpp
@@ -13,12 +13,12 @@ Container::Container() :
     PopulateKnownPropertiesSet();
 }
 
-const std::vector<std::shared_ptr<BaseCardElement>>& Container::GetItems() const
+const std::vector<std::shared_ptr<BaseCardElement>> &Container::GetItems() const
 {
     return m_items;
 }
 
-std::vector<std::shared_ptr<BaseCardElement>>& Container::GetItems()
+std::vector<std::shared_ptr<BaseCardElement>> &Container::GetItems()
 {
     return m_items;
 }
@@ -43,7 +43,7 @@ void Container::SetSelectAction(const std::shared_ptr<BaseActionElement> action)
     m_selectAction = action;
 }
 
-void Container::SetLanguage(const std::string& value)
+void Container::SetLanguage(const std::string &value)
 {
     PropagateLanguage(value, m_items);
 }
@@ -73,9 +73,9 @@ Json::Value Container::SerializeToJsonValue() const
             VerticalContentAlignmentToString(m_verticalContentAlignment);
     }
 
-    std::string const& itemsPropertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Items);
+    std::string const &itemsPropertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Items);
     root[itemsPropertyName] = Json::Value(Json::arrayValue);
-    for (const auto& cardElement : m_items)
+    for (const auto &cardElement : m_items)
     {
         root[itemsPropertyName].append(cardElement->SerializeToJsonValue());
     }
@@ -91,7 +91,7 @@ Json::Value Container::SerializeToJsonValue() const
 
 std::shared_ptr<BaseCardElement> ContainerParser::Deserialize(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& value)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &value)
 {
     ParseUtil::ExpectTypeString(value, CardElementType::Container);
 
@@ -118,7 +118,7 @@ std::shared_ptr<BaseCardElement> ContainerParser::Deserialize(
 
 std::shared_ptr<BaseCardElement> ContainerParser::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString)
 {
     return ContainerParser::Deserialize(
         elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
@@ -132,7 +132,7 @@ void Container::PopulateKnownPropertiesSet()
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Items));
 }
 
-void Container::GetResourceUris(std::vector<std::string>& resourceUris)
+void Container::GetResourceUris(std::vector<std::string> &resourceUris)
 {
     auto items = GetItems();
     for (auto item : items)

--- a/source/shared/cpp/ObjectModel/Container.cpp
+++ b/source/shared/cpp/ObjectModel/Container.cpp
@@ -6,7 +6,9 @@
 
 using namespace AdaptiveSharedNamespace;
 
-Container::Container() : BaseCardElement(CardElementType::Container), m_style(ContainerStyle::None), m_verticalContentAlignment(VerticalContentAlignment::Stretch)
+Container::Container() :
+    BaseCardElement(CardElementType::Container), m_style(ContainerStyle::None),
+    m_verticalContentAlignment(VerticalContentAlignment::Stretch)
 {
     PopulateKnownPropertiesSet();
 }
@@ -67,10 +69,11 @@ Json::Value Container::SerializeToJsonValue() const
 
     if (m_verticalContentAlignment != VerticalContentAlignment::Stretch)
     {
-        root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::VerticalContentAlignment)] = VerticalContentAlignmentToString(m_verticalContentAlignment);
+        root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::VerticalContentAlignment)] =
+            VerticalContentAlignmentToString(m_verticalContentAlignment);
     }
 
-    std::string const &itemsPropertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Items);
+    std::string const& itemsPropertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Items);
     root[itemsPropertyName] = Json::Value(Json::arrayValue);
     for (const auto& cardElement : m_items)
     {
@@ -79,7 +82,8 @@ Json::Value Container::SerializeToJsonValue() const
 
     if (m_selectAction != nullptr)
     {
-        root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::SelectAction)] = BaseCardElement::SerializeSelectAction(m_selectAction);
+        root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::SelectAction)] =
+            BaseCardElement::SerializeSelectAction(m_selectAction);
     }
 
     return root;
@@ -87,38 +91,40 @@ Json::Value Container::SerializeToJsonValue() const
 
 std::shared_ptr<BaseCardElement> ContainerParser::Deserialize(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-    const Json::Value& value)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& value)
 {
     ParseUtil::ExpectTypeString(value, CardElementType::Container);
 
     auto container = BaseCardElement::Deserialize<Container>(value);
 
-    container->SetStyle(
-        ParseUtil::GetEnumValue<ContainerStyle>(value, AdaptiveCardSchemaKey::Style, ContainerStyle::None, ContainerStyleFromString));
+    container->SetStyle(ParseUtil::GetEnumValue<ContainerStyle>(
+        value, AdaptiveCardSchemaKey::Style, ContainerStyle::None, ContainerStyleFromString));
 
-    container->SetVerticalContentAlignment(ParseUtil::GetEnumValue<VerticalContentAlignment>(value, AdaptiveCardSchemaKey::VerticalContentAlignment, 
-        VerticalContentAlignment::Stretch, VerticalContentAlignmentFromString));
+    container->SetVerticalContentAlignment(
+        ParseUtil::GetEnumValue<VerticalContentAlignment>(value, AdaptiveCardSchemaKey::VerticalContentAlignment,
+            VerticalContentAlignment::Stretch, VerticalContentAlignmentFromString));
 
     // Parse Items
-    auto cardElements = ParseUtil::GetElementCollection(elementParserRegistration, actionParserRegistration, value, AdaptiveCardSchemaKey::Items, false);
+    auto cardElements = ParseUtil::GetElementCollection(
+        elementParserRegistration, actionParserRegistration, value, AdaptiveCardSchemaKey::Items, false);
     container->m_items = std::move(cardElements);
 
     // Parse optional selectAction
-    container->SetSelectAction(ParseUtil::GetSelectAction(elementParserRegistration, actionParserRegistration, value, AdaptiveCardSchemaKey::SelectAction, false));
+    container->SetSelectAction(ParseUtil::GetSelectAction(
+        elementParserRegistration, actionParserRegistration, value, AdaptiveCardSchemaKey::SelectAction, false));
 
     return container;
 }
 
 std::shared_ptr<BaseCardElement> ContainerParser::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-    const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
 {
-    return ContainerParser::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
+    return ContainerParser::Deserialize(
+        elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
-void Container::PopulateKnownPropertiesSet() 
+void Container::PopulateKnownPropertiesSet()
 {
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Style));
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::VerticalContentAlignment));

--- a/source/shared/cpp/ObjectModel/Container.h
+++ b/source/shared/cpp/ObjectModel/Container.h
@@ -17,8 +17,8 @@ namespace AdaptiveSharedNamespace
 
         virtual Json::Value SerializeToJsonValue() const override;
 
-        std::vector<std::shared_ptr<BaseCardElement>>& GetItems();
-        const std::vector<std::shared_ptr<BaseCardElement>>& GetItems() const;
+        std::vector<std::shared_ptr<BaseCardElement>> &GetItems();
+        const std::vector<std::shared_ptr<BaseCardElement>> &GetItems() const;
 
         ContainerStyle GetStyle() const;
         void SetStyle(const ContainerStyle value);
@@ -26,12 +26,12 @@ namespace AdaptiveSharedNamespace
         std::shared_ptr<BaseActionElement> GetSelectAction() const;
         void SetSelectAction(const std::shared_ptr<BaseActionElement> action);
 
-        void SetLanguage(const std::string& value);
+        void SetLanguage(const std::string &value);
 
         VerticalContentAlignment GetVerticalContentAlignment() const;
         void SetVerticalContentAlignment(const VerticalContentAlignment value);
 
-        virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
+        virtual void GetResourceUris(std::vector<std::string> &resourceUris) override;
 
     private:
         void PopulateKnownPropertiesSet();
@@ -47,10 +47,10 @@ namespace AdaptiveSharedNamespace
     public:
         std::shared_ptr<BaseCardElement> Deserialize(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &root);
 
         std::shared_ptr<BaseCardElement> DeserializeFromString(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString);
     };
 } // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/Container.h
+++ b/source/shared/cpp/ObjectModel/Container.h
@@ -6,51 +6,51 @@
 #include "BaseCardElement.h"
 #include "ElementParserRegistration.h"
 
-AdaptiveSharedNamespaceStart
-class Container : public BaseCardElement
+namespace AdaptiveSharedNamespace
 {
-friend class ContainerParser;
-public:
-    Container();
+    class Container : public BaseCardElement
+    {
+        friend class ContainerParser;
 
-    virtual Json::Value SerializeToJsonValue() const override;
+        public:
+        Container();
 
-    std::vector<std::shared_ptr<BaseCardElement>>& GetItems();
-    const std::vector<std::shared_ptr<BaseCardElement>>& GetItems() const;
+        virtual Json::Value SerializeToJsonValue() const override;
 
-    ContainerStyle GetStyle() const;
-    void SetStyle(const ContainerStyle value);
+        std::vector<std::shared_ptr<BaseCardElement>>& GetItems();
+        const std::vector<std::shared_ptr<BaseCardElement>>& GetItems() const;
 
-    std::shared_ptr<BaseActionElement> GetSelectAction() const;
-    void SetSelectAction(const std::shared_ptr<BaseActionElement> action);
+        ContainerStyle GetStyle() const;
+        void SetStyle(const ContainerStyle value);
 
-    void SetLanguage(const std::string& value);
+        std::shared_ptr<BaseActionElement> GetSelectAction() const;
+        void SetSelectAction(const std::shared_ptr<BaseActionElement> action);
 
-    VerticalContentAlignment GetVerticalContentAlignment() const;
-    void SetVerticalContentAlignment(const VerticalContentAlignment value);
+        void SetLanguage(const std::string& value);
 
-    virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
+        VerticalContentAlignment GetVerticalContentAlignment() const;
+        void SetVerticalContentAlignment(const VerticalContentAlignment value);
 
-private:
-    void PopulateKnownPropertiesSet();
+        virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
 
-    ContainerStyle m_style;
-    VerticalContentAlignment m_verticalContentAlignment;
-    std::vector<std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>> m_items;
-    std::shared_ptr<BaseActionElement> m_selectAction;
-};
+        private:
+        void PopulateKnownPropertiesSet();
 
-class ContainerParser : public BaseCardElementParser
-{
-public:
-    std::shared_ptr<BaseCardElement> Deserialize(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const Json::Value& root);
+        ContainerStyle m_style;
+        VerticalContentAlignment m_verticalContentAlignment;
+        std::vector<std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>> m_items;
+        std::shared_ptr<BaseActionElement> m_selectAction;
+    };
 
-    std::shared_ptr<BaseCardElement> DeserializeFromString(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const std::string& jsonString);
-};
-AdaptiveSharedNamespaceEnd
+    class ContainerParser : public BaseCardElementParser
+    {
+        public:
+        std::shared_ptr<BaseCardElement> Deserialize(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
+
+        std::shared_ptr<BaseCardElement> DeserializeFromString(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+    };
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/Container.h
+++ b/source/shared/cpp/ObjectModel/Container.h
@@ -12,7 +12,7 @@ namespace AdaptiveSharedNamespace
     {
         friend class ContainerParser;
 
-        public:
+    public:
         Container();
 
         virtual Json::Value SerializeToJsonValue() const override;
@@ -33,7 +33,7 @@ namespace AdaptiveSharedNamespace
 
         virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
 
-        private:
+    private:
         void PopulateKnownPropertiesSet();
 
         ContainerStyle m_style;
@@ -44,7 +44,7 @@ namespace AdaptiveSharedNamespace
 
     class ContainerParser : public BaseCardElementParser
     {
-        public:
+    public:
         std::shared_ptr<BaseCardElement> Deserialize(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
             std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);

--- a/source/shared/cpp/ObjectModel/DateInput.cpp
+++ b/source/shared/cpp/ObjectModel/DateInput.cpp
@@ -4,8 +4,7 @@
 
 using namespace AdaptiveSharedNamespace;
 
-DateInput::DateInput() :
-    BaseInputElement(CardElementType::DateInput)
+DateInput::DateInput() : BaseInputElement(CardElementType::DateInput)
 {
     PopulateKnownPropertiesSet();
 }
@@ -42,7 +41,7 @@ std::string DateInput::GetMax() const
     return m_max;
 }
 
-void DateInput::SetMax(const std::string &value)
+void DateInput::SetMax(const std::string& value)
 {
     m_max = value;
 }
@@ -52,7 +51,7 @@ std::string DateInput::GetMin() const
     return m_min;
 }
 
-void DateInput::SetMin(const std::string &value)
+void DateInput::SetMin(const std::string& value)
 {
     m_min = value;
 }
@@ -62,7 +61,7 @@ std::string DateInput::GetPlaceholder() const
     return m_placeholder;
 }
 
-void DateInput::SetPlaceholder(const std::string &value)
+void DateInput::SetPlaceholder(const std::string& value)
 {
     m_placeholder = value;
 }
@@ -72,15 +71,13 @@ std::string DateInput::GetValue() const
     return m_value;
 }
 
-void DateInput::SetValue(const std::string &value)
+void DateInput::SetValue(const std::string& value)
 {
     m_value = value;
 }
 
 std::shared_ptr<BaseCardElement> DateInputParser::Deserialize(
-    std::shared_ptr<ElementParserRegistration>,
-    std::shared_ptr<ActionParserRegistration>,
-    const Json::Value& json)
+    std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value& json)
 {
     ParseUtil::ExpectTypeString(json, CardElementType::DateInput);
 
@@ -96,13 +93,13 @@ std::shared_ptr<BaseCardElement> DateInputParser::Deserialize(
 
 std::shared_ptr<BaseCardElement> DateInputParser::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-    const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
 {
-    return DateInputParser::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
+    return DateInputParser::Deserialize(
+        elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
-void DateInput::PopulateKnownPropertiesSet() 
+void DateInput::PopulateKnownPropertiesSet()
 {
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Max));
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Min));

--- a/source/shared/cpp/ObjectModel/DateInput.cpp
+++ b/source/shared/cpp/ObjectModel/DateInput.cpp
@@ -41,7 +41,7 @@ std::string DateInput::GetMax() const
     return m_max;
 }
 
-void DateInput::SetMax(const std::string& value)
+void DateInput::SetMax(const std::string &value)
 {
     m_max = value;
 }
@@ -51,7 +51,7 @@ std::string DateInput::GetMin() const
     return m_min;
 }
 
-void DateInput::SetMin(const std::string& value)
+void DateInput::SetMin(const std::string &value)
 {
     m_min = value;
 }
@@ -61,7 +61,7 @@ std::string DateInput::GetPlaceholder() const
     return m_placeholder;
 }
 
-void DateInput::SetPlaceholder(const std::string& value)
+void DateInput::SetPlaceholder(const std::string &value)
 {
     m_placeholder = value;
 }
@@ -71,13 +71,13 @@ std::string DateInput::GetValue() const
     return m_value;
 }
 
-void DateInput::SetValue(const std::string& value)
+void DateInput::SetValue(const std::string &value)
 {
     m_value = value;
 }
 
 std::shared_ptr<BaseCardElement> DateInputParser::Deserialize(
-    std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value& json)
+    std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value &json)
 {
     ParseUtil::ExpectTypeString(json, CardElementType::DateInput);
 
@@ -93,7 +93,7 @@ std::shared_ptr<BaseCardElement> DateInputParser::Deserialize(
 
 std::shared_ptr<BaseCardElement> DateInputParser::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString)
 {
     return DateInputParser::Deserialize(
         elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));

--- a/source/shared/cpp/ObjectModel/DateInput.h
+++ b/source/shared/cpp/ObjectModel/DateInput.h
@@ -15,16 +15,16 @@ namespace AdaptiveSharedNamespace
         virtual Json::Value SerializeToJsonValue() const override;
 
         std::string GetMax() const;
-        void SetMax(const std::string& value);
+        void SetMax(const std::string &value);
 
         std::string GetMin() const;
-        void SetMin(const std::string& value);
+        void SetMin(const std::string &value);
 
         std::string GetPlaceholder() const;
-        void SetPlaceholder(const std::string& value);
+        void SetPlaceholder(const std::string &value);
 
         std::string GetValue() const;
-        void SetValue(const std::string& value);
+        void SetValue(const std::string &value);
 
     private:
         void PopulateKnownPropertiesSet();
@@ -40,10 +40,10 @@ namespace AdaptiveSharedNamespace
     public:
         std::shared_ptr<BaseCardElement> Deserialize(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &root);
 
         std::shared_ptr<BaseCardElement> DeserializeFromString(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString);
     };
 } // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/DateInput.h
+++ b/source/shared/cpp/ObjectModel/DateInput.h
@@ -5,46 +5,45 @@
 #include "Enums.h"
 #include "ElementParserRegistration.h"
 
-AdaptiveSharedNamespaceStart
-class DateInput : public BaseInputElement
+namespace AdaptiveSharedNamespace
 {
-public:
-    DateInput();
+    class DateInput : public BaseInputElement
+    {
+        public:
+        DateInput();
 
-    virtual Json::Value SerializeToJsonValue() const override;
+        virtual Json::Value SerializeToJsonValue() const override;
 
-    std::string GetMax() const;
-    void SetMax(const std::string &value);
+        std::string GetMax() const;
+        void SetMax(const std::string& value);
 
-    std::string GetMin() const;
-    void SetMin(const std::string &value);
+        std::string GetMin() const;
+        void SetMin(const std::string& value);
 
-    std::string GetPlaceholder() const;
-    void SetPlaceholder(const std::string &value);
+        std::string GetPlaceholder() const;
+        void SetPlaceholder(const std::string& value);
 
-    std::string GetValue() const;
-    void SetValue(const std::string &value);
+        std::string GetValue() const;
+        void SetValue(const std::string& value);
 
-private:
-    void PopulateKnownPropertiesSet();
+        private:
+        void PopulateKnownPropertiesSet();
 
-    std::string m_max;
-    std::string m_min;
-    std::string m_placeholder;
-    std::string m_value;
-};
+        std::string m_max;
+        std::string m_min;
+        std::string m_placeholder;
+        std::string m_value;
+    };
 
-class DateInputParser : public BaseCardElementParser
-{
-public:
-    std::shared_ptr<BaseCardElement> Deserialize(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const Json::Value& root);
+    class DateInputParser : public BaseCardElementParser
+    {
+        public:
+        std::shared_ptr<BaseCardElement> Deserialize(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
 
-    std::shared_ptr<BaseCardElement> DeserializeFromString(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const std::string& jsonString);
-};
-AdaptiveSharedNamespaceEnd
+        std::shared_ptr<BaseCardElement> DeserializeFromString(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+    };
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/DateInput.h
+++ b/source/shared/cpp/ObjectModel/DateInput.h
@@ -9,7 +9,7 @@ namespace AdaptiveSharedNamespace
 {
     class DateInput : public BaseInputElement
     {
-        public:
+    public:
         DateInput();
 
         virtual Json::Value SerializeToJsonValue() const override;
@@ -26,7 +26,7 @@ namespace AdaptiveSharedNamespace
         std::string GetValue() const;
         void SetValue(const std::string& value);
 
-        private:
+    private:
         void PopulateKnownPropertiesSet();
 
         std::string m_max;
@@ -37,7 +37,7 @@ namespace AdaptiveSharedNamespace
 
     class DateInputParser : public BaseCardElementParser
     {
-        public:
+    public:
         std::shared_ptr<BaseCardElement> Deserialize(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
             std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);

--- a/source/shared/cpp/ObjectModel/DateTimePreparsedToken.cpp
+++ b/source/shared/cpp/ObjectModel/DateTimePreparsedToken.cpp
@@ -3,16 +3,17 @@
 
 using namespace AdaptiveSharedNamespace;
 
-DateTimePreparsedToken::DateTimePreparsedToken() : m_text(""), m_format(DateTimePreparsedTokenFormat::RegularString)
+DateTimePreparsedToken::DateTimePreparsedToken() : m_text(""), m_format(DateTimePreparsedTokenFormat::RegularString) {}
+
+DateTimePreparsedToken::DateTimePreparsedToken(std::string const& text, DateTimePreparsedTokenFormat format) :
+    m_text(text), m_format(format)
 {
 }
 
-DateTimePreparsedToken::DateTimePreparsedToken(std::string const &text, DateTimePreparsedTokenFormat format) : m_text(text), m_format(format)
-{
-}
-
-DateTimePreparsedToken::DateTimePreparsedToken(std::string const &text, struct tm date, DateTimePreparsedTokenFormat format) :
-    m_text(text), m_date(date), m_format(format)
+DateTimePreparsedToken::DateTimePreparsedToken(
+    std::string const& text, struct tm date, DateTimePreparsedTokenFormat format) :
+    m_text(text),
+    m_date(date), m_format(format)
 {
 }
 

--- a/source/shared/cpp/ObjectModel/DateTimePreparsedToken.cpp
+++ b/source/shared/cpp/ObjectModel/DateTimePreparsedToken.cpp
@@ -5,13 +5,13 @@ using namespace AdaptiveSharedNamespace;
 
 DateTimePreparsedToken::DateTimePreparsedToken() : m_text(""), m_format(DateTimePreparsedTokenFormat::RegularString) {}
 
-DateTimePreparsedToken::DateTimePreparsedToken(std::string const& text, DateTimePreparsedTokenFormat format) :
+DateTimePreparsedToken::DateTimePreparsedToken(std::string const &text, DateTimePreparsedTokenFormat format) :
     m_text(text), m_format(format)
 {
 }
 
 DateTimePreparsedToken::DateTimePreparsedToken(
-    std::string const& text, struct tm date, DateTimePreparsedTokenFormat format) :
+    std::string const &text, struct tm date, DateTimePreparsedTokenFormat format) :
     m_text(text),
     m_date(date), m_format(format)
 {

--- a/source/shared/cpp/ObjectModel/DateTimePreparsedToken.h
+++ b/source/shared/cpp/ObjectModel/DateTimePreparsedToken.h
@@ -9,8 +9,8 @@ namespace AdaptiveSharedNamespace
     {
     public:
         DateTimePreparsedToken();
-        DateTimePreparsedToken(std::string const& text, DateTimePreparsedTokenFormat format);
-        DateTimePreparsedToken(std::string const& text, struct tm date, DateTimePreparsedTokenFormat format);
+        DateTimePreparsedToken(std::string const &text, DateTimePreparsedTokenFormat format);
+        DateTimePreparsedToken(std::string const &text, struct tm date, DateTimePreparsedTokenFormat format);
 
         std::string GetText() const;
         DateTimePreparsedTokenFormat GetFormat() const;

--- a/source/shared/cpp/ObjectModel/DateTimePreparsedToken.h
+++ b/source/shared/cpp/ObjectModel/DateTimePreparsedToken.h
@@ -3,26 +3,27 @@
 #include <vector>
 #include "Enums.h"
 
-AdaptiveSharedNamespaceStart
+namespace AdaptiveSharedNamespace
+{
     class DateTimePreparsedToken
     {
-    public:
+        public:
         DateTimePreparsedToken();
-        DateTimePreparsedToken(std::string const &text, DateTimePreparsedTokenFormat format);
-        DateTimePreparsedToken(std::string const &text, struct tm date, DateTimePreparsedTokenFormat format);
+        DateTimePreparsedToken(std::string const& text, DateTimePreparsedTokenFormat format);
+        DateTimePreparsedToken(std::string const& text, struct tm date, DateTimePreparsedTokenFormat format);
 
         std::string GetText() const;
         DateTimePreparsedTokenFormat GetFormat() const;
         // returns values 1-31
         int GetDay() const;
-        // returns values 0-11 
+        // returns values 0-11
         int GetMonth() const;
         // return values 1900 onward
         int GetYear() const;
 
-    private:
+        private:
         std::string m_text;
         struct tm m_date;
         DateTimePreparsedTokenFormat m_format;
     };
-AdaptiveSharedNamespaceEnd
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/DateTimePreparsedToken.h
+++ b/source/shared/cpp/ObjectModel/DateTimePreparsedToken.h
@@ -7,7 +7,7 @@ namespace AdaptiveSharedNamespace
 {
     class DateTimePreparsedToken
     {
-        public:
+    public:
         DateTimePreparsedToken();
         DateTimePreparsedToken(std::string const& text, DateTimePreparsedTokenFormat format);
         DateTimePreparsedToken(std::string const& text, struct tm date, DateTimePreparsedTokenFormat format);
@@ -21,7 +21,7 @@ namespace AdaptiveSharedNamespace
         // return values 1900 onward
         int GetYear() const;
 
-        private:
+    private:
         std::string m_text;
         struct tm m_date;
         DateTimePreparsedTokenFormat m_format;

--- a/source/shared/cpp/ObjectModel/DateTimePreparser.cpp
+++ b/source/shared/cpp/ObjectModel/DateTimePreparser.cpp
@@ -1,9 +1,9 @@
 #include "pch.h"
 
 #if defined(__ANDROID__) || (__APPLE__) || (__linux__)
-#define LOCALTIME(X,Y) (nullptr == localtime_r(Y, X))
+#define LOCALTIME(X, Y) (nullptr == localtime_r(Y, X))
 #else
-#define LOCALTIME(X,Y) localtime_s(X,Y)
+#define LOCALTIME(X, Y) localtime_s(X, Y)
 #endif
 
 #include "DateTimePreparsedToken.h"
@@ -20,12 +20,9 @@
 
 using namespace AdaptiveSharedNamespace;
 
-DateTimePreparser::DateTimePreparser() :
-    m_hasDateTokens(false)
-{
-}
+DateTimePreparser::DateTimePreparser() : m_hasDateTokens(false) {}
 
-DateTimePreparser::DateTimePreparser(std::string const &in)
+DateTimePreparser::DateTimePreparser(std::string const& in)
 {
     ParseDateTime(in);
 }
@@ -40,7 +37,7 @@ bool DateTimePreparser::HasDateTokens() const
     return m_hasDateTokens;
 }
 
-void DateTimePreparser::AddTextToken(std::string const &text, DateTimePreparsedTokenFormat format)
+void DateTimePreparser::AddTextToken(std::string const& text, DateTimePreparsedTokenFormat format)
 {
     if (!text.empty())
     {
@@ -48,7 +45,7 @@ void DateTimePreparser::AddTextToken(std::string const &text, DateTimePreparsedT
     }
 }
 
-void DateTimePreparser::AddDateToken(std::string const &text, struct tm date, DateTimePreparsedTokenFormat format)
+void DateTimePreparser::AddDateToken(std::string const& text, struct tm date, DateTimePreparsedTokenFormat format)
 {
     m_textTokenCollection.emplace_back(std::make_shared<DateTimePreparsedToken>(text, date, format));
     m_hasDateTokens = true;
@@ -64,10 +61,10 @@ std::string DateTimePreparser::Concatenate() const
     return formedString;
 }
 
-bool DateTimePreparser::IsValidTimeAndDate(const struct tm &parsedTm, int hours, int minutes)
+bool DateTimePreparser::IsValidTimeAndDate(const struct tm& parsedTm, int hours, int minutes)
 {
-    if (parsedTm.tm_mon <= 12 && parsedTm.tm_mday <= 31 && parsedTm.tm_hour <= 24 &&
-        parsedTm.tm_min <= 60 && parsedTm.tm_sec <= 60 && hours <= 24 && minutes <= 60)
+    if (parsedTm.tm_mon <= 12 && parsedTm.tm_mday <= 31 && parsedTm.tm_hour <= 24 && parsedTm.tm_min <= 60 &&
+        parsedTm.tm_sec <= 60 && hours <= 24 && minutes <= 60)
     {
         if (parsedTm.tm_mon == 4 || parsedTm.tm_mon == 6 || parsedTm.tm_mon == 9 || parsedTm.tm_mon == 11)
         {
@@ -89,11 +86,12 @@ bool DateTimePreparser::IsValidTimeAndDate(const struct tm &parsedTm, int hours,
     return false;
 }
 
-void DateTimePreparser::ParseDateTime(std::string const &in)
+void DateTimePreparser::ParseDateTime(std::string const& in)
 {
     std::vector<DateTimePreparsedToken> sections;
 
-    std::regex pattern("\\{\\{((DATE)|(TIME))\\((\\d{4})-{1}(\\d{2})-{1}(\\d{2})T(\\d{2}):{1}(\\d{2}):{1}(\\d{2})(Z|(([+-])(\\d{2}):{1}(\\d{2})))((((, ?SHORT)|(, ?LONG))|(, ?COMPACT))|)\\)\\}\\}");
+    std::regex pattern(
+        "\\{\\{((DATE)|(TIME))\\((\\d{4})-{1}(\\d{2})-{1}(\\d{2})T(\\d{2}):{1}(\\d{2}):{1}(\\d{2})(Z|(([+-])(\\d{2}):{1}(\\d{2})))((((, ?SHORT)|(, ?LONG))|(, ?COMPACT))|)\\)\\}\\}");
     std::smatch matches;
     std::string text = in;
     enum MatchIndex
@@ -116,13 +114,14 @@ void DateTimePreparser::ParseDateTime(std::string const &in)
     while (std::regex_search(text, matches, pattern))
     {
         time_t offset{};
-        int  formatStyle{};
+        int formatStyle{};
         // Date is matched
         bool isDate = matches[IsDate].matched;
         int hours{}, minutes{};
-        struct tm parsedTm{};
-        int *addrs[] = {&parsedTm.tm_year, &parsedTm.tm_mon,
-            &parsedTm.tm_mday, &parsedTm.tm_hour, &parsedTm.tm_min,
+        struct tm parsedTm
+        {
+        };
+        int* addrs[] = {&parsedTm.tm_year, &parsedTm.tm_mon, &parsedTm.tm_mday, &parsedTm.tm_hour, &parsedTm.tm_min,
             &parsedTm.tm_sec, &hours, &minutes};
 
         if (matches[Style].matched)
@@ -155,8 +154,8 @@ void DateTimePreparser::ParseDateTime(std::string const &in)
         // check for date and time validation
         if (IsValidTimeAndDate(parsedTm, hours, minutes))
         {
-            // maches offset sign, 
-            // Z == UTC, 
+            // maches offset sign,
+            // Z == UTC,
             // + == time added from UTC
             // - == time subtracted from UTC
             if (matches[TimeZone].matched)
@@ -167,7 +166,7 @@ void DateTimePreparser::ParseDateTime(std::string const &in)
                 offset = (time_t)hours + (time_t)minutes;
 
                 wchar_t zone = matches[TimeZone].str()[0];
-                // time zone offset calculation 
+                // time zone offset calculation
                 if (zone == '+')
                 {
                     offset *= -1;
@@ -194,12 +193,14 @@ void DateTimePreparser::ParseDateTime(std::string const &in)
             offset += ((time_t)(nTzOffset / 100) * 3600 + (time_t)(nTzOffset % 100) * 60);
             // add offset to utc
             utc += offset;
-            struct tm result{};
+            struct tm result
+            {
+            };
 
             // converts to local time from utc
             if (!LOCALTIME(&result, &utc))
             {
-                // localtime() set dst, put_time adjusts time accordingly which is not what we want since 
+                // localtime() set dst, put_time adjusts time accordingly which is not what we want since
                 // we have already taken cared of it in our calculation
                 if (result.tm_isdst == 1)
                 {
@@ -210,18 +211,19 @@ void DateTimePreparser::ParseDateTime(std::string const &in)
                 {
                     switch (formatStyle)
                     {
-                        // SHORT Style
-                        case 'S':
-                            AddDateToken(matches[0].str(), result, DateTimePreparsedTokenFormat::DateShort);
-                            break;
-                        // LONG Style
-                        case 'L':
-                            AddDateToken(matches[0].str(), result, DateTimePreparsedTokenFormat::DateLong);
-                            break;
-                        // COMPACT or DEFAULT Style
-                        case 'C': default:
-                            AddDateToken(matches[0].str(), result , DateTimePreparsedTokenFormat::DateCompact);
-                            break;
+                    // SHORT Style
+                    case 'S':
+                        AddDateToken(matches[0].str(), result, DateTimePreparsedTokenFormat::DateShort);
+                        break;
+                    // LONG Style
+                    case 'L':
+                        AddDateToken(matches[0].str(), result, DateTimePreparsedTokenFormat::DateLong);
+                        break;
+                    // COMPACT or DEFAULT Style
+                    case 'C':
+                    default:
+                        AddDateToken(matches[0].str(), result, DateTimePreparsedTokenFormat::DateCompact);
+                        break;
                     }
                 }
                 else
@@ -236,7 +238,7 @@ void DateTimePreparser::ParseDateTime(std::string const &in)
         {
             AddTextToken(matches[0].str(), DateTimePreparsedTokenFormat::RegularString);
         }
-        
+
         text = matches.suffix().str();
     }
 

--- a/source/shared/cpp/ObjectModel/DateTimePreparser.cpp
+++ b/source/shared/cpp/ObjectModel/DateTimePreparser.cpp
@@ -22,7 +22,7 @@ using namespace AdaptiveSharedNamespace;
 
 DateTimePreparser::DateTimePreparser() : m_hasDateTokens(false) {}
 
-DateTimePreparser::DateTimePreparser(std::string const& in)
+DateTimePreparser::DateTimePreparser(std::string const &in)
 {
     ParseDateTime(in);
 }
@@ -37,7 +37,7 @@ bool DateTimePreparser::HasDateTokens() const
     return m_hasDateTokens;
 }
 
-void DateTimePreparser::AddTextToken(std::string const& text, DateTimePreparsedTokenFormat format)
+void DateTimePreparser::AddTextToken(std::string const &text, DateTimePreparsedTokenFormat format)
 {
     if (!text.empty())
     {
@@ -45,7 +45,7 @@ void DateTimePreparser::AddTextToken(std::string const& text, DateTimePreparsedT
     }
 }
 
-void DateTimePreparser::AddDateToken(std::string const& text, struct tm date, DateTimePreparsedTokenFormat format)
+void DateTimePreparser::AddDateToken(std::string const &text, struct tm date, DateTimePreparsedTokenFormat format)
 {
     m_textTokenCollection.emplace_back(std::make_shared<DateTimePreparsedToken>(text, date, format));
     m_hasDateTokens = true;
@@ -54,14 +54,14 @@ void DateTimePreparser::AddDateToken(std::string const& text, struct tm date, Da
 std::string DateTimePreparser::Concatenate() const
 {
     std::string formedString;
-    for (const auto& piece : m_textTokenCollection)
+    for (const auto &piece : m_textTokenCollection)
     {
         formedString += piece->GetText();
     }
     return formedString;
 }
 
-bool DateTimePreparser::IsValidTimeAndDate(const struct tm& parsedTm, int hours, int minutes)
+bool DateTimePreparser::IsValidTimeAndDate(const struct tm &parsedTm, int hours, int minutes)
 {
     if (parsedTm.tm_mon <= 12 && parsedTm.tm_mday <= 31 && parsedTm.tm_hour <= 24 && parsedTm.tm_min <= 60 &&
         parsedTm.tm_sec <= 60 && hours <= 24 && minutes <= 60)
@@ -86,7 +86,7 @@ bool DateTimePreparser::IsValidTimeAndDate(const struct tm& parsedTm, int hours,
     return false;
 }
 
-void DateTimePreparser::ParseDateTime(std::string const& in)
+void DateTimePreparser::ParseDateTime(std::string const &in)
 {
     std::vector<DateTimePreparsedToken> sections;
 
@@ -121,7 +121,7 @@ void DateTimePreparser::ParseDateTime(std::string const& in)
         struct tm parsedTm
         {
         };
-        int* addrs[] = {&parsedTm.tm_year, &parsedTm.tm_mon, &parsedTm.tm_mday, &parsedTm.tm_hour, &parsedTm.tm_min,
+        int *addrs[] = {&parsedTm.tm_year, &parsedTm.tm_mon, &parsedTm.tm_mday, &parsedTm.tm_hour, &parsedTm.tm_min,
             &parsedTm.tm_sec, &hours, &minutes};
 
         if (matches[Style].matched)

--- a/source/shared/cpp/ObjectModel/DateTimePreparser.h
+++ b/source/shared/cpp/ObjectModel/DateTimePreparser.h
@@ -4,24 +4,25 @@
 #include "Enums.h"
 #include "DateTimePreparsedToken.h"
 
-AdaptiveSharedNamespaceStart   
+namespace AdaptiveSharedNamespace
+{
     // Still have to rename this thing
     class DateTimePreparser
     {
-    public:
+        public:
         DateTimePreparser();
-        DateTimePreparser(std::string const &in);
+        DateTimePreparser(std::string const& in);
         std::vector<std::shared_ptr<DateTimePreparsedToken>> GetTextTokens() const;
         bool HasDateTokens() const;
 
-    private:
-        void AddTextToken(std::string const &text, DateTimePreparsedTokenFormat format);
-        void AddDateToken(std::string const &text, struct tm date, DateTimePreparsedTokenFormat format);
+        private:
+        void AddTextToken(std::string const& text, DateTimePreparsedTokenFormat format);
+        void AddDateToken(std::string const& text, struct tm date, DateTimePreparsedTokenFormat format);
         std::string Concatenate() const;
-        static bool IsValidTimeAndDate(const struct tm &parsedTm, int hours, int minutes);
-        void ParseDateTime(std::string const &in);        
+        static bool IsValidTimeAndDate(const struct tm& parsedTm, int hours, int minutes);
+        void ParseDateTime(std::string const& in);
 
         std::vector<std::shared_ptr<DateTimePreparsedToken>> m_textTokenCollection;
         bool m_hasDateTokens;
     };
-AdaptiveSharedNamespaceEnd
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/DateTimePreparser.h
+++ b/source/shared/cpp/ObjectModel/DateTimePreparser.h
@@ -11,16 +11,16 @@ namespace AdaptiveSharedNamespace
     {
     public:
         DateTimePreparser();
-        DateTimePreparser(std::string const& in);
+        DateTimePreparser(std::string const &in);
         std::vector<std::shared_ptr<DateTimePreparsedToken>> GetTextTokens() const;
         bool HasDateTokens() const;
 
     private:
-        void AddTextToken(std::string const& text, DateTimePreparsedTokenFormat format);
-        void AddDateToken(std::string const& text, struct tm date, DateTimePreparsedTokenFormat format);
+        void AddTextToken(std::string const &text, DateTimePreparsedTokenFormat format);
+        void AddDateToken(std::string const &text, struct tm date, DateTimePreparsedTokenFormat format);
         std::string Concatenate() const;
-        static bool IsValidTimeAndDate(const struct tm& parsedTm, int hours, int minutes);
-        void ParseDateTime(std::string const& in);
+        static bool IsValidTimeAndDate(const struct tm &parsedTm, int hours, int minutes);
+        void ParseDateTime(std::string const &in);
 
         std::vector<std::shared_ptr<DateTimePreparsedToken>> m_textTokenCollection;
         bool m_hasDateTokens;

--- a/source/shared/cpp/ObjectModel/DateTimePreparser.h
+++ b/source/shared/cpp/ObjectModel/DateTimePreparser.h
@@ -9,13 +9,13 @@ namespace AdaptiveSharedNamespace
     // Still have to rename this thing
     class DateTimePreparser
     {
-        public:
+    public:
         DateTimePreparser();
         DateTimePreparser(std::string const& in);
         std::vector<std::shared_ptr<DateTimePreparsedToken>> GetTextTokens() const;
         bool HasDateTokens() const;
 
-        private:
+    private:
         void AddTextToken(std::string const& text, DateTimePreparsedTokenFormat format);
         void AddDateToken(std::string const& text, struct tm date, DateTimePreparsedTokenFormat format);
         std::string Concatenate() const;

--- a/source/shared/cpp/ObjectModel/ElementParserRegistration.cpp
+++ b/source/shared/cpp/ObjectModel/ElementParserRegistration.cpp
@@ -51,7 +51,7 @@ namespace AdaptiveSharedNamespace
     }
 
     void ElementParserRegistration::AddParser(
-        std::string const& elementType, std::shared_ptr<BaseCardElementParser> parser)
+        std::string const &elementType, std::shared_ptr<BaseCardElementParser> parser)
     {
         if (m_knownElements.find(elementType) == m_knownElements.end())
         {
@@ -64,7 +64,7 @@ namespace AdaptiveSharedNamespace
         }
     }
 
-    void ElementParserRegistration::RemoveParser(std::string const& elementType)
+    void ElementParserRegistration::RemoveParser(std::string const &elementType)
     {
         if (m_knownElements.find(elementType) == m_knownElements.end())
         {
@@ -77,7 +77,7 @@ namespace AdaptiveSharedNamespace
         }
     }
 
-    std::shared_ptr<BaseCardElementParser> ElementParserRegistration::GetParser(std::string const& elementType)
+    std::shared_ptr<BaseCardElementParser> ElementParserRegistration::GetParser(std::string const &elementType)
     {
         auto parser = m_cardElementParsers.find(elementType);
         if (parser != ElementParserRegistration::m_cardElementParsers.end())

--- a/source/shared/cpp/ObjectModel/ElementParserRegistration.cpp
+++ b/source/shared/cpp/ObjectModel/ElementParserRegistration.cpp
@@ -14,10 +14,11 @@
 #include "ToggleInput.h"
 #include "UnknownElement.h"
 
-AdaptiveSharedNamespaceStart
+namespace AdaptiveSharedNamespace
+{
     ElementParserRegistration::ElementParserRegistration()
     {
-        m_knownElements.insert({ 
+        m_knownElements.insert({
             CardElementTypeToString(CardElementType::Container),
             CardElementTypeToString(CardElementType::ColumnSet),
             CardElementTypeToString(CardElementType::FactSet),
@@ -33,24 +34,24 @@ AdaptiveSharedNamespaceStart
             CardElementTypeToString(CardElementType::Unknown),
         });
 
-        m_cardElementParsers.insert({
-            { CardElementTypeToString(CardElementType::Container), std::make_shared<ContainerParser>() },
-            { CardElementTypeToString(CardElementType::ColumnSet), std::make_shared<ColumnSetParser>() },
-            { CardElementTypeToString(CardElementType::FactSet), std::make_shared<FactSetParser>() },
-            { CardElementTypeToString(CardElementType::Image),  std::make_shared<ImageParser>() },
-            { CardElementTypeToString(CardElementType::ImageSet), std::make_shared<ImageSetParser>() },
-            { CardElementTypeToString(CardElementType::ChoiceSetInput), std::make_shared<ChoiceSetInputParser>() },
-            { CardElementTypeToString(CardElementType::DateInput), std::make_shared<DateInputParser>() },
-            { CardElementTypeToString(CardElementType::NumberInput), std::make_shared<NumberInputParser>() },
-            { CardElementTypeToString(CardElementType::TextBlock), std::make_shared<TextBlockParser>() },
-            { CardElementTypeToString(CardElementType::TextInput),  std::make_shared<TextInputParser>() },
-            { CardElementTypeToString(CardElementType::TimeInput), std::make_shared<TimeInputParser>() },
-            { CardElementTypeToString(CardElementType::ToggleInput), std::make_shared<ToggleInputParser>() },
-            { CardElementTypeToString(CardElementType::Unknown), std::make_shared<UnknownElementParser>() }
-        });
+        m_cardElementParsers.insert(
+            {{CardElementTypeToString(CardElementType::Container), std::make_shared<ContainerParser>()},
+                {CardElementTypeToString(CardElementType::ColumnSet), std::make_shared<ColumnSetParser>()},
+                {CardElementTypeToString(CardElementType::FactSet), std::make_shared<FactSetParser>()},
+                {CardElementTypeToString(CardElementType::Image), std::make_shared<ImageParser>()},
+                {CardElementTypeToString(CardElementType::ImageSet), std::make_shared<ImageSetParser>()},
+                {CardElementTypeToString(CardElementType::ChoiceSetInput), std::make_shared<ChoiceSetInputParser>()},
+                {CardElementTypeToString(CardElementType::DateInput), std::make_shared<DateInputParser>()},
+                {CardElementTypeToString(CardElementType::NumberInput), std::make_shared<NumberInputParser>()},
+                {CardElementTypeToString(CardElementType::TextBlock), std::make_shared<TextBlockParser>()},
+                {CardElementTypeToString(CardElementType::TextInput), std::make_shared<TextInputParser>()},
+                {CardElementTypeToString(CardElementType::TimeInput), std::make_shared<TimeInputParser>()},
+                {CardElementTypeToString(CardElementType::ToggleInput), std::make_shared<ToggleInputParser>()},
+                {CardElementTypeToString(CardElementType::Unknown), std::make_shared<UnknownElementParser>()}});
     }
 
-    void ElementParserRegistration::AddParser(std::string const &elementType, std::shared_ptr<BaseCardElementParser> parser)
+    void ElementParserRegistration::AddParser(
+        std::string const& elementType, std::shared_ptr<BaseCardElementParser> parser)
     {
         if (m_knownElements.find(elementType) == m_knownElements.end())
         {
@@ -58,11 +59,12 @@ AdaptiveSharedNamespaceStart
         }
         else
         {
-            throw AdaptiveCardParseException(ErrorStatusCode::UnsupportedParserOverride, "Overriding known element parsers is unsupported");
+            throw AdaptiveCardParseException(
+                ErrorStatusCode::UnsupportedParserOverride, "Overriding known element parsers is unsupported");
         }
     }
 
-    void ElementParserRegistration::RemoveParser(std::string const &elementType)
+    void ElementParserRegistration::RemoveParser(std::string const& elementType)
     {
         if (m_knownElements.find(elementType) == m_knownElements.end())
         {
@@ -70,11 +72,12 @@ AdaptiveSharedNamespaceStart
         }
         else
         {
-            throw AdaptiveCardParseException(ErrorStatusCode::UnsupportedParserOverride, "Overriding known element parsers is unsupported");
+            throw AdaptiveCardParseException(
+                ErrorStatusCode::UnsupportedParserOverride, "Overriding known element parsers is unsupported");
         }
     }
 
-    std::shared_ptr<BaseCardElementParser> ElementParserRegistration::GetParser(std::string const &elementType)
+    std::shared_ptr<BaseCardElementParser> ElementParserRegistration::GetParser(std::string const& elementType)
     {
         auto parser = m_cardElementParsers.find(elementType);
         if (parser != ElementParserRegistration::m_cardElementParsers.end())
@@ -86,4 +89,4 @@ AdaptiveSharedNamespaceStart
             return std::shared_ptr<BaseCardElementParser>(nullptr);
         }
     }
-AdaptiveSharedNamespaceEnd
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/ElementParserRegistration.h
+++ b/source/shared/cpp/ObjectModel/ElementParserRegistration.h
@@ -12,7 +12,7 @@ namespace AdaptiveSharedNamespace
 
     class BaseCardElementParser
     {
-        public:
+    public:
         virtual std::shared_ptr<BaseCardElement> Deserialize(
             std::shared_ptr<AdaptiveSharedNamespace::ElementParserRegistration> elementParserRegistration,
             std::shared_ptr<AdaptiveSharedNamespace::ActionParserRegistration> actionParserRegistration,
@@ -21,7 +21,7 @@ namespace AdaptiveSharedNamespace
 
     class ElementParserRegistration
     {
-        public:
+    public:
         ElementParserRegistration();
 
         void AddParser(
@@ -29,7 +29,7 @@ namespace AdaptiveSharedNamespace
         void RemoveParser(std::string const& elementType);
         std::shared_ptr<AdaptiveSharedNamespace::BaseCardElementParser> GetParser(std::string const& elementType);
 
-        private:
+    private:
         std::unordered_set<std::string> m_knownElements;
         std::unordered_map<std::string, std::shared_ptr<AdaptiveSharedNamespace::BaseCardElementParser>,
             CaseInsensitiveHash, CaseInsensitiveEqualTo>

--- a/source/shared/cpp/ObjectModel/ElementParserRegistration.h
+++ b/source/shared/cpp/ObjectModel/ElementParserRegistration.h
@@ -4,14 +4,15 @@
 #include "Enums.h"
 #include "json/json.h"
 
-AdaptiveSharedNamespaceStart
+namespace AdaptiveSharedNamespace
+{
     class BaseCardElement;
     class ElementParserRegistration;
     class ActionParserRegistration;
 
     class BaseCardElementParser
     {
-    public:
+        public:
         virtual std::shared_ptr<BaseCardElement> Deserialize(
             std::shared_ptr<AdaptiveSharedNamespace::ElementParserRegistration> elementParserRegistration,
             std::shared_ptr<AdaptiveSharedNamespace::ActionParserRegistration> actionParserRegistration,
@@ -20,16 +21,18 @@ AdaptiveSharedNamespaceStart
 
     class ElementParserRegistration
     {
-    public:
-
+        public:
         ElementParserRegistration();
 
-        void AddParser(std::string const &elementType, std::shared_ptr<AdaptiveSharedNamespace::BaseCardElementParser> parser);
-        void RemoveParser(std::string const &elementType);
-        std::shared_ptr<AdaptiveSharedNamespace::BaseCardElementParser> GetParser(std::string const &elementType);
+        void AddParser(
+            std::string const& elementType, std::shared_ptr<AdaptiveSharedNamespace::BaseCardElementParser> parser);
+        void RemoveParser(std::string const& elementType);
+        std::shared_ptr<AdaptiveSharedNamespace::BaseCardElementParser> GetParser(std::string const& elementType);
 
-    private:
+        private:
         std::unordered_set<std::string> m_knownElements;
-        std::unordered_map<std::string, std::shared_ptr<AdaptiveSharedNamespace::BaseCardElementParser>, CaseInsensitiveHash, CaseInsensitiveEqualTo> m_cardElementParsers;
+        std::unordered_map<std::string, std::shared_ptr<AdaptiveSharedNamespace::BaseCardElementParser>,
+            CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            m_cardElementParsers;
     };
-AdaptiveSharedNamespaceEnd
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/ElementParserRegistration.h
+++ b/source/shared/cpp/ObjectModel/ElementParserRegistration.h
@@ -16,7 +16,7 @@ namespace AdaptiveSharedNamespace
         virtual std::shared_ptr<BaseCardElement> Deserialize(
             std::shared_ptr<AdaptiveSharedNamespace::ElementParserRegistration> elementParserRegistration,
             std::shared_ptr<AdaptiveSharedNamespace::ActionParserRegistration> actionParserRegistration,
-            const Json::Value& value) = 0;
+            const Json::Value &value) = 0;
     };
 
     class ElementParserRegistration
@@ -25,9 +25,9 @@ namespace AdaptiveSharedNamespace
         ElementParserRegistration();
 
         void AddParser(
-            std::string const& elementType, std::shared_ptr<AdaptiveSharedNamespace::BaseCardElementParser> parser);
-        void RemoveParser(std::string const& elementType);
-        std::shared_ptr<AdaptiveSharedNamespace::BaseCardElementParser> GetParser(std::string const& elementType);
+            std::string const &elementType, std::shared_ptr<AdaptiveSharedNamespace::BaseCardElementParser> parser);
+        void RemoveParser(std::string const &elementType);
+        std::shared_ptr<AdaptiveSharedNamespace::BaseCardElementParser> GetParser(std::string const &elementType);
 
     private:
         std::unordered_set<std::string> m_knownElements;

--- a/source/shared/cpp/ObjectModel/Enums.cpp
+++ b/source/shared/cpp/ObjectModel/Enums.cpp
@@ -4,9 +4,9 @@
 namespace AdaptiveSharedNamespace
 {
     void GetAdaptiveCardSchemaKeyEnumMappings(
-        std::unordered_map<AdaptiveCardSchemaKey, std::string, EnumHash>* adaptiveCardSchemaKeyEnumToNameOut,
-        std::unordered_map<std::string, AdaptiveCardSchemaKey, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
-            adaptiveCardSchemaKeyNameToEnumOut)
+        std::unordered_map<AdaptiveCardSchemaKey, std::string, EnumHash> *adaptiveCardSchemaKeyEnumToNameOut,
+        std::unordered_map<std::string, AdaptiveCardSchemaKey, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            *adaptiveCardSchemaKeyNameToEnumOut)
     {
         static std::unordered_map<AdaptiveCardSchemaKey, std::string, EnumHash> adaptiveCardSchemaKeyEnumToName = {
             {AdaptiveCardSchemaKey::Accent, "accent"}, {AdaptiveCardSchemaKey::ActionAlignment, "actionAlignment"},
@@ -95,9 +95,9 @@ namespace AdaptiveSharedNamespace
     }
 
     void GetCardElementTypeEnumMappings(
-        std::unordered_map<CardElementType, std::string, EnumHash>* cardElementTypeEnumToNameOut,
-        std::unordered_map<std::string, CardElementType, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
-            cardElementTypeNameToEnumOut)
+        std::unordered_map<CardElementType, std::string, EnumHash> *cardElementTypeEnumToNameOut,
+        std::unordered_map<std::string, CardElementType, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            *cardElementTypeNameToEnumOut)
     {
         static std::unordered_map<CardElementType, std::string, EnumHash> cardElementTypeEnumToName = {
             {CardElementType::AdaptiveCard, "AdaptiveCard"}, {CardElementType::Column, "Column"},
@@ -122,9 +122,9 @@ namespace AdaptiveSharedNamespace
         }
     }
 
-    void GetActionTypeEnumMappings(std::unordered_map<ActionType, std::string, EnumHash>* actionTypeEnumToNameOut,
-        std::unordered_map<std::string, ActionType, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
-            actionTypeNameToEnumOut)
+    void GetActionTypeEnumMappings(std::unordered_map<ActionType, std::string, EnumHash> *actionTypeEnumToNameOut,
+        std::unordered_map<std::string, ActionType, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            *actionTypeNameToEnumOut)
     {
         static std::unordered_map<ActionType, std::string, EnumHash> actionTypeEnumToName = {
             {ActionType::OpenUrl, "Action.OpenUrl"}, {ActionType::ShowCard, "Action.ShowCard"},
@@ -143,9 +143,9 @@ namespace AdaptiveSharedNamespace
         }
     }
 
-    void GetHeightTypeEnumMappings(std::unordered_map<HeightType, std::string, EnumHash>* heightTypeEnumToNameOut,
-        std::unordered_map<std::string, HeightType, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
-            heightTypeNameToEnumOut)
+    void GetHeightTypeEnumMappings(std::unordered_map<HeightType, std::string, EnumHash> *heightTypeEnumToNameOut,
+        std::unordered_map<std::string, HeightType, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            *heightTypeNameToEnumOut)
     {
         static std::unordered_map<HeightType, std::string, EnumHash> heightTypeEnumToName = {
             {HeightType::Auto, "Auto"}, {HeightType::Stretch, "Stretch"}};
@@ -164,8 +164,8 @@ namespace AdaptiveSharedNamespace
         }
     }
 
-    void GetSpacingMappings(std::unordered_map<Spacing, std::string, EnumHash>* spacingEnumToNameOut,
-        std::unordered_map<std::string, Spacing, CaseInsensitiveHash, CaseInsensitiveEqualTo>* spacingNameToEnumOut)
+    void GetSpacingMappings(std::unordered_map<Spacing, std::string, EnumHash> *spacingEnumToNameOut,
+        std::unordered_map<std::string, Spacing, CaseInsensitiveHash, CaseInsensitiveEqualTo> *spacingNameToEnumOut)
     {
         static std::unordered_map<Spacing, std::string, EnumHash> spacingEnumToName = {
             {Spacing::Default, "default"},
@@ -191,9 +191,9 @@ namespace AdaptiveSharedNamespace
     }
 
     void GetSeparatorThicknessEnumMappings(
-        std::unordered_map<SeparatorThickness, std::string, EnumHash>* separatorThicknessEnumToNameOut,
-        std::unordered_map<std::string, SeparatorThickness, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
-            separatorThicknessNameToEnumOut)
+        std::unordered_map<SeparatorThickness, std::string, EnumHash> *separatorThicknessEnumToNameOut,
+        std::unordered_map<std::string, SeparatorThickness, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            *separatorThicknessNameToEnumOut)
     {
         static std::unordered_map<SeparatorThickness, std::string, EnumHash> separatorThicknessEnumToName = {
             {SeparatorThickness::Default, "default"},
@@ -213,9 +213,9 @@ namespace AdaptiveSharedNamespace
         }
     }
 
-    void GetImageStyleEnumMappings(std::unordered_map<ImageStyle, std::string, EnumHash>* imageStyleEnumToNameOut,
-        std::unordered_map<std::string, ImageStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
-            imageStyleNameToEnumOut)
+    void GetImageStyleEnumMappings(std::unordered_map<ImageStyle, std::string, EnumHash> *imageStyleEnumToNameOut,
+        std::unordered_map<std::string, ImageStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            *imageStyleNameToEnumOut)
     {
         static std::unordered_map<ImageStyle, std::string, EnumHash> imageStyleEnumToName = {
             {ImageStyle::Default, "default"}, {ImageStyle::Person, "person"}};
@@ -237,8 +237,8 @@ namespace AdaptiveSharedNamespace
         }
     }
 
-    void GetImageSizeEnumMappings(std::unordered_map<ImageSize, std::string, EnumHash>* imageSizeEnumToNameOut,
-        std::unordered_map<std::string, ImageSize, CaseInsensitiveHash, CaseInsensitiveEqualTo>* imageSizeNameToEnumOut)
+    void GetImageSizeEnumMappings(std::unordered_map<ImageSize, std::string, EnumHash> *imageSizeEnumToNameOut,
+        std::unordered_map<std::string, ImageSize, CaseInsensitiveHash, CaseInsensitiveEqualTo> *imageSizeNameToEnumOut)
     {
         static std::unordered_map<ImageSize, std::string, EnumHash> imageSizeEnumToName = {
             {ImageSize::Auto, "Auto"},
@@ -262,9 +262,9 @@ namespace AdaptiveSharedNamespace
     };
 
     void GetHorizontalAlignmentEnumMappings(
-        std::unordered_map<HorizontalAlignment, std::string, EnumHash>* horizontalAlignmentEnumToNameOut,
-        std::unordered_map<std::string, HorizontalAlignment, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
-            horizontalAlignmentNameToEnumOut)
+        std::unordered_map<HorizontalAlignment, std::string, EnumHash> *horizontalAlignmentEnumToNameOut,
+        std::unordered_map<std::string, HorizontalAlignment, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            *horizontalAlignmentNameToEnumOut)
     {
         static std::unordered_map<HorizontalAlignment, std::string, EnumHash> horizontalAlignmentEnumToName = {
             {HorizontalAlignment::Center, "Center"}, {HorizontalAlignment::Left, "Left"},
@@ -283,9 +283,9 @@ namespace AdaptiveSharedNamespace
         }
     };
 
-    void GetColorEnumMappings(std::unordered_map<ForegroundColor, std::string, EnumHash>* colorEnumToNameOut,
-        std::unordered_map<std::string, ForegroundColor, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
-            colorNameToEnumOut)
+    void GetColorEnumMappings(std::unordered_map<ForegroundColor, std::string, EnumHash> *colorEnumToNameOut,
+        std::unordered_map<std::string, ForegroundColor, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            *colorNameToEnumOut)
     {
         static std::unordered_map<ForegroundColor, std::string, EnumHash> colorEnumToName = {
             {ForegroundColor::Accent, "Accent"},
@@ -310,9 +310,9 @@ namespace AdaptiveSharedNamespace
         }
     }
 
-    void GetTextWeightEnumMappings(std::unordered_map<TextWeight, std::string, EnumHash>* textWeightEnumToNameOut,
-        std::unordered_map<std::string, TextWeight, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
-            textWeightNameToEnumOut)
+    void GetTextWeightEnumMappings(std::unordered_map<TextWeight, std::string, EnumHash> *textWeightEnumToNameOut,
+        std::unordered_map<std::string, TextWeight, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            *textWeightNameToEnumOut)
     {
         static std::unordered_map<TextWeight, std::string, EnumHash> textWeightEnumToName = {
             {TextWeight::Bolder, "Bolder"},
@@ -337,8 +337,8 @@ namespace AdaptiveSharedNamespace
         }
     }
 
-    void GetTextSizeEnumMappings(std::unordered_map<TextSize, std::string, EnumHash>* textSizeEnumToNameOut,
-        std::unordered_map<std::string, TextSize, CaseInsensitiveHash, CaseInsensitiveEqualTo>* textSizeNameToEnumOut)
+    void GetTextSizeEnumMappings(std::unordered_map<TextSize, std::string, EnumHash> *textSizeEnumToNameOut,
+        std::unordered_map<std::string, TextSize, CaseInsensitiveHash, CaseInsensitiveEqualTo> *textSizeNameToEnumOut)
     {
         static std::unordered_map<TextSize, std::string, EnumHash> textSizeEnumToName = {
             {TextSize::ExtraLarge, "ExtraLarge"},
@@ -367,9 +367,9 @@ namespace AdaptiveSharedNamespace
     }
 
     void GetActionsOrientationEnumMappings(
-        std::unordered_map<ActionsOrientation, std::string, EnumHash>* actionsOrientationEnumToNameOut,
-        std::unordered_map<std::string, ActionsOrientation, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
-            actionsOrientationNameToEnumOut)
+        std::unordered_map<ActionsOrientation, std::string, EnumHash> *actionsOrientationEnumToNameOut,
+        std::unordered_map<std::string, ActionsOrientation, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            *actionsOrientationNameToEnumOut)
     {
         static std::unordered_map<ActionsOrientation, std::string, EnumHash> actionsOrientationEnumToName = {
             {ActionsOrientation::Horizontal, "Horizontal"},
@@ -389,9 +389,9 @@ namespace AdaptiveSharedNamespace
         }
     }
 
-    void GetActionModeEnumMappings(std::unordered_map<ActionMode, std::string, EnumHash>* actionModeEnumToNameOut,
-        std::unordered_map<std::string, ActionMode, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
-            actionModeNameToEnumOut)
+    void GetActionModeEnumMappings(std::unordered_map<ActionMode, std::string, EnumHash> *actionModeEnumToNameOut,
+        std::unordered_map<std::string, ActionMode, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            *actionModeNameToEnumOut)
     {
         static std::unordered_map<ActionMode, std::string, EnumHash> actionModeEnumToName = {
             {ActionMode::Inline, "Inline"}, {ActionMode::Popup, "Popup"}};
@@ -410,9 +410,9 @@ namespace AdaptiveSharedNamespace
     }
 
     void GetChoiceSetStyleEnumMappings(
-        std::unordered_map<ChoiceSetStyle, std::string, EnumHash>* choiceSetStyleEnumToNameOut,
-        std::unordered_map<std::string, ChoiceSetStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
-            choiceSetStyleNameToEnumOut)
+        std::unordered_map<ChoiceSetStyle, std::string, EnumHash> *choiceSetStyleEnumToNameOut,
+        std::unordered_map<std::string, ChoiceSetStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            *choiceSetStyleNameToEnumOut)
     {
         static std::unordered_map<ChoiceSetStyle, std::string, EnumHash> choiceSetStyleEnumToName = {
             {ChoiceSetStyle::Compact, "Compact"}, {ChoiceSetStyle::Expanded, "Expanded"}};
@@ -431,9 +431,9 @@ namespace AdaptiveSharedNamespace
     };
 
     void GetTextInputStyleEnumMappings(
-        std::unordered_map<TextInputStyle, std::string, EnumHash>* textInputStyleEnumToNameOut,
-        std::unordered_map<std::string, TextInputStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
-            textInputStyleNameToEnumOut)
+        std::unordered_map<TextInputStyle, std::string, EnumHash> *textInputStyleEnumToNameOut,
+        std::unordered_map<std::string, TextInputStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            *textInputStyleNameToEnumOut)
     {
         static std::unordered_map<TextInputStyle, std::string, EnumHash> textInputStyleEnumToName = {
             {TextInputStyle::Email, "Email"},
@@ -456,9 +456,9 @@ namespace AdaptiveSharedNamespace
     }
 
     void GetContainerStyleEnumMappings(
-        std::unordered_map<ContainerStyle, std::string, EnumHash>* containerStyleEnumToNameOut,
-        std::unordered_map<std::string, ContainerStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
-            containerStyleNameToEnumOut)
+        std::unordered_map<ContainerStyle, std::string, EnumHash> *containerStyleEnumToNameOut,
+        std::unordered_map<std::string, ContainerStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            *containerStyleNameToEnumOut)
     {
         static std::unordered_map<ContainerStyle, std::string, EnumHash> containerStyleEnumToName = {
             {ContainerStyle::Default, "Default"},
@@ -479,9 +479,9 @@ namespace AdaptiveSharedNamespace
     }
 
     void GetActionAlignmentEnumMappings(
-        std::unordered_map<ActionAlignment, std::string, EnumHash>* actionAlignmentEnumToNameOut,
-        std::unordered_map<std::string, ActionAlignment, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
-            actionAlignmentNameToEnumOut)
+        std::unordered_map<ActionAlignment, std::string, EnumHash> *actionAlignmentEnumToNameOut,
+        std::unordered_map<std::string, ActionAlignment, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            *actionAlignmentNameToEnumOut)
     {
         static std::unordered_map<ActionAlignment, std::string, EnumHash> actionAlignmentEnumToName = {
             {ActionAlignment::Left, "Left"},
@@ -504,9 +504,9 @@ namespace AdaptiveSharedNamespace
     }
 
     void GetIconPlacementEnumMappings(
-        std::unordered_map<IconPlacement, std::string, EnumHash>* iconPlacementEnumToNameOut,
-        std::unordered_map<std::string, IconPlacement, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
-            iconPlacementNameToEnumOut)
+        std::unordered_map<IconPlacement, std::string, EnumHash> *iconPlacementEnumToNameOut,
+        std::unordered_map<std::string, IconPlacement, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            *iconPlacementNameToEnumOut)
     {
         static std::unordered_map<IconPlacement, std::string, EnumHash> iconPlacementEnumToName = {
             {IconPlacement::AboveTitle, "AboveTitle"}, {IconPlacement::LeftOfTitle, "LeftOfTitle"}};
@@ -525,9 +525,9 @@ namespace AdaptiveSharedNamespace
     }
 
     void GetVerticalContentAlignmentEnumMappings(
-        std::unordered_map<VerticalContentAlignment, std::string, EnumHash>* verticalContentAlignmentEnumToNameOut,
-        std::unordered_map<std::string, VerticalContentAlignment, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
-            verticalContentAlignmentNameToEnumOut)
+        std::unordered_map<VerticalContentAlignment, std::string, EnumHash> *verticalContentAlignmentEnumToNameOut,
+        std::unordered_map<std::string, VerticalContentAlignment, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            *verticalContentAlignmentNameToEnumOut)
     {
         static std::unordered_map<VerticalContentAlignment, std::string, EnumHash> verticalContentAlignmentEnumToName =
             {{VerticalContentAlignment::Stretch, "Stretch"}, {VerticalContentAlignment::Top, "Top"},
@@ -560,7 +560,7 @@ namespace AdaptiveSharedNamespace
         return adaptiveCardSchemaKeyEnumToName[type];
     }
 
-    AdaptiveCardSchemaKey AdaptiveCardSchemaKeyFromString(const std::string& type)
+    AdaptiveCardSchemaKey AdaptiveCardSchemaKeyFromString(const std::string &type)
     {
         std::unordered_map<std::string, AdaptiveCardSchemaKey, CaseInsensitiveHash, CaseInsensitiveEqualTo>
             adaptiveCardSchemaKeyNameToEnum;
@@ -587,7 +587,7 @@ namespace AdaptiveSharedNamespace
         return cardElementTypeEnumToName[elementType];
     }
 
-    CardElementType CardElementTypeFromString(const std::string& elementType)
+    CardElementType CardElementTypeFromString(const std::string &elementType)
     {
         std::unordered_map<std::string, CardElementType, CaseInsensitiveHash, CaseInsensitiveEqualTo>
             cardElementTypeNameToEnum;
@@ -614,7 +614,7 @@ namespace AdaptiveSharedNamespace
         return actionTypeEnumToName[actionType];
     }
 
-    ActionType ActionTypeFromString(const std::string& actionType)
+    ActionType ActionTypeFromString(const std::string &actionType)
     {
         std::unordered_map<std::string, ActionType, CaseInsensitiveHash, CaseInsensitiveEqualTo> actionTypeNameToEnum;
         GetActionTypeEnumMappings(nullptr, &actionTypeNameToEnum);
@@ -640,7 +640,7 @@ namespace AdaptiveSharedNamespace
         return heightTypeEnumToName[heightType];
     }
 
-    HeightType HeightTypeFromString(const std::string& heightType)
+    HeightType HeightTypeFromString(const std::string &heightType)
     {
         std::unordered_map<std::string, HeightType, CaseInsensitiveHash, CaseInsensitiveEqualTo> heightTypeNameToEnum;
         GetHeightTypeEnumMappings(nullptr, &heightTypeNameToEnum);
@@ -665,7 +665,7 @@ namespace AdaptiveSharedNamespace
         return horizontalAlignmentEnumToName[alignment];
     }
 
-    HorizontalAlignment HorizontalAlignmentFromString(const std::string& alignment)
+    HorizontalAlignment HorizontalAlignmentFromString(const std::string &alignment)
     {
         std::unordered_map<std::string, HorizontalAlignment, CaseInsensitiveHash, CaseInsensitiveEqualTo>
             horizontalAlignmentNameToEnum;
@@ -691,7 +691,7 @@ namespace AdaptiveSharedNamespace
         return colorEnumToName[color];
     }
 
-    ForegroundColor ForegroundColorFromString(const std::string& color)
+    ForegroundColor ForegroundColorFromString(const std::string &color)
     {
         std::unordered_map<std::string, ForegroundColor, CaseInsensitiveHash, CaseInsensitiveEqualTo> colorNameToEnum;
         GetColorEnumMappings(nullptr, &colorNameToEnum);
@@ -716,7 +716,7 @@ namespace AdaptiveSharedNamespace
         return textWeightEnumToName[weight];
     }
 
-    TextWeight TextWeightFromString(const std::string& weight)
+    TextWeight TextWeightFromString(const std::string &weight)
     {
         std::unordered_map<std::string, TextWeight, CaseInsensitiveHash, CaseInsensitiveEqualTo> textWeightNameToEnum;
         GetTextWeightEnumMappings(nullptr, &textWeightNameToEnum);
@@ -741,7 +741,7 @@ namespace AdaptiveSharedNamespace
         return textSizeEnumToName[size];
     }
 
-    TextSize TextSizeFromString(const std::string& size)
+    TextSize TextSizeFromString(const std::string &size)
     {
         std::unordered_map<std::string, TextSize, CaseInsensitiveHash, CaseInsensitiveEqualTo> textSizeNameToEnum;
         GetTextSizeEnumMappings(nullptr, &textSizeNameToEnum);
@@ -766,7 +766,7 @@ namespace AdaptiveSharedNamespace
         return imageSizeEnumToName[size];
     }
 
-    ImageSize ImageSizeFromString(const std::string& size)
+    ImageSize ImageSizeFromString(const std::string &size)
     {
         std::unordered_map<std::string, ImageSize, CaseInsensitiveHash, CaseInsensitiveEqualTo> imageSizeNameToEnum;
         GetImageSizeEnumMappings(nullptr, &imageSizeNameToEnum);
@@ -791,7 +791,7 @@ namespace AdaptiveSharedNamespace
         return spacingEnumToName[spacing];
     }
 
-    Spacing SpacingFromString(const std::string& spacing)
+    Spacing SpacingFromString(const std::string &spacing)
     {
         std::unordered_map<std::string, Spacing, CaseInsensitiveHash, CaseInsensitiveEqualTo> spacingNameToEnum;
         GetSpacingMappings(nullptr, &spacingNameToEnum);
@@ -816,7 +816,7 @@ namespace AdaptiveSharedNamespace
         return separatorThicknessEnumToName[thickness];
     }
 
-    SeparatorThickness SeparatorThicknessFromString(const std::string& thickness)
+    SeparatorThickness SeparatorThicknessFromString(const std::string &thickness)
     {
         std::unordered_map<std::string, SeparatorThickness, CaseInsensitiveHash, CaseInsensitiveEqualTo>
             separatorThicknessNameToEnum;
@@ -842,7 +842,7 @@ namespace AdaptiveSharedNamespace
         return imageStyleEnumToName[style];
     }
 
-    ImageStyle ImageStyleFromString(const std::string& style)
+    ImageStyle ImageStyleFromString(const std::string &style)
     {
         std::unordered_map<std::string, ImageStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo> imageStyleNameToEnum;
         GetImageStyleEnumMappings(nullptr, &imageStyleNameToEnum);
@@ -867,7 +867,7 @@ namespace AdaptiveSharedNamespace
         return actionsOrientationEnumToName[orientation];
     }
 
-    ActionsOrientation ActionsOrientationFromString(const std::string& orientation)
+    ActionsOrientation ActionsOrientationFromString(const std::string &orientation)
     {
         std::unordered_map<std::string, ActionsOrientation, CaseInsensitiveHash, CaseInsensitiveEqualTo>
             actionsOrientationNameToEnum;
@@ -892,7 +892,7 @@ namespace AdaptiveSharedNamespace
         return actionModeEnumToName[mode];
     }
 
-    ActionMode ActionModeFromString(const std::string& mode)
+    ActionMode ActionModeFromString(const std::string &mode)
     {
         std::unordered_map<std::string, ActionMode, CaseInsensitiveHash, CaseInsensitiveEqualTo> actionModeNameToEnum;
         GetActionModeEnumMappings(nullptr, &actionModeNameToEnum);
@@ -915,7 +915,7 @@ namespace AdaptiveSharedNamespace
         }
         return choiceSetStyleEnumToName[style];
     }
-    ChoiceSetStyle ChoiceSetStyleFromString(const std::string& style)
+    ChoiceSetStyle ChoiceSetStyleFromString(const std::string &style)
     {
         std::unordered_map<std::string, ChoiceSetStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo>
             choiceSetStyleNameToEnum;
@@ -940,7 +940,7 @@ namespace AdaptiveSharedNamespace
         return textInputStyleEnumToName[style];
     }
 
-    TextInputStyle TextInputStyleFromString(const std::string& style)
+    TextInputStyle TextInputStyleFromString(const std::string &style)
     {
         std::unordered_map<std::string, TextInputStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo>
             textInputStyleNameToEnum;
@@ -965,7 +965,7 @@ namespace AdaptiveSharedNamespace
         return containerStyleEnumToName[style];
     }
 
-    ContainerStyle ContainerStyleFromString(const std::string& style)
+    ContainerStyle ContainerStyleFromString(const std::string &style)
     {
         std::unordered_map<std::string, ContainerStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo>
             containerStyleNameToEnum;
@@ -990,7 +990,7 @@ namespace AdaptiveSharedNamespace
         return actionAlignmentEnumToName[alignment];
     }
 
-    ActionAlignment ActionAlignmentFromString(const std::string& alignment)
+    ActionAlignment ActionAlignmentFromString(const std::string &alignment)
     {
         std::unordered_map<std::string, ActionAlignment, CaseInsensitiveHash, CaseInsensitiveEqualTo>
             actionAlignmentNameToEnum;
@@ -1015,7 +1015,7 @@ namespace AdaptiveSharedNamespace
         return iconPlacementEnumToName[placement];
     }
 
-    IconPlacement IconPlacementFromString(const std::string& placement)
+    IconPlacement IconPlacementFromString(const std::string &placement)
     {
         std::unordered_map<std::string, IconPlacement, CaseInsensitiveHash, CaseInsensitiveEqualTo>
             iconPlacementNameToEnum;
@@ -1041,7 +1041,7 @@ namespace AdaptiveSharedNamespace
         return verticalContentAlignmentEnumToName[verticalContentAlignment];
     }
 
-    VerticalContentAlignment VerticalContentAlignmentFromString(const std::string& verticalContentAlignment)
+    VerticalContentAlignment VerticalContentAlignmentFromString(const std::string &verticalContentAlignment)
     {
         std::unordered_map<std::string, VerticalContentAlignment, CaseInsensitiveHash, CaseInsensitiveEqualTo>
             verticalContentAlignmentNameToEnum;

--- a/source/shared/cpp/ObjectModel/Enums.cpp
+++ b/source/shared/cpp/ObjectModel/Enums.cpp
@@ -1,1125 +1,1058 @@
 #include "pch.h"
 #include "Enums.h"
 
-AdaptiveSharedNamespaceStart
-
-void GetAdaptiveCardSchemaKeyEnumMappings(
-    std::unordered_map<AdaptiveCardSchemaKey, std::string, EnumHash> * adaptiveCardSchemaKeyEnumToNameOut,
-    std::unordered_map<std::string, AdaptiveCardSchemaKey, CaseInsensitiveHash, CaseInsensitiveEqualTo> * adaptiveCardSchemaKeyNameToEnumOut)
+namespace AdaptiveSharedNamespace
 {
-    static std::unordered_map<AdaptiveCardSchemaKey, std::string, EnumHash> adaptiveCardSchemaKeyEnumToName =
+    void GetAdaptiveCardSchemaKeyEnumMappings(
+        std::unordered_map<AdaptiveCardSchemaKey, std::string, EnumHash>* adaptiveCardSchemaKeyEnumToNameOut,
+        std::unordered_map<std::string, AdaptiveCardSchemaKey, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
+            adaptiveCardSchemaKeyNameToEnumOut)
     {
-        { AdaptiveCardSchemaKey::Accent, "accent" },
-        { AdaptiveCardSchemaKey::ActionAlignment, "actionAlignment" },
-        { AdaptiveCardSchemaKey::ActionMode, "actionMode" },
-        { AdaptiveCardSchemaKey::Actions, "actions" },
-        { AdaptiveCardSchemaKey::ActionSetConfig, "actionSetConfig" },
-        { AdaptiveCardSchemaKey::ActionsOrientation, "actionsOrientation" },
-        { AdaptiveCardSchemaKey::AdaptiveCard, "adaptiveCard" },
-        { AdaptiveCardSchemaKey::AllowCustomStyle, "allowCustomStyle" },
-        { AdaptiveCardSchemaKey::AltText, "altText" },
-        { AdaptiveCardSchemaKey::Attention, "attention" },
-        { AdaptiveCardSchemaKey::BackgroundColor, "backgroundColor" },
-        { AdaptiveCardSchemaKey::BackgroundImage, "backgroundImage" },
-        { AdaptiveCardSchemaKey::BackgroundImageUrl, "backgroundImageUrl" },
-        { AdaptiveCardSchemaKey::BaseCardElement, "baseCardElement" },
-        { AdaptiveCardSchemaKey::Body, "body" },
-        { AdaptiveCardSchemaKey::Bolder, "bolder" },
-        { AdaptiveCardSchemaKey::BorderColor, "borderColor" },
-        { AdaptiveCardSchemaKey::BorderThickness, "borderThickness" },
-        { AdaptiveCardSchemaKey::Bottom, "bottom" },
-        { AdaptiveCardSchemaKey::ButtonSpacing, "buttonSpacing" },
-        { AdaptiveCardSchemaKey::Card, "card" },
-        { AdaptiveCardSchemaKey::Center, "center" },
-        { AdaptiveCardSchemaKey::Choices, "choices" },
-        { AdaptiveCardSchemaKey::ChoiceSet, "choiceSet" },
-        { AdaptiveCardSchemaKey::Color, "color" },
-        { AdaptiveCardSchemaKey::ColorConfig, "colorConfig" },
-        { AdaptiveCardSchemaKey::ForegroundColors, "foregroundColors" },
-        { AdaptiveCardSchemaKey::Column, "column" },
-        { AdaptiveCardSchemaKey::Columns, "columns" },
-        { AdaptiveCardSchemaKey::ColumnSet, "columnSet" },
-        { AdaptiveCardSchemaKey::Container, "container" },
-        { AdaptiveCardSchemaKey::ContainerStyles, "containerStyles" },
-        { AdaptiveCardSchemaKey::Dark, "dark" },
-        { AdaptiveCardSchemaKey::Data, "data" },
-        { AdaptiveCardSchemaKey::DateInput, "dateInput" },
-        { AdaptiveCardSchemaKey::Default, "default" },
-        { AdaptiveCardSchemaKey::Emphasis, "emphasis" },
-        { AdaptiveCardSchemaKey::ExtraLarge, "extraLarge" },
-        { AdaptiveCardSchemaKey::Facts, "facts" },
-        { AdaptiveCardSchemaKey::FactSet, "factSet" },
-        { AdaptiveCardSchemaKey::FallbackText, "fallbackText" },
-        { AdaptiveCardSchemaKey::FontFamily, "fontFamily" },
-        { AdaptiveCardSchemaKey::FontSizes, "fontSizes" },
-        { AdaptiveCardSchemaKey::FontWeights, "fontWeights" },
-        { AdaptiveCardSchemaKey::Good, "good" },
-        { AdaptiveCardSchemaKey::Height, "height" },
-        { AdaptiveCardSchemaKey::HorizontalAlignment, "horizontalAlignment" },
-        { AdaptiveCardSchemaKey::IconPlacement, "iconPlacement" },
-        { AdaptiveCardSchemaKey::IconUrl, "iconUrl" },
-        { AdaptiveCardSchemaKey::Id, "id" },
-        { AdaptiveCardSchemaKey::Image, "image" },
-        { AdaptiveCardSchemaKey::ImageBaseUrl, "imageBaseUrl" },
-        { AdaptiveCardSchemaKey::Images, "images" },
-        { AdaptiveCardSchemaKey::ImageSet, "imageSet" },
-        { AdaptiveCardSchemaKey::ImageSize, "imageSize" },
-        { AdaptiveCardSchemaKey::ImageSizes, "imageSizes" },
-        { AdaptiveCardSchemaKey::InlineTopMargin, "inlineTopMargin" },
-        { AdaptiveCardSchemaKey::IsMultiline, "isMultiline" },
-        { AdaptiveCardSchemaKey::IsMultiSelect, "isMultiSelect" },
-        { AdaptiveCardSchemaKey::IsRequired, "isRequired" },
-        { AdaptiveCardSchemaKey::IsSelected, "isSelected" },
-        { AdaptiveCardSchemaKey::IsSubtle, "isSubtle" },
-        { AdaptiveCardSchemaKey::Items, "items" },
-        { AdaptiveCardSchemaKey::Language, "lang" },
-        { AdaptiveCardSchemaKey::Large, "large" },
-        { AdaptiveCardSchemaKey::Left, "left" },
-        { AdaptiveCardSchemaKey::Light, "light" },
-        { AdaptiveCardSchemaKey::Lighter, "lighter" },
-        { AdaptiveCardSchemaKey::LineColor, "lineColor" },
-        { AdaptiveCardSchemaKey::LineThickness, "lineThickness" },
-        { AdaptiveCardSchemaKey::Max, "max" },
-        { AdaptiveCardSchemaKey::MaxActions, "maxActions" },
-        { AdaptiveCardSchemaKey::MaxImageHeight, "maxImageHeight" },
-        { AdaptiveCardSchemaKey::MaxLength, "maxLength" },
-        { AdaptiveCardSchemaKey::MaxLines, "maxLines" },
-        { AdaptiveCardSchemaKey::MaxWidth, "maxWidth" },
-        { AdaptiveCardSchemaKey::Medium, "medium" },
-        { AdaptiveCardSchemaKey::Method, "method" },
-        { AdaptiveCardSchemaKey::Min, "min" },
-        { AdaptiveCardSchemaKey::NumberInput, "numberInput" },
-        { AdaptiveCardSchemaKey::Padding, "padding" },
-        { AdaptiveCardSchemaKey::Placeholder, "placeholder" },
-        { AdaptiveCardSchemaKey::Right, "right" },
-        { AdaptiveCardSchemaKey::SelectAction, "selectAction" },
-        { AdaptiveCardSchemaKey::Separator, "separator" },
-        { AdaptiveCardSchemaKey::Thickness, "thickness" },
-        { AdaptiveCardSchemaKey::ShowActionMode, "showActionMode" },
-        { AdaptiveCardSchemaKey::ShowCard, "showCard" },
-        { AdaptiveCardSchemaKey::ShowCardActionConfig, "showCardActionConfig" },
-        { AdaptiveCardSchemaKey::Size, "size" },
-        { AdaptiveCardSchemaKey::Small, "small" },
-        { AdaptiveCardSchemaKey::Spacing, "spacing" },
-        { AdaptiveCardSchemaKey::SpacingDefinition, "spacingDefinition" },
-        { AdaptiveCardSchemaKey::Speak, "speak" },
-        { AdaptiveCardSchemaKey::Stretch, "stretch" },
-        { AdaptiveCardSchemaKey::Style, "style" },
-        { AdaptiveCardSchemaKey::Subtle, "subtle" },
-        { AdaptiveCardSchemaKey::SupportsInteractivity, "supportsInteractivity" },
-        { AdaptiveCardSchemaKey::Text, "text" },
-        { AdaptiveCardSchemaKey::TextBlock, "textBlock" },
-        { AdaptiveCardSchemaKey::TextConfig, "textConfig" },
-        { AdaptiveCardSchemaKey::TextInput, "textInput" },
-        { AdaptiveCardSchemaKey::TextWeight, "weight" },
-        { AdaptiveCardSchemaKey::Thick, "thick" },
-        { AdaptiveCardSchemaKey::Thickness, "thickness" },
-        { AdaptiveCardSchemaKey::TimeInput, "timeInput" },
-        { AdaptiveCardSchemaKey::Title, "title" },
-        { AdaptiveCardSchemaKey::ToggleInput, "toggleInput" },
-        { AdaptiveCardSchemaKey::Top, "top" },
-        { AdaptiveCardSchemaKey::Type, "type" },
-        { AdaptiveCardSchemaKey::Url, "url" },
-        { AdaptiveCardSchemaKey::Value, "value" },
-        { AdaptiveCardSchemaKey::ValueOff, "valueOff" },
-        { AdaptiveCardSchemaKey::ValueOn, "valueOn" },
-        { AdaptiveCardSchemaKey::Version, "version" },
-        { AdaptiveCardSchemaKey::VerticalContentAlignment, "verticalContentAlignment" },
-        { AdaptiveCardSchemaKey::Warning, "warning" },
-        { AdaptiveCardSchemaKey::Weight, "weight" },
-        { AdaptiveCardSchemaKey::Width, "width" },
-        { AdaptiveCardSchemaKey::Wrap, "wrap" }
-    };
-    static std::unordered_map<std::string, AdaptiveCardSchemaKey, CaseInsensitiveHash, CaseInsensitiveEqualTo> adaptiveCardSchemaKeyNameToEnum = GenerateStringToEnumMap<AdaptiveCardSchemaKey>(adaptiveCardSchemaKeyEnumToName);
+        static std::unordered_map<AdaptiveCardSchemaKey, std::string, EnumHash> adaptiveCardSchemaKeyEnumToName = {
+            {AdaptiveCardSchemaKey::Accent, "accent"}, {AdaptiveCardSchemaKey::ActionAlignment, "actionAlignment"},
+            {AdaptiveCardSchemaKey::ActionMode, "actionMode"}, {AdaptiveCardSchemaKey::Actions, "actions"},
+            {AdaptiveCardSchemaKey::ActionSetConfig, "actionSetConfig"},
+            {AdaptiveCardSchemaKey::ActionsOrientation, "actionsOrientation"},
+            {AdaptiveCardSchemaKey::AdaptiveCard, "adaptiveCard"},
+            {AdaptiveCardSchemaKey::AllowCustomStyle, "allowCustomStyle"}, {AdaptiveCardSchemaKey::AltText, "altText"},
+            {AdaptiveCardSchemaKey::Attention, "attention"},
+            {AdaptiveCardSchemaKey::BackgroundColor, "backgroundColor"},
+            {AdaptiveCardSchemaKey::BackgroundImage, "backgroundImage"},
+            {AdaptiveCardSchemaKey::BackgroundImageUrl, "backgroundImageUrl"},
+            {AdaptiveCardSchemaKey::BaseCardElement, "baseCardElement"}, {AdaptiveCardSchemaKey::Body, "body"},
+            {AdaptiveCardSchemaKey::Bolder, "bolder"}, {AdaptiveCardSchemaKey::BorderColor, "borderColor"},
+            {AdaptiveCardSchemaKey::BorderThickness, "borderThickness"}, {AdaptiveCardSchemaKey::Bottom, "bottom"},
+            {AdaptiveCardSchemaKey::ButtonSpacing, "buttonSpacing"}, {AdaptiveCardSchemaKey::Card, "card"},
+            {AdaptiveCardSchemaKey::Center, "center"}, {AdaptiveCardSchemaKey::Choices, "choices"},
+            {AdaptiveCardSchemaKey::ChoiceSet, "choiceSet"}, {AdaptiveCardSchemaKey::Color, "color"},
+            {AdaptiveCardSchemaKey::ColorConfig, "colorConfig"},
+            {AdaptiveCardSchemaKey::ForegroundColors, "foregroundColors"}, {AdaptiveCardSchemaKey::Column, "column"},
+            {AdaptiveCardSchemaKey::Columns, "columns"}, {AdaptiveCardSchemaKey::ColumnSet, "columnSet"},
+            {AdaptiveCardSchemaKey::Container, "container"},
+            {AdaptiveCardSchemaKey::ContainerStyles, "containerStyles"}, {AdaptiveCardSchemaKey::Dark, "dark"},
+            {AdaptiveCardSchemaKey::Data, "data"}, {AdaptiveCardSchemaKey::DateInput, "dateInput"},
+            {AdaptiveCardSchemaKey::Default, "default"}, {AdaptiveCardSchemaKey::Emphasis, "emphasis"},
+            {AdaptiveCardSchemaKey::ExtraLarge, "extraLarge"}, {AdaptiveCardSchemaKey::Facts, "facts"},
+            {AdaptiveCardSchemaKey::FactSet, "factSet"}, {AdaptiveCardSchemaKey::FallbackText, "fallbackText"},
+            {AdaptiveCardSchemaKey::FontFamily, "fontFamily"}, {AdaptiveCardSchemaKey::FontSizes, "fontSizes"},
+            {AdaptiveCardSchemaKey::FontWeights, "fontWeights"}, {AdaptiveCardSchemaKey::Good, "good"},
+            {AdaptiveCardSchemaKey::Height, "height"},
+            {AdaptiveCardSchemaKey::HorizontalAlignment, "horizontalAlignment"},
+            {AdaptiveCardSchemaKey::IconPlacement, "iconPlacement"}, {AdaptiveCardSchemaKey::IconUrl, "iconUrl"},
+            {AdaptiveCardSchemaKey::Id, "id"}, {AdaptiveCardSchemaKey::Image, "image"},
+            {AdaptiveCardSchemaKey::ImageBaseUrl, "imageBaseUrl"}, {AdaptiveCardSchemaKey::Images, "images"},
+            {AdaptiveCardSchemaKey::ImageSet, "imageSet"}, {AdaptiveCardSchemaKey::ImageSize, "imageSize"},
+            {AdaptiveCardSchemaKey::ImageSizes, "imageSizes"},
+            {AdaptiveCardSchemaKey::InlineTopMargin, "inlineTopMargin"},
+            {AdaptiveCardSchemaKey::IsMultiline, "isMultiline"},
+            {AdaptiveCardSchemaKey::IsMultiSelect, "isMultiSelect"}, {AdaptiveCardSchemaKey::IsRequired, "isRequired"},
+            {AdaptiveCardSchemaKey::IsSelected, "isSelected"}, {AdaptiveCardSchemaKey::IsSubtle, "isSubtle"},
+            {AdaptiveCardSchemaKey::Items, "items"}, {AdaptiveCardSchemaKey::Language, "lang"},
+            {AdaptiveCardSchemaKey::Large, "large"}, {AdaptiveCardSchemaKey::Left, "left"},
+            {AdaptiveCardSchemaKey::Light, "light"}, {AdaptiveCardSchemaKey::Lighter, "lighter"},
+            {AdaptiveCardSchemaKey::LineColor, "lineColor"}, {AdaptiveCardSchemaKey::LineThickness, "lineThickness"},
+            {AdaptiveCardSchemaKey::Max, "max"}, {AdaptiveCardSchemaKey::MaxActions, "maxActions"},
+            {AdaptiveCardSchemaKey::MaxImageHeight, "maxImageHeight"}, {AdaptiveCardSchemaKey::MaxLength, "maxLength"},
+            {AdaptiveCardSchemaKey::MaxLines, "maxLines"}, {AdaptiveCardSchemaKey::MaxWidth, "maxWidth"},
+            {AdaptiveCardSchemaKey::Medium, "medium"}, {AdaptiveCardSchemaKey::Method, "method"},
+            {AdaptiveCardSchemaKey::Min, "min"}, {AdaptiveCardSchemaKey::NumberInput, "numberInput"},
+            {AdaptiveCardSchemaKey::Padding, "padding"}, {AdaptiveCardSchemaKey::Placeholder, "placeholder"},
+            {AdaptiveCardSchemaKey::Right, "right"}, {AdaptiveCardSchemaKey::SelectAction, "selectAction"},
+            {AdaptiveCardSchemaKey::Separator, "separator"}, {AdaptiveCardSchemaKey::Thickness, "thickness"},
+            {AdaptiveCardSchemaKey::ShowActionMode, "showActionMode"}, {AdaptiveCardSchemaKey::ShowCard, "showCard"},
+            {AdaptiveCardSchemaKey::ShowCardActionConfig, "showCardActionConfig"},
+            {AdaptiveCardSchemaKey::Size, "size"}, {AdaptiveCardSchemaKey::Small, "small"},
+            {AdaptiveCardSchemaKey::Spacing, "spacing"},
+            {AdaptiveCardSchemaKey::SpacingDefinition, "spacingDefinition"}, {AdaptiveCardSchemaKey::Speak, "speak"},
+            {AdaptiveCardSchemaKey::Stretch, "stretch"}, {AdaptiveCardSchemaKey::Style, "style"},
+            {AdaptiveCardSchemaKey::Subtle, "subtle"},
+            {AdaptiveCardSchemaKey::SupportsInteractivity, "supportsInteractivity"},
+            {AdaptiveCardSchemaKey::Text, "text"}, {AdaptiveCardSchemaKey::TextBlock, "textBlock"},
+            {AdaptiveCardSchemaKey::TextConfig, "textConfig"}, {AdaptiveCardSchemaKey::TextInput, "textInput"},
+            {AdaptiveCardSchemaKey::TextWeight, "weight"}, {AdaptiveCardSchemaKey::Thick, "thick"},
+            {AdaptiveCardSchemaKey::Thickness, "thickness"}, {AdaptiveCardSchemaKey::TimeInput, "timeInput"},
+            {AdaptiveCardSchemaKey::Title, "title"}, {AdaptiveCardSchemaKey::ToggleInput, "toggleInput"},
+            {AdaptiveCardSchemaKey::Top, "top"}, {AdaptiveCardSchemaKey::Type, "type"},
+            {AdaptiveCardSchemaKey::Url, "url"}, {AdaptiveCardSchemaKey::Value, "value"},
+            {AdaptiveCardSchemaKey::ValueOff, "valueOff"}, {AdaptiveCardSchemaKey::ValueOn, "valueOn"},
+            {AdaptiveCardSchemaKey::Version, "version"},
+            {AdaptiveCardSchemaKey::VerticalContentAlignment, "verticalContentAlignment"},
+            {AdaptiveCardSchemaKey::Warning, "warning"}, {AdaptiveCardSchemaKey::Weight, "weight"},
+            {AdaptiveCardSchemaKey::Width, "width"}, {AdaptiveCardSchemaKey::Wrap, "wrap"}};
+        static std::unordered_map<std::string, AdaptiveCardSchemaKey, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            adaptiveCardSchemaKeyNameToEnum =
+                GenerateStringToEnumMap<AdaptiveCardSchemaKey>(adaptiveCardSchemaKeyEnumToName);
 
-    if (adaptiveCardSchemaKeyEnumToNameOut != nullptr)
-    {
-        *adaptiveCardSchemaKeyEnumToNameOut = adaptiveCardSchemaKeyEnumToName;
-    }
-
-    if (adaptiveCardSchemaKeyNameToEnumOut != nullptr)
-    {
-        *adaptiveCardSchemaKeyNameToEnumOut = adaptiveCardSchemaKeyNameToEnum;
-    }
-}
-
-void GetCardElementTypeEnumMappings(
-    std::unordered_map<CardElementType, std::string, EnumHash> * cardElementTypeEnumToNameOut,
-    std::unordered_map<std::string, CardElementType, CaseInsensitiveHash, CaseInsensitiveEqualTo> * cardElementTypeNameToEnumOut)
-{
-    static std::unordered_map<CardElementType, std::string, EnumHash> cardElementTypeEnumToName =
-    {
-        { CardElementType::AdaptiveCard, "AdaptiveCard" },
-        { CardElementType::Column, "Column" },
-        { CardElementType::ColumnSet, "ColumnSet" },
-        { CardElementType::Container, "Container" },
-        { CardElementType::Fact, "Fact" },
-        { CardElementType::FactSet, "FactSet" },
-        { CardElementType::Image, "Image" },
-        { CardElementType::ImageSet, "ImageSet" },
-        { CardElementType::ChoiceSetInput, "Input.ChoiceSet" },
-        { CardElementType::DateInput, "Input.Date" },
-        { CardElementType::NumberInput, "Input.Number" },
-        { CardElementType::TextInput, "Input.Text" },
-        { CardElementType::TimeInput, "Input.Time" },
-        { CardElementType::ToggleInput, "Input.Toggle" },
-        { CardElementType::TextBlock, "TextBlock" },
-        { CardElementType::Custom, "Custom" },
-        { CardElementType::Unknown, "Unknown" }
-    };
-    static std::unordered_map<std::string, CardElementType, CaseInsensitiveHash, CaseInsensitiveEqualTo> cardElementTypeNameToEnum = GenerateStringToEnumMap<CardElementType>(cardElementTypeEnumToName);
-
-    if (cardElementTypeEnumToNameOut != nullptr)
-    {
-        *cardElementTypeEnumToNameOut = cardElementTypeEnumToName;
-    }
-
-    if (cardElementTypeNameToEnumOut != nullptr)
-    {
-        *cardElementTypeNameToEnumOut = cardElementTypeNameToEnum;
-    }
-}
-
-void GetActionTypeEnumMappings(
-    std::unordered_map<ActionType, std::string, EnumHash> * actionTypeEnumToNameOut,
-    std::unordered_map<std::string, ActionType, CaseInsensitiveHash, CaseInsensitiveEqualTo> * actionTypeNameToEnumOut)
-{
-    static std::unordered_map<ActionType, std::string, EnumHash> actionTypeEnumToName =
-    {
-        { ActionType::OpenUrl, "Action.OpenUrl" },
-        { ActionType::ShowCard, "Action.ShowCard" },
-        { ActionType::Submit, "Action.Submit" },
-        { ActionType::Custom, "Custom" }
-    };
-    static std::unordered_map<std::string, ActionType, CaseInsensitiveHash, CaseInsensitiveEqualTo> actionTypeNameToEnum = GenerateStringToEnumMap<ActionType>(actionTypeEnumToName);
-
-    if (actionTypeEnumToNameOut != nullptr)
-    {
-        *actionTypeEnumToNameOut = actionTypeEnumToName;
-    }
-
-    if (actionTypeNameToEnumOut != nullptr)
-    {
-        *actionTypeNameToEnumOut = actionTypeNameToEnum;
-    }
-}
-
-void GetHeightTypeEnumMappings(
-    std::unordered_map<HeightType, std::string, EnumHash> * heightTypeEnumToNameOut,
-    std::unordered_map<std::string, HeightType, CaseInsensitiveHash, CaseInsensitiveEqualTo> * heightTypeNameToEnumOut)
-{
-    static std::unordered_map<HeightType, std::string, EnumHash> heightTypeEnumToName =
-    {
-        { HeightType::Auto, "Auto" },
-        { HeightType::Stretch, "Stretch" }
-    };
-
-    static std::unordered_map<std::string, HeightType, CaseInsensitiveHash, CaseInsensitiveEqualTo>
-        heightTypeNameToEnum = GenerateStringToEnumMap<HeightType>(heightTypeEnumToName);
-
-    if (heightTypeEnumToNameOut != nullptr)
-    {
-        *heightTypeEnumToNameOut = heightTypeEnumToName;
-    }
-
-    if (heightTypeNameToEnumOut != nullptr)
-    {
-        *heightTypeNameToEnumOut = heightTypeNameToEnum;
-    }
-}
-
-void GetSpacingMappings(
-    std::unordered_map<Spacing, std::string, EnumHash> * spacingEnumToNameOut,
-    std::unordered_map<std::string, Spacing, CaseInsensitiveHash, CaseInsensitiveEqualTo> * spacingNameToEnumOut)
-{
-    static std::unordered_map<Spacing, std::string, EnumHash> spacingEnumToName =
+        if (adaptiveCardSchemaKeyEnumToNameOut != nullptr)
         {
-            { Spacing::Default, "default" },
-            { Spacing::None, "none" },
-            { Spacing::Small, "small" },
-            { Spacing::Medium, "medium" },
-            { Spacing::Large, "large" },
-            { Spacing::ExtraLarge, "extraLarge" },
-            { Spacing::Padding, "padding" },
+            *adaptiveCardSchemaKeyEnumToNameOut = adaptiveCardSchemaKeyEnumToName;
+        }
+
+        if (adaptiveCardSchemaKeyNameToEnumOut != nullptr)
+        {
+            *adaptiveCardSchemaKeyNameToEnumOut = adaptiveCardSchemaKeyNameToEnum;
+        }
+    }
+
+    void GetCardElementTypeEnumMappings(
+        std::unordered_map<CardElementType, std::string, EnumHash>* cardElementTypeEnumToNameOut,
+        std::unordered_map<std::string, CardElementType, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
+            cardElementTypeNameToEnumOut)
+    {
+        static std::unordered_map<CardElementType, std::string, EnumHash> cardElementTypeEnumToName = {
+            {CardElementType::AdaptiveCard, "AdaptiveCard"}, {CardElementType::Column, "Column"},
+            {CardElementType::ColumnSet, "ColumnSet"}, {CardElementType::Container, "Container"},
+            {CardElementType::Fact, "Fact"}, {CardElementType::FactSet, "FactSet"}, {CardElementType::Image, "Image"},
+            {CardElementType::ImageSet, "ImageSet"}, {CardElementType::ChoiceSetInput, "Input.ChoiceSet"},
+            {CardElementType::DateInput, "Input.Date"}, {CardElementType::NumberInput, "Input.Number"},
+            {CardElementType::TextInput, "Input.Text"}, {CardElementType::TimeInput, "Input.Time"},
+            {CardElementType::ToggleInput, "Input.Toggle"}, {CardElementType::TextBlock, "TextBlock"},
+            {CardElementType::Custom, "Custom"}, {CardElementType::Unknown, "Unknown"}};
+        static std::unordered_map<std::string, CardElementType, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            cardElementTypeNameToEnum = GenerateStringToEnumMap<CardElementType>(cardElementTypeEnumToName);
+
+        if (cardElementTypeEnumToNameOut != nullptr)
+        {
+            *cardElementTypeEnumToNameOut = cardElementTypeEnumToName;
+        }
+
+        if (cardElementTypeNameToEnumOut != nullptr)
+        {
+            *cardElementTypeNameToEnumOut = cardElementTypeNameToEnum;
+        }
+    }
+
+    void GetActionTypeEnumMappings(std::unordered_map<ActionType, std::string, EnumHash>* actionTypeEnumToNameOut,
+        std::unordered_map<std::string, ActionType, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
+            actionTypeNameToEnumOut)
+    {
+        static std::unordered_map<ActionType, std::string, EnumHash> actionTypeEnumToName = {
+            {ActionType::OpenUrl, "Action.OpenUrl"}, {ActionType::ShowCard, "Action.ShowCard"},
+            {ActionType::Submit, "Action.Submit"}, {ActionType::Custom, "Custom"}};
+        static std::unordered_map<std::string, ActionType, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            actionTypeNameToEnum = GenerateStringToEnumMap<ActionType>(actionTypeEnumToName);
+
+        if (actionTypeEnumToNameOut != nullptr)
+        {
+            *actionTypeEnumToNameOut = actionTypeEnumToName;
+        }
+
+        if (actionTypeNameToEnumOut != nullptr)
+        {
+            *actionTypeNameToEnumOut = actionTypeNameToEnum;
+        }
+    }
+
+    void GetHeightTypeEnumMappings(std::unordered_map<HeightType, std::string, EnumHash>* heightTypeEnumToNameOut,
+        std::unordered_map<std::string, HeightType, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
+            heightTypeNameToEnumOut)
+    {
+        static std::unordered_map<HeightType, std::string, EnumHash> heightTypeEnumToName = {
+            {HeightType::Auto, "Auto"}, {HeightType::Stretch, "Stretch"}};
+
+        static std::unordered_map<std::string, HeightType, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            heightTypeNameToEnum = GenerateStringToEnumMap<HeightType>(heightTypeEnumToName);
+
+        if (heightTypeEnumToNameOut != nullptr)
+        {
+            *heightTypeEnumToNameOut = heightTypeEnumToName;
+        }
+
+        if (heightTypeNameToEnumOut != nullptr)
+        {
+            *heightTypeNameToEnumOut = heightTypeNameToEnum;
+        }
+    }
+
+    void GetSpacingMappings(std::unordered_map<Spacing, std::string, EnumHash>* spacingEnumToNameOut,
+        std::unordered_map<std::string, Spacing, CaseInsensitiveHash, CaseInsensitiveEqualTo>* spacingNameToEnumOut)
+    {
+        static std::unordered_map<Spacing, std::string, EnumHash> spacingEnumToName = {
+            {Spacing::Default, "default"},
+            {Spacing::None, "none"},
+            {Spacing::Small, "small"},
+            {Spacing::Medium, "medium"},
+            {Spacing::Large, "large"},
+            {Spacing::ExtraLarge, "extraLarge"},
+            {Spacing::Padding, "padding"},
         };
-    static std::unordered_map<std::string, Spacing, CaseInsensitiveHash, CaseInsensitiveEqualTo> spacingNameToEnum = GenerateStringToEnumMap<Spacing>(spacingEnumToName);
+        static std::unordered_map<std::string, Spacing, CaseInsensitiveHash, CaseInsensitiveEqualTo> spacingNameToEnum =
+            GenerateStringToEnumMap<Spacing>(spacingEnumToName);
 
-    if (spacingEnumToNameOut != nullptr)
-    {
-        *spacingEnumToNameOut = spacingEnumToName;
+        if (spacingEnumToNameOut != nullptr)
+        {
+            *spacingEnumToNameOut = spacingEnumToName;
+        }
+
+        if (spacingNameToEnumOut != nullptr)
+        {
+            *spacingNameToEnumOut = spacingNameToEnum;
+        }
     }
 
-    if (spacingNameToEnumOut != nullptr)
+    void GetSeparatorThicknessEnumMappings(
+        std::unordered_map<SeparatorThickness, std::string, EnumHash>* separatorThicknessEnumToNameOut,
+        std::unordered_map<std::string, SeparatorThickness, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
+            separatorThicknessNameToEnumOut)
     {
-        *spacingNameToEnumOut = spacingNameToEnum;
-    }
-}
+        static std::unordered_map<SeparatorThickness, std::string, EnumHash> separatorThicknessEnumToName = {
+            {SeparatorThickness::Default, "default"},
+            {SeparatorThickness::Thick, "thick"},
+        };
+        static std::unordered_map<std::string, SeparatorThickness, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            separatorThicknessNameToEnum = GenerateStringToEnumMap<SeparatorThickness>(separatorThicknessEnumToName);
 
-void GetSeparatorThicknessEnumMappings(
-    std::unordered_map<SeparatorThickness, std::string, EnumHash> *separatorThicknessEnumToNameOut,
-    std::unordered_map<std::string, SeparatorThickness, CaseInsensitiveHash, CaseInsensitiveEqualTo> * separatorThicknessNameToEnumOut)
-{
-    static std::unordered_map<SeparatorThickness, std::string, EnumHash> separatorThicknessEnumToName =
-    {
-        { SeparatorThickness::Default, "default" },
-        { SeparatorThickness::Thick, "thick" },
-    };
-    static std::unordered_map<std::string, SeparatorThickness, CaseInsensitiveHash, CaseInsensitiveEqualTo> separatorThicknessNameToEnum = GenerateStringToEnumMap<SeparatorThickness>(separatorThicknessEnumToName);
+        if (separatorThicknessEnumToNameOut != nullptr)
+        {
+            *separatorThicknessEnumToNameOut = separatorThicknessEnumToName;
+        }
 
-    if (separatorThicknessEnumToNameOut != nullptr)
-    {
-        *separatorThicknessEnumToNameOut = separatorThicknessEnumToName;
-    }
-
-    if (separatorThicknessNameToEnumOut != nullptr)
-    {
-        *separatorThicknessNameToEnumOut = separatorThicknessNameToEnum;
-    }
-}
-
-void GetImageStyleEnumMappings(
-    std::unordered_map<ImageStyle, std::string, EnumHash> * imageStyleEnumToNameOut,
-    std::unordered_map<std::string, ImageStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo> * imageStyleNameToEnumOut)
-{
-    static std::unordered_map<ImageStyle, std::string, EnumHash> imageStyleEnumToName =
-    {
-        { ImageStyle::Default, "default" },
-        { ImageStyle::Person, "person" }
-    };
-
-    static std::unordered_map<std::string, ImageStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo> imageStyleNameToEnum =
-    {
-        { "default", ImageStyle::Default },
-        { "person", ImageStyle::Person },
-        { "normal", ImageStyle::Default } // Back compat to support "Normal" for "Default" for pre V1.0 payloads
-    };
-
-    if (imageStyleEnumToNameOut != nullptr)
-    {
-        *imageStyleEnumToNameOut = imageStyleEnumToName;
+        if (separatorThicknessNameToEnumOut != nullptr)
+        {
+            *separatorThicknessNameToEnumOut = separatorThicknessNameToEnum;
+        }
     }
 
-    if (imageStyleNameToEnumOut != nullptr)
+    void GetImageStyleEnumMappings(std::unordered_map<ImageStyle, std::string, EnumHash>* imageStyleEnumToNameOut,
+        std::unordered_map<std::string, ImageStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
+            imageStyleNameToEnumOut)
     {
-        *imageStyleNameToEnumOut = imageStyleNameToEnum;
-    }
-}
+        static std::unordered_map<ImageStyle, std::string, EnumHash> imageStyleEnumToName = {
+            {ImageStyle::Default, "default"}, {ImageStyle::Person, "person"}};
 
-void GetImageSizeEnumMappings(
-    std::unordered_map<ImageSize, std::string, EnumHash> * imageSizeEnumToNameOut,
-    std::unordered_map<std::string, ImageSize, CaseInsensitiveHash, CaseInsensitiveEqualTo> * imageSizeNameToEnumOut)
-{
-    static std::unordered_map<ImageSize, std::string, EnumHash> imageSizeEnumToName =
-    {
-        { ImageSize::Auto, "Auto" },
-        { ImageSize::Large, "Large" },
-        { ImageSize::Medium, "Medium" },
-        { ImageSize::Small, "Small" },
-        { ImageSize::Stretch, "Stretch" },
-    };
-    static std::unordered_map<std::string, ImageSize, CaseInsensitiveHash, CaseInsensitiveEqualTo> imageSizeNameToEnum = GenerateStringToEnumMap<ImageSize>(imageSizeEnumToName);
+        static std::unordered_map<std::string, ImageStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            imageStyleNameToEnum = {
+                {"default", ImageStyle::Default}, {"person", ImageStyle::Person},
+                {"normal", ImageStyle::Default} // Back compat to support "Normal" for "Default" for pre V1.0 payloads
+            };
 
-    if (imageSizeEnumToNameOut != nullptr)
-    {
-        *imageSizeEnumToNameOut = imageSizeEnumToName;
-    }
+        if (imageStyleEnumToNameOut != nullptr)
+        {
+            *imageStyleEnumToNameOut = imageStyleEnumToName;
+        }
 
-    if (imageSizeNameToEnumOut != nullptr)
-    {
-        *imageSizeNameToEnumOut = imageSizeNameToEnum;
-    }
-};
-
-void GetHorizontalAlignmentEnumMappings(
-    std::unordered_map<HorizontalAlignment, std::string, EnumHash> * horizontalAlignmentEnumToNameOut,
-    std::unordered_map<std::string, HorizontalAlignment, CaseInsensitiveHash, CaseInsensitiveEqualTo> * horizontalAlignmentNameToEnumOut)
-{
-    static std::unordered_map<HorizontalAlignment, std::string, EnumHash> horizontalAlignmentEnumToName =
-    {
-        {HorizontalAlignment::Center, "Center"},
-        {HorizontalAlignment::Left, "Left"},
-        {HorizontalAlignment::Right, "Right"}
-    };
-    static std::unordered_map<std::string, HorizontalAlignment, CaseInsensitiveHash, CaseInsensitiveEqualTo> horizontalAlignmentNameToEnum = GenerateStringToEnumMap<HorizontalAlignment>(horizontalAlignmentEnumToName);
-
-    if (horizontalAlignmentEnumToNameOut != nullptr)
-    {
-        *horizontalAlignmentEnumToNameOut = horizontalAlignmentEnumToName;
+        if (imageStyleNameToEnumOut != nullptr)
+        {
+            *imageStyleNameToEnumOut = imageStyleNameToEnum;
+        }
     }
 
-    if (horizontalAlignmentNameToEnumOut != nullptr)
+    void GetImageSizeEnumMappings(std::unordered_map<ImageSize, std::string, EnumHash>* imageSizeEnumToNameOut,
+        std::unordered_map<std::string, ImageSize, CaseInsensitiveHash, CaseInsensitiveEqualTo>* imageSizeNameToEnumOut)
     {
-        *horizontalAlignmentNameToEnumOut = horizontalAlignmentNameToEnum;
-    }
-};
+        static std::unordered_map<ImageSize, std::string, EnumHash> imageSizeEnumToName = {
+            {ImageSize::Auto, "Auto"},
+            {ImageSize::Large, "Large"},
+            {ImageSize::Medium, "Medium"},
+            {ImageSize::Small, "Small"},
+            {ImageSize::Stretch, "Stretch"},
+        };
+        static std::unordered_map<std::string, ImageSize, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            imageSizeNameToEnum = GenerateStringToEnumMap<ImageSize>(imageSizeEnumToName);
 
-void GetColorEnumMappings(
-    std::unordered_map<ForegroundColor, std::string, EnumHash> * colorEnumToNameOut,
-    std::unordered_map<std::string, ForegroundColor, CaseInsensitiveHash, CaseInsensitiveEqualTo> * colorNameToEnumOut)
-{
-    static std::unordered_map<ForegroundColor, std::string, EnumHash> colorEnumToName =
-    {
-        {ForegroundColor::Accent, "Accent"},
-        {ForegroundColor::Attention, "Attention"},
-        {ForegroundColor::Dark, "Dark" },
-        {ForegroundColor::Default, "Default"},
-        {ForegroundColor::Good, "Good"},
-        {ForegroundColor::Light, "Light" },
-        {ForegroundColor::Warning, "Warning"},
-    };
-    static std::unordered_map<std::string, ForegroundColor, CaseInsensitiveHash, CaseInsensitiveEqualTo> colorNameToEnum = GenerateStringToEnumMap<ForegroundColor>(colorEnumToName);
+        if (imageSizeEnumToNameOut != nullptr)
+        {
+            *imageSizeEnumToNameOut = imageSizeEnumToName;
+        }
 
-    if (colorEnumToNameOut != nullptr)
-    {
-        *colorEnumToNameOut = colorEnumToName;
-    }
-
-    if (colorNameToEnumOut != nullptr)
-    {
-        *colorNameToEnumOut = colorNameToEnum;
-    }
-}
-
-void GetTextWeightEnumMappings(
-    std::unordered_map<TextWeight, std::string, EnumHash> * textWeightEnumToNameOut,
-    std::unordered_map<std::string, TextWeight, CaseInsensitiveHash, CaseInsensitiveEqualTo> * textWeightNameToEnumOut)
-{
-    static std::unordered_map<TextWeight, std::string, EnumHash> textWeightEnumToName =
-    {
-        {TextWeight::Bolder, "Bolder"},
-        {TextWeight::Lighter, "Lighter"},
-        {TextWeight::Default, "Default"},
+        if (imageSizeNameToEnumOut != nullptr)
+        {
+            *imageSizeNameToEnumOut = imageSizeNameToEnum;
+        }
     };
 
-    static std::unordered_map<std::string, TextWeight, CaseInsensitiveHash, CaseInsensitiveEqualTo> textWeightNameToEnum =
+    void GetHorizontalAlignmentEnumMappings(
+        std::unordered_map<HorizontalAlignment, std::string, EnumHash>* horizontalAlignmentEnumToNameOut,
+        std::unordered_map<std::string, HorizontalAlignment, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
+            horizontalAlignmentNameToEnumOut)
     {
-        { "Bolder", TextWeight::Bolder },
-        { "Lighter", TextWeight::Lighter },
-        { "Default", TextWeight::Default },
-        { "Normal", TextWeight::Default }, // Back compat to support "Normal" for "Default" for pre V1.0 payloads
+        static std::unordered_map<HorizontalAlignment, std::string, EnumHash> horizontalAlignmentEnumToName = {
+            {HorizontalAlignment::Center, "Center"}, {HorizontalAlignment::Left, "Left"},
+            {HorizontalAlignment::Right, "Right"}};
+        static std::unordered_map<std::string, HorizontalAlignment, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            horizontalAlignmentNameToEnum = GenerateStringToEnumMap<HorizontalAlignment>(horizontalAlignmentEnumToName);
+
+        if (horizontalAlignmentEnumToNameOut != nullptr)
+        {
+            *horizontalAlignmentEnumToNameOut = horizontalAlignmentEnumToName;
+        }
+
+        if (horizontalAlignmentNameToEnumOut != nullptr)
+        {
+            *horizontalAlignmentNameToEnumOut = horizontalAlignmentNameToEnum;
+        }
     };
 
-    if (textWeightEnumToNameOut != nullptr)
+    void GetColorEnumMappings(std::unordered_map<ForegroundColor, std::string, EnumHash>* colorEnumToNameOut,
+        std::unordered_map<std::string, ForegroundColor, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
+            colorNameToEnumOut)
     {
-        *textWeightEnumToNameOut = textWeightEnumToName;
+        static std::unordered_map<ForegroundColor, std::string, EnumHash> colorEnumToName = {
+            {ForegroundColor::Accent, "Accent"},
+            {ForegroundColor::Attention, "Attention"},
+            {ForegroundColor::Dark, "Dark"},
+            {ForegroundColor::Default, "Default"},
+            {ForegroundColor::Good, "Good"},
+            {ForegroundColor::Light, "Light"},
+            {ForegroundColor::Warning, "Warning"},
+        };
+        static std::unordered_map<std::string, ForegroundColor, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            colorNameToEnum = GenerateStringToEnumMap<ForegroundColor>(colorEnumToName);
+
+        if (colorEnumToNameOut != nullptr)
+        {
+            *colorEnumToNameOut = colorEnumToName;
+        }
+
+        if (colorNameToEnumOut != nullptr)
+        {
+            *colorNameToEnumOut = colorNameToEnum;
+        }
     }
 
-    if (textWeightNameToEnumOut != nullptr)
+    void GetTextWeightEnumMappings(std::unordered_map<TextWeight, std::string, EnumHash>* textWeightEnumToNameOut,
+        std::unordered_map<std::string, TextWeight, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
+            textWeightNameToEnumOut)
     {
-        *textWeightNameToEnumOut = textWeightNameToEnum;
-    }
-}
+        static std::unordered_map<TextWeight, std::string, EnumHash> textWeightEnumToName = {
+            {TextWeight::Bolder, "Bolder"},
+            {TextWeight::Lighter, "Lighter"},
+            {TextWeight::Default, "Default"},
+        };
 
-void GetTextSizeEnumMappings(
-    std::unordered_map<TextSize, std::string, EnumHash> * textSizeEnumToNameOut,
-    std::unordered_map<std::string, TextSize, CaseInsensitiveHash, CaseInsensitiveEqualTo> * textSizeNameToEnumOut)
-{
-    static std::unordered_map<TextSize, std::string, EnumHash> textSizeEnumToName =
+        static std::unordered_map<std::string, TextWeight, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            textWeightNameToEnum = {
+                {"Bolder", TextWeight::Bolder}, {"Lighter", TextWeight::Lighter}, {"Default", TextWeight::Default},
+                {"Normal", TextWeight::Default}, // Back compat to support "Normal" for "Default" for pre V1.0 payloads
+            };
+
+        if (textWeightEnumToNameOut != nullptr)
+        {
+            *textWeightEnumToNameOut = textWeightEnumToName;
+        }
+
+        if (textWeightNameToEnumOut != nullptr)
+        {
+            *textWeightNameToEnumOut = textWeightNameToEnum;
+        }
+    }
+
+    void GetTextSizeEnumMappings(std::unordered_map<TextSize, std::string, EnumHash>* textSizeEnumToNameOut,
+        std::unordered_map<std::string, TextSize, CaseInsensitiveHash, CaseInsensitiveEqualTo>* textSizeNameToEnumOut)
     {
-        {TextSize::ExtraLarge, "ExtraLarge"},
-        {TextSize::Large, "Large"},
-        {TextSize::Medium, "Medium"},
-        {TextSize::Default, "Default"},
-        {TextSize::Small, "Small"},
+        static std::unordered_map<TextSize, std::string, EnumHash> textSizeEnumToName = {
+            {TextSize::ExtraLarge, "ExtraLarge"},
+            {TextSize::Large, "Large"},
+            {TextSize::Medium, "Medium"},
+            {TextSize::Default, "Default"},
+            {TextSize::Small, "Small"},
+        };
+
+        static std::unordered_map<std::string, TextSize, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            textSizeNameToEnum = {
+                {"ExtraLarge", TextSize::ExtraLarge}, {"Large", TextSize::Large}, {"Medium", TextSize::Medium},
+                {"Default", TextSize::Default}, {"Small", TextSize::Small},
+                {"Normal", TextSize::Default}, // Back compat to support "Normal" for "Default" for pre V1.0 payloads
+            };
+
+        if (textSizeEnumToNameOut != nullptr)
+        {
+            *textSizeEnumToNameOut = textSizeEnumToName;
+        }
+
+        if (textSizeNameToEnumOut != nullptr)
+        {
+            *textSizeNameToEnumOut = textSizeNameToEnum;
+        }
+    }
+
+    void GetActionsOrientationEnumMappings(
+        std::unordered_map<ActionsOrientation, std::string, EnumHash>* actionsOrientationEnumToNameOut,
+        std::unordered_map<std::string, ActionsOrientation, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
+            actionsOrientationNameToEnumOut)
+    {
+        static std::unordered_map<ActionsOrientation, std::string, EnumHash> actionsOrientationEnumToName = {
+            {ActionsOrientation::Horizontal, "Horizontal"},
+            {ActionsOrientation::Vertical, "Vertical"},
+        };
+        static std::unordered_map<std::string, ActionsOrientation, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            actionsOrientationNameToEnum = GenerateStringToEnumMap<ActionsOrientation>(actionsOrientationEnumToName);
+
+        if (actionsOrientationEnumToNameOut != nullptr)
+        {
+            *actionsOrientationEnumToNameOut = actionsOrientationEnumToName;
+        }
+
+        if (actionsOrientationNameToEnumOut != nullptr)
+        {
+            *actionsOrientationNameToEnumOut = actionsOrientationNameToEnum;
+        }
+    }
+
+    void GetActionModeEnumMappings(std::unordered_map<ActionMode, std::string, EnumHash>* actionModeEnumToNameOut,
+        std::unordered_map<std::string, ActionMode, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
+            actionModeNameToEnumOut)
+    {
+        static std::unordered_map<ActionMode, std::string, EnumHash> actionModeEnumToName = {
+            {ActionMode::Inline, "Inline"}, {ActionMode::Popup, "Popup"}};
+        static std::unordered_map<std::string, ActionMode, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            actionModeNameToEnum = GenerateStringToEnumMap<ActionMode>(actionModeEnumToName);
+
+        if (actionModeEnumToNameOut != nullptr)
+        {
+            *actionModeEnumToNameOut = actionModeEnumToName;
+        }
+
+        if (actionModeNameToEnumOut != nullptr)
+        {
+            *actionModeNameToEnumOut = actionModeNameToEnum;
+        }
+    }
+
+    void GetChoiceSetStyleEnumMappings(
+        std::unordered_map<ChoiceSetStyle, std::string, EnumHash>* choiceSetStyleEnumToNameOut,
+        std::unordered_map<std::string, ChoiceSetStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
+            choiceSetStyleNameToEnumOut)
+    {
+        static std::unordered_map<ChoiceSetStyle, std::string, EnumHash> choiceSetStyleEnumToName = {
+            {ChoiceSetStyle::Compact, "Compact"}, {ChoiceSetStyle::Expanded, "Expanded"}};
+        static std::unordered_map<std::string, ChoiceSetStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            choiceSetStyleNameToEnum = GenerateStringToEnumMap<ChoiceSetStyle>(choiceSetStyleEnumToName);
+
+        if (choiceSetStyleEnumToNameOut != nullptr)
+        {
+            *choiceSetStyleEnumToNameOut = choiceSetStyleEnumToName;
+        }
+
+        if (choiceSetStyleNameToEnumOut != nullptr)
+        {
+            *choiceSetStyleNameToEnumOut = choiceSetStyleNameToEnum;
+        }
     };
 
-    static std::unordered_map<std::string, TextSize, CaseInsensitiveHash, CaseInsensitiveEqualTo> textSizeNameToEnum =
+    void GetTextInputStyleEnumMappings(
+        std::unordered_map<TextInputStyle, std::string, EnumHash>* textInputStyleEnumToNameOut,
+        std::unordered_map<std::string, TextInputStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
+            textInputStyleNameToEnumOut)
     {
-        { "ExtraLarge", TextSize::ExtraLarge },
-        { "Large", TextSize::Large },
-        { "Medium", TextSize::Medium },
-        { "Default", TextSize::Default },
-        { "Small", TextSize::Small },
-        { "Normal", TextSize::Default }, // Back compat to support "Normal" for "Default" for pre V1.0 payloads
-    };
+        static std::unordered_map<TextInputStyle, std::string, EnumHash> textInputStyleEnumToName = {
+            {TextInputStyle::Email, "Email"},
+            {TextInputStyle::Tel, "Tel"},
+            {TextInputStyle::Text, "Text"},
+            {TextInputStyle::Url, "Url"},
+        };
+        static std::unordered_map<std::string, TextInputStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            textInputStyleNameToEnum = GenerateStringToEnumMap<TextInputStyle>(textInputStyleEnumToName);
 
-    if (textSizeEnumToNameOut != nullptr)
-    {
-        *textSizeEnumToNameOut = textSizeEnumToName;
+        if (textInputStyleEnumToNameOut != nullptr)
+        {
+            *textInputStyleEnumToNameOut = textInputStyleEnumToName;
+        }
+
+        if (textInputStyleNameToEnumOut != nullptr)
+        {
+            *textInputStyleNameToEnumOut = textInputStyleNameToEnum;
+        }
     }
 
-    if (textSizeNameToEnumOut != nullptr)
+    void GetContainerStyleEnumMappings(
+        std::unordered_map<ContainerStyle, std::string, EnumHash>* containerStyleEnumToNameOut,
+        std::unordered_map<std::string, ContainerStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
+            containerStyleNameToEnumOut)
     {
-        *textSizeNameToEnumOut = textSizeNameToEnum;
-    }
-}
+        static std::unordered_map<ContainerStyle, std::string, EnumHash> containerStyleEnumToName = {
+            {ContainerStyle::Default, "Default"},
+            {ContainerStyle::Emphasis, "Emphasis"},
+        };
+        static std::unordered_map<std::string, ContainerStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            containerStyleNameToEnum = GenerateStringToEnumMap<ContainerStyle>(containerStyleEnumToName);
 
-void GetActionsOrientationEnumMappings(
-    std::unordered_map<ActionsOrientation, std::string, EnumHash> * actionsOrientationEnumToNameOut,
-    std::unordered_map<std::string, ActionsOrientation, CaseInsensitiveHash, CaseInsensitiveEqualTo> * actionsOrientationNameToEnumOut)
-{
-    static std::unordered_map<ActionsOrientation, std::string, EnumHash> actionsOrientationEnumToName =
-    {
-        { ActionsOrientation::Horizontal, "Horizontal" },
-        { ActionsOrientation::Vertical, "Vertical" },
-    };
-    static std::unordered_map<std::string, ActionsOrientation, CaseInsensitiveHash, CaseInsensitiveEqualTo> actionsOrientationNameToEnum = GenerateStringToEnumMap<ActionsOrientation>(actionsOrientationEnumToName);
+        if (containerStyleEnumToNameOut != nullptr)
+        {
+            *containerStyleEnumToNameOut = containerStyleEnumToName;
+        }
 
-    if (actionsOrientationEnumToNameOut != nullptr)
-    {
-        *actionsOrientationEnumToNameOut = actionsOrientationEnumToName;
-    }
-
-    if (actionsOrientationNameToEnumOut != nullptr)
-    {
-        *actionsOrientationNameToEnumOut = actionsOrientationNameToEnum;
-    }
-}
-
-void GetActionModeEnumMappings(
-    std::unordered_map<ActionMode, std::string, EnumHash> * actionModeEnumToNameOut,
-    std::unordered_map<std::string, ActionMode, CaseInsensitiveHash, CaseInsensitiveEqualTo> * actionModeNameToEnumOut)
-{
-    static std::unordered_map<ActionMode, std::string, EnumHash> actionModeEnumToName =
-    {
-        { ActionMode::Inline, "Inline" },
-        { ActionMode::Popup, "Popup" }
-    };
-    static std::unordered_map<std::string, ActionMode, CaseInsensitiveHash, CaseInsensitiveEqualTo> actionModeNameToEnum = GenerateStringToEnumMap<ActionMode>(actionModeEnumToName);
-
-    if (actionModeEnumToNameOut != nullptr)
-    {
-        *actionModeEnumToNameOut = actionModeEnumToName;
+        if (containerStyleNameToEnumOut != nullptr)
+        {
+            *containerStyleNameToEnumOut = containerStyleNameToEnum;
+        }
     }
 
-    if (actionModeNameToEnumOut != nullptr)
+    void GetActionAlignmentEnumMappings(
+        std::unordered_map<ActionAlignment, std::string, EnumHash>* actionAlignmentEnumToNameOut,
+        std::unordered_map<std::string, ActionAlignment, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
+            actionAlignmentNameToEnumOut)
     {
-        *actionModeNameToEnumOut = actionModeNameToEnum;
-    }
-}
+        static std::unordered_map<ActionAlignment, std::string, EnumHash> actionAlignmentEnumToName = {
+            {ActionAlignment::Left, "Left"},
+            {ActionAlignment::Center, "Center"},
+            {ActionAlignment::Right, "Right"},
+            {ActionAlignment::Stretch, "Stretch"},
+        };
+        static std::unordered_map<std::string, ActionAlignment, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            actionAlignmentNameToEnum = GenerateStringToEnumMap<ActionAlignment>(actionAlignmentEnumToName);
 
-void GetChoiceSetStyleEnumMappings(
-    std::unordered_map<ChoiceSetStyle, std::string, EnumHash> * choiceSetStyleEnumToNameOut,
-    std::unordered_map<std::string, ChoiceSetStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo> * choiceSetStyleNameToEnumOut)
-{
-    static std::unordered_map<ChoiceSetStyle, std::string, EnumHash> choiceSetStyleEnumToName =
-    {
-        { ChoiceSetStyle::Compact, "Compact" },
-        { ChoiceSetStyle::Expanded, "Expanded" }
-    };
-    static std::unordered_map<std::string, ChoiceSetStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo> choiceSetStyleNameToEnum = GenerateStringToEnumMap<ChoiceSetStyle>(choiceSetStyleEnumToName);
+        if (actionAlignmentEnumToNameOut != nullptr)
+        {
+            *actionAlignmentEnumToNameOut = actionAlignmentEnumToName;
+        }
 
-    if (choiceSetStyleEnumToNameOut != nullptr)
-    {
-        *choiceSetStyleEnumToNameOut = choiceSetStyleEnumToName;
-    }
-
-    if (choiceSetStyleNameToEnumOut != nullptr)
-    {
-        *choiceSetStyleNameToEnumOut = choiceSetStyleNameToEnum;
-    }
-};
-
-void GetTextInputStyleEnumMappings(
-    std::unordered_map<TextInputStyle, std::string, EnumHash> * textInputStyleEnumToNameOut,
-    std::unordered_map<std::string, TextInputStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo> * textInputStyleNameToEnumOut)
-{
-    static std::unordered_map<TextInputStyle, std::string, EnumHash> textInputStyleEnumToName =
-    {
-        { TextInputStyle::Email, "Email" },
-        { TextInputStyle::Tel, "Tel" },
-        { TextInputStyle::Text, "Text" },
-        { TextInputStyle::Url, "Url" },
-    };
-    static std::unordered_map<std::string, TextInputStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo> textInputStyleNameToEnum = GenerateStringToEnumMap<TextInputStyle>(textInputStyleEnumToName);
-
-    if (textInputStyleEnumToNameOut != nullptr)
-    {
-        *textInputStyleEnumToNameOut = textInputStyleEnumToName;
+        if (actionAlignmentNameToEnumOut != nullptr)
+        {
+            *actionAlignmentNameToEnumOut = actionAlignmentNameToEnum;
+        }
     }
 
-    if (textInputStyleNameToEnumOut != nullptr)
+    void GetIconPlacementEnumMappings(
+        std::unordered_map<IconPlacement, std::string, EnumHash>* iconPlacementEnumToNameOut,
+        std::unordered_map<std::string, IconPlacement, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
+            iconPlacementNameToEnumOut)
     {
-        *textInputStyleNameToEnumOut = textInputStyleNameToEnum;
-    }
-}
+        static std::unordered_map<IconPlacement, std::string, EnumHash> iconPlacementEnumToName = {
+            {IconPlacement::AboveTitle, "AboveTitle"}, {IconPlacement::LeftOfTitle, "LeftOfTitle"}};
+        static std::unordered_map<std::string, IconPlacement, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            iconPlacementNameToEnum = GenerateStringToEnumMap<IconPlacement>(iconPlacementEnumToName);
 
-void GetContainerStyleEnumMappings(
-    std::unordered_map<ContainerStyle, std::string, EnumHash> * containerStyleEnumToNameOut,
-    std::unordered_map<std::string, ContainerStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo> * containerStyleNameToEnumOut)
-{
-    static std::unordered_map<ContainerStyle, std::string, EnumHash> containerStyleEnumToName =
-    {
-        { ContainerStyle::Default, "Default" },
-        { ContainerStyle::Emphasis, "Emphasis" },
-    };
-    static std::unordered_map<std::string, ContainerStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo> containerStyleNameToEnum = GenerateStringToEnumMap<ContainerStyle>(containerStyleEnumToName);
+        if (iconPlacementEnumToNameOut != nullptr)
+        {
+            *iconPlacementEnumToNameOut = iconPlacementEnumToName;
+        }
 
-    if (containerStyleEnumToNameOut != nullptr)
-    {
-        *containerStyleEnumToNameOut = containerStyleEnumToName;
-    }
-
-    if (containerStyleNameToEnumOut != nullptr)
-    {
-        *containerStyleNameToEnumOut = containerStyleNameToEnum;
-    }
-}
-
-void GetActionAlignmentEnumMappings(
-    std::unordered_map<ActionAlignment, std::string, EnumHash> * actionAlignmentEnumToNameOut,
-    std::unordered_map<std::string, ActionAlignment, CaseInsensitiveHash, CaseInsensitiveEqualTo> * actionAlignmentNameToEnumOut)
-{
-    static std::unordered_map<ActionAlignment, std::string, EnumHash> actionAlignmentEnumToName =
-    {
-        { ActionAlignment::Left, "Left" },
-        { ActionAlignment::Center, "Center" },
-        { ActionAlignment::Right, "Right" },
-        { ActionAlignment::Stretch, "Stretch" },
-    };
-    static std::unordered_map<std::string, ActionAlignment, CaseInsensitiveHash, CaseInsensitiveEqualTo> actionAlignmentNameToEnum = GenerateStringToEnumMap<ActionAlignment>(actionAlignmentEnumToName);
-
-    if (actionAlignmentEnumToNameOut != nullptr)
-    {
-        *actionAlignmentEnumToNameOut = actionAlignmentEnumToName;
+        if (iconPlacementNameToEnumOut != nullptr)
+        {
+            *iconPlacementNameToEnumOut = iconPlacementNameToEnum;
+        }
     }
 
-    if (actionAlignmentNameToEnumOut != nullptr)
+    void GetVerticalContentAlignmentEnumMappings(
+        std::unordered_map<VerticalContentAlignment, std::string, EnumHash>* verticalContentAlignmentEnumToNameOut,
+        std::unordered_map<std::string, VerticalContentAlignment, CaseInsensitiveHash, CaseInsensitiveEqualTo>*
+            verticalContentAlignmentNameToEnumOut)
     {
-        *actionAlignmentNameToEnumOut = actionAlignmentNameToEnum;
-    }
-}
+        static std::unordered_map<VerticalContentAlignment, std::string, EnumHash> verticalContentAlignmentEnumToName =
+            {{VerticalContentAlignment::Stretch, "Stretch"}, {VerticalContentAlignment::Top, "Top"},
+                {VerticalContentAlignment::Center, "Center"}, {VerticalContentAlignment::Bottom, "Bottom"}};
+        static std::unordered_map<std::string, VerticalContentAlignment, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            verticalContentAlignmentNameToEnum =
+                GenerateStringToEnumMap<VerticalContentAlignment>(verticalContentAlignmentEnumToName);
 
-void GetIconPlacementEnumMappings(
-    std::unordered_map<IconPlacement, std::string, EnumHash> * iconPlacementEnumToNameOut,
-    std::unordered_map<std::string, IconPlacement, CaseInsensitiveHash, CaseInsensitiveEqualTo> * iconPlacementNameToEnumOut)
-{
-    static std::unordered_map<IconPlacement, std::string, EnumHash> iconPlacementEnumToName =
-    {
-        {IconPlacement::AboveTitle , "AboveTitle"},
-        {IconPlacement::LeftOfTitle, "LeftOfTitle"}
-    };
-    static std::unordered_map<std::string, IconPlacement, CaseInsensitiveHash, CaseInsensitiveEqualTo> iconPlacementNameToEnum = GenerateStringToEnumMap<IconPlacement>(iconPlacementEnumToName);
+        if (verticalContentAlignmentEnumToNameOut != nullptr)
+        {
+            *verticalContentAlignmentEnumToNameOut = verticalContentAlignmentEnumToName;
+        }
 
-    if (iconPlacementEnumToNameOut != nullptr)
-    {
-        *iconPlacementEnumToNameOut = iconPlacementEnumToName;
-    }
-
-    if (iconPlacementNameToEnumOut != nullptr)
-    {
-        *iconPlacementNameToEnumOut = iconPlacementNameToEnum;
-    }
-}
-
-void GetVerticalContentAlignmentEnumMappings(
-    std::unordered_map<VerticalContentAlignment, std::string, EnumHash> * verticalContentAlignmentEnumToNameOut,
-    std::unordered_map<std::string, VerticalContentAlignment, CaseInsensitiveHash, CaseInsensitiveEqualTo> * verticalContentAlignmentNameToEnumOut)
-{
-    static std::unordered_map<VerticalContentAlignment, std::string, EnumHash> verticalContentAlignmentEnumToName =
-    {
-        { VerticalContentAlignment::Stretch, "Stretch" },
-        { VerticalContentAlignment::Top, "Top" },
-        { VerticalContentAlignment::Center, "Center" },
-        { VerticalContentAlignment::Bottom, "Bottom" }
-    };
-    static std::unordered_map<std::string, VerticalContentAlignment, CaseInsensitiveHash, CaseInsensitiveEqualTo> verticalContentAlignmentNameToEnum = 
-        GenerateStringToEnumMap<VerticalContentAlignment>(verticalContentAlignmentEnumToName);
-
-    if (verticalContentAlignmentEnumToNameOut != nullptr)
-    {
-        *verticalContentAlignmentEnumToNameOut = verticalContentAlignmentEnumToName;
+        if (verticalContentAlignmentNameToEnumOut != nullptr)
+        {
+            *verticalContentAlignmentNameToEnumOut = verticalContentAlignmentNameToEnum;
+        }
     }
 
-    if (verticalContentAlignmentNameToEnumOut != nullptr)
+    const std::string AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey type)
     {
-        *verticalContentAlignmentNameToEnumOut = verticalContentAlignmentNameToEnum;
-    }
-}
+        std::unordered_map<AdaptiveCardSchemaKey, std::string, EnumHash> adaptiveCardSchemaKeyEnumToName;
+        GetAdaptiveCardSchemaKeyEnumMappings(&adaptiveCardSchemaKeyEnumToName, nullptr);
 
-const std::string AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey type)
-{
-    std::unordered_map<AdaptiveCardSchemaKey, std::string, EnumHash> adaptiveCardSchemaKeyEnumToName;
-    GetAdaptiveCardSchemaKeyEnumMappings(&adaptiveCardSchemaKeyEnumToName, nullptr);
+        if (adaptiveCardSchemaKeyEnumToName.find(type) == adaptiveCardSchemaKeyEnumToName.end())
+        {
+            throw std::out_of_range("Invalid AdaptiveCardSchemaKey");
+        }
 
-    if (adaptiveCardSchemaKeyEnumToName.find(type) == adaptiveCardSchemaKeyEnumToName.end())
-    {
-        throw std::out_of_range("Invalid AdaptiveCardSchemaKey");
+        return adaptiveCardSchemaKeyEnumToName[type];
     }
 
-    return adaptiveCardSchemaKeyEnumToName[type];
-}
-
-AdaptiveCardSchemaKey AdaptiveCardSchemaKeyFromString(const std::string& type)
-{
-    std::unordered_map<std::string, AdaptiveCardSchemaKey, CaseInsensitiveHash, CaseInsensitiveEqualTo> adaptiveCardSchemaKeyNameToEnum;
-    GetAdaptiveCardSchemaKeyEnumMappings(nullptr, &adaptiveCardSchemaKeyNameToEnum);
-
-    if (adaptiveCardSchemaKeyNameToEnum.find(type) == adaptiveCardSchemaKeyNameToEnum.end())
+    AdaptiveCardSchemaKey AdaptiveCardSchemaKeyFromString(const std::string& type)
     {
-        throw std::out_of_range("Invalid AdaptiveCardSchemaKey: " + type);
+        std::unordered_map<std::string, AdaptiveCardSchemaKey, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            adaptiveCardSchemaKeyNameToEnum;
+        GetAdaptiveCardSchemaKeyEnumMappings(nullptr, &adaptiveCardSchemaKeyNameToEnum);
+
+        if (adaptiveCardSchemaKeyNameToEnum.find(type) == adaptiveCardSchemaKeyNameToEnum.end())
+        {
+            throw std::out_of_range("Invalid AdaptiveCardSchemaKey: " + type);
+        }
+
+        return adaptiveCardSchemaKeyNameToEnum[type];
     }
 
-    return adaptiveCardSchemaKeyNameToEnum[type];
-}
-
-const std::string CardElementTypeToString(CardElementType elementType)
-{
-    std::unordered_map<CardElementType, std::string, EnumHash> cardElementTypeEnumToName;
-    GetCardElementTypeEnumMappings(&cardElementTypeEnumToName, nullptr);
-
-    if (cardElementTypeEnumToName.find(elementType) == cardElementTypeEnumToName.end())
+    const std::string CardElementTypeToString(CardElementType elementType)
     {
-        throw std::out_of_range("Invalid CardElementType");
+        std::unordered_map<CardElementType, std::string, EnumHash> cardElementTypeEnumToName;
+        GetCardElementTypeEnumMappings(&cardElementTypeEnumToName, nullptr);
+
+        if (cardElementTypeEnumToName.find(elementType) == cardElementTypeEnumToName.end())
+        {
+            throw std::out_of_range("Invalid CardElementType");
+        }
+
+        return cardElementTypeEnumToName[elementType];
     }
 
-    return cardElementTypeEnumToName[elementType];
-}
-
-CardElementType CardElementTypeFromString(const std::string& elementType)
-{
-    std::unordered_map<std::string, CardElementType, CaseInsensitiveHash, CaseInsensitiveEqualTo> cardElementTypeNameToEnum;
-    GetCardElementTypeEnumMappings(nullptr, &cardElementTypeNameToEnum);
-
-    if (cardElementTypeNameToEnum.find(elementType) == cardElementTypeNameToEnum.end())
+    CardElementType CardElementTypeFromString(const std::string& elementType)
     {
-        return CardElementType::Unsupported;
+        std::unordered_map<std::string, CardElementType, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            cardElementTypeNameToEnum;
+        GetCardElementTypeEnumMappings(nullptr, &cardElementTypeNameToEnum);
+
+        if (cardElementTypeNameToEnum.find(elementType) == cardElementTypeNameToEnum.end())
+        {
+            return CardElementType::Unsupported;
+        }
+
+        return cardElementTypeNameToEnum[elementType];
     }
 
-    return cardElementTypeNameToEnum[elementType];
-}
-
-const std::string ActionTypeToString(ActionType actionType)
-{
-    std::unordered_map<ActionType, std::string, EnumHash> actionTypeEnumToName;
-    GetActionTypeEnumMappings(&actionTypeEnumToName, nullptr);
-
-    if (actionTypeEnumToName.find(actionType) == actionTypeEnumToName.end())
+    const std::string ActionTypeToString(ActionType actionType)
     {
-        throw std::out_of_range("Invalid ActionType");
+        std::unordered_map<ActionType, std::string, EnumHash> actionTypeEnumToName;
+        GetActionTypeEnumMappings(&actionTypeEnumToName, nullptr);
+
+        if (actionTypeEnumToName.find(actionType) == actionTypeEnumToName.end())
+        {
+            throw std::out_of_range("Invalid ActionType");
+        }
+
+        return actionTypeEnumToName[actionType];
     }
 
-    return actionTypeEnumToName[actionType];
-}
-
-ActionType ActionTypeFromString(const std::string& actionType)
-{
-    std::unordered_map<std::string, ActionType, CaseInsensitiveHash, CaseInsensitiveEqualTo> actionTypeNameToEnum;
-    GetActionTypeEnumMappings(nullptr, &actionTypeNameToEnum);
-
-    if (actionTypeNameToEnum.find(actionType) == actionTypeNameToEnum.end())
+    ActionType ActionTypeFromString(const std::string& actionType)
     {
-        return ActionType::Unsupported;
+        std::unordered_map<std::string, ActionType, CaseInsensitiveHash, CaseInsensitiveEqualTo> actionTypeNameToEnum;
+        GetActionTypeEnumMappings(nullptr, &actionTypeNameToEnum);
+
+        if (actionTypeNameToEnum.find(actionType) == actionTypeNameToEnum.end())
+        {
+            return ActionType::Unsupported;
+        }
+
+        return actionTypeNameToEnum[actionType];
     }
 
-    return actionTypeNameToEnum[actionType];
-}
-
-const std::string HeightTypeToString(HeightType heightType)
-{
-    std::unordered_map<HeightType, std::string, EnumHash> heightTypeEnumToName;
-    GetHeightTypeEnumMappings(&heightTypeEnumToName, nullptr);
-
-    if (heightTypeEnumToName.find(heightType) == heightTypeEnumToName.end())
+    const std::string HeightTypeToString(HeightType heightType)
     {
-        throw std::out_of_range("Invalid HeightType type");
+        std::unordered_map<HeightType, std::string, EnumHash> heightTypeEnumToName;
+        GetHeightTypeEnumMappings(&heightTypeEnumToName, nullptr);
+
+        if (heightTypeEnumToName.find(heightType) == heightTypeEnumToName.end())
+        {
+            throw std::out_of_range("Invalid HeightType type");
+        }
+
+        return heightTypeEnumToName[heightType];
     }
 
-    return heightTypeEnumToName[heightType];
-}
-
-HeightType HeightTypeFromString(const std::string& heightType)
-{
-    std::unordered_map<std::string, HeightType, CaseInsensitiveHash, CaseInsensitiveEqualTo> heightTypeNameToEnum;
-    GetHeightTypeEnumMappings(nullptr, &heightTypeNameToEnum);
-
-    if (heightTypeNameToEnum.find(heightType) == heightTypeNameToEnum.end())
+    HeightType HeightTypeFromString(const std::string& heightType)
     {
-        return HeightType::Auto;
+        std::unordered_map<std::string, HeightType, CaseInsensitiveHash, CaseInsensitiveEqualTo> heightTypeNameToEnum;
+        GetHeightTypeEnumMappings(nullptr, &heightTypeNameToEnum);
+
+        if (heightTypeNameToEnum.find(heightType) == heightTypeNameToEnum.end())
+        {
+            return HeightType::Auto;
+        }
+
+        return heightTypeNameToEnum[heightType];
     }
 
-    return heightTypeNameToEnum[heightType];
-}
-
-const std::string HorizontalAlignmentToString(HorizontalAlignment alignment)
-{
-    std::unordered_map<HorizontalAlignment, std::string, EnumHash> horizontalAlignmentEnumToName;
-    GetHorizontalAlignmentEnumMappings(&horizontalAlignmentEnumToName, nullptr);
-
-    if (horizontalAlignmentEnumToName.find(alignment) == horizontalAlignmentEnumToName.end())
+    const std::string HorizontalAlignmentToString(HorizontalAlignment alignment)
     {
-        throw std::out_of_range("Invalid HorizontalAlignment type");
-    }
-    return horizontalAlignmentEnumToName[alignment];
-}
+        std::unordered_map<HorizontalAlignment, std::string, EnumHash> horizontalAlignmentEnumToName;
+        GetHorizontalAlignmentEnumMappings(&horizontalAlignmentEnumToName, nullptr);
 
-HorizontalAlignment HorizontalAlignmentFromString(const std::string& alignment)
-{
-    std::unordered_map<std::string, HorizontalAlignment, CaseInsensitiveHash, CaseInsensitiveEqualTo> horizontalAlignmentNameToEnum;
-    GetHorizontalAlignmentEnumMappings(nullptr, &horizontalAlignmentNameToEnum);
-
-    if (horizontalAlignmentNameToEnum.find(alignment) == horizontalAlignmentNameToEnum.end())
-    {
-        return HorizontalAlignment::Left;
+        if (horizontalAlignmentEnumToName.find(alignment) == horizontalAlignmentEnumToName.end())
+        {
+            throw std::out_of_range("Invalid HorizontalAlignment type");
+        }
+        return horizontalAlignmentEnumToName[alignment];
     }
 
-    return horizontalAlignmentNameToEnum[alignment];
-}
-
-const std::string ForegroundColorToString(ForegroundColor color)
-{
-    std::unordered_map<ForegroundColor, std::string, EnumHash> colorEnumToName;
-    GetColorEnumMappings(&colorEnumToName, nullptr);
-
-    if (colorEnumToName.find(color) == colorEnumToName.end())
+    HorizontalAlignment HorizontalAlignmentFromString(const std::string& alignment)
     {
-        throw std::out_of_range("Invalid ForegroundColor type");
-    }
-    return colorEnumToName[color];
-}
+        std::unordered_map<std::string, HorizontalAlignment, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            horizontalAlignmentNameToEnum;
+        GetHorizontalAlignmentEnumMappings(nullptr, &horizontalAlignmentNameToEnum);
 
-ForegroundColor ForegroundColorFromString(const std::string& color)
-{
-    std::unordered_map<std::string, ForegroundColor, CaseInsensitiveHash, CaseInsensitiveEqualTo> colorNameToEnum;
-    GetColorEnumMappings(nullptr, &colorNameToEnum);
+        if (horizontalAlignmentNameToEnum.find(alignment) == horizontalAlignmentNameToEnum.end())
+        {
+            return HorizontalAlignment::Left;
+        }
 
-    if (colorNameToEnum.find(color) == colorNameToEnum.end())
-    {
-        return ForegroundColor::Default;
+        return horizontalAlignmentNameToEnum[alignment];
     }
 
-    return colorNameToEnum[color];
-}
-
-const std::string TextWeightToString(TextWeight weight)
-{
-    std::unordered_map<TextWeight, std::string, EnumHash> textWeightEnumToName;
-    GetTextWeightEnumMappings(&textWeightEnumToName, nullptr);
-
-    if (textWeightEnumToName.find(weight) == textWeightEnumToName.end())
+    const std::string ForegroundColorToString(ForegroundColor color)
     {
-        throw std::out_of_range("Invalid TextWeight type");
-    }
-    return textWeightEnumToName[weight];
-}
+        std::unordered_map<ForegroundColor, std::string, EnumHash> colorEnumToName;
+        GetColorEnumMappings(&colorEnumToName, nullptr);
 
-TextWeight TextWeightFromString(const std::string& weight)
-{
-    std::unordered_map<std::string, TextWeight, CaseInsensitiveHash, CaseInsensitiveEqualTo> textWeightNameToEnum;
-    GetTextWeightEnumMappings(nullptr, &textWeightNameToEnum);
-
-    if (textWeightNameToEnum.find(weight) == textWeightNameToEnum.end())
-    {
-        return TextWeight::Default;
+        if (colorEnumToName.find(color) == colorEnumToName.end())
+        {
+            throw std::out_of_range("Invalid ForegroundColor type");
+        }
+        return colorEnumToName[color];
     }
 
-    return textWeightNameToEnum[weight];
-}
-
-const std::string TextSizeToString(TextSize size)
-{
-    std::unordered_map<TextSize, std::string, EnumHash> textSizeEnumToName;
-    GetTextSizeEnumMappings(&textSizeEnumToName, nullptr);
-
-    if (textSizeEnumToName.find(size) == textSizeEnumToName.end())
+    ForegroundColor ForegroundColorFromString(const std::string& color)
     {
-        throw std::out_of_range("Invalid TextSize type");
-    }
-    return textSizeEnumToName[size];
-}
+        std::unordered_map<std::string, ForegroundColor, CaseInsensitiveHash, CaseInsensitiveEqualTo> colorNameToEnum;
+        GetColorEnumMappings(nullptr, &colorNameToEnum);
 
-TextSize TextSizeFromString(const std::string& size)
-{
-    std::unordered_map<std::string, TextSize, CaseInsensitiveHash, CaseInsensitiveEqualTo> textSizeNameToEnum;
-    GetTextSizeEnumMappings(nullptr, &textSizeNameToEnum);
+        if (colorNameToEnum.find(color) == colorNameToEnum.end())
+        {
+            return ForegroundColor::Default;
+        }
 
-    if (textSizeNameToEnum.find(size) == textSizeNameToEnum.end())
-    {
-        return TextSize::Default;
+        return colorNameToEnum[color];
     }
 
-    return textSizeNameToEnum[size];
-}
-
-const std::string ImageSizeToString(ImageSize size)
-{
-    std::unordered_map<ImageSize, std::string, EnumHash> imageSizeEnumToName;
-    GetImageSizeEnumMappings(&imageSizeEnumToName, nullptr);
-
-    if (imageSizeEnumToName.find(size) == imageSizeEnumToName.end())
+    const std::string TextWeightToString(TextWeight weight)
     {
-        throw std::out_of_range("Invalid ImageSize type");
-    }
-    return imageSizeEnumToName[size];
-}
+        std::unordered_map<TextWeight, std::string, EnumHash> textWeightEnumToName;
+        GetTextWeightEnumMappings(&textWeightEnumToName, nullptr);
 
-ImageSize ImageSizeFromString(const std::string& size)
-{
-    std::unordered_map<std::string, ImageSize, CaseInsensitiveHash, CaseInsensitiveEqualTo> imageSizeNameToEnum;
-    GetImageSizeEnumMappings(nullptr, &imageSizeNameToEnum);
-
-    if (imageSizeNameToEnum.find(size) == imageSizeNameToEnum.end())
-    {
-        return ImageSize::Auto;
+        if (textWeightEnumToName.find(weight) == textWeightEnumToName.end())
+        {
+            throw std::out_of_range("Invalid TextWeight type");
+        }
+        return textWeightEnumToName[weight];
     }
 
-    return imageSizeNameToEnum[size];
-}
-
-const std::string SpacingToString(Spacing spacing)
-{
-    std::unordered_map<Spacing, std::string, EnumHash> spacingEnumToName;
-    GetSpacingMappings(&spacingEnumToName, nullptr);
-
-    if (spacingEnumToName.find(spacing) == spacingEnumToName.end())
+    TextWeight TextWeightFromString(const std::string& weight)
     {
-        throw std::out_of_range("Invalid Spacing type");
-    }
-    return spacingEnumToName[spacing];
-}
+        std::unordered_map<std::string, TextWeight, CaseInsensitiveHash, CaseInsensitiveEqualTo> textWeightNameToEnum;
+        GetTextWeightEnumMappings(nullptr, &textWeightNameToEnum);
 
-Spacing SpacingFromString(const std::string& spacing)
-{
-    std::unordered_map<std::string, Spacing, CaseInsensitiveHash, CaseInsensitiveEqualTo> spacingNameToEnum;
-    GetSpacingMappings(nullptr, &spacingNameToEnum);
+        if (textWeightNameToEnum.find(weight) == textWeightNameToEnum.end())
+        {
+            return TextWeight::Default;
+        }
 
-    if (spacingNameToEnum.find(spacing) == spacingNameToEnum.end())
-    {
-        return Spacing::Default;
+        return textWeightNameToEnum[weight];
     }
 
-    return spacingNameToEnum[spacing];
-}
-
-const std::string SeparatorThicknessToString(SeparatorThickness thickness)
-{
-    std::unordered_map<SeparatorThickness, std::string, EnumHash> separatorThicknessEnumToName;
-    GetSeparatorThicknessEnumMappings(&separatorThicknessEnumToName, nullptr);
-
-    if (separatorThicknessEnumToName.find(thickness) == separatorThicknessEnumToName.end())
+    const std::string TextSizeToString(TextSize size)
     {
-        throw std::out_of_range("Invalid SeparatorThickness type");
-    }
-    return separatorThicknessEnumToName[thickness];
-}
+        std::unordered_map<TextSize, std::string, EnumHash> textSizeEnumToName;
+        GetTextSizeEnumMappings(&textSizeEnumToName, nullptr);
 
-SeparatorThickness SeparatorThicknessFromString(const std::string& thickness)
-{
-    std::unordered_map<std::string, SeparatorThickness, CaseInsensitiveHash, CaseInsensitiveEqualTo> separatorThicknessNameToEnum;
-    GetSeparatorThicknessEnumMappings(nullptr, &separatorThicknessNameToEnum);
-
-    if (separatorThicknessNameToEnum.find(thickness) == separatorThicknessNameToEnum.end())
-    {
-        return SeparatorThickness::Default;
+        if (textSizeEnumToName.find(size) == textSizeEnumToName.end())
+        {
+            throw std::out_of_range("Invalid TextSize type");
+        }
+        return textSizeEnumToName[size];
     }
 
-    return separatorThicknessNameToEnum[thickness];
-}
-
-const std::string ImageStyleToString(ImageStyle style)
-{
-    std::unordered_map<ImageStyle, std::string, EnumHash> imageStyleEnumToName;
-    GetImageStyleEnumMappings(&imageStyleEnumToName, nullptr);
-
-    if (imageStyleEnumToName.find(style) == imageStyleEnumToName.end())
+    TextSize TextSizeFromString(const std::string& size)
     {
-        throw std::out_of_range("Invalid ImageStyle style");
-    }
-    return imageStyleEnumToName[style];
-}
+        std::unordered_map<std::string, TextSize, CaseInsensitiveHash, CaseInsensitiveEqualTo> textSizeNameToEnum;
+        GetTextSizeEnumMappings(nullptr, &textSizeNameToEnum);
 
-ImageStyle ImageStyleFromString(const std::string& style)
-{
-    std::unordered_map<std::string, ImageStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo> imageStyleNameToEnum;
-    GetImageStyleEnumMappings(nullptr, &imageStyleNameToEnum);
+        if (textSizeNameToEnum.find(size) == textSizeNameToEnum.end())
+        {
+            return TextSize::Default;
+        }
 
-    if (imageStyleNameToEnum.find(style) == imageStyleNameToEnum.end())
-    {
-        return ImageStyle::Default;
+        return textSizeNameToEnum[size];
     }
 
-    return imageStyleNameToEnum[style];
-}
-
-const std::string ActionsOrientationToString(ActionsOrientation orientation)
-{
-    std::unordered_map<ActionsOrientation, std::string, EnumHash> actionsOrientationEnumToName;
-    GetActionsOrientationEnumMappings(&actionsOrientationEnumToName, nullptr);
-
-    if (actionsOrientationEnumToName.find(orientation) == actionsOrientationEnumToName.end())
+    const std::string ImageSizeToString(ImageSize size)
     {
-        throw std::out_of_range("Invalid ActionsOrientation type");
+        std::unordered_map<ImageSize, std::string, EnumHash> imageSizeEnumToName;
+        GetImageSizeEnumMappings(&imageSizeEnumToName, nullptr);
+
+        if (imageSizeEnumToName.find(size) == imageSizeEnumToName.end())
+        {
+            throw std::out_of_range("Invalid ImageSize type");
+        }
+        return imageSizeEnumToName[size];
     }
-    return actionsOrientationEnumToName[orientation];
-}
 
-ActionsOrientation ActionsOrientationFromString(const std::string& orientation)
-{
-    std::unordered_map<std::string, ActionsOrientation, CaseInsensitiveHash, CaseInsensitiveEqualTo> actionsOrientationNameToEnum;
-    GetActionsOrientationEnumMappings(nullptr, &actionsOrientationNameToEnum);
-
-    if (actionsOrientationNameToEnum.find(orientation) == actionsOrientationNameToEnum.end())
+    ImageSize ImageSizeFromString(const std::string& size)
     {
-        return ActionsOrientation::Horizontal;
+        std::unordered_map<std::string, ImageSize, CaseInsensitiveHash, CaseInsensitiveEqualTo> imageSizeNameToEnum;
+        GetImageSizeEnumMappings(nullptr, &imageSizeNameToEnum);
+
+        if (imageSizeNameToEnum.find(size) == imageSizeNameToEnum.end())
+        {
+            return ImageSize::Auto;
+        }
+
+        return imageSizeNameToEnum[size];
     }
-    return actionsOrientationNameToEnum[orientation];
-}
 
-const std::string ActionModeToString(ActionMode mode)
-{
-    std::unordered_map<ActionMode, std::string, EnumHash> actionModeEnumToName;
-    GetActionModeEnumMappings(&actionModeEnumToName, nullptr);
-
-    if (actionModeEnumToName.find(mode) == actionModeEnumToName.end())
+    const std::string SpacingToString(Spacing spacing)
     {
-        throw std::out_of_range("Invalid ActionMode type");
+        std::unordered_map<Spacing, std::string, EnumHash> spacingEnumToName;
+        GetSpacingMappings(&spacingEnumToName, nullptr);
+
+        if (spacingEnumToName.find(spacing) == spacingEnumToName.end())
+        {
+            throw std::out_of_range("Invalid Spacing type");
+        }
+        return spacingEnumToName[spacing];
     }
-    return actionModeEnumToName[mode];
-}
 
-ActionMode ActionModeFromString(const std::string& mode)
-{
-    std::unordered_map<std::string, ActionMode, CaseInsensitiveHash, CaseInsensitiveEqualTo> actionModeNameToEnum;
-    GetActionModeEnumMappings(nullptr, &actionModeNameToEnum);
-
-    if (actionModeNameToEnum.find(mode) == actionModeNameToEnum.end())
+    Spacing SpacingFromString(const std::string& spacing)
     {
-        return ActionMode::Inline;
+        std::unordered_map<std::string, Spacing, CaseInsensitiveHash, CaseInsensitiveEqualTo> spacingNameToEnum;
+        GetSpacingMappings(nullptr, &spacingNameToEnum);
+
+        if (spacingNameToEnum.find(spacing) == spacingNameToEnum.end())
+        {
+            return Spacing::Default;
+        }
+
+        return spacingNameToEnum[spacing];
     }
-    return actionModeNameToEnum[mode];
-}
 
-const std::string ChoiceSetStyleToString(ChoiceSetStyle style)
-{
-    std::unordered_map<ChoiceSetStyle, std::string, EnumHash> choiceSetStyleEnumToName;
-    GetChoiceSetStyleEnumMappings(&choiceSetStyleEnumToName, nullptr);
-
-    if (choiceSetStyleEnumToName.find(style) == choiceSetStyleEnumToName.end())
+    const std::string SeparatorThicknessToString(SeparatorThickness thickness)
     {
-        throw std::out_of_range("Invalid ChoiceSetStyle");
-    }
-    return choiceSetStyleEnumToName[style];
-}
-ChoiceSetStyle ChoiceSetStyleFromString(const std::string & style)
-{
-    std::unordered_map<std::string, ChoiceSetStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo> choiceSetStyleNameToEnum;
-    GetChoiceSetStyleEnumMappings(nullptr, &choiceSetStyleNameToEnum);
+        std::unordered_map<SeparatorThickness, std::string, EnumHash> separatorThicknessEnumToName;
+        GetSeparatorThicknessEnumMappings(&separatorThicknessEnumToName, nullptr);
 
-    if (choiceSetStyleNameToEnum.find(style) == choiceSetStyleNameToEnum.end())
+        if (separatorThicknessEnumToName.find(thickness) == separatorThicknessEnumToName.end())
+        {
+            throw std::out_of_range("Invalid SeparatorThickness type");
+        }
+        return separatorThicknessEnumToName[thickness];
+    }
+
+    SeparatorThickness SeparatorThicknessFromString(const std::string& thickness)
     {
-        return ChoiceSetStyle::Compact;
+        std::unordered_map<std::string, SeparatorThickness, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            separatorThicknessNameToEnum;
+        GetSeparatorThicknessEnumMappings(nullptr, &separatorThicknessNameToEnum);
+
+        if (separatorThicknessNameToEnum.find(thickness) == separatorThicknessNameToEnum.end())
+        {
+            return SeparatorThickness::Default;
+        }
+
+        return separatorThicknessNameToEnum[thickness];
     }
-    return choiceSetStyleNameToEnum[style];
-}
 
-const std::string TextInputStyleToString(TextInputStyle style)
-{
-    std::unordered_map<TextInputStyle, std::string, EnumHash> textInputStyleEnumToName;
-    GetTextInputStyleEnumMappings(&textInputStyleEnumToName, nullptr);
-
-    if (textInputStyleEnumToName.find(style) == textInputStyleEnumToName.end())
+    const std::string ImageStyleToString(ImageStyle style)
     {
-        throw std::out_of_range("Invalid TextInputStyle");
+        std::unordered_map<ImageStyle, std::string, EnumHash> imageStyleEnumToName;
+        GetImageStyleEnumMappings(&imageStyleEnumToName, nullptr);
+
+        if (imageStyleEnumToName.find(style) == imageStyleEnumToName.end())
+        {
+            throw std::out_of_range("Invalid ImageStyle style");
+        }
+        return imageStyleEnumToName[style];
     }
-    return textInputStyleEnumToName[style];
-}
 
-TextInputStyle TextInputStyleFromString(const std::string & style)
-{
-    std::unordered_map<std::string, TextInputStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo> textInputStyleNameToEnum;
-    GetTextInputStyleEnumMappings(nullptr, &textInputStyleNameToEnum);
-
-    if (textInputStyleNameToEnum.find(style) == textInputStyleNameToEnum.end())
+    ImageStyle ImageStyleFromString(const std::string& style)
     {
-        return TextInputStyle::Text;
+        std::unordered_map<std::string, ImageStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo> imageStyleNameToEnum;
+        GetImageStyleEnumMappings(nullptr, &imageStyleNameToEnum);
+
+        if (imageStyleNameToEnum.find(style) == imageStyleNameToEnum.end())
+        {
+            return ImageStyle::Default;
+        }
+
+        return imageStyleNameToEnum[style];
     }
-    return textInputStyleNameToEnum[style];
-}
 
-const std::string ContainerStyleToString(ContainerStyle style)
-{
-    std::unordered_map<ContainerStyle, std::string, EnumHash> containerStyleEnumToName;
-    GetContainerStyleEnumMappings(&containerStyleEnumToName, nullptr);
-
-    if (containerStyleEnumToName.find(style) == containerStyleEnumToName.end())
+    const std::string ActionsOrientationToString(ActionsOrientation orientation)
     {
-        throw std::out_of_range("Invalid ContainerStyle");
+        std::unordered_map<ActionsOrientation, std::string, EnumHash> actionsOrientationEnumToName;
+        GetActionsOrientationEnumMappings(&actionsOrientationEnumToName, nullptr);
+
+        if (actionsOrientationEnumToName.find(orientation) == actionsOrientationEnumToName.end())
+        {
+            throw std::out_of_range("Invalid ActionsOrientation type");
+        }
+        return actionsOrientationEnumToName[orientation];
     }
-    return containerStyleEnumToName[style];
-}
 
-ContainerStyle ContainerStyleFromString(const std::string & style)
-{
-    std::unordered_map<std::string, ContainerStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo> containerStyleNameToEnum;
-    GetContainerStyleEnumMappings(nullptr, &containerStyleNameToEnum);
-
-    if (containerStyleNameToEnum.find(style) == containerStyleNameToEnum.end())
+    ActionsOrientation ActionsOrientationFromString(const std::string& orientation)
     {
-        return ContainerStyle::Default;
+        std::unordered_map<std::string, ActionsOrientation, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            actionsOrientationNameToEnum;
+        GetActionsOrientationEnumMappings(nullptr, &actionsOrientationNameToEnum);
+
+        if (actionsOrientationNameToEnum.find(orientation) == actionsOrientationNameToEnum.end())
+        {
+            return ActionsOrientation::Horizontal;
+        }
+        return actionsOrientationNameToEnum[orientation];
     }
-    return containerStyleNameToEnum[style];
-}
 
-const std::string ActionAlignmentToString(ActionAlignment alignment)
-{
-    std::unordered_map<ActionAlignment, std::string, EnumHash> actionAlignmentEnumToName;
-    GetActionAlignmentEnumMappings(&actionAlignmentEnumToName, nullptr);
-
-    if (actionAlignmentEnumToName.find(alignment) == actionAlignmentEnumToName.end())
+    const std::string ActionModeToString(ActionMode mode)
     {
-        throw std::out_of_range("Invalid ActionAlignment");
+        std::unordered_map<ActionMode, std::string, EnumHash> actionModeEnumToName;
+        GetActionModeEnumMappings(&actionModeEnumToName, nullptr);
+
+        if (actionModeEnumToName.find(mode) == actionModeEnumToName.end())
+        {
+            throw std::out_of_range("Invalid ActionMode type");
+        }
+        return actionModeEnumToName[mode];
     }
-    return actionAlignmentEnumToName[alignment];
-}
 
-ActionAlignment ActionAlignmentFromString(const std::string & alignment)
-{
-    std::unordered_map<std::string, ActionAlignment, CaseInsensitiveHash, CaseInsensitiveEqualTo> actionAlignmentNameToEnum;
-    GetActionAlignmentEnumMappings(nullptr, &actionAlignmentNameToEnum);
-
-    if (actionAlignmentNameToEnum.find(alignment) == actionAlignmentNameToEnum.end())
+    ActionMode ActionModeFromString(const std::string& mode)
     {
-        return ActionAlignment::Left;
+        std::unordered_map<std::string, ActionMode, CaseInsensitiveHash, CaseInsensitiveEqualTo> actionModeNameToEnum;
+        GetActionModeEnumMappings(nullptr, &actionModeNameToEnum);
+
+        if (actionModeNameToEnum.find(mode) == actionModeNameToEnum.end())
+        {
+            return ActionMode::Inline;
+        }
+        return actionModeNameToEnum[mode];
     }
-    return actionAlignmentNameToEnum[alignment];
-}
 
-const std::string IconPlacementToString(IconPlacement placement)
-{
-    std::unordered_map<IconPlacement, std::string, EnumHash> iconPlacementEnumToName;
-    GetIconPlacementEnumMappings(&iconPlacementEnumToName, nullptr);
-
-    if (iconPlacementEnumToName.find(placement) == iconPlacementEnumToName.end())
+    const std::string ChoiceSetStyleToString(ChoiceSetStyle style)
     {
-        throw std::out_of_range("Invalid IconPlacement");
+        std::unordered_map<ChoiceSetStyle, std::string, EnumHash> choiceSetStyleEnumToName;
+        GetChoiceSetStyleEnumMappings(&choiceSetStyleEnumToName, nullptr);
+
+        if (choiceSetStyleEnumToName.find(style) == choiceSetStyleEnumToName.end())
+        {
+            throw std::out_of_range("Invalid ChoiceSetStyle");
+        }
+        return choiceSetStyleEnumToName[style];
     }
-    return iconPlacementEnumToName[placement];
-}
-
-IconPlacement IconPlacementFromString(const std::string& placement)
-{
-    std::unordered_map<std::string, IconPlacement, CaseInsensitiveHash, CaseInsensitiveEqualTo> iconPlacementNameToEnum;
-    GetIconPlacementEnumMappings(nullptr, &iconPlacementNameToEnum);
-
-    if (iconPlacementNameToEnum.find(placement) == iconPlacementNameToEnum.end())
+    ChoiceSetStyle ChoiceSetStyleFromString(const std::string& style)
     {
-        return IconPlacement::AboveTitle;
+        std::unordered_map<std::string, ChoiceSetStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            choiceSetStyleNameToEnum;
+        GetChoiceSetStyleEnumMappings(nullptr, &choiceSetStyleNameToEnum);
+
+        if (choiceSetStyleNameToEnum.find(style) == choiceSetStyleNameToEnum.end())
+        {
+            return ChoiceSetStyle::Compact;
+        }
+        return choiceSetStyleNameToEnum[style];
     }
-    return iconPlacementNameToEnum[placement];
-}
 
-const std::string VerticalContentAlignmentToString(VerticalContentAlignment verticalContentAlignment)
-{
-    std::unordered_map<VerticalContentAlignment, std::string, EnumHash> verticalContentAlignmentEnumToName;
-    GetVerticalContentAlignmentEnumMappings(&verticalContentAlignmentEnumToName, nullptr);
-
-    if (verticalContentAlignmentEnumToName.find(verticalContentAlignment) == verticalContentAlignmentEnumToName.end())
+    const std::string TextInputStyleToString(TextInputStyle style)
     {
-        throw std::out_of_range("Invalid VerticalContentAlignment");
+        std::unordered_map<TextInputStyle, std::string, EnumHash> textInputStyleEnumToName;
+        GetTextInputStyleEnumMappings(&textInputStyleEnumToName, nullptr);
+
+        if (textInputStyleEnumToName.find(style) == textInputStyleEnumToName.end())
+        {
+            throw std::out_of_range("Invalid TextInputStyle");
+        }
+        return textInputStyleEnumToName[style];
     }
-    return verticalContentAlignmentEnumToName[verticalContentAlignment];
-}
 
-VerticalContentAlignment VerticalContentAlignmentFromString(const std::string& verticalContentAlignment)
-{
-    std::unordered_map<std::string, VerticalContentAlignment, CaseInsensitiveHash, CaseInsensitiveEqualTo> verticalContentAlignmentNameToEnum;
-    GetVerticalContentAlignmentEnumMappings(nullptr, &verticalContentAlignmentNameToEnum);
-
-    if (verticalContentAlignmentNameToEnum.find(verticalContentAlignment) == verticalContentAlignmentNameToEnum.end())
+    TextInputStyle TextInputStyleFromString(const std::string& style)
     {
-        return VerticalContentAlignment::Stretch;
-    }
-    return verticalContentAlignmentNameToEnum[verticalContentAlignment];
-}
+        std::unordered_map<std::string, TextInputStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            textInputStyleNameToEnum;
+        GetTextInputStyleEnumMappings(nullptr, &textInputStyleNameToEnum);
 
-AdaptiveSharedNamespaceEnd
+        if (textInputStyleNameToEnum.find(style) == textInputStyleNameToEnum.end())
+        {
+            return TextInputStyle::Text;
+        }
+        return textInputStyleNameToEnum[style];
+    }
+
+    const std::string ContainerStyleToString(ContainerStyle style)
+    {
+        std::unordered_map<ContainerStyle, std::string, EnumHash> containerStyleEnumToName;
+        GetContainerStyleEnumMappings(&containerStyleEnumToName, nullptr);
+
+        if (containerStyleEnumToName.find(style) == containerStyleEnumToName.end())
+        {
+            throw std::out_of_range("Invalid ContainerStyle");
+        }
+        return containerStyleEnumToName[style];
+    }
+
+    ContainerStyle ContainerStyleFromString(const std::string& style)
+    {
+        std::unordered_map<std::string, ContainerStyle, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            containerStyleNameToEnum;
+        GetContainerStyleEnumMappings(nullptr, &containerStyleNameToEnum);
+
+        if (containerStyleNameToEnum.find(style) == containerStyleNameToEnum.end())
+        {
+            return ContainerStyle::Default;
+        }
+        return containerStyleNameToEnum[style];
+    }
+
+    const std::string ActionAlignmentToString(ActionAlignment alignment)
+    {
+        std::unordered_map<ActionAlignment, std::string, EnumHash> actionAlignmentEnumToName;
+        GetActionAlignmentEnumMappings(&actionAlignmentEnumToName, nullptr);
+
+        if (actionAlignmentEnumToName.find(alignment) == actionAlignmentEnumToName.end())
+        {
+            throw std::out_of_range("Invalid ActionAlignment");
+        }
+        return actionAlignmentEnumToName[alignment];
+    }
+
+    ActionAlignment ActionAlignmentFromString(const std::string& alignment)
+    {
+        std::unordered_map<std::string, ActionAlignment, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            actionAlignmentNameToEnum;
+        GetActionAlignmentEnumMappings(nullptr, &actionAlignmentNameToEnum);
+
+        if (actionAlignmentNameToEnum.find(alignment) == actionAlignmentNameToEnum.end())
+        {
+            return ActionAlignment::Left;
+        }
+        return actionAlignmentNameToEnum[alignment];
+    }
+
+    const std::string IconPlacementToString(IconPlacement placement)
+    {
+        std::unordered_map<IconPlacement, std::string, EnumHash> iconPlacementEnumToName;
+        GetIconPlacementEnumMappings(&iconPlacementEnumToName, nullptr);
+
+        if (iconPlacementEnumToName.find(placement) == iconPlacementEnumToName.end())
+        {
+            throw std::out_of_range("Invalid IconPlacement");
+        }
+        return iconPlacementEnumToName[placement];
+    }
+
+    IconPlacement IconPlacementFromString(const std::string& placement)
+    {
+        std::unordered_map<std::string, IconPlacement, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            iconPlacementNameToEnum;
+        GetIconPlacementEnumMappings(nullptr, &iconPlacementNameToEnum);
+
+        if (iconPlacementNameToEnum.find(placement) == iconPlacementNameToEnum.end())
+        {
+            return IconPlacement::AboveTitle;
+        }
+        return iconPlacementNameToEnum[placement];
+    }
+
+    const std::string VerticalContentAlignmentToString(VerticalContentAlignment verticalContentAlignment)
+    {
+        std::unordered_map<VerticalContentAlignment, std::string, EnumHash> verticalContentAlignmentEnumToName;
+        GetVerticalContentAlignmentEnumMappings(&verticalContentAlignmentEnumToName, nullptr);
+
+        if (verticalContentAlignmentEnumToName.find(verticalContentAlignment) ==
+            verticalContentAlignmentEnumToName.end())
+        {
+            throw std::out_of_range("Invalid VerticalContentAlignment");
+        }
+        return verticalContentAlignmentEnumToName[verticalContentAlignment];
+    }
+
+    VerticalContentAlignment VerticalContentAlignmentFromString(const std::string& verticalContentAlignment)
+    {
+        std::unordered_map<std::string, VerticalContentAlignment, CaseInsensitiveHash, CaseInsensitiveEqualTo>
+            verticalContentAlignmentNameToEnum;
+        GetVerticalContentAlignmentEnumMappings(nullptr, &verticalContentAlignmentNameToEnum);
+
+        if (verticalContentAlignmentNameToEnum.find(verticalContentAlignment) ==
+            verticalContentAlignmentNameToEnum.end())
+        {
+            return VerticalContentAlignment::Stretch;
+        }
+        return verticalContentAlignmentNameToEnum[verticalContentAlignment];
+    }
+
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/Enums.h
+++ b/source/shared/cpp/ObjectModel/Enums.h
@@ -8,398 +8,417 @@
 #include <strings.h>
 #endif // _WIN32
 
-AdaptiveSharedNamespaceStart
-
-struct EnumHash
+namespace AdaptiveSharedNamespace
 {
-    template <typename T>
-    size_t operator()(T t) const
+    struct EnumHash
     {
-        return static_cast<size_t>(t);
-    }
-};
+        template<typename T>
+        size_t operator()(T t) const
+        {
+            return static_cast<size_t>(t);
+        }
+    };
 
-struct CaseInsensitiveEqualTo {
-    bool operator() (const std::string& lhs, const std::string& rhs) const {
-        return strncasecmp(lhs.c_str(), rhs.c_str(), CHAR_MAX) == 0;
-    }
-};
-
-struct CaseInsensitiveHash {
-    size_t operator() (const std::string& keyval) const {
-        return std::accumulate(keyval.begin(), keyval.end(), size_t{ 0 }, [](size_t acc, char c) { return acc + static_cast<size_t>(std::toupper(c)); });
-    }
-};
-
-enum class AdaptiveCardSchemaKey
-{
-    Accent = 0,
-    ActionAlignment,
-    ActionMode,
-    ActionOrientation,
-    Actions,
-    ActionSetConfig,
-    ActionsOrientation,
-    AdaptiveCard,
-    AllowCustomStyle,
-    AltText,
-    Attention,
-    BackgroundColor,
-    BackgroundImage,
-    BackgroundImageUrl,
-    BaseCardElement,
-    Body,
-    Bolder,
-    BorderColor,
-    BorderThickness,
-    Bottom,
-    ButtonSpacing,
-    Card,
-    Center,
-    Choices,
-    ChoiceSet,
-    Color,
-    ColorConfig,
-    ForegroundColors,
-    Column,
-    Columns,
-    ColumnSet,
-    Container,
-    ContainerStyles,
-    Dark,
-    Data,
-    DateInput,
-    Default,
-    Emphasis,
-    ExtraLarge,
-    Facts,
-    FactSet,
-    FallbackText,
-    FontFamily,
-    FontSizes,
-    FontWeights,
-    Good,
-    Height,
-    HorizontalAlignment,
-    IconPlacement,
-    IconUrl,
-    Id,
-    Image,
-    ImageBaseUrl,
-    Images,
-    ImageSet,
-    ImageSize,
-    ImageSizes,
-    InlineTopMargin,
-    IsMultiline,
-    IsMultiSelect,
-    IsRequired,
-    IsSelected,
-    IsSubtle,
-    Items,
-    Language,
-    Large,
-    Left,
-    Light,
-    Lighter,
-    LineColor,
-    LineThickness,
-    Max,
-    MaxActions,
-    MaxImageHeight,
-    MaxLength,
-    MaxLines,
-    MaxWidth,
-    Medium,
-    Method,
-    Min,
-    NumberInput,
-    Padding,
-    Placeholder,
-    Right,
-    SelectAction,
-    Separator,
-    ShowActionMode,
-    ShowCard,
-    ShowCardActionConfig,
-    Size,
-    Small,
-    Spacing,
-    SpacingDefinition,
-    Speak,
-    Stretch,
-    Style,
-    Subtle,
-    SupportsInteractivity,
-    Text,
-    TextBlock,
-    TextConfig,
-    TextInput,
-    TextWeight,
-    Thick,
-    Thickness,
-    TimeInput,
-    Title,
-    ToggleInput,
-    Top,
-    Type,
-    Url,
-    Value,
-    ValueOff,
-    ValueOn,
-    Version,
-    VerticalContentAlignment,
-    Warning,
-    Weight,
-    Width,
-    Wrap,
-};
-
-enum class TextSize
-{
-    Small = 0,
-    Default,
-    Medium,
-    Large,
-    ExtraLarge
-};
-
-enum class TextWeight {
-    Lighter = 0,
-    Default,
-    Bolder
-};
-
-enum class ForegroundColor {
-    Default = 0,
-    Dark,
-    Light,
-    Accent,
-    Good,
-    Warning,
-    Attention
-};
-
-enum class HorizontalAlignment {
-    Left = 0,
-    Center,
-    Right
-};
-
-enum class ImageStyle {
-    Default = 0,
-    Person
-};
-
-enum class ImageSize {
-    None = 0,
-    Auto,
-    Stretch,
-    Small,
-    Medium,
-    Large,
-};
-
-enum class TextInputStyle {
-    Text = 0,
-    Tel,
-    Url,
-    Email,
-};
-
-enum class CardElementType
-{
-    Unsupported = 0,
-    AdaptiveCard,
-    TextBlock,
-    Image,
-    Container,
-    Column,
-    ColumnSet,
-    FactSet,
-    Fact,
-    ImageSet,
-    ChoiceInput,
-    ChoiceSetInput,
-    DateInput,
-    NumberInput,
-    TextInput,
-    TimeInput,
-    ToggleInput,
-    Custom,
-    Unknown,
-};
-
-enum class ActionType
-{
-    Unsupported = 0,
-    ShowCard,
-    Submit,
-    OpenUrl,
-    Custom
-};
-
-enum class ActionAlignment
-{
-    Left = 0,
-    Center,
-    Right,
-    Stretch,
-};
-
-enum class ChoiceSetStyle
-{
-    Compact = 0,
-    Expanded
-};
-
-enum class SeparatorThickness {
-    Default = 0,
-    Thick,
-};
-
-enum class Spacing {
-    Default = 0,
-    None,
-    Small,
-    Medium,
-    Large,
-    ExtraLarge,
-    Padding
-};
-
-enum class ActionsOrientation {
-    Vertical = 0,
-    Horizontal
-};
-
-enum class ActionMode {
-    Inline = 0,
-    Popup
-};
-
-enum class ContainerStyle {
-    None,
-    Default,
-    Emphasis
-};
-
-enum class ErrorStatusCode {
-    InvalidJson = 0,
-    RenderFailed,
-    RequiredPropertyMissing,
-    InvalidPropertyValue,
-    UnsupportedParserOverride
-};
-
-enum class WarningStatusCode {
-    UnknownElementType = 0,
-    UnknownPropertyOnElement,
-    UnknownEnumValue,
-    NoRendererForType,
-    InteractivityNotSupported,
-    MaxActionsExceeded,
-    AssetLoadFailed,
-    UnsupportedSchemaVersion,
-};
-
-enum class DateTimePreparsedTokenFormat {
-    RegularString = 0,
-    Time,
-    DateCompact,
-    DateShort,
-    DateLong
-};
-
-enum class IconPlacement
-{
-    AboveTitle = 0,
-    LeftOfTitle
-};
-
-enum class VerticalContentAlignment
-{
-    Stretch = 0,
-    Top,
-    Center,
-    Bottom
-};
-
-enum class HeightType
-{
-    Auto = 0,
-    Stretch
-};
-
-const std::string AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey type);
-AdaptiveCardSchemaKey AdaptiveCardSchemaKeyFromString(const std::string& type);
-
-const std::string CardElementTypeToString(CardElementType elementType);
-CardElementType CardElementTypeFromString(const std::string& elementType);
-
-const std::string ActionTypeToString(ActionType actionType);
-ActionType ActionTypeFromString(const std::string& actionType);
-
-const std::string HeightTypeToString(HeightType heightType);
-HeightType HeightTypeFromString(const std::string& heightType);
-
-const std::string HorizontalAlignmentToString(HorizontalAlignment alignment);
-HorizontalAlignment HorizontalAlignmentFromString(const std::string& alignment);
-
-const std::string ForegroundColorToString(ForegroundColor type);
-ForegroundColor ForegroundColorFromString(const std::string& type);
-
-const std::string TextWeightToString(TextWeight type);
-TextWeight TextWeightFromString(const std::string& type);
-
-const std::string TextSizeToString(TextSize size);
-TextSize TextSizeFromString(const std::string& size);
-
-const std::string ImageSizeToString(ImageSize size);
-ImageSize ImageSizeFromString(const std::string& size);
-
-const std::string SpacingToString(Spacing spacing);
-Spacing SpacingFromString(const std::string& spacing);
-
-const std::string SeparatorThicknessToString(SeparatorThickness separatorThickness);
-SeparatorThickness SeparatorThicknessFromString(const std::string& separatorThickness);
-
-const std::string ImageStyleToString(ImageStyle style);
-ImageStyle ImageStyleFromString(const std::string& style);
-
-const std::string ActionsOrientationToString(ActionsOrientation orientation);
-ActionsOrientation ActionsOrientationFromString(const std::string& orientation);
-
-const std::string ActionModeToString(ActionMode mode);
-ActionMode ActionModeFromString(const std::string& mode);
-
-const std::string ChoiceSetStyleToString(ChoiceSetStyle style);
-ChoiceSetStyle ChoiceSetStyleFromString(const std::string& style);
-
-const std::string TextInputStyleToString(TextInputStyle style);
-TextInputStyle TextInputStyleFromString(const std::string& style);
-
-const std::string ContainerStyleToString(ContainerStyle style);
-ContainerStyle ContainerStyleFromString(const std::string& style);
-
-const std::string ActionAlignmentToString(ActionAlignment alignment);
-ActionAlignment ActionAlignmentFromString(const std::string& alignment);
-
-const std::string IconPlacementToString(IconPlacement placement);
-IconPlacement IconPlacementFromString(const std::string& placement);
-
-const std::string VerticalContentAlignmentToString(VerticalContentAlignment verticalContentAlignment);
-VerticalContentAlignment VerticalContentAlignmentFromString(const std::string& verticalContentAlignment);
-
-template <typename T>
-const std::unordered_map<std::string, T, CaseInsensitiveHash, CaseInsensitiveEqualTo>
-GenerateStringToEnumMap(const std::unordered_map<T, std::string, EnumHash>& keyToStringMap)
-{
-    std::unordered_map<std::string, T, CaseInsensitiveHash, CaseInsensitiveEqualTo> result;
-    for (auto& kv : keyToStringMap)
+    struct CaseInsensitiveEqualTo
     {
-        result[kv.second] = kv.first;
+        bool operator()(const std::string& lhs, const std::string& rhs) const
+        {
+            return strncasecmp(lhs.c_str(), rhs.c_str(), CHAR_MAX) == 0;
+        }
+    };
+
+    struct CaseInsensitiveHash
+    {
+        size_t operator()(const std::string& keyval) const
+        {
+            return std::accumulate(keyval.begin(), keyval.end(), size_t{0},
+                [](size_t acc, char c) { return acc + static_cast<size_t>(std::toupper(c)); });
+        }
+    };
+
+    enum class AdaptiveCardSchemaKey
+    {
+        Accent = 0,
+        ActionAlignment,
+        ActionMode,
+        ActionOrientation,
+        Actions,
+        ActionSetConfig,
+        ActionsOrientation,
+        AdaptiveCard,
+        AllowCustomStyle,
+        AltText,
+        Attention,
+        BackgroundColor,
+        BackgroundImage,
+        BackgroundImageUrl,
+        BaseCardElement,
+        Body,
+        Bolder,
+        BorderColor,
+        BorderThickness,
+        Bottom,
+        ButtonSpacing,
+        Card,
+        Center,
+        Choices,
+        ChoiceSet,
+        Color,
+        ColorConfig,
+        ForegroundColors,
+        Column,
+        Columns,
+        ColumnSet,
+        Container,
+        ContainerStyles,
+        Dark,
+        Data,
+        DateInput,
+        Default,
+        Emphasis,
+        ExtraLarge,
+        Facts,
+        FactSet,
+        FallbackText,
+        FontFamily,
+        FontSizes,
+        FontWeights,
+        Good,
+        Height,
+        HorizontalAlignment,
+        IconPlacement,
+        IconUrl,
+        Id,
+        Image,
+        ImageBaseUrl,
+        Images,
+        ImageSet,
+        ImageSize,
+        ImageSizes,
+        InlineTopMargin,
+        IsMultiline,
+        IsMultiSelect,
+        IsRequired,
+        IsSelected,
+        IsSubtle,
+        Items,
+        Language,
+        Large,
+        Left,
+        Light,
+        Lighter,
+        LineColor,
+        LineThickness,
+        Max,
+        MaxActions,
+        MaxImageHeight,
+        MaxLength,
+        MaxLines,
+        MaxWidth,
+        Medium,
+        Method,
+        Min,
+        NumberInput,
+        Padding,
+        Placeholder,
+        Right,
+        SelectAction,
+        Separator,
+        ShowActionMode,
+        ShowCard,
+        ShowCardActionConfig,
+        Size,
+        Small,
+        Spacing,
+        SpacingDefinition,
+        Speak,
+        Stretch,
+        Style,
+        Subtle,
+        SupportsInteractivity,
+        Text,
+        TextBlock,
+        TextConfig,
+        TextInput,
+        TextWeight,
+        Thick,
+        Thickness,
+        TimeInput,
+        Title,
+        ToggleInput,
+        Top,
+        Type,
+        Url,
+        Value,
+        ValueOff,
+        ValueOn,
+        Version,
+        VerticalContentAlignment,
+        Warning,
+        Weight,
+        Width,
+        Wrap,
+    };
+
+    enum class TextSize
+    {
+        Small = 0,
+        Default,
+        Medium,
+        Large,
+        ExtraLarge
+    };
+
+    enum class TextWeight
+    {
+        Lighter = 0,
+        Default,
+        Bolder
+    };
+
+    enum class ForegroundColor
+    {
+        Default = 0,
+        Dark,
+        Light,
+        Accent,
+        Good,
+        Warning,
+        Attention
+    };
+
+    enum class HorizontalAlignment
+    {
+        Left = 0,
+        Center,
+        Right
+    };
+
+    enum class ImageStyle
+    {
+        Default = 0,
+        Person
+    };
+
+    enum class ImageSize
+    {
+        None = 0,
+        Auto,
+        Stretch,
+        Small,
+        Medium,
+        Large,
+    };
+
+    enum class TextInputStyle
+    {
+        Text = 0,
+        Tel,
+        Url,
+        Email,
+    };
+
+    enum class CardElementType
+    {
+        Unsupported = 0,
+        AdaptiveCard,
+        TextBlock,
+        Image,
+        Container,
+        Column,
+        ColumnSet,
+        FactSet,
+        Fact,
+        ImageSet,
+        ChoiceInput,
+        ChoiceSetInput,
+        DateInput,
+        NumberInput,
+        TextInput,
+        TimeInput,
+        ToggleInput,
+        Custom,
+        Unknown,
+    };
+
+    enum class ActionType
+    {
+        Unsupported = 0,
+        ShowCard,
+        Submit,
+        OpenUrl,
+        Custom
+    };
+
+    enum class ActionAlignment
+    {
+        Left = 0,
+        Center,
+        Right,
+        Stretch,
+    };
+
+    enum class ChoiceSetStyle
+    {
+        Compact = 0,
+        Expanded
+    };
+
+    enum class SeparatorThickness
+    {
+        Default = 0,
+        Thick,
+    };
+
+    enum class Spacing
+    {
+        Default = 0,
+        None,
+        Small,
+        Medium,
+        Large,
+        ExtraLarge,
+        Padding
+    };
+
+    enum class ActionsOrientation
+    {
+        Vertical = 0,
+        Horizontal
+    };
+
+    enum class ActionMode
+    {
+        Inline = 0,
+        Popup
+    };
+
+    enum class ContainerStyle
+    {
+        None,
+        Default,
+        Emphasis
+    };
+
+    enum class ErrorStatusCode
+    {
+        InvalidJson = 0,
+        RenderFailed,
+        RequiredPropertyMissing,
+        InvalidPropertyValue,
+        UnsupportedParserOverride
+    };
+
+    enum class WarningStatusCode
+    {
+        UnknownElementType = 0,
+        UnknownPropertyOnElement,
+        UnknownEnumValue,
+        NoRendererForType,
+        InteractivityNotSupported,
+        MaxActionsExceeded,
+        AssetLoadFailed,
+        UnsupportedSchemaVersion,
+    };
+
+    enum class DateTimePreparsedTokenFormat
+    {
+        RegularString = 0,
+        Time,
+        DateCompact,
+        DateShort,
+        DateLong
+    };
+
+    enum class IconPlacement
+    {
+        AboveTitle = 0,
+        LeftOfTitle
+    };
+
+    enum class VerticalContentAlignment
+    {
+        Stretch = 0,
+        Top,
+        Center,
+        Bottom
+    };
+
+    enum class HeightType
+    {
+        Auto = 0,
+        Stretch
+    };
+
+    const std::string AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey type);
+    AdaptiveCardSchemaKey AdaptiveCardSchemaKeyFromString(const std::string& type);
+
+    const std::string CardElementTypeToString(CardElementType elementType);
+    CardElementType CardElementTypeFromString(const std::string& elementType);
+
+    const std::string ActionTypeToString(ActionType actionType);
+    ActionType ActionTypeFromString(const std::string& actionType);
+
+    const std::string HeightTypeToString(HeightType heightType);
+    HeightType HeightTypeFromString(const std::string& heightType);
+
+    const std::string HorizontalAlignmentToString(HorizontalAlignment alignment);
+    HorizontalAlignment HorizontalAlignmentFromString(const std::string& alignment);
+
+    const std::string ForegroundColorToString(ForegroundColor type);
+    ForegroundColor ForegroundColorFromString(const std::string& type);
+
+    const std::string TextWeightToString(TextWeight type);
+    TextWeight TextWeightFromString(const std::string& type);
+
+    const std::string TextSizeToString(TextSize size);
+    TextSize TextSizeFromString(const std::string& size);
+
+    const std::string ImageSizeToString(ImageSize size);
+    ImageSize ImageSizeFromString(const std::string& size);
+
+    const std::string SpacingToString(Spacing spacing);
+    Spacing SpacingFromString(const std::string& spacing);
+
+    const std::string SeparatorThicknessToString(SeparatorThickness separatorThickness);
+    SeparatorThickness SeparatorThicknessFromString(const std::string& separatorThickness);
+
+    const std::string ImageStyleToString(ImageStyle style);
+    ImageStyle ImageStyleFromString(const std::string& style);
+
+    const std::string ActionsOrientationToString(ActionsOrientation orientation);
+    ActionsOrientation ActionsOrientationFromString(const std::string& orientation);
+
+    const std::string ActionModeToString(ActionMode mode);
+    ActionMode ActionModeFromString(const std::string& mode);
+
+    const std::string ChoiceSetStyleToString(ChoiceSetStyle style);
+    ChoiceSetStyle ChoiceSetStyleFromString(const std::string& style);
+
+    const std::string TextInputStyleToString(TextInputStyle style);
+    TextInputStyle TextInputStyleFromString(const std::string& style);
+
+    const std::string ContainerStyleToString(ContainerStyle style);
+    ContainerStyle ContainerStyleFromString(const std::string& style);
+
+    const std::string ActionAlignmentToString(ActionAlignment alignment);
+    ActionAlignment ActionAlignmentFromString(const std::string& alignment);
+
+    const std::string IconPlacementToString(IconPlacement placement);
+    IconPlacement IconPlacementFromString(const std::string& placement);
+
+    const std::string VerticalContentAlignmentToString(VerticalContentAlignment verticalContentAlignment);
+    VerticalContentAlignment VerticalContentAlignmentFromString(const std::string& verticalContentAlignment);
+
+    template<typename T>
+    const std::unordered_map<std::string, T, CaseInsensitiveHash, CaseInsensitiveEqualTo> GenerateStringToEnumMap(
+        const std::unordered_map<T, std::string, EnumHash>& keyToStringMap)
+    {
+        std::unordered_map<std::string, T, CaseInsensitiveHash, CaseInsensitiveEqualTo> result;
+        for (auto& kv : keyToStringMap)
+        {
+            result[kv.second] = kv.first;
+        }
+        return result;
     }
-    return result;
-}
-AdaptiveSharedNamespaceEnd
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/Enums.h
+++ b/source/shared/cpp/ObjectModel/Enums.h
@@ -21,7 +21,7 @@ namespace AdaptiveSharedNamespace
 
     struct CaseInsensitiveEqualTo
     {
-        bool operator()(const std::string& lhs, const std::string& rhs) const
+        bool operator()(const std::string &lhs, const std::string &rhs) const
         {
             return strncasecmp(lhs.c_str(), rhs.c_str(), CHAR_MAX) == 0;
         }
@@ -29,7 +29,7 @@ namespace AdaptiveSharedNamespace
 
     struct CaseInsensitiveHash
     {
-        size_t operator()(const std::string& keyval) const
+        size_t operator()(const std::string &keyval) const
         {
             return std::accumulate(keyval.begin(), keyval.end(), size_t{0},
                 [](size_t acc, char c) { return acc + static_cast<size_t>(std::toupper(c)); });
@@ -351,71 +351,71 @@ namespace AdaptiveSharedNamespace
     };
 
     const std::string AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey type);
-    AdaptiveCardSchemaKey AdaptiveCardSchemaKeyFromString(const std::string& type);
+    AdaptiveCardSchemaKey AdaptiveCardSchemaKeyFromString(const std::string &type);
 
     const std::string CardElementTypeToString(CardElementType elementType);
-    CardElementType CardElementTypeFromString(const std::string& elementType);
+    CardElementType CardElementTypeFromString(const std::string &elementType);
 
     const std::string ActionTypeToString(ActionType actionType);
-    ActionType ActionTypeFromString(const std::string& actionType);
+    ActionType ActionTypeFromString(const std::string &actionType);
 
     const std::string HeightTypeToString(HeightType heightType);
-    HeightType HeightTypeFromString(const std::string& heightType);
+    HeightType HeightTypeFromString(const std::string &heightType);
 
     const std::string HorizontalAlignmentToString(HorizontalAlignment alignment);
-    HorizontalAlignment HorizontalAlignmentFromString(const std::string& alignment);
+    HorizontalAlignment HorizontalAlignmentFromString(const std::string &alignment);
 
     const std::string ForegroundColorToString(ForegroundColor type);
-    ForegroundColor ForegroundColorFromString(const std::string& type);
+    ForegroundColor ForegroundColorFromString(const std::string &type);
 
     const std::string TextWeightToString(TextWeight type);
-    TextWeight TextWeightFromString(const std::string& type);
+    TextWeight TextWeightFromString(const std::string &type);
 
     const std::string TextSizeToString(TextSize size);
-    TextSize TextSizeFromString(const std::string& size);
+    TextSize TextSizeFromString(const std::string &size);
 
     const std::string ImageSizeToString(ImageSize size);
-    ImageSize ImageSizeFromString(const std::string& size);
+    ImageSize ImageSizeFromString(const std::string &size);
 
     const std::string SpacingToString(Spacing spacing);
-    Spacing SpacingFromString(const std::string& spacing);
+    Spacing SpacingFromString(const std::string &spacing);
 
     const std::string SeparatorThicknessToString(SeparatorThickness separatorThickness);
-    SeparatorThickness SeparatorThicknessFromString(const std::string& separatorThickness);
+    SeparatorThickness SeparatorThicknessFromString(const std::string &separatorThickness);
 
     const std::string ImageStyleToString(ImageStyle style);
-    ImageStyle ImageStyleFromString(const std::string& style);
+    ImageStyle ImageStyleFromString(const std::string &style);
 
     const std::string ActionsOrientationToString(ActionsOrientation orientation);
-    ActionsOrientation ActionsOrientationFromString(const std::string& orientation);
+    ActionsOrientation ActionsOrientationFromString(const std::string &orientation);
 
     const std::string ActionModeToString(ActionMode mode);
-    ActionMode ActionModeFromString(const std::string& mode);
+    ActionMode ActionModeFromString(const std::string &mode);
 
     const std::string ChoiceSetStyleToString(ChoiceSetStyle style);
-    ChoiceSetStyle ChoiceSetStyleFromString(const std::string& style);
+    ChoiceSetStyle ChoiceSetStyleFromString(const std::string &style);
 
     const std::string TextInputStyleToString(TextInputStyle style);
-    TextInputStyle TextInputStyleFromString(const std::string& style);
+    TextInputStyle TextInputStyleFromString(const std::string &style);
 
     const std::string ContainerStyleToString(ContainerStyle style);
-    ContainerStyle ContainerStyleFromString(const std::string& style);
+    ContainerStyle ContainerStyleFromString(const std::string &style);
 
     const std::string ActionAlignmentToString(ActionAlignment alignment);
-    ActionAlignment ActionAlignmentFromString(const std::string& alignment);
+    ActionAlignment ActionAlignmentFromString(const std::string &alignment);
 
     const std::string IconPlacementToString(IconPlacement placement);
-    IconPlacement IconPlacementFromString(const std::string& placement);
+    IconPlacement IconPlacementFromString(const std::string &placement);
 
     const std::string VerticalContentAlignmentToString(VerticalContentAlignment verticalContentAlignment);
-    VerticalContentAlignment VerticalContentAlignmentFromString(const std::string& verticalContentAlignment);
+    VerticalContentAlignment VerticalContentAlignmentFromString(const std::string &verticalContentAlignment);
 
     template<typename T>
     const std::unordered_map<std::string, T, CaseInsensitiveHash, CaseInsensitiveEqualTo> GenerateStringToEnumMap(
-        const std::unordered_map<T, std::string, EnumHash>& keyToStringMap)
+        const std::unordered_map<T, std::string, EnumHash> &keyToStringMap)
     {
         std::unordered_map<std::string, T, CaseInsensitiveHash, CaseInsensitiveEqualTo> result;
-        for (auto& kv : keyToStringMap)
+        for (auto &kv : keyToStringMap)
         {
             result[kv.second] = kv.first;
         }

--- a/source/shared/cpp/ObjectModel/Fact.cpp
+++ b/source/shared/cpp/ObjectModel/Fact.cpp
@@ -6,10 +6,10 @@ using namespace AdaptiveSharedNamespace;
 
 Fact::Fact() {}
 
-Fact::Fact(std::string const& title, std::string const& value) : m_title(title), m_value(value) {}
+Fact::Fact(std::string const &title, std::string const &value) : m_title(title), m_value(value) {}
 
 std::shared_ptr<Fact> Fact::Deserialize(
-    std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value& json)
+    std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value &json)
 {
     std::string title = ParseUtil::GetString(json, AdaptiveCardSchemaKey::Title, true);
     std::string value = ParseUtil::GetString(json, AdaptiveCardSchemaKey::Value, true);
@@ -19,7 +19,7 @@ std::shared_ptr<Fact> Fact::Deserialize(
 }
 
 std::shared_ptr<Fact> Fact::DeserializeFromString(std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString)
 {
     return Fact::Deserialize(
         elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
@@ -45,7 +45,7 @@ std::string Fact::GetTitle() const
     return m_title;
 }
 
-void Fact::SetTitle(const std::string& value)
+void Fact::SetTitle(const std::string &value)
 {
     m_title = value;
 }
@@ -55,7 +55,7 @@ std::string Fact::GetValue() const
     return m_value;
 }
 
-void Fact::SetValue(const std::string& value)
+void Fact::SetValue(const std::string &value)
 {
     m_value = value;
 }

--- a/source/shared/cpp/ObjectModel/Fact.cpp
+++ b/source/shared/cpp/ObjectModel/Fact.cpp
@@ -4,19 +4,12 @@
 
 using namespace AdaptiveSharedNamespace;
 
-Fact::Fact()
-{
-}
+Fact::Fact() {}
 
-Fact::Fact(std::string const &title, std::string const &value) : 
-    m_title(title), m_value(value)
-{
-}
+Fact::Fact(std::string const& title, std::string const& value) : m_title(title), m_value(value) {}
 
 std::shared_ptr<Fact> Fact::Deserialize(
-    std::shared_ptr<ElementParserRegistration>,
-    std::shared_ptr<ActionParserRegistration>,
-    const Json::Value& json)
+    std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value& json)
 {
     std::string title = ParseUtil::GetString(json, AdaptiveCardSchemaKey::Title, true);
     std::string value = ParseUtil::GetString(json, AdaptiveCardSchemaKey::Value, true);
@@ -25,12 +18,11 @@ std::shared_ptr<Fact> Fact::Deserialize(
     return fact;
 }
 
-std::shared_ptr<Fact> Fact::DeserializeFromString(
-    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-    const std::string& jsonString)
+std::shared_ptr<Fact> Fact::DeserializeFromString(std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
 {
-    return Fact::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
+    return Fact::Deserialize(
+        elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
 std::string Fact::Serialize()
@@ -53,7 +45,7 @@ std::string Fact::GetTitle() const
     return m_title;
 }
 
-void Fact::SetTitle(const std::string &value)
+void Fact::SetTitle(const std::string& value)
 {
     m_title = value;
 }
@@ -63,7 +55,7 @@ std::string Fact::GetValue() const
     return m_value;
 }
 
-void Fact::SetValue(const std::string &value)
+void Fact::SetValue(const std::string& value)
 {
     m_value = value;
 }

--- a/source/shared/cpp/ObjectModel/Fact.h
+++ b/source/shared/cpp/ObjectModel/Fact.h
@@ -11,23 +11,23 @@ namespace AdaptiveSharedNamespace
     {
     public:
         Fact();
-        Fact(std::string const& title, std::string const& value);
+        Fact(std::string const &title, std::string const &value);
 
         std::string Serialize();
         Json::Value SerializeToJsonValue();
 
         std::string GetTitle() const;
-        void SetTitle(const std::string& value);
+        void SetTitle(const std::string &value);
 
         std::string GetValue() const;
-        void SetValue(const std::string& value);
+        void SetValue(const std::string &value);
 
         static std::shared_ptr<Fact> Deserialize(std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &root);
 
         static std::shared_ptr<Fact> DeserializeFromString(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString);
 
     private:
         std::string m_title;

--- a/source/shared/cpp/ObjectModel/Fact.h
+++ b/source/shared/cpp/ObjectModel/Fact.h
@@ -5,34 +5,32 @@
 #include "json/json.h"
 #include "ElementParserRegistration.h"
 
-AdaptiveSharedNamespaceStart
-class Fact
+namespace AdaptiveSharedNamespace
 {
-public:
-    Fact();
-    Fact(std::string const &title, std::string const &value);
+    class Fact
+    {
+        public:
+        Fact();
+        Fact(std::string const& title, std::string const& value);
 
-    std::string Serialize();
-    Json::Value SerializeToJsonValue();
+        std::string Serialize();
+        Json::Value SerializeToJsonValue();
 
-    std::string GetTitle() const;
-    void SetTitle(const std::string &value);
+        std::string GetTitle() const;
+        void SetTitle(const std::string& value);
 
-    std::string GetValue() const;
-    void SetValue(const std::string &value);
+        std::string GetValue() const;
+        void SetValue(const std::string& value);
 
-    static std::shared_ptr<Fact> Deserialize(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const Json::Value& root);
+        static std::shared_ptr<Fact> Deserialize(std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
 
-    static std::shared_ptr<Fact> DeserializeFromString(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const std::string& jsonString);
+        static std::shared_ptr<Fact> DeserializeFromString(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
 
-private:
-    std::string m_title;
-    std::string m_value;
-};
-AdaptiveSharedNamespaceEnd
+        private:
+        std::string m_title;
+        std::string m_value;
+    };
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/Fact.h
+++ b/source/shared/cpp/ObjectModel/Fact.h
@@ -9,7 +9,7 @@ namespace AdaptiveSharedNamespace
 {
     class Fact
     {
-        public:
+    public:
         Fact();
         Fact(std::string const& title, std::string const& value);
 
@@ -29,7 +29,7 @@ namespace AdaptiveSharedNamespace
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
             std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
 
-        private:
+    private:
         std::string m_title;
         std::string m_value;
     };

--- a/source/shared/cpp/ObjectModel/FactSet.cpp
+++ b/source/shared/cpp/ObjectModel/FactSet.cpp
@@ -10,12 +10,12 @@ FactSet::FactSet() : BaseCardElement(CardElementType::FactSet)
     PopulateKnownPropertiesSet();
 }
 
-const std::vector<std::shared_ptr<Fact>>& FactSet::GetFacts() const
+const std::vector<std::shared_ptr<Fact>> &FactSet::GetFacts() const
 {
     return m_facts;
 }
 
-std::vector<std::shared_ptr<Fact>>& FactSet::GetFacts()
+std::vector<std::shared_ptr<Fact>> &FactSet::GetFacts()
 {
     return m_facts;
 }
@@ -26,7 +26,7 @@ Json::Value FactSet::SerializeToJsonValue() const
 
     std::string factsPropertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Facts);
     root[factsPropertyName] = Json::Value(Json::arrayValue);
-    for (const auto& fact : GetFacts())
+    for (const auto &fact : GetFacts())
     {
         root[factsPropertyName].append(fact->SerializeToJsonValue());
     }
@@ -36,7 +36,7 @@ Json::Value FactSet::SerializeToJsonValue() const
 
 std::shared_ptr<BaseCardElement> FactSetParser::Deserialize(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& value)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &value)
 {
     ParseUtil::ExpectTypeString(value, CardElementType::FactSet);
 
@@ -52,7 +52,7 @@ std::shared_ptr<BaseCardElement> FactSetParser::Deserialize(
 
 std::shared_ptr<BaseCardElement> FactSetParser::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString)
 {
     return FactSetParser::Deserialize(
         elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));

--- a/source/shared/cpp/ObjectModel/FactSet.cpp
+++ b/source/shared/cpp/ObjectModel/FactSet.cpp
@@ -36,15 +36,15 @@ Json::Value FactSet::SerializeToJsonValue() const
 
 std::shared_ptr<BaseCardElement> FactSetParser::Deserialize(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-    const Json::Value& value)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& value)
 {
     ParseUtil::ExpectTypeString(value, CardElementType::FactSet);
 
     auto factSet = BaseCardElement::Deserialize<FactSet>(value);
 
     // Parse Facts
-    auto facts = ParseUtil::GetElementCollectionOfSingleType<Fact>(elementParserRegistration, actionParserRegistration, value, AdaptiveCardSchemaKey::Facts, Fact::Deserialize, true);
+    auto facts = ParseUtil::GetElementCollectionOfSingleType<Fact>(elementParserRegistration, actionParserRegistration,
+        value, AdaptiveCardSchemaKey::Facts, Fact::Deserialize, true);
     factSet->m_facts = std::move(facts);
 
     return factSet;
@@ -52,13 +52,13 @@ std::shared_ptr<BaseCardElement> FactSetParser::Deserialize(
 
 std::shared_ptr<BaseCardElement> FactSetParser::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-    const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
 {
-    return FactSetParser::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
+    return FactSetParser::Deserialize(
+        elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
-void FactSet::PopulateKnownPropertiesSet() 
+void FactSet::PopulateKnownPropertiesSet()
 {
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Facts));
 }

--- a/source/shared/cpp/ObjectModel/FactSet.h
+++ b/source/shared/cpp/ObjectModel/FactSet.h
@@ -6,36 +6,36 @@
 #include "BaseCardElement.h"
 #include "ElementParserRegistration.h"
 
-AdaptiveSharedNamespaceStart
-class BaseCardElement;
-class FactSet : public BaseCardElement
+namespace AdaptiveSharedNamespace
 {
-friend class FactSetParser;
-public:
-    FactSet();
+    class BaseCardElement;
+    class FactSet : public BaseCardElement
+    {
+        friend class FactSetParser;
 
-    virtual Json::Value SerializeToJsonValue() const override;
+        public:
+        FactSet();
 
-    std::vector<std::shared_ptr<Fact>>& GetFacts();
-    const std::vector<std::shared_ptr<Fact>>& GetFacts() const;
+        virtual Json::Value SerializeToJsonValue() const override;
 
-private:
-    void PopulateKnownPropertiesSet();
+        std::vector<std::shared_ptr<Fact>>& GetFacts();
+        const std::vector<std::shared_ptr<Fact>>& GetFacts() const;
 
-    std::vector<std::shared_ptr<Fact>> m_facts; 
-};
+        private:
+        void PopulateKnownPropertiesSet();
 
-class FactSetParser : public BaseCardElementParser
-{
-public:
-    std::shared_ptr<BaseCardElement> Deserialize(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const Json::Value& root);
+        std::vector<std::shared_ptr<Fact>> m_facts;
+    };
 
-    std::shared_ptr<BaseCardElement> DeserializeFromString(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const std::string& jsonString);
-};
-AdaptiveSharedNamespaceEnd
+    class FactSetParser : public BaseCardElementParser
+    {
+        public:
+        std::shared_ptr<BaseCardElement> Deserialize(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
+
+        std::shared_ptr<BaseCardElement> DeserializeFromString(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+    };
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/FactSet.h
+++ b/source/shared/cpp/ObjectModel/FactSet.h
@@ -18,8 +18,8 @@ namespace AdaptiveSharedNamespace
 
         virtual Json::Value SerializeToJsonValue() const override;
 
-        std::vector<std::shared_ptr<Fact>>& GetFacts();
-        const std::vector<std::shared_ptr<Fact>>& GetFacts() const;
+        std::vector<std::shared_ptr<Fact>> &GetFacts();
+        const std::vector<std::shared_ptr<Fact>> &GetFacts() const;
 
     private:
         void PopulateKnownPropertiesSet();
@@ -32,10 +32,10 @@ namespace AdaptiveSharedNamespace
     public:
         std::shared_ptr<BaseCardElement> Deserialize(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &root);
 
         std::shared_ptr<BaseCardElement> DeserializeFromString(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString);
     };
 } // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/FactSet.h
+++ b/source/shared/cpp/ObjectModel/FactSet.h
@@ -13,7 +13,7 @@ namespace AdaptiveSharedNamespace
     {
         friend class FactSetParser;
 
-        public:
+    public:
         FactSet();
 
         virtual Json::Value SerializeToJsonValue() const override;
@@ -21,7 +21,7 @@ namespace AdaptiveSharedNamespace
         std::vector<std::shared_ptr<Fact>>& GetFacts();
         const std::vector<std::shared_ptr<Fact>>& GetFacts() const;
 
-        private:
+    private:
         void PopulateKnownPropertiesSet();
 
         std::vector<std::shared_ptr<Fact>> m_facts;
@@ -29,7 +29,7 @@ namespace AdaptiveSharedNamespace
 
     class FactSetParser : public BaseCardElementParser
     {
-        public:
+    public:
         std::shared_ptr<BaseCardElement> Deserialize(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
             std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);

--- a/source/shared/cpp/ObjectModel/HostConfig.cpp
+++ b/source/shared/cpp/ObjectModel/HostConfig.cpp
@@ -15,8 +15,8 @@ HostConfig HostConfig::Deserialize(const Json::Value& json)
     std::string fontFamily = ParseUtil::GetString(json, AdaptiveCardSchemaKey::FontFamily);
     result.fontFamily = fontFamily != "" ? fontFamily : result.fontFamily;
 
-    result.supportsInteractivity = ParseUtil::GetBool(
-        json, AdaptiveCardSchemaKey::SupportsInteractivity, result.supportsInteractivity);
+    result.supportsInteractivity =
+        ParseUtil::GetBool(json, AdaptiveCardSchemaKey::SupportsInteractivity, result.supportsInteractivity);
 
     result.imageBaseUrl = ParseUtil::GetString(json, AdaptiveCardSchemaKey::ImageBaseUrl);
 
@@ -63,7 +63,8 @@ FontSizesConfig FontSizesConfig::Deserialize(const Json::Value& json, const Font
     result.defaultFontSize = ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::Default, defaultValue.defaultFontSize);
     result.mediumFontSize = ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::Medium, defaultValue.mediumFontSize);
     result.largeFontSize = ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::Large, defaultValue.largeFontSize);
-    result.extraLargeFontSize = ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::ExtraLarge, defaultValue.extraLargeFontSize);
+    result.extraLargeFontSize =
+        ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::ExtraLarge, defaultValue.extraLargeFontSize);
     return result;
 }
 
@@ -74,7 +75,7 @@ ColorConfig ColorConfig::Deserialize(const Json::Value& json, const ColorConfig&
     result.defaultColor = defaultColor == "" ? defaultValue.defaultColor : defaultColor;
 
     std::string subtleColor = ParseUtil::GetString(json, AdaptiveCardSchemaKey::Subtle);
-    result.subtleColor = subtleColor == "" ? defaultValue.subtleColor: subtleColor;
+    result.subtleColor = subtleColor == "" ? defaultValue.subtleColor : subtleColor;
 
     return result;
 }
@@ -114,20 +115,17 @@ TextConfig TextConfig::Deserialize(const Json::Value& json, const TextConfig& de
     result.weight = ParseUtil::GetEnumValue<TextWeight>(
         json, AdaptiveCardSchemaKey::Weight, defaultValue.weight, TextWeightFromString);
 
-    result.size = ParseUtil::GetEnumValue<TextSize>(
-        json, AdaptiveCardSchemaKey::Size, defaultValue.size, TextSizeFromString);
+    result.size =
+        ParseUtil::GetEnumValue<TextSize>(json, AdaptiveCardSchemaKey::Size, defaultValue.size, TextSizeFromString);
 
     result.color = ParseUtil::GetEnumValue<ForegroundColor>(
         json, AdaptiveCardSchemaKey::Color, defaultValue.color, ForegroundColorFromString);
 
-    result.isSubtle = ParseUtil::GetBool(
-        json, AdaptiveCardSchemaKey::IsSubtle, defaultValue.isSubtle);
+    result.isSubtle = ParseUtil::GetBool(json, AdaptiveCardSchemaKey::IsSubtle, defaultValue.isSubtle);
 
-    result.wrap = ParseUtil::GetBool(
-        json, AdaptiveCardSchemaKey::Wrap, defaultValue.wrap);
+    result.wrap = ParseUtil::GetBool(json, AdaptiveCardSchemaKey::Wrap, defaultValue.wrap);
 
-    result.maxWidth = ParseUtil::GetUInt(
-        json, AdaptiveCardSchemaKey::MaxWidth, defaultValue.maxWidth);
+    result.maxWidth = ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::MaxWidth, defaultValue.maxWidth);
 
     return result;
 }
@@ -145,7 +143,8 @@ ImageSizesConfig ImageSizesConfig::Deserialize(const Json::Value& json, const Im
 AdaptiveCardConfig AdaptiveCardConfig::Deserialize(const Json::Value& json, const AdaptiveCardConfig& defaultValue)
 {
     AdaptiveCardConfig result;
-    result.allowCustomStyle = ParseUtil::GetBool(json, AdaptiveCardSchemaKey::AllowCustomStyle, defaultValue.allowCustomStyle);
+    result.allowCustomStyle =
+        ParseUtil::GetBool(json, AdaptiveCardSchemaKey::AllowCustomStyle, defaultValue.allowCustomStyle);
 
     return result;
 }
@@ -156,7 +155,8 @@ ImageSetConfig ImageSetConfig::Deserialize(const Json::Value& json, const ImageS
     result.imageSize = ParseUtil::GetEnumValue<ImageSize>(
         json, AdaptiveCardSchemaKey::ImageSize, defaultValue.imageSize, ImageSizeFromString);
 
-    result.maxImageHeight = ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::MaxImageHeight, defaultValue.maxImageHeight);
+    result.maxImageHeight =
+        ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::MaxImageHeight, defaultValue.maxImageHeight);
 
     return result;
 }
@@ -178,12 +178,14 @@ FactSetConfig FactSetConfig::Deserialize(const Json::Value& json, const FactSetC
     return result;
 }
 
-ShowCardActionConfig ShowCardActionConfig::Deserialize(const Json::Value&json, const ShowCardActionConfig& defaultValue)
+ShowCardActionConfig ShowCardActionConfig::Deserialize(
+    const Json::Value& json, const ShowCardActionConfig& defaultValue)
 {
     ShowCardActionConfig result;
     result.actionMode = ParseUtil::GetEnumValue<ActionMode>(
         json, AdaptiveCardSchemaKey::ActionMode, defaultValue.actionMode, ActionModeFromString);
-    result.inlineTopMargin = ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::InlineTopMargin, defaultValue.inlineTopMargin);
+    result.inlineTopMargin =
+        ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::InlineTopMargin, defaultValue.inlineTopMargin);
     result.style = ParseUtil::GetEnumValue<ContainerStyle>(
         json, AdaptiveCardSchemaKey::Style, defaultValue.style, ContainerStyleFromString);
 
@@ -200,17 +202,15 @@ ActionsConfig ActionsConfig::Deserialize(const Json::Value& json, const ActionsC
     result.actionAlignment = ParseUtil::GetEnumValue<ActionAlignment>(
         json, AdaptiveCardSchemaKey::ActionAlignment, defaultValue.actionAlignment, ActionAlignmentFromString);
 
-    result.buttonSpacing = ParseUtil::GetUInt(
-        json, AdaptiveCardSchemaKey::ButtonSpacing, defaultValue.buttonSpacing);
+    result.buttonSpacing = ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::ButtonSpacing, defaultValue.buttonSpacing);
 
-    result.maxActions = ParseUtil::GetUInt(
-        json, AdaptiveCardSchemaKey::MaxActions, defaultValue.maxActions);
+    result.maxActions = ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::MaxActions, defaultValue.maxActions);
 
     result.showCard = ParseUtil::ExtractJsonValueAndMergeWithDefault<ShowCardActionConfig>(
         json, AdaptiveCardSchemaKey::ShowCard, defaultValue.showCard, ShowCardActionConfig::Deserialize);
 
-    result.spacing = ParseUtil::GetEnumValue<Spacing>(
-        json, AdaptiveCardSchemaKey::Spacing, defaultValue.spacing, SpacingFromString);
+    result.spacing =
+        ParseUtil::GetEnumValue<Spacing>(json, AdaptiveCardSchemaKey::Spacing, defaultValue.spacing, SpacingFromString);
 
     result.iconPlacement = ParseUtil::GetEnumValue<IconPlacement>(
         json, AdaptiveCardSchemaKey::IconPlacement, defaultValue.iconPlacement, IconPlacementFromString);
@@ -218,37 +218,31 @@ ActionsConfig ActionsConfig::Deserialize(const Json::Value& json, const ActionsC
     return result;
 }
 
-SpacingConfig SpacingConfig::Deserialize(const Json::Value & json, const SpacingConfig & defaultValue)
+SpacingConfig SpacingConfig::Deserialize(const Json::Value& json, const SpacingConfig& defaultValue)
 {
     SpacingConfig result;
 
-    result.smallSpacing = ParseUtil::GetUInt(
-        json, AdaptiveCardSchemaKey::Small, defaultValue.smallSpacing);
+    result.smallSpacing = ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::Small, defaultValue.smallSpacing);
 
-    result.defaultSpacing = ParseUtil::GetUInt(
-        json, AdaptiveCardSchemaKey::Default, defaultValue.defaultSpacing);
+    result.defaultSpacing = ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::Default, defaultValue.defaultSpacing);
 
-    result.mediumSpacing = ParseUtil::GetUInt(
-        json, AdaptiveCardSchemaKey::Medium, defaultValue.mediumSpacing);
+    result.mediumSpacing = ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::Medium, defaultValue.mediumSpacing);
 
-    result.largeSpacing = ParseUtil::GetUInt(
-        json, AdaptiveCardSchemaKey::Large, defaultValue.largeSpacing);
+    result.largeSpacing = ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::Large, defaultValue.largeSpacing);
 
-    result.extraLargeSpacing = ParseUtil::GetUInt(
-        json, AdaptiveCardSchemaKey::ExtraLarge, defaultValue.extraLargeSpacing);
+    result.extraLargeSpacing =
+        ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::ExtraLarge, defaultValue.extraLargeSpacing);
 
-    result.paddingSpacing = ParseUtil::GetUInt(
-        json, AdaptiveCardSchemaKey::Padding, defaultValue.paddingSpacing);
+    result.paddingSpacing = ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::Padding, defaultValue.paddingSpacing);
 
     return result;
 }
 
-SeparatorConfig SeparatorConfig::Deserialize(const Json::Value & json, const SeparatorConfig & defaultValue)
+SeparatorConfig SeparatorConfig::Deserialize(const Json::Value& json, const SeparatorConfig& defaultValue)
 {
     SeparatorConfig result;
 
-    result.lineThickness = ParseUtil::GetUInt(
-        json, AdaptiveCardSchemaKey::LineThickness, defaultValue.lineThickness);
+    result.lineThickness = ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::LineThickness, defaultValue.lineThickness);
 
     std::string lineColor = ParseUtil::GetString(json, AdaptiveCardSchemaKey::LineColor);
     result.lineColor = lineColor == "" ? defaultValue.lineColor : lineColor;
@@ -256,7 +250,8 @@ SeparatorConfig SeparatorConfig::Deserialize(const Json::Value & json, const Sep
     return result;
 }
 
-ContainerStyleDefinition ContainerStyleDefinition::Deserialize(const Json::Value & json, const ContainerStyleDefinition & defaultValue)
+ContainerStyleDefinition ContainerStyleDefinition::Deserialize(
+    const Json::Value& json, const ContainerStyleDefinition& defaultValue)
 {
     ContainerStyleDefinition result;
 
@@ -266,7 +261,8 @@ ContainerStyleDefinition ContainerStyleDefinition::Deserialize(const Json::Value
     const std::string borderColor = ParseUtil::GetString(json, AdaptiveCardSchemaKey::BorderColor);
     result.borderColor = borderColor == "" ? defaultValue.borderColor : borderColor;
 
-    result.borderThickness = ParseUtil::GetInt(json, AdaptiveCardSchemaKey::BorderThickness, defaultValue.borderThickness);
+    result.borderThickness =
+        ParseUtil::GetInt(json, AdaptiveCardSchemaKey::BorderThickness, defaultValue.borderThickness);
 
     result.foregroundColors = ParseUtil::ExtractJsonValueAndMergeWithDefault<ColorsConfig>(
         json, AdaptiveCardSchemaKey::ForegroundColors, defaultValue.foregroundColors, ColorsConfig::Deserialize);
@@ -274,7 +270,8 @@ ContainerStyleDefinition ContainerStyleDefinition::Deserialize(const Json::Value
     return result;
 }
 
-ContainerStylesDefinition ContainerStylesDefinition::Deserialize(const Json::Value & json, const ContainerStylesDefinition & defaultValue)
+ContainerStylesDefinition ContainerStylesDefinition::Deserialize(
+    const Json::Value& json, const ContainerStylesDefinition& defaultValue)
 {
     ContainerStylesDefinition result;
 
@@ -287,23 +284,20 @@ ContainerStylesDefinition ContainerStylesDefinition::Deserialize(const Json::Val
     return result;
 }
 
-FontWeightsConfig FontWeightsConfig::Deserialize(const Json::Value & json, const FontWeightsConfig & defaultValue)
+FontWeightsConfig FontWeightsConfig::Deserialize(const Json::Value& json, const FontWeightsConfig& defaultValue)
 {
     FontWeightsConfig result;
 
-    result.lighterWeight = ParseUtil::GetUInt(
-        json, AdaptiveCardSchemaKey::Lighter, defaultValue.lighterWeight);
+    result.lighterWeight = ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::Lighter, defaultValue.lighterWeight);
 
-    result.defaultWeight = ParseUtil::GetUInt(
-        json, AdaptiveCardSchemaKey::Default, defaultValue.defaultWeight);
+    result.defaultWeight = ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::Default, defaultValue.defaultWeight);
 
-    result.bolderWeight = ParseUtil::GetUInt(
-        json, AdaptiveCardSchemaKey::Bolder, defaultValue.bolderWeight);
+    result.bolderWeight = ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::Bolder, defaultValue.bolderWeight);
 
     return result;
 }
 
-ImageConfig ImageConfig::Deserialize(const Json::Value & json, const ImageConfig & defaultValue)
+ImageConfig ImageConfig::Deserialize(const Json::Value& json, const ImageConfig& defaultValue)
 {
     ImageConfig result;
 

--- a/source/shared/cpp/ObjectModel/HostConfig.cpp
+++ b/source/shared/cpp/ObjectModel/HostConfig.cpp
@@ -9,7 +9,7 @@ HostConfig HostConfig::DeserializeFromString(const std::string jsonString)
     return HostConfig::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
 }
 
-HostConfig HostConfig::Deserialize(const Json::Value& json)
+HostConfig HostConfig::Deserialize(const Json::Value &json)
 {
     HostConfig result;
     std::string fontFamily = ParseUtil::GetString(json, AdaptiveCardSchemaKey::FontFamily);
@@ -56,7 +56,7 @@ HostConfig HostConfig::Deserialize(const Json::Value& json)
     return result;
 }
 
-FontSizesConfig FontSizesConfig::Deserialize(const Json::Value& json, const FontSizesConfig& defaultValue)
+FontSizesConfig FontSizesConfig::Deserialize(const Json::Value &json, const FontSizesConfig &defaultValue)
 {
     FontSizesConfig result;
     result.smallFontSize = ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::Small, defaultValue.smallFontSize);
@@ -68,7 +68,7 @@ FontSizesConfig FontSizesConfig::Deserialize(const Json::Value& json, const Font
     return result;
 }
 
-ColorConfig ColorConfig::Deserialize(const Json::Value& json, const ColorConfig& defaultValue)
+ColorConfig ColorConfig::Deserialize(const Json::Value &json, const ColorConfig &defaultValue)
 {
     ColorConfig result;
     std::string defaultColor = ParseUtil::GetString(json, AdaptiveCardSchemaKey::Default);
@@ -80,7 +80,7 @@ ColorConfig ColorConfig::Deserialize(const Json::Value& json, const ColorConfig&
     return result;
 }
 
-ColorsConfig ColorsConfig::Deserialize(const Json::Value& json, const ColorsConfig& defaultValue)
+ColorsConfig ColorsConfig::Deserialize(const Json::Value &json, const ColorsConfig &defaultValue)
 {
     ColorsConfig result;
     auto colorDeserializer = &ColorConfig::Deserialize;
@@ -109,7 +109,7 @@ ColorsConfig ColorsConfig::Deserialize(const Json::Value& json, const ColorsConf
     return result;
 }
 
-TextConfig TextConfig::Deserialize(const Json::Value& json, const TextConfig& defaultValue)
+TextConfig TextConfig::Deserialize(const Json::Value &json, const TextConfig &defaultValue)
 {
     TextConfig result;
     result.weight = ParseUtil::GetEnumValue<TextWeight>(
@@ -130,7 +130,7 @@ TextConfig TextConfig::Deserialize(const Json::Value& json, const TextConfig& de
     return result;
 }
 
-ImageSizesConfig ImageSizesConfig::Deserialize(const Json::Value& json, const ImageSizesConfig& defaultValue)
+ImageSizesConfig ImageSizesConfig::Deserialize(const Json::Value &json, const ImageSizesConfig &defaultValue)
 {
     ImageSizesConfig result;
     result.smallSize = ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::Small, defaultValue.smallSize);
@@ -140,7 +140,7 @@ ImageSizesConfig ImageSizesConfig::Deserialize(const Json::Value& json, const Im
     return result;
 }
 
-AdaptiveCardConfig AdaptiveCardConfig::Deserialize(const Json::Value& json, const AdaptiveCardConfig& defaultValue)
+AdaptiveCardConfig AdaptiveCardConfig::Deserialize(const Json::Value &json, const AdaptiveCardConfig &defaultValue)
 {
     AdaptiveCardConfig result;
     result.allowCustomStyle =
@@ -149,7 +149,7 @@ AdaptiveCardConfig AdaptiveCardConfig::Deserialize(const Json::Value& json, cons
     return result;
 }
 
-ImageSetConfig ImageSetConfig::Deserialize(const Json::Value& json, const ImageSetConfig& defaultValue)
+ImageSetConfig ImageSetConfig::Deserialize(const Json::Value &json, const ImageSetConfig &defaultValue)
 {
     ImageSetConfig result;
     result.imageSize = ParseUtil::GetEnumValue<ImageSize>(
@@ -161,7 +161,7 @@ ImageSetConfig ImageSetConfig::Deserialize(const Json::Value& json, const ImageS
     return result;
 }
 
-FactSetConfig FactSetConfig::Deserialize(const Json::Value& json, const FactSetConfig& defaultValue)
+FactSetConfig FactSetConfig::Deserialize(const Json::Value &json, const FactSetConfig &defaultValue)
 {
     FactSetConfig result;
 
@@ -179,7 +179,7 @@ FactSetConfig FactSetConfig::Deserialize(const Json::Value& json, const FactSetC
 }
 
 ShowCardActionConfig ShowCardActionConfig::Deserialize(
-    const Json::Value& json, const ShowCardActionConfig& defaultValue)
+    const Json::Value &json, const ShowCardActionConfig &defaultValue)
 {
     ShowCardActionConfig result;
     result.actionMode = ParseUtil::GetEnumValue<ActionMode>(
@@ -192,7 +192,7 @@ ShowCardActionConfig ShowCardActionConfig::Deserialize(
     return result;
 }
 
-ActionsConfig ActionsConfig::Deserialize(const Json::Value& json, const ActionsConfig& defaultValue)
+ActionsConfig ActionsConfig::Deserialize(const Json::Value &json, const ActionsConfig &defaultValue)
 {
     ActionsConfig result;
 
@@ -218,7 +218,7 @@ ActionsConfig ActionsConfig::Deserialize(const Json::Value& json, const ActionsC
     return result;
 }
 
-SpacingConfig SpacingConfig::Deserialize(const Json::Value& json, const SpacingConfig& defaultValue)
+SpacingConfig SpacingConfig::Deserialize(const Json::Value &json, const SpacingConfig &defaultValue)
 {
     SpacingConfig result;
 
@@ -238,7 +238,7 @@ SpacingConfig SpacingConfig::Deserialize(const Json::Value& json, const SpacingC
     return result;
 }
 
-SeparatorConfig SeparatorConfig::Deserialize(const Json::Value& json, const SeparatorConfig& defaultValue)
+SeparatorConfig SeparatorConfig::Deserialize(const Json::Value &json, const SeparatorConfig &defaultValue)
 {
     SeparatorConfig result;
 
@@ -251,7 +251,7 @@ SeparatorConfig SeparatorConfig::Deserialize(const Json::Value& json, const Sepa
 }
 
 ContainerStyleDefinition ContainerStyleDefinition::Deserialize(
-    const Json::Value& json, const ContainerStyleDefinition& defaultValue)
+    const Json::Value &json, const ContainerStyleDefinition &defaultValue)
 {
     ContainerStyleDefinition result;
 
@@ -271,7 +271,7 @@ ContainerStyleDefinition ContainerStyleDefinition::Deserialize(
 }
 
 ContainerStylesDefinition ContainerStylesDefinition::Deserialize(
-    const Json::Value& json, const ContainerStylesDefinition& defaultValue)
+    const Json::Value &json, const ContainerStylesDefinition &defaultValue)
 {
     ContainerStylesDefinition result;
 
@@ -284,7 +284,7 @@ ContainerStylesDefinition ContainerStylesDefinition::Deserialize(
     return result;
 }
 
-FontWeightsConfig FontWeightsConfig::Deserialize(const Json::Value& json, const FontWeightsConfig& defaultValue)
+FontWeightsConfig FontWeightsConfig::Deserialize(const Json::Value &json, const FontWeightsConfig &defaultValue)
 {
     FontWeightsConfig result;
 
@@ -297,7 +297,7 @@ FontWeightsConfig FontWeightsConfig::Deserialize(const Json::Value& json, const 
     return result;
 }
 
-ImageConfig ImageConfig::Deserialize(const Json::Value& json, const ImageConfig& defaultValue)
+ImageConfig ImageConfig::Deserialize(const Json::Value &json, const ImageConfig &defaultValue)
 {
     ImageConfig result;
 

--- a/source/shared/cpp/ObjectModel/HostConfig.h
+++ b/source/shared/cpp/ObjectModel/HostConfig.h
@@ -14,7 +14,7 @@ namespace AdaptiveSharedNamespace
         unsigned int largeFontSize = 17;
         unsigned int extraLargeFontSize = 20;
 
-        static FontSizesConfig Deserialize(const Json::Value& json, const FontSizesConfig& defaultValue);
+        static FontSizesConfig Deserialize(const Json::Value &json, const FontSizesConfig &defaultValue);
     };
 
     struct FontWeightsConfig
@@ -23,7 +23,7 @@ namespace AdaptiveSharedNamespace
         unsigned int defaultWeight = 400;
         unsigned int bolderWeight = 800;
 
-        static FontWeightsConfig Deserialize(const Json::Value& json, const FontWeightsConfig& defaultValue);
+        static FontWeightsConfig Deserialize(const Json::Value &json, const FontWeightsConfig &defaultValue);
     };
 
     struct ColorConfig
@@ -31,7 +31,7 @@ namespace AdaptiveSharedNamespace
         std::string defaultColor;
         std::string subtleColor;
 
-        static ColorConfig Deserialize(const Json::Value& json, const ColorConfig& defaultValue);
+        static ColorConfig Deserialize(const Json::Value &json, const ColorConfig &defaultValue);
     };
 
     struct ColorsConfig
@@ -44,7 +44,7 @@ namespace AdaptiveSharedNamespace
         ColorConfig warning = {"#FFFFD700", "#B2FFD700"};
         ColorConfig attention = {"#FF8B0000", "#B28B0000"};
 
-        static ColorsConfig Deserialize(const Json::Value& json, const ColorsConfig& defaultValue);
+        static ColorsConfig Deserialize(const Json::Value &json, const ColorsConfig &defaultValue);
     };
 
     struct TextConfig
@@ -56,7 +56,7 @@ namespace AdaptiveSharedNamespace
         bool wrap = true;
         unsigned int maxWidth = (unsigned int)~0;
 
-        static TextConfig Deserialize(const Json::Value& json, const TextConfig& defaultValue);
+        static TextConfig Deserialize(const Json::Value &json, const TextConfig &defaultValue);
     };
 
     struct SpacingConfig
@@ -68,7 +68,7 @@ namespace AdaptiveSharedNamespace
         unsigned int extraLargeSpacing = 40;
         unsigned int paddingSpacing = 20;
 
-        static SpacingConfig Deserialize(const Json::Value& json, const SpacingConfig& defaultValue);
+        static SpacingConfig Deserialize(const Json::Value &json, const SpacingConfig &defaultValue);
     };
 
     struct SeparatorConfig
@@ -76,7 +76,7 @@ namespace AdaptiveSharedNamespace
         unsigned int lineThickness = 1;
         std::string lineColor = "#B2000000";
 
-        static SeparatorConfig Deserialize(const Json::Value& json, const SeparatorConfig& defaultValue);
+        static SeparatorConfig Deserialize(const Json::Value &json, const SeparatorConfig &defaultValue);
     };
 
     struct ImageSizesConfig
@@ -85,7 +85,7 @@ namespace AdaptiveSharedNamespace
         unsigned int mediumSize = 120;
         unsigned int largeSize = 180;
 
-        static ImageSizesConfig Deserialize(const Json::Value& json, const ImageSizesConfig& defaultValue);
+        static ImageSizesConfig Deserialize(const Json::Value &json, const ImageSizesConfig &defaultValue);
     };
 
     struct ImageSetConfig
@@ -93,21 +93,21 @@ namespace AdaptiveSharedNamespace
         ImageSize imageSize = ImageSize::Auto;
         unsigned int maxImageHeight = 100;
 
-        static ImageSetConfig Deserialize(const Json::Value& json, const ImageSetConfig& defaultValue);
+        static ImageSetConfig Deserialize(const Json::Value &json, const ImageSetConfig &defaultValue);
     };
 
     struct ImageConfig
     {
         ImageSize imageSize = ImageSize::Auto;
 
-        static ImageConfig Deserialize(const Json::Value& json, const ImageConfig& defaultValue);
+        static ImageConfig Deserialize(const Json::Value &json, const ImageConfig &defaultValue);
     };
 
     struct AdaptiveCardConfig
     {
         bool allowCustomStyle = true;
 
-        static AdaptiveCardConfig Deserialize(const Json::Value& json, const AdaptiveCardConfig& defaultValue);
+        static AdaptiveCardConfig Deserialize(const Json::Value &json, const AdaptiveCardConfig &defaultValue);
     };
 
     struct FactSetConfig
@@ -117,7 +117,7 @@ namespace AdaptiveSharedNamespace
             TextWeight::Default, TextSize::Default, ForegroundColor::Default, false, true, (unsigned int)~0};
         unsigned int spacing = 10;
 
-        static FactSetConfig Deserialize(const Json::Value& json, const FactSetConfig& defaultValue);
+        static FactSetConfig Deserialize(const Json::Value &json, const FactSetConfig &defaultValue);
     };
 
     struct ContainerStyleDefinition
@@ -129,7 +129,7 @@ namespace AdaptiveSharedNamespace
         ColorsConfig foregroundColors;
 
         static ContainerStyleDefinition Deserialize(
-            const Json::Value& json, const ContainerStyleDefinition& defaultValue);
+            const Json::Value &json, const ContainerStyleDefinition &defaultValue);
     };
 
     struct ContainerStylesDefinition
@@ -147,7 +147,7 @@ namespace AdaptiveSharedNamespace
             }};
 
         static ContainerStylesDefinition Deserialize(
-            const Json::Value& json, const ContainerStylesDefinition& defaultValue);
+            const Json::Value &json, const ContainerStylesDefinition &defaultValue);
     };
 
     struct ShowCardActionConfig
@@ -156,7 +156,7 @@ namespace AdaptiveSharedNamespace
         ContainerStyle style = ContainerStyle::Emphasis;
         unsigned int inlineTopMargin = 16;
 
-        static ShowCardActionConfig Deserialize(const Json::Value& json, const ShowCardActionConfig& defaultValue);
+        static ShowCardActionConfig Deserialize(const Json::Value &json, const ShowCardActionConfig &defaultValue);
     };
 
     struct ActionsConfig
@@ -169,7 +169,7 @@ namespace AdaptiveSharedNamespace
         Spacing spacing = Spacing::Default;
         IconPlacement iconPlacement = IconPlacement::AboveTitle;
 
-        static ActionsConfig Deserialize(const Json::Value& json, const ActionsConfig& defaultValue);
+        static ActionsConfig Deserialize(const Json::Value &json, const ActionsConfig &defaultValue);
     };
 
     struct HostConfig
@@ -189,7 +189,7 @@ namespace AdaptiveSharedNamespace
         ActionsConfig actions;
         ContainerStylesDefinition containerStyles;
 
-        static HostConfig Deserialize(const Json::Value& json);
+        static HostConfig Deserialize(const Json::Value &json);
         static HostConfig DeserializeFromString(const std::string jsonString);
     };
 } // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/HostConfig.h
+++ b/source/shared/cpp/ObjectModel/HostConfig.h
@@ -4,190 +4,192 @@
 #include "Enums.h"
 #include "json/json.h"
 
-AdaptiveSharedNamespaceStart
-
-struct FontSizesConfig
+namespace AdaptiveSharedNamespace
 {
-    unsigned int smallFontSize = 10;
-    unsigned int defaultFontSize = 12;
-    unsigned int mediumFontSize = 14;
-    unsigned int largeFontSize = 17;
-    unsigned int extraLargeFontSize = 20;
+    struct FontSizesConfig
+    {
+        unsigned int smallFontSize = 10;
+        unsigned int defaultFontSize = 12;
+        unsigned int mediumFontSize = 14;
+        unsigned int largeFontSize = 17;
+        unsigned int extraLargeFontSize = 20;
 
-    static FontSizesConfig Deserialize(const Json::Value& json, const FontSizesConfig& defaultValue);
-};
-
-struct FontWeightsConfig
-{
-    unsigned int lighterWeight = 200;
-    unsigned int defaultWeight = 400;
-    unsigned int bolderWeight = 800;
-
-    static FontWeightsConfig Deserialize(const Json::Value& json, const FontWeightsConfig& defaultValue);
-};
-
-struct ColorConfig
-{
-    std::string defaultColor;
-    std::string subtleColor;
-
-    static ColorConfig Deserialize(const Json::Value& json, const ColorConfig& defaultValue);
-};
-
-struct ColorsConfig
-{
-    ColorConfig defaultColor = { "#FF000000", "#B2000000" };
-    ColorConfig accent = { "#FF0000FF", "#B20000FF" };
-    ColorConfig dark = { "#FF101010", "#B2101010" };
-    ColorConfig light = { "#FFFFFFFF", "#B2FFFFFF" };
-    ColorConfig good = { "#FF008000", "#B2008000" };
-    ColorConfig warning = { "#FFFFD700", "#B2FFD700" };
-    ColorConfig attention = { "#FF8B0000", "#B28B0000" };
-
-    static ColorsConfig Deserialize(const Json::Value& json, const ColorsConfig& defaultValue);
-};
-
-struct TextConfig
-{
-    TextWeight weight = TextWeight::Default;
-    TextSize size = TextSize::Default;
-    ForegroundColor color = ForegroundColor::Default;
-    bool isSubtle = false;
-    bool wrap = true;
-    unsigned int maxWidth = (unsigned int) ~0;
-
-    static TextConfig Deserialize(const Json::Value& json, const TextConfig& defaultValue);
-};
-
-struct SpacingConfig
-{
-    unsigned int smallSpacing = 3;
-    unsigned int defaultSpacing = 8;
-    unsigned int mediumSpacing = 20;
-    unsigned int largeSpacing = 30;
-    unsigned int extraLargeSpacing = 40;
-    unsigned int paddingSpacing = 20;
-
-    static SpacingConfig Deserialize(const Json::Value& json, const SpacingConfig& defaultValue);
-};
-
-struct SeparatorConfig
-{
-    unsigned int lineThickness = 1;
-    std::string lineColor = "#B2000000";
-
-    static SeparatorConfig Deserialize(const Json::Value& json, const SeparatorConfig& defaultValue);
-};
-
-struct ImageSizesConfig
-{
-    unsigned int smallSize = 80;
-    unsigned int mediumSize = 120;
-    unsigned int largeSize = 180;
-
-    static ImageSizesConfig Deserialize(const Json::Value& json, const ImageSizesConfig& defaultValue);
-};
-
-struct ImageSetConfig
-{
-    ImageSize imageSize = ImageSize::Auto;
-    unsigned int maxImageHeight = 100;
-
-    static ImageSetConfig Deserialize(const Json::Value& json, const ImageSetConfig& defaultValue);
-};
-
-struct ImageConfig
-{
-    ImageSize imageSize = ImageSize::Auto;
-
-    static ImageConfig Deserialize(const Json::Value& json, const ImageConfig& defaultValue);
-};
-
-struct AdaptiveCardConfig
-{
-    bool allowCustomStyle = true;
-
-    static AdaptiveCardConfig Deserialize(const Json::Value& json, const AdaptiveCardConfig& defaultValue);
-};
-
-struct FactSetConfig
-{
-    TextConfig title{ TextWeight::Bolder, TextSize::Default, ForegroundColor::Default, false, true, 150 };
-    TextConfig value{ TextWeight::Default, TextSize::Default, ForegroundColor::Default, false, true, (unsigned int)~0 };
-    unsigned int spacing = 10;
-
-    static FactSetConfig Deserialize(const Json::Value& json, const FactSetConfig& defaultValue);
-};
-
-struct ContainerStyleDefinition
-{
-    std::string backgroundColor = "#FFFFFFFF";
-    std::string borderColor = "#FF7F7F7F7F"; // CAUTION: Experimental feature for iOS. Not in v1 schema, subject to change.
-    unsigned int borderThickness = 0; // CAUTION: Experimental feature for iOS. Not in v1 schema, subject to change.
-    ColorsConfig foregroundColors;
-
-    static ContainerStyleDefinition Deserialize(const Json::Value& json, const ContainerStyleDefinition& defaultValue);
-};
-
-struct ContainerStylesDefinition
-{
-    ContainerStyleDefinition defaultPalette;
-    ContainerStyleDefinition emphasisPalette = 
-    { "#08000000", "#08000000", 0,
-        {
-            { "#FF000000", "#B2000000" },   //defaultColor
-            { "#FF0000FF", "#B20000FF" },   //accent
-            { "#FF101010", "#B2101010" },   //dark
-            { "#FFFFFFFF", "#B2FFFFFF" },   //light
-            { "#FF008000", "#B2008000" },   //good
-            { "#FFFFD700", "#B2FFD700" },   //warning
-            { "#FF8B0000", "#B28B0000" }    //attention
-        }
+        static FontSizesConfig Deserialize(const Json::Value& json, const FontSizesConfig& defaultValue);
     };
 
-    static ContainerStylesDefinition Deserialize(const Json::Value& json, const ContainerStylesDefinition& defaultValue);
-};
+    struct FontWeightsConfig
+    {
+        unsigned int lighterWeight = 200;
+        unsigned int defaultWeight = 400;
+        unsigned int bolderWeight = 800;
 
-struct ShowCardActionConfig
-{
-    ActionMode actionMode = ActionMode::Inline;
-    ContainerStyle style = ContainerStyle::Emphasis;
-    unsigned int inlineTopMargin = 16;
+        static FontWeightsConfig Deserialize(const Json::Value& json, const FontWeightsConfig& defaultValue);
+    };
 
-    static ShowCardActionConfig Deserialize(const Json::Value& json, const ShowCardActionConfig& defaultValue);
-};
+    struct ColorConfig
+    {
+        std::string defaultColor;
+        std::string subtleColor;
 
-struct ActionsConfig
-{
-    ShowCardActionConfig showCard;
-    ActionsOrientation actionsOrientation = ActionsOrientation::Horizontal;
-    ActionAlignment actionAlignment = ActionAlignment::Stretch;
-    unsigned int buttonSpacing = 10;
-    unsigned int maxActions = 5;
-    Spacing spacing = Spacing::Default;
-    IconPlacement iconPlacement = IconPlacement::AboveTitle;
+        static ColorConfig Deserialize(const Json::Value& json, const ColorConfig& defaultValue);
+    };
 
-    static ActionsConfig Deserialize(const Json::Value& json, const ActionsConfig& defaultValue);
-};
+    struct ColorsConfig
+    {
+        ColorConfig defaultColor = {"#FF000000", "#B2000000"};
+        ColorConfig accent = {"#FF0000FF", "#B20000FF"};
+        ColorConfig dark = {"#FF101010", "#B2101010"};
+        ColorConfig light = {"#FFFFFFFF", "#B2FFFFFF"};
+        ColorConfig good = {"#FF008000", "#B2008000"};
+        ColorConfig warning = {"#FFFFD700", "#B2FFD700"};
+        ColorConfig attention = {"#FF8B0000", "#B28B0000"};
 
-struct HostConfig
-{
-    std::string fontFamily = "Calibri";
-    FontSizesConfig fontSizes;
-    FontWeightsConfig fontWeights;
-    bool supportsInteractivity = true;
-    std::string imageBaseUrl;
-    ImageSizesConfig imageSizes;
-    ImageConfig image;
-    SeparatorConfig separator;
-    SpacingConfig spacing;
-    AdaptiveCardConfig adaptiveCard;
-    ImageSetConfig imageSet;
-    FactSetConfig factSet;
-    ActionsConfig actions;
-    ContainerStylesDefinition containerStyles;
+        static ColorsConfig Deserialize(const Json::Value& json, const ColorsConfig& defaultValue);
+    };
 
-    static HostConfig Deserialize(const Json::Value& json);
-    static HostConfig DeserializeFromString(const std::string jsonString);
-};
-AdaptiveSharedNamespaceEnd
+    struct TextConfig
+    {
+        TextWeight weight = TextWeight::Default;
+        TextSize size = TextSize::Default;
+        ForegroundColor color = ForegroundColor::Default;
+        bool isSubtle = false;
+        bool wrap = true;
+        unsigned int maxWidth = (unsigned int)~0;
+
+        static TextConfig Deserialize(const Json::Value& json, const TextConfig& defaultValue);
+    };
+
+    struct SpacingConfig
+    {
+        unsigned int smallSpacing = 3;
+        unsigned int defaultSpacing = 8;
+        unsigned int mediumSpacing = 20;
+        unsigned int largeSpacing = 30;
+        unsigned int extraLargeSpacing = 40;
+        unsigned int paddingSpacing = 20;
+
+        static SpacingConfig Deserialize(const Json::Value& json, const SpacingConfig& defaultValue);
+    };
+
+    struct SeparatorConfig
+    {
+        unsigned int lineThickness = 1;
+        std::string lineColor = "#B2000000";
+
+        static SeparatorConfig Deserialize(const Json::Value& json, const SeparatorConfig& defaultValue);
+    };
+
+    struct ImageSizesConfig
+    {
+        unsigned int smallSize = 80;
+        unsigned int mediumSize = 120;
+        unsigned int largeSize = 180;
+
+        static ImageSizesConfig Deserialize(const Json::Value& json, const ImageSizesConfig& defaultValue);
+    };
+
+    struct ImageSetConfig
+    {
+        ImageSize imageSize = ImageSize::Auto;
+        unsigned int maxImageHeight = 100;
+
+        static ImageSetConfig Deserialize(const Json::Value& json, const ImageSetConfig& defaultValue);
+    };
+
+    struct ImageConfig
+    {
+        ImageSize imageSize = ImageSize::Auto;
+
+        static ImageConfig Deserialize(const Json::Value& json, const ImageConfig& defaultValue);
+    };
+
+    struct AdaptiveCardConfig
+    {
+        bool allowCustomStyle = true;
+
+        static AdaptiveCardConfig Deserialize(const Json::Value& json, const AdaptiveCardConfig& defaultValue);
+    };
+
+    struct FactSetConfig
+    {
+        TextConfig title{TextWeight::Bolder, TextSize::Default, ForegroundColor::Default, false, true, 150};
+        TextConfig value{
+            TextWeight::Default, TextSize::Default, ForegroundColor::Default, false, true, (unsigned int)~0};
+        unsigned int spacing = 10;
+
+        static FactSetConfig Deserialize(const Json::Value& json, const FactSetConfig& defaultValue);
+    };
+
+    struct ContainerStyleDefinition
+    {
+        std::string backgroundColor = "#FFFFFFFF";
+        std::string borderColor =
+            "#FF7F7F7F7F"; // CAUTION: Experimental feature for iOS. Not in v1 schema, subject to change.
+        unsigned int borderThickness = 0; // CAUTION: Experimental feature for iOS. Not in v1 schema, subject to change.
+        ColorsConfig foregroundColors;
+
+        static ContainerStyleDefinition Deserialize(
+            const Json::Value& json, const ContainerStyleDefinition& defaultValue);
+    };
+
+    struct ContainerStylesDefinition
+    {
+        ContainerStyleDefinition defaultPalette;
+        ContainerStyleDefinition emphasisPalette = {"#08000000", "#08000000", 0,
+            {
+                {"#FF000000", "#B2000000"}, // defaultColor
+                {"#FF0000FF", "#B20000FF"}, // accent
+                {"#FF101010", "#B2101010"}, // dark
+                {"#FFFFFFFF", "#B2FFFFFF"}, // light
+                {"#FF008000", "#B2008000"}, // good
+                {"#FFFFD700", "#B2FFD700"}, // warning
+                {"#FF8B0000", "#B28B0000"} // attention
+            }};
+
+        static ContainerStylesDefinition Deserialize(
+            const Json::Value& json, const ContainerStylesDefinition& defaultValue);
+    };
+
+    struct ShowCardActionConfig
+    {
+        ActionMode actionMode = ActionMode::Inline;
+        ContainerStyle style = ContainerStyle::Emphasis;
+        unsigned int inlineTopMargin = 16;
+
+        static ShowCardActionConfig Deserialize(const Json::Value& json, const ShowCardActionConfig& defaultValue);
+    };
+
+    struct ActionsConfig
+    {
+        ShowCardActionConfig showCard;
+        ActionsOrientation actionsOrientation = ActionsOrientation::Horizontal;
+        ActionAlignment actionAlignment = ActionAlignment::Stretch;
+        unsigned int buttonSpacing = 10;
+        unsigned int maxActions = 5;
+        Spacing spacing = Spacing::Default;
+        IconPlacement iconPlacement = IconPlacement::AboveTitle;
+
+        static ActionsConfig Deserialize(const Json::Value& json, const ActionsConfig& defaultValue);
+    };
+
+    struct HostConfig
+    {
+        std::string fontFamily = "Calibri";
+        FontSizesConfig fontSizes;
+        FontWeightsConfig fontWeights;
+        bool supportsInteractivity = true;
+        std::string imageBaseUrl;
+        ImageSizesConfig imageSizes;
+        ImageConfig image;
+        SeparatorConfig separator;
+        SpacingConfig spacing;
+        AdaptiveCardConfig adaptiveCard;
+        ImageSetConfig imageSet;
+        FactSetConfig factSet;
+        ActionsConfig actions;
+        ContainerStylesDefinition containerStyles;
+
+        static HostConfig Deserialize(const Json::Value& json);
+        static HostConfig DeserializeFromString(const std::string jsonString);
+    };
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/Image.cpp
+++ b/source/shared/cpp/ObjectModel/Image.cpp
@@ -56,6 +56,11 @@ Json::Value Image::SerializeToJsonValue() const
         root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Url)] = m_url;
     }
 
+    if (!m_backgroundColor.empty())
+    {
+        root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::BackgroundColor)] = m_backgroundColor;
+    }
+
     if (m_hAlignment != HorizontalAlignment::Left)
     {
         root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::HorizontalAlignment)] =
@@ -83,6 +88,16 @@ std::string Image::GetUrl() const
 void Image::SetUrl(const std::string &value)
 {
     m_url = value;
+}
+
+std::string Image::GetBackgroundColor() const
+{
+    return m_backgroundColor;
+}
+
+void Image::SetBackgroundColor(const std::string &value)
+{
+    m_backgroundColor = value;
 }
 
 ImageStyle Image::GetImageStyle() const
@@ -180,6 +195,7 @@ std::shared_ptr<BaseCardElement> ImageParser::DeserializeWithoutCheckingType(
     std::shared_ptr<Image> image = BaseCardElement::Deserialize<Image>(json);
 
     image->SetUrl(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Url, true));
+    image->SetBackgroundColor(ParseUtil::GetString(json, AdaptiveCardSchemaKey::BackgroundColor));
     image->SetImageStyle(ParseUtil::GetEnumValue<ImageStyle>(json, AdaptiveCardSchemaKey::Style, ImageStyle::Default, ImageStyleFromString));
     image->SetAltText(ParseUtil::GetString(json, AdaptiveCardSchemaKey::AltText));
     image->SetHorizontalAlignment(ParseUtil::GetEnumValue<HorizontalAlignment>(json, AdaptiveCardSchemaKey::HorizontalAlignment, HorizontalAlignment::Left, HorizontalAlignmentFromString));
@@ -226,6 +242,7 @@ std::shared_ptr<BaseCardElement> ImageParser::DeserializeWithoutCheckingType(
 void Image::PopulateKnownPropertiesSet() 
 {
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Url));
+    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::BackgroundColor));
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Style));
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Size));
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::AltText));

--- a/source/shared/cpp/ObjectModel/Image.cpp
+++ b/source/shared/cpp/ObjectModel/Image.cpp
@@ -82,7 +82,7 @@ std::string Image::GetUrl() const
     return m_url;
 }
 
-void Image::SetUrl(const std::string& value)
+void Image::SetUrl(const std::string &value)
 {
     m_url = value;
 }
@@ -122,7 +122,7 @@ std::string Image::GetAltText() const
     return m_altText;
 }
 
-void Image::SetAltText(const std::string& value)
+void Image::SetAltText(const std::string &value)
 {
     m_altText = value;
 }
@@ -169,7 +169,7 @@ void Image::SetPixelHeight(unsigned int value)
 
 std::shared_ptr<BaseCardElement> ImageParser::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString)
 {
     return ImageParser::Deserialize(
         elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
@@ -177,7 +177,7 @@ std::shared_ptr<BaseCardElement> ImageParser::DeserializeFromString(
 
 std::shared_ptr<BaseCardElement> ImageParser::Deserialize(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& json)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &json)
 {
     ParseUtil::ExpectTypeString(json, CardElementType::Image);
     return ImageParser::DeserializeWithoutCheckingType(elementParserRegistration, actionParserRegistration, json);
@@ -185,7 +185,7 @@ std::shared_ptr<BaseCardElement> ImageParser::Deserialize(
 
 std::shared_ptr<BaseCardElement> ImageParser::DeserializeWithoutCheckingType(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& json)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &json)
 {
     std::shared_ptr<Image> image = BaseCardElement::Deserialize<Image>(json);
 
@@ -251,7 +251,7 @@ void Image::PopulateKnownPropertiesSet()
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::SelectAction));
 }
 
-void Image::GetResourceUris(std::vector<std::string>& resourceUris)
+void Image::GetResourceUris(std::vector<std::string> &resourceUris)
 {
     auto url = GetUrl();
     resourceUris.push_back(url);

--- a/source/shared/cpp/ObjectModel/Image.cpp
+++ b/source/shared/cpp/ObjectModel/Image.cpp
@@ -6,12 +6,8 @@
 using namespace AdaptiveSharedNamespace;
 
 Image::Image() :
-    BaseCardElement(CardElementType::Image),
-    m_imageStyle(ImageStyle::Default),
-    m_imageSize(ImageSize::None),
-    m_pixelWidth(0),
-    m_pixelHeight(0),
-    m_hAlignment(HorizontalAlignment::Left)
+    BaseCardElement(CardElementType::Image), m_imageStyle(ImageStyle::Default), m_imageSize(ImageSize::None),
+    m_pixelWidth(0), m_pixelHeight(0), m_hAlignment(HorizontalAlignment::Left)
 {
     PopulateKnownPropertiesSet();
 }
@@ -74,7 +70,8 @@ Json::Value Image::SerializeToJsonValue() const
 
     if (m_selectAction != nullptr)
     {
-        root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::SelectAction)] = BaseCardElement::SerializeSelectAction(m_selectAction);
+        root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::SelectAction)] =
+            BaseCardElement::SerializeSelectAction(m_selectAction);
     }
 
     return root;
@@ -85,7 +82,7 @@ std::string Image::GetUrl() const
     return m_url;
 }
 
-void Image::SetUrl(const std::string &value)
+void Image::SetUrl(const std::string& value)
 {
     m_url = value;
 }
@@ -125,7 +122,7 @@ std::string Image::GetAltText() const
     return m_altText;
 }
 
-void Image::SetAltText(const std::string &value)
+void Image::SetAltText(const std::string& value)
 {
     m_altText = value;
 }
@@ -150,7 +147,7 @@ void Image::SetSelectAction(const std::shared_ptr<BaseActionElement> action)
     m_selectAction = action;
 }
 
-unsigned int Image::GetPixelWidth() const 
+unsigned int Image::GetPixelWidth() const
 {
     return m_pixelWidth;
 }
@@ -172,16 +169,15 @@ void Image::SetPixelHeight(unsigned int value)
 
 std::shared_ptr<BaseCardElement> ImageParser::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-    const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
 {
-    return ImageParser::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
+    return ImageParser::Deserialize(
+        elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
 std::shared_ptr<BaseCardElement> ImageParser::Deserialize(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-    const Json::Value& json)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& json)
 {
     ParseUtil::ExpectTypeString(json, CardElementType::Image);
     return ImageParser::DeserializeWithoutCheckingType(elementParserRegistration, actionParserRegistration, json);
@@ -189,16 +185,17 @@ std::shared_ptr<BaseCardElement> ImageParser::Deserialize(
 
 std::shared_ptr<BaseCardElement> ImageParser::DeserializeWithoutCheckingType(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-    const Json::Value& json)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& json)
 {
     std::shared_ptr<Image> image = BaseCardElement::Deserialize<Image>(json);
 
     image->SetUrl(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Url, true));
     image->SetBackgroundColor(ParseUtil::GetString(json, AdaptiveCardSchemaKey::BackgroundColor));
-    image->SetImageStyle(ParseUtil::GetEnumValue<ImageStyle>(json, AdaptiveCardSchemaKey::Style, ImageStyle::Default, ImageStyleFromString));
+    image->SetImageStyle(ParseUtil::GetEnumValue<ImageStyle>(
+        json, AdaptiveCardSchemaKey::Style, ImageStyle::Default, ImageStyleFromString));
     image->SetAltText(ParseUtil::GetString(json, AdaptiveCardSchemaKey::AltText));
-    image->SetHorizontalAlignment(ParseUtil::GetEnumValue<HorizontalAlignment>(json, AdaptiveCardSchemaKey::HorizontalAlignment, HorizontalAlignment::Left, HorizontalAlignmentFromString));
+    image->SetHorizontalAlignment(ParseUtil::GetEnumValue<HorizontalAlignment>(
+        json, AdaptiveCardSchemaKey::HorizontalAlignment, HorizontalAlignment::Left, HorizontalAlignmentFromString));
 
     std::vector<std::string> requestedDimensions;
     requestedDimensions.push_back(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Width));
@@ -213,11 +210,11 @@ std::shared_ptr<BaseCardElement> ImageParser::DeserializeWithoutCheckingType(
             const std::string unit = "px";
             std::size_t foundIndex = eachDimension.find(unit);
             /// check if width is determined explicitly
-            if (std::string::npos != foundIndex) 
+            if (std::string::npos != foundIndex)
             {
                 if (eachDimension.size() == foundIndex + unit.size())
-                // validate user inputs
-                ValidateUserInputForDimensionWithUnit(unit, eachDimension, parsedDimension);
+                    // validate user inputs
+                    ValidateUserInputForDimensionWithUnit(unit, eachDimension, parsedDimension);
             }
         }
         parsedDimensions.push_back(parsedDimension);
@@ -230,16 +227,18 @@ std::shared_ptr<BaseCardElement> ImageParser::DeserializeWithoutCheckingType(
     }
     else
     {
-        image->SetImageSize(ParseUtil::GetEnumValue<ImageSize>(json, AdaptiveCardSchemaKey::Size, ImageSize::None, ImageSizeFromString));
+        image->SetImageSize(ParseUtil::GetEnumValue<ImageSize>(
+            json, AdaptiveCardSchemaKey::Size, ImageSize::None, ImageSizeFromString));
     }
 
     // Parse optional selectAction
-    image->SetSelectAction(ParseUtil::GetSelectAction(elementParserRegistration, actionParserRegistration, json, AdaptiveCardSchemaKey::SelectAction, false));
+    image->SetSelectAction(ParseUtil::GetSelectAction(
+        elementParserRegistration, actionParserRegistration, json, AdaptiveCardSchemaKey::SelectAction, false));
 
     return image;
 }
 
-void Image::PopulateKnownPropertiesSet() 
+void Image::PopulateKnownPropertiesSet()
 {
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Url));
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::BackgroundColor));

--- a/source/shared/cpp/ObjectModel/Image.h
+++ b/source/shared/cpp/ObjectModel/Image.h
@@ -17,6 +17,9 @@ public:
     std::string GetUrl() const;
     void SetUrl(const std::string &value);
 
+    std::string GetBackgroundColor() const;
+    void SetBackgroundColor(const std::string &value);
+
     ImageStyle GetImageStyle() const;
     void SetImageStyle(const ImageStyle value);
 
@@ -44,6 +47,7 @@ private:
     void PopulateKnownPropertiesSet();
 
     std::string m_url;
+    std::string m_backgroundColor;
     ImageStyle m_imageStyle;
     ImageSize m_imageSize;
     unsigned int m_pixelWidth;

--- a/source/shared/cpp/ObjectModel/Image.h
+++ b/source/shared/cpp/ObjectModel/Image.h
@@ -16,7 +16,7 @@ namespace AdaptiveSharedNamespace
         virtual Json::Value SerializeToJsonValue() const override;
 
         std::string GetUrl() const;
-        void SetUrl(const std::string& value);
+        void SetUrl(const std::string &value);
 
         std::string GetBackgroundColor() const;
         void SetBackgroundColor(const std::string &value);
@@ -28,7 +28,7 @@ namespace AdaptiveSharedNamespace
         void SetImageSize(const ImageSize value);
 
         std::string GetAltText() const;
-        void SetAltText(const std::string& value);
+        void SetAltText(const std::string &value);
 
         HorizontalAlignment GetHorizontalAlignment() const;
         void SetHorizontalAlignment(const HorizontalAlignment value);
@@ -42,7 +42,7 @@ namespace AdaptiveSharedNamespace
         unsigned int GetPixelHeight() const;
         void SetPixelHeight(unsigned int value);
 
-        virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
+        virtual void GetResourceUris(std::vector<std::string> &resourceUris) override;
 
     private:
         void PopulateKnownPropertiesSet();
@@ -63,14 +63,14 @@ namespace AdaptiveSharedNamespace
     public:
         std::shared_ptr<BaseCardElement> Deserialize(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &root);
 
         std::shared_ptr<BaseCardElement> DeserializeWithoutCheckingType(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &root);
 
         std::shared_ptr<BaseCardElement> DeserializeFromString(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString);
     };
 } // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/Image.h
+++ b/source/shared/cpp/ObjectModel/Image.h
@@ -6,73 +6,71 @@
 #include "Enums.h"
 #include "ElementParserRegistration.h"
 
-AdaptiveSharedNamespaceStart
-class Image : public BaseCardElement
+namespace AdaptiveSharedNamespace
 {
-public:
-    Image();
+    class Image : public BaseCardElement
+    {
+        public:
+        Image();
 
-    virtual Json::Value SerializeToJsonValue() const override;
+        virtual Json::Value SerializeToJsonValue() const override;
 
-    std::string GetUrl() const;
-    void SetUrl(const std::string &value);
+        std::string GetUrl() const;
+        void SetUrl(const std::string& value);
 
-    std::string GetBackgroundColor() const;
-    void SetBackgroundColor(const std::string &value);
+        std::string GetBackgroundColor() const;
+        void SetBackgroundColor(const std::string &value);
 
-    ImageStyle GetImageStyle() const;
-    void SetImageStyle(const ImageStyle value);
+        ImageStyle GetImageStyle() const;
+        void SetImageStyle(const ImageStyle value);
 
-    ImageSize GetImageSize() const;
-    void SetImageSize(const ImageSize value);
+        ImageSize GetImageSize() const;
+        void SetImageSize(const ImageSize value);
 
-    std::string GetAltText() const;
-    void SetAltText(const std::string &value);
+        std::string GetAltText() const;
+        void SetAltText(const std::string& value);
 
-    HorizontalAlignment GetHorizontalAlignment() const;
-    void SetHorizontalAlignment(const HorizontalAlignment value);
+        HorizontalAlignment GetHorizontalAlignment() const;
+        void SetHorizontalAlignment(const HorizontalAlignment value);
 
-    std::shared_ptr<BaseActionElement> GetSelectAction() const;
-    void SetSelectAction(const std::shared_ptr<BaseActionElement> action);
+        std::shared_ptr<BaseActionElement> GetSelectAction() const;
+        void SetSelectAction(const std::shared_ptr<BaseActionElement> action);
 
-    unsigned int GetPixelWidth() const; 
-    void SetPixelWidth(unsigned int value);
+        unsigned int GetPixelWidth() const;
+        void SetPixelWidth(unsigned int value);
 
-    unsigned int GetPixelHeight() const; 
-    void SetPixelHeight(unsigned int value);
+        unsigned int GetPixelHeight() const;
+        void SetPixelHeight(unsigned int value);
 
-    virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
+        virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
 
-private:
-    void PopulateKnownPropertiesSet();
+        private:
+        void PopulateKnownPropertiesSet();
 
-    std::string m_url;
-    std::string m_backgroundColor;
-    ImageStyle m_imageStyle;
-    ImageSize m_imageSize;
-    unsigned int m_pixelWidth;
-    unsigned int m_pixelHeight;
-    std::string m_altText;
-    HorizontalAlignment m_hAlignment;
-    std::shared_ptr<BaseActionElement> m_selectAction;
+        std::string m_url;
+        std::string m_backgroundColor;
+        ImageStyle m_imageStyle;
+        ImageSize m_imageSize;
+        unsigned int m_pixelWidth;
+        unsigned int m_pixelHeight;
+        std::string m_altText;
+        HorizontalAlignment m_hAlignment;
+        std::shared_ptr<BaseActionElement> m_selectAction;
 };
 
-class ImageParser : public BaseCardElementParser
-{
-public:
-    std::shared_ptr<BaseCardElement> Deserialize(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const Json::Value& root);
+    class ImageParser : public BaseCardElementParser
+    {
+        public:
+        std::shared_ptr<BaseCardElement> Deserialize(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
 
-    std::shared_ptr<BaseCardElement> DeserializeWithoutCheckingType(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const Json::Value& root);
+        std::shared_ptr<BaseCardElement> DeserializeWithoutCheckingType(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
 
-    std::shared_ptr<BaseCardElement> DeserializeFromString(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const std::string& jsonString);
-};
-AdaptiveSharedNamespaceEnd
+        std::shared_ptr<BaseCardElement> DeserializeFromString(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+    };
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/Image.h
+++ b/source/shared/cpp/ObjectModel/Image.h
@@ -56,7 +56,7 @@ namespace AdaptiveSharedNamespace
         std::string m_altText;
         HorizontalAlignment m_hAlignment;
         std::shared_ptr<BaseActionElement> m_selectAction;
-};
+    };
 
     class ImageParser : public BaseCardElementParser
     {

--- a/source/shared/cpp/ObjectModel/Image.h
+++ b/source/shared/cpp/ObjectModel/Image.h
@@ -10,7 +10,7 @@ namespace AdaptiveSharedNamespace
 {
     class Image : public BaseCardElement
     {
-        public:
+    public:
         Image();
 
         virtual Json::Value SerializeToJsonValue() const override;
@@ -44,7 +44,7 @@ namespace AdaptiveSharedNamespace
 
         virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
 
-        private:
+    private:
         void PopulateKnownPropertiesSet();
 
         std::string m_url;
@@ -60,7 +60,7 @@ namespace AdaptiveSharedNamespace
 
     class ImageParser : public BaseCardElementParser
     {
-        public:
+    public:
         std::shared_ptr<BaseCardElement> Deserialize(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
             std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);

--- a/source/shared/cpp/ObjectModel/ImageSet.cpp
+++ b/source/shared/cpp/ObjectModel/ImageSet.cpp
@@ -5,9 +5,7 @@
 
 using namespace AdaptiveSharedNamespace;
 
-ImageSet::ImageSet() : 
-    BaseCardElement(CardElementType::ImageSet),
-    m_imageSize(ImageSize::None)
+ImageSet::ImageSet() : BaseCardElement(CardElementType::ImageSet), m_imageSize(ImageSize::None)
 {
     PopulateKnownPropertiesSet();
 }
@@ -41,7 +39,7 @@ Json::Value ImageSet::SerializeToJsonValue() const
         root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::ImageSize)] = ImageSizeToString(GetImageSize());
     }
 
-    std::string const &itemsPropertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Images);
+    std::string const& itemsPropertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Images);
     root[itemsPropertyName] = Json::Value(Json::arrayValue);
     for (const auto& image : m_images)
     {
@@ -53,18 +51,19 @@ Json::Value ImageSet::SerializeToJsonValue() const
 
 std::shared_ptr<BaseCardElement> ImageSetParser::Deserialize(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-    const Json::Value& value)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& value)
 {
     ParseUtil::ExpectTypeString(value, CardElementType::ImageSet);
 
     auto imageSet = BaseCardElement::Deserialize<ImageSet>(value);
 
     // Get ImageSize
-    imageSet->m_imageSize = ParseUtil::GetEnumValue<ImageSize>(value, AdaptiveCardSchemaKey::ImageSize, ImageSize::None, ImageSizeFromString);
+    imageSet->m_imageSize = ParseUtil::GetEnumValue<ImageSize>(
+        value, AdaptiveCardSchemaKey::ImageSize, ImageSize::None, ImageSizeFromString);
 
     // Parse Images
-    auto images = ParseUtil::GetElementCollection(elementParserRegistration, actionParserRegistration, value, AdaptiveCardSchemaKey::Images, true);
+    auto images = ParseUtil::GetElementCollection(
+        elementParserRegistration, actionParserRegistration, value, AdaptiveCardSchemaKey::Images, true);
 
     for (auto image : images)
     {
@@ -76,13 +75,13 @@ std::shared_ptr<BaseCardElement> ImageSetParser::Deserialize(
 
 std::shared_ptr<BaseCardElement> ImageSetParser::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-    const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
 {
-    return ImageSetParser::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
+    return ImageSetParser::Deserialize(
+        elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
-void ImageSet::PopulateKnownPropertiesSet() 
+void ImageSet::PopulateKnownPropertiesSet()
 {
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Images));
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::ImageSize));

--- a/source/shared/cpp/ObjectModel/ImageSet.cpp
+++ b/source/shared/cpp/ObjectModel/ImageSet.cpp
@@ -20,12 +20,12 @@ void ImageSet::SetImageSize(const ImageSize value)
     m_imageSize = value;
 }
 
-const std::vector<std::shared_ptr<Image>>& ImageSet::GetImages() const
+const std::vector<std::shared_ptr<Image>> &ImageSet::GetImages() const
 {
     return m_images;
 }
 
-std::vector<std::shared_ptr<Image>>& ImageSet::GetImages()
+std::vector<std::shared_ptr<Image>> &ImageSet::GetImages()
 {
     return m_images;
 }
@@ -39,9 +39,9 @@ Json::Value ImageSet::SerializeToJsonValue() const
         root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::ImageSize)] = ImageSizeToString(GetImageSize());
     }
 
-    std::string const& itemsPropertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Images);
+    std::string const &itemsPropertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Images);
     root[itemsPropertyName] = Json::Value(Json::arrayValue);
-    for (const auto& image : m_images)
+    for (const auto &image : m_images)
     {
         root[itemsPropertyName].append(image->SerializeToJsonValue());
     }
@@ -51,7 +51,7 @@ Json::Value ImageSet::SerializeToJsonValue() const
 
 std::shared_ptr<BaseCardElement> ImageSetParser::Deserialize(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& value)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &value)
 {
     ParseUtil::ExpectTypeString(value, CardElementType::ImageSet);
 
@@ -75,7 +75,7 @@ std::shared_ptr<BaseCardElement> ImageSetParser::Deserialize(
 
 std::shared_ptr<BaseCardElement> ImageSetParser::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString)
 {
     return ImageSetParser::Deserialize(
         elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
@@ -87,7 +87,7 @@ void ImageSet::PopulateKnownPropertiesSet()
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::ImageSize));
 }
 
-void ImageSet::GetResourceUris(std::vector<std::string>& resourceUris)
+void ImageSet::GetResourceUris(std::vector<std::string> &resourceUris)
 {
     auto images = GetImages();
     for (auto image : images)

--- a/source/shared/cpp/ObjectModel/ImageSet.h
+++ b/source/shared/cpp/ObjectModel/ImageSet.h
@@ -20,10 +20,10 @@ namespace AdaptiveSharedNamespace
         ImageSize GetImageSize() const;
         void SetImageSize(const ImageSize value);
 
-        std::vector<std::shared_ptr<Image>>& GetImages();
-        const std::vector<std::shared_ptr<Image>>& GetImages() const;
+        std::vector<std::shared_ptr<Image>> &GetImages();
+        const std::vector<std::shared_ptr<Image>> &GetImages() const;
 
-        virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
+        virtual void GetResourceUris(std::vector<std::string> &resourceUris) override;
 
     private:
         void PopulateKnownPropertiesSet();
@@ -37,10 +37,10 @@ namespace AdaptiveSharedNamespace
     public:
         std::shared_ptr<BaseCardElement> Deserialize(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &root);
 
         std::shared_ptr<BaseCardElement> DeserializeFromString(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString);
     };
 } // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/ImageSet.h
+++ b/source/shared/cpp/ObjectModel/ImageSet.h
@@ -12,7 +12,7 @@ namespace AdaptiveSharedNamespace
     {
         friend class ImageSetParser;
 
-        public:
+    public:
         ImageSet();
 
         virtual Json::Value SerializeToJsonValue() const override;
@@ -25,7 +25,7 @@ namespace AdaptiveSharedNamespace
 
         virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
 
-        private:
+    private:
         void PopulateKnownPropertiesSet();
 
         std::vector<std::shared_ptr<Image>> m_images;
@@ -34,7 +34,7 @@ namespace AdaptiveSharedNamespace
 
     class ImageSetParser : public BaseCardElementParser
     {
-        public:
+    public:
         std::shared_ptr<BaseCardElement> Deserialize(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
             std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);

--- a/source/shared/cpp/ObjectModel/ImageSet.h
+++ b/source/shared/cpp/ObjectModel/ImageSet.h
@@ -5,42 +5,42 @@
 #include "Image.h"
 #include "BaseCardElement.h"
 
-AdaptiveSharedNamespaceStart
-class BaseCardElement;
-class ImageSet : public BaseCardElement
+namespace AdaptiveSharedNamespace
 {
-friend class ImageSetParser;
-public:
-    ImageSet();
+    class BaseCardElement;
+    class ImageSet : public BaseCardElement
+    {
+        friend class ImageSetParser;
 
-    virtual Json::Value SerializeToJsonValue() const override;
+        public:
+        ImageSet();
 
-    ImageSize GetImageSize() const;
-    void SetImageSize(const ImageSize value);
+        virtual Json::Value SerializeToJsonValue() const override;
 
-    std::vector<std::shared_ptr<Image>>& GetImages();
-    const std::vector<std::shared_ptr<Image>>& GetImages() const;
+        ImageSize GetImageSize() const;
+        void SetImageSize(const ImageSize value);
 
-    virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
+        std::vector<std::shared_ptr<Image>>& GetImages();
+        const std::vector<std::shared_ptr<Image>>& GetImages() const;
 
-private:
-    void PopulateKnownPropertiesSet();
+        virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
 
-    std::vector<std::shared_ptr<Image>> m_images;
-    ImageSize m_imageSize;
-};
-    
-class ImageSetParser : public BaseCardElementParser
-{
-public:
-    std::shared_ptr<BaseCardElement> Deserialize(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const Json::Value& root);
+        private:
+        void PopulateKnownPropertiesSet();
 
-    std::shared_ptr<BaseCardElement> DeserializeFromString(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const std::string& jsonString);
-};
-AdaptiveSharedNamespaceEnd
+        std::vector<std::shared_ptr<Image>> m_images;
+        ImageSize m_imageSize;
+    };
+
+    class ImageSetParser : public BaseCardElementParser
+    {
+        public:
+        std::shared_ptr<BaseCardElement> Deserialize(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
+
+        std::shared_ptr<BaseCardElement> DeserializeFromString(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+    };
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/MarkDownBlockParser.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownBlockParser.cpp
@@ -5,7 +5,7 @@
 using namespace AdaptiveSharedNamespace;
 
 // Parses according to each key words
-void MarkDownBlockParser::ParseBlock(std::stringstream &stream)
+void MarkDownBlockParser::ParseBlock(std::stringstream& stream)
 {
     switch (stream.peek())
     {
@@ -21,13 +21,15 @@ void MarkDownBlockParser::ParseBlock(std::stringstream &stream)
     }
     // handles special cases where these tokens are not encountered
     // as not part of link
-    case ']': case ')':
+    case ']':
+    case ')':
     {
         // add these char as token to code gen list
         m_parsedResult.AddNewTokenToParsedResult((char)stream.get());
         break;
     }
-    case '\n': case '\r':
+    case '\n':
+    case '\r':
     {
         // add new line char as token to code gen list
         m_parsedResult.AddNewLineTokenToParsedResult((char)stream.get());
@@ -43,8 +45,16 @@ void MarkDownBlockParser::ParseBlock(std::stringstream &stream)
         m_parsedResult.AppendParseResult(listParser.GetParsedResult());
         break;
     }
-    case '0': case '1': case '2': case '3': case'4':
-    case '5': case '6': case '7': case '8': case'9':
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9':
     {
         OrderedListParser orderedListParser;
         // do syntax check of list
@@ -68,7 +78,7 @@ void MarkDownBlockParser::ParseBlock(std::stringstream &stream)
 // capture until it can't capture anymore.
 // it moves two states, emphasis state and text state,
 // at each transition of state, one token is captured
-void EmphasisParser::Match(std::stringstream &stream)
+void EmphasisParser::Match(std::stringstream& stream)
 {
     while (m_current_state != EmphasisState::Captured)
     {
@@ -77,10 +87,12 @@ void EmphasisParser::Match(std::stringstream &stream)
 }
 
 /// captures text until it see emphasis character. When it does, switch to Emphasis state
-EmphasisParser::EmphasisState EmphasisParser::MatchText(EmphasisParser &parser, std::stringstream &stream, std::string& token)
+EmphasisParser::EmphasisState EmphasisParser::MatchText(
+    EmphasisParser& parser, std::stringstream& stream, std::string& token)
 {
     /// MarkDown keywords
-    if (stream.peek() == '[' || stream.peek() == ']' || stream.peek() == ')' || stream.peek() == '\n' || stream.peek() == '\r' || stream.eof())
+    if (stream.peek() == '[' || stream.peek() == ']' || stream.peek() == ')' || stream.peek() == '\n' ||
+        stream.peek() == '\r' || stream.eof())
     {
         parser.Flush(stream.peek(), token);
         return EmphasisState::Captured;
@@ -91,7 +103,7 @@ EmphasisParser::EmphasisState EmphasisParser::MatchText(EmphasisParser &parser, 
         // encounterred first emphasis delimiter
         parser.CaptureCurrentCollectedStringAsRegularToken();
         DelimiterType emphasisType = EmphasisParser::GetDelimiterTypeForCharAtCurrentPosition(stream.peek());
-        // get previous character and update the look behind if it was captured before 
+        // get previous character and update the look behind if it was captured before
         if (stream.tellg())
         {
             stream.unget();
@@ -111,11 +123,13 @@ EmphasisParser::EmphasisState EmphasisParser::MatchText(EmphasisParser &parser, 
 }
 
 /// captures text untill it see none-emphasis character. When it does, switch to text state
-EmphasisParser::EmphasisState EmphasisParser::MatchEmphasis(EmphasisParser &parser, std::stringstream &stream, std::string& token)
+EmphasisParser::EmphasisState EmphasisParser::MatchEmphasis(
+    EmphasisParser& parser, std::stringstream& stream, std::string& token)
 {
     // key word is encountered, flush what is being processed, and have those keyword
     // handled by ParseBlock()
-    if (stream.peek() == '[' || stream.peek() == ']' || stream.peek() == ')' || stream.peek() == '\n' || stream.peek() == '\r' || stream.eof())
+    if (stream.peek() == '[' || stream.peek() == ']' || stream.peek() == ')' || stream.peek() == '\n' ||
+        stream.peek() == '\r' || stream.eof())
     {
         parser.Flush(stream.peek(), token);
         return EmphasisState::Captured;
@@ -176,8 +190,7 @@ void EmphasisParser::CaptureCurrentCollectedStringAsRegularToken(std::string& cu
 {
     if (currentToken.empty())
         return;
-    std::shared_ptr<MarkDownHtmlGenerator> codeGen =
-        std::make_shared<MarkDownStringHtmlGenerator>(currentToken);
+    std::shared_ptr<MarkDownHtmlGenerator> codeGen = std::make_shared<MarkDownStringHtmlGenerator>(currentToken);
 
     m_parsedResult.AppendToTokens(codeGen);
 
@@ -202,16 +215,13 @@ void EmphasisParser::UpdateCurrentEmphasisRunState(DelimiterType emphasisType)
 
 bool EmphasisParser::IsRightEmphasisDelimiter(int ch)
 {
-    if ((std::isspace(ch) || (ch == EOF)) &&
-        (m_lookBehind != WhiteSpace) &&
+    if ((std::isspace(ch) || (ch == EOF)) && (m_lookBehind != WhiteSpace) &&
         (m_checkLookAhead || m_checkIntraWord || m_currentDelimiterType == Asterisk))
     {
         return true;
     }
 
-    if (isalnum(ch) &&
-        m_lookBehind != WhiteSpace &&
-        m_lookBehind != Init)
+    if (isalnum(ch) && m_lookBehind != WhiteSpace && m_lookBehind != Init)
     {
         if (!m_checkLookAhead && !m_checkIntraWord)
         {
@@ -229,10 +239,11 @@ bool EmphasisParser::IsRightEmphasisDelimiter(int ch)
         return true;
     }
 
-    return false;;
+    return false;
+    ;
 }
 
-bool EmphasisParser::TryCapturingRightEmphasisToken(int ch, std::string &currentToken)
+bool EmphasisParser::TryCapturingRightEmphasisToken(int ch, std::string& currentToken)
 {
     if (IsRightEmphasisDelimiter(ch))
     {
@@ -241,15 +252,13 @@ bool EmphasisParser::TryCapturingRightEmphasisToken(int ch, std::string &current
         if (IsLeftEmphasisDelimiter(ch))
         {
             // since it is both left and right emphasis, create one accordingly
-            codeGen =
-                std::make_shared<MarkDownLeftAndRightEmphasisHtmlGenerator>(currentToken, m_delimiterCnts,
-                    m_currentDelimiterType);
+            codeGen = std::make_shared<MarkDownLeftAndRightEmphasisHtmlGenerator>(
+                currentToken, m_delimiterCnts, m_currentDelimiterType);
         }
         else
         {
-            codeGen =
-                std::make_shared<MarkDownRightEmphasisHtmlGenerator>(currentToken, m_delimiterCnts,
-                    m_currentDelimiterType);
+            codeGen = std::make_shared<MarkDownRightEmphasisHtmlGenerator>(
+                currentToken, m_delimiterCnts, m_currentDelimiterType);
         }
 
         m_parsedResult.AppendToLookUpTable(codeGen);
@@ -263,14 +272,13 @@ bool EmphasisParser::TryCapturingRightEmphasisToken(int ch, std::string &current
     return false;
 }
 
-bool EmphasisParser::TryCapturingLeftEmphasisToken(int ch, std::string &currentToken)
+bool EmphasisParser::TryCapturingLeftEmphasisToken(int ch, std::string& currentToken)
 {
     // left emphasis detected, save emphasis for later reference
     if (IsLeftEmphasisDelimiter(ch))
     {
         std::shared_ptr<MarkDownEmphasisHtmlGenerator> codeGen =
-            std::make_shared<MarkDownLeftEmphasisHtmlGenerator>(currentToken, m_delimiterCnts,
-                m_currentDelimiterType);
+            std::make_shared<MarkDownLeftEmphasisHtmlGenerator>(currentToken, m_delimiterCnts, m_currentDelimiterType);
 
         m_parsedResult.AppendToLookUpTable(codeGen);
 
@@ -284,7 +292,7 @@ bool EmphasisParser::TryCapturingLeftEmphasisToken(int ch, std::string &currentT
 
 void EmphasisParser::UpdateLookBehind(int ch)
 {
-    //store ch and move itr
+    // store ch and move itr
     if (isspace(ch))
     {
         m_lookBehind = WhiteSpace;
@@ -301,10 +309,9 @@ void EmphasisParser::UpdateLookBehind(int ch)
     }
 }
 
-void EmphasisParser::CaptureEmphasisToken(int ch, std::string &currentToken)
+void EmphasisParser::CaptureEmphasisToken(int ch, std::string& currentToken)
 {
-    if (!TryCapturingRightEmphasisToken(ch, currentToken) &&
-        !TryCapturingLeftEmphasisToken(ch, currentToken) &&
+    if (!TryCapturingRightEmphasisToken(ch, currentToken) && !TryCapturingLeftEmphasisToken(ch, currentToken) &&
         !currentToken.empty())
     {
         // no valid emphasis delimiter runs found during current emphasis delimiter run
@@ -313,14 +320,11 @@ void EmphasisParser::CaptureEmphasisToken(int ch, std::string &currentToken)
     }
 }
 
-void LinkParser::Match(std::stringstream &stream)
+void LinkParser::Match(std::stringstream& stream)
 {
     // link syntax check, match keyword at each stage
-    if (MatchAtLinkInit(stream) &&
-        MatchAtLinkTextRun(stream) &&
-        MatchAtLinkTextEnd(stream) &&
-        MatchAtLinkDestinationStart(stream) &&
-        MatchAtLinkDestinationRun(stream))
+    if (MatchAtLinkInit(stream) && MatchAtLinkTextRun(stream) && MatchAtLinkTextEnd(stream) &&
+        MatchAtLinkDestinationStart(stream) && MatchAtLinkDestinationRun(stream))
     {
         /// Link is in correct syntax, capture it as link
         CaptureLinkToken();
@@ -328,7 +332,7 @@ void LinkParser::Match(std::stringstream &stream)
 }
 
 // link is in form of [txt](url), this method matches '['
-bool LinkParser::MatchAtLinkInit(std::stringstream &lookahead)
+bool LinkParser::MatchAtLinkInit(std::stringstream& lookahead)
 {
     if (lookahead.peek() == '[')
     {
@@ -342,7 +346,7 @@ bool LinkParser::MatchAtLinkInit(std::stringstream &lookahead)
 }
 
 // link is in form of [txt](url), this method matches txt
-bool LinkParser::MatchAtLinkTextRun(std::stringstream &lookahead)
+bool LinkParser::MatchAtLinkTextRun(std::stringstream& lookahead)
 {
     if (lookahead.peek() == ']')
     {
@@ -358,13 +362,13 @@ bool LinkParser::MatchAtLinkTextRun(std::stringstream &lookahead)
         }
         else
         {
-            // Block() will process the inline items within Link Text block 
+            // Block() will process the inline items within Link Text block
             ParseBlock(lookahead);
             m_linkTextParsedResult.AppendParseResult(m_parsedResult);
 
             if (lookahead.peek() == ']')
             {
-                // move code gen objects to link text list to further process it 
+                // move code gen objects to link text list to further process it
                 m_linkTextParsedResult.AddNewTokenToParsedResult((char)lookahead.get());
                 return true;
             }
@@ -376,7 +380,7 @@ bool LinkParser::MatchAtLinkTextRun(std::stringstream &lookahead)
 }
 
 // link is in form of [txt](url), this method matches ']'
-bool LinkParser::MatchAtLinkTextEnd(std::stringstream &lookahead)
+bool LinkParser::MatchAtLinkTextEnd(std::stringstream& lookahead)
 {
     if (lookahead.peek() == '(')
     {
@@ -389,7 +393,7 @@ bool LinkParser::MatchAtLinkTextEnd(std::stringstream &lookahead)
 }
 
 // link is in form of [txt](url), this method matches '('
-bool LinkParser::MatchAtLinkDestinationStart(std::stringstream &lookahead)
+bool LinkParser::MatchAtLinkDestinationStart(std::stringstream& lookahead)
 {
     // control key is detected, syntax check failed
     if (iscntrl(lookahead.peek()))
@@ -417,7 +421,7 @@ bool LinkParser::MatchAtLinkDestinationStart(std::stringstream &lookahead)
 }
 
 // link is in form of [txt](url), this method matches ')'
-bool LinkParser::MatchAtLinkDestinationRun(std::stringstream &lookahead)
+bool LinkParser::MatchAtLinkDestinationRun(std::stringstream& lookahead)
 {
     if (isspace(lookahead.peek()) || iscntrl(lookahead.peek()))
     {
@@ -438,7 +442,7 @@ bool LinkParser::MatchAtLinkDestinationRun(std::stringstream &lookahead)
 
 // this method is called when link syntax check is complete
 // it processes the parsed result from link destination  and link text
-// and build a MarkDownStringHtmlGenerator that will output 
+// and build a MarkDownStringHtmlGenerator that will output
 // string in link syntax (text)[destination) will converts to
 // <a href=\destination\>text</a>
 void LinkParser::CaptureLinkToken()
@@ -452,7 +456,7 @@ void LinkParser::CaptureLinkToken()
     // when syntax check is complete, we have seen
     // '[', ']', '(', these keywords are not
     // needed anymore, so pop them from the parse result
-    // if syntax check failed for link, then they must be 
+    // if syntax check failed for link, then they must be
     // retained as part of parse result
     m_linkTextParsedResult.PopFront();
     m_linkTextParsedResult.PopBack();
@@ -467,8 +471,7 @@ void LinkParser::CaptureLinkToken()
     std::string html_string = html.str();
 
     // Generate a MarkDownStringHtmlGenerator object
-    std::shared_ptr<MarkDownHtmlGenerator> codeGen =
-        std::make_shared<MarkDownStringHtmlGenerator>(html_string);
+    std::shared_ptr<MarkDownHtmlGenerator> codeGen = std::make_shared<MarkDownStringHtmlGenerator>(html_string);
 
     m_parsedResult.Clear();
     m_parsedResult.FoundHtmlTags();
@@ -477,7 +480,7 @@ void LinkParser::CaptureLinkToken()
 
 // list marker have form of ^-\s+ or \r-\s+
 // this method matches -\s
-bool ListParser::MatchNewListItem(std::stringstream &stream)
+bool ListParser::MatchNewListItem(std::stringstream& stream)
 {
     if (IsHyphen(stream.peek()))
     {
@@ -494,11 +497,11 @@ bool ListParser::MatchNewListItem(std::stringstream &stream)
 
 // if lines are seperated by more than two new lines,
 // they are new block items
-// caller of this method is expected to have matched new line char 
+// caller of this method is expected to have matched new line char
 // before calling this method
 // this method will return true, after it mataches new line char
 // at least once.
-bool ListParser::MatchNewBlock(std::stringstream &stream)
+bool ListParser::MatchNewBlock(std::stringstream& stream)
 {
     if (IsNewLine(stream.peek()))
     {
@@ -515,7 +518,7 @@ bool ListParser::MatchNewBlock(std::stringstream &stream)
 
 // ordered list marker has form of ^\d+\.\s* or [\r,\n]\d+\.\s*, and this method checks the syntax
 // this method matches \d+\.
-bool ListParser::MatchNewOrderedListItem(std::stringstream &stream, std::string &number_string)
+bool ListParser::MatchNewOrderedListItem(std::stringstream& stream, std::string& number_string)
 {
     do
     {
@@ -535,7 +538,7 @@ bool ListParser::MatchNewOrderedListItem(std::stringstream &stream, std::string 
 // parse blocks that wasn't captured
 // if what we encounter is one of following items, start of new list, list item, or new block element,
 // we do not include in the current block, we return, and have it handled by the caller
-void ListParser::ParseSubBlocks(std::stringstream &stream)
+void ListParser::ParseSubBlocks(std::stringstream& stream)
 {
     while (!stream.eof())
     {
@@ -566,12 +569,12 @@ void ListParser::ParseSubBlocks(std::stringstream &stream)
     }
 }
 
-bool ListParser::CompleteListParsing(std::stringstream &stream)
+bool ListParser::CompleteListParsing(std::stringstream& stream)
 {
     // check for - of -\s+ list marker
     if (stream.peek() == ' ')
     {
-        // at this point, syntax check is complete, 
+        // at this point, syntax check is complete,
         // thus any other spaces are ignored
         // remove space
         do
@@ -589,7 +592,7 @@ bool ListParser::CompleteListParsing(std::stringstream &stream)
 }
 
 // list marker has a form of ^-\s+ or [\r, \n]-\s+, and this method checks the syntax
-void ListParser::Match(std::stringstream &stream)
+void ListParser::Match(std::stringstream& stream)
 {
     // check for - of -\s+ list marker
     if (IsHyphen(stream.peek()))
@@ -618,8 +621,7 @@ void ListParser::CaptureListToken()
     html << "</li>";
 
     std::string html_string = html.str();
-    std::shared_ptr<MarkDownListHtmlGenerator> codeGen =
-        std::make_shared<MarkDownListHtmlGenerator>(html_string);
+    std::shared_ptr<MarkDownListHtmlGenerator> codeGen = std::make_shared<MarkDownListHtmlGenerator>(html_string);
 
     m_parsedResult.Clear();
     m_parsedResult.FoundHtmlTags();
@@ -627,7 +629,7 @@ void ListParser::CaptureListToken()
 }
 
 // ordered list marker has form of ^\d+\.\s* or [\r,\n]\d+\.\s*, and this method checks the syntax
-void OrderedListParser::Match(std::stringstream &stream)
+void OrderedListParser::Match(std::stringstream& stream)
 {
     // used to capture digit char
     std::string number_string = "";
@@ -657,11 +659,10 @@ void OrderedListParser::Match(std::stringstream &stream)
             // if incorrect syntax, capture as a new token.
             m_parsedResult.AddNewTokenToParsedResult(number_string);
         }
-
     }
 }
 
-void OrderedListParser::CaptureOrderedListToken(std::string &number_string)
+void OrderedListParser::CaptureOrderedListToken(std::string& number_string)
 {
     std::ostringstream html;
     m_parsedResult.Translate();

--- a/source/shared/cpp/ObjectModel/MarkDownBlockParser.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownBlockParser.cpp
@@ -5,7 +5,7 @@
 using namespace AdaptiveSharedNamespace;
 
 // Parses according to each key words
-void MarkDownBlockParser::ParseBlock(std::stringstream& stream)
+void MarkDownBlockParser::ParseBlock(std::stringstream &stream)
 {
     switch (stream.peek())
     {
@@ -78,7 +78,7 @@ void MarkDownBlockParser::ParseBlock(std::stringstream& stream)
 // capture until it can't capture anymore.
 // it moves two states, emphasis state and text state,
 // at each transition of state, one token is captured
-void EmphasisParser::Match(std::stringstream& stream)
+void EmphasisParser::Match(std::stringstream &stream)
 {
     while (m_current_state != EmphasisState::Captured)
     {
@@ -88,7 +88,7 @@ void EmphasisParser::Match(std::stringstream& stream)
 
 /// captures text until it see emphasis character. When it does, switch to Emphasis state
 EmphasisParser::EmphasisState EmphasisParser::MatchText(
-    EmphasisParser& parser, std::stringstream& stream, std::string& token)
+    EmphasisParser &parser, std::stringstream &stream, std::string &token)
 {
     /// MarkDown keywords
     if (stream.peek() == '[' || stream.peek() == ']' || stream.peek() == ')' || stream.peek() == '\n' ||
@@ -124,7 +124,7 @@ EmphasisParser::EmphasisState EmphasisParser::MatchText(
 
 /// captures text untill it see none-emphasis character. When it does, switch to text state
 EmphasisParser::EmphasisState EmphasisParser::MatchEmphasis(
-    EmphasisParser& parser, std::stringstream& stream, std::string& token)
+    EmphasisParser &parser, std::stringstream &stream, std::string &token)
 {
     // key word is encountered, flush what is being processed, and have those keyword
     // handled by ParseBlock()
@@ -167,7 +167,7 @@ EmphasisParser::EmphasisState EmphasisParser::MatchEmphasis(
 
 // Captures remaining charaters in given token
 // and causes the emphasis parsing to terminate
-void EmphasisParser::Flush(int ch, std::string& currentToken)
+void EmphasisParser::Flush(int ch, std::string &currentToken)
 {
     if (m_current_state == EmphasisState::Emphasis)
     {
@@ -186,7 +186,7 @@ bool EmphasisParser::IsMarkDownDelimiter(int ch)
     return ((ch == '*' || ch == '_') && (m_lookBehind != Escape));
 }
 
-void EmphasisParser::CaptureCurrentCollectedStringAsRegularToken(std::string& currentToken)
+void EmphasisParser::CaptureCurrentCollectedStringAsRegularToken(std::string &currentToken)
 {
     if (currentToken.empty())
         return;
@@ -243,7 +243,7 @@ bool EmphasisParser::IsRightEmphasisDelimiter(int ch)
     ;
 }
 
-bool EmphasisParser::TryCapturingRightEmphasisToken(int ch, std::string& currentToken)
+bool EmphasisParser::TryCapturingRightEmphasisToken(int ch, std::string &currentToken)
 {
     if (IsRightEmphasisDelimiter(ch))
     {
@@ -272,7 +272,7 @@ bool EmphasisParser::TryCapturingRightEmphasisToken(int ch, std::string& current
     return false;
 }
 
-bool EmphasisParser::TryCapturingLeftEmphasisToken(int ch, std::string& currentToken)
+bool EmphasisParser::TryCapturingLeftEmphasisToken(int ch, std::string &currentToken)
 {
     // left emphasis detected, save emphasis for later reference
     if (IsLeftEmphasisDelimiter(ch))
@@ -309,7 +309,7 @@ void EmphasisParser::UpdateLookBehind(int ch)
     }
 }
 
-void EmphasisParser::CaptureEmphasisToken(int ch, std::string& currentToken)
+void EmphasisParser::CaptureEmphasisToken(int ch, std::string &currentToken)
 {
     if (!TryCapturingRightEmphasisToken(ch, currentToken) && !TryCapturingLeftEmphasisToken(ch, currentToken) &&
         !currentToken.empty())
@@ -320,7 +320,7 @@ void EmphasisParser::CaptureEmphasisToken(int ch, std::string& currentToken)
     }
 }
 
-void LinkParser::Match(std::stringstream& stream)
+void LinkParser::Match(std::stringstream &stream)
 {
     // link syntax check, match keyword at each stage
     if (MatchAtLinkInit(stream) && MatchAtLinkTextRun(stream) && MatchAtLinkTextEnd(stream) &&
@@ -332,7 +332,7 @@ void LinkParser::Match(std::stringstream& stream)
 }
 
 // link is in form of [txt](url), this method matches '['
-bool LinkParser::MatchAtLinkInit(std::stringstream& lookahead)
+bool LinkParser::MatchAtLinkInit(std::stringstream &lookahead)
 {
     if (lookahead.peek() == '[')
     {
@@ -346,7 +346,7 @@ bool LinkParser::MatchAtLinkInit(std::stringstream& lookahead)
 }
 
 // link is in form of [txt](url), this method matches txt
-bool LinkParser::MatchAtLinkTextRun(std::stringstream& lookahead)
+bool LinkParser::MatchAtLinkTextRun(std::stringstream &lookahead)
 {
     if (lookahead.peek() == ']')
     {
@@ -380,7 +380,7 @@ bool LinkParser::MatchAtLinkTextRun(std::stringstream& lookahead)
 }
 
 // link is in form of [txt](url), this method matches ']'
-bool LinkParser::MatchAtLinkTextEnd(std::stringstream& lookahead)
+bool LinkParser::MatchAtLinkTextEnd(std::stringstream &lookahead)
 {
     if (lookahead.peek() == '(')
     {
@@ -393,7 +393,7 @@ bool LinkParser::MatchAtLinkTextEnd(std::stringstream& lookahead)
 }
 
 // link is in form of [txt](url), this method matches '('
-bool LinkParser::MatchAtLinkDestinationStart(std::stringstream& lookahead)
+bool LinkParser::MatchAtLinkDestinationStart(std::stringstream &lookahead)
 {
     // control key is detected, syntax check failed
     if (iscntrl(lookahead.peek()))
@@ -421,7 +421,7 @@ bool LinkParser::MatchAtLinkDestinationStart(std::stringstream& lookahead)
 }
 
 // link is in form of [txt](url), this method matches ')'
-bool LinkParser::MatchAtLinkDestinationRun(std::stringstream& lookahead)
+bool LinkParser::MatchAtLinkDestinationRun(std::stringstream &lookahead)
 {
     if (isspace(lookahead.peek()) || iscntrl(lookahead.peek()))
     {
@@ -480,7 +480,7 @@ void LinkParser::CaptureLinkToken()
 
 // list marker have form of ^-\s+ or \r-\s+
 // this method matches -\s
-bool ListParser::MatchNewListItem(std::stringstream& stream)
+bool ListParser::MatchNewListItem(std::stringstream &stream)
 {
     if (IsHyphen(stream.peek()))
     {
@@ -501,7 +501,7 @@ bool ListParser::MatchNewListItem(std::stringstream& stream)
 // before calling this method
 // this method will return true, after it mataches new line char
 // at least once.
-bool ListParser::MatchNewBlock(std::stringstream& stream)
+bool ListParser::MatchNewBlock(std::stringstream &stream)
 {
     if (IsNewLine(stream.peek()))
     {
@@ -518,7 +518,7 @@ bool ListParser::MatchNewBlock(std::stringstream& stream)
 
 // ordered list marker has form of ^\d+\.\s* or [\r,\n]\d+\.\s*, and this method checks the syntax
 // this method matches \d+\.
-bool ListParser::MatchNewOrderedListItem(std::stringstream& stream, std::string& number_string)
+bool ListParser::MatchNewOrderedListItem(std::stringstream &stream, std::string &number_string)
 {
     do
     {
@@ -538,7 +538,7 @@ bool ListParser::MatchNewOrderedListItem(std::stringstream& stream, std::string&
 // parse blocks that wasn't captured
 // if what we encounter is one of following items, start of new list, list item, or new block element,
 // we do not include in the current block, we return, and have it handled by the caller
-void ListParser::ParseSubBlocks(std::stringstream& stream)
+void ListParser::ParseSubBlocks(std::stringstream &stream)
 {
     while (!stream.eof())
     {
@@ -569,7 +569,7 @@ void ListParser::ParseSubBlocks(std::stringstream& stream)
     }
 }
 
-bool ListParser::CompleteListParsing(std::stringstream& stream)
+bool ListParser::CompleteListParsing(std::stringstream &stream)
 {
     // check for - of -\s+ list marker
     if (stream.peek() == ' ')
@@ -592,7 +592,7 @@ bool ListParser::CompleteListParsing(std::stringstream& stream)
 }
 
 // list marker has a form of ^-\s+ or [\r, \n]-\s+, and this method checks the syntax
-void ListParser::Match(std::stringstream& stream)
+void ListParser::Match(std::stringstream &stream)
 {
     // check for - of -\s+ list marker
     if (IsHyphen(stream.peek()))
@@ -629,7 +629,7 @@ void ListParser::CaptureListToken()
 }
 
 // ordered list marker has form of ^\d+\.\s* or [\r,\n]\d+\.\s*, and this method checks the syntax
-void OrderedListParser::Match(std::stringstream& stream)
+void OrderedListParser::Match(std::stringstream &stream)
 {
     // used to capture digit char
     std::string number_string = "";
@@ -662,7 +662,7 @@ void OrderedListParser::Match(std::stringstream& stream)
     }
 }
 
-void OrderedListParser::CaptureOrderedListToken(std::string& number_string)
+void OrderedListParser::CaptureOrderedListToken(std::string &number_string)
 {
     std::ostringstream html;
     m_parsedResult.Translate();

--- a/source/shared/cpp/ObjectModel/MarkDownBlockParser.h
+++ b/source/shared/cpp/ObjectModel/MarkDownBlockParser.h
@@ -4,44 +4,45 @@
 #include "BaseCardElement.h"
 #include "MarkDownParsedResult.h"
 
-AdaptiveSharedNamespaceStart
+namespace AdaptiveSharedNamespace
+{
     class MarkDownBlockParser
     {
         public:
         MarkDownBlockParser(){};
         // Matches each MarkDown's Syntax Form
         // For each match, stream moves to the next char
-        virtual void Match(std::stringstream &) = 0;
+        virtual void Match(std::stringstream&) = 0;
         // Parses Block
-        void ParseBlock(std::stringstream &);
+        void ParseBlock(std::stringstream&);
         // Returns Parse result
-        MarkDownParsedResult &GetParsedResult() { return m_parsedResult; }
+        MarkDownParsedResult& GetParsedResult() { return m_parsedResult; }
 
         protected:
         // Holds parsed results
         MarkDownParsedResult m_parsedResult;
     };
 
-    class EmphasisParser: public MarkDownBlockParser
+    class EmphasisParser : public MarkDownBlockParser
     {
         public:
         enum EmphasisState
-        {   
+        {
             // Text is being handled
             Text = 0x0,
             // Emphasis is being handled
-            Emphasis = 0x1,   
+            Emphasis = 0x1,
             // Empahais Parsing is done
             Captured = 0x2,
         };
 
-        virtual void Match(std::stringstream &);
+        virtual void Match(std::stringstream&);
         // Captures remaining charaters in given token
         // and causes the emphasis parsing to terminate
         void Flush(int ch, std::string& currentToken);
         // check if given character is * or _
         bool IsMarkDownDelimiter(int ch);
-        void CaptureCurrentCollectedStringAsRegularToken(std::string&currentToken); 
+        void CaptureCurrentCollectedStringAsRegularToken(std::string& currentToken);
         void CaptureCurrentCollectedStringAsRegularToken();
         void UpdateCurrentEmphasisRunState(DelimiterType emphasisType);
         // Check if current delimiter will be considererd as a delimiter run
@@ -49,26 +50,26 @@ AdaptiveSharedNamespaceStart
         void ResetCurrentEmphasisState() { m_delimiterCnts = 0; }
         bool IsRightEmphasisDelimiter(int ch);
         // Attempt to capture current emphasis as right emphasis
-        bool TryCapturingRightEmphasisToken(int ch, std::string &currentToken);
-        bool IsLeftEmphasisDelimiter(int ch) 
+        bool TryCapturingRightEmphasisToken(int ch, std::string& currentToken);
+        bool IsLeftEmphasisDelimiter(int ch)
         {
-            return (m_delimiterCnts && 
-                    ch != EOF &&
-                    !isspace(ch) && 
-                    !(m_lookBehind == Alphanumeric && ispunct(ch)) && 
-                    !(m_lookBehind == Alphanumeric && m_currentDelimiterType == Underscore));
+            return (m_delimiterCnts && ch != EOF && !isspace(ch) && !(m_lookBehind == Alphanumeric && ispunct(ch)) &&
+                !(m_lookBehind == Alphanumeric && m_currentDelimiterType == Underscore));
         };
         // Attempt to capture current emphasis as right emphasis
-        bool TryCapturingLeftEmphasisToken(int ch, std::string &currentToken);
-        void CaptureEmphasisToken(int ch, std::string &currentToken);
+        bool TryCapturingLeftEmphasisToken(int ch, std::string& currentToken);
+        void CaptureEmphasisToken(int ch, std::string& currentToken);
         void UpdateLookBehind(int ch);
-        static DelimiterType GetDelimiterTypeForCharAtCurrentPosition(int ch) { return (ch == '*')? Asterisk : Underscore; };
+        static DelimiterType GetDelimiterTypeForCharAtCurrentPosition(int ch)
+        {
+            return (ch == '*') ? Asterisk : Underscore;
+        };
 
-        typedef EmphasisState (* MatchWithChar)(EmphasisParser&, std::stringstream &, std::string &);
+        typedef EmphasisState (*MatchWithChar)(EmphasisParser&, std::stringstream&, std::string&);
         // Callback function that handles the Text State
-        static EmphasisState MatchText(EmphasisParser &, std::stringstream &, std::string &);
+        static EmphasisState MatchText(EmphasisParser&, std::stringstream&, std::string&);
         // Callback function that handles the Emphasis State
-        static EmphasisState MatchEmphasis(EmphasisParser &, std::stringstream &, std::string &);
+        static EmphasisState MatchEmphasis(EmphasisParser&, std::stringstream&, std::string&);
 
         protected:
         bool m_checkLookAhead = false;
@@ -79,11 +80,10 @@ AdaptiveSharedNamespaceStart
         unsigned int m_current_state = 0;
 
         // vector of callback functions that handles state transistions
-        std::vector<MatchWithChar> m_stateMachine = 
-            {
-                MatchText, 
-                MatchEmphasis,
-            };
+        std::vector<MatchWithChar> m_stateMachine = {
+            MatchText,
+            MatchEmphasis,
+        };
 
         // holds currently collected token
         std::string m_current_token;
@@ -92,21 +92,21 @@ AdaptiveSharedNamespaceStart
     class LinkParser : public MarkDownBlockParser
     {
         public:
-        void Match(std::stringstream &);
+        void Match(std::stringstream&);
 
         private:
         void CaptureLinkToken();
 
         // Matches Initial sytax of link
-        bool MatchAtLinkInit(std::stringstream &);
+        bool MatchAtLinkInit(std::stringstream&);
         // Matches LinkText Run sytax of link
-        bool MatchAtLinkTextRun(std::stringstream &);
+        bool MatchAtLinkTextRun(std::stringstream&);
         // Matches LinkText End sytax of link
-        bool MatchAtLinkTextEnd(std::stringstream &); 
+        bool MatchAtLinkTextEnd(std::stringstream&);
         // Matches LinkDestination Start sytax of link
-        bool MatchAtLinkDestinationStart(std::stringstream &); 
+        bool MatchAtLinkDestinationStart(std::stringstream&);
         // Matches LinkDestination Run sytax of link
-        bool MatchAtLinkDestinationRun(std::stringstream &);
+        bool MatchAtLinkDestinationRun(std::stringstream&);
 
         // holds intermidiate result of LinkText
         MarkDownParsedResult m_linkTextParsedResult;
@@ -115,17 +115,17 @@ AdaptiveSharedNamespaceStart
     class ListParser : public MarkDownBlockParser
     {
         public:
-        void Match(std::stringstream &);
-        bool MatchNewListItem(std::stringstream &);
-        bool MatchNewBlock(std::stringstream &);
-        bool MatchNewOrderedListItem(std::stringstream &, std::string &);
+        void Match(std::stringstream&);
+        bool MatchNewListItem(std::stringstream&);
+        bool MatchNewBlock(std::stringstream&);
+        bool MatchNewOrderedListItem(std::stringstream&, std::string&);
         static bool IsHyphen(int ch) { return ch == '-'; };
         static bool IsDot(int ch) { return ch == '.'; };
-        static bool IsNewLine(int ch){ return (ch == '\r') || (ch == '\n');};
+        static bool IsNewLine(int ch) { return (ch == '\r') || (ch == '\n'); };
 
         protected:
-        void ParseSubBlocks(std::stringstream &);
-        bool CompleteListParsing(std::stringstream &stream);
+        void ParseSubBlocks(std::stringstream&);
+        bool CompleteListParsing(std::stringstream& stream);
 
         private:
         void CaptureListToken();
@@ -134,9 +134,9 @@ AdaptiveSharedNamespaceStart
     class OrderedListParser : public ListParser
     {
         public:
-        void Match(std::stringstream &);
+        void Match(std::stringstream&);
 
         private:
         void CaptureOrderedListToken(std::string&);
     };
-AdaptiveSharedNamespaceEnd
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/MarkDownBlockParser.h
+++ b/source/shared/cpp/ObjectModel/MarkDownBlockParser.h
@@ -8,7 +8,7 @@ namespace AdaptiveSharedNamespace
 {
     class MarkDownBlockParser
     {
-        public:
+    public:
         MarkDownBlockParser(){};
         // Matches each MarkDown's Syntax Form
         // For each match, stream moves to the next char
@@ -18,14 +18,14 @@ namespace AdaptiveSharedNamespace
         // Returns Parse result
         MarkDownParsedResult& GetParsedResult() { return m_parsedResult; }
 
-        protected:
+    protected:
         // Holds parsed results
         MarkDownParsedResult m_parsedResult;
     };
 
     class EmphasisParser : public MarkDownBlockParser
     {
-        public:
+    public:
         enum EmphasisState
         {
             // Text is being handled
@@ -71,7 +71,7 @@ namespace AdaptiveSharedNamespace
         // Callback function that handles the Emphasis State
         static EmphasisState MatchEmphasis(EmphasisParser&, std::stringstream&, std::string&);
 
-        protected:
+    protected:
         bool m_checkLookAhead = false;
         bool m_checkIntraWord = false;
         int m_lookBehind = Init;
@@ -91,10 +91,10 @@ namespace AdaptiveSharedNamespace
 
     class LinkParser : public MarkDownBlockParser
     {
-        public:
+    public:
         void Match(std::stringstream&);
 
-        private:
+    private:
         void CaptureLinkToken();
 
         // Matches Initial sytax of link
@@ -114,7 +114,7 @@ namespace AdaptiveSharedNamespace
 
     class ListParser : public MarkDownBlockParser
     {
-        public:
+    public:
         void Match(std::stringstream&);
         bool MatchNewListItem(std::stringstream&);
         bool MatchNewBlock(std::stringstream&);
@@ -123,20 +123,20 @@ namespace AdaptiveSharedNamespace
         static bool IsDot(int ch) { return ch == '.'; };
         static bool IsNewLine(int ch) { return (ch == '\r') || (ch == '\n'); };
 
-        protected:
+    protected:
         void ParseSubBlocks(std::stringstream&);
         bool CompleteListParsing(std::stringstream& stream);
 
-        private:
+    private:
         void CaptureListToken();
     };
 
     class OrderedListParser : public ListParser
     {
-        public:
+    public:
         void Match(std::stringstream&);
 
-        private:
+    private:
         void CaptureOrderedListToken(std::string&);
     };
 } // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/MarkDownBlockParser.h
+++ b/source/shared/cpp/ObjectModel/MarkDownBlockParser.h
@@ -12,11 +12,11 @@ namespace AdaptiveSharedNamespace
         MarkDownBlockParser(){};
         // Matches each MarkDown's Syntax Form
         // For each match, stream moves to the next char
-        virtual void Match(std::stringstream&) = 0;
+        virtual void Match(std::stringstream &) = 0;
         // Parses Block
-        void ParseBlock(std::stringstream&);
+        void ParseBlock(std::stringstream &);
         // Returns Parse result
-        MarkDownParsedResult& GetParsedResult() { return m_parsedResult; }
+        MarkDownParsedResult &GetParsedResult() { return m_parsedResult; }
 
     protected:
         // Holds parsed results
@@ -36,13 +36,13 @@ namespace AdaptiveSharedNamespace
             Captured = 0x2,
         };
 
-        virtual void Match(std::stringstream&);
+        virtual void Match(std::stringstream &);
         // Captures remaining charaters in given token
         // and causes the emphasis parsing to terminate
-        void Flush(int ch, std::string& currentToken);
+        void Flush(int ch, std::string &currentToken);
         // check if given character is * or _
         bool IsMarkDownDelimiter(int ch);
-        void CaptureCurrentCollectedStringAsRegularToken(std::string& currentToken);
+        void CaptureCurrentCollectedStringAsRegularToken(std::string &currentToken);
         void CaptureCurrentCollectedStringAsRegularToken();
         void UpdateCurrentEmphasisRunState(DelimiterType emphasisType);
         // Check if current delimiter will be considererd as a delimiter run
@@ -50,26 +50,26 @@ namespace AdaptiveSharedNamespace
         void ResetCurrentEmphasisState() { m_delimiterCnts = 0; }
         bool IsRightEmphasisDelimiter(int ch);
         // Attempt to capture current emphasis as right emphasis
-        bool TryCapturingRightEmphasisToken(int ch, std::string& currentToken);
+        bool TryCapturingRightEmphasisToken(int ch, std::string &currentToken);
         bool IsLeftEmphasisDelimiter(int ch)
         {
             return (m_delimiterCnts && ch != EOF && !isspace(ch) && !(m_lookBehind == Alphanumeric && ispunct(ch)) &&
                 !(m_lookBehind == Alphanumeric && m_currentDelimiterType == Underscore));
         };
         // Attempt to capture current emphasis as right emphasis
-        bool TryCapturingLeftEmphasisToken(int ch, std::string& currentToken);
-        void CaptureEmphasisToken(int ch, std::string& currentToken);
+        bool TryCapturingLeftEmphasisToken(int ch, std::string &currentToken);
+        void CaptureEmphasisToken(int ch, std::string &currentToken);
         void UpdateLookBehind(int ch);
         static DelimiterType GetDelimiterTypeForCharAtCurrentPosition(int ch)
         {
             return (ch == '*') ? Asterisk : Underscore;
         };
 
-        typedef EmphasisState (*MatchWithChar)(EmphasisParser&, std::stringstream&, std::string&);
+        typedef EmphasisState (*MatchWithChar)(EmphasisParser &, std::stringstream &, std::string &);
         // Callback function that handles the Text State
-        static EmphasisState MatchText(EmphasisParser&, std::stringstream&, std::string&);
+        static EmphasisState MatchText(EmphasisParser &, std::stringstream &, std::string &);
         // Callback function that handles the Emphasis State
-        static EmphasisState MatchEmphasis(EmphasisParser&, std::stringstream&, std::string&);
+        static EmphasisState MatchEmphasis(EmphasisParser &, std::stringstream &, std::string &);
 
     protected:
         bool m_checkLookAhead = false;
@@ -92,21 +92,21 @@ namespace AdaptiveSharedNamespace
     class LinkParser : public MarkDownBlockParser
     {
     public:
-        void Match(std::stringstream&);
+        void Match(std::stringstream &);
 
     private:
         void CaptureLinkToken();
 
         // Matches Initial sytax of link
-        bool MatchAtLinkInit(std::stringstream&);
+        bool MatchAtLinkInit(std::stringstream &);
         // Matches LinkText Run sytax of link
-        bool MatchAtLinkTextRun(std::stringstream&);
+        bool MatchAtLinkTextRun(std::stringstream &);
         // Matches LinkText End sytax of link
-        bool MatchAtLinkTextEnd(std::stringstream&);
+        bool MatchAtLinkTextEnd(std::stringstream &);
         // Matches LinkDestination Start sytax of link
-        bool MatchAtLinkDestinationStart(std::stringstream&);
+        bool MatchAtLinkDestinationStart(std::stringstream &);
         // Matches LinkDestination Run sytax of link
-        bool MatchAtLinkDestinationRun(std::stringstream&);
+        bool MatchAtLinkDestinationRun(std::stringstream &);
 
         // holds intermidiate result of LinkText
         MarkDownParsedResult m_linkTextParsedResult;
@@ -115,17 +115,17 @@ namespace AdaptiveSharedNamespace
     class ListParser : public MarkDownBlockParser
     {
     public:
-        void Match(std::stringstream&);
-        bool MatchNewListItem(std::stringstream&);
-        bool MatchNewBlock(std::stringstream&);
-        bool MatchNewOrderedListItem(std::stringstream&, std::string&);
+        void Match(std::stringstream &);
+        bool MatchNewListItem(std::stringstream &);
+        bool MatchNewBlock(std::stringstream &);
+        bool MatchNewOrderedListItem(std::stringstream &, std::string &);
         static bool IsHyphen(int ch) { return ch == '-'; };
         static bool IsDot(int ch) { return ch == '.'; };
         static bool IsNewLine(int ch) { return (ch == '\r') || (ch == '\n'); };
 
     protected:
-        void ParseSubBlocks(std::stringstream&);
-        bool CompleteListParsing(std::stringstream& stream);
+        void ParseSubBlocks(std::stringstream &);
+        bool CompleteListParsing(std::stringstream &stream);
 
     private:
         void CaptureListToken();
@@ -134,9 +134,9 @@ namespace AdaptiveSharedNamespace
     class OrderedListParser : public ListParser
     {
     public:
-        void Match(std::stringstream&);
+        void Match(std::stringstream &);
 
     private:
-        void CaptureOrderedListToken(std::string&);
+        void CaptureOrderedListToken(std::string &);
     };
 } // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.cpp
@@ -29,6 +29,7 @@ bool MarkDownEmphasisHtmlGenerator::IsMatch(const MarkDownEmphasisHtmlGenerator 
         // rule #9 & #10, sum of delimiter count can't be multiple of 3
         return !((this->IsLeftAndRightEmphasis() || emphasisToken.IsLeftAndRightEmphasis()) &&
             (((this->m_numberOfUnusedDelimiters + emphasisToken.m_numberOfUnusedDelimiters) % 3) == 0));
+
     }
     return false;
 }

--- a/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.cpp
@@ -22,7 +22,7 @@ std::string MarkDownStringHtmlGenerator::GenerateHtmlString()
 //     1. they are same types
 //     2. neither of the emphasis tokens are both left and right emphasis tokens, and
 //        if either or both of them are, then their sum is not multiple of 3
-bool MarkDownEmphasisHtmlGenerator::IsMatch(const MarkDownEmphasisHtmlGenerator& emphasisToken)
+bool MarkDownEmphasisHtmlGenerator::IsMatch(const MarkDownEmphasisHtmlGenerator &emphasisToken)
 {
     if (this->type == emphasisToken.type)
     {
@@ -33,13 +33,13 @@ bool MarkDownEmphasisHtmlGenerator::IsMatch(const MarkDownEmphasisHtmlGenerator&
     return false;
 }
 
-bool MarkDownEmphasisHtmlGenerator::IsSameType(const MarkDownEmphasisHtmlGenerator& token)
+bool MarkDownEmphasisHtmlGenerator::IsSameType(const MarkDownEmphasisHtmlGenerator &token)
 {
     return this->type == token.type;
 }
 
 // adjust number of emphasis counts after maching is done
-int MarkDownEmphasisHtmlGenerator::AdjustEmphasisCounts(int leftOver, MarkDownEmphasisHtmlGenerator& rightToken)
+int MarkDownEmphasisHtmlGenerator::AdjustEmphasisCounts(int leftOver, MarkDownEmphasisHtmlGenerator &rightToken)
 {
     int delimiterCount = 0;
     if (leftOver >= 0)
@@ -58,7 +58,7 @@ int MarkDownEmphasisHtmlGenerator::AdjustEmphasisCounts(int leftOver, MarkDownEm
 }
 
 // generate bold and emphasis html tags
-bool MarkDownEmphasisHtmlGenerator::GenerateTags(MarkDownEmphasisHtmlGenerator& token)
+bool MarkDownEmphasisHtmlGenerator::GenerateTags(MarkDownEmphasisHtmlGenerator &token)
 {
     int delimiterCount = 0, leftOver = 0;
     leftOver = this->m_numberOfUnusedDelimiters - token.m_numberOfUnusedDelimiters;

--- a/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.cpp
@@ -22,25 +22,24 @@ std::string MarkDownStringHtmlGenerator::GenerateHtmlString()
 //     1. they are same types
 //     2. neither of the emphasis tokens are both left and right emphasis tokens, and
 //        if either or both of them are, then their sum is not multiple of 3
-bool MarkDownEmphasisHtmlGenerator::IsMatch(const MarkDownEmphasisHtmlGenerator &emphasisToken)
+bool MarkDownEmphasisHtmlGenerator::IsMatch(const MarkDownEmphasisHtmlGenerator& emphasisToken)
 {
     if (this->type == emphasisToken.type)
     {
         // rule #9 & #10, sum of delimiter count can't be multiple of 3
         return !((this->IsLeftAndRightEmphasis() || emphasisToken.IsLeftAndRightEmphasis()) &&
             (((this->m_numberOfUnusedDelimiters + emphasisToken.m_numberOfUnusedDelimiters) % 3) == 0));
-
     }
     return false;
 }
 
-bool MarkDownEmphasisHtmlGenerator::IsSameType(const MarkDownEmphasisHtmlGenerator &token)
+bool MarkDownEmphasisHtmlGenerator::IsSameType(const MarkDownEmphasisHtmlGenerator& token)
 {
     return this->type == token.type;
 }
 
 // adjust number of emphasis counts after maching is done
-int MarkDownEmphasisHtmlGenerator::AdjustEmphasisCounts(int leftOver, MarkDownEmphasisHtmlGenerator &rightToken)
+int MarkDownEmphasisHtmlGenerator::AdjustEmphasisCounts(int leftOver, MarkDownEmphasisHtmlGenerator& rightToken)
 {
     int delimiterCount = 0;
     if (leftOver >= 0)
@@ -59,7 +58,7 @@ int MarkDownEmphasisHtmlGenerator::AdjustEmphasisCounts(int leftOver, MarkDownEm
 }
 
 // generate bold and emphasis html tags
-bool MarkDownEmphasisHtmlGenerator::GenerateTags(MarkDownEmphasisHtmlGenerator &token)
+bool MarkDownEmphasisHtmlGenerator::GenerateTags(MarkDownEmphasisHtmlGenerator& token)
 {
     int delimiterCount = 0, leftOver = 0;
     leftOver = this->m_numberOfUnusedDelimiters - token.m_numberOfUnusedDelimiters;

--- a/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.h
+++ b/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.h
@@ -5,33 +5,33 @@
 #include <list>
 #include "BaseCardElement.h"
 
-AdaptiveSharedNamespaceStart
-
-enum DelimiterType
+namespace AdaptiveSharedNamespace
 {
-    Init,
-    Alphanumeric,
-    Puntuation,
-    Escape,
-    WhiteSpace,
-    Underscore,
-    Asterisk,
-};
+    enum DelimiterType
+    {
+        Init,
+        Alphanumeric,
+        Puntuation,
+        Escape,
+        WhiteSpace,
+        Underscore,
+        Asterisk,
+    };
 
-// this class knows how to generate html string of their types
-// - MarkDownStringHtmlGenerator
-//   it is the most basic form,
-//   it simply retains and return text as string
-// - MarkDownEmphasisHtmlGenerator
-//   it knows how to handle bold and italic html
-//   tags and apply those to its text when asked to generate html string
-// - MarkDownListHtmlGenerator
-//   it functions simmilary as MarkDownStringHtmlGenerator, but its GetBlockType() returns
-//   MarkDownBlockType, this is used in generating html block tags
-//   list uses block tag of <ul> all others use <p>
-class MarkDownHtmlGenerator
-{
-    public:
+    // this class knows how to generate html string of their types
+    // - MarkDownStringHtmlGenerator
+    //   it is the most basic form,
+    //   it simply retains and return text as string
+    // - MarkDownEmphasisHtmlGenerator
+    //   it knows how to handle bold and italic html
+    //   tags and apply those to its text when asked to generate html string
+    // - MarkDownListHtmlGenerator
+    //   it functions simmilary as MarkDownStringHtmlGenerator, but its GetBlockType() returns
+    //   MarkDownBlockType, this is used in generating html block tags
+    //   list uses block tag of <ul> all others use <p>
+    class MarkDownHtmlGenerator
+    {
+        public:
         enum MarkDownBlockType
         {
             ContainerBlock,
@@ -40,7 +40,7 @@ class MarkDownHtmlGenerator
         };
 
         MarkDownHtmlGenerator() : m_token(""){};
-        MarkDownHtmlGenerator(std::string &token) : m_token(token){};
+        MarkDownHtmlGenerator(std::string& token) : m_token(token){};
         void MakeItHead() { m_isHead = true; }
         void MakeItTail() { m_isTail = true; }
         virtual bool IsNewLine() { return false; }
@@ -51,59 +51,55 @@ class MarkDownHtmlGenerator
         std::ostringstream html;
         bool m_isHead = false;
         bool m_isTail = false;
-};
+    };
 
-// - MarkDownStringHtmlGenerator
-//   it is the most basic form,
-//   it simply retains and return text as string
-class MarkDownStringHtmlGenerator : public MarkDownHtmlGenerator
-{
-    public:
-        MarkDownStringHtmlGenerator(std::string &token) : MarkDownHtmlGenerator(token){};
+    // - MarkDownStringHtmlGenerator
+    //   it is the most basic form,
+    //   it simply retains and return text as string
+    class MarkDownStringHtmlGenerator : public MarkDownHtmlGenerator
+    {
+        public:
+        MarkDownStringHtmlGenerator(std::string& token) : MarkDownHtmlGenerator(token){};
         std::string GenerateHtmlString();
-};
+    };
 
-// - MarkDownNewLineHtmlGenerator
-//   it contains new line chars
-class MarkDownNewLineHtmlGenerator : public MarkDownStringHtmlGenerator
-{
-    public:
-        MarkDownNewLineHtmlGenerator(std::string &token) : MarkDownStringHtmlGenerator(token){};
+    // - MarkDownNewLineHtmlGenerator
+    //   it contains new line chars
+    class MarkDownNewLineHtmlGenerator : public MarkDownStringHtmlGenerator
+    {
+        public:
+        MarkDownNewLineHtmlGenerator(std::string& token) : MarkDownStringHtmlGenerator(token){};
         bool IsNewLine() { return true; }
-};
+    };
 
-// - MarkDownEmphasisHtmlGenerator
-//   it knows how to handle bold and italic html
-//   tags and apply those to its text when asked to generate html string
-class MarkDownEmphasisHtmlGenerator : public MarkDownHtmlGenerator
-{
-    public:
-        MarkDownEmphasisHtmlGenerator(std::string &token,
-                int sizeOfEmphasisDelimiterRun,
-                DelimiterType type
-                ) : MarkDownHtmlGenerator(token),
-        m_numberOfUnusedDelimiters(sizeOfEmphasisDelimiterRun), type(type){};
+    // - MarkDownEmphasisHtmlGenerator
+    //   it knows how to handle bold and italic html
+    //   tags and apply those to its text when asked to generate html string
+    class MarkDownEmphasisHtmlGenerator : public MarkDownHtmlGenerator
+    {
+        public:
+        MarkDownEmphasisHtmlGenerator(std::string& token, int sizeOfEmphasisDelimiterRun, DelimiterType type) :
+            MarkDownHtmlGenerator(token), m_numberOfUnusedDelimiters(sizeOfEmphasisDelimiterRun), type(type){};
 
-        MarkDownEmphasisHtmlGenerator(std::string &token,
-                int sizeOfEmphasisDelimiterRun,
-                DelimiterType type,
-                std::vector<std::string> &tags
-                ) : MarkDownHtmlGenerator(token),
-        m_numberOfUnusedDelimiters(sizeOfEmphasisDelimiterRun), type(type), m_tags(tags){};
+        MarkDownEmphasisHtmlGenerator(
+            std::string& token, int sizeOfEmphasisDelimiterRun, DelimiterType type, std::vector<std::string>& tags) :
+            MarkDownHtmlGenerator(token),
+            m_numberOfUnusedDelimiters(sizeOfEmphasisDelimiterRun), type(type), m_tags(tags){};
 
         virtual bool IsRightEmphasis() const { return false; }
-        virtual bool IsLeftEmphasis() const  { return false; }
+        virtual bool IsLeftEmphasis() const { return false; }
         virtual bool IsLeftAndRightEmphasis() const { return false; }
         virtual void PushItalicTag();
         virtual void PushBoldTag();
 
-        bool IsMatch(const MarkDownEmphasisHtmlGenerator &token);
-        bool IsSameType(const MarkDownEmphasisHtmlGenerator &token);
+        bool IsMatch(std::shared_ptr<MarkDownEmphasisHtmlGenerator>& token);
+        bool IsSameType(std::shared_ptr<MarkDownEmphasisHtmlGenerator>& token);
         bool IsDone() const { return m_numberOfUnusedDelimiters == 0; }
         int GetNumberOfUnusedDelimiters() const { return m_numberOfUnusedDelimiters; };
-        bool GenerateTags(MarkDownEmphasisHtmlGenerator &token);
+        bool GenerateTags(std::shared_ptr<MarkDownEmphasisHtmlGenerator>& token);
         void ReverseDirectionType() { m_directionType = !m_directionType; };
-    protected:
+
+        protected:
         enum
         {
             Left = 0,
@@ -115,84 +111,78 @@ class MarkDownEmphasisHtmlGenerator : public MarkDownHtmlGenerator
         int m_directionType = Right;
         DelimiterType type;
         std::vector<std::string> m_tags;
+    };
 
-};
+    // - MarkDownLeftEmphasisHtmlGenerator
+    //   it knows how to generates opening italic and bold html tags
+    class MarkDownLeftEmphasisHtmlGenerator : public MarkDownEmphasisHtmlGenerator
+    {
+        public:
+        MarkDownLeftEmphasisHtmlGenerator(std::string& token, int sizeOfEmphasisDelimiterRun, DelimiterType type) :
+            MarkDownEmphasisHtmlGenerator(token, sizeOfEmphasisDelimiterRun, type){};
 
-// - MarkDownLeftEmphasisHtmlGenerator
-//   it knows how to generates opening italic and bold html tags
-class MarkDownLeftEmphasisHtmlGenerator : public MarkDownEmphasisHtmlGenerator
-{
-    public:
-        MarkDownLeftEmphasisHtmlGenerator (std::string &token,
-                int sizeOfEmphasisDelimiterRun,
-                DelimiterType type) : MarkDownEmphasisHtmlGenerator(token,
-                    sizeOfEmphasisDelimiterRun, type){};
+        MarkDownLeftEmphasisHtmlGenerator(
+            std::string& token, int sizeOfEmphasisDelimiterRun, DelimiterType type, std::vector<std::string>& tags) :
+            MarkDownEmphasisHtmlGenerator(token, sizeOfEmphasisDelimiterRun, type, tags){};
 
-        MarkDownLeftEmphasisHtmlGenerator(std::string &token,
-                int sizeOfEmphasisDelimiterRun,
-                DelimiterType type, std::vector<std::string> &tags) : MarkDownEmphasisHtmlGenerator(token,
-                    sizeOfEmphasisDelimiterRun, type, tags){};
-
-        bool IsLeftEmphasis() const  { return true; }
+        bool IsLeftEmphasis() const { return true; }
         std::string GenerateHtmlString();
-};
+    };
 
-// - MarkDownRightEmphasisHtmlGenerator
-//   it knows how to generates closing italic and bold html tags
-class MarkDownRightEmphasisHtmlGenerator : public MarkDownEmphasisHtmlGenerator
-{
-    public:
-        MarkDownRightEmphasisHtmlGenerator(std::string &token,
-                int sizeOfEmphasisDelimiterRun,
-                DelimiterType type) : MarkDownEmphasisHtmlGenerator(token,
-                    sizeOfEmphasisDelimiterRun, type){};
+    // - MarkDownRightEmphasisHtmlGenerator
+    //   it knows how to generates closing italic and bold html tags
+    class MarkDownRightEmphasisHtmlGenerator : public MarkDownEmphasisHtmlGenerator
+    {
+        public:
+        MarkDownRightEmphasisHtmlGenerator(std::string& token, int sizeOfEmphasisDelimiterRun, DelimiterType type) :
+            MarkDownEmphasisHtmlGenerator(token, sizeOfEmphasisDelimiterRun, type){};
 
-        void GenerateTags(std::shared_ptr<MarkDownEmphasisHtmlGenerator> &token);
+        void GenerateTags(std::shared_ptr<MarkDownEmphasisHtmlGenerator>& token);
         bool IsRightEmphasis() const { return true; }
         std::string GenerateHtmlString();
         void PushItalicTag();
         void PushBoldTag();
-};
+    };
 
-// - MarkDownLeftAndRightEmphasisHtmlGenerator
-//   it can have both directions, and its final direction is determined at the later stage
-class MarkDownLeftAndRightEmphasisHtmlGenerator : public MarkDownRightEmphasisHtmlGenerator
-{
-    public:
-        MarkDownLeftAndRightEmphasisHtmlGenerator(std::string &token,
-                int sizeOfEmphasisDelimiterRun,
-                DelimiterType type) : MarkDownRightEmphasisHtmlGenerator(token,
-                    sizeOfEmphasisDelimiterRun, type) {};
+    // - MarkDownLeftAndRightEmphasisHtmlGenerator
+    //   it can have both directions, and its final direction is determined at the later stage
+    class MarkDownLeftAndRightEmphasisHtmlGenerator : public MarkDownRightEmphasisHtmlGenerator
+    {
+        public:
+        MarkDownLeftAndRightEmphasisHtmlGenerator(
+            std::string& token, int sizeOfEmphasisDelimiterRun, DelimiterType type) :
+            MarkDownRightEmphasisHtmlGenerator(token, sizeOfEmphasisDelimiterRun, type){};
         bool IsRightEmphasis() const { return m_directionType == Right; }
-        bool IsLeftEmphasis() const  { return m_directionType == Left; }
+        bool IsLeftEmphasis() const { return m_directionType == Left; }
         bool IsLeftAndRightEmphasis() const { return true; };
         void PushItalicTag();
         void PushBoldTag();
-};
+    };
 
-// - MarkDownListHtmlGenerator
-//   it functions simmilary as MarkDownStringHtmlGenerator, but its GetBlockType() returns
-//   UnorderedList type, this is used in generating html block tags <ul>
-class MarkDownListHtmlGenerator : public MarkDownStringHtmlGenerator
-{
-    public:
-        MarkDownListHtmlGenerator(std::string &token) : MarkDownStringHtmlGenerator(token) {};
+    // - MarkDownListHtmlGenerator
+    //   it functions simmilary as MarkDownStringHtmlGenerator, but its GetBlockType() returns
+    //   UnorderedList type, this is used in generating html block tags <ul>
+    class MarkDownListHtmlGenerator : public MarkDownStringHtmlGenerator
+    {
+        public:
+        MarkDownListHtmlGenerator(std::string& token) : MarkDownStringHtmlGenerator(token){};
         std::string GenerateHtmlString();
         MarkDownBlockType GetBlockType() const { return UnorderedList; };
-};
+    };
 
-// - MarkDownUnorderedListHtmlGenerator
-//   it functions simmilary as MarkDownStringHtmlGenerator, but its GetBlockType() returns
-//   OrderedList type, this is used in generating html block tags <ol>
-class MarkDownOrderedListHtmlGenerator : public MarkDownStringHtmlGenerator
-{
-    public:
-        MarkDownOrderedListHtmlGenerator(std::string &token, std::string &number_string) :
-            MarkDownStringHtmlGenerator(token), m_numberString(number_string) {};
+    // - MarkDownUnorderedListHtmlGenerator
+    //   it functions simmilary as MarkDownStringHtmlGenerator, but its GetBlockType() returns
+    //   OrderedList type, this is used in generating html block tags <ol>
+    class MarkDownOrderedListHtmlGenerator : public MarkDownStringHtmlGenerator
+    {
+        public:
+        MarkDownOrderedListHtmlGenerator(std::string& token, std::string& number_string) :
+            MarkDownStringHtmlGenerator(token), m_numberString(number_string){};
         std::string GenerateHtmlString();
         MarkDownBlockType GetBlockType() const { return OrderedList; };
-    private:
-        std::string m_numberString;
-};
 
-AdaptiveSharedNamespaceEnd
+        private:
+        std::string m_numberString;
+    };
+
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.h
+++ b/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.h
@@ -40,7 +40,7 @@ namespace AdaptiveSharedNamespace
         };
 
         MarkDownHtmlGenerator() : m_token(""){};
-        MarkDownHtmlGenerator(std::string& token) : m_token(token){};
+        MarkDownHtmlGenerator(std::string &token) : m_token(token){};
         void MakeItHead() { m_isHead = true; }
         void MakeItTail() { m_isTail = true; }
         virtual bool IsNewLine() { return false; }
@@ -60,7 +60,7 @@ namespace AdaptiveSharedNamespace
     class MarkDownStringHtmlGenerator : public MarkDownHtmlGenerator
     {
     public:
-        MarkDownStringHtmlGenerator(std::string& token) : MarkDownHtmlGenerator(token){};
+        MarkDownStringHtmlGenerator(std::string &token) : MarkDownHtmlGenerator(token){};
         std::string GenerateHtmlString();
     };
 
@@ -69,7 +69,7 @@ namespace AdaptiveSharedNamespace
     class MarkDownNewLineHtmlGenerator : public MarkDownStringHtmlGenerator
     {
     public:
-        MarkDownNewLineHtmlGenerator(std::string& token) : MarkDownStringHtmlGenerator(token){};
+        MarkDownNewLineHtmlGenerator(std::string &token) : MarkDownStringHtmlGenerator(token){};
         bool IsNewLine() { return true; }
     };
 
@@ -79,11 +79,11 @@ namespace AdaptiveSharedNamespace
     class MarkDownEmphasisHtmlGenerator : public MarkDownHtmlGenerator
     {
     public:
-        MarkDownEmphasisHtmlGenerator(std::string& token, int sizeOfEmphasisDelimiterRun, DelimiterType type) :
+        MarkDownEmphasisHtmlGenerator(std::string &token, int sizeOfEmphasisDelimiterRun, DelimiterType type) :
             MarkDownHtmlGenerator(token), m_numberOfUnusedDelimiters(sizeOfEmphasisDelimiterRun), type(type){};
 
         MarkDownEmphasisHtmlGenerator(
-            std::string& token, int sizeOfEmphasisDelimiterRun, DelimiterType type, std::vector<std::string>& tags) :
+            std::string &token, int sizeOfEmphasisDelimiterRun, DelimiterType type, std::vector<std::string> &tags) :
             MarkDownHtmlGenerator(token),
             m_numberOfUnusedDelimiters(sizeOfEmphasisDelimiterRun), type(type), m_tags(tags){};
 
@@ -93,11 +93,11 @@ namespace AdaptiveSharedNamespace
         virtual void PushItalicTag();
         virtual void PushBoldTag();
 
-        bool IsMatch(const MarkDownEmphasisHtmlGenerator& token);
-        bool IsSameType(const MarkDownEmphasisHtmlGenerator& token);
+        bool IsMatch(const MarkDownEmphasisHtmlGenerator &token);
+        bool IsSameType(const MarkDownEmphasisHtmlGenerator &token);
         bool IsDone() const { return m_numberOfUnusedDelimiters == 0; }
         int GetNumberOfUnusedDelimiters() const { return m_numberOfUnusedDelimiters; };
-        bool GenerateTags(MarkDownEmphasisHtmlGenerator& token);
+        bool GenerateTags(MarkDownEmphasisHtmlGenerator &token);
         void ReverseDirectionType() { m_directionType = !m_directionType; };
 
     protected:
@@ -107,7 +107,7 @@ namespace AdaptiveSharedNamespace
             Right = 1,
         };
 
-        int AdjustEmphasisCounts(int leftOver, MarkDownEmphasisHtmlGenerator& rightToken);
+        int AdjustEmphasisCounts(int leftOver, MarkDownEmphasisHtmlGenerator &rightToken);
         int m_numberOfUnusedDelimiters;
         int m_directionType = Right;
         DelimiterType type;
@@ -119,11 +119,11 @@ namespace AdaptiveSharedNamespace
     class MarkDownLeftEmphasisHtmlGenerator : public MarkDownEmphasisHtmlGenerator
     {
     public:
-        MarkDownLeftEmphasisHtmlGenerator(std::string& token, int sizeOfEmphasisDelimiterRun, DelimiterType type) :
+        MarkDownLeftEmphasisHtmlGenerator(std::string &token, int sizeOfEmphasisDelimiterRun, DelimiterType type) :
             MarkDownEmphasisHtmlGenerator(token, sizeOfEmphasisDelimiterRun, type){};
 
         MarkDownLeftEmphasisHtmlGenerator(
-            std::string& token, int sizeOfEmphasisDelimiterRun, DelimiterType type, std::vector<std::string>& tags) :
+            std::string &token, int sizeOfEmphasisDelimiterRun, DelimiterType type, std::vector<std::string> &tags) :
             MarkDownEmphasisHtmlGenerator(token, sizeOfEmphasisDelimiterRun, type, tags){};
 
         bool IsLeftEmphasis() const { return true; }
@@ -135,10 +135,10 @@ namespace AdaptiveSharedNamespace
     class MarkDownRightEmphasisHtmlGenerator : public MarkDownEmphasisHtmlGenerator
     {
     public:
-        MarkDownRightEmphasisHtmlGenerator(std::string& token, int sizeOfEmphasisDelimiterRun, DelimiterType type) :
+        MarkDownRightEmphasisHtmlGenerator(std::string &token, int sizeOfEmphasisDelimiterRun, DelimiterType type) :
             MarkDownEmphasisHtmlGenerator(token, sizeOfEmphasisDelimiterRun, type){};
 
-        void GenerateTags(MarkDownEmphasisHtmlGenerator& token);
+        void GenerateTags(MarkDownEmphasisHtmlGenerator &token);
         bool IsRightEmphasis() const { return true; }
         std::string GenerateHtmlString();
         void PushItalicTag();
@@ -151,7 +151,7 @@ namespace AdaptiveSharedNamespace
     {
     public:
         MarkDownLeftAndRightEmphasisHtmlGenerator(
-            std::string& token, int sizeOfEmphasisDelimiterRun, DelimiterType type) :
+            std::string &token, int sizeOfEmphasisDelimiterRun, DelimiterType type) :
             MarkDownRightEmphasisHtmlGenerator(token, sizeOfEmphasisDelimiterRun, type){};
         bool IsRightEmphasis() const { return m_directionType == Right; }
         bool IsLeftEmphasis() const { return m_directionType == Left; }
@@ -166,7 +166,7 @@ namespace AdaptiveSharedNamespace
     class MarkDownListHtmlGenerator : public MarkDownStringHtmlGenerator
     {
     public:
-        MarkDownListHtmlGenerator(std::string& token) : MarkDownStringHtmlGenerator(token){};
+        MarkDownListHtmlGenerator(std::string &token) : MarkDownStringHtmlGenerator(token){};
         std::string GenerateHtmlString();
         MarkDownBlockType GetBlockType() const { return UnorderedList; };
     };
@@ -177,7 +177,7 @@ namespace AdaptiveSharedNamespace
     class MarkDownOrderedListHtmlGenerator : public MarkDownStringHtmlGenerator
     {
     public:
-        MarkDownOrderedListHtmlGenerator(std::string& token, std::string& number_string) :
+        MarkDownOrderedListHtmlGenerator(std::string &token, std::string &number_string) :
             MarkDownStringHtmlGenerator(token), m_numberString(number_string){};
         std::string GenerateHtmlString();
         MarkDownBlockType GetBlockType() const { return OrderedList; };

--- a/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.h
+++ b/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.h
@@ -31,7 +31,7 @@ namespace AdaptiveSharedNamespace
     //   list uses block tag of <ul> all others use <p>
     class MarkDownHtmlGenerator
     {
-        public:
+    public:
         enum MarkDownBlockType
         {
             ContainerBlock,
@@ -47,7 +47,7 @@ namespace AdaptiveSharedNamespace
         virtual std::string GenerateHtmlString() = 0;
         virtual MarkDownBlockType GetBlockType() const { return ContainerBlock; };
 
-        protected:
+    protected:
         std::string m_token;
         std::ostringstream html;
         bool m_isHead = false;
@@ -59,7 +59,7 @@ namespace AdaptiveSharedNamespace
     //   it simply retains and return text as string
     class MarkDownStringHtmlGenerator : public MarkDownHtmlGenerator
     {
-        public:
+    public:
         MarkDownStringHtmlGenerator(std::string& token) : MarkDownHtmlGenerator(token){};
         std::string GenerateHtmlString();
     };
@@ -68,7 +68,7 @@ namespace AdaptiveSharedNamespace
     //   it contains new line chars
     class MarkDownNewLineHtmlGenerator : public MarkDownStringHtmlGenerator
     {
-        public:
+    public:
         MarkDownNewLineHtmlGenerator(std::string& token) : MarkDownStringHtmlGenerator(token){};
         bool IsNewLine() { return true; }
     };
@@ -78,7 +78,7 @@ namespace AdaptiveSharedNamespace
     //   tags and apply those to its text when asked to generate html string
     class MarkDownEmphasisHtmlGenerator : public MarkDownHtmlGenerator
     {
-        public:
+    public:
         MarkDownEmphasisHtmlGenerator(std::string& token, int sizeOfEmphasisDelimiterRun, DelimiterType type) :
             MarkDownHtmlGenerator(token), m_numberOfUnusedDelimiters(sizeOfEmphasisDelimiterRun), type(type){};
 
@@ -100,7 +100,7 @@ namespace AdaptiveSharedNamespace
         bool GenerateTags(MarkDownEmphasisHtmlGenerator& token);
         void ReverseDirectionType() { m_directionType = !m_directionType; };
 
-        protected:
+    protected:
         enum
         {
             Left = 0,
@@ -118,7 +118,7 @@ namespace AdaptiveSharedNamespace
     //   it knows how to generates opening italic and bold html tags
     class MarkDownLeftEmphasisHtmlGenerator : public MarkDownEmphasisHtmlGenerator
     {
-        public:
+    public:
         MarkDownLeftEmphasisHtmlGenerator(std::string& token, int sizeOfEmphasisDelimiterRun, DelimiterType type) :
             MarkDownEmphasisHtmlGenerator(token, sizeOfEmphasisDelimiterRun, type){};
 
@@ -134,11 +134,11 @@ namespace AdaptiveSharedNamespace
     //   it knows how to generates closing italic and bold html tags
     class MarkDownRightEmphasisHtmlGenerator : public MarkDownEmphasisHtmlGenerator
     {
-        public:
+    public:
         MarkDownRightEmphasisHtmlGenerator(std::string& token, int sizeOfEmphasisDelimiterRun, DelimiterType type) :
             MarkDownEmphasisHtmlGenerator(token, sizeOfEmphasisDelimiterRun, type){};
 
-        void GenerateTags(std::shared_ptr<MarkDownEmphasisHtmlGenerator>& token);
+        void GenerateTags(MarkDownEmphasisHtmlGenerator& token);
         bool IsRightEmphasis() const { return true; }
         std::string GenerateHtmlString();
         void PushItalicTag();
@@ -149,7 +149,7 @@ namespace AdaptiveSharedNamespace
     //   it can have both directions, and its final direction is determined at the later stage
     class MarkDownLeftAndRightEmphasisHtmlGenerator : public MarkDownRightEmphasisHtmlGenerator
     {
-        public:
+    public:
         MarkDownLeftAndRightEmphasisHtmlGenerator(
             std::string& token, int sizeOfEmphasisDelimiterRun, DelimiterType type) :
             MarkDownRightEmphasisHtmlGenerator(token, sizeOfEmphasisDelimiterRun, type){};
@@ -165,7 +165,7 @@ namespace AdaptiveSharedNamespace
     //   UnorderedList type, this is used in generating html block tags <ul>
     class MarkDownListHtmlGenerator : public MarkDownStringHtmlGenerator
     {
-        public:
+    public:
         MarkDownListHtmlGenerator(std::string& token) : MarkDownStringHtmlGenerator(token){};
         std::string GenerateHtmlString();
         MarkDownBlockType GetBlockType() const { return UnorderedList; };
@@ -176,13 +176,13 @@ namespace AdaptiveSharedNamespace
     //   OrderedList type, this is used in generating html block tags <ol>
     class MarkDownOrderedListHtmlGenerator : public MarkDownStringHtmlGenerator
     {
-        public:
+    public:
         MarkDownOrderedListHtmlGenerator(std::string& token, std::string& number_string) :
             MarkDownStringHtmlGenerator(token), m_numberString(number_string){};
         std::string GenerateHtmlString();
         MarkDownBlockType GetBlockType() const { return OrderedList; };
 
-        private:
+    private:
         std::string m_numberString;
     };
 

--- a/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.h
+++ b/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.h
@@ -46,7 +46,8 @@ namespace AdaptiveSharedNamespace
         virtual bool IsNewLine() { return false; }
         virtual std::string GenerateHtmlString() = 0;
         virtual MarkDownBlockType GetBlockType() const { return ContainerBlock; };
-    protected:
+
+        protected:
         std::string m_token;
         std::ostringstream html;
         bool m_isHead = false;
@@ -92,11 +93,11 @@ namespace AdaptiveSharedNamespace
         virtual void PushItalicTag();
         virtual void PushBoldTag();
 
-        bool IsMatch(std::shared_ptr<MarkDownEmphasisHtmlGenerator>& token);
-        bool IsSameType(std::shared_ptr<MarkDownEmphasisHtmlGenerator>& token);
+        bool IsMatch(const MarkDownEmphasisHtmlGenerator& token);
+        bool IsSameType(const MarkDownEmphasisHtmlGenerator& token);
         bool IsDone() const { return m_numberOfUnusedDelimiters == 0; }
         int GetNumberOfUnusedDelimiters() const { return m_numberOfUnusedDelimiters; };
-        bool GenerateTags(std::shared_ptr<MarkDownEmphasisHtmlGenerator>& token);
+        bool GenerateTags(MarkDownEmphasisHtmlGenerator& token);
         void ReverseDirectionType() { m_directionType = !m_directionType; };
 
         protected:
@@ -106,7 +107,7 @@ namespace AdaptiveSharedNamespace
             Right = 1,
         };
 
-        int AdjustEmphasisCounts(int leftOver, MarkDownEmphasisHtmlGenerator &rightToken);
+        int AdjustEmphasisCounts(int leftOver, MarkDownEmphasisHtmlGenerator& rightToken);
         int m_numberOfUnusedDelimiters;
         int m_directionType = Right;
         DelimiterType type;

--- a/source/shared/cpp/ObjectModel/MarkDownParsedResult.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownParsedResult.cpp
@@ -18,7 +18,7 @@ void MarkDownParsedResult::AddBlockTags()
     m_codeGenTokens.back()->MakeItTail();
 }
 
-void MarkDownParsedResult::MarkTags(MarkDownHtmlGenerator& x)
+void MarkDownParsedResult::MarkTags(MarkDownHtmlGenerator &x)
 {
     if (m_codeGenTokens.back()->GetBlockType() != x.GetBlockType())
     {
@@ -35,7 +35,7 @@ void MarkDownParsedResult::MarkTags(MarkDownHtmlGenerator& x)
     }
 }
 // append caller's parsed result to callee's parsed result
-void MarkDownParsedResult::AppendParseResult(MarkDownParsedResult& x)
+void MarkDownParsedResult::AppendParseResult(MarkDownParsedResult &x)
 {
     if (!m_codeGenTokens.empty() && !x.m_codeGenTokens.empty())
     {
@@ -48,7 +48,7 @@ void MarkDownParsedResult::AppendParseResult(MarkDownParsedResult& x)
 }
 
 // append MarkDownHtmlGenerator object to callee's prased result
-void MarkDownParsedResult::AppendToTokens(const std::shared_ptr<MarkDownHtmlGenerator>& x)
+void MarkDownParsedResult::AppendToTokens(const std::shared_ptr<MarkDownHtmlGenerator> &x)
 {
     if (!m_codeGenTokens.empty())
     {
@@ -58,7 +58,7 @@ void MarkDownParsedResult::AppendToTokens(const std::shared_ptr<MarkDownHtmlGene
     m_codeGenTokens.push_back(x);
 }
 
-void MarkDownParsedResult::AppendToLookUpTable(const std::shared_ptr<MarkDownEmphasisHtmlGenerator>& x)
+void MarkDownParsedResult::AppendToLookUpTable(const std::shared_ptr<MarkDownEmphasisHtmlGenerator> &x)
 {
     m_emphasisLookUpTable.push_back(x);
 }
@@ -89,7 +89,7 @@ void MarkDownParsedResult::AddNewTokenToParsedResult(char ch)
 }
 
 // create and add new MarkDownStringHtmlGenerator object that has string word
-void MarkDownParsedResult::AddNewTokenToParsedResult(std::string& word)
+void MarkDownParsedResult::AddNewTokenToParsedResult(std::string &word)
 {
     std::shared_ptr<MarkDownStringHtmlGenerator> htmlToken = std::make_shared<MarkDownStringHtmlGenerator>(word);
     AppendToTokens(htmlToken);

--- a/source/shared/cpp/ObjectModel/MarkDownParsedResult.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownParsedResult.cpp
@@ -18,7 +18,7 @@ void MarkDownParsedResult::AddBlockTags()
     m_codeGenTokens.back()->MakeItTail();
 }
 
-void MarkDownParsedResult::MarkTags(MarkDownHtmlGenerator &x)
+void MarkDownParsedResult::MarkTags(MarkDownHtmlGenerator& x)
 {
     if (m_codeGenTokens.back()->GetBlockType() != x.GetBlockType())
     {
@@ -48,7 +48,7 @@ void MarkDownParsedResult::AppendParseResult(MarkDownParsedResult& x)
 }
 
 // append MarkDownHtmlGenerator object to callee's prased result
-void MarkDownParsedResult::AppendToTokens(const std::shared_ptr<MarkDownHtmlGenerator> &x)
+void MarkDownParsedResult::AppendToTokens(const std::shared_ptr<MarkDownHtmlGenerator>& x)
 {
     if (!m_codeGenTokens.empty())
     {
@@ -161,15 +161,14 @@ void MarkDownParsedResult::MatchLeftAndRightEmphasises()
             //        if either or both of them are, then their sum is not multipe of 3
             //
             //     if matches are not found
-            //     1. search left emphasis tokens first for match because of rule 14 matches on the left side is preferred
+            //     1. search left emphasis tokens first for match because of rule 14 matches on the left side is
+            //     preferred
             //        if match is found set left emphasis as the new left emphasis token and proceed to token processing
             //        any non-matching left emphasis will be poped, in this way it always move forward
             //        if still no match is found,
             //     2. search right
-            //        if the right emphasis can be left empahs search matching right emphasis tokens using the right emphasis
-            //        as left emphasis
-            //        else
-            //        use current left emphasis to search, and pop current right emphasis
+            //        if the right emphasis can be left empahs search matching right emphasis tokens using the right
+            //        emphasis as left emphasis else use current left emphasis to search, and pop current right emphasis
             if (!(*currentLeftEmphasis)->IsMatch(*(*currentEmphasis)))
             {
                 std::vector<std::list<std::shared_ptr<MarkDownEmphasisHtmlGenerator>>::iterator> store;

--- a/source/shared/cpp/ObjectModel/MarkDownParsedResult.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownParsedResult.cpp
@@ -35,7 +35,7 @@ void MarkDownParsedResult::MarkTags(MarkDownHtmlGenerator &x)
     }
 }
 // append caller's parsed result to callee's parsed result
-void MarkDownParsedResult::AppendParseResult(MarkDownParsedResult &x)
+void MarkDownParsedResult::AppendParseResult(MarkDownParsedResult& x)
 {
     if (!m_codeGenTokens.empty() && !x.m_codeGenTokens.empty())
     {
@@ -58,7 +58,7 @@ void MarkDownParsedResult::AppendToTokens(const std::shared_ptr<MarkDownHtmlGene
     m_codeGenTokens.push_back(x);
 }
 
-void MarkDownParsedResult::AppendToLookUpTable(const std::shared_ptr<MarkDownEmphasisHtmlGenerator> &x)
+void MarkDownParsedResult::AppendToLookUpTable(const std::shared_ptr<MarkDownEmphasisHtmlGenerator>& x)
 {
     m_emphasisLookUpTable.push_back(x);
 }
@@ -89,10 +89,9 @@ void MarkDownParsedResult::AddNewTokenToParsedResult(char ch)
 }
 
 // create and add new MarkDownStringHtmlGenerator object that has string word
-void MarkDownParsedResult::AddNewTokenToParsedResult(std::string &word)
+void MarkDownParsedResult::AddNewTokenToParsedResult(std::string& word)
 {
-    std::shared_ptr<MarkDownStringHtmlGenerator> htmlToken =
-        std::make_shared<MarkDownStringHtmlGenerator>(word);
+    std::shared_ptr<MarkDownStringHtmlGenerator> htmlToken = std::make_shared<MarkDownStringHtmlGenerator>(word);
     AppendToTokens(htmlToken);
 }
 
@@ -100,8 +99,7 @@ void MarkDownParsedResult::AddNewTokenToParsedResult(std::string &word)
 void MarkDownParsedResult::AddNewLineTokenToParsedResult(char ch)
 {
     std::string string_token = std::string(1, ch);
-    std::shared_ptr<MarkDownHtmlGenerator> htmlToken =
-        std::make_shared<MarkDownNewLineHtmlGenerator>(string_token);
+    std::shared_ptr<MarkDownHtmlGenerator> htmlToken = std::make_shared<MarkDownNewLineHtmlGenerator>(string_token);
     AppendToTokens(htmlToken);
 }
 
@@ -215,7 +213,7 @@ void MarkDownParsedResult::MatchLeftAndRightEmphasises()
                     // check for the reason why we had to backtrack
                     if ((*leftEmphasisToExplore.back())->IsSameType(*(*currentEmphasis)))
                     {
-                        //right emphasis becomes left emphasis
+                        // right emphasis becomes left emphasis
                         /// create new left empahsis html generator from right
                         (*currentEmphasis)->ReverseDirectionType();
                     }

--- a/source/shared/cpp/ObjectModel/MarkDownParsedResult.h
+++ b/source/shared/cpp/ObjectModel/MarkDownParsedResult.h
@@ -18,16 +18,16 @@ namespace AdaptiveSharedNamespace
         // Write to html string
         std::string GenerateHtmlString();
         // Append contents of the given parsing result object
-        void AppendParseResult(MarkDownParsedResult&);
+        void AppendParseResult(MarkDownParsedResult &);
         // Append html code gen object to parse result
-        void AppendToTokens(const std::shared_ptr<MarkDownHtmlGenerator>&);
+        void AppendToTokens(const std::shared_ptr<MarkDownHtmlGenerator> &);
         // Append emphasis html code gen object to parse result
-        void AppendToLookUpTable(const std::shared_ptr<MarkDownEmphasisHtmlGenerator>&);
+        void AppendToLookUpTable(const std::shared_ptr<MarkDownEmphasisHtmlGenerator> &);
         // Take a char and convert it html code gen and append it to the result
         // It is used to store MarkDown keywords such as '[', ']', '(', ')'
         void AddNewTokenToParsedResult(char ch);
         // Take string and convert it html code gen and append it to the result
-        void AddNewTokenToParsedResult(std::string& word);
+        void AddNewTokenToParsedResult(std::string &word);
         // Take a new line char and convert it html code gen and append it to the result
         // It is used to store MarkDown keywords such as '\r', '\n'
         void AddNewLineTokenToParsedResult(char ch);
@@ -38,7 +38,7 @@ namespace AdaptiveSharedNamespace
         void FoundHtmlTags();
 
     private:
-        void MarkTags(MarkDownHtmlGenerator&);
+        void MarkTags(MarkDownHtmlGenerator &);
         std::list<std::shared_ptr<MarkDownHtmlGenerator>> m_codeGenTokens;
         std::list<std::shared_ptr<MarkDownEmphasisHtmlGenerator>> m_emphasisLookUpTable;
         bool m_isHTMLTagsAdded;

--- a/source/shared/cpp/ObjectModel/MarkDownParsedResult.h
+++ b/source/shared/cpp/ObjectModel/MarkDownParsedResult.h
@@ -38,7 +38,7 @@ namespace AdaptiveSharedNamespace
         void FoundHtmlTags();
 
         private:
-        void MarkTags(const std::shared_ptr<MarkDownHtmlGenerator>&);
+        void MarkTags(MarkDownHtmlGenerator&);
         std::list<std::shared_ptr<MarkDownHtmlGenerator>> m_codeGenTokens;
         std::list<std::shared_ptr<MarkDownEmphasisHtmlGenerator>> m_emphasisLookUpTable;
         bool m_isHTMLTagsAdded;

--- a/source/shared/cpp/ObjectModel/MarkDownParsedResult.h
+++ b/source/shared/cpp/ObjectModel/MarkDownParsedResult.h
@@ -4,52 +4,45 @@
 #include "MarkDownHtmlGenerator.h"
 #include <list>
 
-AdaptiveSharedNamespaceStart
-// Holds Parsing Result of MarkDown String
-class MarkDownParsedResult
+namespace AdaptiveSharedNamespace
 {
-public:
-    MarkDownParsedResult() : m_isHTMLTagsAdded(false) {};
+    // Holds Parsing Result of MarkDown String
+    class MarkDownParsedResult
+    {
+        public:
+        MarkDownParsedResult() : m_isHTMLTagsAdded(false){};
+        // Translate Intermediate Parsing Result to a form that can be
+        // written to html string
+        void Translate();
+        void AddBlockTags();
+        // Write to html string
+        std::string GenerateHtmlString();
+        // Append contents of the given parsing result object
+        void AppendParseResult(MarkDownParsedResult&);
+        // Append html code gen object to parse result
+        void AppendToTokens(const std::shared_ptr<MarkDownHtmlGenerator>&);
+        // Append emphasis html code gen object to parse result
+        void AppendToLookUpTable(const std::shared_ptr<MarkDownEmphasisHtmlGenerator>&);
+        // Take a char and convert it html code gen and append it to the result
+        // It is used to store MarkDown keywords such as '[', ']', '(', ')'
+        void AddNewTokenToParsedResult(char ch);
+        // Take string and convert it html code gen and append it to the result
+        void AddNewTokenToParsedResult(std::string& word);
+        // Take a new line char and convert it html code gen and append it to the result
+        // It is used to store MarkDown keywords such as '\r', '\n'
+        void AddNewLineTokenToParsedResult(char ch);
+        void PopFront();
+        void PopBack();
+        void Clear();
+        bool HasHtmlTags();
+        void FoundHtmlTags();
 
-    // Translate Intermediate Parsing Result to a form that can be written to html string
-    void Translate();
-    void AddBlockTags();
-
-    // Write to html string
-    std::string GenerateHtmlString();
-
-    // Append contents of the given parsing result object
-    void AppendParseResult(MarkDownParsedResult &);
-
-    // Append html code gen object to parse result
-    void AppendToTokens(const std::shared_ptr<MarkDownHtmlGenerator> &);
-
-    // Append emphasis html code gen object to parse result
-    void AppendToLookUpTable(const std::shared_ptr<MarkDownEmphasisHtmlGenerator> &);
-
-    // Take a char and convert it html code gen and append it to the result. used to store MarkDown keywords such as
-    // '[', ']', '(', ')'
-    void AddNewTokenToParsedResult(char ch);
-
-    // Take string and convert it html code gen and append it to the result
-    void AddNewTokenToParsedResult(std::string &word);
-
-    // Take a new line char and convert it html code gen and append it to the result It is used to store MarkDown
-    // keywords such as '\r', '\n'
-    void AddNewLineTokenToParsedResult(char ch);
-    void PopFront();
-    void PopBack();
-    void Clear();
-    bool HasHtmlTags();
-    void FoundHtmlTags();
-
-private:
-    void MarkTags(MarkDownHtmlGenerator &);
-    std::list<std::shared_ptr<MarkDownHtmlGenerator>> m_codeGenTokens;
-    std::list<std::shared_ptr<MarkDownEmphasisHtmlGenerator>> m_emphasisLookUpTable;
-    bool m_isHTMLTagsAdded;
-
-    // take m_emphasisLookUpTable and matches left and right emphasises
-    void MatchLeftAndRightEmphasises();
-};
-AdaptiveSharedNamespaceEnd
+        private:
+        void MarkTags(const std::shared_ptr<MarkDownHtmlGenerator>&);
+        std::list<std::shared_ptr<MarkDownHtmlGenerator>> m_codeGenTokens;
+        std::list<std::shared_ptr<MarkDownEmphasisHtmlGenerator>> m_emphasisLookUpTable;
+        bool m_isHTMLTagsAdded;
+        // take m_emphasisLookUpTable and matches left and right emphasises
+        void MatchLeftAndRightEmphasises();
+    };
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/MarkDownParsedResult.h
+++ b/source/shared/cpp/ObjectModel/MarkDownParsedResult.h
@@ -9,7 +9,7 @@ namespace AdaptiveSharedNamespace
     // Holds Parsing Result of MarkDown String
     class MarkDownParsedResult
     {
-        public:
+    public:
         MarkDownParsedResult() : m_isHTMLTagsAdded(false){};
         // Translate Intermediate Parsing Result to a form that can be
         // written to html string
@@ -37,7 +37,7 @@ namespace AdaptiveSharedNamespace
         bool HasHtmlTags();
         void FoundHtmlTags();
 
-        private:
+    private:
         void MarkTags(MarkDownHtmlGenerator&);
         std::list<std::shared_ptr<MarkDownHtmlGenerator>> m_codeGenTokens;
         std::list<std::shared_ptr<MarkDownEmphasisHtmlGenerator>> m_emphasisLookUpTable;

--- a/source/shared/cpp/ObjectModel/MarkDownParser.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownParser.cpp
@@ -6,7 +6,7 @@
 
 using namespace AdaptiveSharedNamespace;
 
-MarkDownParser::MarkDownParser(const std::string& txt) : m_text(txt), m_hasHTMLTag(false) {}
+MarkDownParser::MarkDownParser(const std::string &txt) : m_text(txt), m_hasHTMLTag(false) {}
 
 // transforms string to html
 std::string MarkDownParser::TransformToHtml()

--- a/source/shared/cpp/ObjectModel/MarkDownParser.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownParser.cpp
@@ -6,9 +6,7 @@
 
 using namespace AdaptiveSharedNamespace;
 
-MarkDownParser::MarkDownParser(const std::string &txt) : m_text(txt), m_hasHTMLTag(false)
-{
-}
+MarkDownParser::MarkDownParser(const std::string& txt) : m_text(txt), m_hasHTMLTag(false) {}
 
 // transforms string to html
 std::string MarkDownParser::TransformToHtml()
@@ -20,11 +18,11 @@ std::string MarkDownParser::TransformToHtml()
     // begin parsing html blocks
     ParseBlock();
 
-    // process further what is parsed before outputting 
+    // process further what is parsed before outputting
     // html string
     m_parsedResult.Translate();
 
-    //add block tags such as <p> <ul>
+    // add block tags such as <p> <ul>
     m_parsedResult.AddBlockTags();
 
     m_hasHTMLTag = m_parsedResult.HasHtmlTags();

--- a/source/shared/cpp/ObjectModel/MarkDownParser.h
+++ b/source/shared/cpp/ObjectModel/MarkDownParser.h
@@ -13,14 +13,14 @@ namespace AdaptiveSharedNamespace
 {
     class MarkDownParser
     {
-        public:
+    public:
         MarkDownParser(const std::string& txt);
 
         std::string TransformToHtml();
 
         bool HasHtmlTags();
 
-        private:
+    private:
         void ParseBlock();
         std::string EscapeText();
         std::string m_text;

--- a/source/shared/cpp/ObjectModel/MarkDownParser.h
+++ b/source/shared/cpp/ObjectModel/MarkDownParser.h
@@ -9,21 +9,22 @@
 #include "MarkDownBlockParser.h"
 #include "MarkDownHtmlGenerator.h"
 
-AdaptiveSharedNamespaceStart
-class MarkDownParser
+namespace AdaptiveSharedNamespace
 {
-public:
-    MarkDownParser(const std::string &txt); 
+    class MarkDownParser
+    {
+        public:
+        MarkDownParser(const std::string& txt);
 
-    std::string TransformToHtml();
+        std::string TransformToHtml();
 
-    bool HasHtmlTags();
+        bool HasHtmlTags();
 
-private:
-    void ParseBlock();
-    std::string EscapeText();
-    std::string m_text;
-    MarkDownParsedResult m_parsedResult;
-    bool m_hasHTMLTag;
-};
-AdaptiveSharedNamespaceEnd
+        private:
+        void ParseBlock();
+        std::string EscapeText();
+        std::string m_text;
+        MarkDownParsedResult m_parsedResult;
+        bool m_hasHTMLTag;
+    };
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/MarkDownParser.h
+++ b/source/shared/cpp/ObjectModel/MarkDownParser.h
@@ -14,7 +14,7 @@ namespace AdaptiveSharedNamespace
     class MarkDownParser
     {
     public:
-        MarkDownParser(const std::string& txt);
+        MarkDownParser(const std::string &txt);
 
         std::string TransformToHtml();
 

--- a/source/shared/cpp/ObjectModel/NumberInput.cpp
+++ b/source/shared/cpp/ObjectModel/NumberInput.cpp
@@ -43,7 +43,7 @@ std::string NumberInput::GetPlaceholder() const
     return m_placeholder;
 }
 
-void NumberInput::SetPlaceholder(const std::string& value)
+void NumberInput::SetPlaceholder(const std::string &value)
 {
     m_placeholder = value;
 }
@@ -79,7 +79,7 @@ void NumberInput::SetMin(const int value)
 }
 
 std::shared_ptr<BaseCardElement> NumberInputParser::Deserialize(
-    std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value& json)
+    std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value &json)
 {
     ParseUtil::ExpectTypeString(json, CardElementType::NumberInput);
 
@@ -95,7 +95,7 @@ std::shared_ptr<BaseCardElement> NumberInputParser::Deserialize(
 
 std::shared_ptr<BaseCardElement> NumberInputParser::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString)
 {
     return NumberInputParser::Deserialize(
         elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));

--- a/source/shared/cpp/ObjectModel/NumberInput.cpp
+++ b/source/shared/cpp/ObjectModel/NumberInput.cpp
@@ -5,9 +5,7 @@
 using namespace AdaptiveSharedNamespace;
 
 NumberInput::NumberInput() :
-    BaseInputElement(CardElementType::NumberInput),
-    m_value(0),
-    m_max(std::numeric_limits<int>::max()),
+    BaseInputElement(CardElementType::NumberInput), m_value(0), m_max(std::numeric_limits<int>::max()),
     m_min(std::numeric_limits<int>::min())
 {
     PopulateKnownPropertiesSet();
@@ -45,7 +43,7 @@ std::string NumberInput::GetPlaceholder() const
     return m_placeholder;
 }
 
-void NumberInput::SetPlaceholder(const std::string &value)
+void NumberInput::SetPlaceholder(const std::string& value)
 {
     m_placeholder = value;
 }
@@ -81,9 +79,7 @@ void NumberInput::SetMin(const int value)
 }
 
 std::shared_ptr<BaseCardElement> NumberInputParser::Deserialize(
-    std::shared_ptr<ElementParserRegistration>,
-    std::shared_ptr<ActionParserRegistration>,
-    const Json::Value& json)
+    std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value& json)
 {
     ParseUtil::ExpectTypeString(json, CardElementType::NumberInput);
 
@@ -99,13 +95,13 @@ std::shared_ptr<BaseCardElement> NumberInputParser::Deserialize(
 
 std::shared_ptr<BaseCardElement> NumberInputParser::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-    const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
 {
-    return NumberInputParser::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
+    return NumberInputParser::Deserialize(
+        elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
-void NumberInput::PopulateKnownPropertiesSet() 
+void NumberInput::PopulateKnownPropertiesSet()
 {
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Placeholder));
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Value));

--- a/source/shared/cpp/ObjectModel/NumberInput.h
+++ b/source/shared/cpp/ObjectModel/NumberInput.h
@@ -5,46 +5,45 @@
 #include "Enums.h"
 #include "ElementParserRegistration.h"
 
-AdaptiveSharedNamespaceStart
-class NumberInput : public BaseInputElement
+namespace AdaptiveSharedNamespace
 {
-public:
-    NumberInput();
+    class NumberInput : public BaseInputElement
+    {
+        public:
+        NumberInput();
 
-    virtual Json::Value SerializeToJsonValue() const override;
+        virtual Json::Value SerializeToJsonValue() const override;
 
-    std::string GetPlaceholder() const;
-    void SetPlaceholder(const std::string &value);
+        std::string GetPlaceholder() const;
+        void SetPlaceholder(const std::string& value);
 
-    int GetValue() const;
-    void SetValue(const int value);
+        int GetValue() const;
+        void SetValue(const int value);
 
-    int GetMax() const;
-    void SetMax(const int value);
+        int GetMax() const;
+        void SetMax(const int value);
 
-    int GetMin() const;
-    void SetMin(const int value);
+        int GetMin() const;
+        void SetMin(const int value);
 
-private:
-    void PopulateKnownPropertiesSet();
+        private:
+        void PopulateKnownPropertiesSet();
 
-    std::string m_placeholder;
-    int m_value;
-    int m_max;
-    int m_min;
-};
+        std::string m_placeholder;
+        int m_value;
+        int m_max;
+        int m_min;
+    };
 
-class NumberInputParser : public BaseCardElementParser
-{
-public:
-    std::shared_ptr<BaseCardElement> Deserialize(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const Json::Value& root);
+    class NumberInputParser : public BaseCardElementParser
+    {
+        public:
+        std::shared_ptr<BaseCardElement> Deserialize(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
 
-    std::shared_ptr<BaseCardElement> DeserializeFromString(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const std::string& jsonString);
-};
-AdaptiveSharedNamespaceEnd
+        std::shared_ptr<BaseCardElement> DeserializeFromString(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+    };
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/NumberInput.h
+++ b/source/shared/cpp/ObjectModel/NumberInput.h
@@ -9,7 +9,7 @@ namespace AdaptiveSharedNamespace
 {
     class NumberInput : public BaseInputElement
     {
-        public:
+    public:
         NumberInput();
 
         virtual Json::Value SerializeToJsonValue() const override;
@@ -26,7 +26,7 @@ namespace AdaptiveSharedNamespace
         int GetMin() const;
         void SetMin(const int value);
 
-        private:
+    private:
         void PopulateKnownPropertiesSet();
 
         std::string m_placeholder;
@@ -37,7 +37,7 @@ namespace AdaptiveSharedNamespace
 
     class NumberInputParser : public BaseCardElementParser
     {
-        public:
+    public:
         std::shared_ptr<BaseCardElement> Deserialize(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
             std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);

--- a/source/shared/cpp/ObjectModel/NumberInput.h
+++ b/source/shared/cpp/ObjectModel/NumberInput.h
@@ -15,7 +15,7 @@ namespace AdaptiveSharedNamespace
         virtual Json::Value SerializeToJsonValue() const override;
 
         std::string GetPlaceholder() const;
-        void SetPlaceholder(const std::string& value);
+        void SetPlaceholder(const std::string &value);
 
         int GetValue() const;
         void SetValue(const int value);
@@ -40,10 +40,10 @@ namespace AdaptiveSharedNamespace
     public:
         std::shared_ptr<BaseCardElement> Deserialize(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &root);
 
         std::shared_ptr<BaseCardElement> DeserializeFromString(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString);
     };
 } // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/OpenUrlAction.cpp
+++ b/source/shared/cpp/ObjectModel/OpenUrlAction.cpp
@@ -23,13 +23,13 @@ std::string OpenUrlAction::GetUrl() const
     return m_url;
 }
 
-void OpenUrlAction::SetUrl(const std::string& value)
+void OpenUrlAction::SetUrl(const std::string &value)
 {
     m_url = value;
 }
 
 std::shared_ptr<BaseActionElement> OpenUrlActionParser::Deserialize(
-    std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value& json)
+    std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value &json)
 {
     std::shared_ptr<OpenUrlAction> openUrlAction = BaseActionElement::Deserialize<OpenUrlAction>(json);
 
@@ -40,7 +40,7 @@ std::shared_ptr<BaseActionElement> OpenUrlActionParser::Deserialize(
 
 std::shared_ptr<BaseActionElement> OpenUrlActionParser::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString)
 {
     return OpenUrlActionParser::Deserialize(
         elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));

--- a/source/shared/cpp/ObjectModel/OpenUrlAction.cpp
+++ b/source/shared/cpp/ObjectModel/OpenUrlAction.cpp
@@ -23,15 +23,13 @@ std::string OpenUrlAction::GetUrl() const
     return m_url;
 }
 
-void OpenUrlAction::SetUrl(const std::string &value)
+void OpenUrlAction::SetUrl(const std::string& value)
 {
     m_url = value;
 }
 
 std::shared_ptr<BaseActionElement> OpenUrlActionParser::Deserialize(
-    std::shared_ptr<ElementParserRegistration>,
-    std::shared_ptr<ActionParserRegistration>,
-    const Json::Value& json)
+    std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value& json)
 {
     std::shared_ptr<OpenUrlAction> openUrlAction = BaseActionElement::Deserialize<OpenUrlAction>(json);
 
@@ -42,13 +40,13 @@ std::shared_ptr<BaseActionElement> OpenUrlActionParser::Deserialize(
 
 std::shared_ptr<BaseActionElement> OpenUrlActionParser::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-    const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
 {
-    return OpenUrlActionParser::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
+    return OpenUrlActionParser::Deserialize(
+        elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
-void OpenUrlAction::PopulateKnownPropertiesSet() 
+void OpenUrlAction::PopulateKnownPropertiesSet()
 {
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Url));
 }

--- a/source/shared/cpp/ObjectModel/OpenUrlAction.h
+++ b/source/shared/cpp/ObjectModel/OpenUrlAction.h
@@ -15,7 +15,7 @@ namespace AdaptiveSharedNamespace
         virtual Json::Value SerializeToJsonValue() const override;
 
         std::string GetUrl() const;
-        void SetUrl(const std::string& value);
+        void SetUrl(const std::string &value);
 
     private:
         void PopulateKnownPropertiesSet();
@@ -27,10 +27,10 @@ namespace AdaptiveSharedNamespace
     {
         std::shared_ptr<BaseActionElement> Deserialize(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& value);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &value);
 
         std::shared_ptr<BaseActionElement> DeserializeFromString(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString);
     };
 } // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/OpenUrlAction.h
+++ b/source/shared/cpp/ObjectModel/OpenUrlAction.h
@@ -5,33 +5,32 @@
 #include "Enums.h"
 #include "ActionParserRegistration.h"
 
-AdaptiveSharedNamespaceStart
-class OpenUrlAction : public BaseActionElement
+namespace AdaptiveSharedNamespace
 {
-public:
-    OpenUrlAction();
+    class OpenUrlAction : public BaseActionElement
+    {
+        public:
+        OpenUrlAction();
 
-    virtual Json::Value SerializeToJsonValue() const override;
+        virtual Json::Value SerializeToJsonValue() const override;
 
-    std::string GetUrl() const;
-    void SetUrl(const std::string &value);
+        std::string GetUrl() const;
+        void SetUrl(const std::string& value);
 
-private:
-    void PopulateKnownPropertiesSet();
+        private:
+        void PopulateKnownPropertiesSet();
 
-    std::string m_url;
-};
+        std::string m_url;
+    };
 
-class OpenUrlActionParser : public ActionElementParser
-{
-    std::shared_ptr<BaseActionElement> Deserialize(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const Json::Value& value);
+    class OpenUrlActionParser : public ActionElementParser
+    {
+        std::shared_ptr<BaseActionElement> Deserialize(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& value);
 
-    std::shared_ptr<BaseActionElement> DeserializeFromString(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const std::string& jsonString);
-};
-AdaptiveSharedNamespaceEnd
+        std::shared_ptr<BaseActionElement> DeserializeFromString(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+    };
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/OpenUrlAction.h
+++ b/source/shared/cpp/ObjectModel/OpenUrlAction.h
@@ -9,7 +9,7 @@ namespace AdaptiveSharedNamespace
 {
     class OpenUrlAction : public BaseActionElement
     {
-        public:
+    public:
         OpenUrlAction();
 
         virtual Json::Value SerializeToJsonValue() const override;
@@ -17,7 +17,7 @@ namespace AdaptiveSharedNamespace
         std::string GetUrl() const;
         void SetUrl(const std::string& value);
 
-        private:
+    private:
         void PopulateKnownPropertiesSet();
 
         std::string m_url;

--- a/source/shared/cpp/ObjectModel/ParseResult.cpp
+++ b/source/shared/cpp/ObjectModel/ParseResult.cpp
@@ -6,8 +6,7 @@
 using namespace AdaptiveSharedNamespace;
 
 ParseResult::ParseResult(
-    std::shared_ptr<AdaptiveCard> adaptiveCard,
-    std::vector<std::shared_ptr<AdaptiveCardParseWarning>> warnings) :
+    std::shared_ptr<AdaptiveCard> adaptiveCard, std::vector<std::shared_ptr<AdaptiveCardParseWarning>> warnings) :
     m_adaptiveCard(adaptiveCard),
     m_warnings(warnings)
 {

--- a/source/shared/cpp/ObjectModel/ParseResult.h
+++ b/source/shared/cpp/ObjectModel/ParseResult.h
@@ -3,21 +3,21 @@
 #include "pch.h"
 #include "AdaptiveCardParseWarning.h"
 
-AdaptiveSharedNamespaceStart
+namespace AdaptiveSharedNamespace
+{
     class AdaptiveCard;
 
     class ParseResult
     {
-    public:
-        ParseResult(
-            std::shared_ptr<AdaptiveCard> adaptiveCard,
+        public:
+        ParseResult(std::shared_ptr<AdaptiveCard> adaptiveCard,
             std::vector<std::shared_ptr<AdaptiveCardParseWarning>> warnings);
 
         std::shared_ptr<AdaptiveCard> GetAdaptiveCard() const;
         std::vector<std::shared_ptr<AdaptiveCardParseWarning>> GetWarnings() const;
 
-    private:
+        private:
         std::shared_ptr<AdaptiveCard> m_adaptiveCard;
         std::vector<std::shared_ptr<AdaptiveCardParseWarning>> m_warnings;
     };
-AdaptiveSharedNamespaceEnd
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/ParseResult.h
+++ b/source/shared/cpp/ObjectModel/ParseResult.h
@@ -9,14 +9,14 @@ namespace AdaptiveSharedNamespace
 
     class ParseResult
     {
-        public:
+    public:
         ParseResult(std::shared_ptr<AdaptiveCard> adaptiveCard,
             std::vector<std::shared_ptr<AdaptiveCardParseWarning>> warnings);
 
         std::shared_ptr<AdaptiveCard> GetAdaptiveCard() const;
         std::vector<std::shared_ptr<AdaptiveCardParseWarning>> GetWarnings() const;
 
-        private:
+    private:
         std::shared_ptr<AdaptiveCard> m_adaptiveCard;
         std::vector<std::shared_ptr<AdaptiveCardParseWarning>> m_warnings;
     };

--- a/source/shared/cpp/ObjectModel/ParseUtil.cpp
+++ b/source/shared/cpp/ObjectModel/ParseUtil.cpp
@@ -7,427 +7,439 @@
 #include "Container.h"
 #include "ShowCardAction.h"
 
-AdaptiveSharedNamespaceStart
-
-void ParseUtil::ThrowIfNotJsonObject(const Json::Value& json)
+namespace AdaptiveSharedNamespace
 {
-    if (!json.isObject()) {
-        throw AdaptiveCardParseException(ErrorStatusCode::InvalidJson, "Expected JSON Object\n");
-    }
-}
-
-void ParseUtil::ExpectString(const Json::Value& json)
-{
-    if (!json.isString())
+    void ParseUtil::ThrowIfNotJsonObject(const Json::Value& json)
     {
-        throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "The JSON element did not have the expected type 'string'");
-    }
-}
-
-// TODO: Remove? This code path might not be desirable going forward depending on how we decide to support forward compat. Task 10893205
-std::string ParseUtil::GetTypeAsString(const Json::Value& json)
-{
-    std::string typeKey = "type";
-    if (!json.isMember(typeKey))
-    {
-        throw AdaptiveCardParseException(ErrorStatusCode::RequiredPropertyMissing, "The JSON element is missing the following value: " + typeKey);
-    }
-
-    return json.get(typeKey, Json::Value()).asString();
-}
-
-std::string ParseUtil::TryGetTypeAsString(const Json::Value& json)
-{
-    try
-    {
-        return GetTypeAsString(json);
-    }
-    catch (const AdaptiveCardParseException&)
-    {
-        return "";
-    }
-
-}
-
-std::string ParseUtil::GetString(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired)
-{
-    std::string propertyName = AdaptiveCardSchemaKeyToString(key);
-    auto propertyValue = json.get(propertyName, Json::Value());
-    if (propertyValue.empty())
-    {
-        if (isRequired)
+        if (!json.isObject())
         {
-            throw AdaptiveCardParseException(ErrorStatusCode::RequiredPropertyMissing, "Property is required but was found empty: " + propertyName);
+            throw AdaptiveCardParseException(ErrorStatusCode::InvalidJson, "Expected JSON Object\n");
         }
-        else
+    }
+
+    void ParseUtil::ExpectString(const Json::Value& json)
+    {
+        if (!json.isString())
+        {
+            throw AdaptiveCardParseException(
+                ErrorStatusCode::InvalidPropertyValue, "The JSON element did not have the expected type 'string'");
+        }
+    }
+
+    // TODO: Remove? This code path might not be desirable going forward depending on how we decide to support forward
+    // compat. Task 10893205
+    std::string ParseUtil::GetTypeAsString(const Json::Value& json)
+    {
+        std::string typeKey = "type";
+        if (!json.isMember(typeKey))
+        {
+            throw AdaptiveCardParseException(ErrorStatusCode::RequiredPropertyMissing,
+                "The JSON element is missing the following value: " + typeKey);
+        }
+
+        return json.get(typeKey, Json::Value()).asString();
+    }
+
+    std::string ParseUtil::TryGetTypeAsString(const Json::Value& json)
+    {
+        try
+        {
+            return GetTypeAsString(json);
+        }
+        catch (const AdaptiveCardParseException&)
         {
             return "";
         }
     }
 
-    if (!propertyValue.isString())
+    std::string ParseUtil::GetString(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired)
     {
-        throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "Value for property " + propertyName + " was invalid. Expected type string.");
-    }
-
-    return propertyValue.asString();
-}
-
-std::string ParseUtil::GetJsonString(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired)
-{
-    std::string propertyName = AdaptiveCardSchemaKeyToString(key);
-    auto propertyValue = json.get(propertyName, Json::Value());
-    if (propertyValue.empty())
-    {
-        if (isRequired)
+        std::string propertyName = AdaptiveCardSchemaKeyToString(key);
+        auto propertyValue = json.get(propertyName, Json::Value());
+        if (propertyValue.empty())
         {
-            throw AdaptiveCardParseException(ErrorStatusCode::RequiredPropertyMissing, "Property is required but was found empty: " + propertyName);
+            if (isRequired)
+            {
+                throw AdaptiveCardParseException(ErrorStatusCode::RequiredPropertyMissing,
+                    "Property is required but was found empty: " + propertyName);
+            }
+            else
+            {
+                return "";
+            }
         }
-        else
+
+        if (!propertyValue.isString())
         {
-            return "";
+            throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue,
+                "Value for property " + propertyName + " was invalid. Expected type string.");
         }
+
+        return propertyValue.asString();
     }
 
-    return propertyValue.toStyledString();
-}
-
-std::string ParseUtil::GetValueAsString(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired)
-{
-    std::string propertyName = AdaptiveCardSchemaKeyToString(key);
-    auto propertyValue = json.get(propertyName, Json::Value());
-    if (propertyValue.empty())
+    std::string ParseUtil::GetJsonString(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired)
     {
-        if (isRequired)
+        std::string propertyName = AdaptiveCardSchemaKeyToString(key);
+        auto propertyValue = json.get(propertyName, Json::Value());
+        if (propertyValue.empty())
         {
-            throw AdaptiveCardParseException(ErrorStatusCode::RequiredPropertyMissing, "Property is required but was found empty: " + propertyName);
+            if (isRequired)
+            {
+                throw AdaptiveCardParseException(ErrorStatusCode::RequiredPropertyMissing,
+                    "Property is required but was found empty: " + propertyName);
+            }
+            else
+            {
+                return "";
+            }
         }
-        else
+
+        return propertyValue.toStyledString();
+    }
+
+    std::string ParseUtil::GetValueAsString(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired)
+    {
+        std::string propertyName = AdaptiveCardSchemaKeyToString(key);
+        auto propertyValue = json.get(propertyName, Json::Value());
+        if (propertyValue.empty())
         {
-            return "";
+            if (isRequired)
+            {
+                throw AdaptiveCardParseException(ErrorStatusCode::RequiredPropertyMissing,
+                    "Property is required but was found empty: " + propertyName);
+            }
+            else
+            {
+                return "";
+            }
         }
+
+        return propertyValue.asString();
     }
 
-    return propertyValue.asString();
-}
-
-bool ParseUtil::GetBool(const Json::Value& json, AdaptiveCardSchemaKey key, bool defaultValue, bool isRequired)
-{
-    std::string propertyName = AdaptiveCardSchemaKeyToString(key);
-    auto propertyValue = json.get(propertyName, Json::Value());
-    if (propertyValue.empty())
+    bool ParseUtil::GetBool(const Json::Value& json, AdaptiveCardSchemaKey key, bool defaultValue, bool isRequired)
     {
-        if (isRequired)
+        std::string propertyName = AdaptiveCardSchemaKeyToString(key);
+        auto propertyValue = json.get(propertyName, Json::Value());
+        if (propertyValue.empty())
         {
-            throw AdaptiveCardParseException(ErrorStatusCode::RequiredPropertyMissing, "Property is required but was found empty: " + propertyName);
+            if (isRequired)
+            {
+                throw AdaptiveCardParseException(ErrorStatusCode::RequiredPropertyMissing,
+                    "Property is required but was found empty: " + propertyName);
+            }
+            else
+            {
+                return defaultValue;
+            }
         }
-        else
+
+        if (!propertyValue.isBool())
         {
-            return defaultValue;
+            throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue,
+                "Value for property " + propertyName + " was invalid. Expected type bool.");
         }
+
+        return propertyValue.asBool();
     }
 
-    if (!propertyValue.isBool())
+    unsigned int ParseUtil::GetUInt(
+        const Json::Value& json, AdaptiveCardSchemaKey key, unsigned int defaultValue, bool isRequired)
     {
-        throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "Value for property " + propertyName + " was invalid. Expected type bool.");
-    }
-
-    return propertyValue.asBool();
-}
-
-unsigned int ParseUtil::GetUInt(const Json::Value & json, AdaptiveCardSchemaKey key, unsigned int defaultValue, bool isRequired)
-{
-    std::string propertyName = AdaptiveCardSchemaKeyToString(key);
-    auto propertyValue = json.get(propertyName, Json::Value());
-    if (propertyValue.empty())
-    {
-        if (isRequired)
+        std::string propertyName = AdaptiveCardSchemaKeyToString(key);
+        auto propertyValue = json.get(propertyName, Json::Value());
+        if (propertyValue.empty())
         {
-            throw AdaptiveCardParseException(ErrorStatusCode::RequiredPropertyMissing, "Property is required but was found empty: " + propertyName);
+            if (isRequired)
+            {
+                throw AdaptiveCardParseException(ErrorStatusCode::RequiredPropertyMissing,
+                    "Property is required but was found empty: " + propertyName);
+            }
+            else
+            {
+                return defaultValue;
+            }
         }
-        else
+
+        if (!propertyValue.isUInt())
         {
-            return defaultValue;
+            throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue,
+                "Value for property " + propertyName + " was invalid. Expected type uInt.");
         }
+
+        return propertyValue.asUInt();
     }
 
-    if (!propertyValue.isUInt())
+    int ParseUtil::GetInt(const Json::Value& json, AdaptiveCardSchemaKey key, int defaultValue, bool isRequired)
     {
-        throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "Value for property " + propertyName + " was invalid. Expected type uInt.");
-    }
-
-    return propertyValue.asUInt();
-}
-
-int ParseUtil::GetInt(const Json::Value & json, AdaptiveCardSchemaKey key, int defaultValue, bool isRequired)
-{
-    std::string propertyName = AdaptiveCardSchemaKeyToString(key);
-    auto propertyValue = json.get(propertyName, Json::Value());
-    if (propertyValue.empty())
-    {
-        if (isRequired)
+        std::string propertyName = AdaptiveCardSchemaKeyToString(key);
+        auto propertyValue = json.get(propertyName, Json::Value());
+        if (propertyValue.empty())
         {
-            throw AdaptiveCardParseException(ErrorStatusCode::RequiredPropertyMissing, "Property is required but was found empty: " + propertyName);
+            if (isRequired)
+            {
+                throw AdaptiveCardParseException(ErrorStatusCode::RequiredPropertyMissing,
+                    "Property is required but was found empty: " + propertyName);
+            }
+            else
+            {
+                return defaultValue;
+            }
         }
-        else
+
+        if (!propertyValue.isInt())
         {
-            return defaultValue;
+            throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue,
+                "Value for property " + propertyName + " was invalid. Expected type int.");
+        }
+
+        return propertyValue.asInt();
+    }
+
+    void ParseUtil::ExpectTypeString(const Json::Value& json, CardElementType bodyType)
+    {
+        std::string actualType = GetTypeAsString(json);
+        std::string expectedTypeStr = CardElementTypeToString(bodyType);
+        bool isTypeCorrect = expectedTypeStr.compare(actualType) == 0;
+        if (!isTypeCorrect)
+        {
+            throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue,
+                "The JSON element did not have the correct type. Expected: " + expectedTypeStr +
+                    ", Actual: " + actualType);
         }
     }
 
-    if (!propertyValue.isInt())
+    // throws if the key is missing or the value mapped to the key is the wrong type
+    void ParseUtil::ExpectKeyAndValueType(
+        const Json::Value& json, const char* expectedKey, std::function<void(const Json::Value&)> throwIfWrongType)
     {
-        throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "Value for property " + propertyName + " was invalid. Expected type int.");
+        if (expectedKey == nullptr)
+        {
+            throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "null expectedKey");
+        }
+
+        if (!json.isMember(expectedKey))
+        {
+            throw AdaptiveCardParseException(ErrorStatusCode::RequiredPropertyMissing,
+                "The JSON element is missing the following key: " + std::string(expectedKey));
+        }
+
+        auto value = json.get(expectedKey, Json::Value());
+        throwIfWrongType(value);
     }
 
-    return propertyValue.asInt();
-}
-
-void ParseUtil::ExpectTypeString(const Json::Value& json, CardElementType bodyType)
-{
-    std::string actualType = GetTypeAsString(json);
-    std::string expectedTypeStr = CardElementTypeToString(bodyType);
-    bool isTypeCorrect = expectedTypeStr.compare(actualType) == 0;
-    if (!isTypeCorrect)
+    CardElementType ParseUtil::GetCardElementType(const Json::Value& json)
     {
-        throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "The JSON element did not have the correct type. Expected: " + expectedTypeStr + ", Actual: " + actualType);
-    }
-}
-
-// throws if the key is missing or the value mapped to the key is the wrong type
-void ParseUtil::ExpectKeyAndValueType(const Json::Value& json, const char* expectedKey, std::function<void(const Json::Value&)> throwIfWrongType)
-{
-    if (expectedKey == nullptr)
-    {
-        throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "null expectedKey");
+        std::string actualType = GetTypeAsString(json);
+        try
+        {
+            return CardElementTypeFromString(actualType);
+        }
+        catch (const std::out_of_range&)
+        {
+            throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "Invalid CardElementType");
+        }
     }
 
-    if (!json.isMember(expectedKey))
+    CardElementType ParseUtil::TryGetCardElementType(const Json::Value& json)
     {
-        throw AdaptiveCardParseException(ErrorStatusCode::RequiredPropertyMissing, "The JSON element is missing the following key: " + std::string(expectedKey));
+        try
+        {
+            return GetCardElementType(json);
+        }
+        catch (const AdaptiveCardParseException&)
+        {
+            return CardElementType::Unsupported;
+        }
     }
 
-    auto value = json.get(expectedKey, Json::Value());
-    throwIfWrongType(value);
-}
-
-CardElementType ParseUtil::GetCardElementType(const Json::Value& json)
-{
-    std::string actualType = GetTypeAsString(json);
-    try
+    ActionType ParseUtil::GetActionType(const Json::Value& json)
     {
-        return CardElementTypeFromString(actualType);
-    }
-    catch (const std::out_of_range&)
-    {
-        throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "Invalid CardElementType");
-    }
-}
-
-CardElementType ParseUtil::TryGetCardElementType(const Json::Value& json)
-{
-    try
-    {
-        return GetCardElementType(json);
-    }
-    catch (const AdaptiveCardParseException&)
-    {
-        return CardElementType::Unsupported;
-    }
-}
-
-ActionType ParseUtil::GetActionType(const Json::Value& json)
-{
-    std::string actualType = GetTypeAsString(json);
-    try
-    {
-        return ActionTypeFromString(actualType);
-    }
-    catch (const std::out_of_range&)
-    {
-        throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "Invalid ActionType");
-    }
-}
-
-ActionType ParseUtil::TryGetActionType(const Json::Value& json)
-{
-    try
-    {
-        return GetActionType(json);
-    }
-    catch (const AdaptiveCardParseException&)
-    {
-        return ActionType::Unsupported;
-    }
-}
-
-Json::Value ParseUtil::GetArray(
-    const Json::Value& json,
-    AdaptiveCardSchemaKey key,
-    bool isRequired)
-{
-    std::string propertyName = AdaptiveCardSchemaKeyToString(key);
-    auto elementArray = json.get(propertyName, Json::Value());
-    if (isRequired && elementArray.empty())
-    {
-        throw AdaptiveCardParseException(ErrorStatusCode::RequiredPropertyMissing, "Could not parse required key: " + propertyName + ". It was not found");
+        std::string actualType = GetTypeAsString(json);
+        try
+        {
+            return ActionTypeFromString(actualType);
+        }
+        catch (const std::out_of_range&)
+        {
+            throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "Invalid ActionType");
+        }
     }
 
-    if (!elementArray.empty() && !elementArray.isArray())
+    ActionType ParseUtil::TryGetActionType(const Json::Value& json)
     {
-        throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "Could not parse specified key: " + propertyName + ". It was not an array");
+        try
+        {
+            return GetActionType(json);
+        }
+        catch (const AdaptiveCardParseException&)
+        {
+            return ActionType::Unsupported;
+        }
     }
-    return elementArray;
-}
 
-Json::Value ParseUtil::GetJsonValueFromString(const std::string &jsonString)
-{
-    Json::Reader reader;
-    Json::Value jsonValue;
-    if (!reader.parse(jsonString.c_str(), jsonValue))
+    Json::Value ParseUtil::GetArray(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired)
     {
-        throw AdaptiveCardParseException(ErrorStatusCode::InvalidJson, "Expected JSON Object\n");
+        std::string propertyName = AdaptiveCardSchemaKeyToString(key);
+        auto elementArray = json.get(propertyName, Json::Value());
+        if (isRequired && elementArray.empty())
+        {
+            throw AdaptiveCardParseException(ErrorStatusCode::RequiredPropertyMissing,
+                "Could not parse required key: " + propertyName + ". It was not found");
+        }
+
+        if (!elementArray.empty() && !elementArray.isArray())
+        {
+            throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue,
+                "Could not parse specified key: " + propertyName + ". It was not an array");
+        }
+        return elementArray;
     }
-    return jsonValue;
-}
 
-Json::Value ParseUtil::ExtractJsonValue(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired)
-{
-    std::string propertyName = AdaptiveCardSchemaKeyToString(key);
-    auto propertyValue = json.get(propertyName, Json::Value());
-    if (isRequired && propertyValue.empty())
+    Json::Value ParseUtil::GetJsonValueFromString(const std::string& jsonString)
     {
-        throw AdaptiveCardParseException(ErrorStatusCode::RequiredPropertyMissing, "Could not extract required key: " + propertyName + ".");
+        Json::Reader reader;
+        Json::Value jsonValue;
+        if (!reader.parse(jsonString.c_str(), jsonValue))
+        {
+            throw AdaptiveCardParseException(ErrorStatusCode::InvalidJson, "Expected JSON Object\n");
+        }
+        return jsonValue;
     }
-    return propertyValue;
-}
 
-std::string ParseUtil::ToLowercase(std::string const &value)
-{
-    std::string new_value;
-    new_value.resize(value.size());
-    std::transform(value.begin(), value.end(), new_value.begin(), [](char c) { return std::tolower(c, std::locale()); });
-    return new_value;
-}
-
-std::vector<std::shared_ptr<BaseCardElement>> ParseUtil::GetElementCollection(
-    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-    const Json::Value& json,
-    AdaptiveCardSchemaKey key,
-    bool isRequired)
-{
-    auto elementArray = GetArray(json, key, isRequired);
-
-    std::vector<std::shared_ptr<BaseCardElement>> elements;
-    if (elementArray.empty())
+    Json::Value ParseUtil::ExtractJsonValue(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired)
     {
+        std::string propertyName = AdaptiveCardSchemaKeyToString(key);
+        auto propertyValue = json.get(propertyName, Json::Value());
+        if (isRequired && propertyValue.empty())
+        {
+            throw AdaptiveCardParseException(
+                ErrorStatusCode::RequiredPropertyMissing, "Could not extract required key: " + propertyName + ".");
+        }
+        return propertyValue;
+    }
+
+    std::string ParseUtil::ToLowercase(std::string const& value)
+    {
+        std::string new_value;
+        new_value.resize(value.size());
+        std::transform(
+            value.begin(), value.end(), new_value.begin(), [](char c) { return std::tolower(c, std::locale()); });
+        return new_value;
+    }
+
+    std::vector<std::shared_ptr<BaseCardElement>> ParseUtil::GetElementCollection(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& json,
+        AdaptiveCardSchemaKey key, bool isRequired)
+    {
+        auto elementArray = GetArray(json, key, isRequired);
+
+        std::vector<std::shared_ptr<BaseCardElement>> elements;
+        if (elementArray.empty())
+        {
+            return elements;
+        }
+
+        elements.reserve(elementArray.size());
+
+        for (const auto& curJsonValue : elementArray)
+        {
+            // Get the element's type
+            std::string typeString = GetTypeAsString(curJsonValue);
+
+            std::shared_ptr<BaseCardElementParser> parser = elementParserRegistration->GetParser(typeString);
+
+            // Parse it if it's allowed by the current parsers
+            if (parser != nullptr)
+            {
+                // Use the parser that maps to the type
+                elements.push_back(
+                    parser->Deserialize(elementParserRegistration, actionParserRegistration, curJsonValue));
+            }
+            else
+            {
+                parser = elementParserRegistration->GetParser("Unknown");
+                elements.push_back(
+                    parser->Deserialize(elementParserRegistration, actionParserRegistration, curJsonValue));
+            }
+        }
+
         return elements;
     }
 
-    elements.reserve(elementArray.size());
-
-    for (const auto& curJsonValue : elementArray)
+    std::shared_ptr<BaseActionElement> ParseUtil::GetActionFromJsonValue(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& json)
     {
+        if (json.empty() || !json.isObject())
+        {
+            throw AdaptiveCardParseException(
+                ErrorStatusCode::InvalidPropertyValue, "Expected a Json object to extract Action element");
+        }
+
         // Get the element's type
-        std::string typeString = GetTypeAsString(curJsonValue);
+        std::string typeString = GetTypeAsString(json);
 
-        std::shared_ptr<BaseCardElementParser> parser = elementParserRegistration->GetParser(typeString);
+        auto parser = actionParserRegistration->GetParser(typeString);
 
-        //Parse it if it's allowed by the current parsers
+        // Parse it if it's allowed by the current parsers
         if (parser != nullptr)
         {
             // Use the parser that maps to the type
-            elements.push_back(parser->Deserialize(elementParserRegistration, actionParserRegistration, curJsonValue));
+            return parser->Deserialize(elementParserRegistration, actionParserRegistration, json);
         }
-        else
+
+        return nullptr;
+    }
+
+    std::vector<std::shared_ptr<BaseActionElement>> ParseUtil::GetActionCollection(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& json,
+        AdaptiveCardSchemaKey key, bool isRequired)
+    {
+        auto elementArray = GetArray(json, key, isRequired);
+
+        std::vector<std::shared_ptr<BaseActionElement>> elements;
+
+        if (elementArray.empty())
         {
-            parser = elementParserRegistration->GetParser("Unknown");
-            elements.push_back(parser->Deserialize(elementParserRegistration, actionParserRegistration, curJsonValue));
+            return elements;
         }
-    }
 
-    return elements;
-}
+        elements.reserve(elementArray.size());
 
-std::shared_ptr<BaseActionElement> ParseUtil::GetActionFromJsonValue(
-    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-    const Json::Value& json)
-{
-    if (json.empty() || !json.isObject())
-    {
-        throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "Expected a Json object to extract Action element");
-    }
+        for (const auto& curJsonValue : elementArray)
+        {
+            auto action =
+                ParseUtil::GetActionFromJsonValue(elementParserRegistration, actionParserRegistration, curJsonValue);
+            if (action != nullptr)
+            {
+                elements.push_back(action);
+            }
+        }
 
-    // Get the element's type
-    std::string typeString = GetTypeAsString(json);
-
-    auto parser = actionParserRegistration->GetParser(typeString);
-
-    //Parse it if it's allowed by the current parsers
-    if (parser != nullptr)
-    {
-        // Use the parser that maps to the type
-        return parser->Deserialize(elementParserRegistration, actionParserRegistration, json);
-    }
-
-    return nullptr;
-}
-
-std::vector<std::shared_ptr<BaseActionElement>> ParseUtil::GetActionCollection(
-    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-    const Json::Value& json,
-    AdaptiveCardSchemaKey key,
-    bool isRequired)
-{
-    auto elementArray = GetArray(json, key, isRequired);
-
-    std::vector<std::shared_ptr<BaseActionElement>> elements;
-
-    if (elementArray.empty())
-    {
         return elements;
     }
 
-    elements.reserve(elementArray.size());
-
-    for (const auto& curJsonValue : elementArray)
+    std::shared_ptr<BaseActionElement> ParseUtil::GetSelectAction(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& json,
+        AdaptiveCardSchemaKey key, bool isRequired)
     {
-        auto action = ParseUtil::GetActionFromJsonValue(elementParserRegistration, actionParserRegistration, curJsonValue);
-        if (action != nullptr)
+        auto selectAction = ParseUtil::ExtractJsonValue(json, key, isRequired);
+
+        if (!selectAction.empty())
         {
-            elements.push_back(action);
+            return ParseUtil::GetActionFromJsonValue(elementParserRegistration, actionParserRegistration, selectAction);
         }
+
+        return nullptr;
     }
 
-    return elements;
-}
+    ParseUtil::ParseUtil() {}
 
-std::shared_ptr<BaseActionElement> ParseUtil::GetSelectAction(
-    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-    const Json::Value& json,
-    AdaptiveCardSchemaKey key,
-    bool isRequired)
-{
-    auto selectAction = ParseUtil::ExtractJsonValue(json, key, isRequired);
+    ParseUtil::~ParseUtil() {}
 
-    if (!selectAction.empty())
-    {
-        return ParseUtil::GetActionFromJsonValue(elementParserRegistration, actionParserRegistration, selectAction);
-    }
-
-    return nullptr;
-}
-
-ParseUtil::ParseUtil()
-{
-}
-
-ParseUtil::~ParseUtil()
-{
-}
-
-AdaptiveSharedNamespaceEnd
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/ParseUtil.cpp
+++ b/source/shared/cpp/ObjectModel/ParseUtil.cpp
@@ -9,7 +9,7 @@
 
 namespace AdaptiveSharedNamespace
 {
-    void ParseUtil::ThrowIfNotJsonObject(const Json::Value& json)
+    void ParseUtil::ThrowIfNotJsonObject(const Json::Value &json)
     {
         if (!json.isObject())
         {
@@ -17,7 +17,7 @@ namespace AdaptiveSharedNamespace
         }
     }
 
-    void ParseUtil::ExpectString(const Json::Value& json)
+    void ParseUtil::ExpectString(const Json::Value &json)
     {
         if (!json.isString())
         {
@@ -28,7 +28,7 @@ namespace AdaptiveSharedNamespace
 
     // TODO: Remove? This code path might not be desirable going forward depending on how we decide to support forward
     // compat. Task 10893205
-    std::string ParseUtil::GetTypeAsString(const Json::Value& json)
+    std::string ParseUtil::GetTypeAsString(const Json::Value &json)
     {
         std::string typeKey = "type";
         if (!json.isMember(typeKey))
@@ -40,19 +40,19 @@ namespace AdaptiveSharedNamespace
         return json.get(typeKey, Json::Value()).asString();
     }
 
-    std::string ParseUtil::TryGetTypeAsString(const Json::Value& json)
+    std::string ParseUtil::TryGetTypeAsString(const Json::Value &json)
     {
         try
         {
             return GetTypeAsString(json);
         }
-        catch (const AdaptiveCardParseException&)
+        catch (const AdaptiveCardParseException &)
         {
             return "";
         }
     }
 
-    std::string ParseUtil::GetString(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired)
+    std::string ParseUtil::GetString(const Json::Value &json, AdaptiveCardSchemaKey key, bool isRequired)
     {
         std::string propertyName = AdaptiveCardSchemaKeyToString(key);
         auto propertyValue = json.get(propertyName, Json::Value());
@@ -78,7 +78,7 @@ namespace AdaptiveSharedNamespace
         return propertyValue.asString();
     }
 
-    std::string ParseUtil::GetJsonString(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired)
+    std::string ParseUtil::GetJsonString(const Json::Value &json, AdaptiveCardSchemaKey key, bool isRequired)
     {
         std::string propertyName = AdaptiveCardSchemaKeyToString(key);
         auto propertyValue = json.get(propertyName, Json::Value());
@@ -98,7 +98,7 @@ namespace AdaptiveSharedNamespace
         return propertyValue.toStyledString();
     }
 
-    std::string ParseUtil::GetValueAsString(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired)
+    std::string ParseUtil::GetValueAsString(const Json::Value &json, AdaptiveCardSchemaKey key, bool isRequired)
     {
         std::string propertyName = AdaptiveCardSchemaKeyToString(key);
         auto propertyValue = json.get(propertyName, Json::Value());
@@ -118,7 +118,7 @@ namespace AdaptiveSharedNamespace
         return propertyValue.asString();
     }
 
-    bool ParseUtil::GetBool(const Json::Value& json, AdaptiveCardSchemaKey key, bool defaultValue, bool isRequired)
+    bool ParseUtil::GetBool(const Json::Value &json, AdaptiveCardSchemaKey key, bool defaultValue, bool isRequired)
     {
         std::string propertyName = AdaptiveCardSchemaKeyToString(key);
         auto propertyValue = json.get(propertyName, Json::Value());
@@ -145,7 +145,7 @@ namespace AdaptiveSharedNamespace
     }
 
     unsigned int ParseUtil::GetUInt(
-        const Json::Value& json, AdaptiveCardSchemaKey key, unsigned int defaultValue, bool isRequired)
+        const Json::Value &json, AdaptiveCardSchemaKey key, unsigned int defaultValue, bool isRequired)
     {
         std::string propertyName = AdaptiveCardSchemaKeyToString(key);
         auto propertyValue = json.get(propertyName, Json::Value());
@@ -171,7 +171,7 @@ namespace AdaptiveSharedNamespace
         return propertyValue.asUInt();
     }
 
-    int ParseUtil::GetInt(const Json::Value& json, AdaptiveCardSchemaKey key, int defaultValue, bool isRequired)
+    int ParseUtil::GetInt(const Json::Value &json, AdaptiveCardSchemaKey key, int defaultValue, bool isRequired)
     {
         std::string propertyName = AdaptiveCardSchemaKeyToString(key);
         auto propertyValue = json.get(propertyName, Json::Value());
@@ -197,7 +197,7 @@ namespace AdaptiveSharedNamespace
         return propertyValue.asInt();
     }
 
-    void ParseUtil::ExpectTypeString(const Json::Value& json, CardElementType bodyType)
+    void ParseUtil::ExpectTypeString(const Json::Value &json, CardElementType bodyType)
     {
         std::string actualType = GetTypeAsString(json);
         std::string expectedTypeStr = CardElementTypeToString(bodyType);
@@ -212,7 +212,7 @@ namespace AdaptiveSharedNamespace
 
     // throws if the key is missing or the value mapped to the key is the wrong type
     void ParseUtil::ExpectKeyAndValueType(
-        const Json::Value& json, const char* expectedKey, std::function<void(const Json::Value&)> throwIfWrongType)
+        const Json::Value &json, const char *expectedKey, std::function<void(const Json::Value &)> throwIfWrongType)
     {
         if (expectedKey == nullptr)
         {
@@ -229,57 +229,57 @@ namespace AdaptiveSharedNamespace
         throwIfWrongType(value);
     }
 
-    CardElementType ParseUtil::GetCardElementType(const Json::Value& json)
+    CardElementType ParseUtil::GetCardElementType(const Json::Value &json)
     {
         std::string actualType = GetTypeAsString(json);
         try
         {
             return CardElementTypeFromString(actualType);
         }
-        catch (const std::out_of_range&)
+        catch (const std::out_of_range &)
         {
             throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "Invalid CardElementType");
         }
     }
 
-    CardElementType ParseUtil::TryGetCardElementType(const Json::Value& json)
+    CardElementType ParseUtil::TryGetCardElementType(const Json::Value &json)
     {
         try
         {
             return GetCardElementType(json);
         }
-        catch (const AdaptiveCardParseException&)
+        catch (const AdaptiveCardParseException &)
         {
             return CardElementType::Unsupported;
         }
     }
 
-    ActionType ParseUtil::GetActionType(const Json::Value& json)
+    ActionType ParseUtil::GetActionType(const Json::Value &json)
     {
         std::string actualType = GetTypeAsString(json);
         try
         {
             return ActionTypeFromString(actualType);
         }
-        catch (const std::out_of_range&)
+        catch (const std::out_of_range &)
         {
             throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "Invalid ActionType");
         }
     }
 
-    ActionType ParseUtil::TryGetActionType(const Json::Value& json)
+    ActionType ParseUtil::TryGetActionType(const Json::Value &json)
     {
         try
         {
             return GetActionType(json);
         }
-        catch (const AdaptiveCardParseException&)
+        catch (const AdaptiveCardParseException &)
         {
             return ActionType::Unsupported;
         }
     }
 
-    Json::Value ParseUtil::GetArray(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired)
+    Json::Value ParseUtil::GetArray(const Json::Value &json, AdaptiveCardSchemaKey key, bool isRequired)
     {
         std::string propertyName = AdaptiveCardSchemaKeyToString(key);
         auto elementArray = json.get(propertyName, Json::Value());
@@ -297,7 +297,7 @@ namespace AdaptiveSharedNamespace
         return elementArray;
     }
 
-    Json::Value ParseUtil::GetJsonValueFromString(const std::string& jsonString)
+    Json::Value ParseUtil::GetJsonValueFromString(const std::string &jsonString)
     {
         Json::Reader reader;
         Json::Value jsonValue;
@@ -308,7 +308,7 @@ namespace AdaptiveSharedNamespace
         return jsonValue;
     }
 
-    Json::Value ParseUtil::ExtractJsonValue(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired)
+    Json::Value ParseUtil::ExtractJsonValue(const Json::Value &json, AdaptiveCardSchemaKey key, bool isRequired)
     {
         std::string propertyName = AdaptiveCardSchemaKeyToString(key);
         auto propertyValue = json.get(propertyName, Json::Value());
@@ -320,7 +320,7 @@ namespace AdaptiveSharedNamespace
         return propertyValue;
     }
 
-    std::string ParseUtil::ToLowercase(std::string const& value)
+    std::string ParseUtil::ToLowercase(std::string const &value)
     {
         std::string new_value;
         new_value.resize(value.size());
@@ -331,7 +331,7 @@ namespace AdaptiveSharedNamespace
 
     std::vector<std::shared_ptr<BaseCardElement>> ParseUtil::GetElementCollection(
         std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& json,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &json,
         AdaptiveCardSchemaKey key, bool isRequired)
     {
         auto elementArray = GetArray(json, key, isRequired);
@@ -344,7 +344,7 @@ namespace AdaptiveSharedNamespace
 
         elements.reserve(elementArray.size());
 
-        for (const auto& curJsonValue : elementArray)
+        for (const auto &curJsonValue : elementArray)
         {
             // Get the element's type
             std::string typeString = GetTypeAsString(curJsonValue);
@@ -371,7 +371,7 @@ namespace AdaptiveSharedNamespace
 
     std::shared_ptr<BaseActionElement> ParseUtil::GetActionFromJsonValue(
         std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& json)
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &json)
     {
         if (json.empty() || !json.isObject())
         {
@@ -396,7 +396,7 @@ namespace AdaptiveSharedNamespace
 
     std::vector<std::shared_ptr<BaseActionElement>> ParseUtil::GetActionCollection(
         std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& json,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &json,
         AdaptiveCardSchemaKey key, bool isRequired)
     {
         auto elementArray = GetArray(json, key, isRequired);
@@ -410,7 +410,7 @@ namespace AdaptiveSharedNamespace
 
         elements.reserve(elementArray.size());
 
-        for (const auto& curJsonValue : elementArray)
+        for (const auto &curJsonValue : elementArray)
         {
             auto action =
                 ParseUtil::GetActionFromJsonValue(elementParserRegistration, actionParserRegistration, curJsonValue);
@@ -425,7 +425,7 @@ namespace AdaptiveSharedNamespace
 
     std::shared_ptr<BaseActionElement> ParseUtil::GetSelectAction(
         std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& json,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &json,
         AdaptiveCardSchemaKey key, bool isRequired)
     {
         auto selectAction = ParseUtil::ExtractJsonValue(json, key, isRequired);

--- a/source/shared/cpp/ObjectModel/ParseUtil.h
+++ b/source/shared/cpp/ObjectModel/ParseUtil.h
@@ -14,7 +14,7 @@ namespace AdaptiveSharedNamespace
 
     class ParseUtil
     {
-        public:
+    public:
         static void ThrowIfNotJsonObject(const Json::Value& json);
 
         static void ExpectString(const Json::Value& json);
@@ -99,7 +99,7 @@ namespace AdaptiveSharedNamespace
 
         static std::string ToLowercase(const std::string& value);
 
-        private:
+    private:
         ParseUtil();
         ~ParseUtil();
     };

--- a/source/shared/cpp/ObjectModel/ParseUtil.h
+++ b/source/shared/cpp/ObjectModel/ParseUtil.h
@@ -15,89 +15,89 @@ namespace AdaptiveSharedNamespace
     class ParseUtil
     {
     public:
-        static void ThrowIfNotJsonObject(const Json::Value& json);
+        static void ThrowIfNotJsonObject(const Json::Value &json);
 
-        static void ExpectString(const Json::Value& json);
+        static void ExpectString(const Json::Value &json);
 
-        static std::string GetTypeAsString(const Json::Value& json);
+        static std::string GetTypeAsString(const Json::Value &json);
 
-        static std::string TryGetTypeAsString(const Json::Value& json);
+        static std::string TryGetTypeAsString(const Json::Value &json);
 
-        static std::string GetString(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired = false);
+        static std::string GetString(const Json::Value &json, AdaptiveCardSchemaKey key, bool isRequired = false);
 
         // Gets the specified property and returns a JSON string of the value
-        static std::string GetJsonString(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired = false);
+        static std::string GetJsonString(const Json::Value &json, AdaptiveCardSchemaKey key, bool isRequired = false);
 
         static std::string GetValueAsString(
-            const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired = false);
+            const Json::Value &json, AdaptiveCardSchemaKey key, bool isRequired = false);
 
         static bool GetBool(
-            const Json::Value& json, AdaptiveCardSchemaKey key, bool defaultValue, bool isRequired = false);
+            const Json::Value &json, AdaptiveCardSchemaKey key, bool defaultValue, bool isRequired = false);
 
         static unsigned int GetUInt(
-            const Json::Value& json, AdaptiveCardSchemaKey key, unsigned int defaultValue, bool isRequired = false);
+            const Json::Value &json, AdaptiveCardSchemaKey key, unsigned int defaultValue, bool isRequired = false);
 
         static int GetInt(
-            const Json::Value& json, AdaptiveCardSchemaKey key, int defaultValue, bool isRequired = false);
+            const Json::Value &json, AdaptiveCardSchemaKey key, int defaultValue, bool isRequired = false);
 
-        static CardElementType GetCardElementType(const Json::Value& json);
+        static CardElementType GetCardElementType(const Json::Value &json);
 
-        static CardElementType TryGetCardElementType(const Json::Value& json);
+        static CardElementType TryGetCardElementType(const Json::Value &json);
 
-        static ActionType GetActionType(const Json::Value& json);
+        static ActionType GetActionType(const Json::Value &json);
 
-        static ActionType TryGetActionType(const Json::Value& json);
+        static ActionType TryGetActionType(const Json::Value &json);
 
-        static Json::Value GetArray(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired = false);
+        static Json::Value GetArray(const Json::Value &json, AdaptiveCardSchemaKey key, bool isRequired = false);
 
-        static Json::Value GetJsonValueFromString(const std::string& jsonString);
+        static Json::Value GetJsonValueFromString(const std::string &jsonString);
 
         static Json::Value ExtractJsonValue(
-            const Json::Value& jsonRoot, AdaptiveCardSchemaKey key, bool isRequired = false);
+            const Json::Value &jsonRoot, AdaptiveCardSchemaKey key, bool isRequired = false);
 
         template<typename T>
-        static T GetEnumValue(const Json::Value& json, AdaptiveCardSchemaKey key, T defaultEnumValue,
-            std::function<T(const std::string& name)> enumConverter, bool isRequired = false);
+        static T GetEnumValue(const Json::Value &json, AdaptiveCardSchemaKey key, T defaultEnumValue,
+            std::function<T(const std::string &name)> enumConverter, bool isRequired = false);
 
         static std::vector<std::shared_ptr<BaseCardElement>> GetElementCollection(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& json,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &json,
             AdaptiveCardSchemaKey key, bool isRequired = false);
 
         template<typename T>
         static std::vector<std::shared_ptr<T>> GetElementCollectionOfSingleType(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& json,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &json,
             AdaptiveCardSchemaKey key,
             const std::function<std::shared_ptr<T>(std::shared_ptr<ElementParserRegistration>,
-                std::shared_ptr<ActionParserRegistration>, const Json::Value&)>& deserializer,
+                std::shared_ptr<ActionParserRegistration>, const Json::Value &)> &deserializer,
             bool isRequired = false);
 
         static std::vector<std::shared_ptr<BaseActionElement>> GetActionCollection(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& json,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &json,
             AdaptiveCardSchemaKey key, bool isRequired = false);
 
         static std::shared_ptr<BaseActionElement> GetSelectAction(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& json,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &json,
             AdaptiveCardSchemaKey key, bool isRequired = false);
 
         template<typename T>
-        static T ExtractJsonValueAndMergeWithDefault(const Json::Value& rootJson, AdaptiveCardSchemaKey key,
-            const T& defaultValue, const std::function<T(const Json::Value&, const T&)>& deserializer);
+        static T ExtractJsonValueAndMergeWithDefault(const Json::Value &rootJson, AdaptiveCardSchemaKey key,
+            const T &defaultValue, const std::function<T(const Json::Value &, const T &)> &deserializer);
 
         static std::shared_ptr<BaseActionElement> GetActionFromJsonValue(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& json);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &json);
 
-        static void ExpectTypeString(const Json::Value& json, CardElementType bodyType);
+        static void ExpectTypeString(const Json::Value &json, CardElementType bodyType);
 
         // throws if the key is missing or the value mapped to the key is the wrong type
-        static void ExpectKeyAndValueType(
-            const Json::Value& json, const char* expectedKey, std::function<void(const Json::Value&)> throwIfWrongType);
+        static void ExpectKeyAndValueType(const Json::Value &json, const char *expectedKey,
+            std::function<void(const Json::Value &)> throwIfWrongType);
 
-        static std::string ToLowercase(const std::string& value);
+        static std::string ToLowercase(const std::string &value);
 
     private:
         ParseUtil();
@@ -105,14 +105,14 @@ namespace AdaptiveSharedNamespace
     };
 
     template<typename T>
-    T ParseUtil::GetEnumValue(const Json::Value& json, AdaptiveCardSchemaKey key, T defaultEnumValue,
-        std::function<T(const std::string& name)> enumConverter, bool isRequired)
+    T ParseUtil::GetEnumValue(const Json::Value &json, AdaptiveCardSchemaKey key, T defaultEnumValue,
+        std::function<T(const std::string &name)> enumConverter, bool isRequired)
     {
         std::string propertyValueStr = "";
         try
         {
             const std::string propertyName = AdaptiveCardSchemaKeyToString(key);
-            auto const& propertyValue = json.get(propertyName, Json::Value());
+            auto const &propertyValue = json.get(propertyName, Json::Value());
             if (propertyValue.empty())
             {
                 if (isRequired)
@@ -135,7 +135,7 @@ namespace AdaptiveSharedNamespace
             propertyValueStr = propertyValue.asString();
             return enumConverter(propertyValueStr);
         }
-        catch (const std::out_of_range&)
+        catch (const std::out_of_range &)
         {
             // TODO: Uncomment and add to warnings instead of throwing.
             // throw AdaptiveCardParseException("Enum type was out of range. Actual: " + propertyValueStr);
@@ -146,10 +146,10 @@ namespace AdaptiveSharedNamespace
     template<typename T>
     std::vector<std::shared_ptr<T>> ParseUtil::GetElementCollectionOfSingleType(
         std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& json,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &json,
         AdaptiveCardSchemaKey key,
         const std::function<std::shared_ptr<T>(std::shared_ptr<ElementParserRegistration>,
-            std::shared_ptr<ActionParserRegistration>, const Json::Value&)>& deserializer,
+            std::shared_ptr<ActionParserRegistration>, const Json::Value &)> &deserializer,
         bool isRequired)
     {
         auto elementArray = GetArray(json, key, isRequired);
@@ -163,7 +163,7 @@ namespace AdaptiveSharedNamespace
         elements.reserve(elementArray.size());
 
         // Deserialize every element in the array
-        for (const Json::Value& curJsonValue : elementArray)
+        for (const Json::Value &curJsonValue : elementArray)
         {
             // Parse the element
             auto el = deserializer(elementParserRegistration, actionParserRegistration, curJsonValue);
@@ -177,8 +177,8 @@ namespace AdaptiveSharedNamespace
     }
 
     template<typename T>
-    T ParseUtil::ExtractJsonValueAndMergeWithDefault(const Json::Value& rootJson, AdaptiveCardSchemaKey key,
-        const T& defaultValue, const std::function<T(const Json::Value&, const T&)>& deserializer)
+    T ParseUtil::ExtractJsonValueAndMergeWithDefault(const Json::Value &rootJson, AdaptiveCardSchemaKey key,
+        const T &defaultValue, const std::function<T(const Json::Value &, const T &)> &deserializer)
     {
         auto jsonObject = ParseUtil::ExtractJsonValue(rootJson, key);
         T result = jsonObject.empty() ? defaultValue : deserializer(jsonObject, defaultValue);

--- a/source/shared/cpp/ObjectModel/ParseUtil.h
+++ b/source/shared/cpp/ObjectModel/ParseUtil.h
@@ -7,191 +7,181 @@
 #include "ElementParserRegistration.h"
 #include "ActionParserRegistration.h"
 
-AdaptiveSharedNamespaceStart
-class BaseCardElement;
-class BaseActionElement;
-
-class ParseUtil
+namespace AdaptiveSharedNamespace
 {
+    class BaseCardElement;
+    class BaseActionElement;
 
-public:
-
-    static void ThrowIfNotJsonObject(const Json::Value& json);
-
-    static void ExpectString(const Json::Value& json);
-
-    static std::string GetTypeAsString(const Json::Value& json);
-
-    static std::string TryGetTypeAsString(const Json::Value& json);
-
-    static std::string GetString(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired = false);
-
-    // Gets the specified property and returns a JSON string of the value
-    static std::string GetJsonString(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired = false);
-
-    static std::string GetValueAsString(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired = false);
-
-    static bool GetBool(const Json::Value& json, AdaptiveCardSchemaKey key, bool defaultValue, bool isRequired = false);
-
-    static unsigned int GetUInt(const Json::Value& json, AdaptiveCardSchemaKey key, unsigned int defaultValue, bool isRequired = false);
-
-    static int GetInt(const Json::Value& json, AdaptiveCardSchemaKey key, int defaultValue, bool isRequired = false);
-
-    static CardElementType GetCardElementType(const Json::Value& json);
-
-    static CardElementType TryGetCardElementType(const Json::Value& json);
-
-    static ActionType GetActionType(const Json::Value& json);
-
-    static ActionType TryGetActionType(const Json::Value& json);
-
-    static Json::Value GetArray(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired = false);
-
-    static Json::Value GetJsonValueFromString(const std::string &jsonString);
-
-    static Json::Value ExtractJsonValue(const Json::Value& jsonRoot, AdaptiveCardSchemaKey key, bool isRequired = false);
-
-    template <typename T>
-    static T GetEnumValue(
-        const Json::Value& json,
-        AdaptiveCardSchemaKey key,
-        T defaultEnumValue,
-        std::function<T(const std::string& name)> enumConverter,
-        bool isRequired = false);
-
-    static std::vector<std::shared_ptr<BaseCardElement>> GetElementCollection(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const Json::Value& json,
-        AdaptiveCardSchemaKey key,
-        bool isRequired = false);
-
-    template <typename T>
-    static std::vector<std::shared_ptr<T>> GetElementCollectionOfSingleType(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const Json::Value& json,
-        AdaptiveCardSchemaKey key,
-        const std::function<std::shared_ptr<T>(std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value&)>& deserializer,
-        bool isRequired = false);
-
-    static std::vector<std::shared_ptr<BaseActionElement>> GetActionCollection(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const Json::Value& json,
-        AdaptiveCardSchemaKey key,
-        bool isRequired = false);
-
-    static std::shared_ptr<BaseActionElement> GetSelectAction(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const Json::Value& json,
-        AdaptiveCardSchemaKey key,
-        bool isRequired = false);
-
-    template <typename T>
-    static T ExtractJsonValueAndMergeWithDefault(
-        const Json::Value& rootJson,
-        AdaptiveCardSchemaKey key,
-        const T &defaultValue,
-        const std::function<T(const Json::Value&, const T&)>& deserializer);
-
-    static std::shared_ptr<BaseActionElement> GetActionFromJsonValue(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const Json::Value& json);
-
-    static void ExpectTypeString(const Json::Value& json, CardElementType bodyType);
-
-    // throws if the key is missing or the value mapped to the key is the wrong type
-    static void ExpectKeyAndValueType(const Json::Value& json, const char* expectedKey, std::function<void(const Json::Value&)> throwIfWrongType);
-
-    static std::string ToLowercase(const std::string &value);
-
-private:
-    ParseUtil();
-    ~ParseUtil();
-
-};
-
-template <typename T>
-T ParseUtil::GetEnumValue(const Json::Value& json, AdaptiveCardSchemaKey key, T defaultEnumValue, std::function<T(const std::string& name)> enumConverter, bool isRequired)
-{
-    std::string propertyValueStr = "";
-    try
+    class ParseUtil
     {
-        const std::string propertyName = AdaptiveCardSchemaKeyToString(key);
-        auto const &propertyValue = json.get(propertyName, Json::Value());
-        if (propertyValue.empty())
+        public:
+        static void ThrowIfNotJsonObject(const Json::Value& json);
+
+        static void ExpectString(const Json::Value& json);
+
+        static std::string GetTypeAsString(const Json::Value& json);
+
+        static std::string TryGetTypeAsString(const Json::Value& json);
+
+        static std::string GetString(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired = false);
+
+        // Gets the specified property and returns a JSON string of the value
+        static std::string GetJsonString(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired = false);
+
+        static std::string GetValueAsString(
+            const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired = false);
+
+        static bool GetBool(
+            const Json::Value& json, AdaptiveCardSchemaKey key, bool defaultValue, bool isRequired = false);
+
+        static unsigned int GetUInt(
+            const Json::Value& json, AdaptiveCardSchemaKey key, unsigned int defaultValue, bool isRequired = false);
+
+        static int GetInt(
+            const Json::Value& json, AdaptiveCardSchemaKey key, int defaultValue, bool isRequired = false);
+
+        static CardElementType GetCardElementType(const Json::Value& json);
+
+        static CardElementType TryGetCardElementType(const Json::Value& json);
+
+        static ActionType GetActionType(const Json::Value& json);
+
+        static ActionType TryGetActionType(const Json::Value& json);
+
+        static Json::Value GetArray(const Json::Value& json, AdaptiveCardSchemaKey key, bool isRequired = false);
+
+        static Json::Value GetJsonValueFromString(const std::string& jsonString);
+
+        static Json::Value ExtractJsonValue(
+            const Json::Value& jsonRoot, AdaptiveCardSchemaKey key, bool isRequired = false);
+
+        template<typename T>
+        static T GetEnumValue(const Json::Value& json, AdaptiveCardSchemaKey key, T defaultEnumValue,
+            std::function<T(const std::string& name)> enumConverter, bool isRequired = false);
+
+        static std::vector<std::shared_ptr<BaseCardElement>> GetElementCollection(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& json,
+            AdaptiveCardSchemaKey key, bool isRequired = false);
+
+        template<typename T>
+        static std::vector<std::shared_ptr<T>> GetElementCollectionOfSingleType(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& json,
+            AdaptiveCardSchemaKey key,
+            const std::function<std::shared_ptr<T>(std::shared_ptr<ElementParserRegistration>,
+                std::shared_ptr<ActionParserRegistration>, const Json::Value&)>& deserializer,
+            bool isRequired = false);
+
+        static std::vector<std::shared_ptr<BaseActionElement>> GetActionCollection(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& json,
+            AdaptiveCardSchemaKey key, bool isRequired = false);
+
+        static std::shared_ptr<BaseActionElement> GetSelectAction(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& json,
+            AdaptiveCardSchemaKey key, bool isRequired = false);
+
+        template<typename T>
+        static T ExtractJsonValueAndMergeWithDefault(const Json::Value& rootJson, AdaptiveCardSchemaKey key,
+            const T& defaultValue, const std::function<T(const Json::Value&, const T&)>& deserializer);
+
+        static std::shared_ptr<BaseActionElement> GetActionFromJsonValue(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& json);
+
+        static void ExpectTypeString(const Json::Value& json, CardElementType bodyType);
+
+        // throws if the key is missing or the value mapped to the key is the wrong type
+        static void ExpectKeyAndValueType(
+            const Json::Value& json, const char* expectedKey, std::function<void(const Json::Value&)> throwIfWrongType);
+
+        static std::string ToLowercase(const std::string& value);
+
+        private:
+        ParseUtil();
+        ~ParseUtil();
+    };
+
+    template<typename T>
+    T ParseUtil::GetEnumValue(const Json::Value& json, AdaptiveCardSchemaKey key, T defaultEnumValue,
+        std::function<T(const std::string& name)> enumConverter, bool isRequired)
+    {
+        std::string propertyValueStr = "";
+        try
         {
-            if (isRequired)
+            const std::string propertyName = AdaptiveCardSchemaKeyToString(key);
+            auto const& propertyValue = json.get(propertyName, Json::Value());
+            if (propertyValue.empty())
             {
-                throw AdaptiveCardParseException(ErrorStatusCode::RequiredPropertyMissing, "Property is required but was found empty: " + propertyName);
+                if (isRequired)
+                {
+                    throw AdaptiveCardParseException(ErrorStatusCode::RequiredPropertyMissing,
+                        "Property is required but was found empty: " + propertyName);
+                }
+                else
+                {
+                    return defaultEnumValue;
+                }
             }
-            else
+
+            if (!propertyValue.isString())
             {
-                return defaultEnumValue;
+                throw AdaptiveCardParseException(
+                    ErrorStatusCode::InvalidPropertyValue, "Enum type was invalid. Expected type string.");
+            }
+
+            propertyValueStr = propertyValue.asString();
+            return enumConverter(propertyValueStr);
+        }
+        catch (const std::out_of_range&)
+        {
+            // TODO: Uncomment and add to warnings instead of throwing.
+            // throw AdaptiveCardParseException("Enum type was out of range. Actual: " + propertyValueStr);
+            return defaultEnumValue;
+        }
+    }
+
+    template<typename T>
+    std::vector<std::shared_ptr<T>> ParseUtil::GetElementCollectionOfSingleType(
+        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+        std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& json,
+        AdaptiveCardSchemaKey key,
+        const std::function<std::shared_ptr<T>(std::shared_ptr<ElementParserRegistration>,
+            std::shared_ptr<ActionParserRegistration>, const Json::Value&)>& deserializer,
+        bool isRequired)
+    {
+        auto elementArray = GetArray(json, key, isRequired);
+
+        std::vector<std::shared_ptr<T>> elements;
+        if (elementArray.empty())
+        {
+            return elements;
+        }
+
+        elements.reserve(elementArray.size());
+
+        // Deserialize every element in the array
+        for (const Json::Value& curJsonValue : elementArray)
+        {
+            // Parse the element
+            auto el = deserializer(elementParserRegistration, actionParserRegistration, curJsonValue);
+            if (el != nullptr)
+            {
+                elements.push_back(el);
             }
         }
 
-        if (!propertyValue.isString())
-        {
-            throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "Enum type was invalid. Expected type string.");
-        }
-
-        propertyValueStr = propertyValue.asString();
-        return enumConverter(propertyValueStr);
-    }
-    catch (const std::out_of_range&)
-    {
-        // TODO: Uncomment and add to warnings instead of throwing.
-        // throw AdaptiveCardParseException("Enum type was out of range. Actual: " + propertyValueStr);
-        return defaultEnumValue;
-    }
-}
-
-template <typename T>
-std::vector<std::shared_ptr<T>> ParseUtil::GetElementCollectionOfSingleType(
-    std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-    const Json::Value& json,
-    AdaptiveCardSchemaKey key,
-    const std::function<std::shared_ptr<T>(std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value&)>& deserializer,
-    bool isRequired)
-{
-    auto elementArray = GetArray(json, key, isRequired);
-
-    std::vector<std::shared_ptr<T>> elements;
-    if (elementArray.empty())
-    {
         return elements;
     }
 
-    elements.reserve(elementArray.size());
-
-    // Deserialize every element in the array
-    for (const Json::Value& curJsonValue : elementArray)
+    template<typename T>
+    T ParseUtil::ExtractJsonValueAndMergeWithDefault(const Json::Value& rootJson, AdaptiveCardSchemaKey key,
+        const T& defaultValue, const std::function<T(const Json::Value&, const T&)>& deserializer)
     {
-        // Parse the element
-        auto el = deserializer(elementParserRegistration, actionParserRegistration, curJsonValue);
-        if (el != nullptr)
-        {
-            elements.push_back(el);
-        }
+        auto jsonObject = ParseUtil::ExtractJsonValue(rootJson, key);
+        T result = jsonObject.empty() ? defaultValue : deserializer(jsonObject, defaultValue);
+        return result;
     }
-
-    return elements;
-}
-
-template <typename T>
-T ParseUtil::ExtractJsonValueAndMergeWithDefault(
-    const Json::Value& rootJson,
-    AdaptiveCardSchemaKey key,
-    const T& defaultValue,
-    const std::function<T(const Json::Value&, const T&)>& deserializer)
-{
-    auto jsonObject = ParseUtil::ExtractJsonValue(rootJson, key);
-    T result = jsonObject.empty() ? defaultValue : deserializer(jsonObject, defaultValue);
-    return result;
-}
-AdaptiveSharedNamespaceEnd
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/Separator.cpp
+++ b/source/shared/cpp/ObjectModel/Separator.cpp
@@ -6,7 +6,7 @@ using namespace AdaptiveSharedNamespace;
 
 Separator::Separator() : m_thickness(SeparatorThickness::Default), m_color(ForegroundColor::Default) {}
 
-std::shared_ptr<Separator> Separator::Deserialize(const Json::Value& json)
+std::shared_ptr<Separator> Separator::Deserialize(const Json::Value &json)
 {
     std::shared_ptr<Separator> separator = std::make_shared<Separator>();
 
@@ -18,7 +18,7 @@ std::shared_ptr<Separator> Separator::Deserialize(const Json::Value& json)
     return separator;
 }
 
-std::shared_ptr<Separator> Separator::DeserializeFromString(const std::string& jsonString)
+std::shared_ptr<Separator> Separator::DeserializeFromString(const std::string &jsonString)
 {
     return Separator::Deserialize(ParseUtil::GetJsonValueFromString(jsonString));
 }

--- a/source/shared/cpp/ObjectModel/Separator.cpp
+++ b/source/shared/cpp/ObjectModel/Separator.cpp
@@ -4,17 +4,16 @@
 
 using namespace AdaptiveSharedNamespace;
 
-Separator::Separator(): m_thickness(SeparatorThickness::Default), m_color(ForegroundColor::Default)
-{
-}
-
+Separator::Separator() : m_thickness(SeparatorThickness::Default), m_color(ForegroundColor::Default) {}
 
 std::shared_ptr<Separator> Separator::Deserialize(const Json::Value& json)
 {
     std::shared_ptr<Separator> separator = std::make_shared<Separator>();
 
-    separator->SetColor(ParseUtil::GetEnumValue<ForegroundColor>(json, AdaptiveCardSchemaKey::Color, ForegroundColor::Default, ForegroundColorFromString));
-    separator->SetThickness(ParseUtil::GetEnumValue<SeparatorThickness>(json, AdaptiveCardSchemaKey::Thickness, SeparatorThickness::Default, SeparatorThicknessFromString));
+    separator->SetColor(ParseUtil::GetEnumValue<ForegroundColor>(
+        json, AdaptiveCardSchemaKey::Color, ForegroundColor::Default, ForegroundColorFromString));
+    separator->SetThickness(ParseUtil::GetEnumValue<SeparatorThickness>(
+        json, AdaptiveCardSchemaKey::Thickness, SeparatorThickness::Default, SeparatorThicknessFromString));
 
     return separator;
 }

--- a/source/shared/cpp/ObjectModel/Separator.h
+++ b/source/shared/cpp/ObjectModel/Separator.h
@@ -8,7 +8,7 @@ namespace AdaptiveSharedNamespace
 {
     class Separator
     {
-        public:
+    public:
         Separator();
 
         std::string Serialize();
@@ -23,7 +23,7 @@ namespace AdaptiveSharedNamespace
         static std::shared_ptr<Separator> Deserialize(const Json::Value& root);
         static std::shared_ptr<Separator> DeserializeFromString(const std::string& jsonString);
 
-        private:
+    private:
         SeparatorThickness m_thickness;
         ForegroundColor m_color;
     };

--- a/source/shared/cpp/ObjectModel/Separator.h
+++ b/source/shared/cpp/ObjectModel/Separator.h
@@ -20,8 +20,8 @@ namespace AdaptiveSharedNamespace
         ForegroundColor GetColor() const;
         void SetColor(const ForegroundColor value);
 
-        static std::shared_ptr<Separator> Deserialize(const Json::Value& root);
-        static std::shared_ptr<Separator> DeserializeFromString(const std::string& jsonString);
+        static std::shared_ptr<Separator> Deserialize(const Json::Value &root);
+        static std::shared_ptr<Separator> DeserializeFromString(const std::string &jsonString);
 
     private:
         SeparatorThickness m_thickness;

--- a/source/shared/cpp/ObjectModel/Separator.h
+++ b/source/shared/cpp/ObjectModel/Separator.h
@@ -4,26 +4,27 @@
 #include "Enums.h"
 #include "json/json.h"
 
-AdaptiveSharedNamespaceStart
-class Separator
+namespace AdaptiveSharedNamespace
 {
-public:
-    Separator();
+    class Separator
+    {
+        public:
+        Separator();
 
-    std::string Serialize();
-    Json::Value SerializeToJsonValue();
+        std::string Serialize();
+        Json::Value SerializeToJsonValue();
 
-    SeparatorThickness GetThickness() const;
-    void SetThickness(SeparatorThickness value);
+        SeparatorThickness GetThickness() const;
+        void SetThickness(SeparatorThickness value);
 
-    ForegroundColor GetColor() const;
-    void SetColor(const ForegroundColor value);
+        ForegroundColor GetColor() const;
+        void SetColor(const ForegroundColor value);
 
-    static std::shared_ptr<Separator> Deserialize(const Json::Value& root);
-    static std::shared_ptr<Separator> DeserializeFromString(const std::string& jsonString);
+        static std::shared_ptr<Separator> Deserialize(const Json::Value& root);
+        static std::shared_ptr<Separator> DeserializeFromString(const std::string& jsonString);
 
-private:
-    SeparatorThickness m_thickness;
-    ForegroundColor m_color;
-};
-AdaptiveSharedNamespaceEnd
+        private:
+        SeparatorThickness m_thickness;
+        ForegroundColor m_color;
+    };
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
+++ b/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
@@ -8,61 +8,35 @@
 
 using namespace AdaptiveSharedNamespace;
 
-AdaptiveCard::AdaptiveCard(): m_style(ContainerStyle::None), m_height(HeightType::Auto)
-{
-}
+AdaptiveCard::AdaptiveCard() : m_style(ContainerStyle::None), m_height(HeightType::Auto) {}
 
-AdaptiveCard::AdaptiveCard(std::string const &version,
-    std::string const &fallbackText,
-    std::string const &backgroundImage,
-    ContainerStyle style,
-    std::string const &speak,
-    std::string const &language,
-    VerticalContentAlignment verticalContentAlignment,
-    HeightType height) :
+AdaptiveCard::AdaptiveCard(std::string const& version, std::string const& fallbackText,
+    std::string const& backgroundImage, ContainerStyle style, std::string const& speak, std::string const& language,
+    VerticalContentAlignment verticalContentAlignment, HeightType height) :
     m_version(version),
-    m_fallbackText(fallbackText),
-    m_backgroundImage(backgroundImage),
-    m_speak(speak),
-    m_style(style),
-    m_language(language),
-    m_verticalContentAlignment(verticalContentAlignment),
-    m_height(height)
+    m_fallbackText(fallbackText), m_backgroundImage(backgroundImage), m_speak(speak), m_style(style),
+    m_language(language), m_verticalContentAlignment(verticalContentAlignment), m_height(height)
 {
 }
 
-AdaptiveCard::AdaptiveCard(std::string const &version,
-    std::string const &fallbackText,
-    std::string const &backgroundImage,
-    ContainerStyle style,
-    std::string const &speak,
-    std::string const &language,
-    VerticalContentAlignment verticalContentAlignment,
-    HeightType height,
+AdaptiveCard::AdaptiveCard(std::string const& version, std::string const& fallbackText,
+    std::string const& backgroundImage, ContainerStyle style, std::string const& speak, std::string const& language,
+    VerticalContentAlignment verticalContentAlignment, HeightType height,
     std::vector<std::shared_ptr<BaseCardElement>>& body, std::vector<std::shared_ptr<BaseActionElement>>& actions) :
     m_version(version),
-    m_fallbackText(fallbackText),
-    m_backgroundImage(backgroundImage),
-    m_speak(speak),
-    m_style(style),
-    m_language(language),
-    m_verticalContentAlignment(verticalContentAlignment),
-    m_height(height),
-    m_body(body),
+    m_fallbackText(fallbackText), m_backgroundImage(backgroundImage), m_speak(speak), m_style(style),
+    m_language(language), m_verticalContentAlignment(verticalContentAlignment), m_height(height), m_body(body),
     m_actions(actions)
 {
 }
 
 #ifdef __ANDROID__
-std::shared_ptr<ParseResult> AdaptiveCard::DeserializeFromFile(
-    const std::string& jsonFile,
-    double rendererVersion,
+std::shared_ptr<ParseResult> AdaptiveCard::DeserializeFromFile(const std::string& jsonFile, double rendererVersion,
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration) throw(AdaptiveSharedNamespace::AdaptiveCardParseException)
+    std::shared_ptr<ActionParserRegistration>
+        actionParserRegistration) throw(AdaptiveSharedNamespace::AdaptiveCardParseException)
 #else
-std::shared_ptr<ParseResult> AdaptiveCard::DeserializeFromFile(
-    const std::string& jsonFile,
-    double rendererVersion,
+std::shared_ptr<ParseResult> AdaptiveCard::DeserializeFromFile(const std::string& jsonFile, double rendererVersion,
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
     std::shared_ptr<ActionParserRegistration> actionParserRegistration)
 #endif // __ANDROID__
@@ -76,15 +50,12 @@ std::shared_ptr<ParseResult> AdaptiveCard::DeserializeFromFile(
 }
 
 #ifdef __ANDROID__
-std::shared_ptr<ParseResult> AdaptiveCard::Deserialize(
-    const Json::Value& json,
-    double rendererVersion,
+std::shared_ptr<ParseResult> AdaptiveCard::Deserialize(const Json::Value& json, double rendererVersion,
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration) throw(AdaptiveSharedNamespace::AdaptiveCardParseException)
+    std::shared_ptr<ActionParserRegistration>
+        actionParserRegistration) throw(AdaptiveSharedNamespace::AdaptiveCardParseException)
 #else
-std::shared_ptr<ParseResult> AdaptiveCard::Deserialize(
-    const Json::Value& json,
-    double rendererVersion,
+std::shared_ptr<ParseResult> AdaptiveCard::Deserialize(const Json::Value& json, double rendererVersion,
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
     std::shared_ptr<ActionParserRegistration> actionParserRegistration)
 #endif // __ANDROID__
@@ -119,19 +90,24 @@ std::shared_ptr<ParseResult> AdaptiveCard::Deserialize(
                 fallbackText = "We're sorry, this card couldn't be displayed";
             }
 
-            warnings.push_back(std::make_shared<AdaptiveCardParseWarning>(AdaptiveSharedNamespace::WarningStatusCode::UnsupportedSchemaVersion, "Schema version not supported"));
+            warnings.push_back(std::make_shared<AdaptiveCardParseWarning>(
+                AdaptiveSharedNamespace::WarningStatusCode::UnsupportedSchemaVersion, "Schema version not supported"));
             return std::make_shared<ParseResult>(MakeFallbackTextCard(fallbackText, language), warnings);
         }
     }
 
     std::string backgroundImageUrl = ParseUtil::GetString(json, AdaptiveCardSchemaKey::BackgroundImageUrl);
-    std::string backgroundImage = backgroundImageUrl != "" ? backgroundImageUrl :
+    std::string backgroundImage = backgroundImageUrl != "" ?
+        backgroundImageUrl :
         ParseUtil::GetString(json, AdaptiveCardSchemaKey::BackgroundImage);
     std::string speak = ParseUtil::GetString(json, AdaptiveCardSchemaKey::Speak);
-    ContainerStyle style = ParseUtil::GetEnumValue<ContainerStyle>(json, AdaptiveCardSchemaKey::Style, ContainerStyle::None, ContainerStyleFromString);
-    VerticalContentAlignment verticalContentAlignment = ParseUtil::GetEnumValue<VerticalContentAlignment>(json, AdaptiveCardSchemaKey::VerticalContentAlignment, 
-        VerticalContentAlignment::Stretch, VerticalContentAlignmentFromString);
-    HeightType height = ParseUtil::GetEnumValue<HeightType>(json, AdaptiveCardSchemaKey::Height, HeightType::Auto, HeightTypeFromString);
+    ContainerStyle style = ParseUtil::GetEnumValue<ContainerStyle>(
+        json, AdaptiveCardSchemaKey::Style, ContainerStyle::None, ContainerStyleFromString);
+    VerticalContentAlignment verticalContentAlignment =
+        ParseUtil::GetEnumValue<VerticalContentAlignment>(json, AdaptiveCardSchemaKey::VerticalContentAlignment,
+            VerticalContentAlignment::Stretch, VerticalContentAlignmentFromString);
+    HeightType height = ParseUtil::GetEnumValue<HeightType>(
+        json, AdaptiveCardSchemaKey::Height, HeightType::Auto, HeightTypeFromString);
 
     if (elementParserRegistration == nullptr)
     {
@@ -143,40 +119,43 @@ std::shared_ptr<ParseResult> AdaptiveCard::Deserialize(
     }
 
     // Parse body
-    auto body = ParseUtil::GetElementCollection(elementParserRegistration, actionParserRegistration, json, AdaptiveCardSchemaKey::Body, false);
+    auto body = ParseUtil::GetElementCollection(
+        elementParserRegistration, actionParserRegistration, json, AdaptiveCardSchemaKey::Body, false);
     // Parse actions if present
-    auto actions = ParseUtil::GetActionCollection(elementParserRegistration, actionParserRegistration, json, AdaptiveCardSchemaKey::Actions, false);
+    auto actions = ParseUtil::GetActionCollection(
+        elementParserRegistration, actionParserRegistration, json, AdaptiveCardSchemaKey::Actions, false);
 
-    auto result = std::make_shared<AdaptiveCard>(version, fallbackText, backgroundImage, style, speak, language, verticalContentAlignment, height, body, actions);
+    auto result = std::make_shared<AdaptiveCard>(version, fallbackText, backgroundImage, style, speak, language,
+        verticalContentAlignment, height, body, actions);
     result->SetLanguage(language);
 
     // Parse optional selectAction
-    result->SetSelectAction(ParseUtil::GetSelectAction(elementParserRegistration, actionParserRegistration, json, AdaptiveCardSchemaKey::SelectAction, false));
+    result->SetSelectAction(ParseUtil::GetSelectAction(
+        elementParserRegistration, actionParserRegistration, json, AdaptiveCardSchemaKey::SelectAction, false));
 
     return std::make_shared<ParseResult>(result, warnings);
 }
 
 #ifdef __ANDROID__
-std::shared_ptr<ParseResult> AdaptiveCard::DeserializeFromString(
-    const std::string& jsonString,
-    double rendererVersion,
+std::shared_ptr<ParseResult> AdaptiveCard::DeserializeFromString(const std::string& jsonString, double rendererVersion,
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration) throw(AdaptiveSharedNamespace::AdaptiveCardParseException)
+    std::shared_ptr<ActionParserRegistration>
+        actionParserRegistration) throw(AdaptiveSharedNamespace::AdaptiveCardParseException)
 #else
-std::shared_ptr<ParseResult> AdaptiveCard::DeserializeFromString(
-    const std::string& jsonString,
-    double rendererVersion,
+std::shared_ptr<ParseResult> AdaptiveCard::DeserializeFromString(const std::string& jsonString, double rendererVersion,
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
     std::shared_ptr<ActionParserRegistration> actionParserRegistration)
 #endif // __ANDROID__
 {
-    return AdaptiveCard::Deserialize(ParseUtil::GetJsonValueFromString(jsonString), rendererVersion, elementParserRegistration, actionParserRegistration);
+    return AdaptiveCard::Deserialize(ParseUtil::GetJsonValueFromString(jsonString), rendererVersion,
+        elementParserRegistration, actionParserRegistration);
 }
 
 Json::Value AdaptiveCard::SerializeToJsonValue() const
 {
     Json::Value root;
-    root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Type)] = CardElementTypeToString(CardElementType::AdaptiveCard);
+    root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Type)] =
+        CardElementTypeToString(CardElementType::AdaptiveCard);
     root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Version)] = GetVersion();
 
     if (!m_fallbackText.empty())
@@ -201,7 +180,8 @@ Json::Value AdaptiveCard::SerializeToJsonValue() const
     }
     if (m_verticalContentAlignment != VerticalContentAlignment::Stretch)
     {
-        root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::VerticalContentAlignment)] = VerticalContentAlignmentToString(m_verticalContentAlignment);
+        root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::VerticalContentAlignment)] =
+            VerticalContentAlignmentToString(m_verticalContentAlignment);
     }
 
     HeightType height = GetHeight();
@@ -228,16 +208,15 @@ Json::Value AdaptiveCard::SerializeToJsonValue() const
 }
 
 #ifdef __ANDROID__
-std::shared_ptr<AdaptiveCard> AdaptiveCard::MakeFallbackTextCard(
-    const std::string& fallbackText,
+std::shared_ptr<AdaptiveCard> AdaptiveCard::MakeFallbackTextCard(const std::string& fallbackText,
     const std::string& language) throw(AdaptiveSharedNamespace::AdaptiveCardParseException)
 #else
 std::shared_ptr<AdaptiveCard> AdaptiveCard::MakeFallbackTextCard(
-    const std::string& fallbackText,
-    const std::string& language)
+    const std::string& fallbackText, const std::string& language)
 #endif // __ANDROID__
 {
-    std::shared_ptr<AdaptiveCard> fallbackCard = std::make_shared<AdaptiveCard>("1.0", fallbackText, "", ContainerStyle::Default, "", language, VerticalContentAlignment::Stretch, HeightType::Auto);
+    std::shared_ptr<AdaptiveCard> fallbackCard = std::make_shared<AdaptiveCard>("1.0", fallbackText, "",
+        ContainerStyle::Default, "", language, VerticalContentAlignment::Stretch, HeightType::Auto);
 
     std::shared_ptr<TextBlock> textBlock = std::make_shared<TextBlock>();
     textBlock->SetText(fallbackText);
@@ -259,7 +238,7 @@ std::string AdaptiveCard::GetVersion() const
     return m_version;
 }
 
-void AdaptiveCard::SetVersion(const std::string &value)
+void AdaptiveCard::SetVersion(const std::string& value)
 {
     m_version = value;
 }
@@ -269,7 +248,7 @@ std::string AdaptiveCard::GetFallbackText() const
     return m_fallbackText;
 }
 
-void AdaptiveCard::SetFallbackText(const std::string &value)
+void AdaptiveCard::SetFallbackText(const std::string& value)
 {
     m_fallbackText = value;
 }
@@ -279,7 +258,7 @@ std::string AdaptiveCard::GetBackgroundImage() const
     return m_backgroundImage;
 }
 
-void AdaptiveCard::SetBackgroundImage(const std::string &value)
+void AdaptiveCard::SetBackgroundImage(const std::string& value)
 {
     m_backgroundImage = value;
 }
@@ -289,7 +268,7 @@ std::string AdaptiveCard::GetSpeak() const
     return m_speak;
 }
 
-void AdaptiveCard::SetSpeak(const std::string &value)
+void AdaptiveCard::SetSpeak(const std::string& value)
 {
     m_speak = value;
 }

--- a/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
+++ b/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
@@ -10,8 +10,8 @@ using namespace AdaptiveSharedNamespace;
 
 AdaptiveCard::AdaptiveCard() : m_style(ContainerStyle::None), m_height(HeightType::Auto) {}
 
-AdaptiveCard::AdaptiveCard(std::string const& version, std::string const& fallbackText,
-    std::string const& backgroundImage, ContainerStyle style, std::string const& speak, std::string const& language,
+AdaptiveCard::AdaptiveCard(std::string const &version, std::string const &fallbackText,
+    std::string const &backgroundImage, ContainerStyle style, std::string const &speak, std::string const &language,
     VerticalContentAlignment verticalContentAlignment, HeightType height) :
     m_version(version),
     m_fallbackText(fallbackText), m_backgroundImage(backgroundImage), m_speak(speak), m_style(style),
@@ -19,10 +19,10 @@ AdaptiveCard::AdaptiveCard(std::string const& version, std::string const& fallba
 {
 }
 
-AdaptiveCard::AdaptiveCard(std::string const& version, std::string const& fallbackText,
-    std::string const& backgroundImage, ContainerStyle style, std::string const& speak, std::string const& language,
+AdaptiveCard::AdaptiveCard(std::string const &version, std::string const &fallbackText,
+    std::string const &backgroundImage, ContainerStyle style, std::string const &speak, std::string const &language,
     VerticalContentAlignment verticalContentAlignment, HeightType height,
-    std::vector<std::shared_ptr<BaseCardElement>>& body, std::vector<std::shared_ptr<BaseActionElement>>& actions) :
+    std::vector<std::shared_ptr<BaseCardElement>> &body, std::vector<std::shared_ptr<BaseActionElement>> &actions) :
     m_version(version),
     m_fallbackText(fallbackText), m_backgroundImage(backgroundImage), m_speak(speak), m_style(style),
     m_language(language), m_verticalContentAlignment(verticalContentAlignment), m_height(height), m_body(body),
@@ -31,12 +31,12 @@ AdaptiveCard::AdaptiveCard(std::string const& version, std::string const& fallba
 }
 
 #ifdef __ANDROID__
-std::shared_ptr<ParseResult> AdaptiveCard::DeserializeFromFile(const std::string& jsonFile, double rendererVersion,
+std::shared_ptr<ParseResult> AdaptiveCard::DeserializeFromFile(const std::string &jsonFile, double rendererVersion,
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
     std::shared_ptr<ActionParserRegistration>
         actionParserRegistration) throw(AdaptiveSharedNamespace::AdaptiveCardParseException)
 #else
-std::shared_ptr<ParseResult> AdaptiveCard::DeserializeFromFile(const std::string& jsonFile, double rendererVersion,
+std::shared_ptr<ParseResult> AdaptiveCard::DeserializeFromFile(const std::string &jsonFile, double rendererVersion,
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
     std::shared_ptr<ActionParserRegistration> actionParserRegistration)
 #endif // __ANDROID__
@@ -50,12 +50,12 @@ std::shared_ptr<ParseResult> AdaptiveCard::DeserializeFromFile(const std::string
 }
 
 #ifdef __ANDROID__
-std::shared_ptr<ParseResult> AdaptiveCard::Deserialize(const Json::Value& json, double rendererVersion,
+std::shared_ptr<ParseResult> AdaptiveCard::Deserialize(const Json::Value &json, double rendererVersion,
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
     std::shared_ptr<ActionParserRegistration>
         actionParserRegistration) throw(AdaptiveSharedNamespace::AdaptiveCardParseException)
 #else
-std::shared_ptr<ParseResult> AdaptiveCard::Deserialize(const Json::Value& json, double rendererVersion,
+std::shared_ptr<ParseResult> AdaptiveCard::Deserialize(const Json::Value &json, double rendererVersion,
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
     std::shared_ptr<ActionParserRegistration> actionParserRegistration)
 #endif // __ANDROID__
@@ -137,12 +137,12 @@ std::shared_ptr<ParseResult> AdaptiveCard::Deserialize(const Json::Value& json, 
 }
 
 #ifdef __ANDROID__
-std::shared_ptr<ParseResult> AdaptiveCard::DeserializeFromString(const std::string& jsonString, double rendererVersion,
+std::shared_ptr<ParseResult> AdaptiveCard::DeserializeFromString(const std::string &jsonString, double rendererVersion,
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
     std::shared_ptr<ActionParserRegistration>
         actionParserRegistration) throw(AdaptiveSharedNamespace::AdaptiveCardParseException)
 #else
-std::shared_ptr<ParseResult> AdaptiveCard::DeserializeFromString(const std::string& jsonString, double rendererVersion,
+std::shared_ptr<ParseResult> AdaptiveCard::DeserializeFromString(const std::string &jsonString, double rendererVersion,
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
     std::shared_ptr<ActionParserRegistration> actionParserRegistration)
 #endif // __ANDROID__
@@ -192,14 +192,14 @@ Json::Value AdaptiveCard::SerializeToJsonValue() const
 
     std::string bodyPropertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Body);
     root[bodyPropertyName] = Json::Value(Json::arrayValue);
-    for (const auto& cardElement : GetBody())
+    for (const auto &cardElement : GetBody())
     {
         root[bodyPropertyName].append(cardElement->SerializeToJsonValue());
     }
 
     std::string actionsPropertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Actions);
     root[actionsPropertyName] = Json::Value(Json::arrayValue);
-    for (const auto& action : GetActions())
+    for (const auto &action : GetActions())
     {
         root[actionsPropertyName].append(action->SerializeToJsonValue());
     }
@@ -208,11 +208,11 @@ Json::Value AdaptiveCard::SerializeToJsonValue() const
 }
 
 #ifdef __ANDROID__
-std::shared_ptr<AdaptiveCard> AdaptiveCard::MakeFallbackTextCard(const std::string& fallbackText,
-    const std::string& language) throw(AdaptiveSharedNamespace::AdaptiveCardParseException)
+std::shared_ptr<AdaptiveCard> AdaptiveCard::MakeFallbackTextCard(const std::string &fallbackText,
+    const std::string &language) throw(AdaptiveSharedNamespace::AdaptiveCardParseException)
 #else
 std::shared_ptr<AdaptiveCard> AdaptiveCard::MakeFallbackTextCard(
-    const std::string& fallbackText, const std::string& language)
+    const std::string &fallbackText, const std::string &language)
 #endif // __ANDROID__
 {
     std::shared_ptr<AdaptiveCard> fallbackCard = std::make_shared<AdaptiveCard>("1.0", fallbackText, "",
@@ -238,7 +238,7 @@ std::string AdaptiveCard::GetVersion() const
     return m_version;
 }
 
-void AdaptiveCard::SetVersion(const std::string& value)
+void AdaptiveCard::SetVersion(const std::string &value)
 {
     m_version = value;
 }
@@ -248,7 +248,7 @@ std::string AdaptiveCard::GetFallbackText() const
     return m_fallbackText;
 }
 
-void AdaptiveCard::SetFallbackText(const std::string& value)
+void AdaptiveCard::SetFallbackText(const std::string &value)
 {
     m_fallbackText = value;
 }
@@ -258,7 +258,7 @@ std::string AdaptiveCard::GetBackgroundImage() const
     return m_backgroundImage;
 }
 
-void AdaptiveCard::SetBackgroundImage(const std::string& value)
+void AdaptiveCard::SetBackgroundImage(const std::string &value)
 {
     m_backgroundImage = value;
 }
@@ -268,7 +268,7 @@ std::string AdaptiveCard::GetSpeak() const
     return m_speak;
 }
 
-void AdaptiveCard::SetSpeak(const std::string& value)
+void AdaptiveCard::SetSpeak(const std::string &value)
 {
     m_speak = value;
 }
@@ -288,13 +288,13 @@ std::string AdaptiveCard::GetLanguage() const
     return m_language;
 }
 
-void AdaptiveCard::SetLanguage(const std::string& value)
+void AdaptiveCard::SetLanguage(const std::string &value)
 {
     m_language = value;
     // Propagate language to ColumnSet, Containers, TextBlocks and showCardActions
     PropagateLanguage(value, m_body);
 
-    for (auto& actionElement : m_actions)
+    for (auto &actionElement : m_actions)
     {
         if (actionElement->GetElementType() == ActionType::ShowCard)
         {
@@ -322,22 +322,22 @@ const CardElementType AdaptiveCard::GetElementType() const
     return CardElementType::AdaptiveCard;
 }
 
-std::vector<std::shared_ptr<BaseCardElement>>& AdaptiveCard::GetBody()
+std::vector<std::shared_ptr<BaseCardElement>> &AdaptiveCard::GetBody()
 {
     return m_body;
 }
 
-const std::vector<std::shared_ptr<BaseCardElement>>& AdaptiveCard::GetBody() const
+const std::vector<std::shared_ptr<BaseCardElement>> &AdaptiveCard::GetBody() const
 {
     return m_body;
 }
 
-std::vector<std::shared_ptr<BaseActionElement>>& AdaptiveCard::GetActions()
+std::vector<std::shared_ptr<BaseActionElement>> &AdaptiveCard::GetActions()
 {
     return m_actions;
 }
 
-const std::vector<std::shared_ptr<BaseActionElement>>& AdaptiveCard::GetActions() const
+const std::vector<std::shared_ptr<BaseActionElement>> &AdaptiveCard::GetActions() const
 {
     return m_actions;
 }

--- a/source/shared/cpp/ObjectModel/SharedAdaptiveCard.h
+++ b/source/shared/cpp/ObjectModel/SharedAdaptiveCard.h
@@ -14,27 +14,27 @@ namespace AdaptiveSharedNamespace
     {
     public:
         AdaptiveCard();
-        AdaptiveCard(std::string const& version, std::string const& fallbackText, std::string const& backgroundImage,
-            ContainerStyle style, std::string const& speak, std::string const& language,
+        AdaptiveCard(std::string const &version, std::string const &fallbackText, std::string const &backgroundImage,
+            ContainerStyle style, std::string const &speak, std::string const &language,
             VerticalContentAlignment verticalContentAlignment, HeightType height);
-        AdaptiveCard(std::string const& version, std::string const& fallbackText, std::string const& backgroundImage,
-            ContainerStyle style, std::string const& speak, std::string const& language,
+        AdaptiveCard(std::string const &version, std::string const &fallbackText, std::string const &backgroundImage,
+            ContainerStyle style, std::string const &speak, std::string const &language,
             VerticalContentAlignment verticalContentAlignment, HeightType height,
-            std::vector<std::shared_ptr<BaseCardElement>>& body,
-            std::vector<std::shared_ptr<BaseActionElement>>& actions);
+            std::vector<std::shared_ptr<BaseCardElement>> &body,
+            std::vector<std::shared_ptr<BaseActionElement>> &actions);
 
         std::string GetVersion() const;
-        void SetVersion(const std::string& value);
+        void SetVersion(const std::string &value);
         std::string GetFallbackText() const;
-        void SetFallbackText(const std::string& value);
+        void SetFallbackText(const std::string &value);
         std::string GetBackgroundImage() const;
-        void SetBackgroundImage(const std::string& value);
+        void SetBackgroundImage(const std::string &value);
         std::string GetSpeak() const;
-        void SetSpeak(const std::string& value);
+        void SetSpeak(const std::string &value);
         ContainerStyle GetStyle() const;
         void SetStyle(const ContainerStyle value);
         std::string GetLanguage() const;
-        void SetLanguage(const std::string& value);
+        void SetLanguage(const std::string &value);
         VerticalContentAlignment GetVerticalContentAlignment() const;
         void SetVerticalContentAlignment(const VerticalContentAlignment value);
         HeightType GetHeight() const;
@@ -43,44 +43,44 @@ namespace AdaptiveSharedNamespace
         std::shared_ptr<BaseActionElement> GetSelectAction() const;
         void SetSelectAction(const std::shared_ptr<BaseActionElement> action);
 
-        std::vector<std::shared_ptr<BaseCardElement>>& GetBody();
-        const std::vector<std::shared_ptr<BaseCardElement>>& GetBody() const;
-        std::vector<std::shared_ptr<BaseActionElement>>& GetActions();
-        const std::vector<std::shared_ptr<BaseActionElement>>& GetActions() const;
+        std::vector<std::shared_ptr<BaseCardElement>> &GetBody();
+        const std::vector<std::shared_ptr<BaseCardElement>> &GetBody() const;
+        std::vector<std::shared_ptr<BaseActionElement>> &GetActions();
+        const std::vector<std::shared_ptr<BaseActionElement>> &GetActions() const;
 
         std::vector<std::string> GetResourceUris();
 
         const CardElementType GetElementType() const;
 #ifdef __ANDROID__
-        static std::shared_ptr<ParseResult> DeserializeFromFile(const std::string& jsonFile, double rendererVersion,
+        static std::shared_ptr<ParseResult> DeserializeFromFile(const std::string &jsonFile, double rendererVersion,
             std::shared_ptr<ElementParserRegistration> elementParserRegistration = nullptr,
             std::shared_ptr<ActionParserRegistration> actionParserRegistration =
                 nullptr) throw(AdaptiveSharedNamespace::AdaptiveCardParseException);
-        static std::shared_ptr<ParseResult> Deserialize(const Json::Value& json, double rendererVersion,
+        static std::shared_ptr<ParseResult> Deserialize(const Json::Value &json, double rendererVersion,
             std::shared_ptr<ElementParserRegistration> elementParserRegistration = nullptr,
             std::shared_ptr<ActionParserRegistration> actionParserRegistration =
                 nullptr) throw(AdaptiveSharedNamespace::AdaptiveCardParseException);
-        static std::shared_ptr<ParseResult> DeserializeFromString(const std::string& jsonString, double rendererVersion,
+        static std::shared_ptr<ParseResult> DeserializeFromString(const std::string &jsonString, double rendererVersion,
             std::shared_ptr<ElementParserRegistration> elementParserRegistration = nullptr,
             std::shared_ptr<ActionParserRegistration> actionParserRegistration =
                 nullptr) throw(AdaptiveSharedNamespace::AdaptiveCardParseException);
-        static std::shared_ptr<AdaptiveCard> MakeFallbackTextCard(const std::string& fallbackText,
-            const std::string& language) throw(AdaptiveSharedNamespace::AdaptiveCardParseException);
+        static std::shared_ptr<AdaptiveCard> MakeFallbackTextCard(const std::string &fallbackText,
+            const std::string &language) throw(AdaptiveSharedNamespace::AdaptiveCardParseException);
 #else
-        static std::shared_ptr<ParseResult> DeserializeFromFile(const std::string& jsonFile, double rendererVersion,
+        static std::shared_ptr<ParseResult> DeserializeFromFile(const std::string &jsonFile, double rendererVersion,
             std::shared_ptr<ElementParserRegistration> elementParserRegistration = nullptr,
             std::shared_ptr<ActionParserRegistration> actionParserRegistration = nullptr);
 
-        static std::shared_ptr<ParseResult> Deserialize(const Json::Value& json, double rendererVersion,
+        static std::shared_ptr<ParseResult> Deserialize(const Json::Value &json, double rendererVersion,
             std::shared_ptr<ElementParserRegistration> elementParserRegistration = nullptr,
             std::shared_ptr<ActionParserRegistration> actionParserRegistration = nullptr);
 
-        static std::shared_ptr<ParseResult> DeserializeFromString(const std::string& jsonString, double rendererVersion,
+        static std::shared_ptr<ParseResult> DeserializeFromString(const std::string &jsonString, double rendererVersion,
             std::shared_ptr<ElementParserRegistration> elementParserRegistration = nullptr,
             std::shared_ptr<ActionParserRegistration> actionParserRegistration = nullptr);
 
         static std::shared_ptr<AdaptiveCard> MakeFallbackTextCard(
-            const std::string& fallbackText, const std::string& language);
+            const std::string &fallbackText, const std::string &language);
 
 #endif // __ANDROID__
         Json::Value SerializeToJsonValue() const;

--- a/source/shared/cpp/ObjectModel/SharedAdaptiveCard.h
+++ b/source/shared/cpp/ObjectModel/SharedAdaptiveCard.h
@@ -6,116 +6,99 @@
 #include "pch.h"
 #include "ParseResult.h"
 
-AdaptiveSharedNamespaceStart
-class Container;
-
-class AdaptiveCard
+namespace AdaptiveSharedNamespace
 {
-public:
-    AdaptiveCard();
-    AdaptiveCard(
-        std::string const &version,
-        std::string const &fallbackText,
-        std::string const &backgroundImage,
-        ContainerStyle style,
-        std::string const &speak,
-        std::string const &language,
-        VerticalContentAlignment verticalContentAlignment,
-        HeightType height);
-    AdaptiveCard(
-        std::string const &version,
-        std::string const &fallbackText,
-        std::string const &backgroundImage,
-        ContainerStyle style,
-        std::string const &speak,
-        std::string const &language,
-        VerticalContentAlignment verticalContentAlignment,
-        HeightType height,
-        std::vector<std::shared_ptr<BaseCardElement>>& body,
-        std::vector<std::shared_ptr<BaseActionElement>>& actions);
+    class Container;
 
-    std::string GetVersion() const;
-    void SetVersion(const std::string &value);
-    std::string GetFallbackText() const;
-    void SetFallbackText(const std::string &value);
-    std::string GetBackgroundImage() const;
-    void SetBackgroundImage(const std::string &value);
-    std::string GetSpeak() const;
-    void SetSpeak(const std::string &value);
-    ContainerStyle GetStyle() const;
-    void SetStyle(const ContainerStyle value);
-    std::string GetLanguage() const;
-    void SetLanguage(const std::string& value);
-    VerticalContentAlignment GetVerticalContentAlignment() const;
-    void SetVerticalContentAlignment(const VerticalContentAlignment value);
-    HeightType GetHeight() const;
-    void SetHeight(const HeightType value);
+    class AdaptiveCard
+    {
+        public:
+        AdaptiveCard();
+        AdaptiveCard(std::string const& version, std::string const& fallbackText, std::string const& backgroundImage,
+            ContainerStyle style, std::string const& speak, std::string const& language,
+            VerticalContentAlignment verticalContentAlignment, HeightType height);
+        AdaptiveCard(std::string const& version, std::string const& fallbackText, std::string const& backgroundImage,
+            ContainerStyle style, std::string const& speak, std::string const& language,
+            VerticalContentAlignment verticalContentAlignment, HeightType height,
+            std::vector<std::shared_ptr<BaseCardElement>>& body,
+            std::vector<std::shared_ptr<BaseActionElement>>& actions);
 
-    std::shared_ptr<BaseActionElement> GetSelectAction() const;
-    void SetSelectAction(const std::shared_ptr<BaseActionElement> action);
+        std::string GetVersion() const;
+        void SetVersion(const std::string& value);
+        std::string GetFallbackText() const;
+        void SetFallbackText(const std::string& value);
+        std::string GetBackgroundImage() const;
+        void SetBackgroundImage(const std::string& value);
+        std::string GetSpeak() const;
+        void SetSpeak(const std::string& value);
+        ContainerStyle GetStyle() const;
+        void SetStyle(const ContainerStyle value);
+        std::string GetLanguage() const;
+        void SetLanguage(const std::string& value);
+        VerticalContentAlignment GetVerticalContentAlignment() const;
+        void SetVerticalContentAlignment(const VerticalContentAlignment value);
+        HeightType GetHeight() const;
+        void SetHeight(const HeightType value);
 
-    std::vector<std::shared_ptr<BaseCardElement>>& GetBody();
-    const std::vector<std::shared_ptr<BaseCardElement>>& GetBody() const;
-    std::vector<std::shared_ptr<BaseActionElement>>& GetActions();
-    const std::vector<std::shared_ptr<BaseActionElement>>& GetActions() const;
+        std::shared_ptr<BaseActionElement> GetSelectAction() const;
+        void SetSelectAction(const std::shared_ptr<BaseActionElement> action);
 
-    std::vector<std::string> GetResourceUris();
+        std::vector<std::shared_ptr<BaseCardElement>>& GetBody();
+        const std::vector<std::shared_ptr<BaseCardElement>>& GetBody() const;
+        std::vector<std::shared_ptr<BaseActionElement>>& GetActions();
+        const std::vector<std::shared_ptr<BaseActionElement>>& GetActions() const;
 
-    const CardElementType GetElementType() const;
+        std::vector<std::string> GetResourceUris();
+
+        const CardElementType GetElementType() const;
 #ifdef __ANDROID__
-    static std::shared_ptr<ParseResult> DeserializeFromFile(const std::string& jsonFile,
-        double rendererVersion,
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration = nullptr,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration = nullptr) throw(AdaptiveSharedNamespace::AdaptiveCardParseException);
-    static std::shared_ptr<ParseResult> Deserialize(const Json::Value& json,
-        double rendererVersion,
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration = nullptr,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration = nullptr) throw(AdaptiveSharedNamespace::AdaptiveCardParseException);
-    static std::shared_ptr<ParseResult> DeserializeFromString(const std::string& jsonString,
-        double rendererVersion,
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration = nullptr,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration = nullptr) throw(AdaptiveSharedNamespace::AdaptiveCardParseException);
-    static std::shared_ptr<AdaptiveCard> MakeFallbackTextCard(
-        const std::string& fallbackText,
-        const std::string& language) throw(AdaptiveSharedNamespace::AdaptiveCardParseException);
+        static std::shared_ptr<ParseResult> DeserializeFromFile(const std::string& jsonFile, double rendererVersion,
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration = nullptr,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration =
+                nullptr) throw(AdaptiveSharedNamespace::AdaptiveCardParseException);
+        static std::shared_ptr<ParseResult> Deserialize(const Json::Value& json, double rendererVersion,
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration = nullptr,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration =
+                nullptr) throw(AdaptiveSharedNamespace::AdaptiveCardParseException);
+        static std::shared_ptr<ParseResult> DeserializeFromString(const std::string& jsonString, double rendererVersion,
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration = nullptr,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration =
+                nullptr) throw(AdaptiveSharedNamespace::AdaptiveCardParseException);
+        static std::shared_ptr<AdaptiveCard> MakeFallbackTextCard(const std::string& fallbackText,
+            const std::string& language) throw(AdaptiveSharedNamespace::AdaptiveCardParseException);
 #else
-    static std::shared_ptr<ParseResult> DeserializeFromFile(
-        const std::string& jsonFile,
-        double rendererVersion,
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration = nullptr,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration = nullptr);
+        static std::shared_ptr<ParseResult> DeserializeFromFile(const std::string& jsonFile, double rendererVersion,
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration = nullptr,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration = nullptr);
 
-    static std::shared_ptr<ParseResult> Deserialize(const Json::Value& json,
-        double rendererVersion,
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration = nullptr,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration = nullptr);
+        static std::shared_ptr<ParseResult> Deserialize(const Json::Value& json, double rendererVersion,
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration = nullptr,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration = nullptr);
 
-    static std::shared_ptr<ParseResult> DeserializeFromString(const std::string& jsonString,
-        double rendererVersion,
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration = nullptr,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration = nullptr);
+        static std::shared_ptr<ParseResult> DeserializeFromString(const std::string& jsonString, double rendererVersion,
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration = nullptr,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration = nullptr);
 
-    static std::shared_ptr<AdaptiveCard> MakeFallbackTextCard(
-        const std::string& fallbackText,
-        const std::string& language);
+        static std::shared_ptr<AdaptiveCard> MakeFallbackTextCard(
+            const std::string& fallbackText, const std::string& language);
 
 #endif // __ANDROID__
-    Json::Value SerializeToJsonValue() const;
-    std::string Serialize() const;
+        Json::Value SerializeToJsonValue() const;
+        std::string Serialize() const;
 
-private:
-    std::string m_version;
-    std::string m_fallbackText;
-    std::string m_backgroundImage;
-    std::string m_speak;
-    ContainerStyle m_style;
-    std::string m_language;
-    VerticalContentAlignment m_verticalContentAlignment;
-    HeightType m_height;
+        private:
+        std::string m_version;
+        std::string m_fallbackText;
+        std::string m_backgroundImage;
+        std::string m_speak;
+        ContainerStyle m_style;
+        std::string m_language;
+        VerticalContentAlignment m_verticalContentAlignment;
+        HeightType m_height;
 
-    std::vector<std::shared_ptr<BaseCardElement>> m_body;
-    std::vector<std::shared_ptr<BaseActionElement>> m_actions;
+        std::vector<std::shared_ptr<BaseCardElement>> m_body;
+        std::vector<std::shared_ptr<BaseActionElement>> m_actions;
 
-    std::shared_ptr<BaseActionElement> m_selectAction;
-};
-AdaptiveSharedNamespaceEnd
+        std::shared_ptr<BaseActionElement> m_selectAction;
+    };
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/SharedAdaptiveCard.h
+++ b/source/shared/cpp/ObjectModel/SharedAdaptiveCard.h
@@ -12,7 +12,7 @@ namespace AdaptiveSharedNamespace
 
     class AdaptiveCard
     {
-        public:
+    public:
         AdaptiveCard();
         AdaptiveCard(std::string const& version, std::string const& fallbackText, std::string const& backgroundImage,
             ContainerStyle style, std::string const& speak, std::string const& language,
@@ -86,7 +86,7 @@ namespace AdaptiveSharedNamespace
         Json::Value SerializeToJsonValue() const;
         std::string Serialize() const;
 
-        private:
+    private:
         std::string m_version;
         std::string m_fallbackText;
         std::string m_backgroundImage;

--- a/source/shared/cpp/ObjectModel/ShowCardAction.cpp
+++ b/source/shared/cpp/ObjectModel/ShowCardAction.cpp
@@ -40,26 +40,27 @@ void ShowCardAction::SetLanguage(const std::string& value)
 
 std::shared_ptr<BaseActionElement> ShowCardActionParser::Deserialize(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-    const Json::Value& json)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& json)
 {
     std::shared_ptr<ShowCardAction> showCardAction = BaseActionElement::Deserialize<ShowCardAction>(json);
 
     std::string propertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Card);
-    showCardAction->SetCard(AdaptiveCard::Deserialize(json.get(propertyName, Json::Value()), std::numeric_limits<double>::max(), elementParserRegistration, actionParserRegistration)->GetAdaptiveCard());
+    showCardAction->SetCard(AdaptiveCard::Deserialize(json.get(propertyName, Json::Value()),
+        std::numeric_limits<double>::max(), elementParserRegistration, actionParserRegistration)
+                                ->GetAdaptiveCard());
 
     return showCardAction;
 }
 
 std::shared_ptr<BaseActionElement> ShowCardActionParser::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-    const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
 {
-    return ShowCardActionParser::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
+    return ShowCardActionParser::Deserialize(
+        elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
-void ShowCardAction::PopulateKnownPropertiesSet() 
+void ShowCardAction::PopulateKnownPropertiesSet()
 {
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Card));
 }

--- a/source/shared/cpp/ObjectModel/ShowCardAction.cpp
+++ b/source/shared/cpp/ObjectModel/ShowCardAction.cpp
@@ -29,7 +29,7 @@ void ShowCardAction::SetCard(const std::shared_ptr<AdaptiveCard> card)
     m_card = card;
 }
 
-void ShowCardAction::SetLanguage(const std::string& value)
+void ShowCardAction::SetLanguage(const std::string &value)
 {
     // If the card inside doesn't specify language, propagate
     if (m_card->GetLanguage().empty())
@@ -40,7 +40,7 @@ void ShowCardAction::SetLanguage(const std::string& value)
 
 std::shared_ptr<BaseActionElement> ShowCardActionParser::Deserialize(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& json)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &json)
 {
     std::shared_ptr<ShowCardAction> showCardAction = BaseActionElement::Deserialize<ShowCardAction>(json);
 
@@ -54,7 +54,7 @@ std::shared_ptr<BaseActionElement> ShowCardActionParser::Deserialize(
 
 std::shared_ptr<BaseActionElement> ShowCardActionParser::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString)
 {
     return ShowCardActionParser::Deserialize(
         elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
@@ -65,7 +65,7 @@ void ShowCardAction::PopulateKnownPropertiesSet()
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Card));
 }
 
-void ShowCardAction::GetResourceUris(std::vector<std::string>& resourceUris)
+void ShowCardAction::GetResourceUris(std::vector<std::string> &resourceUris)
 {
     auto card = GetCard();
     auto showCardImages = card->GetResourceUris();

--- a/source/shared/cpp/ObjectModel/ShowCardAction.h
+++ b/source/shared/cpp/ObjectModel/ShowCardAction.h
@@ -10,7 +10,7 @@ namespace AdaptiveSharedNamespace
 {
     class ShowCardAction : public BaseActionElement
     {
-        public:
+    public:
         ShowCardAction();
 
         virtual Json::Value SerializeToJsonValue() const override;
@@ -22,7 +22,7 @@ namespace AdaptiveSharedNamespace
 
         virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
 
-        private:
+    private:
         void PopulateKnownPropertiesSet();
 
         std::shared_ptr<AdaptiveCard> m_card;

--- a/source/shared/cpp/ObjectModel/ShowCardAction.h
+++ b/source/shared/cpp/ObjectModel/ShowCardAction.h
@@ -18,9 +18,9 @@ namespace AdaptiveSharedNamespace
         std::shared_ptr<AdaptiveSharedNamespace::AdaptiveCard> GetCard() const;
         void SetCard(const std::shared_ptr<AdaptiveSharedNamespace::AdaptiveCard>);
 
-        void SetLanguage(const std::string& value);
+        void SetLanguage(const std::string &value);
 
-        virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
+        virtual void GetResourceUris(std::vector<std::string> &resourceUris) override;
 
     private:
         void PopulateKnownPropertiesSet();
@@ -32,10 +32,10 @@ namespace AdaptiveSharedNamespace
     {
         std::shared_ptr<BaseActionElement> Deserialize(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& value);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &value);
 
         std::shared_ptr<BaseActionElement> DeserializeFromString(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString);
     };
 } // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/ShowCardAction.h
+++ b/source/shared/cpp/ObjectModel/ShowCardAction.h
@@ -6,37 +6,36 @@
 #include "Enums.h"
 #include "ActionParserRegistration.h"
 
-AdaptiveSharedNamespaceStart
-class ShowCardAction : public BaseActionElement
+namespace AdaptiveSharedNamespace
 {
-public:
-    ShowCardAction();
+    class ShowCardAction : public BaseActionElement
+    {
+        public:
+        ShowCardAction();
 
-    virtual Json::Value SerializeToJsonValue() const override;
+        virtual Json::Value SerializeToJsonValue() const override;
 
-    std::shared_ptr<AdaptiveSharedNamespace::AdaptiveCard> GetCard() const;
-    void SetCard(const std::shared_ptr<AdaptiveSharedNamespace::AdaptiveCard>);
+        std::shared_ptr<AdaptiveSharedNamespace::AdaptiveCard> GetCard() const;
+        void SetCard(const std::shared_ptr<AdaptiveSharedNamespace::AdaptiveCard>);
 
-    void SetLanguage(const std::string& value);
+        void SetLanguage(const std::string& value);
 
-    virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
+        virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
 
-private:
-    void PopulateKnownPropertiesSet();
+        private:
+        void PopulateKnownPropertiesSet();
 
-    std::shared_ptr<AdaptiveCard> m_card;
-};
+        std::shared_ptr<AdaptiveCard> m_card;
+    };
 
-class ShowCardActionParser : public ActionElementParser
-{
-    std::shared_ptr<BaseActionElement> Deserialize(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const Json::Value& value);
+    class ShowCardActionParser : public ActionElementParser
+    {
+        std::shared_ptr<BaseActionElement> Deserialize(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& value);
 
-    std::shared_ptr<BaseActionElement> DeserializeFromString(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const std::string& jsonString);
-};
-AdaptiveSharedNamespaceEnd
+        std::shared_ptr<BaseActionElement> DeserializeFromString(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+    };
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/SubmitAction.cpp
+++ b/source/shared/cpp/ObjectModel/SubmitAction.cpp
@@ -14,7 +14,7 @@ std::string SubmitAction::GetDataJson() const
     return m_dataJson;
 }
 
-void SubmitAction::SetDataJson(const std::string &value)
+void SubmitAction::SetDataJson(const std::string& value)
 {
     m_dataJson = value;
 }
@@ -31,11 +31,8 @@ Json::Value SubmitAction::SerializeToJsonValue() const
     return root;
 }
 
-
 std::shared_ptr<BaseActionElement> SubmitActionParser::Deserialize(
-    std::shared_ptr<ElementParserRegistration>,
-    std::shared_ptr<ActionParserRegistration>,
-    const Json::Value& json)
+    std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value& json)
 {
     std::shared_ptr<SubmitAction> submitAction = BaseActionElement::Deserialize<SubmitAction>(json);
 
@@ -46,13 +43,13 @@ std::shared_ptr<BaseActionElement> SubmitActionParser::Deserialize(
 
 std::shared_ptr<BaseActionElement> SubmitActionParser::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-    const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
 {
-    return SubmitActionParser::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
+    return SubmitActionParser::Deserialize(
+        elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
-void SubmitAction::PopulateKnownPropertiesSet() 
+void SubmitAction::PopulateKnownPropertiesSet()
 {
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Data));
 }

--- a/source/shared/cpp/ObjectModel/SubmitAction.cpp
+++ b/source/shared/cpp/ObjectModel/SubmitAction.cpp
@@ -14,7 +14,7 @@ std::string SubmitAction::GetDataJson() const
     return m_dataJson;
 }
 
-void SubmitAction::SetDataJson(const std::string& value)
+void SubmitAction::SetDataJson(const std::string &value)
 {
     m_dataJson = value;
 }
@@ -32,7 +32,7 @@ Json::Value SubmitAction::SerializeToJsonValue() const
 }
 
 std::shared_ptr<BaseActionElement> SubmitActionParser::Deserialize(
-    std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value& json)
+    std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value &json)
 {
     std::shared_ptr<SubmitAction> submitAction = BaseActionElement::Deserialize<SubmitAction>(json);
 
@@ -43,7 +43,7 @@ std::shared_ptr<BaseActionElement> SubmitActionParser::Deserialize(
 
 std::shared_ptr<BaseActionElement> SubmitActionParser::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString)
 {
     return SubmitActionParser::Deserialize(
         elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));

--- a/source/shared/cpp/ObjectModel/SubmitAction.h
+++ b/source/shared/cpp/ObjectModel/SubmitAction.h
@@ -5,33 +5,32 @@
 #include "Enums.h"
 #include "ActionParserRegistration.h"
 
-AdaptiveSharedNamespaceStart
-class SubmitAction : public BaseActionElement
+namespace AdaptiveSharedNamespace
 {
-public:
-    SubmitAction();
+    class SubmitAction : public BaseActionElement
+    {
+        public:
+        SubmitAction();
 
-    std::string GetDataJson() const;
-    void SetDataJson(const std::string &value);
+        std::string GetDataJson() const;
+        void SetDataJson(const std::string& value);
 
-    virtual Json::Value SerializeToJsonValue() const override;
+        virtual Json::Value SerializeToJsonValue() const override;
 
-private:
-    void PopulateKnownPropertiesSet();
+        private:
+        void PopulateKnownPropertiesSet();
 
-    std::string m_dataJson;
-};
+        std::string m_dataJson;
+    };
 
-class SubmitActionParser : public ActionElementParser
-{
-    std::shared_ptr<BaseActionElement> Deserialize(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const Json::Value& value);
+    class SubmitActionParser : public ActionElementParser
+    {
+        std::shared_ptr<BaseActionElement> Deserialize(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& value);
 
-    std::shared_ptr<BaseActionElement> DeserializeFromString(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const std::string& jsonString);
-};
-AdaptiveSharedNamespaceEnd
+        std::shared_ptr<BaseActionElement> DeserializeFromString(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+    };
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/SubmitAction.h
+++ b/source/shared/cpp/ObjectModel/SubmitAction.h
@@ -13,7 +13,7 @@ namespace AdaptiveSharedNamespace
         SubmitAction();
 
         std::string GetDataJson() const;
-        void SetDataJson(const std::string& value);
+        void SetDataJson(const std::string &value);
 
         virtual Json::Value SerializeToJsonValue() const override;
 
@@ -27,10 +27,10 @@ namespace AdaptiveSharedNamespace
     {
         std::shared_ptr<BaseActionElement> Deserialize(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& value);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &value);
 
         std::shared_ptr<BaseActionElement> DeserializeFromString(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString);
     };
 } // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/SubmitAction.h
+++ b/source/shared/cpp/ObjectModel/SubmitAction.h
@@ -9,7 +9,7 @@ namespace AdaptiveSharedNamespace
 {
     class SubmitAction : public BaseActionElement
     {
-        public:
+    public:
         SubmitAction();
 
         std::string GetDataJson() const;
@@ -17,7 +17,7 @@ namespace AdaptiveSharedNamespace
 
         virtual Json::Value SerializeToJsonValue() const override;
 
-        private:
+    private:
         void PopulateKnownPropertiesSet();
 
         std::string m_dataJson;

--- a/source/shared/cpp/ObjectModel/TextBlock.cpp
+++ b/source/shared/cpp/ObjectModel/TextBlock.cpp
@@ -10,15 +10,9 @@
 using namespace AdaptiveSharedNamespace;
 
 TextBlock::TextBlock() :
-    BaseCardElement(CardElementType::TextBlock),
-    m_textSize(TextSize::Default),
-    m_textWeight(TextWeight::Default),
-    m_textColor(ForegroundColor::Default),
-    m_isSubtle(false),
-    m_wrap(false),
-    m_maxLines(0),
-    m_hAlignment(HorizontalAlignment::Left),
-    m_language()
+    BaseCardElement(CardElementType::TextBlock), m_textSize(TextSize::Default), m_textWeight(TextWeight::Default),
+    m_textColor(ForegroundColor::Default), m_isSubtle(false), m_wrap(false), m_maxLines(0),
+    m_hAlignment(HorizontalAlignment::Left), m_language()
 {
     PopulateKnownPropertiesSet();
 }
@@ -73,7 +67,7 @@ std::string TextBlock::GetText() const
     return m_text;
 }
 
-void TextBlock::SetText(const std::string &value)
+void TextBlock::SetText(const std::string& value)
 {
     m_text = value;
 }
@@ -164,35 +158,37 @@ void TextBlock::SetLanguage(const std::string& value)
 }
 
 std::shared_ptr<BaseCardElement> TextBlockParser::Deserialize(
-    std::shared_ptr<ElementParserRegistration>,
-    std::shared_ptr<ActionParserRegistration>,
-    const Json::Value& json)
+    std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value& json)
 {
     ParseUtil::ExpectTypeString(json, CardElementType::TextBlock);
 
     std::shared_ptr<TextBlock> textBlock = BaseCardElement::Deserialize<TextBlock>(json);
 
     textBlock->SetText(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Text, true));
-    textBlock->SetTextSize(ParseUtil::GetEnumValue<TextSize>(json, AdaptiveCardSchemaKey::Size, TextSize::Default, TextSizeFromString));
-    textBlock->SetTextColor(ParseUtil::GetEnumValue<ForegroundColor>(json, AdaptiveCardSchemaKey::Color, ForegroundColor::Default, ForegroundColorFromString));
-    textBlock->SetTextWeight(ParseUtil::GetEnumValue<TextWeight>(json, AdaptiveCardSchemaKey::TextWeight, TextWeight::Default, TextWeightFromString));
+    textBlock->SetTextSize(
+        ParseUtil::GetEnumValue<TextSize>(json, AdaptiveCardSchemaKey::Size, TextSize::Default, TextSizeFromString));
+    textBlock->SetTextColor(ParseUtil::GetEnumValue<ForegroundColor>(
+        json, AdaptiveCardSchemaKey::Color, ForegroundColor::Default, ForegroundColorFromString));
+    textBlock->SetTextWeight(ParseUtil::GetEnumValue<TextWeight>(
+        json, AdaptiveCardSchemaKey::TextWeight, TextWeight::Default, TextWeightFromString));
     textBlock->SetWrap(ParseUtil::GetBool(json, AdaptiveCardSchemaKey::Wrap, false));
     textBlock->SetIsSubtle(ParseUtil::GetBool(json, AdaptiveCardSchemaKey::IsSubtle, false));
     textBlock->SetMaxLines(ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::MaxLines, 0));
-    textBlock->SetHorizontalAlignment(ParseUtil::GetEnumValue<HorizontalAlignment>(json, AdaptiveCardSchemaKey::HorizontalAlignment, HorizontalAlignment::Left, HorizontalAlignmentFromString));
+    textBlock->SetHorizontalAlignment(ParseUtil::GetEnumValue<HorizontalAlignment>(
+        json, AdaptiveCardSchemaKey::HorizontalAlignment, HorizontalAlignment::Left, HorizontalAlignmentFromString));
 
     return textBlock;
 }
 
 std::shared_ptr<BaseCardElement> TextBlockParser::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-    const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
 {
-    return TextBlockParser::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
+    return TextBlockParser::Deserialize(
+        elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
-void TextBlock::PopulateKnownPropertiesSet() 
+void TextBlock::PopulateKnownPropertiesSet()
 {
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Text));
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Size));

--- a/source/shared/cpp/ObjectModel/TextBlock.cpp
+++ b/source/shared/cpp/ObjectModel/TextBlock.cpp
@@ -67,7 +67,7 @@ std::string TextBlock::GetText() const
     return m_text;
 }
 
-void TextBlock::SetText(const std::string& value)
+void TextBlock::SetText(const std::string &value)
 {
     m_text = value;
 }
@@ -152,13 +152,13 @@ std::string TextBlock::GetLanguage()
     return m_language;
 }
 
-void TextBlock::SetLanguage(const std::string& value)
+void TextBlock::SetLanguage(const std::string &value)
 {
     m_language = value;
 }
 
 std::shared_ptr<BaseCardElement> TextBlockParser::Deserialize(
-    std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value& json)
+    std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value &json)
 {
     ParseUtil::ExpectTypeString(json, CardElementType::TextBlock);
 
@@ -182,7 +182,7 @@ std::shared_ptr<BaseCardElement> TextBlockParser::Deserialize(
 
 std::shared_ptr<BaseCardElement> TextBlockParser::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString)
 {
     return TextBlockParser::Deserialize(
         elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));

--- a/source/shared/cpp/ObjectModel/TextBlock.h
+++ b/source/shared/cpp/ObjectModel/TextBlock.h
@@ -11,7 +11,7 @@ namespace AdaptiveSharedNamespace
 {
     class TextBlock : public BaseCardElement
     {
-        public:
+    public:
         TextBlock();
 
         virtual Json::Value SerializeToJsonValue() const override;
@@ -44,7 +44,7 @@ namespace AdaptiveSharedNamespace
         void SetLanguage(const std::string& value);
         std::string GetLanguage();
 
-        private:
+    private:
         std::string m_text;
         TextSize m_textSize;
         TextWeight m_textWeight;
@@ -59,7 +59,7 @@ namespace AdaptiveSharedNamespace
 
     class TextBlockParser : public BaseCardElementParser
     {
-        public:
+    public:
         std::shared_ptr<BaseCardElement> Deserialize(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
             std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);

--- a/source/shared/cpp/ObjectModel/TextBlock.h
+++ b/source/shared/cpp/ObjectModel/TextBlock.h
@@ -7,66 +7,65 @@
 #include "ElementParserRegistration.h"
 #include "DateTimePreparser.h"
 
-AdaptiveSharedNamespaceStart
-class TextBlock : public BaseCardElement
+namespace AdaptiveSharedNamespace
 {
-public:
-    TextBlock();
+    class TextBlock : public BaseCardElement
+    {
+        public:
+        TextBlock();
 
-    virtual Json::Value SerializeToJsonValue() const override;
+        virtual Json::Value SerializeToJsonValue() const override;
 
-    std::string GetText() const;
-    void SetText(const std::string &value);
-    DateTimePreparser GetTextForDateParsing() const;
+        std::string GetText() const;
+        void SetText(const std::string& value);
+        DateTimePreparser GetTextForDateParsing() const;
 
-    TextSize GetTextSize() const;
-    void SetTextSize(const TextSize value);
+        TextSize GetTextSize() const;
+        void SetTextSize(const TextSize value);
 
-    TextWeight GetTextWeight() const;
-    void SetTextWeight(const TextWeight value);
+        TextWeight GetTextWeight() const;
+        void SetTextWeight(const TextWeight value);
 
-    ForegroundColor GetTextColor() const;
-    void SetTextColor(const ForegroundColor value);
+        ForegroundColor GetTextColor() const;
+        void SetTextColor(const ForegroundColor value);
 
-    bool GetWrap() const;
-    void SetWrap(const bool value);
+        bool GetWrap() const;
+        void SetWrap(const bool value);
 
-    bool GetIsSubtle() const;
-    void SetIsSubtle(const bool value);
+        bool GetIsSubtle() const;
+        void SetIsSubtle(const bool value);
 
-    unsigned int GetMaxLines() const;
-    void SetMaxLines(const unsigned int value);
+        unsigned int GetMaxLines() const;
+        void SetMaxLines(const unsigned int value);
 
-    HorizontalAlignment GetHorizontalAlignment() const;
-    void SetHorizontalAlignment(const HorizontalAlignment value);
+        HorizontalAlignment GetHorizontalAlignment() const;
+        void SetHorizontalAlignment(const HorizontalAlignment value);
 
-    void SetLanguage(const std::string& value);
-    std::string GetLanguage();
+        void SetLanguage(const std::string& value);
+        std::string GetLanguage();
 
-private:
-    std::string m_text;
-    TextSize m_textSize;
-    TextWeight m_textWeight;
-    ForegroundColor m_textColor;
-    bool m_isSubtle;
-    bool m_wrap;
-    unsigned int m_maxLines;
-    HorizontalAlignment m_hAlignment;
-    void PopulateKnownPropertiesSet();
-    std::string m_language;
-};
+        private:
+        std::string m_text;
+        TextSize m_textSize;
+        TextWeight m_textWeight;
+        ForegroundColor m_textColor;
+        bool m_isSubtle;
+        bool m_wrap;
+        unsigned int m_maxLines;
+        HorizontalAlignment m_hAlignment;
+        void PopulateKnownPropertiesSet();
+        std::string m_language;
+    };
 
-class TextBlockParser : public BaseCardElementParser
-{
-public:
-    std::shared_ptr<BaseCardElement> Deserialize(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const Json::Value& root);
+    class TextBlockParser : public BaseCardElementParser
+    {
+        public:
+        std::shared_ptr<BaseCardElement> Deserialize(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
 
-    std::shared_ptr<BaseCardElement> DeserializeFromString(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const std::string& jsonString);
-};
-AdaptiveSharedNamespaceEnd
+        std::shared_ptr<BaseCardElement> DeserializeFromString(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+    };
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/TextBlock.h
+++ b/source/shared/cpp/ObjectModel/TextBlock.h
@@ -17,7 +17,7 @@ namespace AdaptiveSharedNamespace
         virtual Json::Value SerializeToJsonValue() const override;
 
         std::string GetText() const;
-        void SetText(const std::string& value);
+        void SetText(const std::string &value);
         DateTimePreparser GetTextForDateParsing() const;
 
         TextSize GetTextSize() const;
@@ -41,7 +41,7 @@ namespace AdaptiveSharedNamespace
         HorizontalAlignment GetHorizontalAlignment() const;
         void SetHorizontalAlignment(const HorizontalAlignment value);
 
-        void SetLanguage(const std::string& value);
+        void SetLanguage(const std::string &value);
         std::string GetLanguage();
 
     private:
@@ -62,10 +62,10 @@ namespace AdaptiveSharedNamespace
     public:
         std::shared_ptr<BaseCardElement> Deserialize(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &root);
 
         std::shared_ptr<BaseCardElement> DeserializeFromString(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString);
     };
 } // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/TextInput.cpp
+++ b/source/shared/cpp/ObjectModel/TextInput.cpp
@@ -5,10 +5,7 @@
 using namespace AdaptiveSharedNamespace;
 
 TextInput::TextInput() :
-    BaseInputElement(CardElementType::TextInput),
-    m_isMultiline(false),
-    m_maxLength(0),
-    m_style(TextInputStyle::Text)
+    BaseInputElement(CardElementType::TextInput), m_isMultiline(false), m_maxLength(0), m_style(TextInputStyle::Text)
 {
     PopulateKnownPropertiesSet();
 }
@@ -50,7 +47,7 @@ std::string TextInput::GetPlaceholder() const
     return m_placeholder;
 }
 
-void TextInput::SetPlaceholder(const std::string &value)
+void TextInput::SetPlaceholder(const std::string& value)
 {
     m_placeholder = value;
 }
@@ -60,7 +57,7 @@ std::string TextInput::GetValue() const
     return m_value;
 }
 
-void TextInput::SetValue(const std::string &value)
+void TextInput::SetValue(const std::string& value)
 {
     m_value = value;
 }
@@ -96,9 +93,7 @@ void TextInput::SetTextInputStyle(const TextInputStyle value)
 }
 
 std::shared_ptr<BaseCardElement> TextInputParser::Deserialize(
-    std::shared_ptr<ElementParserRegistration>,
-    std::shared_ptr<ActionParserRegistration>,
-    const Json::Value& json)
+    std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value& json)
 {
     ParseUtil::ExpectTypeString(json, CardElementType::TextInput);
 
@@ -108,20 +103,21 @@ std::shared_ptr<BaseCardElement> TextInputParser::Deserialize(
     textInput->SetValue(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Value));
     textInput->SetIsMultiline(ParseUtil::GetBool(json, AdaptiveCardSchemaKey::IsMultiline, false));
     textInput->SetMaxLength(ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::MaxLength, 0));
-    textInput->SetTextInputStyle(ParseUtil::GetEnumValue<TextInputStyle>(json, AdaptiveCardSchemaKey::Style, TextInputStyle::Text, TextInputStyleFromString));
+    textInput->SetTextInputStyle(ParseUtil::GetEnumValue<TextInputStyle>(
+        json, AdaptiveCardSchemaKey::Style, TextInputStyle::Text, TextInputStyleFromString));
 
     return textInput;
 }
 
 std::shared_ptr<BaseCardElement> TextInputParser::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-    const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
 {
-    return TextInputParser::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
+    return TextInputParser::Deserialize(
+        elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
-void TextInput::PopulateKnownPropertiesSet() 
+void TextInput::PopulateKnownPropertiesSet()
 {
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Placeholder));
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Value));

--- a/source/shared/cpp/ObjectModel/TextInput.cpp
+++ b/source/shared/cpp/ObjectModel/TextInput.cpp
@@ -47,7 +47,7 @@ std::string TextInput::GetPlaceholder() const
     return m_placeholder;
 }
 
-void TextInput::SetPlaceholder(const std::string& value)
+void TextInput::SetPlaceholder(const std::string &value)
 {
     m_placeholder = value;
 }
@@ -57,7 +57,7 @@ std::string TextInput::GetValue() const
     return m_value;
 }
 
-void TextInput::SetValue(const std::string& value)
+void TextInput::SetValue(const std::string &value)
 {
     m_value = value;
 }
@@ -93,7 +93,7 @@ void TextInput::SetTextInputStyle(const TextInputStyle value)
 }
 
 std::shared_ptr<BaseCardElement> TextInputParser::Deserialize(
-    std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value& json)
+    std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value &json)
 {
     ParseUtil::ExpectTypeString(json, CardElementType::TextInput);
 
@@ -111,7 +111,7 @@ std::shared_ptr<BaseCardElement> TextInputParser::Deserialize(
 
 std::shared_ptr<BaseCardElement> TextInputParser::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString)
 {
     return TextInputParser::Deserialize(
         elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));

--- a/source/shared/cpp/ObjectModel/TextInput.h
+++ b/source/shared/cpp/ObjectModel/TextInput.h
@@ -5,50 +5,49 @@
 #include "Enums.h"
 #include "ElementParserRegistration.h"
 
-AdaptiveSharedNamespaceStart
-class TextInput : public BaseInputElement
+namespace AdaptiveSharedNamespace
 {
-public:
-    TextInput();
+    class TextInput : public BaseInputElement
+    {
+        public:
+        TextInput();
 
-    virtual Json::Value SerializeToJsonValue() const override;
+        virtual Json::Value SerializeToJsonValue() const override;
 
-    std::string GetPlaceholder() const;
-    void SetPlaceholder(const std::string &value);
+        std::string GetPlaceholder() const;
+        void SetPlaceholder(const std::string& value);
 
-    std::string GetValue() const;
-    void SetValue(const std::string &value);
+        std::string GetValue() const;
+        void SetValue(const std::string& value);
 
-    bool GetIsMultiline() const;
-    void SetIsMultiline(const bool value);
+        bool GetIsMultiline() const;
+        void SetIsMultiline(const bool value);
 
-    unsigned int GetMaxLength() const;
-    void SetMaxLength(const unsigned int value);
+        unsigned int GetMaxLength() const;
+        void SetMaxLength(const unsigned int value);
 
-    TextInputStyle GetTextInputStyle() const;
-    void SetTextInputStyle(const TextInputStyle value);
+        TextInputStyle GetTextInputStyle() const;
+        void SetTextInputStyle(const TextInputStyle value);
 
-private:
-    void PopulateKnownPropertiesSet();
+        private:
+        void PopulateKnownPropertiesSet();
 
-    std::string m_placeholder;
-    std::string m_value;
-    bool m_isMultiline;
-    unsigned int m_maxLength;
-    TextInputStyle m_style;
-};
+        std::string m_placeholder;
+        std::string m_value;
+        bool m_isMultiline;
+        unsigned int m_maxLength;
+        TextInputStyle m_style;
+    };
 
-class TextInputParser : public BaseCardElementParser
-{
-public:
-    std::shared_ptr<BaseCardElement> Deserialize(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const Json::Value& root);
+    class TextInputParser : public BaseCardElementParser
+    {
+        public:
+        std::shared_ptr<BaseCardElement> Deserialize(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
 
-    std::shared_ptr<BaseCardElement> DeserializeFromString(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const std::string& jsonString);
-};
-AdaptiveSharedNamespaceEnd
+        std::shared_ptr<BaseCardElement> DeserializeFromString(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+    };
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/TextInput.h
+++ b/source/shared/cpp/ObjectModel/TextInput.h
@@ -9,7 +9,7 @@ namespace AdaptiveSharedNamespace
 {
     class TextInput : public BaseInputElement
     {
-        public:
+    public:
         TextInput();
 
         virtual Json::Value SerializeToJsonValue() const override;
@@ -29,7 +29,7 @@ namespace AdaptiveSharedNamespace
         TextInputStyle GetTextInputStyle() const;
         void SetTextInputStyle(const TextInputStyle value);
 
-        private:
+    private:
         void PopulateKnownPropertiesSet();
 
         std::string m_placeholder;
@@ -41,7 +41,7 @@ namespace AdaptiveSharedNamespace
 
     class TextInputParser : public BaseCardElementParser
     {
-        public:
+    public:
         std::shared_ptr<BaseCardElement> Deserialize(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
             std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);

--- a/source/shared/cpp/ObjectModel/TextInput.h
+++ b/source/shared/cpp/ObjectModel/TextInput.h
@@ -15,10 +15,10 @@ namespace AdaptiveSharedNamespace
         virtual Json::Value SerializeToJsonValue() const override;
 
         std::string GetPlaceholder() const;
-        void SetPlaceholder(const std::string& value);
+        void SetPlaceholder(const std::string &value);
 
         std::string GetValue() const;
-        void SetValue(const std::string& value);
+        void SetValue(const std::string &value);
 
         bool GetIsMultiline() const;
         void SetIsMultiline(const bool value);
@@ -44,10 +44,10 @@ namespace AdaptiveSharedNamespace
     public:
         std::shared_ptr<BaseCardElement> Deserialize(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &root);
 
         std::shared_ptr<BaseCardElement> DeserializeFromString(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString);
     };
 } // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/TimeInput.cpp
+++ b/source/shared/cpp/ObjectModel/TimeInput.cpp
@@ -4,8 +4,7 @@
 
 using namespace AdaptiveSharedNamespace;
 
-TimeInput::TimeInput() :
-    BaseInputElement(CardElementType::TimeInput)
+TimeInput::TimeInput() : BaseInputElement(CardElementType::TimeInput)
 {
     PopulateKnownPropertiesSet();
 }
@@ -42,7 +41,7 @@ std::string TimeInput::GetMax() const
     return m_max;
 }
 
-void TimeInput::SetMax(const std::string &value)
+void TimeInput::SetMax(const std::string& value)
 {
     m_max = value;
 }
@@ -52,7 +51,7 @@ std::string TimeInput::GetMin() const
     return m_min;
 }
 
-void TimeInput::SetMin(const std::string &value)
+void TimeInput::SetMin(const std::string& value)
 {
     m_min = value;
 }
@@ -62,7 +61,7 @@ std::string TimeInput::GetPlaceholder() const
     return m_placeholder;
 }
 
-void TimeInput::SetPlaceholder(const std::string &value)
+void TimeInput::SetPlaceholder(const std::string& value)
 {
     m_placeholder = value;
 }
@@ -72,15 +71,13 @@ std::string TimeInput::GetValue() const
     return m_value;
 }
 
-void TimeInput::SetValue(const std::string &value)
+void TimeInput::SetValue(const std::string& value)
 {
     m_value = value;
 }
 
 std::shared_ptr<BaseCardElement> TimeInputParser::Deserialize(
-    std::shared_ptr<ElementParserRegistration>,
-    std::shared_ptr<ActionParserRegistration>,
-    const Json::Value& json)
+    std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value& json)
 {
     ParseUtil::ExpectTypeString(json, CardElementType::TimeInput);
 
@@ -96,13 +93,13 @@ std::shared_ptr<BaseCardElement> TimeInputParser::Deserialize(
 
 std::shared_ptr<BaseCardElement> TimeInputParser::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-    const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
 {
-    return TimeInputParser::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
+    return TimeInputParser::Deserialize(
+        elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
-void TimeInput::PopulateKnownPropertiesSet() 
+void TimeInput::PopulateKnownPropertiesSet()
 {
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Max));
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Min));

--- a/source/shared/cpp/ObjectModel/TimeInput.cpp
+++ b/source/shared/cpp/ObjectModel/TimeInput.cpp
@@ -41,7 +41,7 @@ std::string TimeInput::GetMax() const
     return m_max;
 }
 
-void TimeInput::SetMax(const std::string& value)
+void TimeInput::SetMax(const std::string &value)
 {
     m_max = value;
 }
@@ -51,7 +51,7 @@ std::string TimeInput::GetMin() const
     return m_min;
 }
 
-void TimeInput::SetMin(const std::string& value)
+void TimeInput::SetMin(const std::string &value)
 {
     m_min = value;
 }
@@ -61,7 +61,7 @@ std::string TimeInput::GetPlaceholder() const
     return m_placeholder;
 }
 
-void TimeInput::SetPlaceholder(const std::string& value)
+void TimeInput::SetPlaceholder(const std::string &value)
 {
     m_placeholder = value;
 }
@@ -71,13 +71,13 @@ std::string TimeInput::GetValue() const
     return m_value;
 }
 
-void TimeInput::SetValue(const std::string& value)
+void TimeInput::SetValue(const std::string &value)
 {
     m_value = value;
 }
 
 std::shared_ptr<BaseCardElement> TimeInputParser::Deserialize(
-    std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value& json)
+    std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value &json)
 {
     ParseUtil::ExpectTypeString(json, CardElementType::TimeInput);
 
@@ -93,7 +93,7 @@ std::shared_ptr<BaseCardElement> TimeInputParser::Deserialize(
 
 std::shared_ptr<BaseCardElement> TimeInputParser::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString)
 {
     return TimeInputParser::Deserialize(
         elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));

--- a/source/shared/cpp/ObjectModel/TimeInput.h
+++ b/source/shared/cpp/ObjectModel/TimeInput.h
@@ -15,16 +15,16 @@ namespace AdaptiveSharedNamespace
         virtual Json::Value SerializeToJsonValue() const override;
 
         std::string GetMax() const;
-        void SetMax(const std::string& value);
+        void SetMax(const std::string &value);
 
         std::string GetMin() const;
-        void SetMin(const std::string& value);
+        void SetMin(const std::string &value);
 
         std::string GetPlaceholder() const;
-        void SetPlaceholder(const std::string& value);
+        void SetPlaceholder(const std::string &value);
 
         std::string GetValue() const;
-        void SetValue(const std::string& value);
+        void SetValue(const std::string &value);
 
     private:
         void PopulateKnownPropertiesSet();
@@ -40,10 +40,10 @@ namespace AdaptiveSharedNamespace
     public:
         std::shared_ptr<BaseCardElement> Deserialize(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &root);
 
         std::shared_ptr<BaseCardElement> DeserializeFromString(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString);
     };
 } // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/TimeInput.h
+++ b/source/shared/cpp/ObjectModel/TimeInput.h
@@ -5,46 +5,45 @@
 #include "Enums.h"
 #include "ElementParserRegistration.h"
 
-AdaptiveSharedNamespaceStart
-class TimeInput : public BaseInputElement
+namespace AdaptiveSharedNamespace
 {
-public:
-    TimeInput();
+    class TimeInput : public BaseInputElement
+    {
+        public:
+        TimeInput();
 
-    virtual Json::Value SerializeToJsonValue() const override;
+        virtual Json::Value SerializeToJsonValue() const override;
 
-    std::string GetMax() const;
-    void SetMax(const std::string &value);
+        std::string GetMax() const;
+        void SetMax(const std::string& value);
 
-    std::string GetMin() const;
-    void SetMin(const std::string &value);
+        std::string GetMin() const;
+        void SetMin(const std::string& value);
 
-    std::string GetPlaceholder() const;
-    void SetPlaceholder(const std::string &value);
+        std::string GetPlaceholder() const;
+        void SetPlaceholder(const std::string& value);
 
-    std::string GetValue() const;
-    void SetValue(const std::string &value);
+        std::string GetValue() const;
+        void SetValue(const std::string& value);
 
-private:
-    void PopulateKnownPropertiesSet();
+        private:
+        void PopulateKnownPropertiesSet();
 
-    std::string m_max;
-    std::string m_min;
-    std::string m_placeholder;
-    std::string m_value;
-};
+        std::string m_max;
+        std::string m_min;
+        std::string m_placeholder;
+        std::string m_value;
+    };
 
-class TimeInputParser : public BaseCardElementParser
-{
-public:
-    std::shared_ptr<BaseCardElement> Deserialize(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const Json::Value& root);
+    class TimeInputParser : public BaseCardElementParser
+    {
+        public:
+        std::shared_ptr<BaseCardElement> Deserialize(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
 
-    std::shared_ptr<BaseCardElement> DeserializeFromString(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const std::string& jsonString);
-};
-AdaptiveSharedNamespaceEnd
+        std::shared_ptr<BaseCardElement> DeserializeFromString(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+    };
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/TimeInput.h
+++ b/source/shared/cpp/ObjectModel/TimeInput.h
@@ -9,7 +9,7 @@ namespace AdaptiveSharedNamespace
 {
     class TimeInput : public BaseInputElement
     {
-        public:
+    public:
         TimeInput();
 
         virtual Json::Value SerializeToJsonValue() const override;
@@ -26,7 +26,7 @@ namespace AdaptiveSharedNamespace
         std::string GetValue() const;
         void SetValue(const std::string& value);
 
-        private:
+    private:
         void PopulateKnownPropertiesSet();
 
         std::string m_max;
@@ -37,7 +37,7 @@ namespace AdaptiveSharedNamespace
 
     class TimeInputParser : public BaseCardElementParser
     {
-        public:
+    public:
         std::shared_ptr<BaseCardElement> Deserialize(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
             std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);

--- a/source/shared/cpp/ObjectModel/ToggleInput.cpp
+++ b/source/shared/cpp/ObjectModel/ToggleInput.cpp
@@ -38,7 +38,7 @@ std::string ToggleInput::GetTitle() const
     return m_title;
 }
 
-void ToggleInput::SetTitle(const std::string& value)
+void ToggleInput::SetTitle(const std::string &value)
 {
     m_title = value;
 }
@@ -48,11 +48,11 @@ std::string ToggleInput::GetValue() const
     return m_value;
 }
 
-void ToggleInput::SetValue(const std::string& value)
+void ToggleInput::SetValue(const std::string &value)
 {
     m_value = value;
 }
-void ToggleInput::SetValueOff(const std::string& valueOff)
+void ToggleInput::SetValueOff(const std::string &valueOff)
 {
     m_valueOff = valueOff;
 }
@@ -67,13 +67,13 @@ std::string ToggleInput::GetValueOn() const
     return m_valueOn;
 }
 
-void ToggleInput::SetValueOn(const std::string& valueOn)
+void ToggleInput::SetValueOn(const std::string &valueOn)
 {
     m_valueOn = valueOn;
 }
 
 std::shared_ptr<BaseCardElement> ToggleInputParser::Deserialize(
-    std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value& json)
+    std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value &json)
 {
     ParseUtil::ExpectTypeString(json, CardElementType::ToggleInput);
 
@@ -99,7 +99,7 @@ std::shared_ptr<BaseCardElement> ToggleInputParser::Deserialize(
 
 std::shared_ptr<BaseCardElement> ToggleInputParser::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString)
 {
     return ToggleInputParser::Deserialize(
         elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));

--- a/source/shared/cpp/ObjectModel/ToggleInput.cpp
+++ b/source/shared/cpp/ObjectModel/ToggleInput.cpp
@@ -4,10 +4,7 @@
 
 using namespace AdaptiveSharedNamespace;
 
-ToggleInput::ToggleInput() :
-    BaseInputElement(CardElementType::ToggleInput),
-    m_valueOff("false"),
-    m_valueOn("true")
+ToggleInput::ToggleInput() : BaseInputElement(CardElementType::ToggleInput), m_valueOff("false"), m_valueOn("true")
 {
     PopulateKnownPropertiesSet();
 }
@@ -41,7 +38,7 @@ std::string ToggleInput::GetTitle() const
     return m_title;
 }
 
-void ToggleInput::SetTitle(const std::string &value)
+void ToggleInput::SetTitle(const std::string& value)
 {
     m_title = value;
 }
@@ -51,11 +48,11 @@ std::string ToggleInput::GetValue() const
     return m_value;
 }
 
-void ToggleInput::SetValue(const std::string &value)
+void ToggleInput::SetValue(const std::string& value)
 {
     m_value = value;
 }
-void ToggleInput::SetValueOff(const std::string &valueOff)
+void ToggleInput::SetValueOff(const std::string& valueOff)
 {
     m_valueOff = valueOff;
 }
@@ -70,15 +67,13 @@ std::string ToggleInput::GetValueOn() const
     return m_valueOn;
 }
 
-void ToggleInput::SetValueOn(const std::string &valueOn)
+void ToggleInput::SetValueOn(const std::string& valueOn)
 {
     m_valueOn = valueOn;
 }
 
 std::shared_ptr<BaseCardElement> ToggleInputParser::Deserialize(
-    std::shared_ptr<ElementParserRegistration>,
-    std::shared_ptr<ActionParserRegistration>,
-    const Json::Value& json)
+    std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value& json)
 {
     ParseUtil::ExpectTypeString(json, CardElementType::ToggleInput);
 
@@ -104,13 +99,13 @@ std::shared_ptr<BaseCardElement> ToggleInputParser::Deserialize(
 
 std::shared_ptr<BaseCardElement> ToggleInputParser::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-    const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
 {
-    return ToggleInputParser::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
+    return ToggleInputParser::Deserialize(
+        elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
-void ToggleInput::PopulateKnownPropertiesSet() 
+void ToggleInput::PopulateKnownPropertiesSet()
 {
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Title));
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Value));

--- a/source/shared/cpp/ObjectModel/ToggleInput.h
+++ b/source/shared/cpp/ObjectModel/ToggleInput.h
@@ -5,46 +5,45 @@
 #include "Enums.h"
 #include "ElementParserRegistration.h"
 
-AdaptiveSharedNamespaceStart
-class ToggleInput : public BaseInputElement
+namespace AdaptiveSharedNamespace
 {
-public:
-    ToggleInput();
+    class ToggleInput : public BaseInputElement
+    {
+        public:
+        ToggleInput();
 
-    virtual Json::Value SerializeToJsonValue() const override;
+        virtual Json::Value SerializeToJsonValue() const override;
 
-    std::string GetTitle() const;
-    void SetTitle(const std::string &value);
+        std::string GetTitle() const;
+        void SetTitle(const std::string& value);
 
-    std::string GetValue() const;
-    void SetValue(const std::string &value);
+        std::string GetValue() const;
+        void SetValue(const std::string& value);
 
-    std::string GetValueOff() const;
-    void SetValueOff(const std::string &value);
+        std::string GetValueOff() const;
+        void SetValueOff(const std::string& value);
 
-    std::string GetValueOn() const;
-    void SetValueOn(const std::string &value);
+        std::string GetValueOn() const;
+        void SetValueOn(const std::string& value);
 
-private:
-    void PopulateKnownPropertiesSet();
+        private:
+        void PopulateKnownPropertiesSet();
 
-    std::string m_title;
-    std::string m_value;
-    std::string m_valueOff;
-    std::string m_valueOn;
-};
+        std::string m_title;
+        std::string m_value;
+        std::string m_valueOff;
+        std::string m_valueOn;
+    };
 
-class ToggleInputParser : public BaseCardElementParser
-{
-public:
-    std::shared_ptr<BaseCardElement> Deserialize(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const Json::Value& root);
+    class ToggleInputParser : public BaseCardElementParser
+    {
+        public:
+        std::shared_ptr<BaseCardElement> Deserialize(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
 
-    std::shared_ptr<BaseCardElement> DeserializeFromString(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const std::string& jsonString);
-};
-AdaptiveSharedNamespaceEnd
+        std::shared_ptr<BaseCardElement> DeserializeFromString(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+    };
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/ToggleInput.h
+++ b/source/shared/cpp/ObjectModel/ToggleInput.h
@@ -15,16 +15,16 @@ namespace AdaptiveSharedNamespace
         virtual Json::Value SerializeToJsonValue() const override;
 
         std::string GetTitle() const;
-        void SetTitle(const std::string& value);
+        void SetTitle(const std::string &value);
 
         std::string GetValue() const;
-        void SetValue(const std::string& value);
+        void SetValue(const std::string &value);
 
         std::string GetValueOff() const;
-        void SetValueOff(const std::string& value);
+        void SetValueOff(const std::string &value);
 
         std::string GetValueOn() const;
-        void SetValueOn(const std::string& value);
+        void SetValueOn(const std::string &value);
 
     private:
         void PopulateKnownPropertiesSet();
@@ -40,10 +40,10 @@ namespace AdaptiveSharedNamespace
     public:
         std::shared_ptr<BaseCardElement> Deserialize(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &root);
 
         std::shared_ptr<BaseCardElement> DeserializeFromString(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString);
     };
 } // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/ToggleInput.h
+++ b/source/shared/cpp/ObjectModel/ToggleInput.h
@@ -9,7 +9,7 @@ namespace AdaptiveSharedNamespace
 {
     class ToggleInput : public BaseInputElement
     {
-        public:
+    public:
         ToggleInput();
 
         virtual Json::Value SerializeToJsonValue() const override;
@@ -26,7 +26,7 @@ namespace AdaptiveSharedNamespace
         std::string GetValueOn() const;
         void SetValueOn(const std::string& value);
 
-        private:
+    private:
         void PopulateKnownPropertiesSet();
 
         std::string m_title;
@@ -37,7 +37,7 @@ namespace AdaptiveSharedNamespace
 
     class ToggleInputParser : public BaseCardElementParser
     {
-        public:
+    public:
         std::shared_ptr<BaseCardElement> Deserialize(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
             std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);

--- a/source/shared/cpp/ObjectModel/UnknownElement.cpp
+++ b/source/shared/cpp/ObjectModel/UnknownElement.cpp
@@ -9,15 +9,10 @@
 
 using namespace AdaptiveSharedNamespace;
 
-UnknownElement::UnknownElement() :
-    BaseCardElement(CardElementType::Unknown)
-{
-}
+UnknownElement::UnknownElement() : BaseCardElement(CardElementType::Unknown) {}
 
 std::shared_ptr<BaseCardElement> UnknownElementParser::Deserialize(
-    std::shared_ptr<ElementParserRegistration>,
-    std::shared_ptr<ActionParserRegistration>,
-    const Json::Value& json)
+    std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value& json)
 {
     std::shared_ptr<UnknownElement> unknown = BaseCardElement::Deserialize<UnknownElement>(json);
     return unknown;
@@ -25,8 +20,8 @@ std::shared_ptr<BaseCardElement> UnknownElementParser::Deserialize(
 
 std::shared_ptr<BaseCardElement> UnknownElementParser::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-    const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
 {
-    return UnknownElementParser::Deserialize(elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
+    return UnknownElementParser::Deserialize(
+        elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));
 }

--- a/source/shared/cpp/ObjectModel/UnknownElement.cpp
+++ b/source/shared/cpp/ObjectModel/UnknownElement.cpp
@@ -12,7 +12,7 @@ using namespace AdaptiveSharedNamespace;
 UnknownElement::UnknownElement() : BaseCardElement(CardElementType::Unknown) {}
 
 std::shared_ptr<BaseCardElement> UnknownElementParser::Deserialize(
-    std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value& json)
+    std::shared_ptr<ElementParserRegistration>, std::shared_ptr<ActionParserRegistration>, const Json::Value &json)
 {
     std::shared_ptr<UnknownElement> unknown = BaseCardElement::Deserialize<UnknownElement>(json);
     return unknown;
@@ -20,7 +20,7 @@ std::shared_ptr<BaseCardElement> UnknownElementParser::Deserialize(
 
 std::shared_ptr<BaseCardElement> UnknownElementParser::DeserializeFromString(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString)
+    std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString)
 {
     return UnknownElementParser::Deserialize(
         elementParserRegistration, actionParserRegistration, ParseUtil::GetJsonValueFromString(jsonString));

--- a/source/shared/cpp/ObjectModel/UnknownElement.h
+++ b/source/shared/cpp/ObjectModel/UnknownElement.h
@@ -11,13 +11,13 @@ namespace AdaptiveSharedNamespace
 {
     class UnknownElement : public BaseCardElement
     {
-        public:
+    public:
         UnknownElement();
     };
 
     class UnknownElementParser : public BaseCardElementParser
     {
-        public:
+    public:
         std::shared_ptr<BaseCardElement> Deserialize(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
             std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);

--- a/source/shared/cpp/ObjectModel/UnknownElement.h
+++ b/source/shared/cpp/ObjectModel/UnknownElement.h
@@ -7,24 +7,23 @@
 #include "ElementParserRegistration.h"
 #include "DateTimePreparser.h"
 
-AdaptiveSharedNamespaceStart
-class UnknownElement: public BaseCardElement
+namespace AdaptiveSharedNamespace
 {
-public:
-    UnknownElement();
-};
+    class UnknownElement : public BaseCardElement
+    {
+        public:
+        UnknownElement();
+    };
 
-class UnknownElementParser : public BaseCardElementParser
-{
-public:
-    std::shared_ptr<BaseCardElement> Deserialize(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const Json::Value& root);
+    class UnknownElementParser : public BaseCardElementParser
+    {
+        public:
+        std::shared_ptr<BaseCardElement> Deserialize(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
 
-    std::shared_ptr<BaseCardElement> DeserializeFromString(
-        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-        std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-        const std::string& jsonString);
-};
-AdaptiveSharedNamespaceEnd
+        std::shared_ptr<BaseCardElement> DeserializeFromString(
+            std::shared_ptr<ElementParserRegistration> elementParserRegistration,
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+    };
+} // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/UnknownElement.h
+++ b/source/shared/cpp/ObjectModel/UnknownElement.h
@@ -20,10 +20,10 @@ namespace AdaptiveSharedNamespace
     public:
         std::shared_ptr<BaseCardElement> Deserialize(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value& root);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const Json::Value &root);
 
         std::shared_ptr<BaseCardElement> DeserializeFromString(
             std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string& jsonString);
+            std::shared_ptr<ActionParserRegistration> actionParserRegistration, const std::string &jsonString);
     };
 } // namespace AdaptiveSharedNamespace

--- a/source/shared/cpp/ObjectModel/Util.cpp
+++ b/source/shared/cpp/ObjectModel/Util.cpp
@@ -34,12 +34,11 @@ void PropagateLanguage(const std::string& language, std::vector<std::shared_ptr<
                 textBlock->SetLanguage(language);
             }
         }
-
     }
-
 }
 
-void ValidateUserInputForDimensionWithUnit(const std::string &unit, const std::string &requestedDimension, int &parsedDimension)
+void ValidateUserInputForDimensionWithUnit(
+    const std::string& unit, const std::string& requestedDimension, int& parsedDimension)
 {
     if (requestedDimension.empty())
     {
@@ -50,26 +49,30 @@ void ValidateUserInputForDimensionWithUnit(const std::string &unit, const std::s
         std::size_t foundIndex = requestedDimension.find(unit);
         if (std::string::npos == foundIndex || requestedDimension.size() != foundIndex + unit.size())
         {
-            throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "unit is either missing or inproper form: " + requestedDimension);
+            throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue,
+                "unit is either missing or inproper form: " + requestedDimension);
         }
         try
         {
             float parsedVal = stof(requestedDimension.substr(0, foundIndex));
-            if(parsedVal != (int) parsedVal || parsedVal < 0)
+            if (parsedVal != (int)parsedVal || parsedVal < 0)
             {
-                throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "unsigned integer is accepted but received : " + requestedDimension);
+                throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue,
+                    "unsigned integer is accepted but received : " + requestedDimension);
             }
             parsedDimension = (int)parsedVal;
         }
-        catch (const std::invalid_argument &e)
+        catch (const std::invalid_argument& e)
         {
             (void)e;
-            throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "unsigned integer is accepted but received : " + requestedDimension);
+            throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue,
+                "unsigned integer is accepted but received : " + requestedDimension);
         }
-        catch (const std::out_of_range &e)
+        catch (const std::out_of_range& e)
         {
             (void)e;
-            throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "out of range: " + requestedDimension);
+            throw AdaptiveCardParseException(
+                ErrorStatusCode::InvalidPropertyValue, "out of range: " + requestedDimension);
         }
     }
 }

--- a/source/shared/cpp/ObjectModel/Util.cpp
+++ b/source/shared/cpp/ObjectModel/Util.cpp
@@ -4,9 +4,9 @@
 #include "Container.h"
 #include "TextBlock.h"
 
-void PropagateLanguage(const std::string& language, std::vector<std::shared_ptr<BaseCardElement>>& m_body)
+void PropagateLanguage(const std::string &language, std::vector<std::shared_ptr<BaseCardElement>> &m_body)
 {
-    for (auto& bodyElement : m_body)
+    for (auto &bodyElement : m_body)
     {
         CardElementType elementType = bodyElement->GetElementType();
 
@@ -38,7 +38,7 @@ void PropagateLanguage(const std::string& language, std::vector<std::shared_ptr<
 }
 
 void ValidateUserInputForDimensionWithUnit(
-    const std::string& unit, const std::string& requestedDimension, int& parsedDimension)
+    const std::string &unit, const std::string &requestedDimension, int &parsedDimension)
 {
     if (requestedDimension.empty())
     {
@@ -62,13 +62,13 @@ void ValidateUserInputForDimensionWithUnit(
             }
             parsedDimension = (int)parsedVal;
         }
-        catch (const std::invalid_argument& e)
+        catch (const std::invalid_argument &e)
         {
             (void)e;
             throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue,
                 "unsigned integer is accepted but received : " + requestedDimension);
         }
-        catch (const std::out_of_range& e)
+        catch (const std::out_of_range &e)
         {
             (void)e;
             throw AdaptiveCardParseException(

--- a/source/shared/cpp/ObjectModel/Util.h
+++ b/source/shared/cpp/ObjectModel/Util.h
@@ -6,7 +6,7 @@
 
 using namespace AdaptiveSharedNamespace;
 
-void PropagateLanguage(const std::string& language, std::vector<std::shared_ptr<BaseCardElement>>& m_body);
+void PropagateLanguage(const std::string &language, std::vector<std::shared_ptr<BaseCardElement>> &m_body);
 
 void ValidateUserInputForDimensionWithUnit(
-    const std::string& unit, const std::string& requestedDimension, int& parsedDimension);
+    const std::string &unit, const std::string &requestedDimension, int &parsedDimension);

--- a/source/shared/cpp/ObjectModel/Util.h
+++ b/source/shared/cpp/ObjectModel/Util.h
@@ -8,4 +8,5 @@ using namespace AdaptiveSharedNamespace;
 
 void PropagateLanguage(const std::string& language, std::vector<std::shared_ptr<BaseCardElement>>& m_body);
 
-void ValidateUserInputForDimensionWithUnit(const std::string &unit, const std::string &requestedDimension, int &parsedDimension);
+void ValidateUserInputForDimensionWithUnit(
+    const std::string& unit, const std::string& requestedDimension, int& parsedDimension);

--- a/source/shared/cpp/ObjectModel/pch.h
+++ b/source/shared/cpp/ObjectModel/pch.h
@@ -4,10 +4,8 @@
 #include "winPch.h"
 #endif
 
-#ifndef AdaptiveSharedNamespaceStart
-#define AdaptiveSharedNamespaceStart namespace AdaptiveCards {
+#ifndef AdaptiveSharedNamespace
 #define AdaptiveSharedNamespace AdaptiveCards
-#define AdaptiveSharedNamespaceEnd }
 #endif
 
 #include <memory>

--- a/source/shared/cpp/ObjectModel/pch.h
+++ b/source/shared/cpp/ObjectModel/pch.h
@@ -23,9 +23,9 @@
 
 #if !defined(__ANDROID__) && !defined(__APPLE__)
 #include <CppCoreCheck\warnings.h>
-#pragma warning(disable: ALL_CPPCORECHECK_WARNINGS)
-#pragma warning(default: CPPCORECHECK_STYLE_WARNINGS)
-#pragma warning(default: CPPCORECHECK_CONCURRENCY_WARNINGS)
-#pragma warning(default: CPPCORECHECK_ARITHMETIC_WARNINGS)
-#pragma warning(default: CPPCORECHECK_UNIQUE_POINTER_WARNINGS)
+#pragma warning(disable : ALL_CPPCORECHECK_WARNINGS)
+#pragma warning(default : CPPCORECHECK_STYLE_WARNINGS)
+#pragma warning(default : CPPCORECHECK_CONCURRENCY_WARNINGS)
+#pragma warning(default : CPPCORECHECK_ARITHMETIC_WARNINGS)
+#pragma warning(default : CPPCORECHECK_UNIQUE_POINTER_WARNINGS)
 #endif


### PR DESCRIPTION
We will eventually be moving this standardization up the tree, but for now we're just enforcing it in `shared/cpp`.

In order for the tools to work correctly, I've reworked our namespacing macro.

There are lots of different ways to utilize this functionality. Visual Studio support is built in to recent versions and available as a plugin in older versions. Lots of other editors have native or pluggable support for this format. Additionally, the `clang-format` console application is available for pretty much all platforms.

