### PR TITLE
[.NET] Prevent async exceptions from tearing down the process

### DIFF
--- a/source/dotnet/Build/SignNugetConfig.xml
+++ b/source/dotnet/Build/SignNugetConfig.xml
@@ -9,13 +9,13 @@
     <!-- AdaptiveCards -->
     <file src="__RELBINPATH__\..\..\..\a\AdaptiveCards.*.nupkg" signType="Nuget"  />
     <file src="__RELBINPATH__\..\..\..\a\AdaptiveCards.*.symbols.nupkg" signType="Nuget"  />
-    <!-- AdaptiveCards.Html -->
+    <!-- AdaptiveCards.Rendering.Html -->
     <file src="__RELBINPATH__\..\..\..\a\AdaptiveCards.Rendering.Html.*.nupkg" signType="Nuget"  />
     <file src="__RELBINPATH__\..\..\..\a\AdaptiveCards.Rendering.Html.*.symbols.nupkg" signType="Nuget"  />
-    <!-- AdaptiveCards.Wpf-->
+    <!-- AdaptiveCards.Rendering.Wpf-->
     <file src="__RELBINPATH__\..\..\..\a\AdaptiveCards.Rendering.Wpf.*.nupkg" signType="Nuget"  />
     <file src="__RELBINPATH__\..\..\..\a\AdaptiveCards.Rendering.Wpf.*.symbols.nupkg" signType="Nuget"  />
-    <!-- AdaptiveCards.Wpf.Xceed-->
+    <!-- AdaptiveCards.Rendering.Wpf.Xceed-->
     <file src="__RELBINPATH__\..\..\..\a\AdaptiveCards.Rendering.Wpf.Xceed.*.nupkg" signType="Nuget"  />
     <file src="__RELBINPATH__\..\..\..\a\AdaptiveCards.Rendering.Wpf.Xceed.*.symbols.nupkg" signType="Nuget"  />
   </job>

--- a/source/dotnet/Build/SignNugetConfig.xml
+++ b/source/dotnet/Build/SignNugetConfig.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+      signType indicates which certificates are used to sign the output
+      signType = "StrongName = 72 , Authenticode = 10006 , Both = 72 & 10006"
+-->
+<SignConfigXML>
+  <!-- Release sign job -->
+  <job platform="AnyCPU" configuration="release" dest="__RELBINPATH__\..\..\..\a\signed" jobname="Adaptive Cards .NET Nuget" approvers="">
+    <!-- AdaptiveCards -->
+    <file src="__RELBINPATH__\..\..\..\a\AdaptiveCards.*.nupkg" signType="Nuget"  />
+    <file src="__RELBINPATH__\..\..\..\a\AdaptiveCards.*.symbols.nupkg" signType="Nuget"  />
+    <!-- AdaptiveCards.Html -->
+    <file src="__RELBINPATH__\..\..\..\a\AdaptiveCards.Rendering.Html.*.nupkg" signType="Nuget"  />
+    <file src="__RELBINPATH__\..\..\..\a\AdaptiveCards.Rendering.Html.*.symbols.nupkg" signType="Nuget"  />
+    <!-- AdaptiveCards.Wpf-->
+    <file src="__RELBINPATH__\..\..\..\a\AdaptiveCards.Rendering.Wpf.*.nupkg" signType="Nuget"  />
+    <file src="__RELBINPATH__\..\..\..\a\AdaptiveCards.Rendering.Wpf.*.symbols.nupkg" signType="Nuget"  />
+    <!-- AdaptiveCards.Wpf.Xceed-->
+    <file src="__RELBINPATH__\..\..\..\a\AdaptiveCards.Rendering.Wpf.Xceed.*.nupkg" signType="Nuget"  />
+    <file src="__RELBINPATH__\..\..\..\a\AdaptiveCards.Rendering.Wpf.Xceed.*.symbols.nupkg" signType="Nuget"  />
+  </job>
+</SignConfigXML>

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveCardRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveCardRenderer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -165,20 +166,29 @@ namespace AdaptiveCards.Rendering.Wpf
 
         private async Task<RenderedAdaptiveCardImage> RenderCardToImageInternalAsync(AdaptiveCard card, int width, CancellationToken cancellationToken)
         {
-            var cardAssets = await LoadAssetsForCardAsync(card, cancellationToken);
+            RenderedAdaptiveCardImage renderCard = null;
 
-            var context = new AdaptiveRenderContext(null, null)
+            try
             {
-                CardAssets = cardAssets,
-                ResourceResolvers = ResourceResolvers,
-                ActionHandlers = ActionHandlers,
-                Config = HostConfig ?? new AdaptiveHostConfig(),
-                Resources = Resources,
-                ElementRenderers = ElementRenderers
-            };
+                var cardAssets = await LoadAssetsForCardAsync(card, cancellationToken);
 
-            var stream = context.Render(card).RenderToImage(width);
-            var renderCard = new RenderedAdaptiveCardImage(stream, card, context.Warnings);
+                var context = new AdaptiveRenderContext(null, null)
+                {
+                    CardAssets = cardAssets,
+                    ResourceResolvers = ResourceResolvers,
+                    ActionHandlers = ActionHandlers,
+                    Config = HostConfig ?? new AdaptiveHostConfig(),
+                    Resources = Resources,
+                    ElementRenderers = ElementRenderers
+                };
+
+                var stream = context.Render(card).RenderToImage(width);
+                renderCard = new RenderedAdaptiveCardImage(stream, card, context.Warnings);
+            }
+            catch(Exception e)
+            {
+                Debug.WriteLine($"RENDER Failed. {e.Message}");
+            }
 
             return renderCard;
         }

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveRenderContext.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveRenderContext.cs
@@ -69,13 +69,13 @@ namespace AdaptiveCards.Rendering.Wpf
             var completeTask = new TaskCompletionSource<object>();
             AssetTasks.Add(completeTask.Task);
 
-            // Load the stream from the pre-populated CardAssets or try to load from the ResourceResolver
-            var streamTask = CardAssets.TryGetValue(url, out var s) ? Task.FromResult(s) : ResourceResolvers.LoadAssetAsync(url);
-
-            Debug.WriteLine($"ASSETS: Starting asset down task for {url}");
-
             try
             {
+                // Load the stream from the pre-populated CardAssets or try to load from the ResourceResolver
+                var streamTask = CardAssets.TryGetValue(url, out var s) ? Task.FromResult(s) : ResourceResolvers.LoadAssetAsync(url);
+
+                Debug.WriteLine($"ASSETS: Starting asset down task for {url}");
+
                 var source = new BitmapImage();
 
                 var stream = await streamTask;


### PR DESCRIPTION
This helps catch exceptions in async calls that might tear down the process.


