### PR TITLE
added handler for column width in pixels

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Rendering.Html/AdaptiveCardRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Html/AdaptiveCardRenderer.cs
@@ -385,11 +385,14 @@ namespace AdaptiveCards.Rendering.Html
                 }
                 else
                 {
-                    double val;
-                    if (double.TryParse(width, out val))
+                    if (double.TryParse(width, out double val) && val >= 0)
                     {
                         var percent = Convert.ToInt32(100 * (val / max));
                         uiColumn = uiColumn.Style("flex", $"1 1 {percent}%");
+                    }
+                    else if (width.EndsWith("px") && double.TryParse(width.Substring(0, width.Length-2), out double pxVal) && pxVal >= 0)
+                    {
+                        uiColumn = uiColumn.Style("flex", $"0 0 {(int)pxVal}px");
                     }
                     else
                     {

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveColumnSetRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveColumnSetRenderer.cs
@@ -53,10 +53,10 @@ namespace AdaptiveCards.Rendering.Wpf
                     uiColumnSet.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Auto });
                 else
                 {
-                    if (double.TryParse(width, out double val))
+                    if (double.TryParse(width, out double val) && val >= 0)
                         // Weighted proportion (number only)
                         uiColumnSet.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(val, GridUnitType.Star) });
-                    else if (width.EndsWith("px") && int.TryParse(width.Substring(0, width.Length-2), out int pxVal))
+                    else if (width.EndsWith("px") && double.TryParse(width.Substring(0, width.Length-2), out double pxVal) && pxVal >= 0)
                         // Exact pixel (number followed by "px")
                         uiColumnSet.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(pxVal, GridUnitType.Pixel) });
                     else

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveColumnSetRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveColumnSetRenderer.cs
@@ -53,13 +53,12 @@ namespace AdaptiveCards.Rendering.Wpf
                     uiColumnSet.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Auto });
                 else
                 {
-                    double val;
-                    if (double.TryParse(width, out val))
+                    if (double.TryParse(width, out double val))
                         // Weighted proportion
                         uiColumnSet.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(val, GridUnitType.Star) });
-                    else if (width.EndsWith("px") && double.TryParse(width.Substring(0, width.Length-2), out val))
+                    else if (width.EndsWith("px") && int.TryParse(width.Substring(0, width.Length-2), out int pxVal))
                         // Exact pixel
-                        uiColumnSet.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(val, GridUnitType.Pixel) });
+                        uiColumnSet.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(pxVal, GridUnitType.Pixel) });
                     else
                         uiColumnSet.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Auto });
                 }

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveColumnSetRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveColumnSetRenderer.cs
@@ -54,10 +54,10 @@ namespace AdaptiveCards.Rendering.Wpf
                 else
                 {
                     if (double.TryParse(width, out double val))
-                        // Weighted proportion (string contains number only)
+                        // Weighted proportion (number only)
                         uiColumnSet.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(val, GridUnitType.Star) });
                     else if (width.EndsWith("px") && int.TryParse(width.Substring(0, width.Length-2), out int pxVal))
-                        // Exact pixel (string contains number followed by "px")
+                        // Exact pixel (number followed by "px")
                         uiColumnSet.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(pxVal, GridUnitType.Pixel) });
                     else
                         uiColumnSet.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Auto });

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveColumnSetRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveColumnSetRenderer.cs
@@ -54,10 +54,10 @@ namespace AdaptiveCards.Rendering.Wpf
                 else
                 {
                     if (double.TryParse(width, out double val))
-                        // Weighted proportion
+                        // Weighted proportion (string contains number only)
                         uiColumnSet.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(val, GridUnitType.Star) });
                     else if (width.EndsWith("px") && int.TryParse(width.Substring(0, width.Length-2), out int pxVal))
-                        // Exact pixel
+                        // Exact pixel (string contains number followed by "px")
                         uiColumnSet.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(pxVal, GridUnitType.Pixel) });
                     else
                         uiColumnSet.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Auto });

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveColumnSetRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveColumnSetRenderer.cs
@@ -55,7 +55,11 @@ namespace AdaptiveCards.Rendering.Wpf
                 {
                     double val;
                     if (double.TryParse(width, out val))
+                        // Weighted proportion
                         uiColumnSet.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(val, GridUnitType.Star) });
+                    else if (width.EndsWith("px") && double.TryParse(width.Substring(0, width.Length-2), out val))
+                        // Exact pixel
+                        uiColumnSet.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(val, GridUnitType.Pixel) });
                     else
                         uiColumnSet.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Auto });
                 }

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveColumnSetRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveColumnSetRenderer.cs
@@ -58,7 +58,7 @@ namespace AdaptiveCards.Rendering.Wpf
                         uiColumnSet.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(val, GridUnitType.Star) });
                     else if (width.EndsWith("px") && double.TryParse(width.Substring(0, width.Length-2), out double pxVal) && pxVal >= 0)
                         // Exact pixel (number followed by "px")
-                        uiColumnSet.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(pxVal, GridUnitType.Pixel) });
+                        uiColumnSet.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength((int)pxVal, GridUnitType.Pixel) });
                     else
                         uiColumnSet.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Auto });
                 }


### PR DESCRIPTION
Not sure if double unit makes sense for pixel (e.g., `50.3px`) and also for weighted proportion (already in use)

For testing, you can use the payload below. I noticed the payload provided in the [epic](https://github.com/Microsoft/AdaptiveCards/issues/1026) does not have `"type": "Column"` anywhere and the .NET renderer throws an error for it. Is that something missing from the .NET renderer? 
```
{
  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
  "type": "AdaptiveCard",
  "version": "1.0",
  "body": [
    {
      "type": "ColumnSet",
      "columns": [
        {
          "type": "Column",
          "width": "50px",
          "items": [
            {
              "type": "Image",
              "url": "http://3.bp.blogspot.com/-Xo0EuTNYNQg/UEI1zqGDUTI/AAAAAAAAAYE/PLYx5H4J4-k/s1600/smiley+face+super+happy.jpg",
              "size": "stretch"
            }
          ]
        },
        {
          "type": "Column",
          "width": "stretch",
          "items": [
            {
              "type": "TextBlock",
              "text": "This card has two ColumnSets on top of each other. In each, the left column is explicitly sized to be 50 pixels wide.",
              "wrap": true
            }
          ]
        }
      ]
    },
    {
      "type": "ColumnSet",
      "columns": [
        {
          "type": "Column",
          "width": "50px"
        },
        {
          "type": "Column",
          "width": "stretch",
          "items": [
            {
              "type": "TextBlock",
              "text": "In this second ColumnSet, columns align perfectly even though there is nothing in the left column.",
              "wrap": true
            }
          ]
        }
      ]
    }
  ]
}
```