### PR TITLE
Enable member init checks and fix errors

### DIFF
--- a/source/shared/cpp/ObjectModel/BaseInputElement.cpp
+++ b/source/shared/cpp/ObjectModel/BaseInputElement.cpp
@@ -4,13 +4,12 @@
 
 using namespace AdaptiveSharedNamespace;
 
-BaseInputElement::BaseInputElement(CardElementType elementType) :
-    BaseCardElement(elementType)
+BaseInputElement::BaseInputElement(CardElementType elementType) : BaseCardElement(elementType), m_isRequired(false)
 {
 }
 
 BaseInputElement::BaseInputElement(CardElementType elementType, Spacing spacing, bool separator, HeightType height) :
-    BaseCardElement(elementType, spacing, separator, height)
+    BaseCardElement(elementType, spacing, separator, height), m_isRequired(false)
 {
 }
 

--- a/source/shared/cpp/ObjectModel/ChoiceSetInput.cpp
+++ b/source/shared/cpp/ObjectModel/ChoiceSetInput.cpp
@@ -5,7 +5,8 @@
 
 using namespace AdaptiveSharedNamespace;
 
-ChoiceSetInput::ChoiceSetInput() : BaseInputElement(CardElementType::ChoiceSetInput)
+ChoiceSetInput::ChoiceSetInput() : BaseInputElement(CardElementType::ChoiceSetInput), m_isMultiSelect(false),
+    m_choiceSetStyle(ChoiceSetStyle::Compact)
 {
     PopulateKnownPropertiesSet();
 }
@@ -106,7 +107,7 @@ std::shared_ptr<BaseCardElement> ChoiceSetInputParser::DeserializeFromString(
     return ChoiceSetInputParser::Deserialize(elementParserRegistration, actionParserRegistration, warnings, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
-void ChoiceSetInput::PopulateKnownPropertiesSet() 
+void ChoiceSetInput::PopulateKnownPropertiesSet()
 {
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Choices));
     m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::IsMultiSelect));

--- a/source/shared/cpp/ObjectModel/DateTimePreparsedToken.cpp
+++ b/source/shared/cpp/ObjectModel/DateTimePreparsedToken.cpp
@@ -3,16 +3,18 @@
 
 using namespace AdaptiveSharedNamespace;
 
-DateTimePreparsedToken::DateTimePreparsedToken() : m_text(""), m_format(DateTimePreparsedTokenFormat::RegularString)
+DateTimePreparsedToken::DateTimePreparsedToken() : m_text(""), m_format(DateTimePreparsedTokenFormat::RegularString),
+    m_date{}
 {
 }
 
-DateTimePreparsedToken::DateTimePreparsedToken(std::string const &text, DateTimePreparsedTokenFormat format) : m_text(text), m_format(format)
+DateTimePreparsedToken::DateTimePreparsedToken(std::string const &text, DateTimePreparsedTokenFormat format) :
+    m_text(text), m_format(format), m_date{}
 {
 }
 
-DateTimePreparsedToken::DateTimePreparsedToken(std::string const &text, struct tm date, DateTimePreparsedTokenFormat format) :
-    m_text(text), m_date(date), m_format(format)
+DateTimePreparsedToken::DateTimePreparsedToken(std::string const &text, struct tm date,
+    DateTimePreparsedTokenFormat format) : m_text(text), m_date(date), m_format(format)
 {
 }
 

--- a/source/shared/cpp/ObjectModel/DateTimePreparser.cpp
+++ b/source/shared/cpp/ObjectModel/DateTimePreparser.cpp
@@ -20,12 +20,11 @@
 
 using namespace AdaptiveSharedNamespace;
 
-DateTimePreparser::DateTimePreparser() :
-    m_hasDateTokens(false)
+DateTimePreparser::DateTimePreparser() : m_hasDateTokens(false)
 {
 }
 
-DateTimePreparser::DateTimePreparser(std::string const &in)
+DateTimePreparser::DateTimePreparser(std::string const &in) : m_hasDateTokens(false)
 {
     ParseDateTime(in);
 }
@@ -155,8 +154,8 @@ void DateTimePreparser::ParseDateTime(std::string const &in)
         // check for date and time validation
         if (IsValidTimeAndDate(parsedTm, hours, minutes))
         {
-            // maches offset sign, 
-            // Z == UTC, 
+            // maches offset sign,
+            // Z == UTC,
             // + == time added from UTC
             // - == time subtracted from UTC
             if (matches[TimeZone].matched)
@@ -167,7 +166,7 @@ void DateTimePreparser::ParseDateTime(std::string const &in)
                 offset = (time_t)hours + (time_t)minutes;
 
                 wchar_t zone = matches[TimeZone].str()[0];
-                // time zone offset calculation 
+                // time zone offset calculation
                 if (zone == '+')
                 {
                     offset *= -1;
@@ -199,7 +198,7 @@ void DateTimePreparser::ParseDateTime(std::string const &in)
             // converts to local time from utc
             if (!LOCALTIME(&result, &utc))
             {
-                // localtime() set dst, put_time adjusts time accordingly which is not what we want since 
+                // localtime() set dst, put_time adjusts time accordingly which is not what we want since
                 // we have already taken cared of it in our calculation
                 if (result.tm_isdst == 1)
                 {
@@ -236,7 +235,7 @@ void DateTimePreparser::ParseDateTime(std::string const &in)
         {
             AddTextToken(matches[0].str(), DateTimePreparsedTokenFormat::RegularString);
         }
-        
+
         text = matches.suffix().str();
     }
 

--- a/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
+++ b/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
@@ -8,7 +8,8 @@
 
 using namespace AdaptiveSharedNamespace;
 
-AdaptiveCard::AdaptiveCard(): m_style(ContainerStyle::None), m_height(HeightType::Auto)
+AdaptiveCard::AdaptiveCard(): m_style(ContainerStyle::None), m_height(HeightType::Auto),
+    m_verticalContentAlignment(VerticalContentAlignment::Stretch)
 {
 }
 
@@ -129,7 +130,7 @@ std::shared_ptr<ParseResult> AdaptiveCard::Deserialize(
         ParseUtil::GetString(json, AdaptiveCardSchemaKey::BackgroundImage);
     std::string speak = ParseUtil::GetString(json, AdaptiveCardSchemaKey::Speak);
     ContainerStyle style = ParseUtil::GetEnumValue<ContainerStyle>(json, AdaptiveCardSchemaKey::Style, ContainerStyle::None, ContainerStyleFromString);
-    VerticalContentAlignment verticalContentAlignment = ParseUtil::GetEnumValue<VerticalContentAlignment>(json, AdaptiveCardSchemaKey::VerticalContentAlignment, 
+    VerticalContentAlignment verticalContentAlignment = ParseUtil::GetEnumValue<VerticalContentAlignment>(json, AdaptiveCardSchemaKey::VerticalContentAlignment,
         VerticalContentAlignment::Stretch, VerticalContentAlignmentFromString);
     HeightType height = ParseUtil::GetEnumValue<HeightType>(json, AdaptiveCardSchemaKey::Height, HeightType::Auto, HeightTypeFromString);
 

--- a/source/shared/cpp/ObjectModel/pch.h
+++ b/source/shared/cpp/ObjectModel/pch.h
@@ -28,4 +28,6 @@
 #pragma warning(default: CPPCORECHECK_CONCURRENCY_WARNINGS)
 #pragma warning(default: CPPCORECHECK_ARITHMETIC_WARNINGS)
 #pragma warning(default: CPPCORECHECK_UNIQUE_POINTER_WARNINGS)
+// ECppCoreCheckWarningCodes::WARNING_MEMBER_UNINIT
+#pragma warning(default: 26495)
 #endif


### PR DESCRIPTION
This PR turns on member variable initialization checking (part of cppcorecheck). Also, fixes up instances of missing initialization. Please double-check the defaults here to make sure they make sense. :)