### PR TITLE
Remove Resource Type from the RemoteResourceInformation structure

### DIFF
--- a/source/android/adaptivecards/src/main/cpp/objectmodel_wrap.cpp
+++ b/source/android/adaptivecards/src/main/cpp/objectmodel_wrap.cpp
@@ -5007,40 +5007,6 @@ SWIGEXPORT jstring JNICALL Java_io_adaptivecards_objectmodel_AdaptiveCardObjectM
 }
 
 
-SWIGEXPORT void JNICALL Java_io_adaptivecards_objectmodel_AdaptiveCardObjectModelJNI_RemoteResourceInformation_1resourceType_1set(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jint jarg2) {
-  AdaptiveCards::RemoteResourceInformation *arg1 = (AdaptiveCards::RemoteResourceInformation *) 0 ;
-  AdaptiveCards::CardElementType arg2 ;
-  std::shared_ptr< AdaptiveCards::RemoteResourceInformation > *smartarg1 = 0 ;
-  
-  (void)jenv;
-  (void)jcls;
-  (void)jarg1_;
-  
-  smartarg1 = *(std::shared_ptr<  AdaptiveCards::RemoteResourceInformation > **)&jarg1;
-  arg1 = (AdaptiveCards::RemoteResourceInformation *)(smartarg1 ? smartarg1->get() : 0); 
-  arg2 = (AdaptiveCards::CardElementType)jarg2; 
-  if (arg1) (arg1)->resourceType = arg2;
-}
-
-
-SWIGEXPORT jint JNICALL Java_io_adaptivecards_objectmodel_AdaptiveCardObjectModelJNI_RemoteResourceInformation_1resourceType_1get(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
-  jint jresult = 0 ;
-  AdaptiveCards::RemoteResourceInformation *arg1 = (AdaptiveCards::RemoteResourceInformation *) 0 ;
-  std::shared_ptr< AdaptiveCards::RemoteResourceInformation > *smartarg1 = 0 ;
-  AdaptiveCards::CardElementType result;
-  
-  (void)jenv;
-  (void)jcls;
-  (void)jarg1_;
-  
-  smartarg1 = *(std::shared_ptr<  AdaptiveCards::RemoteResourceInformation > **)&jarg1;
-  arg1 = (AdaptiveCards::RemoteResourceInformation *)(smartarg1 ? smartarg1->get() : 0); 
-  result = (AdaptiveCards::CardElementType) ((arg1)->resourceType);
-  jresult = (jint)result; 
-  return jresult;
-}
-
-
 SWIGEXPORT void JNICALL Java_io_adaptivecards_objectmodel_AdaptiveCardObjectModelJNI_RemoteResourceInformation_1mimeType_1set(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jstring jarg2) {
   AdaptiveCards::RemoteResourceInformation *arg1 = (AdaptiveCards::RemoteResourceInformation *) 0 ;
   std::string *arg2 = 0 ;
@@ -17111,6 +17077,21 @@ SWIGEXPORT jboolean JNICALL Java_io_adaptivecards_objectmodel_AdaptiveCardObject
   (void)jarg1_;
   arg1 = *(AdaptiveCards::MarkDownParser **)&jarg1; 
   result = (bool)(arg1)->HasHtmlTags();
+  jresult = (jboolean)result; 
+  return jresult;
+}
+
+
+SWIGEXPORT jboolean JNICALL Java_io_adaptivecards_objectmodel_AdaptiveCardObjectModelJNI_MarkDownParser_1IsEscaped(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
+  jboolean jresult = 0 ;
+  AdaptiveCards::MarkDownParser *arg1 = (AdaptiveCards::MarkDownParser *) 0 ;
+  bool result;
+  
+  (void)jenv;
+  (void)jcls;
+  (void)jarg1_;
+  arg1 = *(AdaptiveCards::MarkDownParser **)&jarg1; 
+  result = (bool)((AdaptiveCards::MarkDownParser const *)arg1)->IsEscaped();
   jresult = (jboolean)result; 
   return jresult;
 }

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/objectmodel/AdaptiveCardObjectModelJNI.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/objectmodel/AdaptiveCardObjectModelJNI.java
@@ -212,8 +212,6 @@ public class AdaptiveCardObjectModelJNI {
   public final static native int VerticalContentAlignmentFromString(String jarg1);
   public final static native void RemoteResourceInformation_url_set(long jarg1, RemoteResourceInformation jarg1_, String jarg2);
   public final static native String RemoteResourceInformation_url_get(long jarg1, RemoteResourceInformation jarg1_);
-  public final static native void RemoteResourceInformation_resourceType_set(long jarg1, RemoteResourceInformation jarg1_, int jarg2);
-  public final static native int RemoteResourceInformation_resourceType_get(long jarg1, RemoteResourceInformation jarg1_);
   public final static native void RemoteResourceInformation_mimeType_set(long jarg1, RemoteResourceInformation jarg1_, String jarg2);
   public final static native String RemoteResourceInformation_mimeType_get(long jarg1, RemoteResourceInformation jarg1_);
   public final static native long new_RemoteResourceInformation();
@@ -838,6 +836,7 @@ public class AdaptiveCardObjectModelJNI {
   public final static native long new_MarkDownParser(String jarg1);
   public final static native String MarkDownParser_TransformToHtml(long jarg1, MarkDownParser jarg1_);
   public final static native boolean MarkDownParser_HasHtmlTags(long jarg1, MarkDownParser jarg1_);
+  public final static native boolean MarkDownParser_IsEscaped(long jarg1, MarkDownParser jarg1_);
   public final static native void delete_MarkDownParser(long jarg1);
   public final static native long new_DateTimePreparsedToken__SWIG_0();
   public final static native long new_DateTimePreparsedToken__SWIG_1(String jarg1, int jarg2);

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/objectmodel/MarkDownParser.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/objectmodel/MarkDownParser.java
@@ -47,4 +47,8 @@ public class MarkDownParser {
     return AdaptiveCardObjectModelJNI.MarkDownParser_HasHtmlTags(swigCPtr, this);
   }
 
+  public boolean IsEscaped() {
+    return AdaptiveCardObjectModelJNI.MarkDownParser_IsEscaped(swigCPtr, this);
+  }
+
 }

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/objectmodel/RemoteResourceInformation.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/objectmodel/RemoteResourceInformation.java
@@ -43,14 +43,6 @@ public class RemoteResourceInformation {
     return AdaptiveCardObjectModelJNI.RemoteResourceInformation_url_get(swigCPtr, this);
   }
 
-  public void setResourceType(CardElementType value) {
-    AdaptiveCardObjectModelJNI.RemoteResourceInformation_resourceType_set(swigCPtr, this, value.swigValue());
-  }
-
-  public CardElementType getResourceType() {
-    return CardElementType.swigToEnum(AdaptiveCardObjectModelJNI.RemoteResourceInformation_resourceType_get(swigCPtr, this));
-  }
-
   public void setMimeType(String value) {
     AdaptiveCardObjectModelJNI.RemoteResourceInformation_mimeType_set(swigCPtr, this, value);
   }

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveCard.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveCard.cs
@@ -281,8 +281,7 @@ namespace AdaptiveCards
             {
                 resourceInformationList.Add(new RemoteResourceInformation(
                     card.BackgroundImageString,
-                    typeof(AdaptiveImage),
-                    null
+                    "image"
                 ));
             }
 
@@ -300,8 +299,7 @@ namespace AdaptiveCards
                 {
                     resourceInformationList.Add(new RemoteResourceInformation(
                         action.IconUrl,
-                        typeof(AdaptiveImage),
-                        null
+                        "image"
                     ));
                 }
 
@@ -324,8 +322,7 @@ namespace AdaptiveCards
             {
                 resourceInformationList.Add(new RemoteResourceInformation(
                     imageElement.UrlString,
-                    typeof(AdaptiveImage),
-                    null
+                    "image"
                 ));
             }
 

--- a/source/dotnet/Library/AdaptiveCards/RemoteResourceInformation.cs
+++ b/source/dotnet/Library/AdaptiveCards/RemoteResourceInformation.cs
@@ -9,13 +9,11 @@ namespace AdaptiveCards
     public struct RemoteResourceInformation
     {
         readonly string url;
-        readonly Type type;
         readonly string mimeType;
 
-        public RemoteResourceInformation(string url, Type type, string mimeType)
+        public RemoteResourceInformation(string url, string mimeType)
         {
             this.url = url;
-            this.type = type;
             this.mimeType = mimeType;
         }
     }

--- a/source/dotnet/Test/AdaptiveCards.Test/AdaptiveCardApiTests.cs
+++ b/source/dotnet/Test/AdaptiveCards.Test/AdaptiveCardApiTests.cs
@@ -189,38 +189,31 @@ namespace AdaptiveCards.Test
             {
                 new RemoteResourceInformation(
                     "http://adaptivecards.io/content/cats/1.png",
-                    typeof(AdaptiveImage),
-                    null
+                    "image"
                 ),
                 new RemoteResourceInformation(
                     "http://adaptivecards.io/content/cats/2.png",
-                    typeof(AdaptiveImage),
-                    null
+                    "image"
                 ),
                 new RemoteResourceInformation(
                     "http://adaptivecards.io/content/cats/3.png",
-                    typeof(AdaptiveImage),
-                    null
+                    "image"
                 ),
                 new RemoteResourceInformation(
                     "http://adaptivecards.io/content/cats/2.png",
-                    typeof(AdaptiveImage),
-                    null
+                    "image"
                 ),
                 new RemoteResourceInformation(
                     "content/cats/4.png",
-                    typeof(AdaptiveImage),
-                    null
+                    "image"
                 ),
                 new RemoteResourceInformation(
                     "http://adaptivecards.io/content/cats/5.png",
-                    typeof(AdaptiveImage),
-                    null
+                    "image"
                 ),
                 new RemoteResourceInformation(
                     "http://adaptivecards.io/content/cats/6.png",
-                    typeof(AdaptiveImage),
-                    null
+                    "image"
                 )
             };
             var actual = card.GetResourceInformation();

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizerTests/ADCIOSVisualizerTests.mm
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizerTests/ADCIOSVisualizerTests.mm
@@ -64,8 +64,7 @@
         unsigned int index = 0;
         for(ACORemoteResourceInformation *info in remoteInformation){
             XCTAssertTrue([[testStrings objectAtIndex:index++] isEqualToString:info.url.absoluteString]);        
-            XCTAssertTrue([@"" isEqualToString:info.mimeType]);     
-            XCTAssertTrue(ACRImage == info.resourceType);
+            XCTAssertTrue([@"Image" isEqualToString:info.mimeType]);     
         }
     }
 }

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACORemoteResourceInformation.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACORemoteResourceInformation.h
@@ -11,7 +11,6 @@
 @interface ACORemoteResourceInformation:NSObject
 
 @property (readonly) NSURL* url;
-@property (readonly) ACRCardElementType resourceType;
 @property (readonly) NSString* mimeType;
 
 @end    

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACORemoteResourceInformation.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACORemoteResourceInformation.mm
@@ -20,7 +20,6 @@ using namespace AdaptiveCards;
             _url =[NSURL URLWithString:URLString];
         }
         _mimeType = [NSString stringWithCString:remoteResourceInformation.mimeType.c_str() encoding:NSUTF8StringEncoding]; ;
-        _resourceType = (ACRCardElementType)remoteResourceInformation.resourceType;
     }
     return self;
 }

--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/ResourceInformationTests.cpp
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/ResourceInformationTests.cpp
@@ -46,16 +46,16 @@ namespace AdaptiveCardsSharedModelUnitTest
         {
             // Expected images to find in the card
             std::vector<RemoteResourceInformation> expectedValues = {
-                {"BackgroundImage.png", "Image"},
-                { "Image.png", "Image" },
-                { "ImageSet.Image1.png", "Image" },
-                { "ImageSet.Image2.png", "Image" },
-                { "Container.Image1.png", "Image" },
-                { "Container.Image2.png", "Image" },
-                { "ColumnSet.Column1.Image.png", "Image" },
-                { "ColumnSet.Column2.Image.png", "Image" },
-                { "ShowCard.Image.png", "Image" },
-                { "Media.Poster.png", "Image" },
+                {"BackgroundImage.png", "image"},
+                { "Image.png", "image" },
+                { "ImageSet.Image1.png", "image" },
+                { "ImageSet.Image2.png", "image" },
+                { "Container.Image1.png", "image" },
+                { "Container.Image2.png", "image" },
+                { "ColumnSet.Column1.Image.png", "image" },
+                { "ColumnSet.Column2.Image.png", "image" },
+                { "ShowCard.Image.png", "image" },
+                { "Media.Poster.png", "image" },
                 { "Media1.mp4", "video/mp4" },
                 { "Media2.ogg", "video/ogg" },
             };
@@ -170,10 +170,10 @@ namespace AdaptiveCardsSharedModelUnitTest
         {
             // Expected images to find in the card
             std::vector<RemoteResourceInformation> expectedValues = {
-                { "BackgroundImage.png", "Image" },
-                { "Image.png", "Image" },
-                { "Custom.png", "Image" },
-                { "Action.Custom.png", "Image" },
+                { "BackgroundImage.png", "image" },
+                { "Image.png", "image" },
+                { "Custom.png", "image" },
+                { "Action.Custom.png", "image" },
             };
 
             // Test card containing custom element and action with images
@@ -218,7 +218,7 @@ namespace AdaptiveCardsSharedModelUnitTest
                     {
                         RemoteResourceInformation resourceInfo;
                         resourceInfo.url = m_customImage;
-                        resourceInfo.mimeType = "Image";
+                        resourceInfo.mimeType = "image";
                         resourceUris.push_back(resourceInfo);
                     }
 
@@ -270,10 +270,10 @@ namespace AdaptiveCardsSharedModelUnitTest
         {
             // Expected images to find in the card
             std::vector<RemoteResourceInformation> expectedValues = {
-                { "BackgroundImage.png", "Image" },
-                { "Image.png", "Image" },
-                { "SubmitAction.png", "Image" },
-                { "OpenUrl.png", "Image" },
+                { "BackgroundImage.png", "image" },
+                { "Image.png", "image" },
+                { "SubmitAction.png", "image" },
+                { "OpenUrl.png", "image" },
             };
 
             // Test card containing custom element and action with images

--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/ResourceInformationTests.cpp
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/ResourceInformationTests.cpp
@@ -28,7 +28,6 @@ namespace AdaptiveCardsSharedModelUnitTest
                 for (auto resourceInfo : resourceInfos)
                 {
                     if (resourceInfo.url == expectedValue.url &&
-                        resourceInfo.resourceType == expectedValue.resourceType &&
                         resourceInfo.mimeType == expectedValue.mimeType)
                     {
                         found = true;
@@ -47,18 +46,18 @@ namespace AdaptiveCardsSharedModelUnitTest
         {
             // Expected images to find in the card
             std::vector<RemoteResourceInformation> expectedValues = {
-                {"BackgroundImage.png", CardElementType::Image, ""},
-                { "Image.png", CardElementType::Image, "" },
-                { "ImageSet.Image1.png", CardElementType::Image, "" },
-                { "ImageSet.Image2.png", CardElementType::Image, "" },
-                { "Container.Image1.png", CardElementType::Image, "" },
-                { "Container.Image2.png", CardElementType::Image, "" },
-                { "ColumnSet.Column1.Image.png", CardElementType::Image, "" },
-                { "ColumnSet.Column2.Image.png", CardElementType::Image, "" },
-                { "ShowCard.Image.png", CardElementType::Image, "" },
-                { "Media.Poster.png", CardElementType::Image, "" },
-                { "Media1.mp4", CardElementType::Media, "video/mp4" },
-                { "Media2.ogg", CardElementType::Media, "video/ogg" },
+                {"BackgroundImage.png", "Image"},
+                { "Image.png", "Image" },
+                { "ImageSet.Image1.png", "Image" },
+                { "ImageSet.Image2.png", "Image" },
+                { "Container.Image1.png", "Image" },
+                { "Container.Image2.png", "Image" },
+                { "ColumnSet.Column1.Image.png", "Image" },
+                { "ColumnSet.Column2.Image.png", "Image" },
+                { "ShowCard.Image.png", "Image" },
+                { "Media.Poster.png", "Image" },
+                { "Media1.mp4", "video/mp4" },
+                { "Media2.ogg", "video/ogg" },
             };
 
             // Test card containing all supported image locations
@@ -171,10 +170,10 @@ namespace AdaptiveCardsSharedModelUnitTest
         {
             // Expected images to find in the card
             std::vector<RemoteResourceInformation> expectedValues = {
-                { "BackgroundImage.png", CardElementType::Image, "" },
-                { "Image.png", CardElementType::Image, "" },
-                { "Custom.png", CardElementType::Image, "" },
-                { "Action.Custom.png", CardElementType::Image, "" },
+                { "BackgroundImage.png", "Image" },
+                { "Image.png", "Image" },
+                { "Custom.png", "Image" },
+                { "Action.Custom.png", "Image" },
             };
 
             // Test card containing custom element and action with images
@@ -219,7 +218,7 @@ namespace AdaptiveCardsSharedModelUnitTest
                     {
                         RemoteResourceInformation resourceInfo;
                         resourceInfo.url = m_customImage;
-                        resourceInfo.resourceType = CardElementType::Image;
+                        resourceInfo.mimeType = "Image";
                         resourceUris.push_back(resourceInfo);
                     }
 
@@ -271,10 +270,10 @@ namespace AdaptiveCardsSharedModelUnitTest
         {
             // Expected images to find in the card
             std::vector<RemoteResourceInformation> expectedValues = {
-                { "BackgroundImage.png", CardElementType::Image, "" },
-                { "Image.png", CardElementType::Image, "" },
-                { "SubmitAction.png", CardElementType::Image, "" },
-                { "OpenUrl.png", CardElementType::Image, "" },
+                { "BackgroundImage.png", "Image" },
+                { "Image.png", "Image" },
+                { "SubmitAction.png", "Image" },
+                { "OpenUrl.png", "Image" },
             };
 
             // Test card containing custom element and action with images

--- a/source/shared/cpp/ObjectModel/BaseActionElement.cpp
+++ b/source/shared/cpp/ObjectModel/BaseActionElement.cpp
@@ -101,7 +101,7 @@ void BaseActionElement::GetResourceInformation(std::vector<RemoteResourceInforma
     {
         RemoteResourceInformation imageResourceInfo;
         imageResourceInfo.url = m_iconUrl;
-        imageResourceInfo.resourceType = CardElementType::Image;
+        imageResourceInfo.mimeType = "Image";
         resourceInfo.push_back(imageResourceInfo);
     }
 }

--- a/source/shared/cpp/ObjectModel/BaseActionElement.cpp
+++ b/source/shared/cpp/ObjectModel/BaseActionElement.cpp
@@ -101,7 +101,7 @@ void BaseActionElement::GetResourceInformation(std::vector<RemoteResourceInforma
     {
         RemoteResourceInformation imageResourceInfo;
         imageResourceInfo.url = m_iconUrl;
-        imageResourceInfo.mimeType = "Image";
+        imageResourceInfo.mimeType = "image";
         resourceInfo.push_back(imageResourceInfo);
     }
 }

--- a/source/shared/cpp/ObjectModel/Image.cpp
+++ b/source/shared/cpp/ObjectModel/Image.cpp
@@ -259,7 +259,7 @@ void Image::GetResourceInformation(std::vector<RemoteResourceInformation>& resou
 {
     RemoteResourceInformation imageResourceInfo;
     imageResourceInfo.url = GetUrl();
-    imageResourceInfo.resourceType = CardElementType::Image;
+    imageResourceInfo.mimeType = "Image";
     resourceInfo.push_back(imageResourceInfo);
     return;
 }

--- a/source/shared/cpp/ObjectModel/Image.cpp
+++ b/source/shared/cpp/ObjectModel/Image.cpp
@@ -259,7 +259,7 @@ void Image::GetResourceInformation(std::vector<RemoteResourceInformation>& resou
 {
     RemoteResourceInformation imageResourceInfo;
     imageResourceInfo.url = GetUrl();
-    imageResourceInfo.mimeType = "Image";
+    imageResourceInfo.mimeType = "image";
     resourceInfo.push_back(imageResourceInfo);
     return;
 }

--- a/source/shared/cpp/ObjectModel/Media.cpp
+++ b/source/shared/cpp/ObjectModel/Media.cpp
@@ -70,7 +70,7 @@ void Media::GetResourceInformation(std::vector<RemoteResourceInformation>& resou
 {
     RemoteResourceInformation posterResourceInfo;
     posterResourceInfo.url = GetPoster();
-    posterResourceInfo.mimeType = "Image";
+    posterResourceInfo.mimeType = "image";
     resourceInfo.push_back(posterResourceInfo);
 
     auto sources = GetSources();

--- a/source/shared/cpp/ObjectModel/Media.cpp
+++ b/source/shared/cpp/ObjectModel/Media.cpp
@@ -70,7 +70,7 @@ void Media::GetResourceInformation(std::vector<RemoteResourceInformation>& resou
 {
     RemoteResourceInformation posterResourceInfo;
     posterResourceInfo.url = GetPoster();
-    posterResourceInfo.resourceType = CardElementType::Image;
+    posterResourceInfo.mimeType = "Image";
     resourceInfo.push_back(posterResourceInfo);
 
     auto sources = GetSources();

--- a/source/shared/cpp/ObjectModel/MediaSource.cpp
+++ b/source/shared/cpp/ObjectModel/MediaSource.cpp
@@ -49,7 +49,6 @@ void MediaSource::GetResourceInformation(std::vector<RemoteResourceInformation>&
 {
     RemoteResourceInformation sourceInfo;
     sourceInfo.url = GetUrl();
-    sourceInfo.resourceType = CardElementType::Media;
     sourceInfo.mimeType = GetMimeType();
 
     resourceInfo.push_back(sourceInfo);

--- a/source/shared/cpp/ObjectModel/RemoteResourceInformation.h
+++ b/source/shared/cpp/ObjectModel/RemoteResourceInformation.h
@@ -7,7 +7,6 @@ namespace AdaptiveSharedNamespace {
     struct RemoteResourceInformation
     {
         std::string url;
-        AdaptiveCards::CardElementType resourceType = CardElementType::Image;
         std::string mimeType;
     };
 

--- a/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
+++ b/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
@@ -399,7 +399,7 @@ std::vector<RemoteResourceInformation> AdaptiveCard::GetResourceInformation()
     {
         RemoteResourceInformation backgroundImageInfo;
         backgroundImageInfo.url = backgroundImage;
-        backgroundImageInfo.mimeType = "Image";
+        backgroundImageInfo.mimeType = "image";
         resourceVector.push_back(backgroundImageInfo);
     }
 

--- a/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
+++ b/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
@@ -399,7 +399,7 @@ std::vector<RemoteResourceInformation> AdaptiveCard::GetResourceInformation()
     {
         RemoteResourceInformation backgroundImageInfo;
         backgroundImageInfo.url = backgroundImage;
-        backgroundImageInfo.resourceType = CardElementType::Image;
+        backgroundImageInfo.mimeType = "Image";
         resourceVector.push_back(backgroundImageInfo);
     }
 

--- a/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
+++ b/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
@@ -504,9 +504,6 @@ AdaptiveNamespaceStart
         [propget] HRESULT Url([out, retval] HSTRING* value);
         [propput] HRESULT Url([in] HSTRING value);
 
-        [propget] HRESULT ResourceType([out, retval] ElementType* value);
-        [propput] HRESULT ResourceType([in] ElementType value);
-
         [propget] HRESULT MimeType([out, retval] HSTRING* value);
         [propput] HRESULT MimeType([in] HSTRING value);
     };

--- a/source/uwp/Renderer/lib/AdaptiveCard.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveCard.cpp
@@ -354,8 +354,6 @@ AdaptiveNamespaceStart
             RETURN_IF_FAILED(UTF8ToHString(sharedResourceInformation.mimeType, mimeType.GetAddressOf()));
             RETURN_IF_FAILED(remoteResourceInformation->put_MimeType(mimeType.Get()));
 
-            RETURN_IF_FAILED(remoteResourceInformation->put_ResourceType(static_cast<ABI::AdaptiveNamespace::ElementType>(sharedResourceInformation.resourceType)));
-
             RETURN_IF_FAILED(resourceInformation->Append(remoteResourceInformation.Get()));
         }
 

--- a/source/uwp/Renderer/lib/AdaptiveRemoteResourceInformation.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveRemoteResourceInformation.cpp
@@ -21,7 +21,6 @@ AdaptiveNamespaceStart
     {
         RETURN_IF_FAILED(UTF8ToHString(uriInformation.url, m_url.GetAddressOf()));
         RETURN_IF_FAILED(UTF8ToHString(uriInformation.mimeType, m_mimeType.GetAddressOf()));
-        m_urlType = static_cast<ABI::AdaptiveNamespace::ElementType>(uriInformation.resourceType);
 
         return S_OK;
     } CATCH_RETURN;
@@ -48,20 +47,6 @@ AdaptiveNamespaceStart
     HRESULT AdaptiveRemoteResourceInformation::put_MimeType(HSTRING mimeType)
     {
         return m_mimeType.Set(mimeType);
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveRemoteResourceInformation::get_ResourceType(ElementType* elementType)
-    {
-        *elementType = m_urlType;
-        return S_OK;
-    }
-
-    _Use_decl_annotations_
-    HRESULT AdaptiveRemoteResourceInformation::put_ResourceType(ElementType elementType)
-    {
-        m_urlType = elementType;
-        return S_OK;
     }
 
 AdaptiveNamespaceEnd

--- a/source/uwp/Renderer/lib/AdaptiveRemoteResourceInformation.h
+++ b/source/uwp/Renderer/lib/AdaptiveRemoteResourceInformation.h
@@ -21,16 +21,12 @@ AdaptiveNamespaceStart
         IFACEMETHODIMP get_Url(_Out_ HSTRING *url);
         IFACEMETHODIMP put_Url(_In_ HSTRING url);
 
-        IFACEMETHODIMP get_ResourceType(_Out_ ABI::AdaptiveNamespace::ElementType* elementType);
-        IFACEMETHODIMP put_ResourceType(ABI::AdaptiveNamespace::ElementType elementType);
-
         IFACEMETHODIMP get_MimeType(_Out_ HSTRING *text);
         IFACEMETHODIMP put_MimeType(_In_ HSTRING text);
 
     private:
         Microsoft::WRL::Wrappers::HString m_url;
         Microsoft::WRL::Wrappers::HString m_mimeType;
-        ABI::AdaptiveNamespace::ElementType m_urlType;
     };
 
     ActivatableClass(AdaptiveRemoteResourceInformation);

--- a/source/uwp/Renderer/lib/Util.cpp
+++ b/source/uwp/Renderer/lib/Util.cpp
@@ -867,11 +867,6 @@ void RemoteResourceElementToRemoteResourceInformationVector(
         RemoteResourceInformation uriInfo;
         THROW_IF_FAILED(HStringToUTF8(url.Get(), uriInfo.url));
 
-        ABI::AdaptiveNamespace::ElementType elementType;
-        THROW_IF_FAILED(resourceInformation->get_ResourceType(&elementType));
-
-        uriInfo.resourceType = (AdaptiveSharedNamespace::CardElementType) elementType;
-
         HString mimeType;
         THROW_IF_FAILED(resourceInformation->get_MimeType(mimeType.GetAddressOf()));
 


### PR DESCRIPTION
ResourceType was intended to indicate the type of a resource for which we didn't have an author provided mimeType. This has proved to be confusing, so updated the code to just set the mimeType to "image" for image types.