### PR TITLE
More cppcore changes

### DIFF
--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModel/AdaptiveCardsSharedModel.vcxproj
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModel/AdaptiveCardsSharedModel.vcxproj
@@ -71,6 +71,7 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <CodeAnalysisRuleSet>CppCoreCheckRules.ruleset</CodeAnalysisRuleSet>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <CodeAnalysisRuleSet>CppCoreCheckRules.ruleset</CodeAnalysisRuleSet>
@@ -91,6 +92,8 @@
       <TreatWarningAsError>true</TreatWarningAsError>
       <DisableSpecificWarnings>4702</DisableSpecificWarnings>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <EnablePREfast>true</EnablePREfast>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/ExplicitDimensionTest.cpp
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/ExplicitDimensionTest.cpp
@@ -349,15 +349,8 @@ namespace AdaptiveCardsSharedModelUnitTest
                     }\
                 ]\
             }";
-            try
-            {
-                std::shared_ptr<ParseResult> parseResult = AdaptiveCard::DeserializeFromString(testJsonString, 1.0);
-                Assert::Fail();
-            }
-            catch(const AdaptiveCardParseException &e)
-            { 
-                Assert::AreEqual<bool>(e.GetStatusCode() == ErrorStatusCode::InvalidPropertyValue, true);
-            }
+
+			std::shared_ptr<ParseResult> parseResult = AdaptiveCard::DeserializeFromString(testJsonString, 1.0);
         }
     };
 }

--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/ExplicitDimensionTest.cpp
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/ExplicitDimensionTest.cpp
@@ -20,7 +20,7 @@ namespace AdaptiveCardsSharedModelUnitTest
     public:
         TEST_METHOD(PositiveTest)
         {
-            std::string testJsonString = 
+            std::string testJsonString =
             "{\
                 \"$schema\":\"http://adaptivecards.io/schemas/adaptive-card.json\",\
                 \"type\": \"AdaptiveCard\",\
@@ -44,7 +44,7 @@ namespace AdaptiveCardsSharedModelUnitTest
         }
         TEST_METHOD(PositiveTestWithOneDimensionOnly)
         {
-            std::string testJsonString = 
+            std::string testJsonString =
             "{\
                 \"$schema\":\"http://adaptivecards.io/schemas/adaptive-card.json\",\
                 \"type\": \"AdaptiveCard\",\
@@ -68,7 +68,7 @@ namespace AdaptiveCardsSharedModelUnitTest
 
         TEST_METHOD(MalformedUnitTest)
         {
-            std::string testJsonString = 
+            std::string testJsonString =
             "{\
                 \"$schema\":\"http://adaptivecards.io/schemas/adaptive-card.json\",\
                 \"type\": \"AdaptiveCard\",\
@@ -88,14 +88,14 @@ namespace AdaptiveCardsSharedModelUnitTest
                 std::shared_ptr<Image> image = std::static_pointer_cast<Image>(elem);
             }
             catch(const AdaptiveCardParseException &e)
-            { 
+            {
                 Assert::AreEqual<bool>(e.GetStatusCode() == ErrorStatusCode::InvalidPropertyValue, true);
             }
         }
 
         TEST_METHOD(MalformedUnitLengthTest)
         {
-            std::string testJsonString = 
+            std::string testJsonString =
             "{\
                 \"$schema\":\"http://adaptivecards.io/schemas/adaptive-card.json\",\
                 \"type\": \"AdaptiveCard\",\
@@ -115,14 +115,14 @@ namespace AdaptiveCardsSharedModelUnitTest
                 std::shared_ptr<Image> image = std::static_pointer_cast<Image>(elem);
             }
             catch(const AdaptiveCardParseException &e)
-            { 
+            {
                 Assert::AreEqual<bool>(e.GetStatusCode() == ErrorStatusCode::InvalidPropertyValue, true);
             }
         }
 
         TEST_METHOD(MalformedUnitTypeTest)
         {
-            std::string testJsonString = 
+            std::string testJsonString =
             "{\
                 \"$schema\":\"http://adaptivecards.io/schemas/adaptive-card.json\",\
                 \"type\": \"AdaptiveCard\",\
@@ -142,14 +142,14 @@ namespace AdaptiveCardsSharedModelUnitTest
                 std::shared_ptr<Image> image = std::static_pointer_cast<Image>(elem);
             }
             catch(const AdaptiveCardParseException &e)
-            { 
+            {
                 Assert::AreEqual<bool>(e.GetStatusCode() == ErrorStatusCode::InvalidPropertyValue, true);
             }
         }
 
         TEST_METHOD(MalformedNegativeIntValueTest)
         {
-            std::string testJsonString = 
+            std::string testJsonString =
             "{\
                 \"$schema\":\"http://adaptivecards.io/schemas/adaptive-card.json\",\
                 \"type\": \"AdaptiveCard\",\
@@ -169,7 +169,7 @@ namespace AdaptiveCardsSharedModelUnitTest
                 std::shared_ptr<Image> image = std::static_pointer_cast<Image>(elem);
             }
             catch(const AdaptiveCardParseException &e)
-            { 
+            {
                 Assert::AreEqual<bool>(e.GetStatusCode() == ErrorStatusCode::InvalidPropertyValue, true);
             }
         }
@@ -180,7 +180,7 @@ namespace AdaptiveCardsSharedModelUnitTest
     public:
         TEST_METHOD(PositiveValueTest)
         {
-            std::string testJsonString = 
+            std::string testJsonString =
             "{\
                 \"$schema\":\"http://adaptivecards.io/schemas/adaptive-card.json\",\
                 \"type\": \"AdaptiveCard\",\
@@ -208,7 +208,7 @@ namespace AdaptiveCardsSharedModelUnitTest
 
         TEST_METHOD(PositiveRelativeWidthTest)
         {
-            std::string testJsonString = 
+            std::string testJsonString =
             "{\
                 \"$schema\":\"http://adaptivecards.io/schemas/adaptive-card.json\",\
                 \"type\": \"AdaptiveCard\",\
@@ -237,7 +237,7 @@ namespace AdaptiveCardsSharedModelUnitTest
 
         TEST_METHOD(PositiveExplicitWidthTest)
         {
-            std::string testJsonString = 
+            std::string testJsonString =
             "{\
                 \"$schema\":\"http://adaptivecards.io/schemas/adaptive-card.json\",\
                 \"type\": \"AdaptiveCard\",\
@@ -266,7 +266,7 @@ namespace AdaptiveCardsSharedModelUnitTest
 
         TEST_METHOD(ExplicitWidthMalformedUnitTest)
         {
-            std::string testJsonString = 
+            std::string testJsonString =
             "{\
                 \"$schema\":\"http://adaptivecards.io/schemas/adaptive-card.json\",\
                 \"type\": \"AdaptiveCard\",\
@@ -291,14 +291,14 @@ namespace AdaptiveCardsSharedModelUnitTest
                 Assert::Fail();
             }
             catch(const AdaptiveCardParseException &e)
-            { 
+            {
                 Assert::AreEqual<bool>(e.GetStatusCode() == ErrorStatusCode::InvalidPropertyValue, true);
             }
         }
 
         TEST_METHOD(ExplicitWidthMalformedValueTest)
         {
-            std::string testJsonString = 
+            std::string testJsonString =
             "{\
                 \"$schema\":\"http://adaptivecards.io/schemas/adaptive-card.json\",\
                 \"type\": \"AdaptiveCard\",\
@@ -323,14 +323,14 @@ namespace AdaptiveCardsSharedModelUnitTest
                 Assert::Fail();
             }
             catch(const AdaptiveCardParseException &e)
-            { 
+            {
                 Assert::AreEqual<bool>(e.GetStatusCode() == ErrorStatusCode::InvalidPropertyValue, true);
             }
         }
 
         TEST_METHOD(ExplicitWidthFloatValueTest)
         {
-            std::string testJsonString = 
+            std::string testJsonString =
             "{\
                 \"$schema\":\"http://adaptivecards.io/schemas/adaptive-card.json\",\
                 \"type\": \"AdaptiveCard\",\
@@ -350,7 +350,12 @@ namespace AdaptiveCardsSharedModelUnitTest
                 ]\
             }";
 
-			std::shared_ptr<ParseResult> parseResult = AdaptiveCard::DeserializeFromString(testJsonString, 1.0);
+            std::shared_ptr<ParseResult> parseResult = AdaptiveCard::DeserializeFromString(testJsonString, 1.0);
+			std::shared_ptr<BaseCardElement> element = parseResult->GetAdaptiveCard()->GetBody().front();
+			std::shared_ptr<ColumnSet> columnSet = std::static_pointer_cast<ColumnSet>(element);
+			std::shared_ptr<Column> column = columnSet->GetColumns().front();
+			Assert::AreEqual<std::string>("20.5px", column->GetWidth());
+			Assert::AreEqual<bool>(column->GetPixelWidth() == 20, true);
         }
     };
 }

--- a/source/shared/cpp/ObjectModel/DateTimePreparser.cpp
+++ b/source/shared/cpp/ObjectModel/DateTimePreparser.cpp
@@ -88,6 +88,15 @@ bool DateTimePreparser::IsValidTimeAndDate(const struct tm &parsedTm, const int 
     return false;
 }
 
+constexpr time_t IntToTimeT(int timeToConvert)
+{
+#pragma warning(push)
+#pragma warning(disable: 26472)
+	// disable warning about using static_cast since we need to hard cast up.
+	return static_cast<time_t>(timeToConvert);
+#pragma warning(pop)
+}
+
 void DateTimePreparser::ParseDateTime(std::string const &in)
 {
     std::vector<DateTimePreparsedToken> sections;
@@ -163,7 +172,7 @@ void DateTimePreparser::ParseDateTime(std::string const &in)
                 // converts to seconds
                 hours *= 3600;
                 minutes *= 60;
-                offset = static_cast<time_t>(hours) + static_cast<time_t>(minutes);
+                offset = IntToTimeT(hours) + IntToTimeT(minutes);
 
                 wchar_t zone = matches[TimeZone].str().at(0);
                 // time zone offset calculation
@@ -192,8 +201,8 @@ void DateTimePreparser::ParseDateTime(std::string const &in)
             // gets local time zone offset
             strftime(tzOffsetBuff, 6, "%z", &parsedTm);
             std::string localTimeZoneOffsetStr(tzOffsetBuff);
-            const int nTzOffset = std::stoi(localTimeZoneOffsetStr);
-            offset += ((time_t)(nTzOffset / 100) * 3600 + (time_t)(nTzOffset % 100) * 60);
+            const time_t nTzOffset = IntToTimeT(std::stoi(localTimeZoneOffsetStr));
+            offset += ((nTzOffset / 100) * 3600 + (nTzOffset % 100) * 60);
             // add offset to utc
             utc += offset;
             struct tm result{};

--- a/source/shared/cpp/ObjectModel/DateTimePreparser.cpp
+++ b/source/shared/cpp/ObjectModel/DateTimePreparser.cpp
@@ -114,7 +114,6 @@ void DateTimePreparser::ParseDateTime(std::string const &in)
 
     while (std::regex_search(text, matches, pattern))
     {
-        time_t offset{};
         int formatStyle{};
         // Date is matched
         const bool isDate = matches[IsDate].matched;
@@ -154,6 +153,7 @@ void DateTimePreparser::ParseDateTime(std::string const &in)
         // check for date and time validation
         if (IsValidTimeAndDate(parsedTm, hours, minutes))
         {
+			time_t offset{};
             // maches offset sign,
             // Z == UTC,
             // + == time added from UTC
@@ -163,7 +163,7 @@ void DateTimePreparser::ParseDateTime(std::string const &in)
                 // converts to seconds
                 hours *= 3600;
                 minutes *= 60;
-                offset = (time_t)hours + (time_t)minutes;
+                offset = static_cast<time_t>(hours) + static_cast<time_t>(minutes);
 
                 wchar_t zone = matches[TimeZone].str().at(0);
                 // time zone offset calculation

--- a/source/shared/cpp/ObjectModel/DateTimePreparser.cpp
+++ b/source/shared/cpp/ObjectModel/DateTimePreparser.cpp
@@ -63,7 +63,7 @@ std::string DateTimePreparser::Concatenate() const
     return formedString;
 }
 
-bool DateTimePreparser::IsValidTimeAndDate(const struct tm &parsedTm, int hours, int minutes)
+bool DateTimePreparser::IsValidTimeAndDate(const struct tm &parsedTm, const int hours, const int minutes)
 {
     if (parsedTm.tm_mon <= 12 && parsedTm.tm_mday <= 31 && parsedTm.tm_hour <= 24 &&
         parsedTm.tm_min <= 60 && parsedTm.tm_sec <= 60 && hours <= 24 && minutes <= 60)
@@ -115,7 +115,7 @@ void DateTimePreparser::ParseDateTime(std::string const &in)
     while (std::regex_search(text, matches, pattern))
     {
         time_t offset{};
-        int  formatStyle{};
+        int formatStyle{};
         // Date is matched
         const bool isDate = matches[IsDate].matched;
         int hours{}, minutes{};

--- a/source/shared/cpp/ObjectModel/DateTimePreparser.h
+++ b/source/shared/cpp/ObjectModel/DateTimePreparser.h
@@ -18,7 +18,7 @@ namespace AdaptiveSharedNamespace {
         void AddTextToken(std::string const &text, DateTimePreparsedTokenFormat format);
         void AddDateToken(std::string const &text, struct tm date, DateTimePreparsedTokenFormat format);
         std::string Concatenate() const;
-        static bool IsValidTimeAndDate(const struct tm &parsedTm, int hours, int minutes);
+        static bool IsValidTimeAndDate(const struct tm &parsedTm, const int hours, const int minutes);
         void ParseDateTime(std::string const &in);
 
         std::vector<std::shared_ptr<DateTimePreparsedToken>> m_textTokenCollection;

--- a/source/shared/cpp/ObjectModel/Enums.h
+++ b/source/shared/cpp/ObjectModel/Enums.h
@@ -27,7 +27,7 @@ struct CaseInsensitiveEqualTo {
 
 struct CaseInsensitiveHash {
     size_t operator() (const std::string& keyval) const {
-        return std::accumulate(keyval.begin(), keyval.end(), size_t{ 0 }, [](size_t acc, char c) { return acc + static_cast<size_t>(std::toupper(c)); });
+        return std::accumulate(keyval.begin(), keyval.end(), size_t{ 0 }, [](size_t acc, unsigned char c) { return acc + std::toupper(c); });
     }
 };
 

--- a/source/shared/cpp/ObjectModel/HostConfig.h
+++ b/source/shared/cpp/ObjectModel/HostConfig.h
@@ -54,7 +54,7 @@ struct TextConfig
     ForegroundColor color = ForegroundColor::Default;
     bool isSubtle = false;
     bool wrap = true;
-    unsigned int maxWidth = (unsigned int) ~0;
+    unsigned int maxWidth = ~0U;
 
     static TextConfig Deserialize(const Json::Value& json, const TextConfig& defaultValue);
 };
@@ -113,7 +113,7 @@ struct AdaptiveCardConfig
 struct FactSetConfig
 {
     TextConfig title{ TextWeight::Bolder, TextSize::Default, ForegroundColor::Default, false, true, 150 };
-    TextConfig value{ TextWeight::Default, TextSize::Default, ForegroundColor::Default, false, true, (unsigned int)~0 };
+    TextConfig value{ TextWeight::Default, TextSize::Default, ForegroundColor::Default, false, true, ~0U };
     unsigned int spacing = 10;
 
     static FactSetConfig Deserialize(const Json::Value& json, const FactSetConfig& defaultValue);

--- a/source/shared/cpp/ObjectModel/Image.cpp
+++ b/source/shared/cpp/ObjectModel/Image.cpp
@@ -18,7 +18,7 @@ Image::Image() :
 
 Json::Value Image::SerializeToJsonValue() const
 {
-    const char pixelstring[] = "px";
+	const std::string pixelstring("px");
 
     Json::Value root = BaseCardElement::SerializeToJsonValue();
 
@@ -226,10 +226,10 @@ std::shared_ptr<BaseCardElement> ImageParser::DeserializeWithoutCheckingType(
         parsedDimensions.push_back(parsedDimension);
     }
 
-    if (parsedDimensions[0] != 0 || parsedDimensions[1] != 0)
+    if (parsedDimensions.at(0) != 0 || parsedDimensions.at(1) != 0)
     {
-        image->SetPixelWidth(parsedDimensions[0]);
-        image->SetPixelHeight(parsedDimensions[1]);
+        image->SetPixelWidth(parsedDimensions.at(0));
+        image->SetPixelHeight(parsedDimensions.at(1));
     }
     else
     {

--- a/source/shared/cpp/ObjectModel/MarkDownBlockParser.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownBlockParser.cpp
@@ -24,13 +24,17 @@ void MarkDownBlockParser::ParseBlock(std::stringstream &stream)
     case ']': case ')':
     {
         // add these char as token to code gen list
-        m_parsedResult.AddNewTokenToParsedResult((char)stream.get());
+		char streamChar;
+		stream.get(streamChar);
+        m_parsedResult.AddNewTokenToParsedResult(streamChar);
         break;
     }
     case '\n': case '\r':
     {
         // add new line char as token to code gen list
-        m_parsedResult.AddNewLineTokenToParsedResult((char)stream.get());
+		char streamChar;
+		stream.get(streamChar);
+        m_parsedResult.AddNewLineTokenToParsedResult(streamChar);
         break;
     }
     // handles list block
@@ -99,13 +103,17 @@ EmphasisParser::EmphasisState EmphasisParser::MatchText(EmphasisParser &parser, 
         }
 
         parser.UpdateCurrentEmphasisRunState(emphasisType);
-        token += (char)stream.get();
+		char streamChar;
+		stream.get(streamChar);
+        token += streamChar;
         return EmphasisState::Emphasis;
     }
     else
     {
         parser.UpdateLookBehind(stream.peek());
-        token += (char)stream.get();
+		char streamChar;
+		stream.get(streamChar);
+        token += streamChar;
         return EmphasisState::Text;
     }
 }
@@ -130,7 +138,9 @@ EmphasisParser::EmphasisState EmphasisParser::MatchEmphasis(EmphasisParser &pars
             parser.UpdateCurrentEmphasisRunState(emphasisType);
         }
 
-        token += (char)stream.get();
+		char streamChar;
+		stream.get(streamChar);
+        token += streamChar;
     }
     /// delimiter run is ended, capture the current accumulated token as emphasis
     else
@@ -145,7 +155,9 @@ EmphasisParser::EmphasisState EmphasisParser::MatchEmphasis(EmphasisParser &pars
 
         parser.ResetCurrentEmphasisState();
         parser.UpdateLookBehind(stream.peek());
-        token += (char)stream.get();
+		char streamChar;
+		stream.get(streamChar);
+        token += streamChar;
         return EmphasisState::Text;
     }
     return EmphasisState::Emphasis;
@@ -332,7 +344,9 @@ bool LinkParser::MatchAtLinkInit(std::stringstream &lookahead)
 {
     if (lookahead.peek() == '[')
     {
-        m_linkTextParsedResult.AddNewTokenToParsedResult((char)lookahead.get());
+		char streamChar;
+		lookahead.get(streamChar);
+        m_linkTextParsedResult.AddNewTokenToParsedResult(streamChar);
         return true;
     }
 
@@ -346,7 +360,9 @@ bool LinkParser::MatchAtLinkTextRun(std::stringstream &lookahead)
 {
     if (lookahead.peek() == ']')
     {
-        m_linkTextParsedResult.AddNewTokenToParsedResult((char)lookahead.get());
+		char streamChar;
+		lookahead.get(streamChar);
+        m_linkTextParsedResult.AddNewTokenToParsedResult(streamChar);
         return true;
     }
     else
@@ -365,7 +381,9 @@ bool LinkParser::MatchAtLinkTextRun(std::stringstream &lookahead)
             if (lookahead.peek() == ']')
             {
                 // move code gen objects to link text list to further process it 
-                m_linkTextParsedResult.AddNewTokenToParsedResult((char)lookahead.get());
+				char streamChar;
+				lookahead.get(streamChar);
+                m_linkTextParsedResult.AddNewTokenToParsedResult(streamChar);
                 return true;
             }
 
@@ -380,7 +398,9 @@ bool LinkParser::MatchAtLinkTextEnd(std::stringstream &lookahead)
 {
     if (lookahead.peek() == '(')
     {
-        m_linkTextParsedResult.AddNewTokenToParsedResult((char)lookahead.get());
+		char streamChar;
+		lookahead.get(streamChar);
+        m_linkTextParsedResult.AddNewTokenToParsedResult(streamChar);
         return true;
     }
 
@@ -519,7 +539,9 @@ bool ListParser::MatchNewOrderedListItem(std::stringstream &stream, std::string 
 {
     do
     {
-        number_string += (char)stream.get();
+		char streamChar;
+		stream.get(streamChar);
+        number_string += streamChar;
     } while (isdigit(stream.peek()));
 
     if (stream.peek() == '.')
@@ -541,7 +563,8 @@ void ListParser::ParseSubBlocks(std::stringstream &stream)
     {
         if (IsNewLine(stream.peek()))
         {
-            const int newLineChar = stream.get();
+			char newLineChar;
+			stream.get(newLineChar);
             // check if it is the start of new block items
             if (isdigit(stream.peek()))
             {
@@ -560,7 +583,7 @@ void ListParser::ParseSubBlocks(std::stringstream &stream)
                 break;
             }
 
-            m_parsedResult.AddNewTokenToParsedResult((char)newLineChar);
+            m_parsedResult.AddNewTokenToParsedResult(newLineChar);
         }
         ParseBlock(stream);
     }
@@ -635,7 +658,9 @@ void OrderedListParser::Match(std::stringstream &stream)
     {
         do
         {
-            number_string += (char)stream.get();
+			char streamChar;
+			stream.get(streamChar);
+            number_string += streamChar;
         } while (isdigit(stream.peek()));
 
         if (IsDot(stream.peek()))

--- a/source/shared/cpp/ObjectModel/MarkDownBlockParser.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownBlockParser.cpp
@@ -72,7 +72,7 @@ void EmphasisParser::Match(std::stringstream &stream)
 {
     while (m_current_state != EmphasisState::Captured)
     {
-        m_current_state = m_stateMachine[m_current_state](*this, stream, m_current_token);
+        m_current_state = m_stateMachine.at(m_current_state)(*this, stream, m_current_token);
     }
 }
 

--- a/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.cpp
@@ -95,7 +95,7 @@ std::string MarkDownLeftEmphasisHtmlGenerator::GenerateHtmlString()
 {
     if (m_numberOfUnusedDelimiters)
     {
-        const unsigned long startIdx = static_cast<unsigned long>(m_token.size()) - m_numberOfUnusedDelimiters;
+        const size_t startIdx = m_token.size() - m_numberOfUnusedDelimiters;
         html << m_token.substr(startIdx, std::string::npos);
     }
 
@@ -139,7 +139,7 @@ std::string MarkDownRightEmphasisHtmlGenerator::GenerateHtmlString()
     // if there are unused emphasis, append them
     if (m_numberOfUnusedDelimiters)
     {
-        const unsigned long startIdx = static_cast<unsigned long>(m_token.size()) - m_numberOfUnusedDelimiters;
+        const size_t startIdx = m_token.size() - m_numberOfUnusedDelimiters;
         html << m_token.substr(startIdx, std::string::npos);
     }
 

--- a/source/shared/cpp/ObjectModel/MarkDownParser.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownParser.cpp
@@ -53,7 +53,7 @@ std::string MarkDownParser::EscapeText()
 
     for (std::string::size_type i = 0; i < m_text.length(); i++)
     {
-        switch (m_text[i])
+        switch (m_text.at(i))
         {
         case '<':
             escaped += "&lt;";
@@ -68,7 +68,7 @@ std::string MarkDownParser::EscapeText()
             escaped += "&amp;";
             break;
         default:
-            escaped += m_text[i];
+            escaped += m_text.at(i);
             break;
         }
     }

--- a/source/shared/cpp/ObjectModel/Media.h
+++ b/source/shared/cpp/ObjectModel/Media.h
@@ -23,7 +23,7 @@ public:
 
     std::vector<std::shared_ptr<MediaSource>>& GetSources();
 
-    virtual void GetResourceInformation(std::vector<RemoteResourceInformation>& resourceInfo) override;
+    void GetResourceInformation(std::vector<RemoteResourceInformation>& resourceInfo) override;
 
 private:
     std::string m_poster;

--- a/source/shared/cpp/ObjectModel/MediaSource.cpp
+++ b/source/shared/cpp/ObjectModel/MediaSource.cpp
@@ -62,7 +62,7 @@ std::shared_ptr<MediaSource> MediaSourceParser::Deserialize(
     std::vector<std::shared_ptr<AdaptiveCardParseWarning>>&,
     const Json::Value& json)
 {
-    std::shared_ptr<MediaSource> mediaSource{ new MediaSource() };
+    std::shared_ptr<MediaSource> mediaSource = std::make_shared<MediaSource>();
 
     mediaSource->SetMimeType(ParseUtil::GetString(json, AdaptiveCardSchemaKey::MimeType, false));
     mediaSource->SetUrl(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Url, false));

--- a/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
+++ b/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
@@ -146,11 +146,11 @@ std::shared_ptr<ParseResult> AdaptiveCard::Deserialize(
 
     if (elementParserRegistration == nullptr)
     {
-        elementParserRegistration.reset(new ElementParserRegistration());
+        elementParserRegistration = std::make_shared<ElementParserRegistration>();
     }
     if (actionParserRegistration == nullptr)
     {
-        actionParserRegistration.reset(new ActionParserRegistration());
+        actionParserRegistration = std::make_shared<ActionParserRegistration>();
     }
 
     // Parse body

--- a/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
+++ b/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
@@ -92,7 +92,7 @@ std::shared_ptr<ParseResult> AdaptiveCard::Deserialize(
 {
     ParseUtil::ThrowIfNotJsonObject(json);
 
-    bool enforceVersion = (rendererVersion != std::numeric_limits<double>::max());
+    const bool enforceVersion = (rendererVersion != std::numeric_limits<double>::max());
 
     // Verify this is an adaptive card
     ParseUtil::ExpectTypeString(json, CardElementType::AdaptiveCard);

--- a/source/shared/cpp/ObjectModel/Util.cpp
+++ b/source/shared/cpp/ObjectModel/Util.cpp
@@ -37,7 +37,8 @@ void PropagateLanguage(const std::string& language, std::vector<std::shared_ptr<
     }
 }
 
-void ValidateUserInputForDimensionWithUnit(const std::string &unit, const std::string &requestedDimension, int &parsedDimension)
+void ValidateUserInputForDimensionWithUnit(const std::string &unit, const std::string &requestedDimension,
+    int &parsedDimension)
 {
     if (requestedDimension.empty())
     {
@@ -48,26 +49,30 @@ void ValidateUserInputForDimensionWithUnit(const std::string &unit, const std::s
         const std::size_t foundIndex = requestedDimension.find(unit);
         if (std::string::npos == foundIndex || requestedDimension.size() != foundIndex + unit.size())
         {
-            throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "unit is either missing or inproper form: " + requestedDimension);
+            throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue,
+                "unit is either missing or inproper form: " + requestedDimension);
         }
         try
         {
-            float parsedVal = stof(requestedDimension.substr(0, foundIndex));
-            if(parsedVal != (int) parsedVal || parsedVal < 0)
+            int parsedVal = std::stoi(requestedDimension.substr(0, foundIndex));
+            if (parsedVal < 0)
             {
-                throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "unsigned integer is accepted but received : " + requestedDimension);
+                throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue,
+                    "unsigned integer is accepted but received : " + requestedDimension);
             }
-            parsedDimension = (int)parsedVal;
+            parsedDimension = parsedVal;
         }
         catch (const std::invalid_argument &e)
         {
             (void)e;
-            throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "unsigned integer is accepted but received : " + requestedDimension);
+            throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue,
+                "unsigned integer is accepted but received : " + requestedDimension);
         }
         catch (const std::out_of_range &e)
         {
             (void)e;
-            throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue, "out of range: " + requestedDimension);
+            throw AdaptiveCardParseException(ErrorStatusCode::InvalidPropertyValue,
+                "out of range: " + requestedDimension);
         }
     }
 }

--- a/source/shared/cpp/ObjectModel/pch.h
+++ b/source/shared/cpp/ObjectModel/pch.h
@@ -40,8 +40,4 @@
 #pragma warning(default: CPPCORECHECK_STYLE_WARNINGS)
 #pragma warning(default: CPPCORECHECK_TYPE_WARNINGS)
 #pragma warning(default: CPPCORECHECK_UNIQUE_POINTER_WARNINGS)
-
-// ECppCoreCheckWarningCodes::WARNING_MEMBER_UNINIT
-#pragma warning(default: 26495)
-
 #endif

--- a/source/shared/cpp/ObjectModel/pch.h
+++ b/source/shared/cpp/ObjectModel/pch.h
@@ -34,7 +34,11 @@
 #pragma warning(default: CPPCORECHECK_CONCURRENCY_WARNINGS)
 #pragma warning(default: CPPCORECHECK_CONST_WARNINGS)
 #pragma warning(default: CPPCORECHECK_DECLARATION_WARNINGS)
+#pragma warning(default: CPPCORECHECK_OWNER_POINTER_WARNINGS)
+#pragma warning(default: CPPCORECHECK_RAW_POINTER_WARNINGS)
+#pragma warning(default: CPPCORECHECK_SHARED_POINTER_WARNINGS)
 #pragma warning(default: CPPCORECHECK_STYLE_WARNINGS)
+#pragma warning(default: CPPCORECHECK_TYPE_WARNINGS)
 #pragma warning(default: CPPCORECHECK_UNIQUE_POINTER_WARNINGS)
 
 // ECppCoreCheckWarningCodes::WARNING_MEMBER_UNINIT

--- a/source/shared/cpp/ObjectModel/pch.h
+++ b/source/shared/cpp/ObjectModel/pch.h
@@ -29,6 +29,7 @@
 #include <CppCoreCheck\warnings.h>
 #pragma warning(disable: ALL_CPPCORECHECK_WARNINGS)
 #pragma warning(default: CPPCORECHECK_ARITHMETIC_WARNINGS)
+#pragma warning(default: CPPCORECHECK_BOUNDS_WARNINGS)
 #pragma warning(default: CPPCORECHECK_CLASS_WARNINGS)
 #pragma warning(default: CPPCORECHECK_CONCURRENCY_WARNINGS)
 #pragma warning(default: CPPCORECHECK_CONST_WARNINGS)


### PR DESCRIPTION
Enable the following checks:
* [CPPCORECHECK_BOUNDS_WARNINGS](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#probounds-bounds-safety-profile)
   - The check that we had the most errors in deals with unchecked bounds access via `operator[]`. When indexing into a container type via `[]`, no bounds checking occurs, making it easy to walk off the end of, say, a `std::vector<>`. Access via `at()` **is** bounds checked and will throw if an attempt is made to retrieve an element at an invalid index. The fix is to switch to using `at()` when possible.
* [CPPCORECHECK_OWNER_POINTER_WARNINGS, CPPCORECHECK_RAW_POINTER_WARNINGS, and CPPCORECHECK_SHARED_POINTER_WARNINGS](http://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#r-resource-management)
  - There were actually few issues caught by these checks. They were all to do with a ban on the explicit use of `operator new` -- prefer using `std::make_unique<>` and `std::make_shared<>`.
* [CPPCORECHECK_TYPE_WARNINGS](http://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#prosafety-type-safety-profile)
   - This profile was responsible for most changes in this PR. Most of the issues caught were due to either the use of c-style casts (rather than `static_cast<>`) or the use of casts (of any kind) when doing arithmetic operations. The trickiest of these issues was in `ValidateUserInputForDimensionWithUnit()`, where we were doing some calisthenics around the conversion of a dimensional unit in a string (e.g. `17px`) to an `int` (`17`). The existing code allowed for the use of fractional values, but only if they converted directly to an `int`. For example, `20.0px` and `20.0000000000000000001px` are accepted by the model, but `20.1px` is not. However, the [visualizer](http://adaptivecards.io/visualizer/) allows fractional pixels, so the fix is to just switch to `std::stoi()` for our conversion.
