### PR TITLE
Enable unit test code coverage in Debug Win32 builds

### DIFF
--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/AdaptiveCardsSharedModelUnitTest.vcxproj
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/AdaptiveCardsSharedModelUnitTest.vcxproj
@@ -76,7 +76,7 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <LinkIncremental>true</LinkIncremental>
+    <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
@@ -95,10 +95,13 @@
       <AdditionalIncludeDirectories>$(SolutionDir)..\ObjectModel;$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <OptimizeReferences>false</OptimizeReferences>
+      <Profile>true</Profile>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/stdafx.cpp
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/stdafx.cpp
@@ -4,5 +4,9 @@
 
 #include "stdafx.h"
 
-// TODO: reference any additional headers you need in STDAFX.H
-// and not in this file
+#pragma managed(push, off)
+ExcludeFromCodeCoverage(BasicStringExclusion, L"*std::*");
+ExcludeFromCodeCoverage(TestExclusion, L"AdaptiveCardsSharedModelUnitTest::*");
+ExcludeSourceFromCodeCoverage(JsonCppExclusion, L"*\\jsoncpp.cpp");
+ExcludeSourceFromCodeCoverage(JsonHeaderExclusion, L"*\\json.h");
+#pragma managed(pop)

--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/stdafx.h
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/stdafx.h
@@ -11,3 +11,4 @@
 #include "CppUnitTest.h"
 
 // TODO: reference additional headers your program requires here
+#include <CodeCoverage\CodeCoverage.h>


### PR DESCRIPTION
Just a couple tweaks to the VS unit test config to allow generating code coverage numbers from our tests.