### PR TITLE
Add MSC directive to prevent cppcorecheck build failures on non-VS builds

### DIFF
--- a/source/shared/cpp/ObjectModel/pch.h
+++ b/source/shared/cpp/ObjectModel/pch.h
@@ -23,7 +23,7 @@
 #include <fstream>
 #include <locale>
 
-#if !defined(__ANDROID__) && !defined(__APPLE__) && !defined(ADAPTIVE_CARDS_WINDOWS)
+#if defined(_MSC_BUILD) && !defined(__ANDROID__) && !defined(__APPLE__) && !defined(ADAPTIVE_CARDS_WINDOWS)
 #include <CppCoreCheck\warnings.h>
 #pragma warning(disable: ALL_CPPCORECHECK_WARNINGS)
 #pragma warning(default: CPPCORECHECK_STYLE_WARNINGS)


### PR DESCRIPTION
Simple fix for #1550 -- Only include cppcorecheck headers when compiling with MS toolchain.