### PR TITLE
Remove namespace macros in UWP

### DIFF
--- a/source/uwp/Renderer/lib/AdaptiveActionElement.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveActionElement.cpp
@@ -9,7 +9,7 @@ using namespace ABI::Windows::Foundation::Collections;
 using namespace ABI::Windows::UI::Xaml;
 using namespace ABI::Windows::UI::Xaml::Controls;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveActionElementBase::InitializeBaseElement(const std::shared_ptr<AdaptiveSharedNamespace::BaseActionElement>& sharedModel)
     {
         RETURN_IF_FAILED(UTF8ToHString(sharedModel->GetId(), m_id.GetAddressOf()));
@@ -95,4 +95,4 @@ AdaptiveNamespaceStart
 
         return S_OK;
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveActionElement.h
+++ b/source/uwp/Renderer/lib/AdaptiveActionElement.h
@@ -4,7 +4,7 @@
 #include <windows.foundation.h>
 #include "Enums.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class DECLSPEC_UUID("CDCCC115-7C53-4A04-9F5B-754BBC00C80E") AdaptiveActionElementBase : public IUnknown
     {
     protected:
@@ -38,4 +38,4 @@ AdaptiveNamespaceStart
         Microsoft::WRL::ComPtr<ABI::Windows::Data::Json::IJsonObject> m_additionalProperties;
         Microsoft::WRL::Wrappers::HString m_typeString;
     };
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveActionEventArgs.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveActionEventArgs.cpp
@@ -5,7 +5,7 @@ using namespace Microsoft::WRL;
 using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::Data::Json;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveActionEventArgs::RuntimeClassInitialize()
     {
         return S_OK;
@@ -29,4 +29,4 @@ AdaptiveNamespaceStart
     {
         return m_inputs.CopyTo(inputs);
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveActionEventArgs.h
+++ b/source/uwp/Renderer/lib/AdaptiveActionEventArgs.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "AdaptiveCards.Rendering.Uwp.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveActionEventArgs :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRt>,
@@ -21,4 +21,4 @@ AdaptiveNamespaceStart
         Microsoft::WRL::ComPtr<ABI::AdaptiveNamespace::IAdaptiveActionElement> m_action;
         Microsoft::WRL::ComPtr<ABI::AdaptiveNamespace::IAdaptiveInputs> m_inputs;
     };
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveActionInvoker.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveActionInvoker.cpp
@@ -9,7 +9,7 @@ using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::Foundation;
 using namespace ABI::Windows::UI::Xaml;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveActionInvoker::RuntimeClassInitialize() noexcept
     {
         return S_OK;
@@ -28,4 +28,4 @@ AdaptiveNamespaceStart
         return m_renderResult->SendActionEvent(actionElement);
     }
 
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveActionInvoker.h
+++ b/source/uwp/Renderer/lib/AdaptiveActionInvoker.h
@@ -3,7 +3,7 @@
 #include "AdaptiveCards.Rendering.Uwp.h"
 #include "RenderedAdaptiveCard.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveActionInvoker :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -23,4 +23,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveActionInvoker);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveActionParserRegistration.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveActionParserRegistration.cpp
@@ -10,7 +10,7 @@ using namespace Microsoft::WRL::Wrappers;
 using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::UI;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     AdaptiveActionParserRegistration::AdaptiveActionParserRegistration()
     {
     }
@@ -106,4 +106,4 @@ AdaptiveNamespaceStart
         std::shared_ptr<CustomActionWrapper> actionWrapper = std::make_shared<CustomActionWrapper>(actionElement.Get());
         return actionWrapper;
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveActionParserRegistration.h
+++ b/source/uwp/Renderer/lib/AdaptiveActionParserRegistration.h
@@ -3,7 +3,7 @@
 #include "AdaptiveCards.Rendering.Uwp.h"
 #include "Util.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class DECLSPEC_UUID("fc95029a-9ec0-4d93-b170-09c99876db20") AdaptiveActionParserRegistration :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -61,4 +61,4 @@ AdaptiveNamespaceStart
     private:
         Microsoft::WRL::ComPtr<AdaptiveNamespace::AdaptiveActionParserRegistration> m_parserRegistration;
     };
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveActionsConfig.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveActionsConfig.cpp
@@ -7,7 +7,7 @@ using namespace Microsoft::WRL;
 using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::UI;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveActionsConfig::RuntimeClassInitialize() noexcept try
     {
         ActionsConfig actionsConfig;
@@ -139,4 +139,4 @@ AdaptiveNamespaceStart
         m_iconSize = value;
         return S_OK;
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveActionsConfig.h
+++ b/source/uwp/Renderer/lib/AdaptiveActionsConfig.h
@@ -4,7 +4,7 @@
 #include "Enums.h"
 #include "HostConfig.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveActionsConfig :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -53,4 +53,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveActionsConfig);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveCard.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveCard.cpp
@@ -21,7 +21,7 @@ using namespace ABI::Windows::UI::Xaml;
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     _Use_decl_annotations_
     HRESULT AdaptiveCardStaticsImpl::FromJsonString(HSTRING adaptiveJson, IAdaptiveCardParseResult** parseResult) noexcept try
     {
@@ -361,4 +361,4 @@ AdaptiveNamespaceStart
 
         return S_OK;
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveCard.h
+++ b/source/uwp/Renderer/lib/AdaptiveCard.h
@@ -3,7 +3,7 @@
 #include "AdaptiveCards.Rendering.Uwp.h"
 #include "SharedAdaptiveCard.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class DECLSPEC_UUID("6a88e6d4-373a-48ba-840e-16c4b39278b1") AdaptiveCard :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRt>,
@@ -122,4 +122,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClassWithFactory(AdaptiveCard, AdaptiveCardStaticsImpl);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveCardConfig.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveCardConfig.cpp
@@ -6,7 +6,7 @@ using namespace Microsoft::WRL;
 using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::UI;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveCardConfig::RuntimeClassInitialize() noexcept try
     {
         AdaptiveSharedNamespace::AdaptiveCardConfig cardConfig;
@@ -32,4 +32,4 @@ AdaptiveNamespaceStart
         m_allowCustomStyle = allowCustomStyle;
         return S_OK;
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveCardConfig.h
+++ b/source/uwp/Renderer/lib/AdaptiveCardConfig.h
@@ -4,7 +4,7 @@
 #include "Enums.h"
 #include "HostConfig.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveCardConfig :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -24,4 +24,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveCardConfig);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveCardElement.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveCardElement.cpp
@@ -8,7 +8,7 @@ using namespace ABI::Windows::Foundation::Collections;
 using namespace ABI::Windows::UI::Xaml;
 using namespace ABI::Windows::UI::Xaml::Controls;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveCardElementBase::InitializeBaseElement(const std::shared_ptr<AdaptiveSharedNamespace::BaseCardElement>& sharedModel)
     {
         m_spacing = static_cast<ABI::AdaptiveNamespace::Spacing>(sharedModel->GetSpacing());
@@ -108,4 +108,4 @@ AdaptiveNamespaceStart
 
         return S_OK;
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveCardElement.h
+++ b/source/uwp/Renderer/lib/AdaptiveCardElement.h
@@ -3,7 +3,7 @@
 #include "AdaptiveCards.Rendering.Uwp.h"
 #include "Enums.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class DECLSPEC_UUID("49496982-18E7-48A8-9D16-99E389BE9133") AdaptiveCardElementBase : public IUnknown
     {
     protected:
@@ -41,4 +41,4 @@ AdaptiveNamespaceStart
         Microsoft::WRL::Wrappers::HString m_typeString;
         ABI::AdaptiveNamespace::HeightType m_height;
     };
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveCardGetResourceStreamArgs.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveCardGetResourceStreamArgs.cpp
@@ -5,7 +5,7 @@ using namespace Microsoft::WRL;
 using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::Foundation;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     _Use_decl_annotations_
     HRESULT AdaptiveCardGetResourceStreamArgs::RuntimeClassInitialize(IUriRuntimeClass* url)
     {
@@ -20,4 +20,4 @@ AdaptiveNamespaceStart
         *url = localUrl.Detach();
         return S_OK;
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveCardGetResourceStreamArgs.h
+++ b/source/uwp/Renderer/lib/AdaptiveCardGetResourceStreamArgs.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "AdaptiveCards.Rendering.Uwp.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveCardGetResourceStreamArgs :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRt>,
@@ -17,4 +17,4 @@ AdaptiveNamespaceStart
     private:
         Microsoft::WRL::ComPtr<ABI::Windows::Foundation::IUriRuntimeClass> m_url;
     };
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveCardParseResult.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveCardParseResult.cpp
@@ -19,7 +19,7 @@ using namespace ABI::Windows::UI;
 using namespace ABI::Windows::UI::Xaml;
 using namespace ABI::Windows::UI::Xaml::Controls;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     AdaptiveCardParseResult::AdaptiveCardParseResult()
     {
     }
@@ -61,4 +61,4 @@ AdaptiveNamespaceStart
             m_adaptiveCard = value;
             return S_OK;
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveCardParseResult.h
+++ b/source/uwp/Renderer/lib/AdaptiveCardParseResult.h
@@ -2,7 +2,7 @@
 
 #include "util.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveCardParseResult :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -30,4 +30,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveCardParseResult);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveCardRendererComponent.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveCardRendererComponent.cpp
@@ -45,7 +45,7 @@ using namespace ABI::Windows::UI::Xaml::Markup;
 using namespace ABI::Windows::UI::Xaml::Media;
 using namespace ABI::Windows::UI::Xaml::Media::Imaging;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
 
     HRESULT AdaptiveCardRenderer::RuntimeClassInitialize()
     {
@@ -307,4 +307,4 @@ AdaptiveNamespaceStart
     {
         return m_xamlBuilder;
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveCardRendererComponent.h
+++ b/source/uwp/Renderer/lib/AdaptiveCardRendererComponent.h
@@ -3,7 +3,7 @@
 #include "AdaptiveCards.Rendering.Uwp.h"
 #include "XamlBuilder.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class XamlBuilder;
 
     // This class is effectively a singleton, and stays around between subsequent renders.
@@ -75,4 +75,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveCardRenderer);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveCardResourceResolvers.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveCardResourceResolvers.cpp
@@ -5,7 +5,7 @@ using namespace Microsoft::WRL;
 using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::Foundation;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveCardResourceResolvers::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -28,4 +28,4 @@ AdaptiveNamespaceStart
         ComPtr<IAdaptiveCardResourceResolver> resolverPtr = m_resourceResolvers[schemeString];
         return resolverPtr.CopyTo(resolver);
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveCardResourceResolvers.h
+++ b/source/uwp/Renderer/lib/AdaptiveCardResourceResolvers.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "AdaptiveCards.Rendering.Uwp.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveCardResourceResolvers :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -20,4 +20,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveCardResourceResolvers);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveChoiceInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceInput.cpp
@@ -10,7 +10,7 @@ using namespace ABI::Windows::Foundation::Collections;
 using namespace ABI::Windows::UI::Xaml;
 using namespace ABI::Windows::UI::Xaml::Controls;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveChoiceInput::RuntimeClassInitialize() noexcept try
     {
         m_sharedChoiceInput = std::make_shared<ChoiceInput>();
@@ -66,4 +66,4 @@ AdaptiveNamespaceStart
         sharedModel = m_sharedChoiceInput;
         return S_OK;
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveChoiceInput.h
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceInput.h
@@ -4,7 +4,7 @@
 #include "Enums.h"
 #include "ChoiceInput.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class DECLSPEC_UUID("7263dbfb-cb43-47f9-9022-b43372f529f9") AdaptiveChoiceInput :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -39,4 +39,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveChoiceInput);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveChoiceSetInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceSetInput.cpp
@@ -12,7 +12,7 @@ using namespace ABI::Windows::Foundation::Collections;
 using namespace ABI::Windows::UI::Xaml;
 using namespace ABI::Windows::UI::Xaml::Controls;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     AdaptiveChoiceSetInput::AdaptiveChoiceSetInput()
     {
         m_choices = Microsoft::WRL::Make<Vector<IAdaptiveChoiceInput*>>();
@@ -113,4 +113,4 @@ AdaptiveNamespaceStart
         return S_OK;
     } CATCH_RETURN;
 
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveChoiceSetInput.h
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceSetInput.h
@@ -6,7 +6,7 @@
 #include <windows.foundation.h>
 #include "AdaptiveInputElement.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class DECLSPEC_UUID("fa103f57-5d54-48ba-80a5-d8939b85e82d") AdaptiveChoiceSetInput :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -79,4 +79,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveChoiceSetInput);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.cpp
@@ -12,7 +12,7 @@ using namespace Microsoft::WRL::Wrappers;
 using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::Foundation;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveChoiceSetInputRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -38,4 +38,4 @@ AdaptiveNamespaceStart
     {
         return AdaptiveNamespace::FromJson<AdaptiveNamespace::AdaptiveChoiceSetInput, AdaptiveSharedNamespace::ChoiceSetInput, AdaptiveSharedNamespace::ChoiceSetInputParser>(jsonObject, elementParserRegistration, actionParserRegistration, adaptiveWarnings, element);
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.h
@@ -4,7 +4,7 @@
 #include "Enums.h"
 #include "ChoiceSetInput.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveChoiceSetInputRenderer :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -31,4 +31,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveChoiceSetInputRenderer);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveColorConfig.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveColorConfig.cpp
@@ -6,7 +6,7 @@ using namespace Microsoft::WRL;
 using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::UI;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveColorConfig::RuntimeClassInitialize() noexcept try
     {
         ColorConfig colorConfig;
@@ -48,4 +48,4 @@ AdaptiveNamespaceStart
         m_subtleColor = color;
         return S_OK;
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveColorConfig.h
+++ b/source/uwp/Renderer/lib/AdaptiveColorConfig.h
@@ -4,7 +4,7 @@
 #include "Enums.h"
 #include "HostConfig.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveColorConfig :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -28,4 +28,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveColorConfig);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveColorsConfig.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveColorsConfig.cpp
@@ -5,7 +5,7 @@
 using namespace Microsoft::WRL;
 using namespace ABI::AdaptiveNamespace;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveColorsConfig::RuntimeClassInitialize() noexcept try
     {
         ColorsConfig colorsConfig;
@@ -114,4 +114,4 @@ AdaptiveNamespaceStart
         m_attention = colorConfig;
         return S_OK;
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveColorsConfig.h
+++ b/source/uwp/Renderer/lib/AdaptiveColorsConfig.h
@@ -4,7 +4,7 @@
 #include "Enums.h"
 #include "HostConfig.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveColorsConfig :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -48,4 +48,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveColorsConfig);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveColumn.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveColumn.cpp
@@ -12,7 +12,7 @@ using namespace ABI::Windows::Foundation::Collections;
 using namespace ABI::Windows::UI::Xaml;
 using namespace ABI::Windows::UI::Xaml::Controls;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     AdaptiveColumn::AdaptiveColumn()
     {
         m_items = Microsoft::WRL::Make<Vector<IAdaptiveCardElement*>>();
@@ -139,4 +139,4 @@ AdaptiveNamespaceStart
         sharedModel = column;
         return S_OK;
     }CATCH_RETURN;
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveColumn.h
+++ b/source/uwp/Renderer/lib/AdaptiveColumn.h
@@ -6,7 +6,7 @@
 #include "Column.h"
 #include <windows.foundation.h>
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class DECLSPEC_UUID("d674610a-a76b-4283-bd09-b5a25c41433d") AdaptiveColumn :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -82,4 +82,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveColumn);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveColumnRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveColumnRenderer.cpp
@@ -10,7 +10,7 @@ using namespace Microsoft::WRL::Wrappers;
 using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::Foundation;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveColumnRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -27,4 +27,4 @@ AdaptiveNamespaceStart
         return S_OK;
     }
 
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveColumnRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveColumnRenderer.h
@@ -4,7 +4,7 @@
 #include "Enums.h"
 #include "Column.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveColumnRenderer :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -23,4 +23,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveColumnRenderer);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveColumnSet.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveColumnSet.cpp
@@ -14,7 +14,7 @@ using namespace ABI::Windows::Foundation::Collections;
 using namespace ABI::Windows::UI::Xaml;
 using namespace ABI::Windows::UI::Xaml::Controls;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     AdaptiveColumnSet::AdaptiveColumnSet()
     {
         m_columns = Microsoft::WRL::Make<Vector<IAdaptiveColumn*>>();
@@ -101,4 +101,4 @@ AdaptiveNamespaceStart
         sharedModel = columnSet;
         return S_OK;
     }CATCH_RETURN;
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveColumnSet.h
+++ b/source/uwp/Renderer/lib/AdaptiveColumnSet.h
@@ -6,7 +6,7 @@
 #include <windows.foundation.h>
 #include "AdaptiveCardElement.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class DECLSPEC_UUID("3f54eed2-03e8-480b-aede-6f4faae4b731") AdaptiveColumnSet :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -65,4 +65,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveColumnSet);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveColumnSetRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveColumnSetRenderer.cpp
@@ -12,7 +12,7 @@ using namespace Microsoft::WRL::Wrappers;
 using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::Foundation;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveColumnSetRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -38,4 +38,4 @@ AdaptiveNamespaceStart
     {
         return AdaptiveNamespace::FromJson<AdaptiveNamespace::AdaptiveColumnSet, AdaptiveSharedNamespace::ColumnSet, AdaptiveSharedNamespace::ColumnSetParser>(jsonObject, elementParserRegistration, actionParserRegistration, adaptiveWarnings, element);
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveColumnSetRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveColumnSetRenderer.h
@@ -4,7 +4,7 @@
 #include "Enums.h"
 #include "ColumnSet.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveColumnSetRenderer :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -31,4 +31,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveColumnSetRenderer);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveContainer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveContainer.cpp
@@ -12,7 +12,7 @@ using namespace ABI::Windows::Foundation::Collections;
 using namespace ABI::Windows::UI::Xaml;
 using namespace ABI::Windows::UI::Xaml::Controls;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     AdaptiveContainer::AdaptiveContainer()
     {
         m_items = Microsoft::WRL::Make<Vector<IAdaptiveCardElement*>>();
@@ -115,4 +115,4 @@ AdaptiveNamespaceStart
         sharedModel = container;
         return S_OK;
     }CATCH_RETURN;
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveContainer.h
+++ b/source/uwp/Renderer/lib/AdaptiveContainer.h
@@ -6,7 +6,7 @@
 #include <windows.foundation.h>
 #include "AdaptiveCardElement.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class DECLSPEC_UUID("d6031009-7039-4735-bd07-ab6d99b29f03") AdaptiveContainer :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -72,4 +72,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveContainer);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveContainerRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveContainerRenderer.cpp
@@ -12,7 +12,7 @@ using namespace Microsoft::WRL::Wrappers;
 using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::Foundation;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveContainerRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -38,4 +38,4 @@ AdaptiveNamespaceStart
     {
         return AdaptiveNamespace::FromJson<AdaptiveNamespace::AdaptiveContainer, AdaptiveSharedNamespace::Container, AdaptiveSharedNamespace::ContainerParser>(jsonObject, elementParserRegistration, actionParserRegistration, adaptiveWarnings, element);
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveContainerRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveContainerRenderer.h
@@ -4,7 +4,7 @@
 #include "Enums.h"
 #include "Container.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveContainerRenderer :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -31,4 +31,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveContainerRenderer);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveContainerStyleDefinition.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveContainerStyleDefinition.cpp
@@ -5,7 +5,7 @@
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveContainerStyleDefinition::RuntimeClassInitialize() noexcept try
     {
         ContainerStyleDefinition styleDefinition;
@@ -46,4 +46,4 @@ AdaptiveNamespaceStart
         m_foregroundColors = colorsConfig;
         return S_OK;
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveContainerStyleDefinition.h
+++ b/source/uwp/Renderer/lib/AdaptiveContainerStyleDefinition.h
@@ -4,7 +4,7 @@
 #include "Enums.h"
 #include "HostConfig.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveContainerStyleDefinition :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -28,4 +28,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveContainerStyleDefinition);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveContainerStylesDefinition.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveContainerStylesDefinition.cpp
@@ -5,7 +5,7 @@
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveContainerStylesDefinition::RuntimeClassInitialize() noexcept try
     {
         ContainerStylesDefinition stylesDefinition;
@@ -45,4 +45,4 @@ AdaptiveNamespaceStart
         m_emphasis = value;
         return S_OK;
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveContainerStylesDefinition.h
+++ b/source/uwp/Renderer/lib/AdaptiveContainerStylesDefinition.h
@@ -4,7 +4,7 @@
 #include "Enums.h"
 #include "HostConfig.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveContainerStylesDefinition :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -28,4 +28,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveContainerStylesDefinition);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveDateInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveDateInput.cpp
@@ -10,7 +10,7 @@ using namespace ABI::Windows::Foundation::Collections;
 using namespace ABI::Windows::UI::Xaml;
 using namespace ABI::Windows::UI::Xaml::Controls;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveDateInput::RuntimeClassInitialize() noexcept try
     {
         std::shared_ptr<AdaptiveSharedNamespace::DateInput> dateInput = std::make_shared<AdaptiveSharedNamespace::DateInput>();
@@ -103,4 +103,4 @@ AdaptiveNamespaceStart
 
         return S_OK;
     }CATCH_RETURN;
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveDateInput.h
+++ b/source/uwp/Renderer/lib/AdaptiveDateInput.h
@@ -5,7 +5,7 @@
 #include "Enums.h"
 #include "AdaptiveInputElement.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class DECLSPEC_UUID("9aa05662-098b-4588-addb-af62378a8706") AdaptiveDateInput :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -76,4 +76,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveDateInput);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveDateInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveDateInputRenderer.cpp
@@ -12,7 +12,7 @@ using namespace Microsoft::WRL::Wrappers;
 using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::Foundation;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveDateInputRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -38,4 +38,4 @@ AdaptiveNamespaceStart
     {
         return AdaptiveNamespace::FromJson<AdaptiveNamespace::AdaptiveDateInput, AdaptiveSharedNamespace::DateInput, AdaptiveSharedNamespace::DateInputParser>(jsonObject, elementParserRegistration, actionParserRegistration, adaptiveWarnings, element);
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveDateInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveDateInputRenderer.h
@@ -4,7 +4,7 @@
 #include "Enums.h"
 #include "DateInput.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveDateInputRenderer :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -31,4 +31,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveDateInputRenderer);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveElementParserRegistration.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveElementParserRegistration.cpp
@@ -10,7 +10,7 @@ using namespace Microsoft::WRL::Wrappers;
 using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::UI;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     AdaptiveElementParserRegistration::AdaptiveElementParserRegistration()
     {
     }
@@ -106,4 +106,4 @@ AdaptiveNamespaceStart
         std::shared_ptr<CustomElementWrapper> elementWrapper = std::make_shared<CustomElementWrapper>(cardElement.Get());
         return elementWrapper;
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveElementParserRegistration.h
+++ b/source/uwp/Renderer/lib/AdaptiveElementParserRegistration.h
@@ -4,7 +4,7 @@
 #include "Util.h"
 #include "AdaptiveActionParserRegistration.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class DECLSPEC_UUID("fdf8457d-639f-4bbd-9e32-26c14bac3813") AdaptiveElementParserRegistration :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -109,4 +109,4 @@ AdaptiveNamespaceStart
 
         return S_OK;
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveElementRendererRegistration.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveElementRendererRegistration.cpp
@@ -6,7 +6,7 @@ using namespace Microsoft::WRL;
 using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::UI;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     AdaptiveElementRendererRegistration::AdaptiveElementRendererRegistration()
     {
     }
@@ -44,4 +44,4 @@ AdaptiveNamespaceStart
         m_registration->erase(HStringToUTF8(type));
         return S_OK;
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveElementRendererRegistration.h
+++ b/source/uwp/Renderer/lib/AdaptiveElementRendererRegistration.h
@@ -3,7 +3,7 @@
 #include "AdaptiveCards.Rendering.Uwp.h"
 #include "Util.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveElementRendererRegistration :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -31,4 +31,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveElementRendererRegistration);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveError.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveError.cpp
@@ -5,7 +5,7 @@ using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;
 using namespace ABI::AdaptiveNamespace;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
 
     HRESULT AdaptiveError::RuntimeClassInitialize()
     {
@@ -46,4 +46,4 @@ AdaptiveNamespaceStart
     {
         return m_message.Set(value);
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveError.h
+++ b/source/uwp/Renderer/lib/AdaptiveError.h
@@ -2,7 +2,7 @@
 
 #include "AdaptiveCards.Rendering.Uwp.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveError:
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -31,4 +31,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveError);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveFact.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveFact.cpp
@@ -10,7 +10,7 @@ using namespace ABI::Windows::Foundation::Collections;
 using namespace ABI::Windows::UI::Xaml;
 using namespace ABI::Windows::UI::Xaml::Controls;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveFact::RuntimeClassInitialize() noexcept try
     {
         RuntimeClassInitialize(std::make_shared<Fact>());
@@ -91,4 +91,4 @@ AdaptiveNamespaceStart
         sharedModel = fact;
         return S_OK;
     } CATCH_RETURN;
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveFact.h
+++ b/source/uwp/Renderer/lib/AdaptiveFact.h
@@ -4,7 +4,7 @@
 #include "Enums.h"
 #include "Fact.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class DECLSPEC_UUID("d37e5b66-2a5e-4a9e-b087-dbef5a1705b1") AdaptiveFact :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -44,4 +44,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveFact);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveFactSet.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveFactSet.cpp
@@ -12,7 +12,7 @@ using namespace ABI::Windows::Foundation::Collections;
 using namespace ABI::Windows::UI::Xaml;
 using namespace ABI::Windows::UI::Xaml::Controls;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     AdaptiveFactSet::AdaptiveFactSet()
     {
         m_facts = Microsoft::WRL::Make<Vector<IAdaptiveFact*>>();
@@ -62,4 +62,4 @@ AdaptiveNamespaceStart
 
         return S_OK;
     }CATCH_RETURN;
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveFactSet.h
+++ b/source/uwp/Renderer/lib/AdaptiveFactSet.h
@@ -6,7 +6,7 @@
 #include <windows.foundation.h>
 #include "AdaptiveCardElement.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class DECLSPEC_UUID("3aacc7c9-f600-4928-ae06-4cc21a83f4b3") AdaptiveFactSet :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -61,4 +61,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveFactSet);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveFactSetConfig.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveFactSetConfig.cpp
@@ -5,7 +5,7 @@
 using namespace Microsoft::WRL;
 using namespace ABI::AdaptiveNamespace;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveFactSetConfig::RuntimeClassInitialize() noexcept try
     {
         FactSetConfig factSetConfig;
@@ -60,4 +60,4 @@ AdaptiveNamespaceStart
         m_spacing = value;
         return S_OK;
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveFactSetConfig.h
+++ b/source/uwp/Renderer/lib/AdaptiveFactSetConfig.h
@@ -4,7 +4,7 @@
 #include "Enums.h"
 #include "HostConfig.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveFactSetConfig :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -32,4 +32,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveFactSetConfig);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveFactSetRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveFactSetRenderer.cpp
@@ -12,7 +12,7 @@ using namespace Microsoft::WRL::Wrappers;
 using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::Foundation;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveFactSetRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -38,4 +38,4 @@ AdaptiveNamespaceStart
     {
         return AdaptiveNamespace::FromJson<AdaptiveNamespace::AdaptiveFactSet, AdaptiveSharedNamespace::FactSet, AdaptiveSharedNamespace::FactSetParser>(jsonObject, elementParserRegistration, actionParserRegistration, adaptiveWarnings, element);
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveFactSetRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveFactSetRenderer.h
@@ -4,7 +4,7 @@
 #include "Enums.h"
 #include "FactSet.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveFactSetRenderer :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -31,4 +31,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveFactSetRenderer);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveFontSizesConfig.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveFontSizesConfig.cpp
@@ -4,7 +4,7 @@
 using namespace Microsoft::WRL;
 using namespace ABI::AdaptiveNamespace;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveFontSizesConfig::RuntimeClassInitialize() noexcept try
     {
         FontSizesConfig fontSizesConfig;
@@ -91,4 +91,4 @@ AdaptiveNamespaceStart
         m_extraLarge = extraLargeFontSize;
         return S_OK;
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveFontSizesConfig.h
+++ b/source/uwp/Renderer/lib/AdaptiveFontSizesConfig.h
@@ -4,7 +4,7 @@
 #include "Enums.h"
 #include "HostConfig.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveFontSizesConfig :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -41,4 +41,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveFontSizesConfig);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveFontWeightsConfig.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveFontWeightsConfig.cpp
@@ -4,7 +4,7 @@
 using namespace Microsoft::WRL;
 using namespace ABI::AdaptiveNamespace;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveFontWeightsConfig::RuntimeClassInitialize() noexcept try
     {
         FontWeightsConfig fontWeightsConfig;
@@ -61,4 +61,4 @@ AdaptiveNamespaceStart
         m_bolder = bolder;
         return S_OK;
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveFontWeightsConfig.h
+++ b/source/uwp/Renderer/lib/AdaptiveFontWeightsConfig.h
@@ -4,7 +4,7 @@
 #include "Enums.h"
 #include "HostConfig.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveFontWeightsConfig :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -32,4 +32,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveFontWeightsConfig);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveHostConfig.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveHostConfig.cpp
@@ -20,7 +20,7 @@ using namespace Microsoft::WRL;
 using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::Data::Json;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     _Use_decl_annotations_
     HRESULT AdaptiveHostConfigStaticsImpl::FromJsonString(HSTRING adaptiveJson, IAdaptiveHostConfigParseResult** parseResult) noexcept try
     {
@@ -277,4 +277,4 @@ AdaptiveNamespaceStart
         m_media = mediaConfig;
         return S_OK;
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveHostConfig.h
+++ b/source/uwp/Renderer/lib/AdaptiveHostConfig.h
@@ -4,7 +4,7 @@
 #include "Enums.h"
 #include "HostConfig.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveHostConfig :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -104,4 +104,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClassWithFactory(AdaptiveHostConfig, AdaptiveHostConfigStaticsImpl);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveHostConfigParseResult.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveHostConfigParseResult.cpp
@@ -19,7 +19,7 @@ using namespace ABI::Windows::UI;
 using namespace ABI::Windows::UI::Xaml;
 using namespace ABI::Windows::UI::Xaml::Controls;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     AdaptiveHostConfigParseResult::AdaptiveHostConfigParseResult()
     {
     }
@@ -47,4 +47,4 @@ AdaptiveNamespaceStart
     {
         return m_errors.CopyTo(value);
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveHostConfigParseResult.h
+++ b/source/uwp/Renderer/lib/AdaptiveHostConfigParseResult.h
@@ -2,7 +2,7 @@
 
 #include "util.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveHostConfigParseResult :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -27,4 +27,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveHostConfigParseResult);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveImage.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImage.cpp
@@ -10,7 +10,7 @@ using namespace ABI::Windows::Foundation;
 using namespace ABI::Windows::UI::Xaml;
 using namespace ABI::Windows::UI::Xaml::Controls;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     AdaptiveImage::AdaptiveImage()
     {
     }
@@ -203,4 +203,4 @@ AdaptiveNamespaceStart
         sharedImage = image;
         return S_OK;
     } CATCH_RETURN;
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveImage.h
+++ b/source/uwp/Renderer/lib/AdaptiveImage.h
@@ -6,7 +6,7 @@
 #include <windows.foundation.h>
 #include "AdaptiveCardElement.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class DECLSPEC_UUID("c940ac19-5faa-47f3-9d4b-f4d8e7d6ec1d") AdaptiveImage :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -93,4 +93,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveImage);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveImageConfig.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImageConfig.cpp
@@ -4,7 +4,7 @@
 using namespace Microsoft::WRL;
 using namespace ABI::AdaptiveNamespace;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveImageConfig::RuntimeClassInitialize() noexcept try
     {
         ImageConfig imageConfig;
@@ -30,4 +30,4 @@ AdaptiveNamespaceStart
         m_imageSize = imageSize;
         return S_OK;
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveImageConfig.h
+++ b/source/uwp/Renderer/lib/AdaptiveImageConfig.h
@@ -4,7 +4,7 @@
 #include "Enums.h"
 #include "HostConfig.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveImageConfig :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -24,4 +24,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveImageConfig);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveImageRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImageRenderer.cpp
@@ -11,7 +11,7 @@ using namespace Microsoft::WRL::Wrappers;
 using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::Foundation;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     AdaptiveImageRenderer::AdaptiveImageRenderer()
     {
         m_xamlBuilder = std::make_shared<XamlBuilder>();
@@ -46,4 +46,4 @@ AdaptiveNamespaceStart
     {
         return AdaptiveNamespace::FromJson<AdaptiveNamespace::AdaptiveImage, AdaptiveSharedNamespace::Image, AdaptiveSharedNamespace::ImageParser>(jsonObject, elementParserRegistration, actionParserRegistration, adaptiveWarnings, element);
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveImageRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveImageRenderer.h
@@ -5,7 +5,7 @@
 #include "Image.h"
 #include "XamlBuilder.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveImageRenderer :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -37,4 +37,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveImageRenderer);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveImageSet.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImageSet.cpp
@@ -12,7 +12,7 @@ using namespace ABI::Windows::Foundation::Collections;
 using namespace ABI::Windows::UI::Xaml;
 using namespace ABI::Windows::UI::Xaml::Controls;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     AdaptiveImageSet::AdaptiveImageSet()
     {
         m_images = Microsoft::WRL::Make<Vector<IAdaptiveImage*>>();
@@ -80,4 +80,4 @@ AdaptiveNamespaceStart
         sharedModel = imageSet;
         return S_OK;
     }CATCH_RETURN;
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveImageSet.h
+++ b/source/uwp/Renderer/lib/AdaptiveImageSet.h
@@ -6,7 +6,7 @@
 #include <windows.foundation.h>
 #include "AdaptiveCardElement.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class DECLSPEC_UUID("04ed4200-de21-4587-8bc5-74b000809985") AdaptiveImageSet :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -65,4 +65,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveImageSet);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveImageSetConfig.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImageSetConfig.cpp
@@ -4,7 +4,7 @@
 using namespace Microsoft::WRL;
 using namespace ABI::AdaptiveNamespace;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveImageSetConfig::RuntimeClassInitialize() noexcept try
     {
         ImageSetConfig imageSetConfig;
@@ -45,4 +45,4 @@ AdaptiveNamespaceStart
         m_maxImageHeight = maxImageHeight;
         return S_OK;
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveImageSetConfig.h
+++ b/source/uwp/Renderer/lib/AdaptiveImageSetConfig.h
@@ -4,7 +4,7 @@
 #include "Enums.h"
 #include "HostConfig.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveImageSetConfig :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -28,4 +28,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveImageSetConfig);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveImageSetRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImageSetRenderer.cpp
@@ -12,7 +12,7 @@ using namespace Microsoft::WRL::Wrappers;
 using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::Foundation;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveImageSetRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -38,4 +38,4 @@ AdaptiveNamespaceStart
     {
         return AdaptiveNamespace::FromJson<AdaptiveNamespace::AdaptiveImageSet, AdaptiveSharedNamespace::ImageSet, AdaptiveSharedNamespace::ImageSetParser>(jsonObject, elementParserRegistration, actionParserRegistration, adaptiveWarnings, element);
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveImageSetRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveImageSetRenderer.h
@@ -4,7 +4,7 @@
 #include "Enums.h"
 #include "ImageSet.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveImageSetRenderer :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -31,4 +31,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveImageSetRenderer);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveImageSizesConfig.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImageSizesConfig.cpp
@@ -4,7 +4,7 @@
 using namespace Microsoft::WRL;
 using namespace ABI::AdaptiveNamespace;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveImageSizesConfig::RuntimeClassInitialize() noexcept try
     {
         ImageSizesConfig imageSizesConfig;
@@ -60,4 +60,4 @@ AdaptiveNamespaceStart
         m_large = largeSize;
         return S_OK;
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveImageSizesConfig.h
+++ b/source/uwp/Renderer/lib/AdaptiveImageSizesConfig.h
@@ -4,7 +4,7 @@
 #include "Enums.h"
 #include "HostConfig.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveImageSizesConfig :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -32,4 +32,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveImageSizesConfig);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveInputElement.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveInputElement.cpp
@@ -8,7 +8,7 @@ using namespace ABI::Windows::Foundation::Collections;
 using namespace ABI::Windows::UI::Xaml;
 using namespace ABI::Windows::UI::Xaml::Controls;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveInputElementBase::InitializeBaseElement(const std::shared_ptr<AdaptiveSharedNamespace::BaseInputElement>& sharedModel)
     {
         AdaptiveCardElementBase::InitializeBaseElement(std::static_pointer_cast<AdaptiveSharedNamespace::BaseCardElement>(sharedModel));
@@ -37,4 +37,4 @@ AdaptiveNamespaceStart
         sharedCardElement->SetIsRequired(m_isRequired);
         return S_OK;
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveInputElement.h
+++ b/source/uwp/Renderer/lib/AdaptiveInputElement.h
@@ -5,7 +5,7 @@
 #include "BaseInputElement.h"
 #include "AdaptiveCardElement.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class DECLSPEC_UUID("E2E42BA6-A0AE-4B01-B161-29AF2F2B302B") AdaptiveInputElementBase : public AdaptiveCardElementBase
     {
     protected:
@@ -20,4 +20,4 @@ AdaptiveNamespaceStart
     private:
         boolean m_isRequired;
     };
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveInputs.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveInputs.cpp
@@ -12,7 +12,7 @@ using namespace ABI::Windows::UI;
 using namespace ABI::Windows::UI::Xaml;
 using namespace ABI::Windows::UI::Xaml::Controls;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     AdaptiveInputs::AdaptiveInputs()
     {
         m_inputValues = std::make_shared<std::vector<ComPtr<IAdaptiveInputValue>>>();
@@ -98,4 +98,4 @@ AdaptiveNamespaceStart
         return valueSet.CopyTo(value);
     }
 
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveInputs.h
+++ b/source/uwp/Renderer/lib/AdaptiveInputs.h
@@ -3,7 +3,7 @@
 #include "AdaptiveCards.Rendering.Uwp.h"
 #include "InputValue.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveInputs :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -27,4 +27,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveInputs);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveMedia.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveMedia.cpp
@@ -5,7 +5,7 @@
 using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::Foundation::Collections;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveMedia::RuntimeClassInitialize() noexcept try
     {
         std::shared_ptr<AdaptiveSharedNamespace::Media> media = std::make_shared<AdaptiveSharedNamespace::Media>();
@@ -82,4 +82,4 @@ AdaptiveNamespaceStart
         sharedMedia = media;
         return S_OK;
     } CATCH_RETURN;
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveMedia.h
+++ b/source/uwp/Renderer/lib/AdaptiveMedia.h
@@ -4,7 +4,7 @@
 #include "AdaptiveCardElement.h"
 #include "Media.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class DECLSPEC_UUID("0c87566c-a58c-4332-8b3b-79c9714074f6") AdaptiveMedia :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -65,4 +65,4 @@ AdaptiveNamespaceStart
 };
 
     ActivatableClass(AdaptiveMedia);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveMediaConfig.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveMediaConfig.cpp
@@ -5,7 +5,7 @@
 using namespace Microsoft::WRL;
 using namespace ABI::AdaptiveNamespace;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveMediaConfig::RuntimeClassInitialize() noexcept try
     {
         MediaConfig mediaConfig;
@@ -60,4 +60,4 @@ AdaptiveNamespaceStart
         return S_OK;
     }
 
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveMediaConfig.h
+++ b/source/uwp/Renderer/lib/AdaptiveMediaConfig.h
@@ -4,7 +4,7 @@
 #include "Enums.h"
 #include "HostConfig.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveMediaConfig :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -31,4 +31,4 @@ AdaptiveNamespaceStart
         boolean m_allowInlinePlayback;
     };
     ActivatableClass(AdaptiveMediaConfig);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveMediaEventArgs.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveMediaEventArgs.cpp
@@ -5,7 +5,7 @@ using namespace Microsoft::WRL;
 using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::Data::Json;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveMediaEventArgs::RuntimeClassInitialize()
     {
         return S_OK;
@@ -23,4 +23,4 @@ AdaptiveNamespaceStart
     {
         return m_media.CopyTo(media);
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveMediaEventArgs.h
+++ b/source/uwp/Renderer/lib/AdaptiveMediaEventArgs.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "AdaptiveCards.Rendering.Uwp.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveMediaEventArgs :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRt>,
@@ -19,4 +19,4 @@ AdaptiveNamespaceStart
     private:
         Microsoft::WRL::ComPtr<ABI::AdaptiveNamespace::IAdaptiveMedia> m_media;
     };
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveMediaEventInvoker.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveMediaEventInvoker.cpp
@@ -9,7 +9,7 @@ using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::Foundation;
 using namespace ABI::Windows::UI::Xaml;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveMediaEventInvoker::RuntimeClassInitialize() noexcept
     {
         return S_OK;
@@ -28,4 +28,4 @@ AdaptiveNamespaceStart
         return m_renderResult->SendMediaClickedEvent(mediaElement);
     }
 
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveMediaEventInvoker.h
+++ b/source/uwp/Renderer/lib/AdaptiveMediaEventInvoker.h
@@ -3,7 +3,7 @@
 #include "AdaptiveCards.Rendering.Uwp.h"
 #include "RenderedAdaptiveCard.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveMediaEventInvoker :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -23,4 +23,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveMediaEventInvoker);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveMediaRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveMediaRenderer.cpp
@@ -8,7 +8,7 @@
 using namespace Microsoft::WRL;
 using namespace ABI::AdaptiveNamespace;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveMediaRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -34,4 +34,4 @@ AdaptiveNamespaceStart
     {
         return AdaptiveNamespace::FromJson<AdaptiveNamespace::AdaptiveMedia, AdaptiveSharedNamespace::Media, AdaptiveSharedNamespace::MediaParser>(jsonObject, elementParserRegistration, actionParserRegistration, adaptiveWarnings, element);
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveMediaRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveMediaRenderer.h
@@ -1,6 +1,6 @@
 #pragma once
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveMediaRenderer :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -27,4 +27,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveMediaRenderer);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveMediaSource.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveMediaSource.cpp
@@ -1,7 +1,7 @@
 #include "pch.h"
 #include "AdaptiveMediaSource.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveMediaSource::RuntimeClassInitialize() noexcept try
     {
         std::shared_ptr<AdaptiveSharedNamespace::MediaSource> mediaSource = std::make_shared<AdaptiveSharedNamespace::MediaSource>();
@@ -56,4 +56,4 @@ AdaptiveNamespaceStart
         sharedMediaSource = mediaSource;
         return S_OK;
     } CATCH_RETURN;
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveMediaSource.h
+++ b/source/uwp/Renderer/lib/AdaptiveMediaSource.h
@@ -1,6 +1,6 @@
 #pragma once
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class DECLSPEC_UUID("0c87566c-a58c-4332-8b3b-79c9714074f6") AdaptiveMediaSource :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -34,4 +34,4 @@ AdaptiveNamespaceStart
 };
 
     ActivatableClass(AdaptiveMediaSource);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveNumberInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveNumberInput.cpp
@@ -11,7 +11,7 @@ using namespace ABI::Windows::Foundation::Collections;
 using namespace ABI::Windows::UI::Xaml;
 using namespace ABI::Windows::UI::Xaml::Controls;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveNumberInput::RuntimeClassInitialize() noexcept try
     {
         std::shared_ptr<AdaptiveSharedNamespace::NumberInput> numberInput = std::make_shared<AdaptiveSharedNamespace::NumberInput>();
@@ -110,4 +110,4 @@ AdaptiveNamespaceStart
         sharedModel = numberInput;
         return S_OK;
     }CATCH_RETURN;
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveNumberInput.h
+++ b/source/uwp/Renderer/lib/AdaptiveNumberInput.h
@@ -5,7 +5,7 @@
 #include "NumberInput.h"
 #include "AdaptiveInputElement.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class DECLSPEC_UUID("e54a7a83-8961-4745-8663-bbf5d45b6345") AdaptiveNumberInput :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -76,4 +76,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveNumberInput);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveNumberInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveNumberInputRenderer.cpp
@@ -12,7 +12,7 @@ using namespace Microsoft::WRL::Wrappers;
 using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::Foundation;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveNumberInputRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -38,4 +38,4 @@ AdaptiveNamespaceStart
     {
         return AdaptiveNamespace::FromJson<AdaptiveNamespace::AdaptiveNumberInput, AdaptiveSharedNamespace::NumberInput, AdaptiveSharedNamespace::NumberInputParser>(jsonObject, elementParserRegistration, actionParserRegistration, adaptiveWarnings, element);
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveNumberInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveNumberInputRenderer.h
@@ -4,7 +4,7 @@
 #include "Enums.h"
 #include "NumberInput.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveNumberInputRenderer :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -31,4 +31,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveNumberInputRenderer);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveOpenUrlAction.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveOpenUrlAction.cpp
@@ -7,7 +7,7 @@ using namespace Microsoft::WRL::Wrappers;
 using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::Foundation;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveOpenUrlAction::RuntimeClassInitialize() noexcept try
     {
         std::shared_ptr<AdaptiveSharedNamespace::OpenUrlAction> openUrlAction = std::make_shared<AdaptiveSharedNamespace::OpenUrlAction>();
@@ -71,4 +71,4 @@ AdaptiveNamespaceStart
         sharedModel = openUrlAction;
         return S_OK;
     } CATCH_RETURN;
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveOpenUrlAction.h
+++ b/source/uwp/Renderer/lib/AdaptiveOpenUrlAction.h
@@ -5,7 +5,7 @@
 #include "OpenUrlAction.h"
 #include "AdaptiveActionElement.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class DECLSPEC_UUID("96c1ded5-1ef8-4aa8-8ccf-0bea96295ac8") AdaptiveOpenUrlAction :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -55,4 +55,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveOpenUrlAction);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveRemoteResourceInformation.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveRemoteResourceInformation.cpp
@@ -9,7 +9,7 @@ using namespace ABI::Windows::Foundation::Collections;
 using namespace ABI::Windows::UI::Xaml;
 using namespace ABI::Windows::UI::Xaml::Controls;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveRemoteResourceInformation::RuntimeClassInitialize() noexcept try
     {
         RemoteResourceInformation uriInformation;
@@ -49,4 +49,4 @@ AdaptiveNamespaceStart
         return m_mimeType.Set(mimeType);
     }
 
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveRemoteResourceInformation.h
+++ b/source/uwp/Renderer/lib/AdaptiveRemoteResourceInformation.h
@@ -5,7 +5,7 @@
 #include "TextBlock.h"
 #include "AdaptiveCardElement.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class DECLSPEC_UUID("0c87566c-a58c-4332-8b3b-79c9714074f6") AdaptiveRemoteResourceInformation :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -30,4 +30,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveRemoteResourceInformation);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveRenderArgs.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveRenderArgs.cpp
@@ -8,7 +8,7 @@ using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::Foundation;
 using namespace ABI::Windows::UI::Xaml;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveRenderArgs::RuntimeClassInitialize() noexcept
     {
         return S_OK;
@@ -49,4 +49,4 @@ AdaptiveNamespaceStart
         m_parentElement = value;
         return S_OK;
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveRenderArgs.h
+++ b/source/uwp/Renderer/lib/AdaptiveRenderArgs.h
@@ -2,7 +2,7 @@
 
 #include "AdaptiveCards.Rendering.Uwp.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveRenderArgs :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -28,4 +28,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveRenderArgs);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveRenderContext.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveRenderContext.cpp
@@ -13,7 +13,7 @@ using namespace ABI::Windows::Foundation;
 using namespace ABI::Windows::Foundation::Collections;
 using namespace ABI::Windows::UI::Xaml;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveRenderContext::RuntimeClassInitialize() noexcept
     {
         return S_OK;
@@ -99,4 +99,4 @@ AdaptiveNamespaceStart
     {
         return m_renderResult->AddInputValue(inputValue);
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveRenderContext.h
+++ b/source/uwp/Renderer/lib/AdaptiveRenderContext.h
@@ -5,7 +5,7 @@
 #include "AdaptiveActionInvoker.h"
 #include "AdaptiveMediaEventInvoker.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveRenderContext :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -44,4 +44,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveRenderContext);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveSeparator.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveSeparator.cpp
@@ -10,7 +10,7 @@ using namespace ABI::Windows::Foundation::Collections;
 using namespace ABI::Windows::UI::Xaml;
 using namespace ABI::Windows::UI::Xaml::Controls;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveSeparator::RuntimeClassInitialize() noexcept try
     {
         m_sharedSeparator = std::make_shared<Separator>();
@@ -51,4 +51,4 @@ AdaptiveNamespaceStart
         m_sharedSeparator->SetThickness(static_cast<AdaptiveSharedNamespace::SeparatorThickness>(thickness));
         return S_OK;
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveSeparator.h
+++ b/source/uwp/Renderer/lib/AdaptiveSeparator.h
@@ -4,7 +4,7 @@
 #include "Enums.h"
 #include "Separator.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveSeparator :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -28,4 +28,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveSeparator);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveSeparatorConfig.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveSeparatorConfig.cpp
@@ -4,7 +4,7 @@
 using namespace Microsoft::WRL;
 using namespace ABI::AdaptiveNamespace;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveSeparatorConfig::RuntimeClassInitialize() noexcept try
     {
         SeparatorConfig separatorConfig;
@@ -45,4 +45,4 @@ AdaptiveNamespaceStart
         m_lineColor = color;
         return S_OK;
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveSeparatorConfig.h
+++ b/source/uwp/Renderer/lib/AdaptiveSeparatorConfig.h
@@ -4,7 +4,7 @@
 #include "Enums.h"
 #include "HostConfig.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveSeparatorConfig :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -28,4 +28,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveSeparatorConfig);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveShowCardAction.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveShowCardAction.cpp
@@ -6,7 +6,7 @@
 using namespace Microsoft::WRL;
 using namespace ABI::AdaptiveNamespace;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveShowCardAction::RuntimeClassInitialize() noexcept try
     {
         std::shared_ptr<AdaptiveSharedNamespace::ShowCardAction> showCardAction = std::make_shared<AdaptiveSharedNamespace::ShowCardAction>();
@@ -60,4 +60,4 @@ AdaptiveNamespaceStart
         sharedModel = showCardAction;
         return S_OK;
     } CATCH_RETURN;
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveShowCardAction.h
+++ b/source/uwp/Renderer/lib/AdaptiveShowCardAction.h
@@ -5,7 +5,7 @@
 #include "ShowCardAction.h"
 #include "AdaptiveActionElement.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class DECLSPEC_UUID("429d6be9-a5f4-44dc-8dc3-3fe9b633ff1c") AdaptiveShowCardAction :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -56,4 +56,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveShowCardAction);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveShowCardActionConfig.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveShowCardActionConfig.cpp
@@ -6,7 +6,7 @@ using namespace Microsoft::WRL;
 using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::UI;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveShowCardActionConfig::RuntimeClassInitialize() noexcept try
     {
         ShowCardActionConfig showCardActionConfig;
@@ -62,4 +62,4 @@ AdaptiveNamespaceStart
         m_inlineTopMargin = inlineTopMargin;
         return S_OK;
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveShowCardActionConfig.h
+++ b/source/uwp/Renderer/lib/AdaptiveShowCardActionConfig.h
@@ -4,7 +4,7 @@
 #include "Enums.h"
 #include "HostConfig.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveShowCardActionConfig :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -32,4 +32,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveShowCardActionConfig);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveSpacingConfig.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveSpacingConfig.cpp
@@ -4,7 +4,7 @@
 using namespace Microsoft::WRL;
 using namespace ABI::AdaptiveNamespace;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveSpacingConfig::RuntimeClassInitialize() noexcept try
     {
         SpacingConfig spacingConfig;
@@ -105,4 +105,4 @@ AdaptiveNamespaceStart
         m_padding = paddingSpacing;
         return S_OK;
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveSpacingConfig.h
+++ b/source/uwp/Renderer/lib/AdaptiveSpacingConfig.h
@@ -4,7 +4,7 @@
 #include "Enums.h"
 #include "HostConfig.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveSpacingConfig :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -44,4 +44,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveSpacingConfig);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveSubmitAction.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveSubmitAction.cpp
@@ -6,7 +6,7 @@ using namespace Microsoft::WRL;
 using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::Data::Json;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveSubmitAction::RuntimeClassInitialize() noexcept try
     {
         std::shared_ptr<AdaptiveSharedNamespace::SubmitAction> submitAction = std::make_shared<AdaptiveSharedNamespace::SubmitAction>();
@@ -58,4 +58,4 @@ AdaptiveNamespaceStart
         sharedModel = submitAction;
         return S_OK;
     }CATCH_RETURN;
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveSubmitAction.h
+++ b/source/uwp/Renderer/lib/AdaptiveSubmitAction.h
@@ -5,7 +5,7 @@
 #include "SubmitAction.h"
 #include "AdaptiveActionElement.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class DECLSPEC_UUID("32114ce2-7e10-4f7f-8225-bfd661c6794c") AdaptiveSubmitAction :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -55,4 +55,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveSubmitAction);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveTextBlock.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTextBlock.cpp
@@ -11,7 +11,7 @@ using namespace ABI::Windows::Foundation::Collections;
 using namespace ABI::Windows::UI::Xaml;
 using namespace ABI::Windows::UI::Xaml::Controls;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveTextBlock::RuntimeClassInitialize() noexcept try
     {
         std::shared_ptr<AdaptiveSharedNamespace::TextBlock> textBlock = std::make_shared<AdaptiveSharedNamespace::TextBlock>();
@@ -199,4 +199,4 @@ AdaptiveNamespaceStart
         sharedTextBlock = textBlock;
         return S_OK;
     } CATCH_RETURN;
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveTextBlock.h
+++ b/source/uwp/Renderer/lib/AdaptiveTextBlock.h
@@ -5,7 +5,7 @@
 #include "TextBlock.h"
 #include "AdaptiveCardElement.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class DECLSPEC_UUID("0c87566c-a58c-4332-8b3b-79c9714074f6") AdaptiveTextBlock :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -91,4 +91,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveTextBlock);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveTextBlockRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTextBlockRenderer.cpp
@@ -12,7 +12,7 @@ using namespace Microsoft::WRL::Wrappers;
 using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::Foundation;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveTextBlockRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -39,4 +39,4 @@ AdaptiveNamespaceStart
         return AdaptiveNamespace::FromJson<AdaptiveNamespace::AdaptiveTextBlock, AdaptiveSharedNamespace::TextBlock, AdaptiveSharedNamespace::TextBlockParser>(jsonObject, elementParserRegistration, actionParserRegistration, adaptiveWarnings, element);
     }
 
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveTextBlockRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveTextBlockRenderer.h
@@ -4,7 +4,7 @@
 #include "Enums.h"
 #include "TextBlock.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveTextBlockRenderer :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -31,4 +31,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveTextBlockRenderer);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveTextConfig.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTextConfig.cpp
@@ -5,7 +5,7 @@
 using namespace Microsoft::WRL;
 using namespace ABI::AdaptiveNamespace;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveTextConfig::RuntimeClassInitialize() noexcept try
     {
         TextConfig textConfig;
@@ -104,4 +104,4 @@ AdaptiveNamespaceStart
         m_maxWidth = maxWidth;
         return S_OK;
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveTextConfig.h
+++ b/source/uwp/Renderer/lib/AdaptiveTextConfig.h
@@ -4,7 +4,7 @@
 #include "Enums.h"
 #include "HostConfig.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveTextConfig :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -44,4 +44,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveTextConfig);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveTextInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTextInput.cpp
@@ -11,7 +11,7 @@ using namespace ABI::Windows::Foundation::Collections;
 using namespace ABI::Windows::UI::Xaml;
 using namespace ABI::Windows::UI::Xaml::Controls;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveTextInput::RuntimeClassInitialize() noexcept try
     {
         std::shared_ptr<AdaptiveSharedNamespace::TextInput> textInput = std::make_shared<AdaptiveSharedNamespace::TextInput>();
@@ -125,4 +125,4 @@ AdaptiveNamespaceStart
 
         return S_OK;
     }CATCH_RETURN;
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveTextInput.h
+++ b/source/uwp/Renderer/lib/AdaptiveTextInput.h
@@ -5,7 +5,7 @@
 #include "TextInput.h"
 #include "AdaptiveInputElement.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class DECLSPEC_UUID("2e716e94-a83a-4e9b-9873-bff858af068d") AdaptiveTextInput :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -80,4 +80,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveTextInput);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.cpp
@@ -12,7 +12,7 @@ using namespace Microsoft::WRL::Wrappers;
 using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::Foundation;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveTextInputRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -38,4 +38,4 @@ AdaptiveNamespaceStart
     {
         return AdaptiveNamespace::FromJson<AdaptiveNamespace::AdaptiveTextInput, AdaptiveSharedNamespace::TextInput, AdaptiveSharedNamespace::TextInputParser>(jsonObject, elementParserRegistration, actionParserRegistration, adaptiveWarnings, element);
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.h
@@ -4,7 +4,7 @@
 #include "Enums.h"
 #include "TextInput.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveTextInputRenderer :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -31,4 +31,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveTextInputRenderer);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveTimeInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTimeInput.cpp
@@ -11,7 +11,7 @@ using namespace ABI::Windows::Foundation::Collections;
 using namespace ABI::Windows::UI::Xaml;
 using namespace ABI::Windows::UI::Xaml::Controls;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveTimeInput::RuntimeClassInitialize() noexcept try
     {
         std::shared_ptr<AdaptiveSharedNamespace::TimeInput> timeInput = std::make_shared<AdaptiveSharedNamespace::TimeInput>();
@@ -106,4 +106,4 @@ AdaptiveNamespaceStart
 
         return S_OK;
     }CATCH_RETURN;
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveTimeInput.h
+++ b/source/uwp/Renderer/lib/AdaptiveTimeInput.h
@@ -5,7 +5,7 @@
 #include "TimeInput.h"
 #include "AdaptiveInputElement.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class DECLSPEC_UUID("5d05c3fe-f808-4181-9f44-3a802b556a43")  AdaptiveTimeInput :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -76,4 +76,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveTimeInput);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveTimeInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTimeInputRenderer.cpp
@@ -12,7 +12,7 @@ using namespace Microsoft::WRL::Wrappers;
 using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::Foundation;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveTimeInputRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -38,4 +38,4 @@ AdaptiveNamespaceStart
     {
         return AdaptiveNamespace::FromJson<AdaptiveNamespace::AdaptiveTimeInput, AdaptiveSharedNamespace::TimeInput, AdaptiveSharedNamespace::TimeInputParser>(jsonObject, elementParserRegistration, actionParserRegistration, adaptiveWarnings, element);
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveTimeInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveTimeInputRenderer.h
@@ -4,7 +4,7 @@
 #include "Enums.h"
 #include "TimeInput.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveTimeInputRenderer :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -31,4 +31,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveTimeInputRenderer);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveToggleInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveToggleInput.cpp
@@ -11,7 +11,7 @@ using namespace ABI::Windows::Foundation::Collections;
 using namespace ABI::Windows::UI::Xaml;
 using namespace ABI::Windows::UI::Xaml::Controls;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveToggleInput::RuntimeClassInitialize() noexcept try
     {
         std::shared_ptr<AdaptiveSharedNamespace::ToggleInput> toggleInput = std::make_shared<AdaptiveSharedNamespace::ToggleInput>();
@@ -105,4 +105,4 @@ AdaptiveNamespaceStart
 
         return S_OK;
     }CATCH_RETURN;
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveToggleInput.h
+++ b/source/uwp/Renderer/lib/AdaptiveToggleInput.h
@@ -5,7 +5,7 @@
 #include "ToggleInput.h"
 #include "AdaptiveInputElement.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class DECLSPEC_UUID("502edea9-72fd-4856-a89e-54565181bed8") AdaptiveToggleInput :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -76,4 +76,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveToggleInput);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveToggleInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveToggleInputRenderer.cpp
@@ -12,7 +12,7 @@ using namespace Microsoft::WRL::Wrappers;
 using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::Foundation;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT AdaptiveToggleInputRenderer::RuntimeClassInitialize() noexcept try
     {
         return S_OK;
@@ -38,4 +38,4 @@ AdaptiveNamespaceStart
     {
         return AdaptiveNamespace::FromJson<AdaptiveNamespace::AdaptiveToggleInput, AdaptiveSharedNamespace::ToggleInput, AdaptiveSharedNamespace::ToggleInputParser>(jsonObject, elementParserRegistration, actionParserRegistration, adaptiveWarnings, element);
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveToggleInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveToggleInputRenderer.h
@@ -4,7 +4,7 @@
 #include "Enums.h"
 #include "ToggleInput.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveToggleInputRenderer :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -31,4 +31,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveToggleInputRenderer);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveWarning.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveWarning.cpp
@@ -5,7 +5,7 @@ using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;
 using namespace ABI::AdaptiveNamespace;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
 
     HRESULT AdaptiveWarning::RuntimeClassInitialize()
     {
@@ -46,4 +46,4 @@ AdaptiveNamespaceStart
     {
         return m_message.Set(value);
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/AdaptiveWarning.h
+++ b/source/uwp/Renderer/lib/AdaptiveWarning.h
@@ -2,7 +2,7 @@
 
 #include "AdaptiveCards.Rendering.Uwp.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveWarning:
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -31,4 +31,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(AdaptiveWarning);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/CustomActionWrapper.cpp
+++ b/source/uwp/Renderer/lib/CustomActionWrapper.cpp
@@ -4,7 +4,7 @@
 using namespace Microsoft::WRL;
 using namespace ABI::AdaptiveNamespace;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
 
 std::string CustomActionWrapper::GetId() const
 {
@@ -58,4 +58,4 @@ void CustomActionWrapper::GetResourceInformation(std::vector<RemoteResourceInfor
         RemoteResourceElementToRemoteResourceInformationVector(remoteResources.Get(), resourceInfo);
     }
 }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/CustomActionWrapper.h
+++ b/source/uwp/Renderer/lib/CustomActionWrapper.h
@@ -3,7 +3,7 @@
 #include "AdaptiveCards.Rendering.Uwp.h"
 #include "Util.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class CustomActionWrapper : public AdaptiveSharedNamespace::BaseActionElement
     {
     public:
@@ -27,4 +27,4 @@ AdaptiveNamespaceStart
     private:
         Microsoft::WRL::ComPtr<ABI::AdaptiveNamespace::IAdaptiveActionElement> m_actionElement;
     };
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/CustomElementWrapper.cpp
+++ b/source/uwp/Renderer/lib/CustomElementWrapper.cpp
@@ -4,7 +4,7 @@
 using namespace Microsoft::WRL;
 using namespace ABI::AdaptiveNamespace;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
 
     bool CustomElementWrapper::GetSeparator() const
     {
@@ -69,4 +69,4 @@ AdaptiveNamespaceStart
     {
         return m_cardElement.CopyTo(cardElement);
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/CustomElementWrapper.h
+++ b/source/uwp/Renderer/lib/CustomElementWrapper.h
@@ -3,7 +3,7 @@
 #include "AdaptiveCards.Rendering.Uwp.h"
 #include "Util.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class CustomElementWrapper : public AdaptiveSharedNamespace::BaseCardElement
     {
     public:
@@ -30,4 +30,4 @@ AdaptiveNamespaceStart
     private:
         Microsoft::WRL::ComPtr<ABI::AdaptiveNamespace::IAdaptiveCardElement> m_cardElement;
     };
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/DateTimeParser.cpp
+++ b/source/uwp/Renderer/lib/DateTimeParser.cpp
@@ -4,7 +4,7 @@
 #include <iomanip>
 #include <sstream>
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
 
 DateTimeParser::DateTimeParser(const std::string& language)
 {
@@ -60,4 +60,4 @@ std::string DateTimeParser::GenerateString(DateTimePreparser text)
     return WstringToString(parsedostr.str());
 }
 
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/DateTimeParser.h
+++ b/source/uwp/Renderer/lib/DateTimeParser.h
@@ -4,7 +4,7 @@
 #include <codecvt>
 #include <string>
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class DateTimeParser
     {
     public:
@@ -14,4 +14,4 @@ AdaptiveNamespaceStart
     private:
         std::string m_languageString;
     };
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/IImageLoadTrackerListener.h
+++ b/source/uwp/Renderer/lib/IImageLoadTrackerListener.h
@@ -1,6 +1,6 @@
 #pragma once
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
 
 MIDL_INTERFACE("D940E878-F2E0-4AF7-A844-4D090C7379E3")
 IImageLoadTrackerListener : public IInspectable
@@ -10,4 +10,4 @@ public:
     IFACEMETHOD(ImagesLoadingHadError)() = 0;
 };
 
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/IXamlBuilderListener.h
+++ b/source/uwp/Renderer/lib/IXamlBuilderListener.h
@@ -1,6 +1,6 @@
 #pragma once
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
 
 MIDL_INTERFACE("BF58F7BB-A330-4C75-AF7F-6E5FD8C0C070")
 IXamlBuilderListener : public IInspectable
@@ -11,4 +11,4 @@ public:
     IFACEMETHOD(XamlBuilderHadError)() = 0;
 };
 
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/ImageLoadTracker.cpp
+++ b/source/uwp/Renderer/lib/ImageLoadTracker.cpp
@@ -9,7 +9,7 @@ using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::UI::Xaml;
 using namespace ABI::Windows::UI::Xaml::Media::Imaging;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     ImageLoadTracker::~ImageLoadTracker()
     {
         for (auto& eventRegistration : m_eventRegistrations)
@@ -156,4 +156,4 @@ AdaptiveNamespaceStart
             listener->ImagesLoadingHadError();
         }
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/ImageLoadTracker.h
+++ b/source/uwp/Renderer/lib/ImageLoadTracker.h
@@ -3,7 +3,7 @@
 #include "AdaptiveCards.Rendering.Uwp.h"
 #include "IImageLoadTrackerListener.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     struct TrackedImageDetails
     {
         EventRegistrationToken imageOpenedRegistration;
@@ -37,4 +37,4 @@ AdaptiveNamespaceStart
         void FireAllImagesLoaded();
         void FireImagesLoadingHadError();
     };
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/InputValue.h
+++ b/source/uwp/Renderer/lib/InputValue.h
@@ -2,7 +2,7 @@
 
 #include "AdaptiveCards.Rendering.Uwp.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class DECLSPEC_UUID("BB1D1269-2243-4F34-B4EC-5216296EBBA0") InputValue :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -34,4 +34,4 @@ AdaptiveNamespaceStart
         Microsoft::WRL::ComPtr<ABI::AdaptiveNamespace::IAdaptiveInputElement> m_adaptiveInputElement;
         Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IUIElement> m_uiInputElement;
     };
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/RenderedAdaptiveCard.cpp
+++ b/source/uwp/Renderer/lib/RenderedAdaptiveCard.cpp
@@ -23,7 +23,7 @@ using namespace ABI::Windows::UI;
 using namespace ABI::Windows::UI::Xaml;
 using namespace ABI::Windows::UI::Xaml::Controls;
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     RenderedAdaptiveCard::RenderedAdaptiveCard()
     {
     }
@@ -137,4 +137,4 @@ AdaptiveNamespaceStart
     {
         return m_inputs->AddInputValue(inputItem);
     }
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/RenderedAdaptiveCard.h
+++ b/source/uwp/Renderer/lib/RenderedAdaptiveCard.h
@@ -5,7 +5,7 @@
 #include "InputValue.h"
 #include "AdaptiveInputs.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class RenderedAdaptiveCard :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
@@ -59,4 +59,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(RenderedAdaptiveCard);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/WholeItemsPanel.cpp
+++ b/source/uwp/Renderer/lib/WholeItemsPanel.cpp
@@ -18,7 +18,7 @@ using namespace ABI::Windows::UI::Xaml::Shapes;
 using namespace ABI::Windows::UI::Xaml::Media;
 
 static const float OutsidePanelY = -1000.0f;
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     HRESULT WholeItemsPanel::RuntimeClassInitialize()
     {
         ComPtr<IPanelFactory> spFactory;
@@ -589,4 +589,4 @@ AdaptiveNamespaceStart
         return !isnan(definedImageHeight) || !isnan(definedImageWidth);
     }
 
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/WholeItemsPanel.h
+++ b/source/uwp/Renderer/lib/WholeItemsPanel.h
@@ -3,7 +3,7 @@
 #include "AdaptiveCards.Rendering.Uwp.h"
 #include <windows.ui.xaml.shapes.h>
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class DECLSPEC_UUID("32934D77-6248-4915-BD2A-8F52EF6C8322") WholeItemsPanel : public Microsoft::WRL::RuntimeClass<
         ABI::AdaptiveNamespace::IWholeItemsPanel,
         ABI::Windows::UI::Xaml::IFrameworkElementOverrides,
@@ -83,4 +83,4 @@ AdaptiveNamespaceStart
     };
 
     ActivatableClass(WholeItemsPanel);
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -47,7 +47,7 @@ using namespace ABI::Windows::Web::Http::Filters;
 const PCWSTR c_TextBlockSubtleOpacityKey = L"TextBlock.SubtleOpacity";
 const PCWSTR c_BackgroundImageOverlayBrushKey = L"AdaptiveCard.BackgroundOverlayBrush";
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     XamlBuilder::XamlBuilder()
     {
 
@@ -3122,4 +3122,4 @@ AdaptiveNamespaceStart
         panel->SetVerticalContentAlignment(verticalContentAlignment);
     }
 
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/XamlBuilder.h
+++ b/source/uwp/Renderer/lib/XamlBuilder.h
@@ -9,7 +9,7 @@
 #include "RenderedAdaptiveCard.h"
 #include "AdaptiveRenderContext.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class AdaptiveCardRenderer;
 
     class XamlBuilder : public Microsoft::WRL::RuntimeClass<
@@ -268,4 +268,4 @@ AdaptiveNamespaceStart
             _In_ ABI::AdaptiveNamespace::VerticalContentAlignment verticalContentAlignment);
 
     };
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/XamlHelpers.h
+++ b/source/uwp/Renderer/lib/XamlHelpers.h
@@ -3,7 +3,7 @@
 #include "AdaptiveCards.Rendering.Uwp.h"
 #include "WholeItemsPanel.h"
 
-AdaptiveNamespaceStart
+namespace AdaptiveNamespace {
     class XamlHelpers
     {
     public:
@@ -168,4 +168,4 @@ AdaptiveNamespaceStart
             XamlHelpers::AppendXamlElementToPanel(item, localPanel.Get());
         }
     };
-AdaptiveNamespaceEnd
+}

--- a/source/uwp/Renderer/lib/pch.h
+++ b/source/uwp/Renderer/lib/pch.h
@@ -9,9 +9,7 @@
 #define AdaptiveRuntime(cls) InspectableClass(RuntimeClass_AdaptiveCards_Rendering_Uwp_##cls, BaseTrust)
 #define AdaptiveRuntimeStatic(cls) InspectableClassStatic(RuntimeClass_AdaptiveCards_Rendering_Uwp_##cls, BaseTrust)
 #define AdaptiveRuntimeStringClass(cls) InspectableClass(L"AdaptiveCards.Rendering.Uwp." L#cls, BaseTrust)
-#define AdaptiveNamespaceStart namespace AdaptiveCards { namespace Rendering { namespace Uwp {
 #define AdaptiveNamespace AdaptiveCards::Rendering::Uwp
-#define AdaptiveNamespaceEnd }}}
 #define AdaptiveRuntimeClass RuntimeClass_AdaptiveCards_Rendering_Uwp
 #define AdaptivePointerCast dynamic_pointer_cast
 #endif


### PR DESCRIPTION
This is the first step needed to bring UWP into the `.clang-format` fold.