### PR TITLE
Tupha/support card level select action dotnet

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Rendering.Html/AdaptiveCardRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Html/AdaptiveCardRenderer.cs
@@ -52,6 +52,7 @@ namespace AdaptiveCards.Rendering.Html
             try
             {
                 var context = new AdaptiveRenderContext(HostConfig, ElementRenderers);
+
                 var tag = context.Render(card);
                 return new RenderedAdaptiveCard(tag, card, context.Warnings);
             }
@@ -143,7 +144,43 @@ namespace AdaptiveCards.Rendering.Html
 
             AddContainerElements(uiCard, card.Body, card.Actions, context);
 
+            AddSelectAction(uiCard, card.SelectAction, context);
+
+            // Add all accumulated selectAction show cards
+            foreach (var showCard in context.ShowCardTags)
+            {
+                uiCard.Children.Add(showCard);
+            }
+
             return uiCard;
+        }
+
+        protected static void AddSelectAction(HtmlTag tag, AdaptiveAction selectAction, AdaptiveRenderContext context)
+        {
+            if (context.Config.SupportsInteractivity && selectAction != null)
+            {
+                tag.AddClass("ac-selectable");
+                AddActionAttributes(selectAction, tag, context);
+
+                // Create the additional card below for showCard actions
+                if (selectAction is AdaptiveShowCardAction showCardAction)
+                {
+                    var cardId = tag.Attributes["data-ac-showCardId"];
+
+                    var uiShowCard = context.Render(showCardAction.Card);
+                    if (uiShowCard != null)
+                    {
+                        uiShowCard.Attr("id", cardId)
+                            .AddClass("ac-showCard")
+                            .Style("padding", "0")
+                            .Style("display", "none")
+                            .Style("margin-top", $"{context.Config.Actions.ShowCard.InlineTopMargin}px");
+
+                        // Store all showCard tags inside context
+                        context.ShowCardTags.Add(uiShowCard);
+                    }
+                }
+            }
         }
 
         protected static void AddContainerElements(HtmlTag uiContainer, IList<AdaptiveElement> elements, IList<AdaptiveAction> actions, AdaptiveRenderContext context)
@@ -309,12 +346,7 @@ namespace AdaptiveCards.Rendering.Html
 
             AddContainerElements(uiColumn, column.Items, null, context);
 
-            // selectAction
-            if (context.Config.SupportsInteractivity && column.SelectAction != null)
-            {
-                uiColumn.AddClass("ac-selectable");
-                AddActionAttributes(column.SelectAction, uiColumn, context);
-            }
+            AddSelectAction(uiColumn, column.SelectAction, context);
 
             return uiColumn;
         }
@@ -326,12 +358,7 @@ namespace AdaptiveCards.Rendering.Html
                 .Style("overflow", "hidden")
                 .Style("display", "flex");
 
-            // selectAction
-            if (context.Config.SupportsInteractivity && columnSet.SelectAction != null)
-            {
-                uiColumnSet.AddClass("ac-selectable");
-                AddActionAttributes(columnSet.SelectAction, uiColumnSet, context);
-            }
+            AddSelectAction(uiColumnSet, columnSet.SelectAction, context);
 
             var max = Math.Max(1.0, columnSet.Columns.Select(col =>
             {
@@ -410,11 +437,7 @@ namespace AdaptiveCards.Rendering.Html
 
             AddContainerElements(uiContainer, container.Items, null, context);
 
-            if (context.Config.SupportsInteractivity && container.SelectAction != null)
-            {
-                uiContainer.AddClass("ac-selectable");
-                AddActionAttributes(container.SelectAction, uiContainer, context);
-            }
+            AddSelectAction(uiContainer, container.SelectAction, context);
 
             return uiContainer;
         }
@@ -626,11 +649,7 @@ namespace AdaptiveCards.Rendering.Html
             }
             uiDiv.Children.Add(uiImage);
 
-            if (context.Config.SupportsInteractivity && image.SelectAction != null)
-            {
-                uiDiv.AddClass("ac-selectable");
-                AddActionAttributes(image.SelectAction, uiDiv, context);
-            }
+            AddSelectAction(uiDiv, image.SelectAction, context);
             return uiDiv;
         }
 

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Html/AdaptiveRenderContext.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Html/AdaptiveRenderContext.cs
@@ -19,6 +19,8 @@ namespace AdaptiveCards.Rendering.Html
 
         public IList<AdaptiveWarning> Warnings { get; } = new List<AdaptiveWarning>();
 
+        public IList<HtmlTag> ShowCardTags { get; } = new List<HtmlTag>();
+
         public HtmlTag Render(AdaptiveTypedElement element)
         {
             // If non-inertactive, inputs should just render text

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveActionRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveActionRenderer.cs
@@ -24,9 +24,7 @@ namespace AdaptiveCards.Rendering.Wpf
         {
             var uiButton = new Button
             {
-                //HorizontalAlignment = HorizontalAlignment.Stretch,
                 Style = context.GetStyle($"Adaptive.{action.Type}"),
-                Padding = new Thickness(6, 4, 6, 4),
                 Content = new TextBlock
                 {
                     Text = action.Title,

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveCardRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveCardRenderer.cs
@@ -106,6 +106,16 @@ namespace AdaptiveCards.Rendering.Wpf
             AdaptiveContainerRenderer.AddContainerElements(grid, card.Body, context);
             AdaptiveActionSetRenderer.AddActions(grid, card.Actions, context);
 
+            if (card.SelectAction != null && context.Config.SupportsInteractivity)
+            {
+                // If card has a select action, create a button to contain the inner grid
+                var button = (Button) context.RenderSelectAction(card.SelectAction, outerGrid);
+                button.Content = grid;
+
+                // TODO: Remove overlapping action handling
+                return button;
+            }
+
             outerGrid.Children.Add(grid);
             return outerGrid;
         }

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveCardRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveCardRenderer.cs
@@ -106,17 +106,13 @@ namespace AdaptiveCards.Rendering.Wpf
             AdaptiveContainerRenderer.AddContainerElements(grid, card.Body, context);
             AdaptiveActionSetRenderer.AddActions(grid, card.Actions, context);
 
-            if (card.SelectAction != null && context.Config.SupportsInteractivity)
-            {
-                // If card has a select action, create a button to contain the inner grid
-                var button = (Button) context.RenderSelectAction(card.SelectAction, outerGrid);
-                button.Content = grid;
+            outerGrid.Children.Add(grid);
 
-                // TODO: Remove overlapping action handling
-                return button;
+            if (card.SelectAction != null)
+            {
+                return context.RenderSelectAction(card.SelectAction, outerGrid);
             }
 
-            outerGrid.Children.Add(grid);
             return outerGrid;
         }
 

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveContainerRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveContainerRenderer.cs
@@ -20,7 +20,6 @@ namespace AdaptiveCards.Rendering.Wpf
             }
 
             Grid uiOuterContainer = new Grid();
-            uiOuterContainer.Background = context.GetColorBrush(containerStyle.BackgroundColor);
             uiOuterContainer.Children.Add(uiContainer);
             Border border = new Border();
             border.Child = uiOuterContainer;

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/Helpers/SelectActionHelper.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/Helpers/SelectActionHelper.cs
@@ -11,8 +11,16 @@ namespace AdaptiveCards.Rendering.Wpf
             if (context.Config.SupportsInteractivity)
             {
                 var uiButton = (Button) context.Render(selectAction);
-                uiButton.HorizontalAlignment = HorizontalAlignment.Left;
-                uiButton.Background = new SolidColorBrush(Colors.Transparent);
+                uiButton.HorizontalAlignment = HorizontalAlignment.Stretch;
+                uiButton.HorizontalContentAlignment = HorizontalAlignment.Stretch;
+
+                // Adopt the child element's background to parent and set the child's background
+                // to be transparent in order for button's on mouse hover color to work properly
+                if (uiElement is Panel p)
+                {
+                    uiButton.Background = p.Background;
+                    p.Background = new SolidColorBrush(Colors.Transparent);
+                }
                 uiButton.BorderThickness = new Thickness(0);
                 uiButton.Content = uiElement;
                 uiButton.Style = context.GetStyle("Adaptive.Action.Tap");

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveCard.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveCard.cs
@@ -172,6 +172,16 @@ namespace AdaptiveCards
         public string Lang { get; set; }
 
         /// <summary>
+        ///     Action for the card (this allows a default action at the card level)
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+#if !NETSTANDARD1_3
+        [XmlElement]
+#endif
+        [DefaultValue(null)]
+        public AdaptiveAction SelectAction { get; set; }
+
+        /// <summary>
         /// Parse an AdaptiveCard from a JSON string
         /// </summary>
         /// <param name="json">A JSON-serialized Adaptive Card</param>


### PR DESCRIPTION
- Added support for card-level `selectAction` in WPF and HTML
- Fixed `Action.ShowCard` in HTML. Previously, the additional cards were not added to the card
- Cleaned up UI (spacing, hover color) for Button elements created for `selectAction`