### PR TITLE
[TS] added a test to ensure Unicode/Emoji support

### DIFF
--- a/source/nodejs/adaptivecards/src/__tests__/components/text_block.spec.ts
+++ b/source/nodejs/adaptivecards/src/__tests__/components/text_block.spec.ts
@@ -1,6 +1,25 @@
-import {TextBlock} from "../../card-elements";
+import {AdaptiveCard,TextBlock} from "../../card-elements";
 
 test('TextBlock should be instantiated', ()=>{
     const textBlock = new TextBlock();
     expect(textBlock).toEqual(expect.anything());
 })
+
+const emoji_message = "Mix 🗣 emoji inside 🙌 text";
+const simple_test_card = {
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "type": "AdaptiveCard",
+    "version": "1.0",
+    "body": [{
+        "type": "TextBlock",
+        "text": emoji_message
+    }]
+};
+
+test('TextBlock should allow for Unicode chars including Emoji', ()=>{
+    const ac = new AdaptiveCard();
+    ac.parse(simple_test_card);
+    const result = ac.render();
+    const text = result.textContent.trim();
+    expect(text).toEqual(emoji_message);
+});


### PR DESCRIPTION
Just a test (passes currently) to ensure that we transfer text as-is to HTML, including Unicode.
Addressing the question posed at https://github.com/Microsoft/AdaptiveCards/issues/1645 