### PR TITLE
Ordered list support for WPF renderer

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveXamlMarkdownRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveXamlMarkdownRenderer.cs
@@ -14,6 +14,8 @@ namespace AdaptiveCards.Rendering.Wpf
         {
         }
 
+        private static readonly string listMarker = "<ListMarker/>";
+
         public override string Blockquote(string quote)
         {
             // not supported
@@ -76,12 +78,27 @@ namespace AdaptiveCards.Rendering.Wpf
 
         public override string List(string body, bool ordered, int start)
         {
+            if (ordered)
+            {
+                int outputNum;
+                int iMarker;
+                for (outputNum = start, iMarker = body.IndexOf(listMarker);
+                    iMarker > 0; 
+                    iMarker = body.IndexOf(listMarker), outputNum++)
+                {
+                    body = body.Remove(iMarker, listMarker.Length).Insert(iMarker, outputNum.ToString() + ".");
+                }
+            }
+            else
+            {
+                body = body.Replace(listMarker, "•");
+            }
             return $"{body}<LineBreak/>";
         }
 
         public override string ListItem(string text)
         {
-            return $" • {text}<LineBreak/>";
+            return $" {listMarker} {text}<LineBreak/>";
         }
 
         public override string Paragraph(string text)


### PR DESCRIPTION
The dotnet WPF renderer was rendering ordered lists as unordered lists. This fixes that. :)