### PR TITLE
[Android] Remove untrustable fix for fact set wrapping issue

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/FactSetRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/FactSetRenderer.java
@@ -41,7 +41,7 @@ public class FactSetRenderer extends BaseCardElementRenderer
         return s_instance;
     }
 
-    static TextView createTextView(Context context, String text, TextConfig textConfig, HostConfig hostConfig, long spacing, ContainerStyle containerStyle, boolean isValue)
+    static TextView createTextView(Context context, String text, TextConfig textConfig, HostConfig hostConfig, long spacing, ContainerStyle containerStyle)
     {
         TextView textView = new TextView(context);
         textView.setText(text);
@@ -58,11 +58,6 @@ public class FactSetRenderer extends BaseCardElementRenderer
                 GridLayout.spec(GridLayout.UNDEFINED));
 
         parem.rightMargin = (int) spacing;
-        if (isValue)
-        {
-            parem.width = 0;
-            parem.setGravity(Gravity.FILL_HORIZONTAL);
-        }
 
         textView.setLayoutParams(parem);
         return textView;
@@ -102,8 +97,8 @@ public class FactSetRenderer extends BaseCardElementRenderer
         for (int i = 0; i < factVectorSize; i++)
         {
             Fact fact = factVector.get(i);
-            gridLayout.addView(createTextView(context, fact.GetTitle(), hostConfig.getFactSet().getTitle(), hostConfig, spacing, containerStyle, false));
-            gridLayout.addView(createTextView(context, fact.GetValue(), hostConfig.getFactSet().getValue(), hostConfig, 0, containerStyle, true));
+            gridLayout.addView(createTextView(context, fact.GetTitle(), hostConfig.getFactSet().getTitle(), hostConfig, spacing, containerStyle));
+            gridLayout.addView(createTextView(context, fact.GetValue(), hostConfig.getFactSet().getValue(), hostConfig, 0, containerStyle));
         }
 
         viewGroup.addView(gridLayout);


### PR DESCRIPTION
The issue before the fix was that the text in some factsets would not wrap correctly, so the text would be clipped https://github.com/Microsoft/AdaptiveCards/issues/1472

The issue after the fix is that cards like StockUpdate dont render the text at all for the fact values http://adaptivecards.io/samples/StockUpdate.html

So we'll remove the fix until we find a reliable fix for this