### PR TITLE
BitCode Added in Project configuration

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards.xcodeproj/project.pbxproj
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards.xcodeproj/project.pbxproj
@@ -1268,6 +1268,7 @@
 		F423C0CA1EE1FBAA00905679 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BITCODE_GENERATION_MODE = bitcode;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
@@ -1300,6 +1301,7 @@
 		F423C0CB1EE1FBAA00905679 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BITCODE_GENERATION_MODE = bitcode;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
While Submitting the Teams App to app store we were getting the following error 
**ERROR ITMS-90668: "Invalid Bundle Executable. The executable file 'TeamSpaceApp.app/Frameworks/AdaptiveCards.framework/AdaptiveCards' contains incomplete bitcode. To compile binaries with complete bitcode, open Xcode and choose Archive in the Product menu."**
Enable BitCode is set to yes in Adaptive Cards , but it is putting marker bit code not the actual one. 
To fix the issue we added one more property in User Defined Setting BITCODE_GENERATION_MODE = bitcode;

