### PR TITLE
Add 3rd party notices file for FullScreenVideoLayout in Android Renderer

### DIFF
--- a/THIRD-PARTY-NOTICES.TXT
+++ b/THIRD-PARTY-NOTICES.TXT
@@ -1,0 +1,26 @@
+.Adaptive Cards uses third-party libraries or other resources that may be
+distributed under licenses different than the Adaptive Cards Core software.
+
+In the event that we accidentally failed to list a required notice, please
+bring it to our attention. Post an issue or email us:
+
+           adaptivecardsdep@microsoft.com
+
+The attached notices are provided for information only.
+
+License notice for FullScreenVideoLayout
+---------------------------
+
+Copyright (C) 2016 Toshiro Sugii
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
Add a 3rd party notices file that we can use to setup the appropriate attributions.