### PR TITLE
Fix bug in XceedNumberInput.Render

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf.Xceed/XceedNumberInput.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf.Xceed/XceedNumberInput.cs
@@ -21,7 +21,7 @@ namespace AdaptiveCards.Rendering.Wpf
                     numberPicker.Minimum = Convert.ToInt32(input.Min);
 
                 if (!Double.IsNaN(input.Max))
-                    numberPicker.Minimum = Convert.ToInt32(input.Max);
+                    numberPicker.Maximum = Convert.ToInt32(input.Max);
 
                 numberPicker.Watermark = input.Placeholder;
                 numberPicker.Style = context.GetStyle("Adaptive.Input.Number");


### PR DESCRIPTION
XceedNumberInput.Render was setting numberPicker.Minimum to input.Max.  This fixes it to set numberPicker.Maximum instead.