### PR TITLE
ignore multiple specified values in cases when only 1 is accepted

### DIFF
--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -2391,7 +2391,8 @@ AdaptiveNamespaceStart
 
             XamlHelpers::SetContent(comboBoxItem.Get(), title.Get());
 
-            if (IsChoiceSelected(values, adaptiveChoiceInput))
+            // If multiple values are specified, no option is selected
+            if (values.size() == 1 && IsChoiceSelected(values, adaptiveChoiceInput))
             {
                 selectedIndex = currentIndex;
             }
@@ -2444,6 +2445,8 @@ AdaptiveNamespaceStart
                 ComPtr<IFrameworkElement> frameworkElement;
                 THROW_IF_FAILED(checkBox.As(&frameworkElement));
                 SetStyleFromResourceDictionary(renderContext, L"Adaptive.Input.Choice.Multiselect", frameworkElement.Get());
+
+                XamlHelpers::SetToggleValue(choiceItem.Get(), IsChoiceSelected(values, adaptiveChoiceInput));
             }
             else
             {
@@ -2453,13 +2456,18 @@ AdaptiveNamespaceStart
                 ComPtr<IFrameworkElement> frameworkElement;
                 THROW_IF_FAILED(radioButton.As(&frameworkElement));
                 SetStyleFromResourceDictionary(renderContext, L"Adaptive.Input.Choice.SingleSelect", frameworkElement.Get());
+
+                if (values.size() == 1)
+                {
+                    // When isMultiSelect is false, only 1 specified value is accepted.
+                    // Otherwise, leave all options unset
+                    XamlHelpers::SetToggleValue(choiceItem.Get(), IsChoiceSelected(values, adaptiveChoiceInput));
+                }
             }
 
             HString title;
             THROW_IF_FAILED(adaptiveChoiceInput->get_Title(title.GetAddressOf()));
             XamlHelpers::SetContent(choiceItem.Get(), title.Get());
-
-            XamlHelpers::SetToggleValue(choiceItem.Get(), IsChoiceSelected(values, adaptiveChoiceInput));
 
             THROW_IF_FAILED(AddHandledTappedEvent(choiceItem.Get()));
             


### PR DESCRIPTION
## Modification
Fixed the bug when an `Input.ChoiceSet` has multiple specified values, it should not pre-select any option, whereas right now the option with the biggest value is selected.

## Examples
**Expanded:**
- Payload:
```
{
  "type": "AdaptiveCard",
  "version": "1.0",
  "body": [
    {
      "type": "Input.ChoiceSet",
      "value": "1,3",
      "isMultiSelect": false,
      "style": "expanded",
      "choices": [
        {
          "title": "value 1",
          "value": "1"
        },
        {
          "title": "value 2",
          "value": "2"
        },
        {
          "title": "value 3",
          "value": "3"
        }
      ],
      "id": "4"
    }
  ]
}
```
- Before:
![uwp-expanded](https://user-images.githubusercontent.com/3454845/44357868-1b842800-a468-11e8-8271-8f23bba7bd4a.JPG)

- After:
![uwp-expanded-after](https://user-images.githubusercontent.com/3454845/44357875-1e7f1880-a468-11e8-9c46-14f65c35327b.JPG)


**Collapsed:**
```
{
  "type": "AdaptiveCard",
  "version": "1.0",
  "body": [
    {
      "type": "Input.ChoiceSet",
      "value": "1,3",
      "choices": [
        {
          "title": "value 1",
          "value": "1"
        },
        {
          "title": "value 2",
          "value": "2"
        },
        {
          "title": "value 3",
          "value": "3"
        }
      ],
      "id": "4"
    }
  ]
}
```
- Before
![uwp-collapsed](https://user-images.githubusercontent.com/3454845/44357889-28a11700-a468-11e8-8709-f6ec2c7a709c.JPG)

- After
![uwp-collapsed-after](https://user-images.githubusercontent.com/3454845/44357895-2d65cb00-a468-11e8-8015-2106f4c7c116.JPG)
