### PR TITLE
Refactor/card elements

### DIFF
--- a/source/nodejs/adaptivecards/package.json
+++ b/source/nodejs/adaptivecards/package.json
@@ -44,6 +44,7 @@
     "dts-generator": "^2.1.0",
     "jest": "^21.2.1",
     "json-loader": "0.5.4",
+    "prepend-file": "^1.3.1",
     "regenerator-runtime": "^0.11.0",
     "ts-jest": "^21.2.3",
     "tslint": "^4.4.2",

--- a/source/nodejs/adaptivecards/src/refactor.js
+++ b/source/nodejs/adaptivecards/src/refactor.js
@@ -2,6 +2,7 @@
 exports.__esModule = true;
 var fs = require("fs");
 var ts = require("typescript");
+var prepend = require("prepend-file");
 var fileName = 'card-elements.ts';
 var sourceFile = ts.createSourceFile(fileName, fs.readFileSync(fileName).toString(), ts.ScriptTarget.ES2015, /*setParentNodes */ true);
 var prolog = "";
@@ -9,12 +10,15 @@ var declared_in_utility = [];
 var preserve_for_prolog = function (node) {
     prolog += node.getFullText();
 };
-var create_prolog = function () {
-    return prolog +
+var create_prolog = function (exclude_file) {
+    var rex = new RegExp("^.*'\\.\\/" + exclude_file.substr(0, exclude_file.length - 3) + "'.*$", "gm");
+    var result = prolog +
         "\nimport {" +
         declared_in_utility.join(",") +
         "} from './utility'\n\n";
+    return result.replace(rex, "");
 };
+var files_created = ["utility.ts"];
 var modules_created = {};
 var move_to_its_own_file = function (cl) {
     var declaration_node = cl;
@@ -23,19 +27,19 @@ var move_to_its_own_file = function (cl) {
     var is_export = (cl.modifiers && cl.modifiers[0].kind == ts.SyntaxKind.ExportKeyword);
     var module_name = declared_name.toLowerCase();
     var file_name = module_name + ".ts";
-    fs.writeFileSync(file_name, create_prolog() + (is_export ? "" : "export ") + cl.getFullText());
+    fs.writeFileSync(file_name, (is_export ? "" : "\n\nexport ") + cl.getFullText().trim());
+    files_created.push(file_name);
     modules_created[declared_name] = file_name;
     prolog += "import {" + declared_name + "} from './" + module_name + "'\n";
 };
-var prologued_utilty = false;
 var move_to_utility_file = function (cl) {
-    if (!prologued_utilty) {
-        fs.writeFileSync("utility.ts", prolog + "\n\n");
-        prologued_utilty = true;
-    }
     if (ts.isVariableStatement(cl)) {
         var stmt = cl;
-        declared_in_utility.concat(stmt.declarationList.declarations.map(function (vd) { return vd.name.getFullText().trim(); }));
+        console.log("got a declaration for " + stmt.declarationList.declarations.length);
+        declared_in_utility = declared_in_utility.concat(stmt.declarationList.declarations.map(function (vd) {
+            console.log(vd.name.getFullText().trim());
+            return vd.name.getFullText().trim();
+        }));
     }
     else {
         var declaration_node = cl;
@@ -47,10 +51,11 @@ var move_to_utility_file = function (cl) {
             console.log(declaration_node.getFullText());
         }
     }
-    fs.appendFileSync("utility.ts", cl.getFullText());
+    var is_export = (cl.modifiers && cl.modifiers[0].kind == ts.SyntaxKind.ExportKeyword);
+    fs.appendFileSync("utility.ts", (is_export ? "" : "\n\nexport ") + cl.getFullText().trim());
 };
 var ignore = function () { return null; };
-var show_error = function (node) { return console.log("I have no rule for " + node.kind); };
+var show_error = function (node) { console.log("I have no rule for " + node.kind); process.abort(); };
 // 229 - ClassDeclaration - move to its own file
 // 238 - ImportDeclaration - preserve then copy on every file
 // 228 - FunctionDeclaration - move to Utilty file
@@ -74,3 +79,15 @@ sourceFile.forEachChild(function (node) {
     var strategy = kind_to_strategy[node.kind] || show_error;
     strategy(node);
 });
+// second pass - prolog
+files_created.forEach(function (fname) {
+    prepend.sync(fname, create_prolog(fname));
+});
+// final pass - rewrite global import
+var contents = files_created.map(function (f) { return "export * from \"./" + f.substr(0, f.length - 3) + "\";"; }).join("\n") +
+    "\
+export * from \"./enums\";\n\
+export * from \"./host-config\";\n\
+export { getEnumValueOrDefault } from \"./utils\";\n\
+export { IAdaptiveCard, ICardElement } from \"./schema\";";
+fs.writeFileSync("adaptivecards.ts", contents);

--- a/source/nodejs/adaptivecards/src/refactor.js
+++ b/source/nodejs/adaptivecards/src/refactor.js
@@ -1,0 +1,76 @@
+"use strict";
+exports.__esModule = true;
+var fs = require("fs");
+var ts = require("typescript");
+var fileName = 'card-elements.ts';
+var sourceFile = ts.createSourceFile(fileName, fs.readFileSync(fileName).toString(), ts.ScriptTarget.ES2015, /*setParentNodes */ true);
+var prolog = "";
+var declared_in_utility = [];
+var preserve_for_prolog = function (node) {
+    prolog += node.getFullText();
+};
+var create_prolog = function () {
+    return prolog +
+        "\nimport {" +
+        declared_in_utility.join(",") +
+        "} from './utility'\n\n";
+};
+var modules_created = {};
+var move_to_its_own_file = function (cl) {
+    var declaration_node = cl;
+    var declared_name = declaration_node.name.getFullText().trim();
+    // TODO: make sure the declaration is exported
+    var is_export = (cl.modifiers && cl.modifiers[0].kind == ts.SyntaxKind.ExportKeyword);
+    var module_name = declared_name.toLowerCase();
+    var file_name = module_name + ".ts";
+    fs.writeFileSync(file_name, create_prolog() + (is_export ? "" : "export ") + cl.getFullText());
+    modules_created[declared_name] = file_name;
+    prolog += "import {" + declared_name + "} from './" + module_name + "'\n";
+};
+var prologued_utilty = false;
+var move_to_utility_file = function (cl) {
+    if (!prologued_utilty) {
+        fs.writeFileSync("utility.ts", prolog + "\n\n");
+        prologued_utilty = true;
+    }
+    if (ts.isVariableStatement(cl)) {
+        var stmt = cl;
+        declared_in_utility.concat(stmt.declarationList.declarations.map(function (vd) { return vd.name.getFullText().trim(); }));
+    }
+    else {
+        var declaration_node = cl;
+        if (declaration_node.name) {
+            var declared_name = declaration_node.name.getFullText().trim();
+            declared_in_utility.push(declared_name);
+        }
+        else {
+            console.log(declaration_node.getFullText());
+        }
+    }
+    fs.appendFileSync("utility.ts", cl.getFullText());
+};
+var ignore = function () { return null; };
+var show_error = function (node) { return console.log("I have no rule for " + node.kind); };
+// 229 - ClassDeclaration - move to its own file
+// 238 - ImportDeclaration - preserve then copy on every file
+// 228 - FunctionDeclaration - move to Utilty file
+// 231 - TypeAliasDeclaration - move to utilty
+// 208 - VariableStatement - move to Utilty file
+// 230 - InterfaceDeclaration - move to its own file?
+// 232 - EnumDeclaration - move to its own file?
+// 1 - EndOfFileToken - do nothing
+var kind_to_strategy = {
+    229: move_to_its_own_file,
+    230: move_to_its_own_file,
+    232: move_to_its_own_file,
+    1: ignore,
+    228: move_to_utility_file,
+    208: move_to_utility_file,
+    231: move_to_utility_file,
+    238: preserve_for_prolog
+};
+// first pass - process all
+sourceFile.forEachChild(function (node) {
+    var strategy = kind_to_strategy[node.kind] || show_error;
+    strategy(node);
+});

--- a/source/nodejs/adaptivecards/src/refactor.ts
+++ b/source/nodejs/adaptivecards/src/refactor.ts
@@ -1,0 +1,87 @@
+import * as fs from "fs";
+import * as ts from "typescript";
+
+const fileName = 'card-elements.ts';
+let sourceFile = ts.createSourceFile(fileName, fs.readFileSync(fileName).toString(), ts.ScriptTarget.ES2015, /*setParentNodes */ true);
+
+let prolog: string = "";
+let declared_in_utility: Array<string> = [];
+
+const preserve_for_prolog = (node: ts.Node) => {
+	prolog += node.getFullText();
+};
+
+const create_prolog = () => {
+	return prolog +
+		"\nimport {" +
+		declared_in_utility.join(",") +
+		"} from './utility'\n\n";
+};
+
+let modules_created: {[key: string]: string} = {};
+const move_to_its_own_file = (cl: ts.Node) => {
+	let declaration_node = <ts.DeclarationStatement>cl;
+	let declared_name = declaration_node.name.getFullText().trim();
+	// TODO: make sure the declaration is exported
+	let is_export = (cl.modifiers && cl.modifiers[0].kind == ts.SyntaxKind.ExportKeyword);
+	let module_name = declared_name.toLowerCase();
+	let file_name = module_name + ".ts";
+	fs.writeFileSync(file_name, create_prolog() + (is_export ? "" : "export ") + cl.getFullText());
+	modules_created[declared_name] = file_name;
+	prolog += "import {" + declared_name + "} from './" + module_name + "'\n";
+};
+
+let prologued_utilty = false;
+const move_to_utility_file = (cl: ts.Node) => {
+	if (!prologued_utilty) {
+		fs.writeFileSync("utility.ts", prolog + "\n\n");
+		prologued_utilty = true;
+	}
+	if (ts.isVariableStatement(cl)) {
+		let stmt = <ts.VariableStatement>cl;
+		declared_in_utility.concat(stmt.declarationList.declarations.map(vd => vd.name.getFullText().trim()));
+	}
+	else {
+		let declaration_node = <ts.DeclarationStatement>cl;
+		if (declaration_node.name) {
+			let declared_name = declaration_node.name.getFullText().trim();
+			declared_in_utility.push(declared_name);
+		}
+		else {
+			console.log(declaration_node.getFullText());
+		}
+	}
+	fs.appendFileSync("utility.ts", cl.getFullText());
+};
+
+const ignore = () => null;
+
+declare const process: { abort: ()=>any };
+const show_error = (node: ts.Node) => { console.log("I have no rule for " + node.kind); process.abort(); }
+
+// 229 - ClassDeclaration - move to its own file
+// 238 - ImportDeclaration - preserve then copy on every file
+// 228 - FunctionDeclaration - move to Utilty file
+// 231 - TypeAliasDeclaration - move to utilty
+// 208 - VariableStatement - move to Utilty file
+// 230 - InterfaceDeclaration - move to its own file?
+// 232 - EnumDeclaration - move to its own file?
+// 1 - EndOfFileToken - do nothing
+
+let kind_to_strategy: {[propname: number]: any} = {
+	229: move_to_its_own_file,
+	230: move_to_its_own_file,
+	232: move_to_its_own_file,
+	1: ignore,
+	228: move_to_utility_file,
+	208: move_to_utility_file,
+	231: move_to_utility_file,
+	238: preserve_for_prolog
+};
+
+// first pass - process all
+sourceFile.forEachChild(node => {
+	let strategy = kind_to_strategy[node.kind] || show_error;
+	strategy(node);
+});
+


### PR DESCRIPTION
Hey @dclaux please take a look at this. Took more than I anticipated but just because this thing of having to work for a living, you know. Still I'm pretty happy and hope you like it.

Considering:

- https://github.com/Microsoft/AdaptiveCards/issues/1652
- this refactoring is on a moving target (by definition)
- folks may have their changes done on the big file already, before rebasing

So I'm offering this refactor assistant, that you can run ``` node refactor.js ``` and will create 42 new files, and patch the global include (adaptivecards.ts) to export from each.

The Good:
- After running the refactoring, you can ``` jest ``` and all tests pass. This is important because you could say "usage style that we want to support needs to be covered by tests || die()".
- Say you have some changes on the big file, but the project has already moved on to per-class; you can still run this refactor on your code base and it will redistribute code on the same fashion, so there will be effectively no changes on what you haven't changed.
The Bad:
- It produces a long list of unused imports. Removing them manually would lose the idempotence (is that a word?) and remove the second benefit listed.
The Ugly:
- All that's not a class ends on a new 'utility.ts' file. Some "export" clauses look bit weirdly stated.

Eager to read your thoughts on this.
Sincerely, Ignacio.//