### PR TITLE
Enable all cppcorecheck class warnings and fix errors

### DIFF
--- a/source/shared/cpp/ObjectModel/AdaptiveCardParseException.h
+++ b/source/shared/cpp/ObjectModel/AdaptiveCardParseException.h
@@ -10,7 +10,7 @@ class AdaptiveCardParseException : public std::exception
 public:
     AdaptiveCardParseException(AdaptiveSharedNamespace::ErrorStatusCode statusCode, const std::string& message);
 
-    virtual const char* what() const throw() override;
+    const char* what() const throw() override;
     AdaptiveSharedNamespace::ErrorStatusCode GetStatusCode() const;
     const std::string& GetReason() const;
 

--- a/source/shared/cpp/ObjectModel/AdaptiveCardParseException.h
+++ b/source/shared/cpp/ObjectModel/AdaptiveCardParseException.h
@@ -10,7 +10,7 @@ class AdaptiveCardParseException : public std::exception
 public:
     AdaptiveCardParseException(AdaptiveSharedNamespace::ErrorStatusCode statusCode, const std::string& message);
 
-    virtual const char* what() const throw();
+    virtual const char* what() const throw() override;
     AdaptiveSharedNamespace::ErrorStatusCode GetStatusCode() const;
     const std::string& GetReason() const;
 

--- a/source/shared/cpp/ObjectModel/BaseActionElement.h
+++ b/source/shared/cpp/ObjectModel/BaseActionElement.h
@@ -43,7 +43,7 @@ public:
     virtual void GetResourceUris(std::vector<std::string>& resourceUris);
 
 private:
-    void PopulateKnownPropertiesSet();
+    virtual void PopulateKnownPropertiesSet();
 
     ActionType m_type;
     std::string m_typeString;

--- a/source/shared/cpp/ObjectModel/BaseCardElement.h
+++ b/source/shared/cpp/ObjectModel/BaseCardElement.h
@@ -38,7 +38,7 @@ public:
 
     virtual const CardElementType GetElementType() const;
 
-    std::string Serialize() const;
+    virtual std::string Serialize() const;
     virtual Json::Value SerializeToJsonValue() const;
 
     template <typename T>
@@ -55,7 +55,7 @@ protected:
     std::unordered_set<std::string> m_knownProperties;
 
 private:
-    void PopulateKnownPropertiesSet();
+    virtual void PopulateKnownPropertiesSet();
 
     CardElementType m_type;
     Spacing m_spacing;

--- a/source/shared/cpp/ObjectModel/BaseInputElement.h
+++ b/source/shared/cpp/ObjectModel/BaseInputElement.h
@@ -14,7 +14,7 @@ public:
     BaseInputElement(CardElementType type, Spacing spacing, bool separator, HeightType height);
 
     std::string GetId() const override;
-    virtual void SetId(const std::string &value) override;
+    void SetId(const std::string &value) override;
 
     template <typename T>
     static std::shared_ptr<T> Deserialize(const Json::Value& json);
@@ -22,7 +22,7 @@ public:
     bool GetIsRequired() const;
     void SetIsRequired(const bool isRequired);
 
-    virtual Json::Value SerializeToJsonValue() const override;
+    Json::Value SerializeToJsonValue() const override;
 
 private:
     std::string m_id;

--- a/source/shared/cpp/ObjectModel/ChoiceSetInput.h
+++ b/source/shared/cpp/ObjectModel/ChoiceSetInput.h
@@ -14,7 +14,7 @@ friend class ChoiceSetInputParser;
 public:
     ChoiceSetInput();
 
-    virtual Json::Value SerializeToJsonValue() const override;
+    Json::Value SerializeToJsonValue() const override;
 
     bool GetIsMultiSelect() const;
     void SetIsMultiSelect(const bool isMultiSelect);
@@ -41,6 +41,13 @@ private:
 class ChoiceSetInputParser : public BaseCardElementParser
 {
 public:
+    ChoiceSetInputParser() = default;
+    ChoiceSetInputParser(const ChoiceSetInputParser&) = default;
+    ChoiceSetInputParser(ChoiceSetInputParser&&) = default;
+    ChoiceSetInputParser& operator=(const ChoiceSetInputParser&) = default;
+    ChoiceSetInputParser& operator=(ChoiceSetInputParser&&) = default;
+    virtual ~ChoiceSetInputParser() = default;
+
     std::shared_ptr<BaseCardElement> Deserialize(
         std::shared_ptr<ElementParserRegistration> elementParserRegistration,
         std::shared_ptr<ActionParserRegistration> actionParserRegistration,

--- a/source/shared/cpp/ObjectModel/ChoiceSetInput.h
+++ b/source/shared/cpp/ObjectModel/ChoiceSetInput.h
@@ -29,7 +29,7 @@ public:
     void SetValue(const std::string &value);
 
 private:
-    void PopulateKnownPropertiesSet();
+    void PopulateKnownPropertiesSet() override;
 
     std::string m_value;
     bool m_isMultiSelect;

--- a/source/shared/cpp/ObjectModel/Column.h
+++ b/source/shared/cpp/ObjectModel/Column.h
@@ -12,7 +12,7 @@ public:
     Column();
 
     std::string Serialize() const override;
-    virtual Json::Value SerializeToJsonValue() const override;
+    Json::Value SerializeToJsonValue() const override;
 
     static std::shared_ptr<Column> Deserialize(
         std::shared_ptr<ElementParserRegistration> elementParserRegistration,
@@ -47,7 +47,7 @@ public:
     VerticalContentAlignment GetVerticalContentAlignment() const;
     void SetVerticalContentAlignment(const VerticalContentAlignment value);
 
-    virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
+    void GetResourceUris(std::vector<std::string>& resourceUris) override;
 
 private:
     void PopulateKnownPropertiesSet() override;

--- a/source/shared/cpp/ObjectModel/Column.h
+++ b/source/shared/cpp/ObjectModel/Column.h
@@ -11,7 +11,7 @@ class Column : public BaseCardElement
 public:
     Column();
 
-    virtual std::string Serialize() const;
+    std::string Serialize() const override;
     virtual Json::Value SerializeToJsonValue() const override;
 
     static std::shared_ptr<Column> Deserialize(
@@ -50,7 +50,7 @@ public:
     virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
 
 private:
-    void PopulateKnownPropertiesSet();
+    void PopulateKnownPropertiesSet() override;
 
     std::string m_width;
     unsigned int m_pixelWidth;

--- a/source/shared/cpp/ObjectModel/ColumnSet.h
+++ b/source/shared/cpp/ObjectModel/ColumnSet.h
@@ -13,7 +13,7 @@ friend class ColumnSetParser;
 public:
     ColumnSet();
 
-    virtual Json::Value SerializeToJsonValue() const override;
+    Json::Value SerializeToJsonValue() const override;
 
     std::vector<std::shared_ptr<Column>>& GetColumns();
     const std::vector<std::shared_ptr<Column>>& GetColumns() const;
@@ -23,7 +23,7 @@ public:
 
     void SetLanguage(const std::string& language);
 
-    virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
+    void GetResourceUris(std::vector<std::string>& resourceUris) override;
 
 private:
     void PopulateKnownPropertiesSet() override;
@@ -36,6 +36,13 @@ private:
 class ColumnSetParser : public BaseCardElementParser
 {
 public:
+    ColumnSetParser() = default;
+    ColumnSetParser(const ColumnSetParser&) = default;
+    ColumnSetParser(ColumnSetParser&&) = default;
+    ColumnSetParser& operator=(const ColumnSetParser&) = default;
+    ColumnSetParser& operator=(ColumnSetParser&&) = default;
+    virtual ~ColumnSetParser() = default;
+
     std::shared_ptr<BaseCardElement> Deserialize(
         std::shared_ptr<ElementParserRegistration> elementParserRegistration,
         std::shared_ptr<ActionParserRegistration> actionParserRegistration,

--- a/source/shared/cpp/ObjectModel/ColumnSet.h
+++ b/source/shared/cpp/ObjectModel/ColumnSet.h
@@ -26,7 +26,7 @@ public:
     virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
 
 private:
-    void PopulateKnownPropertiesSet();
+    void PopulateKnownPropertiesSet() override;
 
     static const std::unordered_map<CardElementType, std::function<std::shared_ptr<Column>(const Json::Value&)>, EnumHash> ColumnParser;
     std::vector<std::shared_ptr<Column>> m_columns;

--- a/source/shared/cpp/ObjectModel/Container.h
+++ b/source/shared/cpp/ObjectModel/Container.h
@@ -32,7 +32,7 @@ public:
     virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
 
 private:
-    void PopulateKnownPropertiesSet();
+    void PopulateKnownPropertiesSet() override;
 
     ContainerStyle m_style;
     VerticalContentAlignment m_verticalContentAlignment;

--- a/source/shared/cpp/ObjectModel/Container.h
+++ b/source/shared/cpp/ObjectModel/Container.h
@@ -13,7 +13,7 @@ friend class ContainerParser;
 public:
     Container();
 
-    virtual Json::Value SerializeToJsonValue() const override;
+    Json::Value SerializeToJsonValue() const override;
 
     std::vector<std::shared_ptr<BaseCardElement>>& GetItems();
     const std::vector<std::shared_ptr<BaseCardElement>>& GetItems() const;
@@ -29,7 +29,7 @@ public:
     VerticalContentAlignment GetVerticalContentAlignment() const;
     void SetVerticalContentAlignment(const VerticalContentAlignment value);
 
-    virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
+    void GetResourceUris(std::vector<std::string>& resourceUris) override;
 
 private:
     void PopulateKnownPropertiesSet() override;
@@ -43,6 +43,13 @@ private:
 class ContainerParser : public BaseCardElementParser
 {
 public:
+    ContainerParser() = default;
+    ContainerParser(const ContainerParser&) = default;
+    ContainerParser(ContainerParser&&) = default;
+    ContainerParser& operator=(const ContainerParser&) = default;
+    ContainerParser& operator=(ContainerParser&&) = default;
+    virtual ~ContainerParser() = default;
+
     std::shared_ptr<BaseCardElement> Deserialize(
         std::shared_ptr<ElementParserRegistration> elementParserRegistration,
         std::shared_ptr<ActionParserRegistration> actionParserRegistration,

--- a/source/shared/cpp/ObjectModel/DateInput.h
+++ b/source/shared/cpp/ObjectModel/DateInput.h
@@ -26,7 +26,7 @@ public:
     void SetValue(const std::string &value);
 
 private:
-    void PopulateKnownPropertiesSet();
+    void PopulateKnownPropertiesSet() override;
 
     std::string m_max;
     std::string m_min;

--- a/source/shared/cpp/ObjectModel/DateInput.h
+++ b/source/shared/cpp/ObjectModel/DateInput.h
@@ -11,7 +11,7 @@ class DateInput : public BaseInputElement
 public:
     DateInput();
 
-    virtual Json::Value SerializeToJsonValue() const override;
+    Json::Value SerializeToJsonValue() const override;
 
     std::string GetMax() const;
     void SetMax(const std::string &value);
@@ -37,6 +37,13 @@ private:
 class DateInputParser : public BaseCardElementParser
 {
 public:
+    DateInputParser() = default;
+    DateInputParser(const DateInputParser&) = default;
+    DateInputParser(DateInputParser&&) = default;
+    DateInputParser& operator=(const DateInputParser&) = default;
+    DateInputParser& operator=(DateInputParser&&) = default;
+    virtual ~DateInputParser() = default;
+
     std::shared_ptr<BaseCardElement> Deserialize(
         std::shared_ptr<ElementParserRegistration> elementParserRegistration,
         std::shared_ptr<ActionParserRegistration> actionParserRegistration,

--- a/source/shared/cpp/ObjectModel/FactSet.h
+++ b/source/shared/cpp/ObjectModel/FactSet.h
@@ -20,7 +20,7 @@ public:
     const std::vector<std::shared_ptr<Fact>>& GetFacts() const;
 
 private:
-    void PopulateKnownPropertiesSet();
+    void PopulateKnownPropertiesSet() override;
 
     std::vector<std::shared_ptr<Fact>> m_facts;
 };

--- a/source/shared/cpp/ObjectModel/FactSet.h
+++ b/source/shared/cpp/ObjectModel/FactSet.h
@@ -14,7 +14,7 @@ friend class FactSetParser;
 public:
     FactSet();
 
-    virtual Json::Value SerializeToJsonValue() const override;
+    Json::Value SerializeToJsonValue() const override;
 
     std::vector<std::shared_ptr<Fact>>& GetFacts();
     const std::vector<std::shared_ptr<Fact>>& GetFacts() const;
@@ -28,6 +28,13 @@ private:
 class FactSetParser : public BaseCardElementParser
 {
 public:
+    FactSetParser() = default;
+    FactSetParser(const FactSetParser&) = default;
+    FactSetParser(FactSetParser&&) = default;
+    FactSetParser& operator=(const FactSetParser&) = default;
+    FactSetParser& operator=(FactSetParser&&) = default;
+    virtual ~FactSetParser() = default;
+
     std::shared_ptr<BaseCardElement> Deserialize(
         std::shared_ptr<ElementParserRegistration> elementParserRegistration,
         std::shared_ptr<ActionParserRegistration> actionParserRegistration,

--- a/source/shared/cpp/ObjectModel/Image.h
+++ b/source/shared/cpp/ObjectModel/Image.h
@@ -12,7 +12,7 @@ class Image : public BaseCardElement
 public:
     Image();
 
-    virtual Json::Value SerializeToJsonValue() const override;
+    Json::Value SerializeToJsonValue() const override;
 
     std::string GetUrl() const;
     void SetUrl(const std::string &value);
@@ -41,7 +41,7 @@ public:
     unsigned int GetPixelHeight() const;
     void SetPixelHeight(unsigned int value);
 
-    virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
+    void GetResourceUris(std::vector<std::string>& resourceUris) override;
 
 private:
     void PopulateKnownPropertiesSet() override;
@@ -60,6 +60,13 @@ private:
 class ImageParser : public BaseCardElementParser
 {
 public:
+    ImageParser() = default;
+    ImageParser(const ImageParser&) = default;
+    ImageParser(ImageParser&&) = default;
+    ImageParser& operator=(const ImageParser&) = default;
+    ImageParser& operator=(ImageParser&&) = default;
+    virtual ~ImageParser() = default;
+
     std::shared_ptr<BaseCardElement> Deserialize(
         std::shared_ptr<ElementParserRegistration> elementParserRegistration,
         std::shared_ptr<ActionParserRegistration> actionParserRegistration,

--- a/source/shared/cpp/ObjectModel/Image.h
+++ b/source/shared/cpp/ObjectModel/Image.h
@@ -44,7 +44,7 @@ public:
     virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
 
 private:
-    void PopulateKnownPropertiesSet();
+    void PopulateKnownPropertiesSet() override;
 
     std::string m_url;
     std::string m_backgroundColor;

--- a/source/shared/cpp/ObjectModel/ImageSet.h
+++ b/source/shared/cpp/ObjectModel/ImageSet.h
@@ -24,7 +24,7 @@ public:
     virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
 
 private:
-    void PopulateKnownPropertiesSet();
+    void PopulateKnownPropertiesSet() override;
 
     std::vector<std::shared_ptr<Image>> m_images;
     ImageSize m_imageSize;

--- a/source/shared/cpp/ObjectModel/ImageSet.h
+++ b/source/shared/cpp/ObjectModel/ImageSet.h
@@ -13,7 +13,7 @@ friend class ImageSetParser;
 public:
     ImageSet();
 
-    virtual Json::Value SerializeToJsonValue() const override;
+    Json::Value SerializeToJsonValue() const override;
 
     ImageSize GetImageSize() const;
     void SetImageSize(const ImageSize value);
@@ -21,7 +21,7 @@ public:
     std::vector<std::shared_ptr<Image>>& GetImages();
     const std::vector<std::shared_ptr<Image>>& GetImages() const;
 
-    virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
+    void GetResourceUris(std::vector<std::string>& resourceUris) override;
 
 private:
     void PopulateKnownPropertiesSet() override;
@@ -33,6 +33,13 @@ private:
 class ImageSetParser : public BaseCardElementParser
 {
 public:
+    ImageSetParser() = default;
+    ImageSetParser(const ImageSetParser&) = default;
+    ImageSetParser(ImageSetParser&&) = default;
+    ImageSetParser& operator=(const ImageSetParser&) = default;
+    ImageSetParser& operator=(ImageSetParser&&) = default;
+    virtual ~ImageSetParser() = default;
+
     std::shared_ptr<BaseCardElement> Deserialize(
         std::shared_ptr<ElementParserRegistration> elementParserRegistration,
         std::shared_ptr<ActionParserRegistration> actionParserRegistration,

--- a/source/shared/cpp/ObjectModel/MarkDownBlockParser.h
+++ b/source/shared/cpp/ObjectModel/MarkDownBlockParser.h
@@ -7,7 +7,7 @@
 namespace AdaptiveSharedNamespace {
     class MarkDownBlockParser
     {
-        public:
+    public:
         MarkDownBlockParser(){};
         // Matches each MarkDown's Syntax Form
         // For each match, stream moves to the next char
@@ -24,7 +24,14 @@ namespace AdaptiveSharedNamespace {
 
     class EmphasisParser: public MarkDownBlockParser
     {
-        public:
+    public:
+        EmphasisParser() = default;
+        EmphasisParser(const EmphasisParser&) = default;
+        EmphasisParser(EmphasisParser&&) = default;
+        EmphasisParser& operator=(const EmphasisParser&) = default;
+        EmphasisParser& operator=(EmphasisParser&&) = default;
+        virtual ~EmphasisParser() = default;
+
         enum EmphasisState
         {
             // Text is being handled
@@ -35,7 +42,7 @@ namespace AdaptiveSharedNamespace {
             Captured = 0x2,
         };
 
-        virtual void Match(std::stringstream &) override;
+        void Match(std::stringstream &) override;
         // Captures remaining charaters in given token
         // and causes the emphasis parsing to terminate
         void Flush(int ch, std::string& currentToken);
@@ -91,7 +98,14 @@ namespace AdaptiveSharedNamespace {
 
     class LinkParser : public MarkDownBlockParser
     {
-        public:
+    public:
+        LinkParser() = default;
+        LinkParser(const LinkParser&) = default;
+        LinkParser(LinkParser&&) = default;
+        LinkParser& operator=(const LinkParser&) = default;
+        LinkParser& operator=(LinkParser&&) = default;
+        virtual ~LinkParser() = default;
+
         void Match(std::stringstream &) override;
 
         private:
@@ -114,7 +128,14 @@ namespace AdaptiveSharedNamespace {
 
     class ListParser : public MarkDownBlockParser
     {
-        public:
+    public:
+        ListParser() = default;
+        ListParser(const ListParser&) = default;
+        ListParser(ListParser&&) = default;
+        ListParser& operator=(const ListParser&) = default;
+        ListParser& operator=(ListParser&&) = default;
+        virtual ~ListParser() = default;
+
         void Match(std::stringstream &) override;
         bool MatchNewListItem(std::stringstream &);
         bool MatchNewBlock(std::stringstream &);
@@ -123,20 +144,27 @@ namespace AdaptiveSharedNamespace {
         static constexpr bool IsDot(int ch) { return ch == '.'; };
         static constexpr bool IsNewLine(int ch){ return (ch == '\r') || (ch == '\n');};
 
-        protected:
+    protected:
         void ParseSubBlocks(std::stringstream &);
         bool CompleteListParsing(std::stringstream &stream);
 
-        private:
+    private:
         void CaptureListToken();
     };
 
     class OrderedListParser : public ListParser
     {
-        public:
+    public:
+        OrderedListParser() = default;
+        OrderedListParser(const OrderedListParser&) = default;
+        OrderedListParser(OrderedListParser&&) = default;
+        OrderedListParser& operator=(const OrderedListParser&) = default;
+        OrderedListParser& operator=(OrderedListParser&&) = default;
+        ~OrderedListParser() = default;
+
         void Match(std::stringstream &) override;
 
-        private:
+    private:
         void CaptureOrderedListToken(std::string&);
     };
 }

--- a/source/shared/cpp/ObjectModel/MarkDownBlockParser.h
+++ b/source/shared/cpp/ObjectModel/MarkDownBlockParser.h
@@ -35,7 +35,7 @@ namespace AdaptiveSharedNamespace {
             Captured = 0x2,
         };
 
-        virtual void Match(std::stringstream &);
+        virtual void Match(std::stringstream &) override;
         // Captures remaining charaters in given token
         // and causes the emphasis parsing to terminate
         void Flush(int ch, std::string& currentToken);
@@ -92,7 +92,7 @@ namespace AdaptiveSharedNamespace {
     class LinkParser : public MarkDownBlockParser
     {
         public:
-        void Match(std::stringstream &);
+        void Match(std::stringstream &) override;
 
         private:
         void CaptureLinkToken();
@@ -115,7 +115,7 @@ namespace AdaptiveSharedNamespace {
     class ListParser : public MarkDownBlockParser
     {
         public:
-        void Match(std::stringstream &);
+        void Match(std::stringstream &) override;
         bool MatchNewListItem(std::stringstream &);
         bool MatchNewBlock(std::stringstream &);
         bool MatchNewOrderedListItem(std::stringstream &, std::string &);
@@ -134,7 +134,7 @@ namespace AdaptiveSharedNamespace {
     class OrderedListParser : public ListParser
     {
         public:
-        void Match(std::stringstream &);
+        void Match(std::stringstream &) override;
 
         private:
         void CaptureOrderedListToken(std::string&);

--- a/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.h
+++ b/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.h
@@ -31,26 +31,32 @@ enum DelimiterType
 //   list uses block tag of <ul> all others use <p>
 class MarkDownHtmlGenerator
 {
-    public:
-        enum MarkDownBlockType
-        {
-            ContainerBlock,
-            UnorderedList,
-            OrderedList
-        };
+public:
+    MarkDownHtmlGenerator(const MarkDownHtmlGenerator&) = default;
+    MarkDownHtmlGenerator(MarkDownHtmlGenerator&&) = default;
+    MarkDownHtmlGenerator& operator=(const MarkDownHtmlGenerator&) = default;
+    MarkDownHtmlGenerator& operator=(MarkDownHtmlGenerator&&) = default;
+    virtual ~MarkDownHtmlGenerator() = default;
 
-        MarkDownHtmlGenerator() : m_token(""){};
-        MarkDownHtmlGenerator(std::string &token) : m_token(token){};
-        void MakeItHead() { m_isHead = true; }
-        void MakeItTail() { m_isTail = true; }
-        virtual bool IsNewLine() { return false; }
-        virtual std::string GenerateHtmlString() = 0;
-        virtual MarkDownBlockType GetBlockType() const { return ContainerBlock; };
-    protected:
-        std::string m_token;
-        std::ostringstream html;
-        bool m_isHead = false;
-        bool m_isTail = false;
+    enum MarkDownBlockType
+    {
+        ContainerBlock,
+        UnorderedList,
+        OrderedList
+    };
+
+    MarkDownHtmlGenerator() : m_token(""){};
+    MarkDownHtmlGenerator(std::string &token) : m_token(token){};
+    void MakeItHead() { m_isHead = true; }
+    void MakeItTail() { m_isTail = true; }
+    virtual bool IsNewLine() { return false; }
+    virtual std::string GenerateHtmlString() = 0;
+    virtual MarkDownBlockType GetBlockType() const { return ContainerBlock; };
+protected:
+    std::string m_token;
+    std::ostringstream html;
+    bool m_isHead = false;
+    bool m_isTail = false;
 };
 
 // - MarkDownStringHtmlGenerator
@@ -58,18 +64,32 @@ class MarkDownHtmlGenerator
 //   it simply retains and return text as string
 class MarkDownStringHtmlGenerator : public MarkDownHtmlGenerator
 {
-    public:
-        MarkDownStringHtmlGenerator(std::string &token) : MarkDownHtmlGenerator(token){};
-        std::string GenerateHtmlString() override;
+public:
+    MarkDownStringHtmlGenerator() = delete;
+    MarkDownStringHtmlGenerator(const MarkDownStringHtmlGenerator&) = default;
+    MarkDownStringHtmlGenerator(MarkDownStringHtmlGenerator&&) = default;
+    MarkDownStringHtmlGenerator& operator=(const MarkDownStringHtmlGenerator&) = default;
+    MarkDownStringHtmlGenerator& operator=(MarkDownStringHtmlGenerator&&) = default;
+    ~MarkDownStringHtmlGenerator() = default;
+
+    MarkDownStringHtmlGenerator(std::string &token) : MarkDownHtmlGenerator(token){};
+    std::string GenerateHtmlString() override;
 };
 
 // - MarkDownNewLineHtmlGenerator
 //   it contains new line chars
 class MarkDownNewLineHtmlGenerator : public MarkDownStringHtmlGenerator
 {
-    public:
-        MarkDownNewLineHtmlGenerator(std::string &token) : MarkDownStringHtmlGenerator(token){};
-        bool IsNewLine() override { return true; }
+public:
+    MarkDownNewLineHtmlGenerator() = delete;
+    MarkDownNewLineHtmlGenerator(const MarkDownNewLineHtmlGenerator&) = default;
+    MarkDownNewLineHtmlGenerator(MarkDownNewLineHtmlGenerator&&) = default;
+    MarkDownNewLineHtmlGenerator& operator=(const MarkDownNewLineHtmlGenerator&) = default;
+    MarkDownNewLineHtmlGenerator& operator=(MarkDownNewLineHtmlGenerator&&) = default;
+    ~MarkDownNewLineHtmlGenerator() = default;
+
+    MarkDownNewLineHtmlGenerator(std::string &token) : MarkDownStringHtmlGenerator(token){};
+    bool IsNewLine() override { return true; }
 };
 
 // - MarkDownEmphasisHtmlGenerator
@@ -77,97 +97,119 @@ class MarkDownNewLineHtmlGenerator : public MarkDownStringHtmlGenerator
 //   tags and apply those to its text when asked to generate html string
 class MarkDownEmphasisHtmlGenerator : public MarkDownHtmlGenerator
 {
-    public:
-        MarkDownEmphasisHtmlGenerator(std::string &token,
-                int sizeOfEmphasisDelimiterRun,
-                DelimiterType type
-                ) : MarkDownHtmlGenerator(token),
-        m_numberOfUnusedDelimiters(sizeOfEmphasisDelimiterRun), type(type){};
+public:
+    MarkDownEmphasisHtmlGenerator() = delete;
+    MarkDownEmphasisHtmlGenerator(const MarkDownEmphasisHtmlGenerator&) = default;
+    MarkDownEmphasisHtmlGenerator(MarkDownEmphasisHtmlGenerator&&) = default;
+    MarkDownEmphasisHtmlGenerator& operator=(const MarkDownEmphasisHtmlGenerator&) = default;
+    MarkDownEmphasisHtmlGenerator& operator=(MarkDownEmphasisHtmlGenerator&&) = default;
+    ~MarkDownEmphasisHtmlGenerator() = default;
 
-        MarkDownEmphasisHtmlGenerator(std::string &token,
-                int sizeOfEmphasisDelimiterRun,
-                DelimiterType type,
-                std::vector<std::string> &tags
-                ) : MarkDownHtmlGenerator(token),
+    MarkDownEmphasisHtmlGenerator(std::string &token, int sizeOfEmphasisDelimiterRun, DelimiterType type) :
+        MarkDownHtmlGenerator(token), m_numberOfUnusedDelimiters(sizeOfEmphasisDelimiterRun), type(type){};
+
+    MarkDownEmphasisHtmlGenerator(std::string &token, int sizeOfEmphasisDelimiterRun, DelimiterType type,
+        std::vector<std::string> &tags) : MarkDownHtmlGenerator(token),
         m_numberOfUnusedDelimiters(sizeOfEmphasisDelimiterRun), type(type), m_tags(tags){};
 
-        virtual bool IsRightEmphasis() const { return false; }
-        virtual bool IsLeftEmphasis() const  { return false; }
-        virtual bool IsLeftAndRightEmphasis() const { return false; }
-        virtual void PushItalicTag();
-        virtual void PushBoldTag();
+    virtual bool IsRightEmphasis() const { return false; }
+    virtual bool IsLeftEmphasis() const  { return false; }
+    virtual bool IsLeftAndRightEmphasis() const { return false; }
+    virtual void PushItalicTag();
+    virtual void PushBoldTag();
 
-        bool IsMatch(const MarkDownEmphasisHtmlGenerator &token);
-        bool IsSameType(const MarkDownEmphasisHtmlGenerator &token);
-        bool IsDone() const { return m_numberOfUnusedDelimiters == 0; }
-        int GetNumberOfUnusedDelimiters() const { return m_numberOfUnusedDelimiters; };
-        bool GenerateTags(MarkDownEmphasisHtmlGenerator &token);
-        void ReverseDirectionType() { m_directionType = !m_directionType; };
-    protected:
-        enum
-        {
-            Left = 0,
-            Right = 1,
-        };
+    bool IsMatch(const MarkDownEmphasisHtmlGenerator &token);
+    bool IsSameType(const MarkDownEmphasisHtmlGenerator &token);
+    bool IsDone() const { return m_numberOfUnusedDelimiters == 0; }
+    int GetNumberOfUnusedDelimiters() const { return m_numberOfUnusedDelimiters; };
+    bool GenerateTags(MarkDownEmphasisHtmlGenerator &token);
+    void ReverseDirectionType() { m_directionType = !m_directionType; };
 
-        int AdjustEmphasisCounts(int leftOver, MarkDownEmphasisHtmlGenerator &rightToken);
-        int m_numberOfUnusedDelimiters;
-        int m_directionType = Right;
-        DelimiterType type;
-        std::vector<std::string> m_tags;
+protected:
+    enum
+    {
+        Left = 0,
+        Right = 1,
+    };
 
+    int AdjustEmphasisCounts(int leftOver, MarkDownEmphasisHtmlGenerator &rightToken);
+    int m_numberOfUnusedDelimiters;
+    int m_directionType = Right;
+    DelimiterType type;
+    std::vector<std::string> m_tags;
 };
 
 // - MarkDownLeftEmphasisHtmlGenerator
 //   it knows how to generates opening italic and bold html tags
 class MarkDownLeftEmphasisHtmlGenerator : public MarkDownEmphasisHtmlGenerator
 {
-    public:
-        MarkDownLeftEmphasisHtmlGenerator (std::string &token,
-                int sizeOfEmphasisDelimiterRun,
-                DelimiterType type) : MarkDownEmphasisHtmlGenerator(token,
-                    sizeOfEmphasisDelimiterRun, type){};
+public:
+    MarkDownLeftEmphasisHtmlGenerator() = delete;
+    MarkDownLeftEmphasisHtmlGenerator(const MarkDownLeftEmphasisHtmlGenerator&) = default;
+    MarkDownLeftEmphasisHtmlGenerator(MarkDownLeftEmphasisHtmlGenerator&&) = default;
+    MarkDownLeftEmphasisHtmlGenerator& operator=(const MarkDownLeftEmphasisHtmlGenerator&) = default;
+    MarkDownLeftEmphasisHtmlGenerator& operator=(MarkDownLeftEmphasisHtmlGenerator&&) = default;
+    ~MarkDownLeftEmphasisHtmlGenerator() = default;
 
-        MarkDownLeftEmphasisHtmlGenerator(std::string &token,
-                int sizeOfEmphasisDelimiterRun,
-                DelimiterType type, std::vector<std::string> &tags) : MarkDownEmphasisHtmlGenerator(token,
-                    sizeOfEmphasisDelimiterRun, type, tags){};
+    MarkDownLeftEmphasisHtmlGenerator (std::string &token,
+            int sizeOfEmphasisDelimiterRun,
+            DelimiterType type) : MarkDownEmphasisHtmlGenerator(token,
+                sizeOfEmphasisDelimiterRun, type){};
 
-        bool IsLeftEmphasis() const override  { return true; }
-        std::string GenerateHtmlString() override;
+    MarkDownLeftEmphasisHtmlGenerator(std::string &token,
+            int sizeOfEmphasisDelimiterRun,
+            DelimiterType type, std::vector<std::string> &tags) : MarkDownEmphasisHtmlGenerator(token,
+                sizeOfEmphasisDelimiterRun, type, tags){};
+
+    bool IsLeftEmphasis() const override  { return true; }
+    std::string GenerateHtmlString() override;
 };
 
 // - MarkDownRightEmphasisHtmlGenerator
 //   it knows how to generates closing italic and bold html tags
 class MarkDownRightEmphasisHtmlGenerator : public MarkDownEmphasisHtmlGenerator
 {
-    public:
-        MarkDownRightEmphasisHtmlGenerator(std::string &token,
-                int sizeOfEmphasisDelimiterRun,
-                DelimiterType type) : MarkDownEmphasisHtmlGenerator(token,
-                    sizeOfEmphasisDelimiterRun, type){};
+public:
+    MarkDownRightEmphasisHtmlGenerator() = delete;
+    MarkDownRightEmphasisHtmlGenerator(const MarkDownRightEmphasisHtmlGenerator&) = default;
+    MarkDownRightEmphasisHtmlGenerator(MarkDownRightEmphasisHtmlGenerator&&) = default;
+    MarkDownRightEmphasisHtmlGenerator& operator=(const MarkDownRightEmphasisHtmlGenerator&) = default;
+    MarkDownRightEmphasisHtmlGenerator& operator=(MarkDownRightEmphasisHtmlGenerator&&) = default;
+    ~MarkDownRightEmphasisHtmlGenerator() = default;
 
-        void GenerateTags(std::shared_ptr<MarkDownEmphasisHtmlGenerator> &token);
-        bool IsRightEmphasis() const override { return true; }
-        std::string GenerateHtmlString() override;
-        void PushItalicTag() override;
-        void PushBoldTag() override;
+    MarkDownRightEmphasisHtmlGenerator(std::string &token,
+            int sizeOfEmphasisDelimiterRun,
+            DelimiterType type) : MarkDownEmphasisHtmlGenerator(token,
+                sizeOfEmphasisDelimiterRun, type){};
+
+    void GenerateTags(std::shared_ptr<MarkDownEmphasisHtmlGenerator> &token);
+    bool IsRightEmphasis() const override { return true; }
+    std::string GenerateHtmlString() override;
+    void PushItalicTag() override;
+    void PushBoldTag() override;
 };
 
 // - MarkDownLeftAndRightEmphasisHtmlGenerator
 //   it can have both directions, and its final direction is determined at the later stage
 class MarkDownLeftAndRightEmphasisHtmlGenerator : public MarkDownRightEmphasisHtmlGenerator
 {
-    public:
-        MarkDownLeftAndRightEmphasisHtmlGenerator(std::string &token,
-                int sizeOfEmphasisDelimiterRun,
-                DelimiterType type) : MarkDownRightEmphasisHtmlGenerator(token,
-                    sizeOfEmphasisDelimiterRun, type) {};
-        bool IsRightEmphasis() const override { return m_directionType == Right; }
-        bool IsLeftEmphasis() const override  { return m_directionType == Left; }
-        bool IsLeftAndRightEmphasis() const override { return true; };
-        void PushItalicTag() override;
-        void PushBoldTag() override;
+public:
+    MarkDownLeftAndRightEmphasisHtmlGenerator() = delete;
+    MarkDownLeftAndRightEmphasisHtmlGenerator(const MarkDownLeftAndRightEmphasisHtmlGenerator&) = default;
+    MarkDownLeftAndRightEmphasisHtmlGenerator(MarkDownLeftAndRightEmphasisHtmlGenerator&&) = default;
+    MarkDownLeftAndRightEmphasisHtmlGenerator& operator=(const MarkDownLeftAndRightEmphasisHtmlGenerator&) = default;
+    MarkDownLeftAndRightEmphasisHtmlGenerator& operator=(MarkDownLeftAndRightEmphasisHtmlGenerator&&) = default;
+    ~MarkDownLeftAndRightEmphasisHtmlGenerator() = default;
+
+    MarkDownLeftAndRightEmphasisHtmlGenerator(std::string &token,
+            int sizeOfEmphasisDelimiterRun,
+            DelimiterType type) : MarkDownRightEmphasisHtmlGenerator(token,
+                sizeOfEmphasisDelimiterRun, type) {};
+    bool IsRightEmphasis() const override { return m_directionType == Right; }
+    bool IsLeftEmphasis() const override  { return m_directionType == Left; }
+    bool IsLeftAndRightEmphasis() const override { return true; };
+    void PushItalicTag() override;
+    void PushBoldTag() override;
 };
 
 // - MarkDownListHtmlGenerator
@@ -175,10 +217,17 @@ class MarkDownLeftAndRightEmphasisHtmlGenerator : public MarkDownRightEmphasisHt
 //   UnorderedList type, this is used in generating html block tags <ul>
 class MarkDownListHtmlGenerator : public MarkDownStringHtmlGenerator
 {
-    public:
-        MarkDownListHtmlGenerator(std::string &token) : MarkDownStringHtmlGenerator(token) {};
-        std::string GenerateHtmlString() override;
-        MarkDownBlockType GetBlockType() const override { return UnorderedList; };
+public:
+    MarkDownListHtmlGenerator() = delete;
+    MarkDownListHtmlGenerator(const MarkDownListHtmlGenerator&) = default;
+    MarkDownListHtmlGenerator(MarkDownListHtmlGenerator&&) = default;
+    MarkDownListHtmlGenerator& operator=(const MarkDownListHtmlGenerator&) = default;
+    MarkDownListHtmlGenerator& operator=(MarkDownListHtmlGenerator&&) = default;
+    ~MarkDownListHtmlGenerator() = default;
+
+    MarkDownListHtmlGenerator(std::string &token) : MarkDownStringHtmlGenerator(token) {};
+    std::string GenerateHtmlString() override;
+    MarkDownBlockType GetBlockType() const override { return UnorderedList; };
 };
 
 // - MarkDownUnorderedListHtmlGenerator
@@ -186,13 +235,21 @@ class MarkDownListHtmlGenerator : public MarkDownStringHtmlGenerator
 //   OrderedList type, this is used in generating html block tags <ol>
 class MarkDownOrderedListHtmlGenerator : public MarkDownStringHtmlGenerator
 {
-    public:
-        MarkDownOrderedListHtmlGenerator(std::string &token, std::string &number_string) :
-            MarkDownStringHtmlGenerator(token), m_numberString(number_string) {};
-        std::string GenerateHtmlString() override;
-        MarkDownBlockType GetBlockType() const override { return OrderedList; };
-    private:
-        std::string m_numberString;
+public:
+    MarkDownOrderedListHtmlGenerator() = delete;
+    MarkDownOrderedListHtmlGenerator(const MarkDownOrderedListHtmlGenerator&) = default;
+    MarkDownOrderedListHtmlGenerator(MarkDownOrderedListHtmlGenerator&&) = default;
+    MarkDownOrderedListHtmlGenerator& operator=(const MarkDownOrderedListHtmlGenerator&) = default;
+    MarkDownOrderedListHtmlGenerator& operator=(MarkDownOrderedListHtmlGenerator&&) = default;
+    ~MarkDownOrderedListHtmlGenerator() = default;
+
+    MarkDownOrderedListHtmlGenerator(std::string &token, std::string &number_string) :
+        MarkDownStringHtmlGenerator(token), m_numberString(number_string) {};
+    std::string GenerateHtmlString() override;
+    MarkDownBlockType GetBlockType() const override { return OrderedList; };
+
+private:
+    std::string m_numberString;
 };
 
 }

--- a/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.h
+++ b/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.h
@@ -26,7 +26,7 @@ enum DelimiterType
 //   it knows how to handle bold and italic html
 //   tags and apply those to its text when asked to generate html string
 // - MarkDownListHtmlGenerator
-//   it functions simmilary as MarkDownStringHtmlGenerator, but its GetBlockType() returns
+//   it functions similarly as MarkDownStringHtmlGenerator, but its GetBlockType() returns
 //   MarkDownBlockType, this is used in generating html block tags
 //   list uses block tag of <ul> all others use <p>
 class MarkDownHtmlGenerator
@@ -60,7 +60,7 @@ class MarkDownStringHtmlGenerator : public MarkDownHtmlGenerator
 {
     public:
         MarkDownStringHtmlGenerator(std::string &token) : MarkDownHtmlGenerator(token){};
-        std::string GenerateHtmlString();
+        std::string GenerateHtmlString() override;
 };
 
 // - MarkDownNewLineHtmlGenerator
@@ -69,7 +69,7 @@ class MarkDownNewLineHtmlGenerator : public MarkDownStringHtmlGenerator
 {
     public:
         MarkDownNewLineHtmlGenerator(std::string &token) : MarkDownStringHtmlGenerator(token){};
-        bool IsNewLine() { return true; }
+        bool IsNewLine() override { return true; }
 };
 
 // - MarkDownEmphasisHtmlGenerator
@@ -133,8 +133,8 @@ class MarkDownLeftEmphasisHtmlGenerator : public MarkDownEmphasisHtmlGenerator
                 DelimiterType type, std::vector<std::string> &tags) : MarkDownEmphasisHtmlGenerator(token,
                     sizeOfEmphasisDelimiterRun, type, tags){};
 
-        bool IsLeftEmphasis() const  { return true; }
-        std::string GenerateHtmlString();
+        bool IsLeftEmphasis() const override  { return true; }
+        std::string GenerateHtmlString() override;
 };
 
 // - MarkDownRightEmphasisHtmlGenerator
@@ -148,10 +148,10 @@ class MarkDownRightEmphasisHtmlGenerator : public MarkDownEmphasisHtmlGenerator
                     sizeOfEmphasisDelimiterRun, type){};
 
         void GenerateTags(std::shared_ptr<MarkDownEmphasisHtmlGenerator> &token);
-        bool IsRightEmphasis() const { return true; }
-        std::string GenerateHtmlString();
-        void PushItalicTag();
-        void PushBoldTag();
+        bool IsRightEmphasis() const override { return true; }
+        std::string GenerateHtmlString() override;
+        void PushItalicTag() override;
+        void PushBoldTag() override;
 };
 
 // - MarkDownLeftAndRightEmphasisHtmlGenerator
@@ -163,34 +163,34 @@ class MarkDownLeftAndRightEmphasisHtmlGenerator : public MarkDownRightEmphasisHt
                 int sizeOfEmphasisDelimiterRun,
                 DelimiterType type) : MarkDownRightEmphasisHtmlGenerator(token,
                     sizeOfEmphasisDelimiterRun, type) {};
-        bool IsRightEmphasis() const { return m_directionType == Right; }
-        bool IsLeftEmphasis() const  { return m_directionType == Left; }
-        bool IsLeftAndRightEmphasis() const { return true; };
-        void PushItalicTag();
-        void PushBoldTag();
+        bool IsRightEmphasis() const override { return m_directionType == Right; }
+        bool IsLeftEmphasis() const override  { return m_directionType == Left; }
+        bool IsLeftAndRightEmphasis() const override { return true; };
+        void PushItalicTag() override;
+        void PushBoldTag() override;
 };
 
 // - MarkDownListHtmlGenerator
-//   it functions simmilary as MarkDownStringHtmlGenerator, but its GetBlockType() returns
+//   it functions similarly as MarkDownStringHtmlGenerator, but its GetBlockType() returns
 //   UnorderedList type, this is used in generating html block tags <ul>
 class MarkDownListHtmlGenerator : public MarkDownStringHtmlGenerator
 {
     public:
         MarkDownListHtmlGenerator(std::string &token) : MarkDownStringHtmlGenerator(token) {};
-        std::string GenerateHtmlString();
-        MarkDownBlockType GetBlockType() const { return UnorderedList; };
+        std::string GenerateHtmlString() override;
+        MarkDownBlockType GetBlockType() const override { return UnorderedList; };
 };
 
 // - MarkDownUnorderedListHtmlGenerator
-//   it functions simmilary as MarkDownStringHtmlGenerator, but its GetBlockType() returns
+//   it functions similarly as MarkDownStringHtmlGenerator, but its GetBlockType() returns
 //   OrderedList type, this is used in generating html block tags <ol>
 class MarkDownOrderedListHtmlGenerator : public MarkDownStringHtmlGenerator
 {
     public:
         MarkDownOrderedListHtmlGenerator(std::string &token, std::string &number_string) :
             MarkDownStringHtmlGenerator(token), m_numberString(number_string) {};
-        std::string GenerateHtmlString();
-        MarkDownBlockType GetBlockType() const { return OrderedList; };
+        std::string GenerateHtmlString() override;
+        MarkDownBlockType GetBlockType() const override { return OrderedList; };
     private:
         std::string m_numberString;
 };

--- a/source/shared/cpp/ObjectModel/Media.h
+++ b/source/shared/cpp/ObjectModel/Media.h
@@ -13,7 +13,7 @@ class Media : public BaseCardElement
 public:
     Media();
 
-    virtual Json::Value SerializeToJsonValue() const override;
+    Json::Value SerializeToJsonValue() const override;
 
     std::string GetPoster() const;
     void SetPoster(const std::string& value);
@@ -34,6 +34,13 @@ private:
 class MediaParser : public BaseCardElementParser
 {
 public:
+    MediaParser() = default;
+    MediaParser(const MediaParser&) = default;
+    MediaParser(MediaParser&&) = default;
+    MediaParser& operator=(const MediaParser&) = default;
+    MediaParser& operator=(MediaParser&&) = default;
+    virtual ~MediaParser() = default;
+
     std::shared_ptr<BaseCardElement> Deserialize(
         std::shared_ptr<ElementParserRegistration> elementParserRegistration,
         std::shared_ptr<ActionParserRegistration> actionParserRegistration,

--- a/source/shared/cpp/ObjectModel/Media.h
+++ b/source/shared/cpp/ObjectModel/Media.h
@@ -28,7 +28,7 @@ private:
     std::string m_altText;
     std::vector<std::shared_ptr<MediaSource>> m_sources;
 
-    void PopulateKnownPropertiesSet();
+    void PopulateKnownPropertiesSet() override;
 };
 
 class MediaParser : public BaseCardElementParser

--- a/source/shared/cpp/ObjectModel/MediaSource.h
+++ b/source/shared/cpp/ObjectModel/MediaSource.h
@@ -10,6 +10,11 @@ class MediaSource
 {
 public:
     MediaSource();
+    MediaSource(const MediaSource&) = default;
+    MediaSource(MediaSource&&) = default;
+    MediaSource& operator=(const MediaSource&) = default;
+    MediaSource& operator=(MediaSource&&) = default;
+    virtual ~MediaSource() = default;
 
     virtual Json::Value SerializeToJsonValue() const;
 
@@ -27,6 +32,13 @@ private:
 class MediaSourceParser
 {
 public:
+    MediaSourceParser() = default;
+    MediaSourceParser(const MediaSourceParser&) = default;
+    MediaSourceParser(MediaSourceParser&&) = default;
+    MediaSourceParser& operator=(const MediaSourceParser&) = default;
+    MediaSourceParser& operator=(MediaSourceParser&&) = default;
+    virtual ~MediaSourceParser() = default;
+
     static std::shared_ptr<MediaSource> Deserialize(
         std::shared_ptr<ElementParserRegistration> elementParserRegistration,
         std::shared_ptr<ActionParserRegistration> actionParserRegistration,

--- a/source/shared/cpp/ObjectModel/NumberInput.h
+++ b/source/shared/cpp/ObjectModel/NumberInput.h
@@ -11,7 +11,7 @@ class NumberInput : public BaseInputElement
 public:
     NumberInput();
 
-    virtual Json::Value SerializeToJsonValue() const override;
+    Json::Value SerializeToJsonValue() const override;
 
     std::string GetPlaceholder() const;
     void SetPlaceholder(const std::string &value);
@@ -37,6 +37,13 @@ private:
 class NumberInputParser : public BaseCardElementParser
 {
 public:
+    NumberInputParser() = default;
+    NumberInputParser(const NumberInputParser&) = default;
+    NumberInputParser(NumberInputParser&&) = default;
+    NumberInputParser& operator=(const NumberInputParser&) = default;
+    NumberInputParser& operator=(NumberInputParser&&) = default;
+    virtual ~NumberInputParser() = default;
+
     std::shared_ptr<BaseCardElement> Deserialize(
         std::shared_ptr<ElementParserRegistration> elementParserRegistration,
         std::shared_ptr<ActionParserRegistration> actionParserRegistration,

--- a/source/shared/cpp/ObjectModel/NumberInput.h
+++ b/source/shared/cpp/ObjectModel/NumberInput.h
@@ -26,7 +26,7 @@ public:
     void SetMin(const int value);
 
 private:
-    void PopulateKnownPropertiesSet();
+    void PopulateKnownPropertiesSet() override;
 
     std::string m_placeholder;
     int m_value;

--- a/source/shared/cpp/ObjectModel/OpenUrlAction.h
+++ b/source/shared/cpp/ObjectModel/OpenUrlAction.h
@@ -11,7 +11,7 @@ class OpenUrlAction : public BaseActionElement
 public:
     OpenUrlAction();
 
-    virtual Json::Value SerializeToJsonValue() const override;
+    Json::Value SerializeToJsonValue() const override;
 
     std::string GetUrl() const;
     void SetUrl(const std::string &value);
@@ -24,6 +24,14 @@ private:
 
 class OpenUrlActionParser : public ActionElementParser
 {
+public:
+    OpenUrlActionParser() = default;
+    OpenUrlActionParser(const OpenUrlActionParser&) = default;
+    OpenUrlActionParser(OpenUrlActionParser&&) = default;
+    OpenUrlActionParser& operator=(const OpenUrlActionParser&) = default;
+    OpenUrlActionParser& operator=(OpenUrlActionParser&&) = default;
+    virtual ~OpenUrlActionParser() = default;
+
     std::shared_ptr<BaseActionElement> Deserialize(
         std::shared_ptr<ElementParserRegistration> elementParserRegistration,
         std::shared_ptr<ActionParserRegistration> actionParserRegistration,

--- a/source/shared/cpp/ObjectModel/OpenUrlAction.h
+++ b/source/shared/cpp/ObjectModel/OpenUrlAction.h
@@ -17,7 +17,7 @@ public:
     void SetUrl(const std::string &value);
 
 private:
-    void PopulateKnownPropertiesSet();
+    void PopulateKnownPropertiesSet() override;
 
     std::string m_url;
 };

--- a/source/shared/cpp/ObjectModel/ShowCardAction.h
+++ b/source/shared/cpp/ObjectModel/ShowCardAction.h
@@ -12,14 +12,14 @@ class ShowCardAction : public BaseActionElement
 public:
     ShowCardAction();
 
-    virtual Json::Value SerializeToJsonValue() const override;
+    Json::Value SerializeToJsonValue() const override;
 
     std::shared_ptr<AdaptiveSharedNamespace::AdaptiveCard> GetCard() const;
     void SetCard(const std::shared_ptr<AdaptiveSharedNamespace::AdaptiveCard>);
 
     void SetLanguage(const std::string& value);
 
-    virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
+    void GetResourceUris(std::vector<std::string>& resourceUris) override;
 
 private:
     void PopulateKnownPropertiesSet() override;
@@ -29,6 +29,14 @@ private:
 
 class ShowCardActionParser : public ActionElementParser
 {
+public:
+    ShowCardActionParser() = default;
+    ShowCardActionParser(const ShowCardActionParser&) = default;
+    ShowCardActionParser(ShowCardActionParser&&) = default;
+    ShowCardActionParser& operator=(const ShowCardActionParser&) = default;
+    ShowCardActionParser& operator=(ShowCardActionParser&&) = default;
+    virtual ~ShowCardActionParser() = default;
+
     std::shared_ptr<BaseActionElement> Deserialize(
         std::shared_ptr<ElementParserRegistration> elementParserRegistration,
         std::shared_ptr<ActionParserRegistration> actionParserRegistration,

--- a/source/shared/cpp/ObjectModel/ShowCardAction.h
+++ b/source/shared/cpp/ObjectModel/ShowCardAction.h
@@ -22,7 +22,7 @@ public:
     virtual void GetResourceUris(std::vector<std::string>& resourceUris) override;
 
 private:
-    void PopulateKnownPropertiesSet();
+    void PopulateKnownPropertiesSet() override;
 
     std::shared_ptr<AdaptiveCard> m_card;
 };

--- a/source/shared/cpp/ObjectModel/SubmitAction.h
+++ b/source/shared/cpp/ObjectModel/SubmitAction.h
@@ -18,7 +18,7 @@ public:
     virtual Json::Value SerializeToJsonValue() const override;
 
 private:
-    void PopulateKnownPropertiesSet();
+    void PopulateKnownPropertiesSet() override;
 
     Json::Value m_dataJson;
 };

--- a/source/shared/cpp/ObjectModel/SubmitAction.h
+++ b/source/shared/cpp/ObjectModel/SubmitAction.h
@@ -15,7 +15,7 @@ public:
     Json::Value GetDataJsonAsValue() const;
     void SetDataJson(const Json::Value &value);
 
-    virtual Json::Value SerializeToJsonValue() const override;
+    Json::Value SerializeToJsonValue() const override;
 
 private:
     void PopulateKnownPropertiesSet() override;
@@ -25,6 +25,14 @@ private:
 
 class SubmitActionParser : public ActionElementParser
 {
+public:
+    SubmitActionParser() = default;
+    SubmitActionParser(const SubmitActionParser&) = default;
+    SubmitActionParser(SubmitActionParser&&) = default;
+    SubmitActionParser& operator=(const SubmitActionParser&) = default;
+    SubmitActionParser& operator=(SubmitActionParser&&) = default;
+    virtual ~SubmitActionParser() = default;
+
     std::shared_ptr<BaseActionElement> Deserialize(
         std::shared_ptr<ElementParserRegistration> elementParserRegistration,
         std::shared_ptr<ActionParserRegistration> actionParserRegistration,

--- a/source/shared/cpp/ObjectModel/TextBlock.h
+++ b/source/shared/cpp/ObjectModel/TextBlock.h
@@ -52,7 +52,7 @@ private:
     bool m_wrap;
     unsigned int m_maxLines;
     HorizontalAlignment m_hAlignment;
-    void PopulateKnownPropertiesSet();
+    void PopulateKnownPropertiesSet() override;
     std::string m_language;
 };
 

--- a/source/shared/cpp/ObjectModel/TextBlock.h
+++ b/source/shared/cpp/ObjectModel/TextBlock.h
@@ -13,7 +13,7 @@ class TextBlock : public BaseCardElement
 public:
     TextBlock();
 
-    virtual Json::Value SerializeToJsonValue() const override;
+    Json::Value SerializeToJsonValue() const override;
 
     std::string GetText() const;
     void SetText(const std::string &value);
@@ -59,6 +59,13 @@ private:
 class TextBlockParser : public BaseCardElementParser
 {
 public:
+    TextBlockParser() = default;
+    TextBlockParser(const TextBlockParser&) = default;
+    TextBlockParser(TextBlockParser&&) = default;
+    TextBlockParser& operator=(const TextBlockParser&) = default;
+    TextBlockParser& operator=(TextBlockParser&&) = default;
+    virtual ~TextBlockParser() = default;
+
     std::shared_ptr<BaseCardElement> Deserialize(
         std::shared_ptr<ElementParserRegistration> elementParserRegistration,
         std::shared_ptr<ActionParserRegistration> actionParserRegistration,

--- a/source/shared/cpp/ObjectModel/TextInput.h
+++ b/source/shared/cpp/ObjectModel/TextInput.h
@@ -29,7 +29,7 @@ public:
     void SetTextInputStyle(const TextInputStyle value);
 
 private:
-    void PopulateKnownPropertiesSet();
+    void PopulateKnownPropertiesSet() override;
 
     std::string m_placeholder;
     std::string m_value;

--- a/source/shared/cpp/ObjectModel/TextInput.h
+++ b/source/shared/cpp/ObjectModel/TextInput.h
@@ -11,7 +11,7 @@ class TextInput : public BaseInputElement
 public:
     TextInput();
 
-    virtual Json::Value SerializeToJsonValue() const override;
+    Json::Value SerializeToJsonValue() const override;
 
     std::string GetPlaceholder() const;
     void SetPlaceholder(const std::string &value);
@@ -41,6 +41,13 @@ private:
 class TextInputParser : public BaseCardElementParser
 {
 public:
+    TextInputParser() = default;
+    TextInputParser(const TextInputParser&) = default;
+    TextInputParser(TextInputParser&&) = default;
+    TextInputParser& operator=(const TextInputParser&) = default;
+    TextInputParser& operator=(TextInputParser&&) = default;
+    virtual ~TextInputParser() = default;
+
     std::shared_ptr<BaseCardElement> Deserialize(
         std::shared_ptr<ElementParserRegistration> elementParserRegistration,
         std::shared_ptr<ActionParserRegistration> actionParserRegistration,

--- a/source/shared/cpp/ObjectModel/TimeInput.h
+++ b/source/shared/cpp/ObjectModel/TimeInput.h
@@ -11,7 +11,7 @@ class TimeInput : public BaseInputElement
 public:
     TimeInput();
 
-    virtual Json::Value SerializeToJsonValue() const override;
+    Json::Value SerializeToJsonValue() const override;
 
     std::string GetMax() const;
     void SetMax(const std::string &value);
@@ -37,6 +37,13 @@ private:
 class TimeInputParser : public BaseCardElementParser
 {
 public:
+    TimeInputParser() = default;
+    TimeInputParser(const TimeInputParser&) = default;
+    TimeInputParser(TimeInputParser&&) = default;
+    TimeInputParser& operator=(const TimeInputParser&) = default;
+    TimeInputParser& operator=(TimeInputParser&&) = default;
+    virtual ~TimeInputParser() = default;
+
     std::shared_ptr<BaseCardElement> Deserialize(
         std::shared_ptr<ElementParserRegistration> elementParserRegistration,
         std::shared_ptr<ActionParserRegistration> actionParserRegistration,

--- a/source/shared/cpp/ObjectModel/TimeInput.h
+++ b/source/shared/cpp/ObjectModel/TimeInput.h
@@ -26,7 +26,7 @@ public:
     void SetValue(const std::string &value);
 
 private:
-    void PopulateKnownPropertiesSet();
+    void PopulateKnownPropertiesSet() override;
 
     std::string m_max;
     std::string m_min;

--- a/source/shared/cpp/ObjectModel/ToggleInput.h
+++ b/source/shared/cpp/ObjectModel/ToggleInput.h
@@ -11,7 +11,7 @@ class ToggleInput : public BaseInputElement
 public:
     ToggleInput();
 
-    virtual Json::Value SerializeToJsonValue() const override;
+    Json::Value SerializeToJsonValue() const override;
 
     std::string GetTitle() const;
     void SetTitle(const std::string &value);
@@ -37,6 +37,13 @@ private:
 class ToggleInputParser : public BaseCardElementParser
 {
 public:
+    ToggleInputParser() = default;
+    ToggleInputParser(const ToggleInputParser&) = default;
+    ToggleInputParser(ToggleInputParser&&) = default;
+    ToggleInputParser& operator=(const ToggleInputParser&) = default;
+    ToggleInputParser& operator=(ToggleInputParser&&) = default;
+    virtual ~ToggleInputParser() = default;
+
     std::shared_ptr<BaseCardElement> Deserialize(
         std::shared_ptr<ElementParserRegistration> elementParserRegistration,
         std::shared_ptr<ActionParserRegistration> actionParserRegistration,

--- a/source/shared/cpp/ObjectModel/ToggleInput.h
+++ b/source/shared/cpp/ObjectModel/ToggleInput.h
@@ -26,7 +26,7 @@ public:
     void SetValueOn(const std::string &value);
 
 private:
-    void PopulateKnownPropertiesSet();
+    void PopulateKnownPropertiesSet() override;
 
     std::string m_title;
     std::string m_value;

--- a/source/shared/cpp/ObjectModel/UnknownElement.h
+++ b/source/shared/cpp/ObjectModel/UnknownElement.h
@@ -17,6 +17,13 @@ public:
 class UnknownElementParser : public BaseCardElementParser
 {
 public:
+    UnknownElementParser() = default;
+    UnknownElementParser(const UnknownElementParser&) = default;
+    UnknownElementParser(UnknownElementParser&&) = default;
+    UnknownElementParser& operator=(const UnknownElementParser&) = default;
+    UnknownElementParser& operator=(UnknownElementParser&&) = default;
+    virtual ~UnknownElementParser() = default;
+
     std::shared_ptr<BaseCardElement> Deserialize(
         std::shared_ptr<ElementParserRegistration> elementParserRegistration,
         std::shared_ptr<ActionParserRegistration> actionParserRegistration,

--- a/source/shared/cpp/ObjectModel/pch.h
+++ b/source/shared/cpp/ObjectModel/pch.h
@@ -43,4 +43,7 @@
 
 // ECppCoreCheckWarningCodes::WARNING_OVERRIDE_EXPLICITLY
 #pragma warning(default: 26433)
+
+// ECppCoreCheckWarningCodes::WARNING_DONT_HIDE_METHODS
+#pragma warning(default: 26434)
 #endif

--- a/source/shared/cpp/ObjectModel/pch.h
+++ b/source/shared/cpp/ObjectModel/pch.h
@@ -29,6 +29,7 @@
 #include <CppCoreCheck\warnings.h>
 #pragma warning(disable: ALL_CPPCORECHECK_WARNINGS)
 #pragma warning(default: CPPCORECHECK_ARITHMETIC_WARNINGS)
+#pragma warning(default: CPPCORECHECK_CLASS_WARNINGS)
 #pragma warning(default: CPPCORECHECK_CONCURRENCY_WARNINGS)
 #pragma warning(default: CPPCORECHECK_CONST_WARNINGS)
 #pragma warning(default: CPPCORECHECK_DECLARATION_WARNINGS)
@@ -38,12 +39,4 @@
 // ECppCoreCheckWarningCodes::WARNING_MEMBER_UNINIT
 #pragma warning(default: 26495)
 
-// ECppCoreCheckWarningCodes::WARNING_DEFINE_OR_DELETE_SPECIAL_OPS
-#pragma warning(default: 26432)
-
-// ECppCoreCheckWarningCodes::WARNING_OVERRIDE_EXPLICITLY
-#pragma warning(default: 26433)
-
-// ECppCoreCheckWarningCodes::WARNING_DONT_HIDE_METHODS
-#pragma warning(default: 26434)
 #endif

--- a/source/shared/cpp/ObjectModel/pch.h
+++ b/source/shared/cpp/ObjectModel/pch.h
@@ -40,4 +40,7 @@
 
 // ECppCoreCheckWarningCodes::WARNING_DEFINE_OR_DELETE_SPECIAL_OPS
 #pragma warning(default: 26432)
+
+// ECppCoreCheckWarningCodes::WARNING_OVERRIDE_EXPLICITLY
+#pragma warning(default: 26433)
 #endif


### PR DESCRIPTION
There are quite a few checks that are enabled with `CPPCORECHECK_CLASS_WARNINGS`. Most of these warnings are around class hierarchy and virtual functions:
- Don't hide functions
   - If a derived class has a function that hides a non-`virtual` function from its base class, it implies that either the function should be `virtual`, or it should perhaps have a different name. In our case, it seems that we just needed to mark the base functions as `virtual`.
- Always use `override` when applicable
   - Improves class structure comprehension when read
- Use only one of `virtual`, `override`, or `final`
   - `override` implies `virtual`, and `final` implies `override` -- prefer using only the most relevant keyword to improve legibility.
   - note that the guidelines [suggest](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rh-override) **not** using the `override` keyword for derived virtual destructors:
   > If a base class destructor is declared virtual, one should avoid declaring derived class destructors virtual or override. Some code base and tools might insist on override for destructors, but that is not the recommendation of these guidelines.

   I don't personally agree with this, but rules is rules.
- Use the rule of zero, five, or six
   - [Rule of zero](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c20-if-you-can-avoid-defining-default-operations-do): don't declare default ctor/dtor/copy ctor/etc. unless required
   - [Rule of five](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c21-if-you-define-or-delete-any-default-operation-define-or-delete-them-all): if you have to declare any of default dtor/copy ctor/etc., you should declare them all
   - Rule of six: same as rule of five, but with default ctor
- Base classes have to have either a public `virtual` dtor, or a protected/private non-`virtual` dtor

Noteworthy changes with these checks:
- `PopulateKnownPropertiesSet()` is now `virtual`
- `Serialize()` is now `virtual`