### PR TITLE
Introduce parser registration, parser warning, and parser error tests

### DIFF
--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/AdaptiveCardParseExceptionTest.cpp
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/AdaptiveCardParseExceptionTest.cpp
@@ -1,0 +1,37 @@
+#include "stdafx.h"
+#include "CppUnitTest.h"
+#include "TextBlock.h"
+#include <time.h>
+#include <Windows.h>
+#include <StrSafe.h>
+#include "SharedAdaptiveCard.h"
+#include "BaseCardElement.h"
+#include "ActionParserRegistration.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace AdaptiveCards;
+using namespace std::string_literals;
+
+namespace AdaptiveCardsSharedModelUnitTest
+{
+	TEST_CLASS(AdaptiveCardParseExceptionTests)
+	{
+	public:
+		TEST_METHOD(AdaptiveCardParseExceptionTest)
+		{
+			std::string errorMessage("error message");
+			auto parseException = std::make_unique<AdaptiveCardParseException>(ErrorStatusCode::InvalidJson, errorMessage);
+			Assert::AreEqual(parseException->what(), errorMessage.c_str());
+			Assert::IsTrue(parseException->GetStatusCode() == ErrorStatusCode::InvalidJson);
+			Assert::AreEqual(parseException->GetReason(), errorMessage);
+		}
+
+		TEST_METHOD(AdaptiveCardParseWarningTest)
+		{
+			std::string errorMessage("error message");
+			auto parseWarning = std::make_unique<AdaptiveCardParseWarning>(WarningStatusCode::AssetLoadFailed, errorMessage);
+			Assert::IsTrue(parseWarning->GetStatusCode() == WarningStatusCode::AssetLoadFailed);
+			Assert::AreEqual(parseWarning->GetReason(), errorMessage);
+		}
+	};
+}

--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/AdaptiveCardsSharedModelUnitTest.vcxproj
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/AdaptiveCardsSharedModelUnitTest.vcxproj
@@ -160,10 +160,12 @@
     <ClInclude Include="targetver.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="AdaptiveCardParseExceptionTest.cpp" />
     <ClCompile Include="AdditionalPropertiesTest.cpp" />
     <ClCompile Include="CustomParsingForIOSTest.cpp" />
     <ClCompile Include="ExplicitDimensionTest.cpp" />
     <ClCompile Include="ImageBackgroundColorTest.cpp" />
+    <ClCompile Include="ParserRegistrationTest.cpp" />
     <ClCompile Include="ResourceInformationTests.cpp" />
     <ClCompile Include="MarkDownUnitTest.cpp" />
     <ClCompile Include="ObjectModelTest.cpp" />

--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/AdaptiveCardsSharedModelUnitTest.vcxproj.filters
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/AdaptiveCardsSharedModelUnitTest.vcxproj.filters
@@ -53,5 +53,11 @@
     <ClCompile Include="ImageBackgroundColorTest.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ParserRegistrationTest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="AdaptiveCardParseExceptionTest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/ParserRegistrationTest.cpp
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/ParserRegistrationTest.cpp
@@ -28,15 +28,7 @@ namespace AdaptiveCardsSharedModelUnitTest
 					BaseCardElement(AdaptiveCards::CardElementType::Custom),
 					BaseActionElement(AdaptiveCards::ActionType::Custom)
 				{
-					m_customImage = value.get("customImageProperty", Json::Value()).asString();
-				}
-
-				virtual void GetResourceInformation(std::vector<RemoteResourceInformation>& resourceUris) override
-				{
-					RemoteResourceInformation resourceInfo;
-					resourceInfo.url = m_customImage;
-					resourceInfo.resourceType = CardElementType::Image;
-					resourceUris.push_back(resourceInfo);
+					m_customImage = value.get("customProperty", Json::Value()).asString();
 				}
 
 			private:

--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/ParserRegistrationTest.cpp
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/ParserRegistrationTest.cpp
@@ -44,7 +44,7 @@ namespace AdaptiveCardsSharedModelUnitTest
 			};
 
 			// Define custom element parser
-			class TestCustomParser : public BaseCardElementParser
+			class TestCustomElementParser : public BaseCardElementParser
 			{
 			public:
 				virtual std::shared_ptr<BaseCardElement> Deserialize(
@@ -71,35 +71,50 @@ namespace AdaptiveCardsSharedModelUnitTest
 				}
 			};
 
-			ActionParserRegistration parser;
+			ActionParserRegistration actionParser;
+			ElementParserRegistration elementParser;
 
 			std::string elemType("notRegisteredYet");
 			// make sure we don't already have this parser
-			Assert::IsTrue(!parser.GetParser(elemType));
-			auto customParser = std::make_shared<TestCustomActionParser>();
+			Assert::IsTrue(!actionParser.GetParser(elemType));
+			auto customActionParser = std::make_shared<TestCustomActionParser>();
+			auto customElementParser = std::make_shared<TestCustomElementParser>();
 
 			// make sure we can't override a known parser
-			Assert::ExpectException<AdaptiveCardParseException>([&]() { parser.AddParser(ActionTypeToString(ActionType::OpenUrl), customParser); });
+			Assert::ExpectException<AdaptiveCardParseException>([&]() { actionParser.AddParser(ActionTypeToString(ActionType::OpenUrl), customActionParser); });
+			Assert::ExpectException<AdaptiveCardParseException>([&]() { elementParser.AddParser(CardElementTypeToString(CardElementType::Container), customElementParser); });
 
 			// add our new parser
-			parser.AddParser(elemType, customParser);
-			Assert::IsTrue(customParser == parser.GetParser(elemType));
+			actionParser.AddParser(elemType, customActionParser);
+			Assert::IsTrue(customActionParser == actionParser.GetParser(elemType));
+			elementParser.AddParser(elemType, customElementParser);
+			Assert::IsTrue(customElementParser == elementParser.GetParser(elemType));
 			
 			// overwrite our new parser
-			auto customParser2 = std::make_shared<TestCustomActionParser>();
-			parser.AddParser(elemType, customParser2);
-			Assert::IsTrue(customParser2 == parser.GetParser(elemType));
+			auto customActionParser2 = std::make_shared<TestCustomActionParser>();
+			actionParser.AddParser(elemType, customActionParser2);
+			Assert::IsTrue(customActionParser2 == actionParser.GetParser(elemType));
+			auto customElementParser2 = std::make_shared<TestCustomElementParser>();
+			elementParser.AddParser(elemType, customElementParser2);
+			Assert::IsTrue(customElementParser2 == elementParser.GetParser(elemType));
 
 			// remove custom parser twice. shouldn't throw
-			parser.RemoveParser(elemType);
-			Assert::IsTrue(!parser.GetParser(elemType));
-			parser.RemoveParser(elemType);
-			Assert::IsTrue(!parser.GetParser(elemType));
+			actionParser.RemoveParser(elemType);
+			Assert::IsTrue(!actionParser.GetParser(elemType));
+			actionParser.RemoveParser(elemType);
+			Assert::IsTrue(!actionParser.GetParser(elemType));
+			elementParser.RemoveParser(elemType);
+			Assert::IsTrue(!elementParser.GetParser(elemType));
+			elementParser.RemoveParser(elemType);
+			Assert::IsTrue(!elementParser.GetParser(elemType));
 
-			// attempt to remove known parser. shouldn't throw, but shouldn't remove
-			Assert::IsTrue((bool)parser.GetParser(ActionTypeToString(ActionType::OpenUrl)));
-			parser.RemoveParser(ActionTypeToString(ActionType::OpenUrl));
-			Assert::IsTrue((bool)parser.GetParser(ActionTypeToString(ActionType::OpenUrl)));
+			// make sure we can't remove known parser
+			Assert::IsTrue((bool)actionParser.GetParser(ActionTypeToString(ActionType::OpenUrl)));
+			Assert::ExpectException<AdaptiveCardParseException>([&]() { actionParser.RemoveParser(ActionTypeToString(ActionType::OpenUrl)); });
+			Assert::IsTrue((bool)actionParser.GetParser(ActionTypeToString(ActionType::OpenUrl)));
+			Assert::IsTrue((bool)elementParser.GetParser(CardElementTypeToString(CardElementType::Container)));
+			Assert::ExpectException<AdaptiveCardParseException>([&]() { elementParser.RemoveParser(CardElementTypeToString(CardElementType::Container)); });
+			Assert::IsTrue((bool)elementParser.GetParser(CardElementTypeToString(CardElementType::Container)));
 		}
 	};
 }

--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/ParserRegistrationTest.cpp
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/ParserRegistrationTest.cpp
@@ -1,0 +1,105 @@
+#include "stdafx.h"
+#include "CppUnitTest.h"
+#include "TextBlock.h"
+#include <time.h>
+#include <Windows.h>
+#include <StrSafe.h>
+#include "SharedAdaptiveCard.h"
+#include "BaseCardElement.h"
+#include "ActionParserRegistration.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace AdaptiveCards;
+using namespace std::string_literals;
+
+namespace AdaptiveCardsSharedModelUnitTest
+{
+	TEST_CLASS(ParserRegistrationTest)
+	{
+	public:
+		TEST_METHOD(ParserRegistrationTests)
+		{
+			// Define custom type. This implements both element and action for convenience
+			class TestCustomElement : public BaseCardElement, public BaseActionElement
+			{
+			public:
+				TestCustomElement(
+					const Json::Value& value) :
+					BaseCardElement(AdaptiveCards::CardElementType::Custom),
+					BaseActionElement(AdaptiveCards::ActionType::Custom)
+				{
+					m_customImage = value.get("customImageProperty", Json::Value()).asString();
+				}
+
+				virtual void GetResourceInformation(std::vector<RemoteResourceInformation>& resourceUris) override
+				{
+					RemoteResourceInformation resourceInfo;
+					resourceInfo.url = m_customImage;
+					resourceInfo.resourceType = CardElementType::Image;
+					resourceUris.push_back(resourceInfo);
+				}
+
+			private:
+				std::string m_customImage;
+			};
+
+			// Define custom element parser
+			class TestCustomParser : public BaseCardElementParser
+			{
+			public:
+				virtual std::shared_ptr<BaseCardElement> Deserialize(
+					std::shared_ptr<AdaptiveCards::ElementParserRegistration> elementParserRegistration,
+					std::shared_ptr<AdaptiveCards::ActionParserRegistration> actionParserRegistration,
+					std::vector<std::shared_ptr<AdaptiveCards::AdaptiveCardParseWarning>>& warnings,
+					const Json::Value& value) override
+				{
+					return std::make_shared<TestCustomElement>(value);
+				}
+			};
+
+			// Define custom action parser
+			class TestCustomActionParser : public ActionElementParser
+			{
+			public:
+				virtual std::shared_ptr<BaseActionElement> Deserialize(
+					std::shared_ptr<AdaptiveCards::ElementParserRegistration> elementParserRegistration,
+					std::shared_ptr<AdaptiveCards::ActionParserRegistration> actionParserRegistration,
+					std::vector<std::shared_ptr<AdaptiveCards::AdaptiveCardParseWarning>>& warnings,
+					const Json::Value& value) override
+				{
+					return std::make_shared<TestCustomElement>(value);
+				}
+			};
+
+			ActionParserRegistration parser;
+
+			std::string elemType("notRegisteredYet");
+			// make sure we don't already have this parser
+			Assert::IsTrue(!parser.GetParser(elemType));
+			auto customParser = std::make_shared<TestCustomActionParser>();
+
+			// make sure we can't override a known parser
+			Assert::ExpectException<AdaptiveCardParseException>([&]() { parser.AddParser(ActionTypeToString(ActionType::OpenUrl), customParser); });
+
+			// add our new parser
+			parser.AddParser(elemType, customParser);
+			Assert::IsTrue(customParser == parser.GetParser(elemType));
+			
+			// overwrite our new parser
+			auto customParser2 = std::make_shared<TestCustomActionParser>();
+			parser.AddParser(elemType, customParser2);
+			Assert::IsTrue(customParser2 == parser.GetParser(elemType));
+
+			// remove custom parser twice. shouldn't throw
+			parser.RemoveParser(elemType);
+			Assert::IsTrue(!parser.GetParser(elemType));
+			parser.RemoveParser(elemType);
+			Assert::IsTrue(!parser.GetParser(elemType));
+
+			// attempt to remove known parser. shouldn't throw, but shouldn't remove
+			Assert::IsTrue((bool)parser.GetParser(ActionTypeToString(ActionType::OpenUrl)));
+			parser.RemoveParser(ActionTypeToString(ActionType::OpenUrl));
+			Assert::IsTrue((bool)parser.GetParser(ActionTypeToString(ActionType::OpenUrl)));
+		}
+	};
+}

--- a/source/shared/cpp/ObjectModel/ActionParserRegistration.cpp
+++ b/source/shared/cpp/ObjectModel/ActionParserRegistration.cpp
@@ -42,6 +42,11 @@ namespace AdaptiveSharedNamespace {
         {
             ActionParserRegistration::m_cardElementParsers.erase(elementType);
         }
+		else
+		{
+			throw AdaptiveCardParseException(ErrorStatusCode::UnsupportedParserOverride,
+				"Removing known action parsers is unsupported");
+		}
     }
 
     std::shared_ptr<ActionElementParser> ActionParserRegistration::GetParser(std::string const &elementType)

--- a/source/shared/cpp/ObjectModel/ActionParserRegistration.cpp
+++ b/source/shared/cpp/ObjectModel/ActionParserRegistration.cpp
@@ -20,21 +20,25 @@ namespace AdaptiveSharedNamespace {
         });
     }
 
-    void ActionParserRegistration::AddParser(std::string const &elementType, std::shared_ptr<ActionElementParser> parser)
+    void ActionParserRegistration::AddParser(std::string const &elementType,
+        std::shared_ptr<ActionElementParser> parser)
     {
+        // make sure caller isn't attempting to overwrite a known element's parser
         if (m_knownElements.find(elementType) == m_knownElements.end())
         {
             ActionParserRegistration::m_cardElementParsers[elementType] = parser;
         }
         else
         {
-            throw AdaptiveCardParseException(ErrorStatusCode::UnsupportedParserOverride, "Overriding known action parsers is unsupported");
+            throw AdaptiveCardParseException(ErrorStatusCode::UnsupportedParserOverride,
+                "Overriding known action parsers is unsupported");
         }
     }
 
     void ActionParserRegistration::RemoveParser(std::string const &elementType)
     {
-        if (m_knownElements.find(elementType) != m_knownElements.end())
+        // make sure caller isn't attempting to remove a known element's parser
+        if (m_knownElements.find(elementType) == m_knownElements.end())
         {
             ActionParserRegistration::m_cardElementParsers.erase(elementType);
         }


### PR DESCRIPTION
Bolster code coverage for `ActionParserRegistration`, `ElementParserRegistration`, `AdaptiveCardParseWarning`, and `AdaptiveCardParseException`. Fix logic flaw in `ActionParserRegistration::RemoveParser()` where a caller can remove known parsers, but can't remove custom parsers. Also throw when attempting to remove a known action parser, to be consistent with `ElementParserRegistration`.