### PR TITLE
removed TextBlock's 100% height

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Rendering.Html/AdaptiveCardRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Html/AdaptiveCardRenderer.cs
@@ -576,8 +576,7 @@ namespace AdaptiveCards.Rendering.Html
                 .Style("color", context.GetColor(textBlock.Color, textBlock.IsSubtle))
                 .Style("line-height", $"{lineHeight.ToString("F")}px")
                 .Style("font-size", $"{fontSize}px")
-                .Style("font-weight", $"{weight}")
-                .Style("height", "100%");
+                .Style("font-weight", $"{weight}");
 
             if (textBlock.MaxLines > 0)
                 uiTextBlock = uiTextBlock

--- a/source/dotnet/Test/AdaptiveCards.Rendering.Html.Test/HtmlRendererTests.cs
+++ b/source/dotnet/Test/AdaptiveCards.Rendering.Html.Test/HtmlRendererTests.cs
@@ -23,7 +23,7 @@ namespace AdaptiveCards.Rendering.Html.Test
 
             // Generated HTML should have two <p> tags, with appropriate styles set.
             Assert.AreEqual(
-                "<div class=\'ac-textblock\' style=\'box-sizing: border-box;text-align: left;color: rgba(0, 0, 0, 1.00);line-height: 18.62px;font-size: 14px;font-weight: 400;height: 100%;white-space: nowrap;\'><p style=\'margin-top: 0px;margin-bottom: 0px;width: 100%;text-overflow: ellipsis;overflow: hidden;\'>first line</p><p style=\'margin-top: 0px;margin-bottom: 0px;width: 100%;text-overflow: ellipsis;overflow: hidden;\'>second line</p></div>",
+                "<div class=\'ac-textblock\' style=\'box-sizing: border-box;text-align: left;color: rgba(0, 0, 0, 1.00);line-height: 18.62px;font-size: 14px;font-weight: 400;white-space: nowrap;\'><p style=\'margin-top: 0px;margin-bottom: 0px;width: 100%;text-overflow: ellipsis;overflow: hidden;\'>first line</p><p style=\'margin-top: 0px;margin-bottom: 0px;width: 100%;text-overflow: ellipsis;overflow: hidden;\'>second line</p></div>",
                 generatedHtml);
         }
 


### PR DESCRIPTION
This style attribute is redundant and causes a `TextBlock` to consume all available space in a `Column`