### PR TITLE
Add support for auto-versioning

### DIFF
--- a/custom.props
+++ b/custom.props
@@ -3,6 +3,8 @@
   <PropertyGroup Label="Version">
     <VersionMajor>1</VersionMajor>
     <VersionMinor>1</VersionMinor>
+    <!-- The nuget package version should be incremented when we produce QFEs -->
+    <NuGetPackVersion>1.1.0</NuGetPackVersion>
     <VersionInfoProductName>AdaptiveCards</VersionInfoProductName>
   </PropertyGroup>
 </Project>

--- a/custom.props
+++ b/custom.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Version">
+    <VersionMajor>1</VersionMajor>
+    <VersionMinor>1</VersionMinor>
+    <VersionInfoProductName>AdaptiveCards</VersionInfoProductName>
+  </PropertyGroup>
+</Project>

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Html/AdaptiveCards.Rendering.Html.csproj
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Html/AdaptiveCards.Rendering.Html.csproj
@@ -12,6 +12,7 @@
     <RepositoryUrl>https://github.com/Microsoft/AdaptiveCards</RepositoryUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/Microsoft/AdaptiveCards/master/LICENSE</PackageLicenseUrl>
     <DefineConstants>$(DefineConstants);$(AdditionalConstants)</DefineConstants>
+    <GenerateAssemblyInfo Condition="$(Tfs_PackageVersionNumber) != ''">false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf.Xceed/AdaptiveCards.Rendering.Wpf.Xceed.csproj
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf.Xceed/AdaptiveCards.Rendering.Wpf.Xceed.csproj
@@ -13,6 +13,7 @@
     <PackageLicenseUrl>https://raw.githubusercontent.com/Microsoft/AdaptiveCards/master/LICENSE</PackageLicenseUrl>
     <RootNamespace>AdaptiveCards.Rendering.Wpf</RootNamespace>
     <DefineConstants>WPF;$(DefineConstants);$(AdditionalConstants)</DefineConstants>
+    <GenerateAssemblyInfo Condition="$(Tfs_PackageVersionNumber) != ''">false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveCards.Rendering.Wpf.csproj
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveCards.Rendering.Wpf.csproj
@@ -12,6 +12,7 @@
     <RepositoryUrl>https://github.com/Microsoft/AdaptiveCards</RepositoryUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/Microsoft/AdaptiveCards/master/LICENSE</PackageLicenseUrl>
     <DefineConstants>WPF;$(DefineConstants);$(AdditionalConstants)</DefineConstants>
+    <GenerateAssemblyInfo Condition="$(Tfs_PackageVersionNumber) != ''">false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveCards.csproj
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveCards.csproj
@@ -13,6 +13,7 @@
     <PackageLicenseUrl>https://raw.githubusercontent.com/Microsoft/AdaptiveCards/master/LICENSE</PackageLicenseUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <DefineConstants>$(DefineConstants);$(AdditionalConstants)</DefineConstants>
+    <GenerateAssemblyInfo Condition="$(Tfs_PackageVersionNumber) != ''">false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <!--HACKY check to see if UWP SDK is installed, if so, generate a uap10.0 output --> 
@@ -52,5 +53,4 @@
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.4.0" />
   </ItemGroup>
-
 </Project>

--- a/source/dotnet/RunAllTests.ps1
+++ b/source/dotnet/RunAllTests.ps1
@@ -1,12 +1,14 @@
 Push-Location $PSScriptRoot
 
+# Disable our build versionning for the tests as it doesn't support .NETCore
+$env:XES_DISABLEMSBUILDVERSIONING ="True"
+
 $testResultsPath = New-Item -ErrorAction Ignore -ItemType directory -Path .\TestResults\$(get-date -f MM-dd-yyyy-HH-mm-ss)
 New-Item -ItemType directory $testResultsPath/HTML
 New-Item -ItemType directory $testResultsPath/WPF
 
 $samplesPath =  "..\..\..\..\samples\v1.0"
 $scenariosPath = $samplesPath + "\scenarios"
-
 
 Write-Host Running unit tests...
 dotnet test .\test\AdaptiveCards.Test

--- a/source/dotnet/Samples/AdaptiveCards.Sample.Html/AdaptiveCards.Sample.Html.csproj
+++ b/source/dotnet/Samples/AdaptiveCards.Sample.Html/AdaptiveCards.Sample.Html.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    <GenerateAssemblyInfo Condition="$(Tfs_PackageVersionNumber) != ''">false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/dotnet/Samples/AdaptiveCards.Sample.ImageRender/AdaptiveCards.Sample.ImageRender.csproj
+++ b/source/dotnet/Samples/AdaptiveCards.Sample.ImageRender/AdaptiveCards.Sample.ImageRender.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net4.5.2</TargetFramework>
+    <GenerateAssemblyInfo Condition="$(Tfs_PackageVersionNumber) != ''">false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/dotnet/Samples/ImageRendererServer/ImageRendererServer.csproj
+++ b/source/dotnet/Samples/ImageRendererServer/ImageRendererServer.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
+    <GenerateAssemblyInfo Condition="$(Tfs_PackageVersionNumber) != ''">false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/dotnet/Test/AdaptiveCards.Rendering.Html.Test/AdaptiveCards.Rendering.Html.Test.csproj
+++ b/source/dotnet/Test/AdaptiveCards.Rendering.Html.Test/AdaptiveCards.Rendering.Html.Test.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    <GenerateAssemblyInfo Condition="$(Tfs_PackageVersionNumber) != ''">false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/dotnet/Test/AdaptiveCards.Test/AdaptiveCards.Test.csproj
+++ b/source/dotnet/Test/AdaptiveCards.Test/AdaptiveCards.Test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-
+    <GenerateAssemblyInfo Condition="$(Tfs_PackageVersionNumber) != ''">false</GenerateAssemblyInfo>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
Enable auto-versioning of our DLLs and packages. This leverages our internal build infrastructure to automatically stamp the packages and dlls with the build version taken from the `custom.props` files as well as the build number that produced the binaries.
