### PR TITLE
Fix a couple issues with background color that slipped past PR

### DIFF
--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/ImageBackgroundColorTest.cpp
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/ImageBackgroundColorTest.cpp
@@ -16,7 +16,26 @@ namespace AdaptiveCardsSharedModelUnitTest
     {
 
     public:
-
+		TEST_METHOD(NoBackgroundColorTest)
+		{
+			std::string testJsonString =
+				"{\
+                \"$schema\":\"http://adaptivecards.io/schemas/adaptive-card.json\",\
+                \"type\": \"AdaptiveCard\",\
+                \"version\": \"1.0\",\
+                \"body\": [\
+                    {\
+                        \"type\": \"Image\",\
+                        \"url\": \"Image\"\
+                    }\
+                ]\
+            }";
+			std::shared_ptr<ParseResult> parseResult = AdaptiveCard::DeserializeFromString(testJsonString, 1.0);
+			std::shared_ptr<BaseCardElement> elem = parseResult->GetAdaptiveCard()->GetBody().front();
+			std::shared_ptr<Image> image = std::static_pointer_cast<Image>(elem);
+			std::string backgroundColor = image->GetBackgroundColor();
+			Assert::AreEqual(std::string(""), backgroundColor);
+		}
         TEST_METHOD(AARRGGBBTest)
         {
             std::string testJsonString =

--- a/source/shared/cpp/ObjectModel/Util.cpp
+++ b/source/shared/cpp/ObjectModel/Util.cpp
@@ -37,18 +37,26 @@ void PropagateLanguage(const std::string& language, std::vector<std::shared_ptr<
     }
 }
 
-std::string ValidateColor(const std::string& backgroundColor, std::vector<std::shared_ptr<AdaptiveCardParseWarning>>& warnings) 
+std::string ValidateColor(const std::string& backgroundColor,
+    std::vector<std::shared_ptr<AdaptiveCardParseWarning>>& warnings)
 {
-    size_t backgroundColorLength = backgroundColor.length();
-    bool isValidColor = ((backgroundColor[0] == '#') && (backgroundColorLength == 7 || backgroundColorLength == 9));
+    if (backgroundColor.empty())
+    {
+        return backgroundColor;
+    }
+
+    const size_t backgroundColorLength = backgroundColor.length();
+    bool isValidColor = ((backgroundColor.at(0) == '#') && (backgroundColorLength == 7 || backgroundColorLength == 9));
     for (size_t i = 1; i < backgroundColorLength && isValidColor; ++i)
     {
-        isValidColor = isxdigit(backgroundColor[i]);
+        isValidColor = isxdigit(backgroundColor.at(i));
     }
 
     if (!isValidColor)
     {
-        warnings.emplace_back(std::make_shared<AdaptiveCardParseWarning>(AdaptiveSharedNamespace::WarningStatusCode::InvalidColorFormat, "Image background color doesn't follor #AARRGGBB or #RRGGBB format"));
+        warnings.emplace_back(std::make_shared<AdaptiveCardParseWarning>(
+                AdaptiveSharedNamespace::WarningStatusCode::InvalidColorFormat,
+                "Image background color specified, but doesn't follow #AARRGGBB or #RRGGBB format"));
         return "#00000000";
     }
 
@@ -105,4 +113,3 @@ void ValidateUserInputForDimensionWithUnit(const std::string &unit, const std::s
         }
     }
 }
-


### PR DESCRIPTION
A few issues got missed in PR that needed fixing:
* An `Image` with no `backgroundColor` set would trigger a parse warning because `""` doesn't fit the expected format
* Minor typo in warning string
* Missing a `const`
* Needed to use `at(index)` instead of `[index]`

I also added a unit test for the `backgroundColor`-not-specified case.