### PR TITLE
Speak and Language for Fallback Card

### DIFF
--- a/source/android/adaptivecards/src/main/cpp/objectmodel_wrap.cpp
+++ b/source/android/adaptivecards/src/main/cpp/objectmodel_wrap.cpp
@@ -13790,10 +13790,11 @@ SWIGEXPORT jlong JNICALL Java_io_adaptivecards_objectmodel_AdaptiveCardObjectMod
 }
 
 
-SWIGEXPORT jlong JNICALL Java_io_adaptivecards_objectmodel_AdaptiveCardObjectModelJNI_AdaptiveCard_1MakeFallbackTextCard(JNIEnv *jenv, jclass jcls, jstring jarg1, jstring jarg2) {
+SWIGEXPORT jlong JNICALL Java_io_adaptivecards_objectmodel_AdaptiveCardObjectModelJNI_AdaptiveCard_1MakeFallbackTextCard(JNIEnv *jenv, jclass jcls, jstring jarg1, jstring jarg2, jstring jarg3) {
   jlong jresult = 0 ;
   std::string *arg1 = 0 ;
   std::string *arg2 = 0 ;
+  std::string *arg3 = 0 ;
   std::shared_ptr< AdaptiveCards::AdaptiveCard > result;
   
   (void)jenv;
@@ -13816,8 +13817,17 @@ SWIGEXPORT jlong JNICALL Java_io_adaptivecards_objectmodel_AdaptiveCardObjectMod
   std::string arg2_str(arg2_pstr);
   arg2 = &arg2_str;
   jenv->ReleaseStringUTFChars(jarg2, arg2_pstr); 
+  if(!jarg3) {
+    SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null string");
+    return 0;
+  }
+  const char *arg3_pstr = (const char *)jenv->GetStringUTFChars(jarg3, 0); 
+  if (!arg3_pstr) return 0;
+  std::string arg3_str(arg3_pstr);
+  arg3 = &arg3_str;
+  jenv->ReleaseStringUTFChars(jarg3, arg3_pstr); 
   try {
-    result = AdaptiveCards::AdaptiveCard::MakeFallbackTextCard((std::string const &)*arg1,(std::string const &)*arg2);
+    result = AdaptiveCards::AdaptiveCard::MakeFallbackTextCard((std::string const &)*arg1,(std::string const &)*arg2,(std::string const &)*arg3);
   }
   catch(AdaptiveCards::AdaptiveCardParseException &_e) {
     {
@@ -17111,6 +17121,21 @@ SWIGEXPORT jboolean JNICALL Java_io_adaptivecards_objectmodel_AdaptiveCardObject
   (void)jarg1_;
   arg1 = *(AdaptiveCards::MarkDownParser **)&jarg1; 
   result = (bool)(arg1)->HasHtmlTags();
+  jresult = (jboolean)result; 
+  return jresult;
+}
+
+
+SWIGEXPORT jboolean JNICALL Java_io_adaptivecards_objectmodel_AdaptiveCardObjectModelJNI_MarkDownParser_1IsEscaped(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
+  jboolean jresult = 0 ;
+  AdaptiveCards::MarkDownParser *arg1 = (AdaptiveCards::MarkDownParser *) 0 ;
+  bool result;
+  
+  (void)jenv;
+  (void)jcls;
+  (void)jarg1_;
+  arg1 = *(AdaptiveCards::MarkDownParser **)&jarg1; 
+  result = (bool)((AdaptiveCards::MarkDownParser const *)arg1)->IsEscaped();
   jresult = (jboolean)result; 
   return jresult;
 }

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/objectmodel/AdaptiveCard.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/objectmodel/AdaptiveCard.java
@@ -181,8 +181,8 @@ public class AdaptiveCard {
     return (cPtr == 0) ? null : new ParseResult(cPtr, true);
   }
 
-  public static AdaptiveCard MakeFallbackTextCard(String fallbackText, String language) throws java.io.IOException {
-    long cPtr = AdaptiveCardObjectModelJNI.AdaptiveCard_MakeFallbackTextCard(fallbackText, language);
+  public static AdaptiveCard MakeFallbackTextCard(String fallbackText, String language, String speak) throws java.io.IOException {
+    long cPtr = AdaptiveCardObjectModelJNI.AdaptiveCard_MakeFallbackTextCard(fallbackText, language, speak);
     return (cPtr == 0) ? null : new AdaptiveCard(cPtr, true);
   }
 

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/objectmodel/AdaptiveCardObjectModelJNI.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/objectmodel/AdaptiveCardObjectModelJNI.java
@@ -619,7 +619,7 @@ public class AdaptiveCardObjectModelJNI {
   public final static native long AdaptiveCard_DeserializeFromString__SWIG_0(String jarg1, String jarg2, long jarg3, ElementParserRegistration jarg3_, long jarg4, ActionParserRegistration jarg4_) throws java.io.IOException;
   public final static native long AdaptiveCard_DeserializeFromString__SWIG_1(String jarg1, String jarg2, long jarg3, ElementParserRegistration jarg3_) throws java.io.IOException;
   public final static native long AdaptiveCard_DeserializeFromString__SWIG_2(String jarg1, String jarg2) throws java.io.IOException;
-  public final static native long AdaptiveCard_MakeFallbackTextCard(String jarg1, String jarg2) throws java.io.IOException;
+  public final static native long AdaptiveCard_MakeFallbackTextCard(String jarg1, String jarg2, String jarg3) throws java.io.IOException;
   public final static native long AdaptiveCard_SerializeToJsonValue(long jarg1, AdaptiveCard jarg1_);
   public final static native String AdaptiveCard_Serialize(long jarg1, AdaptiveCard jarg1_);
   public final static native void delete_AdaptiveCard(long jarg1);
@@ -838,6 +838,7 @@ public class AdaptiveCardObjectModelJNI {
   public final static native long new_MarkDownParser(String jarg1);
   public final static native String MarkDownParser_TransformToHtml(long jarg1, MarkDownParser jarg1_);
   public final static native boolean MarkDownParser_HasHtmlTags(long jarg1, MarkDownParser jarg1_);
+  public final static native boolean MarkDownParser_IsEscaped(long jarg1, MarkDownParser jarg1_);
   public final static native void delete_MarkDownParser(long jarg1);
   public final static native long new_DateTimePreparsedToken__SWIG_0();
   public final static native long new_DateTimePreparsedToken__SWIG_1(String jarg1, int jarg2);

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/objectmodel/MarkDownParser.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/objectmodel/MarkDownParser.java
@@ -47,4 +47,8 @@ public class MarkDownParser {
     return AdaptiveCardObjectModelJNI.MarkDownParser_HasHtmlTags(swigCPtr, this);
   }
 
+  public boolean IsEscaped() {
+    return AdaptiveCardObjectModelJNI.MarkDownParser_IsEscaped(swigCPtr, this);
+  }
+
 }

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveCardConverter.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveCardConverter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -60,18 +61,32 @@ namespace AdaptiveCards
 
         private AdaptiveCard MakeFallbackTextCard(JObject jObject)
         {
-            // Retrieve fallbackText and language defined by parsed json
-            string language = jObject.Value<string>("language");
+            // Retrieve values defined by parsed json
             string fallbackText = jObject.Value<string>("fallbackText");
+            string speak = jObject.Value<string>("speak");
+            string language = jObject.Value<string>("lang");
 
-            if (String.IsNullOrEmpty(fallbackText))
+            // Replace undefined values by default values
+            if (string.IsNullOrEmpty(fallbackText))
             {
                 fallbackText = "We're sorry, this card couldn't be displayed";
             }
+            if (string.IsNullOrEmpty(speak))
+            {
+                speak = fallbackText;
+            }
+            if (string.IsNullOrEmpty(language))
+            {
+                language = CultureInfo.CurrentCulture.TwoLetterISOLanguageName;
+            }
 
             // Define AdaptiveCard to return
-            AdaptiveCard fallbackTextCard = new AdaptiveCard("1.0");
-            fallbackTextCard.Body.Add(new AdaptiveTextBlock
+            AdaptiveCard fallbackCard = new AdaptiveCard("1.0")
+            {
+                Speak = speak,
+                Lang = language
+            };
+            fallbackCard.Body.Add(new AdaptiveTextBlock
             {
                 Text = fallbackText
             });
@@ -79,7 +94,7 @@ namespace AdaptiveCards
             // Add relevant warning
             Warnings.Add(new AdaptiveWarning((int) WarningStatusCode.UnsupportedSchemaVersion, "Schema version is not supported"));
 
-            return fallbackTextCard;
+            return fallbackCard;
         }
     }
 }

--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/EverythingBagel.cpp
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/EverythingBagel.cpp
@@ -428,10 +428,11 @@ namespace AdaptiveCardsSharedModelUnitTest
 
     void ValidateFallbackCard(const AdaptiveCard &everythingBagel)
     {
-        auto fallbackCard = everythingBagel.MakeFallbackTextCard("fallback"s, "en"s, "");
+        auto fallbackCard = everythingBagel.MakeFallbackTextCard("fallback"s, "en"s, "speak"s);
         auto fallbackTextBlock = std::static_pointer_cast<TextBlock>(fallbackCard->GetBody().at(0));
         Assert::AreEqual("fallback"s, fallbackTextBlock->GetText());
         Assert::AreEqual("en"s, fallbackTextBlock->GetLanguage());
+        Assert::AreEqual("speak"s, fallbackCard->GetSpeak());
     }
 
     TEST_CLASS(EverythingBagel)

--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/EverythingBagel.cpp
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/EverythingBagel.cpp
@@ -428,7 +428,7 @@ namespace AdaptiveCardsSharedModelUnitTest
 
     void ValidateFallbackCard(const AdaptiveCard &everythingBagel)
     {
-        auto fallbackCard = everythingBagel.MakeFallbackTextCard("fallback"s, "en"s);
+        auto fallbackCard = everythingBagel.MakeFallbackTextCard("fallback"s, "en"s, "");
         auto fallbackTextBlock = std::static_pointer_cast<TextBlock>(fallbackCard->GetBody().at(0));
         Assert::AreEqual("fallback"s, fallbackTextBlock->GetText());
         Assert::AreEqual("en"s, fallbackTextBlock->GetLanguage());

--- a/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
+++ b/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
@@ -232,7 +232,8 @@ Json::Value AdaptiveCard::SerializeToJsonValue() const
 #ifdef __ANDROID__
 std::shared_ptr<AdaptiveCard> AdaptiveCard::MakeFallbackTextCard(
     const std::string& fallbackText,
-    const std::string& language) throw(AdaptiveSharedNamespace::AdaptiveCardParseException)
+    const std::string& language,
+    const std::string& speak) throw(AdaptiveSharedNamespace::AdaptiveCardParseException)
 #else
 std::shared_ptr<AdaptiveCard> AdaptiveCard::MakeFallbackTextCard(
     const std::string& fallbackText,

--- a/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
+++ b/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
@@ -103,6 +103,7 @@ std::shared_ptr<ParseResult> AdaptiveCard::Deserialize(
     std::string version = ParseUtil::GetString(json, AdaptiveCardSchemaKey::Version, enforceVersion);
     std::string fallbackText = ParseUtil::GetString(json, AdaptiveCardSchemaKey::FallbackText);
     std::string language = ParseUtil::GetString(json, AdaptiveCardSchemaKey::Language);
+    std::string speak = ParseUtil::GetString(json, AdaptiveCardSchemaKey::Speak);
 
     if (enforceVersion)
     {
@@ -116,15 +117,19 @@ std::shared_ptr<ParseResult> AdaptiveCard::Deserialize(
                 fallbackText = "We're sorry, this card couldn't be displayed";
             }
 
+            if (speak.empty())
+            {
+                speak = fallbackText;
+            }
+
             warnings.push_back(std::make_shared<AdaptiveCardParseWarning>(AdaptiveSharedNamespace::WarningStatusCode::UnsupportedSchemaVersion, "Schema version not supported"));
-            return std::make_shared<ParseResult>(MakeFallbackTextCard(fallbackText, language), warnings);
+            return std::make_shared<ParseResult>(MakeFallbackTextCard(fallbackText, language, speak), warnings);
         }
     }
 
     std::string backgroundImageUrl = ParseUtil::GetString(json, AdaptiveCardSchemaKey::BackgroundImageUrl);
     std::string backgroundImage = backgroundImageUrl != "" ? backgroundImageUrl :
         ParseUtil::GetString(json, AdaptiveCardSchemaKey::BackgroundImage);
-    std::string speak = ParseUtil::GetString(json, AdaptiveCardSchemaKey::Speak);
     ContainerStyle style = ParseUtil::GetEnumValue<ContainerStyle>(json, AdaptiveCardSchemaKey::Style, ContainerStyle::None, ContainerStyleFromString);
     VerticalContentAlignment verticalContentAlignment = ParseUtil::GetEnumValue<VerticalContentAlignment>(json, AdaptiveCardSchemaKey::VerticalContentAlignment,
         VerticalContentAlignment::Top, VerticalContentAlignmentFromString);
@@ -231,10 +236,11 @@ std::shared_ptr<AdaptiveCard> AdaptiveCard::MakeFallbackTextCard(
 #else
 std::shared_ptr<AdaptiveCard> AdaptiveCard::MakeFallbackTextCard(
     const std::string& fallbackText,
-    const std::string& language)
+    const std::string& language,
+    const std::string& speak)
 #endif // __ANDROID__
 {
-    std::shared_ptr<AdaptiveCard> fallbackCard = std::make_shared<AdaptiveCard>("1.0", fallbackText, "", ContainerStyle::Default, "", language, VerticalContentAlignment::Top, HeightType::Auto);
+    std::shared_ptr<AdaptiveCard> fallbackCard = std::make_shared<AdaptiveCard>("1.0", fallbackText, "", ContainerStyle::Default, speak, language, VerticalContentAlignment::Top, HeightType::Auto);
 
     std::shared_ptr<TextBlock> textBlock = std::make_shared<TextBlock>();
     textBlock->SetText(fallbackText);

--- a/source/shared/cpp/ObjectModel/SharedAdaptiveCard.h
+++ b/source/shared/cpp/ObjectModel/SharedAdaptiveCard.h
@@ -97,7 +97,8 @@ public:
 
     static std::shared_ptr<AdaptiveCard> MakeFallbackTextCard(
         const std::string& fallbackText,
-        const std::string& language);
+        const std::string& language,
+        const std::string& speak);
 
 #endif // __ANDROID__
     Json::Value SerializeToJsonValue() const;

--- a/source/shared/cpp/ObjectModel/SharedAdaptiveCard.h
+++ b/source/shared/cpp/ObjectModel/SharedAdaptiveCard.h
@@ -77,7 +77,8 @@ public:
         std::shared_ptr<ActionParserRegistration> actionParserRegistration = nullptr) throw(AdaptiveSharedNamespace::AdaptiveCardParseException);
     static std::shared_ptr<AdaptiveCard> MakeFallbackTextCard(
         const std::string& fallbackText,
-        const std::string& language) throw(AdaptiveSharedNamespace::AdaptiveCardParseException);
+        const std::string& language,
+        const std::string& speak) throw(AdaptiveSharedNamespace::AdaptiveCardParseException);
 #else
     static std::shared_ptr<ParseResult> DeserializeFromFile(
         const std::string& jsonFile,


### PR DESCRIPTION
# Speak for Fallback Card
Added speak to fallback card in .NET and Shared Model. Logic shown in table below:

Text pre-defined? | Speak pre-defined? | Result
------------------- | --------------------- | ------
N | N | Text = Speak = default
N | Y | Text = default, Speak = **SPEAK**'s defined val
Y | N | Text = Speak = **TEXT**'s defined val
Y | Y | Each to their own pre-defined val

# Lang for Fallback Card
Also made fallback card have language.
* **SharedModel**: if lang not defined, pass on as empty/not-defined and have renderer deal with it
* **.NET**: at parse time, if lang not defined, set to `CultureInfo.CurrentCulture.TwoLetterISOLanguageName`

This one seems a little odd, so let me know what your thoughts are.
