### PR TITLE
Enable "rule of five" checker, fix errors

### DIFF
--- a/source/shared/cpp/ObjectModel/AdaptiveCardParseException.cpp
+++ b/source/shared/cpp/ObjectModel/AdaptiveCardParseException.cpp
@@ -7,10 +7,6 @@ AdaptiveCardParseException::AdaptiveCardParseException(ErrorStatusCode statusCod
 {
 }
 
-AdaptiveCardParseException::~AdaptiveCardParseException()
-{
-}
-
 const char* AdaptiveCardParseException::what() const throw()
 {
     return m_message.c_str();

--- a/source/shared/cpp/ObjectModel/AdaptiveCardParseException.h
+++ b/source/shared/cpp/ObjectModel/AdaptiveCardParseException.h
@@ -9,7 +9,6 @@ class AdaptiveCardParseException : public std::exception
 {
 public:
     AdaptiveCardParseException(AdaptiveSharedNamespace::ErrorStatusCode statusCode, const std::string& message);
-    ~AdaptiveCardParseException();
 
     virtual const char* what() const throw();
     AdaptiveSharedNamespace::ErrorStatusCode GetStatusCode() const;

--- a/source/shared/cpp/ObjectModel/AdaptiveCardParseWarning.cpp
+++ b/source/shared/cpp/ObjectModel/AdaptiveCardParseWarning.cpp
@@ -7,10 +7,6 @@ AdaptiveCardParseWarning::AdaptiveCardParseWarning(const WarningStatusCode statu
 {
 }
 
-AdaptiveCardParseWarning::~AdaptiveCardParseWarning()
-{
-}
-
 WarningStatusCode AdaptiveCardParseWarning::GetStatusCode() const
 {
     return m_statusCode;

--- a/source/shared/cpp/ObjectModel/AdaptiveCardParseWarning.h
+++ b/source/shared/cpp/ObjectModel/AdaptiveCardParseWarning.h
@@ -9,7 +9,6 @@ class AdaptiveCardParseWarning
 {
 public:
     AdaptiveCardParseWarning(AdaptiveSharedNamespace::WarningStatusCode statusCode, const std::string& message);
-    ~AdaptiveCardParseWarning();
 
     AdaptiveSharedNamespace::WarningStatusCode GetStatusCode() const;
     const std::string& GetReason() const;

--- a/source/shared/cpp/ObjectModel/BaseActionElement.cpp
+++ b/source/shared/cpp/ObjectModel/BaseActionElement.cpp
@@ -11,10 +11,6 @@ BaseActionElement::BaseActionElement(ActionType type) :
     PopulateKnownPropertiesSet();
 }
 
-BaseActionElement::~BaseActionElement()
-{
-}
-
 std::string BaseActionElement::GetElementTypeString() const
 {
     return m_typeString;

--- a/source/shared/cpp/ObjectModel/BaseActionElement.h
+++ b/source/shared/cpp/ObjectModel/BaseActionElement.h
@@ -11,7 +11,11 @@ class BaseActionElement
 public:
     BaseActionElement(ActionType type);
 
-    virtual ~BaseActionElement();
+    BaseActionElement(const BaseActionElement&) = default;
+    BaseActionElement(BaseActionElement&&) = default;
+    BaseActionElement& operator=(const BaseActionElement&) = default;
+    BaseActionElement& operator=(BaseActionElement&&) = default;
+    virtual ~BaseActionElement() = default;
 
     virtual std::string GetElementTypeString() const;
     virtual void SetElementTypeString(const std::string &value);

--- a/source/shared/cpp/ObjectModel/BaseCardElement.cpp
+++ b/source/shared/cpp/ObjectModel/BaseCardElement.cpp
@@ -35,10 +35,6 @@ void BaseCardElement::PopulateKnownPropertiesSet()
          AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Height)});
 }
 
-BaseCardElement::~BaseCardElement()
-{
-}
-
 std::string BaseCardElement::GetElementTypeString() const
 {
     return m_typeString;

--- a/source/shared/cpp/ObjectModel/BaseCardElement.h
+++ b/source/shared/cpp/ObjectModel/BaseCardElement.h
@@ -15,7 +15,11 @@ public:
     BaseCardElement(CardElementType type, Spacing spacing, bool separator, HeightType height);
     BaseCardElement(CardElementType type);
 
-    virtual ~BaseCardElement();
+    BaseCardElement(const BaseCardElement&) = default;
+    BaseCardElement(BaseCardElement&&) = default;
+    BaseCardElement& operator=(const BaseCardElement&) = default;
+    BaseCardElement& operator=(BaseCardElement&&) = default;
+    virtual ~BaseCardElement() = default;
 
     virtual std::string GetElementTypeString() const;
     virtual void SetElementTypeString(const std::string &value);

--- a/source/shared/cpp/ObjectModel/json/json.h
+++ b/source/shared/cpp/ObjectModel/json/json.h
@@ -6,28 +6,28 @@
 // //////////////////////////////////////////////////////////////////////
 
 /*
-The JsonCpp library's source code, including accompanying documentation, 
+The JsonCpp library's source code, including accompanying documentation,
 tests and demonstration applications, are licensed under the following
 conditions...
 
-The author (Baptiste Lepilleur) explicitly disclaims copyright in all 
-jurisdictions which recognize such a disclaimer. In such jurisdictions, 
+The author (Baptiste Lepilleur) explicitly disclaims copyright in all
+jurisdictions which recognize such a disclaimer. In such jurisdictions,
 this software is released into the Public Domain.
 
 In jurisdictions which do not recognize Public Domain property (e.g. Germany as of
 2010), this software is Copyright (c) 2007-2010 by Baptiste Lepilleur, and is
 released under the terms of the MIT License (see below).
 
-In jurisdictions which recognize Public Domain property, the user of this 
-software may choose to accept it either as 1) Public Domain, 2) under the 
-conditions of the MIT License (see below), or 3) under the terms of dual 
+In jurisdictions which recognize Public Domain property, the user of this
+software may choose to accept it either as 1) Public Domain, 2) under the
+conditions of the MIT License (see below), or 3) under the terms of dual
 Public Domain/MIT License conditions described here, as they choose.
 
 The MIT License is about as close to Public Domain as a license can get, and is
 described in clear, concise terms at:
 
    http://en.wikipedia.org/wiki/MIT_License
-   
+
 The full text of the MIT License follows:
 
 ========================================================================
@@ -68,8 +68,10 @@ license you like.
 // End of content of file: LICENSE
 // //////////////////////////////////////////////////////////////////////
 
-
-
+#ifdef USE_CPPCORECHECK
+#pragma warning(push)
+#pragma warning(disable: ALL_CPPCORECHECK_WARNINGS)
+#endif
 
 
 #ifndef JSON_AMALGATED_H_INCLUDED
@@ -465,7 +467,7 @@ public:
 #endif
 
 //Conditional NORETURN attribute on the throw functions would:
-// a) suppress false positives from static code analysis 
+// a) suppress false positives from static code analysis
 // b) possibly improve optimization opportunities.
 #if !defined(JSONCPP_NORETURN)
 #  if defined(_MSC_VER)
@@ -506,7 +508,7 @@ protected:
 /** Exceptions which the user cannot easily avoid.
  *
  * E.g. out-of-memory (when we use malloc), stack-overflow, malicious input
- * 
+ *
  * \remark derived from Json::Exception
  */
 class JSON_API RuntimeError : public Exception {
@@ -517,7 +519,7 @@ public:
 /** Exceptions thrown by JSON_ASSERT/JSON_FAIL macros.
  *
  * These are precondition-violations (user bugs) and internal errors (our bugs).
- * 
+ *
  * \remark derived from Json::Exception
  */
 class JSON_API LogicError : public Exception {
@@ -1650,7 +1652,7 @@ public:
     - `"rejectDupKeys": false or true`
       - If true, `parse()` returns false when a key is duplicated within an object.
     - `"allowSpecialFloats": false or true`
-      - If true, special float values (NaNs and infinities) are allowed 
+      - If true, special float values (NaNs and infinities) are allowed
         and their values are lossfree restorable.
 
     You can examine 'settings_` yourself
@@ -2159,3 +2161,7 @@ JSON_API JSONCPP_OSTREAM& operator<<(JSONCPP_OSTREAM&, const Value& root);
 
 
 #endif //ifndef JSON_AMALGATED_H_INCLUDED
+
+#ifdef USE_CPPCORECHECK
+#pragma warning(pop)
+#endif

--- a/source/shared/cpp/ObjectModel/jsoncpp.cpp
+++ b/source/shared/cpp/ObjectModel/jsoncpp.cpp
@@ -6,28 +6,28 @@
 // //////////////////////////////////////////////////////////////////////
 
 /*
-The JsonCpp library's source code, including accompanying documentation, 
+The JsonCpp library's source code, including accompanying documentation,
 tests and demonstration applications, are licensed under the following
 conditions...
 
-The author (Baptiste Lepilleur) explicitly disclaims copyright in all 
-jurisdictions which recognize such a disclaimer. In such jurisdictions, 
+The author (Baptiste Lepilleur) explicitly disclaims copyright in all
+jurisdictions which recognize such a disclaimer. In such jurisdictions,
 this software is released into the Public Domain.
 
 In jurisdictions which do not recognize Public Domain property (e.g. Germany as of
 2010), this software is Copyright (c) 2007-2010 by Baptiste Lepilleur, and is
 released under the terms of the MIT License (see below).
 
-In jurisdictions which recognize Public Domain property, the user of this 
-software may choose to accept it either as 1) Public Domain, 2) under the 
-conditions of the MIT License (see below), or 3) under the terms of dual 
+In jurisdictions which recognize Public Domain property, the user of this
+software may choose to accept it either as 1) Public Domain, 2) under the
+conditions of the MIT License (see below), or 3) under the terms of dual
 Public Domain/MIT License conditions described here, as they choose.
 
 The MIT License is about as close to Public Domain as a license can get, and is
 described in clear, concise terms at:
 
    http://en.wikipedia.org/wiki/MIT_License
-   
+
 The full text of the MIT License follows:
 
 ========================================================================
@@ -74,7 +74,7 @@ license you like.
 
 #include "pch.h"
 
-#ifndef ADAPTIVE_CARDS_WINDOWS
+#ifdef USE_CPPCORECHECK
 #pragma warning(disable: ALL_CPPCORECHECK_WARNINGS)
 #endif
 
@@ -243,7 +243,7 @@ static inline void fixNumericLocaleInput(char* begin, char* end) {
 #include <limits>
 
 #if defined(_MSC_VER)
-#if !defined(WINCE) && defined(__STDC_SECURE_LIB__) && _MSC_VER >= 1500 // VC++ 9.0 and above 
+#if !defined(WINCE) && defined(__STDC_SECURE_LIB__) && _MSC_VER >= 1500 // VC++ 9.0 and above
 #define snprintf sprintf_s
 #elif _MSC_VER >= 1900 // VC++ 14.0 and above
 #define snprintf std::snprintf
@@ -392,7 +392,7 @@ bool Reader::parse(const char* beginDoc,
 
 bool Reader::readValue() {
   // readValue() may call itself only if it calls readObject() or ReadArray().
-  // These methods execute nodes_.push() just before and nodes_.pop)() just after calling readValue(). 
+  // These methods execute nodes_.push() just before and nodes_.pop)() just after calling readValue().
   // parse() executes one nodes_.push(), so > instead of >=.
   if (nodes_.size() > stackLimit_g) throwRuntimeError("Exceeded stackLimit in readValue().");
 
@@ -4149,7 +4149,7 @@ Value& Path::make(Value& root) const {
 #endif
 #endif
 
-#if defined(__BORLANDC__)  
+#if defined(__BORLANDC__)
 #include <float.h>
 #define isfinite _finite
 #define snprintf _snprintf
@@ -4237,7 +4237,7 @@ JSONCPP_STRING valueToString(double value, bool useSpecialFloats, unsigned int p
   // concepts of reals and integers.
   if (isfinite(value)) {
     len = snprintf(buffer, sizeof(buffer), formatString, value);
-    
+
     // try to ensure we preserve the fact that this was given to us as a double on input
     if (!strstr(buffer, ".") && !strstr(buffer, "e")) {
       strcat(buffer, ".0");
@@ -5224,7 +5224,7 @@ StreamWriter* StreamWriterBuilder::newStreamWriter() const
   JSONCPP_STRING cs_str = settings_["commentStyle"].asString();
   bool eyc = settings_["enableYAMLCompatibility"].asBool();
   bool dnp = settings_["dropNullPlaceholders"].asBool();
-  bool usf = settings_["useSpecialFloats"].asBool(); 
+  bool usf = settings_["useSpecialFloats"].asBool();
   unsigned int pre = settings_["precision"].asUInt();
   CommentStyle::Enum cs = CommentStyle::All;
   if (cs_str == "All") {
@@ -5313,8 +5313,3 @@ JSONCPP_OSTREAM& operator<<(JSONCPP_OSTREAM& sout, Value const& root) {
 // //////////////////////////////////////////////////////////////////////
 // End of content of file: src/lib_json/json_writer.cpp
 // //////////////////////////////////////////////////////////////////////
-
-
-
-
-

--- a/source/shared/cpp/ObjectModel/pch.h
+++ b/source/shared/cpp/ObjectModel/pch.h
@@ -37,4 +37,7 @@
 
 // ECppCoreCheckWarningCodes::WARNING_MEMBER_UNINIT
 #pragma warning(default: 26495)
+
+// ECppCoreCheckWarningCodes::WARNING_DEFINE_OR_DELETE_SPECIAL_OPS
+#pragma warning(default: 26432)
 #endif


### PR DESCRIPTION
Per core [guidelines](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#example-good-5), if explicitly declaring a dtor to make it `virtual`, just declare the rest as `default`. Also, don't declare a default dtor if you're not going to have anything in it. :)