### PR TITLE
Media event changes

### DIFF
--- a/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
+++ b/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
@@ -2539,11 +2539,8 @@ AdaptiveNamespaceStart
         [eventadd] HRESULT Action([in] Windows.Foundation.TypedEventHandler<RenderedAdaptiveCard*, AdaptiveActionEventArgs*>* pHandler, [out][retval] EventRegistrationToken* pToken);
         [eventremove] HRESULT Action([in] EventRegistrationToken token);
 
-        [eventadd] HRESULT MediaPlay([in] Windows.Foundation.TypedEventHandler<RenderedAdaptiveCard*, AdaptiveMediaEventArgs*>* pHandler, [out][retval] EventRegistrationToken* pToken);
-        [eventremove] HRESULT MediaPlay([in] EventRegistrationToken token);
-
-        [eventadd] HRESULT MediaEnded([in] Windows.Foundation.TypedEventHandler<RenderedAdaptiveCard*, AdaptiveMediaEventArgs*>* pHandler, [out][retval] EventRegistrationToken* pToken);
-        [eventremove] HRESULT MediaEnded([in] EventRegistrationToken token);
+        [eventadd] HRESULT MediaClicked([in] Windows.Foundation.TypedEventHandler<RenderedAdaptiveCard*, AdaptiveMediaEventArgs*>* pHandler, [out][retval] EventRegistrationToken* pToken);
+        [eventremove] HRESULT MediaClicked([in] EventRegistrationToken token);
     };
 
     [
@@ -2770,8 +2767,7 @@ AdaptiveNamespaceStart
     ]
     interface IAdaptiveMediaEventInvoker : IInspectable
     {
-        HRESULT SendMediaPlayEvent([in] AdaptiveMedia* mediaElement);
-        HRESULT SendMediaEndedEvent([in] AdaptiveMedia* mediaElement);
+        HRESULT SendMediaClickedEvent([in] AdaptiveMedia* mediaElement);
     };
 
     [

--- a/source/uwp/Renderer/lib/AdaptiveMediaEventInvoker.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveMediaEventInvoker.cpp
@@ -23,15 +23,9 @@ AdaptiveNamespaceStart
     } CATCH_RETURN;
 
     _Use_decl_annotations_
-    HRESULT AdaptiveMediaEventInvoker::SendMediaPlayEvent(IAdaptiveMedia* mediaElement)
+    HRESULT AdaptiveMediaEventInvoker::SendMediaClickedEvent(IAdaptiveMedia* mediaElement)
     {
-        return m_renderResult->SendMediaPlayEvent(mediaElement);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveMediaEventInvoker::SendMediaEndedEvent(IAdaptiveMedia* mediaElement)
-    {
-        return m_renderResult->SendMediaEndedEvent(mediaElement);
+        return m_renderResult->SendMediaClickedEvent(mediaElement);
     }
 
 AdaptiveNamespaceEnd

--- a/source/uwp/Renderer/lib/AdaptiveMediaEventInvoker.h
+++ b/source/uwp/Renderer/lib/AdaptiveMediaEventInvoker.h
@@ -16,8 +16,7 @@ AdaptiveNamespaceStart
 
         HRESULT RuntimeClassInitialize(AdaptiveNamespace::RenderedAdaptiveCard* renderResult) noexcept;
 
-        IFACEMETHODIMP SendMediaPlayEvent(_In_ ABI::AdaptiveNamespace::IAdaptiveMedia* mediaElement);
-        IFACEMETHODIMP SendMediaEndedEvent(_In_ ABI::AdaptiveNamespace::IAdaptiveMedia* mediaElement);
+        IFACEMETHODIMP SendMediaClickedEvent(_In_ ABI::AdaptiveNamespace::IAdaptiveMedia* mediaElement);
 
     private:
         Microsoft::WRL::ComPtr<AdaptiveNamespace::RenderedAdaptiveCard> m_renderResult;

--- a/source/uwp/Renderer/lib/MediaHelpers.cpp
+++ b/source/uwp/Renderer/lib/MediaHelpers.cpp
@@ -366,14 +366,13 @@ HRESULT HandleMediaClick(
         EventRegistrationToken mediaOpenedToken;
         THROW_IF_FAILED(mediaElement->add_MediaOpened(Callback<IRoutedEventHandler>([=](IInspectable* /*sender*/, IRoutedEventArgs* /*args*/) -> HRESULT
         {
-            RETURN_IF_FAILED(mediaInvoker->SendMediaPlayEvent(adaptiveMedia));
             RETURN_IF_FAILED(mediaElement->Play());
             return S_OK;
         }).Get(), &mediaOpenedToken));
     }
     else
     {
-        RETURN_IF_FAILED(mediaInvoker->SendMediaPlayEvent(adaptiveMedia));
+        RETURN_IF_FAILED(mediaInvoker->SendMediaClickedEvent(adaptiveMedia));
     }
 
     return S_OK;

--- a/source/uwp/Renderer/lib/RenderedAdaptiveCard.cpp
+++ b/source/uwp/Renderer/lib/RenderedAdaptiveCard.cpp
@@ -42,8 +42,7 @@ AdaptiveNamespaceStart
         m_warnings = warnings;
         RETURN_IF_FAILED(MakeAndInitialize<AdaptiveNamespace::AdaptiveInputs>(&m_inputs));
         m_actionEvents = std::make_shared<ActionEventSource>();
-        m_mediaPlayEvents = std::make_shared<MediaEventSource>();
-        m_mediaEndedEvents = std::make_shared<MediaEventSource>();
+        m_mediaClickedEvents = std::make_shared<MediaEventSource>();
         return S_OK;
     }
 
@@ -80,31 +79,17 @@ AdaptiveNamespaceStart
     }
 
     _Use_decl_annotations_
-    HRESULT RenderedAdaptiveCard::add_MediaPlay(
+    HRESULT RenderedAdaptiveCard::add_MediaClicked(
         ABI::Windows::Foundation::ITypedEventHandler<ABI::AdaptiveNamespace::RenderedAdaptiveCard*, ABI::AdaptiveNamespace::AdaptiveMediaEventArgs*>* handler,
         EventRegistrationToken* token)
     {
-        return m_mediaPlayEvents->Add(handler, token);
+        return m_mediaClickedEvents->Add(handler, token);
     }
 
     _Use_decl_annotations_
-    HRESULT RenderedAdaptiveCard::remove_MediaPlay(EventRegistrationToken token)
+    HRESULT RenderedAdaptiveCard::remove_MediaClicked(EventRegistrationToken token)
     {
-        return m_mediaPlayEvents->Remove(token);
-    }
-
-    _Use_decl_annotations_
-    HRESULT RenderedAdaptiveCard::add_MediaEnded(
-        ABI::Windows::Foundation::ITypedEventHandler<ABI::AdaptiveNamespace::RenderedAdaptiveCard*, ABI::AdaptiveNamespace::AdaptiveMediaEventArgs*>* handler,
-        EventRegistrationToken* token)
-    {
-        return m_mediaEndedEvents->Add(handler, token);
-    }
-
-    _Use_decl_annotations_
-    HRESULT RenderedAdaptiveCard::remove_MediaEnded(EventRegistrationToken token)
-    {
-        return m_mediaEndedEvents->Remove(token);
+        return m_mediaClickedEvents->Remove(token);
     }
 
     _Use_decl_annotations_
@@ -130,20 +115,12 @@ AdaptiveNamespaceStart
         return m_actionEvents->InvokeAll(this, eventArgs.Get());
     }
 
-    HRESULT RenderedAdaptiveCard::SendMediaPlayEvent(IAdaptiveMedia* mediaElement)
+    HRESULT RenderedAdaptiveCard::SendMediaClickedEvent(IAdaptiveMedia* mediaElement)
     {
         ComPtr<IAdaptiveMediaEventArgs> eventArgs;
         RETURN_IF_FAILED(MakeAndInitialize<AdaptiveMediaEventArgs>(&eventArgs, mediaElement));
 
-        return m_mediaPlayEvents->InvokeAll(this, eventArgs.Get());
-    }
-
-    HRESULT RenderedAdaptiveCard::SendMediaEndedEvent(IAdaptiveMedia* mediaElement)
-    {
-        ComPtr<IAdaptiveMediaEventArgs> eventArgs;
-        RETURN_IF_FAILED(MakeAndInitialize<AdaptiveMediaEventArgs>(&eventArgs, mediaElement));
-
-        return m_mediaEndedEvents->InvokeAll(this, eventArgs.Get());
+        return m_mediaClickedEvents->InvokeAll(this, eventArgs.Get());
     }
 
     void RenderedAdaptiveCard::SetFrameworkElement(ABI::Windows::UI::Xaml::IFrameworkElement* value)

--- a/source/uwp/Renderer/lib/RenderedAdaptiveCard.h
+++ b/source/uwp/Renderer/lib/RenderedAdaptiveCard.h
@@ -32,19 +32,12 @@ AdaptiveNamespaceStart
             _Out_ EventRegistrationToken* token);
         IFACEMETHODIMP remove_Action(_In_ EventRegistrationToken token);
 
-        IFACEMETHODIMP add_MediaPlay(
+        IFACEMETHODIMP add_MediaClicked(
             _In_ ABI::Windows::Foundation::ITypedEventHandler<
             ABI::AdaptiveNamespace::RenderedAdaptiveCard*,
             ABI::AdaptiveNamespace::AdaptiveMediaEventArgs*>* handler,
             _Out_ EventRegistrationToken* token);
-        IFACEMETHODIMP remove_MediaPlay(_In_ EventRegistrationToken token);
-
-        IFACEMETHODIMP add_MediaEnded(
-            _In_ ABI::Windows::Foundation::ITypedEventHandler<
-            ABI::AdaptiveNamespace::RenderedAdaptiveCard*,
-            ABI::AdaptiveNamespace::AdaptiveMediaEventArgs*>* handler,
-            _Out_ EventRegistrationToken* token);
-        IFACEMETHODIMP remove_MediaEnded(_In_ EventRegistrationToken token);
+        IFACEMETHODIMP remove_MediaClicked(_In_ EventRegistrationToken token);
 
         IFACEMETHODIMP get_Errors(_COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveError*>** value);
         IFACEMETHODIMP get_Warnings(_COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>** value);
@@ -53,8 +46,7 @@ AdaptiveNamespaceStart
         void SetFrameworkElement(ABI::Windows::UI::Xaml::IFrameworkElement* value);
         void SetOriginatingCard(ABI::AdaptiveNamespace::IAdaptiveCard* value);
         HRESULT SendActionEvent(ABI::AdaptiveNamespace::IAdaptiveActionElement* eventArgs);
-        HRESULT SendMediaPlayEvent(ABI::AdaptiveNamespace::IAdaptiveMedia* eventArgs);
-        HRESULT SendMediaEndedEvent(ABI::AdaptiveNamespace::IAdaptiveMedia* eventArgs);
+        HRESULT SendMediaClickedEvent(ABI::AdaptiveNamespace::IAdaptiveMedia* eventArgs);
 
     private:
         Microsoft::WRL::ComPtr<ABI::AdaptiveNamespace::IAdaptiveCard> m_originatingCard;
@@ -63,8 +55,7 @@ AdaptiveNamespaceStart
         Microsoft::WRL::ComPtr<ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveError*>> m_errors;
         Microsoft::WRL::ComPtr<ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>> m_warnings;
         std::shared_ptr<ActionEventSource> m_actionEvents;
-        std::shared_ptr<MediaEventSource> m_mediaPlayEvents;
-        std::shared_ptr<MediaEventSource> m_mediaEndedEvents;
+        std::shared_ptr<MediaEventSource> m_mediaClickedEvents;
     };
 
     ActivatableClass(RenderedAdaptiveCard);

--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -2867,15 +2867,6 @@ AdaptiveNamespaceStart
             // Make the media element collapsed until the user clicks
             THROW_IF_FAILED(mediaUIElement->put_Visibility(Visibility_Collapsed));
 
-            // Add an event for media ended
-            EventRegistrationToken mediaEndedToken;
-            THROW_IF_FAILED(mediaElement->add_MediaEnded(Callback<IRoutedEventHandler>([mediaInvoker, adaptiveMedia](IInspectable* /*sender*/, IRoutedEventArgs* /*args*/) -> HRESULT
-            {
-                RETURN_IF_FAILED(mediaInvoker->SendMediaEndedEvent(adaptiveMedia.Get()));
-
-                return S_OK;
-            }).Get(), &mediaEndedToken));
-
             XamlHelpers::AppendXamlElementToPanel(mediaElement.Get(), mediaPanel.Get());
         }
 

--- a/source/uwp/Visualizer/ViewModel/DocumentViewModel.cs
+++ b/source/uwp/Visualizer/ViewModel/DocumentViewModel.cs
@@ -110,10 +110,10 @@ namespace AdaptiveCardVisualizer.ViewModel
 
                         if (!MainPageViewModel.HostConfigEditor.HostConfig.Media.AllowInlinePlayback)
                         {
-                            renderResult.MediaPlay += async (sender, e) =>
+                            renderResult.MediaClicked += async (sender, e) =>
                             {
                                 var onPlayDialog = new ContentDialog();
-                                onPlayDialog.Content = "MediaPlayEvent:";
+                                onPlayDialog.Content = "MediaClickedEvent:";
 
                                 foreach (var source in e.Media.Sources)
                                 {
@@ -123,23 +123,6 @@ namespace AdaptiveCardVisualizer.ViewModel
                                 onPlayDialog.PrimaryButtonText = "Close";
 
                                 await onPlayDialog.ShowAsync();
-                            };
-                        }
-                        else
-                        {
-                            renderResult.MediaEnded += async (sender, e) =>
-                            {
-                                var mediaEndedDialog = new ContentDialog();
-                                mediaEndedDialog.Content = "Media Ended Event:";
-
-                                foreach (var source in e.Media.Sources)
-                                {
-                                    mediaEndedDialog.Content += "\n" + source.Url + " (" + source.MimeType + ")";
-                                }
-
-                                mediaEndedDialog.PrimaryButtonText = "Close";
-
-                                await mediaEndedDialog.ShowAsync();
                             };
                         }
                     }


### PR DESCRIPTION
Remove the MediaEnded event, rename MediaPlay to MediaClicked, and don't send MediaClicked for the inline playback case.