### PR TITLE
[Android] Move time Handler initialization away from card rendering

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/layout/FullscreenVideoLayout.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/layout/FullscreenVideoLayout.java
@@ -41,7 +41,7 @@ import java.util.Locale;
 public class FullscreenVideoLayout extends FullscreenVideoView implements View.OnClickListener, SeekBar.OnSeekBarChangeListener, MediaPlayer.OnPreparedListener, View.OnTouchListener
 {
     // Handler and Runnable to keep tracking on elapsed time
-    protected static final Handler TIME_THREAD = new Handler();
+    protected static Handler TIME_THREAD = null;
     protected Runnable updateTimeRunnable = new Runnable()
     {
         public void run()
@@ -172,6 +172,10 @@ public class FullscreenVideoLayout extends FullscreenVideoView implements View.O
 
     protected void startCounter()
     {
+        if(TIME_THREAD == null)
+        {
+            TIME_THREAD = new Handler();
+        }
         TIME_THREAD.postDelayed(updateTimeRunnable, 200);
     }
 

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/layout/FullscreenVideoLayout.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/layout/FullscreenVideoLayout.java
@@ -16,6 +16,10 @@ package io.adaptivecards.renderer.layout;
  * limitations under the License.
  */
 
+/**
+ * Portions Copyright (c) Microsoft Corporation
+ */
+
 import android.content.Context;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/layout/FullscreenVideoView.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/layout/FullscreenVideoView.java
@@ -53,6 +53,11 @@ import io.adaptivecards.renderer.registration.CardRendererRegistration;
  * @version 2015.0527
  * @since 1.0
  */
+
+/**
+ * Portions Copyright (c) Microsoft Corporation
+ */
+
 @SuppressLint("NewApi")
 public class FullscreenVideoView extends FrameLayout implements OnPreparedListener, OnErrorListener, OnSeekCompleteListener, OnCompletionListener, OnInfoListener, OnVideoSizeChangedListener, OnBufferingUpdateListener, TextureView.SurfaceTextureListener
 {

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/MediaRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/MediaRenderer.java
@@ -243,7 +243,7 @@ public class MediaRenderer extends BaseCardElementRenderer
                     {
                         try
                         {
-                            new MediaLoaderAsync(mediaView, mediaSource, hostConfig, isAudio, context).execute("").get();
+                            new MediaLoaderAsync(mediaView, mediaSource, hostConfig, isAudio, context).execute("");
                             break;
                         }
                         catch (Exception e)

--- a/source/android/mobilechatapp/src/main/java/com/example/mobilechatapp/MainActivity.java
+++ b/source/android/mobilechatapp/src/main/java/com/example/mobilechatapp/MainActivity.java
@@ -76,10 +76,7 @@ public class MainActivity extends AppCompatActivity implements ICardActionHandle
                         {
                             if(card.getParsedCard() != null)
                             {
-                                if(!card.ContainsElementType("media"))
-                                {
-                                    m_adapter.addItem(card.getFileName(), card.getParsedCard(), MainActivity.this, getSupportFragmentManager(), MainActivity.this, m_hostConfig);
-                                }
+                                m_adapter.addItem(card.getFileName(), card.getParsedCard(), MainActivity.this, getSupportFragmentManager(), MainActivity.this, m_hostConfig);
                             }
                             else
                             {


### PR DESCRIPTION
Fixes this issue: https://github.com/Microsoft/AdaptiveCards/issues/1897