### PR TITLE
Disallow Strings to Ints

### DIFF
--- a/source/dotnet/Library/AdaptiveCards/AdaptiveCard.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveCard.cs
@@ -184,7 +184,8 @@ namespace AdaptiveCards
             {
                 parseResult.Card = JsonConvert.DeserializeObject<AdaptiveCard>(json, new JsonSerializerSettings
                 {
-                    ContractResolver = new WarningLoggingContractResolver(parseResult)
+                    ContractResolver = new WarningLoggingContractResolver(parseResult),
+                    Converters = { new StrictIntConverter() }
                 });
             }
             catch (JsonException ex)

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveSubmitAction.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveSubmitAction.cs
@@ -48,7 +48,10 @@ namespace AdaptiveCards
                 if (value == null)
                     Data = null;
                 else
-                    Data = JsonConvert.DeserializeObject(value);
+                    Data = JsonConvert.DeserializeObject(value, new JsonSerializerSettings
+                    {
+                        Converters = { new StrictIntConverter() }
+                    });
             }
         }
     }

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveTextBlock.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveTextBlock.cs
@@ -103,7 +103,6 @@ namespace AdaptiveCards
         ///     When Wrap is true, you can specify the maximum number of lines to allow the textBlock to use.
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-        //[JsonConverter(typeof(StrictIntConverter))]
 #if !NETSTANDARD1_3
         [XmlAttribute]
 #endif

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveTextBlock.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveTextBlock.cs
@@ -103,6 +103,7 @@ namespace AdaptiveCards
         ///     When Wrap is true, you can specify the maximum number of lines to allow the textBlock to use.
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        //[JsonConverter(typeof(StrictIntConverter))]
 #if !NETSTANDARD1_3
         [XmlAttribute]
 #endif

--- a/source/dotnet/Library/AdaptiveCards/Rendering/AdaptiveHostConfig.cs
+++ b/source/dotnet/Library/AdaptiveCards/Rendering/AdaptiveHostConfig.cs
@@ -75,7 +75,10 @@ namespace AdaptiveCards.Rendering
         {
             try
             {
-                return JsonConvert.DeserializeObject<AdaptiveHostConfig>(json);
+                return JsonConvert.DeserializeObject<AdaptiveHostConfig>(json, new JsonSerializerSettings
+                {
+                    Converters = { new StrictIntConverter() }
+                });
             }
             catch (JsonException ex)
             {

--- a/source/dotnet/Library/AdaptiveCards/StrictIntConverter.cs
+++ b/source/dotnet/Library/AdaptiveCards/StrictIntConverter.cs
@@ -9,15 +9,15 @@ namespace AdaptiveCards
 
         public override bool CanConvert(Type objectType)
         {
-            //throw new NotImplementedException();
+            // Only use this converter for Integer types
             return objectType.IsIntegerType();
         }
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            //throw new NotImplementedException();
             switch (reader.TokenType)
             {
+                // Only allow Integer or Null
                 case JsonToken.Integer:
                 case JsonToken.Null:
                     return defaultSerializer.Deserialize(reader, objectType);

--- a/source/dotnet/Library/AdaptiveCards/StrictIntConverter.cs
+++ b/source/dotnet/Library/AdaptiveCards/StrictIntConverter.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace AdaptiveCards
+{
+    public class StrictIntConverter : JsonConverter
+    {
+        readonly JsonSerializer defaultSerializer = new JsonSerializer();
+
+        public override bool CanConvert(Type objectType)
+        {
+            //throw new NotImplementedException();
+            return objectType.IsIntegerType();
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            //throw new NotImplementedException();
+            switch (reader.TokenType)
+            {
+                case JsonToken.Integer:
+                case JsonToken.Null:
+                    return defaultSerializer.Deserialize(reader, objectType);
+                default:
+                    throw new JsonSerializationException(string.Format("Token \"{0}\" of type {1} was not a JSON integer", reader.Value, reader.TokenType));
+            }
+        }
+
+        public override bool CanWrite { get { return false; } }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public static class JsonExtensions
+    {
+        public static bool IsIntegerType(this Type type)
+        {
+            type = Nullable.GetUnderlyingType(type) ?? type;
+            if (type == typeof(long)
+                || type == typeof(ulong)
+                || type == typeof(int)
+                || type == typeof(uint)
+                || type == typeof(short)
+                || type == typeof(ushort)
+                || type == typeof(byte)
+                || type == typeof(sbyte)
+                || type == typeof(System.Numerics.BigInteger))
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/source/dotnet/Test/AdaptiveCards.Test/AllPayloadTests.cs
+++ b/source/dotnet/Test/AdaptiveCards.Test/AllPayloadTests.cs
@@ -53,7 +53,10 @@ namespace AdaptiveCards.Test
                     Assert.AreEqual(0, parseResult.Warnings.Count);
 
                     // Make sure JsonConvert works also
-                    var card = JsonConvert.DeserializeObject<AdaptiveCard>(json);
+                    var card = JsonConvert.DeserializeObject<AdaptiveCard>(json, new JsonSerializerSettings
+                    {
+                        Converters = { new StrictIntConverter() }
+                    });
                     Assert.AreEqual(parseResult.Card.Body.Count, card.Body.Count);
                     Assert.AreEqual(parseResult.Card.Actions.Count, card.Actions.Count);
                 }

--- a/source/dotnet/Test/AdaptiveCards.Test/XmlSerializationTests.cs
+++ b/source/dotnet/Test/AdaptiveCards.Test/XmlSerializationTests.cs
@@ -32,7 +32,10 @@ namespace AdaptiveCards.Test
             foreach (var file in Directory.EnumerateFiles(@"..\..\..\..\..\..\..\samples\v1.0\Scenarios"))
             {
                 string json = File.ReadAllText(file);
-                var card = JsonConvert.DeserializeObject<AdaptiveCard>(json);
+                var card = JsonConvert.DeserializeObject<AdaptiveCard>(json, new JsonSerializerSettings
+                {
+                    Converters = { new StrictIntConverter() }
+                });
                 StringBuilder sb = new StringBuilder();
                 serializer.Serialize(new StringWriter(sb), card);
                 string xml = sb.ToString();


### PR DESCRIPTION
The `.NET` parser has the same bug as reported in the original issue. This is the default behavior of NewtonSoft. So we just need a custom Integer converter with stricter rule that disallows String to be accepted for all Int attributes