### PR TITLE
 Aligning rows within ColumnSets by default, unless element height explicitly = "auto"

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveColumnSetRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveColumnSetRenderer.cs
@@ -9,6 +9,7 @@ namespace AdaptiveCards.Rendering.Wpf
         public static FrameworkElement Render(AdaptiveColumnSet columnSet, AdaptiveRenderContext context)
         {
             var uiColumnSet = new Grid();
+            Grid.SetIsSharedSizeScope(uiColumnSet, true);
             uiColumnSet.Style = context.GetStyle($"Adaptive.{columnSet.Type}");
 
             foreach (var column in columnSet.Columns)

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveContainerRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveContainerRenderer.cs
@@ -45,7 +45,21 @@ namespace AdaptiveCards.Rendering.Wpf
                         uiElement.Margin = new Thickness(0, spacing, 0, 0);
                     }
 
-                    uiContainer.RowDefinitions.Add(new RowDefinition() { Height = GridLength.Auto });
+                    // do some sizing magic using the magic GridUnitType.Star
+                    var height = cardElement.Height?.ToLower();
+                    if (height == AdaptiveElementHeight.Stretch.ToLower())
+                        uiContainer.RowDefinitions.Add(new RowDefinition() { Height = new GridLength(1, GridUnitType.Star) });
+                    else if (height == null || height == AdaptiveElementHeight.Auto.ToLower())
+                        uiContainer.RowDefinitions.Add(new RowDefinition() { Height = GridLength.Auto });
+                    else
+                    {
+                        double val;
+                        if (double.TryParse(height, out val))
+                            uiContainer.RowDefinitions.Add(new RowDefinition() { Height = new GridLength(val, GridUnitType.Star) });
+                        else
+                            uiContainer.RowDefinitions.Add(new RowDefinition() { Height = GridLength.Auto });
+                    }
+
                     Grid.SetRow(uiElement, uiContainer.RowDefinitions.Count - 1);
                     uiContainer.Children.Add(uiElement);
                 }

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveContainerRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveContainerRenderer.cs
@@ -49,15 +49,17 @@ namespace AdaptiveCards.Rendering.Wpf
                     var height = cardElement.Height?.ToLower();
                     if (height == AdaptiveElementHeight.Stretch.ToLower())
                         uiContainer.RowDefinitions.Add(new RowDefinition() { Height = new GridLength(1, GridUnitType.Star) });
-                    else if (height == null || height == AdaptiveElementHeight.Auto.ToLower())
+                    else if (height == AdaptiveElementHeight.Auto.ToLower())
                         uiContainer.RowDefinitions.Add(new RowDefinition() { Height = GridLength.Auto });
+                    else if (height == null)
+                        uiContainer.RowDefinitions.Add(new RowDefinition() { SharedSizeGroup = "Row" + uiContainer.RowDefinitions.Count });
                     else
                     {
                         double val;
                         if (double.TryParse(height, out val))
                             uiContainer.RowDefinitions.Add(new RowDefinition() { Height = new GridLength(val, GridUnitType.Star) });
                         else
-                            uiContainer.RowDefinitions.Add(new RowDefinition() { Height = GridLength.Auto });
+                            uiContainer.RowDefinitions.Add(new RowDefinition() { SharedSizeGroup = "Row" + uiContainer.RowDefinitions.Count });
                     }
 
                     Grid.SetRow(uiElement, uiContainer.RowDefinitions.Count - 1);

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveElement.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveElement.cs
@@ -86,5 +86,15 @@ namespace AdaptiveCards
                 }
             }
         }
+
+        /// <summary>
+        ///     Height for the element (either ElementHeight string or number which is relative size of the element)
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+#if !NETSTANDARD1_3
+        [XmlAttribute]
+#endif
+        [DefaultValue(null)]
+        public string Height { get; set; } // TODO: this should be a ElementHeight type with implict converter
     }
 }

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveElementHeight.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveElementHeight.cs
@@ -1,0 +1,18 @@
+﻿namespace AdaptiveCards
+{
+    /// <summary>
+    ///     Controls the vertical size (height) of Element.
+    /// </summary>
+    public class AdaptiveElementHeight
+    {
+        /// <summary>
+        ///     The height of the Element is optimally chosen depending on the space available in the element's container
+        /// </summary>
+        public const string Auto = "Auto";
+
+        /// <summary>
+        ///     The height of the Element adjusts to match that of its container
+        /// </summary>
+        public const string Stretch = "Stretch";
+    }
+}


### PR DESCRIPTION
This is an optional addition on top of #1683 that also aligns elements inside ColumnSets by default, unless users explicitly set the height property to "auto", which seems like a much better default behavior.