### PR TITLE
Enable CPPCORECHECK_DECLARATION_WARNINGS and fix errors

### DIFF
--- a/source/shared/cpp/ObjectModel/BaseActionElement.cpp
+++ b/source/shared/cpp/ObjectModel/BaseActionElement.cpp
@@ -93,10 +93,10 @@ void BaseActionElement::SetAdditionalProperties(Json::Value const &value)
 
 void BaseActionElement::PopulateKnownPropertiesSet()
 {
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Type));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Title));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Id));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::IconUrl));
+    m_knownProperties.insert({ AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Type),
+         AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Title),
+         AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Id),
+         AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::IconUrl)});
 }
 
 void BaseActionElement::GetResourceUris(std::vector<std::string>&)

--- a/source/shared/cpp/ObjectModel/BaseActionElement.h
+++ b/source/shared/cpp/ObjectModel/BaseActionElement.h
@@ -65,7 +65,7 @@ std::shared_ptr<T> BaseActionElement::Deserialize(const Json::Value& json)
     baseActionElement->SetIconUrl(ParseUtil::GetString(json, AdaptiveCardSchemaKey::IconUrl));
 
     // Walk all properties and put any unknown ones in the additional properties json
-    for (Json::Value::const_iterator it = json.begin(); it != json.end(); it++)
+    for (auto it = json.begin(); it != json.end(); ++it)
     {
         std::string key = it.key().asCString();
         if (baseActionElement->m_knownProperties.find(key) == baseActionElement->m_knownProperties.end())

--- a/source/shared/cpp/ObjectModel/BaseCardElement.cpp
+++ b/source/shared/cpp/ObjectModel/BaseCardElement.cpp
@@ -21,18 +21,18 @@ BaseCardElement::BaseCardElement(
     PopulateKnownPropertiesSet();
 }
 
-BaseCardElement::BaseCardElement(CardElementType type) :
-    m_type(type), m_spacing(Spacing::Default), m_typeString(CardElementTypeToString(type)), m_separator(false), m_height(HeightType::Auto)
+BaseCardElement::BaseCardElement(CardElementType type) : m_type(type), m_spacing(Spacing::Default),
+    m_typeString(CardElementTypeToString(type)), m_separator(false), m_height(HeightType::Auto)
 {
     PopulateKnownPropertiesSet();
 }
 
 void BaseCardElement::PopulateKnownPropertiesSet()
 {
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Type));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Spacing));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Separator));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Height));
+    m_knownProperties.insert({AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Type),
+         AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Spacing),
+         AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Separator),
+         AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Height)});
 }
 
 BaseCardElement::~BaseCardElement()
@@ -128,7 +128,7 @@ Json::Value BaseCardElement::SerializeToJsonValue() const
     return root;
 }
 
-Json::Value BaseCardElement::SerializeSelectAction(const std::shared_ptr<BaseActionElement> selectAction) 
+Json::Value BaseCardElement::SerializeSelectAction(const std::shared_ptr<BaseActionElement> selectAction)
 {
     if (selectAction != nullptr)
     {

--- a/source/shared/cpp/ObjectModel/BaseCardElement.h
+++ b/source/shared/cpp/ObjectModel/BaseCardElement.h
@@ -78,7 +78,7 @@ std::shared_ptr<T> BaseCardElement::Deserialize(const Json::Value& json)
         ParseUtil::GetEnumValue<HeightType>(json, AdaptiveCardSchemaKey::Height, HeightType::Auto, HeightTypeFromString));
 
     // Walk all properties and put any unknown ones in the additional properties json
-    for (Json::Value::const_iterator it = json.begin(); it != json.end(); it++)
+    for (auto it = json.begin(); it != json.end(); ++it)
     {
         std::string key = it.key().asCString();
         if (baseCardElement->m_knownProperties.find(key) == baseCardElement->m_knownProperties.end())

--- a/source/shared/cpp/ObjectModel/ChoiceSetInput.cpp
+++ b/source/shared/cpp/ObjectModel/ChoiceSetInput.cpp
@@ -109,8 +109,8 @@ std::shared_ptr<BaseCardElement> ChoiceSetInputParser::DeserializeFromString(
 
 void ChoiceSetInput::PopulateKnownPropertiesSet()
 {
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Choices));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::IsMultiSelect));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Style));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Value));
+    m_knownProperties.insert({AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Choices),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::IsMultiSelect),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Style),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Value)});
 }

--- a/source/shared/cpp/ObjectModel/Column.cpp
+++ b/source/shared/cpp/ObjectModel/Column.cpp
@@ -20,7 +20,7 @@ void Column::SetWidth(const std::string &value)
     m_width = ParseUtil::ToLowercase(value);
 }
 
-// explicit width takes precedence over relative width 
+// explicit width takes precedence over relative width
 int Column::GetPixelWidth() const
 {
     return m_pixelWidth;
@@ -116,7 +116,7 @@ std::shared_ptr<Column> Column::Deserialize(
         columnWidth = ParseUtil::GetValueAsString(value, AdaptiveCardSchemaKey::Size);
     }
 
-    // validate user input; validation only applies to user input for explicit column width 
+    // validate user input; validation only applies to user input for explicit column width
     // the other input checks are remained unchanged
     column->SetPixelWidth(0);
     if (!columnWidth.empty() && (isdigit(columnWidth.at(0)) || ('-' == columnWidth.at(0))))
@@ -124,7 +124,7 @@ std::shared_ptr<Column> Column::Deserialize(
         const std::string unit = "px";
         const std::size_t foundIndex = columnWidth.find(unit);
         /// check if width is determined explicitly
-        if (std::string::npos != foundIndex) 
+        if (std::string::npos != foundIndex)
         {
             if (columnWidth.size() == foundIndex + unit.size())
             {
@@ -133,7 +133,7 @@ std::shared_ptr<Column> Column::Deserialize(
                 ValidateUserInputForDimensionWithUnit(unit, requestedDimensions, parsedDimension);
                 column->SetPixelWidth(parsedDimension);
             }
-            else 
+            else
             {
                 throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "unit is in inproper form: " + columnWidth);
             }
@@ -177,13 +177,13 @@ void Column::SetSelectAction(const std::shared_ptr<BaseActionElement> action)
     m_selectAction = action;
 }
 
-void Column::PopulateKnownPropertiesSet() 
+void Column::PopulateKnownPropertiesSet()
 {
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Items));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::SelectAction));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Width));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Style));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::VerticalContentAlignment));
+    m_knownProperties.insert({AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Items),
+         AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::SelectAction),
+         AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Width),
+         AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Style),
+         AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::VerticalContentAlignment)});
 }
 
 void Column::SetLanguage(const std::string& language)

--- a/source/shared/cpp/ObjectModel/ColumnSet.cpp
+++ b/source/shared/cpp/ObjectModel/ColumnSet.cpp
@@ -87,10 +87,10 @@ std::shared_ptr<BaseCardElement> ColumnSetParser::DeserializeFromString(
     return ColumnSetParser::Deserialize(elementParserRegistration, actionParserRegistration, warnings, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
-void ColumnSet::PopulateKnownPropertiesSet() 
+void ColumnSet::PopulateKnownPropertiesSet()
 {
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Columns));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::SelectAction));
+    m_knownProperties.insert({AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Columns),
+         AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::SelectAction)});
 }
 
 void ColumnSet::GetResourceUris(std::vector<std::string>& resourceUris)

--- a/source/shared/cpp/ObjectModel/Container.cpp
+++ b/source/shared/cpp/ObjectModel/Container.cpp
@@ -98,7 +98,7 @@ std::shared_ptr<BaseCardElement> ContainerParser::Deserialize(
     container->SetStyle(
         ParseUtil::GetEnumValue<ContainerStyle>(value, AdaptiveCardSchemaKey::Style, ContainerStyle::None, ContainerStyleFromString));
 
-    container->SetVerticalContentAlignment(ParseUtil::GetEnumValue<VerticalContentAlignment>(value, AdaptiveCardSchemaKey::VerticalContentAlignment, 
+    container->SetVerticalContentAlignment(ParseUtil::GetEnumValue<VerticalContentAlignment>(value, AdaptiveCardSchemaKey::VerticalContentAlignment,
         VerticalContentAlignment::Stretch, VerticalContentAlignmentFromString));
 
     // Parse Items
@@ -120,12 +120,12 @@ std::shared_ptr<BaseCardElement> ContainerParser::DeserializeFromString(
     return ContainerParser::Deserialize(elementParserRegistration, actionParserRegistration, warnings, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
-void Container::PopulateKnownPropertiesSet() 
+void Container::PopulateKnownPropertiesSet()
 {
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Style));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::VerticalContentAlignment));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::SelectAction));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Items));
+    m_knownProperties.insert({AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Style),
+         AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::VerticalContentAlignment),
+         AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::SelectAction),
+         AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Items)});
 }
 
 void Container::GetResourceUris(std::vector<std::string>& resourceUris)

--- a/source/shared/cpp/ObjectModel/DateInput.cpp
+++ b/source/shared/cpp/ObjectModel/DateInput.cpp
@@ -104,10 +104,10 @@ std::shared_ptr<BaseCardElement> DateInputParser::DeserializeFromString(
     return DateInputParser::Deserialize(elementParserRegistration, actionParserRegistration, warnings, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
-void DateInput::PopulateKnownPropertiesSet() 
+void DateInput::PopulateKnownPropertiesSet()
 {
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Max));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Min));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Value));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Placeholder));
+    m_knownProperties.insert({AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Max),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Min),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Value),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Placeholder)});
 }

--- a/source/shared/cpp/ObjectModel/Enums.cpp
+++ b/source/shared/cpp/ObjectModel/Enums.cpp
@@ -1,6 +1,16 @@
 #include "pch.h"
 #include "Enums.h"
 
+#ifdef USE_CPPCORECHECK
+#pragma warning(push)
+
+// Unfortunately, the checker for WARNING_NO_GLOBAL_INIT_CALLS (26426) has an issue: it considers initialization of the
+// below std::unordered_map statics to be global, and thus flags them all as having overly-complex initialization. We
+// want to keep this check on, in general, but turn it off for this file (all warning instances were reviewed prior to
+// disablement).
+#pragma warning(disable: 26426)
+#endif
+
 namespace AdaptiveSharedNamespace {
 
 void GetAdaptiveCardSchemaKeyEnumMappings(
@@ -1131,3 +1141,7 @@ VerticalContentAlignment VerticalContentAlignmentFromString(const std::string& v
 }
 
 }
+
+#ifdef USE_CPPCORECHECK
+#pragma warning(pop)
+#endif

--- a/source/shared/cpp/ObjectModel/FactSet.cpp
+++ b/source/shared/cpp/ObjectModel/FactSet.cpp
@@ -60,7 +60,7 @@ std::shared_ptr<BaseCardElement> FactSetParser::DeserializeFromString(
     return FactSetParser::Deserialize(elementParserRegistration, actionParserRegistration, warnings, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
-void FactSet::PopulateKnownPropertiesSet() 
+void FactSet::PopulateKnownPropertiesSet()
 {
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Facts));
+    m_knownProperties.insert({AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Facts)});
 }

--- a/source/shared/cpp/ObjectModel/Image.cpp
+++ b/source/shared/cpp/ObjectModel/Image.cpp
@@ -150,7 +150,7 @@ void Image::SetSelectAction(const std::shared_ptr<BaseActionElement> action)
     m_selectAction = action;
 }
 
-unsigned int Image::GetPixelWidth() const 
+unsigned int Image::GetPixelWidth() const
 {
     return m_pixelWidth;
 }
@@ -216,7 +216,7 @@ std::shared_ptr<BaseCardElement> ImageParser::DeserializeWithoutCheckingType(
             const std::string unit = "px";
             const std::size_t foundIndex = eachDimension.find(unit);
             /// check if width is determined explicitly
-            if (std::string::npos != foundIndex) 
+            if (std::string::npos != foundIndex)
             {
                 if (eachDimension.size() == foundIndex + unit.size())
                 // validate user inputs
@@ -242,17 +242,17 @@ std::shared_ptr<BaseCardElement> ImageParser::DeserializeWithoutCheckingType(
     return image;
 }
 
-void Image::PopulateKnownPropertiesSet() 
+void Image::PopulateKnownPropertiesSet()
 {
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Url));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::BackgroundColor));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Style));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Size));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::AltText));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::HorizontalAlignment));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Width));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Height));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::SelectAction));
+    m_knownProperties.insert({AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Url),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::BackgroundColor),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Style),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Size),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::AltText),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::HorizontalAlignment),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Width),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Height),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::SelectAction)});
 }
 
 void Image::GetResourceUris(std::vector<std::string>& resourceUris)

--- a/source/shared/cpp/ObjectModel/ImageSet.cpp
+++ b/source/shared/cpp/ObjectModel/ImageSet.cpp
@@ -5,7 +5,7 @@
 
 using namespace AdaptiveSharedNamespace;
 
-ImageSet::ImageSet() : 
+ImageSet::ImageSet() :
     BaseCardElement(CardElementType::ImageSet),
     m_imageSize(ImageSize::None)
 {
@@ -84,10 +84,10 @@ std::shared_ptr<BaseCardElement> ImageSetParser::DeserializeFromString(
     return ImageSetParser::Deserialize(elementParserRegistration, actionParserRegistration, warnings, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
-void ImageSet::PopulateKnownPropertiesSet() 
+void ImageSet::PopulateKnownPropertiesSet()
 {
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Images));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::ImageSize));
+    m_knownProperties.insert({AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Images),
+         AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::ImageSize)});
 }
 
 void ImageSet::GetResourceUris(std::vector<std::string>& resourceUris)

--- a/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.cpp
@@ -100,7 +100,7 @@ std::string MarkDownLeftEmphasisHtmlGenerator::GenerateHtmlString()
     }
 
     // append tags; since left delims, append it in the reverse order
-    for (auto itr = m_tags.rbegin(); itr != m_tags.rend(); itr++)
+    for (auto itr = m_tags.rbegin(); itr != m_tags.rend(); ++itr)
     {
         html << *itr;
     }
@@ -131,7 +131,7 @@ void MarkDownRightEmphasisHtmlGenerator::PushBoldTag()
 std::string MarkDownRightEmphasisHtmlGenerator::GenerateHtmlString()
 {
     // append tags;
-    for (auto itr = m_tags.begin(); itr != m_tags.end(); itr++)
+    for (auto itr = m_tags.begin(); itr != m_tags.end(); ++itr)
     {
         html << *itr;
     }

--- a/source/shared/cpp/ObjectModel/MarkDownParsedResult.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownParsedResult.cpp
@@ -110,7 +110,7 @@ std::string MarkDownParsedResult::GenerateHtmlString()
     // process tags
     std::ostringstream html;
 
-    for (auto itr = m_codeGenTokens.begin(); itr != m_codeGenTokens.end(); itr++)
+    for (auto itr = m_codeGenTokens.begin(); itr != m_codeGenTokens.end(); ++itr)
     {
         html << (*itr)->GenerateHtmlString();
     }
@@ -222,7 +222,7 @@ void MarkDownParsedResult::MatchLeftAndRightEmphasises()
                     else
                     {
                         // move to next token for right delim tokens
-                        currentEmphasis++;
+                        ++currentEmphasis;
                     }
                     // no maching found begin from the start
                     continue;
@@ -234,7 +234,7 @@ void MarkDownParsedResult::MatchLeftAndRightEmphasises()
             // all right delims used, move to next
             if ((*currentEmphasis)->IsDone())
             {
-                currentEmphasis++;
+                ++currentEmphasis;
             }
 
             // all left or right delims used, pop
@@ -245,7 +245,7 @@ void MarkDownParsedResult::MatchLeftAndRightEmphasises()
         }
         else
         {
-            currentEmphasis++;
+            ++currentEmphasis;
         }
     }
 }

--- a/source/shared/cpp/ObjectModel/Media.cpp
+++ b/source/shared/cpp/ObjectModel/Media.cpp
@@ -108,9 +108,9 @@ std::shared_ptr<BaseCardElement> MediaParser::DeserializeFromString(
     return MediaParser::Deserialize(elementParserRegistration, actionParserRegistration, warnings, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
-void Media::PopulateKnownPropertiesSet() 
+void Media::PopulateKnownPropertiesSet()
 {
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Poster));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::AltText));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Sources));
+    m_knownProperties.insert({AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Poster),
+         AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::AltText),
+         AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Sources)});
 }

--- a/source/shared/cpp/ObjectModel/NumberInput.cpp
+++ b/source/shared/cpp/ObjectModel/NumberInput.cpp
@@ -107,10 +107,10 @@ std::shared_ptr<BaseCardElement> NumberInputParser::DeserializeFromString(
     return NumberInputParser::Deserialize(elementParserRegistration, actionParserRegistration, warnings, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
-void NumberInput::PopulateKnownPropertiesSet() 
+void NumberInput::PopulateKnownPropertiesSet()
 {
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Placeholder));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Value));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Max));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Min));
+    m_knownProperties.insert({AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Placeholder),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Value),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Max),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Min)});
 }

--- a/source/shared/cpp/ObjectModel/OpenUrlAction.cpp
+++ b/source/shared/cpp/ObjectModel/OpenUrlAction.cpp
@@ -50,7 +50,7 @@ std::shared_ptr<BaseActionElement> OpenUrlActionParser::DeserializeFromString(
     return OpenUrlActionParser::Deserialize(elementParserRegistration, actionParserRegistration, warnings, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
-void OpenUrlAction::PopulateKnownPropertiesSet() 
+void OpenUrlAction::PopulateKnownPropertiesSet()
 {
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Url));
+    m_knownProperties.insert({AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Url)});
 }

--- a/source/shared/cpp/ObjectModel/ParseUtil.cpp
+++ b/source/shared/cpp/ObjectModel/ParseUtil.cpp
@@ -306,7 +306,7 @@ std::string ParseUtil::ToLowercase(std::string const &value)
 {
     std::string new_value;
     new_value.resize(value.size());
-    std::transform(value.begin(), value.end(), new_value.begin(), [](char c) { return std::tolower(c, std::locale()); });
+    auto new_end = std::transform(value.begin(), value.end(), new_value.begin(), [](char c) { return std::tolower(c, std::locale()); });
     return new_value;
 }
 

--- a/source/shared/cpp/ObjectModel/ShowCardAction.cpp
+++ b/source/shared/cpp/ObjectModel/ShowCardAction.cpp
@@ -49,7 +49,7 @@ std::shared_ptr<BaseActionElement> ShowCardActionParser::Deserialize(
     std::string propertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Card);
 
     auto parseResult = AdaptiveCard::Deserialize(json.get(propertyName, Json::Value()), std::numeric_limits<double>::max(), elementParserRegistration, actionParserRegistration);
-    
+
     auto showCardWarnings = parseResult->GetWarnings();
     warnings.insert(warnings.end(), showCardWarnings.begin(), showCardWarnings.end());
 
@@ -67,9 +67,9 @@ std::shared_ptr<BaseActionElement> ShowCardActionParser::DeserializeFromString(
     return ShowCardActionParser::Deserialize(elementParserRegistration, actionParserRegistration, warnings, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
-void ShowCardAction::PopulateKnownPropertiesSet() 
+void ShowCardAction::PopulateKnownPropertiesSet()
 {
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Card));
+    m_knownProperties.insert({AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Card)});
 }
 
 void ShowCardAction::GetResourceUris(std::vector<std::string>& resourceUris)

--- a/source/shared/cpp/ObjectModel/ShowCardAction.cpp
+++ b/source/shared/cpp/ObjectModel/ShowCardAction.cpp
@@ -51,7 +51,7 @@ std::shared_ptr<BaseActionElement> ShowCardActionParser::Deserialize(
     auto parseResult = AdaptiveCard::Deserialize(json.get(propertyName, Json::Value()), std::numeric_limits<double>::max(), elementParserRegistration, actionParserRegistration);
 
     auto showCardWarnings = parseResult->GetWarnings();
-    warnings.insert(warnings.end(), showCardWarnings.begin(), showCardWarnings.end());
+    auto warningsEnd = warnings.insert(warnings.end(), showCardWarnings.begin(), showCardWarnings.end());
 
     showCardAction->SetCard(parseResult->GetAdaptiveCard());
 
@@ -76,6 +76,6 @@ void ShowCardAction::GetResourceUris(std::vector<std::string>& resourceUris)
 {
     auto card = GetCard();
     auto showCardImages = card->GetResourceUris();
-    resourceUris.insert(resourceUris.end(), showCardImages.begin(), showCardImages.end());
+    auto resourceUrisEnd = resourceUris.insert(resourceUris.end(), showCardImages.begin(), showCardImages.end());
     return;
 }

--- a/source/shared/cpp/ObjectModel/SubmitAction.cpp
+++ b/source/shared/cpp/ObjectModel/SubmitAction.cpp
@@ -59,7 +59,7 @@ std::shared_ptr<BaseActionElement> SubmitActionParser::DeserializeFromString(
     return SubmitActionParser::Deserialize(elementParserRegistration, actionParserRegistration, warnings, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
-void SubmitAction::PopulateKnownPropertiesSet() 
+void SubmitAction::PopulateKnownPropertiesSet()
 {
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Data));
+    m_knownProperties.insert({AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Data)});
 }

--- a/source/shared/cpp/ObjectModel/TextBlock.cpp
+++ b/source/shared/cpp/ObjectModel/TextBlock.cpp
@@ -194,14 +194,14 @@ std::shared_ptr<BaseCardElement> TextBlockParser::DeserializeFromString(
     return TextBlockParser::Deserialize(elementParserRegistration, actionParserRegistration, warnings, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
-void TextBlock::PopulateKnownPropertiesSet() 
+void TextBlock::PopulateKnownPropertiesSet()
 {
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Text));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Size));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Color));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::TextWeight));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Wrap));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::IsSubtle));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::MaxLines));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::HorizontalAlignment));
+    m_knownProperties.insert({AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Text),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Size),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Color),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::TextWeight),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Wrap),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::IsSubtle),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::MaxLines),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::HorizontalAlignment)});
 }

--- a/source/shared/cpp/ObjectModel/TextInput.cpp
+++ b/source/shared/cpp/ObjectModel/TextInput.cpp
@@ -123,11 +123,11 @@ std::shared_ptr<BaseCardElement> TextInputParser::DeserializeFromString(
     return TextInputParser::Deserialize(elementParserRegistration, actionParserRegistration, warnings, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
-void TextInput::PopulateKnownPropertiesSet() 
+void TextInput::PopulateKnownPropertiesSet()
 {
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Placeholder));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Value));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::IsMultiline));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::MaxLength));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::TextInput));
+    m_knownProperties.insert({AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Placeholder),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Value),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::IsMultiline),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::MaxLength),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::TextInput)});
 }

--- a/source/shared/cpp/ObjectModel/TimeInput.cpp
+++ b/source/shared/cpp/ObjectModel/TimeInput.cpp
@@ -104,10 +104,10 @@ std::shared_ptr<BaseCardElement> TimeInputParser::DeserializeFromString(
     return TimeInputParser::Deserialize(elementParserRegistration, actionParserRegistration, warnings, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
-void TimeInput::PopulateKnownPropertiesSet() 
+void TimeInput::PopulateKnownPropertiesSet()
 {
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Max));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Min));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Placeholder));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Value));
+    m_knownProperties.insert({AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Max),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Min),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Placeholder),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Value)});
 }

--- a/source/shared/cpp/ObjectModel/ToggleInput.cpp
+++ b/source/shared/cpp/ObjectModel/ToggleInput.cpp
@@ -112,10 +112,10 @@ std::shared_ptr<BaseCardElement> ToggleInputParser::DeserializeFromString(
     return ToggleInputParser::Deserialize(elementParserRegistration, actionParserRegistration, warnings, ParseUtil::GetJsonValueFromString(jsonString));
 }
 
-void ToggleInput::PopulateKnownPropertiesSet() 
+void ToggleInput::PopulateKnownPropertiesSet()
 {
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Title));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Value));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::ValueOn));
-    m_knownProperties.insert(AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::ValueOff));
+    m_knownProperties.insert({AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Title),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Value),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::ValueOn),
+        AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::ValueOff)});
 }

--- a/source/shared/cpp/ObjectModel/pch.h
+++ b/source/shared/cpp/ObjectModel/pch.h
@@ -27,6 +27,7 @@
 #pragma warning(default: CPPCORECHECK_ARITHMETIC_WARNINGS)
 #pragma warning(default: CPPCORECHECK_CONCURRENCY_WARNINGS)
 #pragma warning(default: CPPCORECHECK_CONST_WARNINGS)
+#pragma warning(default: CPPCORECHECK_DECLARATION_WARNINGS)
 #pragma warning(default: CPPCORECHECK_STYLE_WARNINGS)
 #pragma warning(default: CPPCORECHECK_UNIQUE_POINTER_WARNINGS)
 

--- a/source/shared/cpp/ObjectModel/pch.h
+++ b/source/shared/cpp/ObjectModel/pch.h
@@ -22,6 +22,10 @@
 #include <locale>
 
 #if defined(_MSC_BUILD) && !defined(__ANDROID__) && !defined(__APPLE__) && !defined(ADAPTIVE_CARDS_WINDOWS)
+#define USE_CPPCORECHECK
+#endif
+
+#ifdef USE_CPPCORECHECK
 #include <CppCoreCheck\warnings.h>
 #pragma warning(disable: ALL_CPPCORECHECK_WARNINGS)
 #pragma warning(default: CPPCORECHECK_ARITHMETIC_WARNINGS)


### PR DESCRIPTION
There are effectively two class of error that we have in our codebase that was caught by `CPPCORECHECK_DECLARATION_WARNINGS`:

* [I.22: Avoid complex initialization of global objects](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#i22-avoid-complex-initialization-of-global-objects)
This check is a good one -- it ensures that global variable initialization is only done with `constexpr`s - meaning that there's no concern about the order in which global variables init. Unfortunately, the checker has a bug where it sees function-static variables as global, so basically all of `Enums.cpp` shows up as hits. I reviewed static variable use in this file and then disabled the check in that file's scope.
* [ES.84: Don't (try to) declare a local variable with no name](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#es84-dont-try-to-declare-a-local-variable-with-no-name)
Basically, some functions return an object and some operations create temporary objects. These objects may have complex ctors or dtors which run in a way and at a time that's not obvious to the reader. There are 3 classes of error found in our codebase that needed to be addressed:
   - `std::unordered_set::insert()` has a number of overloads. When tracking known properties, we were adding each element individually, which is calling an overload that returns a `std::pair<>`. Since we don't actually care about anything in the `pair`, we can just call the overload that takes an initializer list, which has a `void` return type. And since it's a list we're passing in, we might as well just make one call to `insert()` with all of the properties.
   - When using an iterator in a `for` loop, it's best practice to increment using the prefix operator rather than the postfix, since postfix [causes a temporary object to be constructed](https://en.cppreference.com/w/cpp/language/operator_incdec) (see `Notes` section).
   - There are a few places where we were calling either `std::transform()` or an `insert()` function where it didn't make sense to change to a different form. For these, I assigned the return to a new local variable, which squelches the warning and also alerts the reader to the fact that there's an object being created (even if it's not going to be used).