### PR TITLE
Fix up android CI build

### DIFF
--- a/source/android/build.gradle
+++ b/source/android/build.gradle
@@ -16,6 +16,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 


### PR DESCRIPTION
We were missing a reference to the Google project repos, so we were at the mercy of our build system having already populated the libraries we need.