### PR TITLE
Restore the functionality that when SubmitAction has an empty value, …

### DIFF
--- a/source/shared/cpp/ObjectModel/SubmitAction.cpp
+++ b/source/shared/cpp/ObjectModel/SubmitAction.cpp
@@ -11,7 +11,14 @@ SubmitAction::SubmitAction() : BaseActionElement(ActionType::Submit)
 
 std::string SubmitAction::GetDataJson() const
 {
-    return m_dataJson.toStyledString();
+    if(m_dataJson.empty())
+    {
+        return "";
+    }
+    else
+    {
+        return m_dataJson.toStyledString();
+    }
 }
 
 Json::Value SubmitAction::GetDataJsonAsValue() const


### PR DESCRIPTION
…an empty string is returned instead of "null\n"