### PR TITLE
Add support for BackgroundColor on images in .NET

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Rendering.Html/AdaptiveCardRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Html/AdaptiveCardRenderer.cs
@@ -703,7 +703,6 @@ namespace AdaptiveCards.Rendering.Html
                     break;
             }
 
-
             switch (image.HorizontalAlignment)
             {
                 case AdaptiveHorizontalAlignment.Left:
@@ -722,6 +721,12 @@ namespace AdaptiveCards.Rendering.Html
                         .Style("display", "block");
                     break;
             }
+
+            if (!string.IsNullOrEmpty(image.BackgroundColor))
+            {
+                uiImage.Style("background-color", context.GetRGBColor(image.BackgroundColor));
+            }
+
             uiDiv.Children.Add(uiImage);
 
             AddSelectAction(uiDiv, image.SelectAction, context);

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveImageRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveImageRenderer.cs
@@ -13,19 +13,6 @@ namespace AdaptiveCards.Rendering.Wpf
         {
             FrameworkElement uiBorder = null;
             var uiImage = new Image();
-            // If we have a background color, we'll create a border for the background and put the image on top
-            if (!string.IsNullOrEmpty(image.BackgroundColor))
-            {
-                Color color = (Color)ColorConverter.ConvertFromString(image.BackgroundColor);
-                if (color.A != 0)
-                {
-                    uiBorder = new Border()
-                    {
-                        Background = new SolidColorBrush(color),
-                        Child = uiImage
-                    };
-                }
-            }
 
             // Try to resolve the image URI
             Uri finalUri = context.Config.ResolveFinalAbsoluteUri(image.Url);
@@ -35,7 +22,6 @@ namespace AdaptiveCards.Rendering.Wpf
             }
 
             uiImage.SetSource(finalUri, context);
-
             uiImage.SetHorizontalAlignment(image.HorizontalAlignment);
 
             string style = $"Adaptive.{image.Type}";
@@ -54,14 +40,28 @@ namespace AdaptiveCards.Rendering.Wpf
                 mask.GradientStops.Add(new GradientStop((Color)ColorConverter.ConvertFromString("#ffffffff"), 1.0));
                 mask.GradientStops.Add(new GradientStop((Color)ColorConverter.ConvertFromString("#00ffffff"), 1.0));
                 uiImage.OpacityMask = mask;
-                if (uiBorder != null)
-                {
-                    uiBorder.OpacityMask = mask;
-                }
             }
             uiImage.Style = context.GetStyle(style);
             uiImage.SetImageProperties(image, context);
 
+            // If we have a background color, we'll create a border for the background and put the image on top
+            if (!string.IsNullOrEmpty(image.BackgroundColor))
+            {
+                Color color = (Color)ColorConverter.ConvertFromString(image.BackgroundColor);
+                if (color.A != 0)
+                {
+                    uiBorder = new Border()
+                    {
+                        Background = new SolidColorBrush(color),
+                        Child = uiImage,
+                        Width = uiImage.Width,
+                        Height = uiImage.Height,
+                        HorizontalAlignment = uiImage.HorizontalAlignment,
+                        VerticalAlignment = uiImage.VerticalAlignment,
+                        OpacityMask = uiImage.OpacityMask
+                    };
+                }
+            }
             if (image.SelectAction != null)
             {
                 return context.RenderSelectAction(image.SelectAction, uiBorder ?? uiImage);

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveImage.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveImage.cs
@@ -91,6 +91,17 @@ namespace AdaptiveCards
         public AdaptiveHorizontalAlignment HorizontalAlignment { get; set; }
 
         /// <summary>
+        ///     A background color for the image specified as #AARRGGBB or #RRGGBB
+        /// </summary>
+        [JsonConverter(typeof(HashColorConverter))]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+#if !NETSTANDARD1_3
+        [XmlAttribute]
+#endif
+        [DefaultValue(null)]
+        public string BackgroundColor { get; set; }
+
+        /// <summary>
         ///     Action for this image (this allows a default action to happen when a click on an image happens)
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]

--- a/source/dotnet/Library/AdaptiveCards/HashColorConverter.cs
+++ b/source/dotnet/Library/AdaptiveCards/HashColorConverter.cs
@@ -50,7 +50,7 @@ namespace AdaptiveCards
                 }
             }
 
-            Warnings.Add(new AdaptiveWarning(-1, $"Token \"{reader.Value}\" of type {reader.TokenType} was not specified as a proper color in the format #AARRGGBB or #RRGGBB"));
+            Warnings.Add(new AdaptiveWarning(-1, $"The Value \"{reader.Value}\" for field \"{reader.Path}\" of type \"{reader.TokenType}\" was not specified as a proper color in the format #AARRGGBB or #RRGGBB, it will be ignored."));
             return null;
         }
 

--- a/source/dotnet/Library/AdaptiveCards/HashColorConverter.cs
+++ b/source/dotnet/Library/AdaptiveCards/HashColorConverter.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace AdaptiveCards
+{
+    public class HashColorConverter : JsonConverter, ILogWarnings
+    {
+        public List<AdaptiveWarning> Warnings { get; set; } = new List<AdaptiveWarning>();
+
+        readonly JsonSerializer defaultSerializer = new JsonSerializer();
+
+        public override bool CanConvert(Type objectType)
+        {
+            // Only use this converter for string types that match our format
+            return (objectType == typeof(string));
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            bool fValidString = true;
+            if (reader.TokenType == JsonToken.String)
+            {
+                var colorString = defaultSerializer.Deserialize(reader, objectType) as string;
+                // We need to have a string in the format #AARRGGBB or #RRGGBB
+                if (!string.IsNullOrEmpty(colorString) && (colorString.Length == 7 || colorString.Length == 9) && colorString[0] == '#')
+                {
+                    // Verify that each character is a proper hex digit
+                    for (int i = 1; i < colorString.Length; i++)
+                    {
+                        if (!colorString[i].IsHexDigit())
+                        {
+                            fValidString = false;
+                            break;
+                        }
+                    }
+
+                    // We have the right format, and all the digits are hex, return the string
+                    if (fValidString)
+                    {
+                        if (colorString.Length == 7)
+                        {
+                            return $"#FF{colorString.Substring(1).ToUpperInvariant()}";
+                        }
+                        else
+                        {
+                            return colorString.ToUpperInvariant();
+                        }
+                    }
+                }
+            }
+
+            Warnings.Add(new AdaptiveWarning(-1, $"Token \"{reader.Value}\" of type {reader.TokenType} was not specified as a proper color in the format #AARRGGBB or #RRGGBB"));
+            return null;
+        }
+
+        public override bool CanWrite { get { return false; } }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public static partial class JsonExtensions
+    {
+        public static bool IsHexDigit(this char c)
+        {
+            return (c >= '0' && c <= '9') ||
+                   (c >= 'A' && c <= 'F') ||
+                   (c >= 'a' && c <= 'f');
+        }
+    }
+}

--- a/source/dotnet/Library/AdaptiveCards/StrictIntConverter.cs
+++ b/source/dotnet/Library/AdaptiveCards/StrictIntConverter.cs
@@ -34,7 +34,7 @@ namespace AdaptiveCards
         }
     }
 
-    public static class JsonExtensions
+    public static partial class JsonExtensions
     {
         public static bool IsIntegerType(this Type type)
         {

--- a/source/dotnet/Library/AdaptiveCards/WarningLoggingContractResolver.cs
+++ b/source/dotnet/Library/AdaptiveCards/WarningLoggingContractResolver.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
@@ -15,6 +16,7 @@ namespace AdaptiveCards
         {
             _parseResult = parseResult;
         }
+
         protected override JsonConverter ResolveContractConverter(Type type)
         {
             var converter = base.ResolveContractConverter(type);
@@ -25,6 +27,29 @@ namespace AdaptiveCards
             }
 
             return converter;
+        }
+
+        /// <summary>
+        ///     Override when a member property is being instantiated. At this point we know what converter
+        ///     is being used for the property. If the converter can log warnings, then give it our collection
+        /// </summary>
+        /// <param name="member"></param>
+        /// <param name="memberSerialization"></param>
+        /// <returns></returns>
+        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        {
+            var property = base.CreateProperty(member, memberSerialization);
+            if (property?.Converter is ILogWarnings converter)
+            {
+                converter.Warnings = _parseResult.Warnings;
+            }
+
+            if (property?.MemberConverter is ILogWarnings memberConverter)
+            {
+                memberConverter.Warnings = _parseResult.Warnings;
+            }
+
+            return property;
         }
     }
 }

--- a/source/dotnet/Test/AdaptiveCards.Test/AllPayloadTests.cs
+++ b/source/dotnet/Test/AdaptiveCards.Test/AllPayloadTests.cs
@@ -41,10 +41,6 @@ namespace AdaptiveCards.Test
                 if (file.Contains("Image.ImageBaseUrl"))
                     continue;
 
-                // TODO: bring this test back when issue #1415 is implemented
-                if (file.Contains("Image.BackgroundColor"))
-                    continue;
-
                 try
                 {
                     var json = File.ReadAllText(file, Encoding.UTF8);

--- a/source/dotnet/Test/AdaptiveCards.Test/SerializationTests.cs
+++ b/source/dotnet/Test/AdaptiveCards.Test/SerializationTests.cs
@@ -375,5 +375,46 @@ namespace AdaptiveCards.Test
             var containerNonStyle = card.Body[2] as AdaptiveContainer;
             Assert.AreEqual(null, containerNonStyle.Style);
         }
+
+
+        [TestMethod]
+        public void ImageBackgroundColor()
+        {
+            var json = @"{
+  ""type"": ""AdaptiveCard"",
+  ""version"": ""1.0"",
+  ""body"": [
+    {
+      ""type"": ""Image"",
+      ""url"": ""http://adaptivecards.io/content/cats/2.png"",
+      ""backgroundColor"" : ""Blue""
+    },
+    {
+      ""type"": ""Image"",
+      ""url"": ""http://adaptivecards.io/content/cats/2.png"",
+      ""backgroundColor"" : ""#FF00FF""
+    },
+    {
+      ""type"": ""Image"",
+      ""url"": ""http://adaptivecards.io/content/cats/2.png"",
+      ""backgroundColor"" : ""#FF00FFAA""
+    },
+    {
+      ""type"": ""Image"",
+      ""url"": ""http://adaptivecards.io/content/cats/2.png"",
+      ""backgroundColor"" : ""#FREEBACE""
+    },
+    {
+      ""type"": ""Image"",
+      ""url"": ""http://adaptivecards.io/content/cats/2.png"",
+      ""backgroundColor"" : ""#GREENS""
+    }
+  ]
+}";
+
+            // There should be 3 invalid colors in this card
+            var parseResult = AdaptiveCard.FromJson(json);
+            Assert.AreEqual(3, parseResult.Warnings.Count);
+        }
     }
 }


### PR DESCRIPTION
This adds supports for BackgroundColor on images in the .NET renderer.

As per spec, only #AARRGGBB and #RRGGBB colors are accepted and this is enforced at the object model level.

I had to connect up the warnings to a new converter, since the color is coming is a string, it has to be specifically specified for the field and cannot be a generic type converter.