### PR TITLE
[UWP v2.0 prototype] Separate json templating from parsing and add templating panel to visualizer

### DIFF
--- a/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
+++ b/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
@@ -6,7 +6,6 @@
 #include "TextBlock.h"
 #include "AdaptiveCardParseWarning.h"
 #include "SemanticVersion.h"
-#include "FrameTranslator.h"
 
 using namespace AdaptiveSharedNamespace;
 
@@ -55,8 +54,7 @@ std::shared_ptr<ParseResult> AdaptiveCard::DeserializeFromFile(
 std::shared_ptr<ParseResult> AdaptiveCard::DeserializeFromFile(const std::string& jsonFile,
                                                                std::string rendererVersion,
                                                                std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-                                                               std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-                                                               const std::string& jsonFrameFile)
+                                                               std::shared_ptr<ActionParserRegistration> actionParserRegistration)
 #endif // __ANDROID__
 {
     std::ifstream jsonFileStream(jsonFile);
@@ -64,13 +62,7 @@ std::shared_ptr<ParseResult> AdaptiveCard::DeserializeFromFile(const std::string
     Json::Value root;
     jsonFileStream >> root;
 
-    Json::Value frame;
-    if (!jsonFrameFile.empty())
-    {
-        jsonFileStream >> frame;
-    }
-
-    return AdaptiveCard::Deserialize(root, frame, rendererVersion, elementParserRegistration, actionParserRegistration);
+    return AdaptiveCard::Deserialize(root, rendererVersion, elementParserRegistration, actionParserRegistration);
 }
 
 #ifdef __ANDROID__
@@ -80,15 +72,12 @@ std::shared_ptr<ParseResult> AdaptiveCard::Deserialize(
     std::shared_ptr<ElementParserRegistration> elementParserRegistration,
     std::shared_ptr<ActionParserRegistration> actionParserRegistration) throw(AdaptiveSharedNamespace::AdaptiveCardParseException)
 #else
-std::shared_ptr<ParseResult> AdaptiveCard::Deserialize(const Json::Value& inputJson,
-                                                       const Json::Value& frame,
+std::shared_ptr<ParseResult> AdaptiveCard::Deserialize(const Json::Value& json,
                                                        std::string rendererVersion,
                                                        std::shared_ptr<ElementParserRegistration> elementParserRegistration,
                                                        std::shared_ptr<ActionParserRegistration> actionParserRegistration)
 #endif // __ANDROID__
 {
-    Json::Value json = ApplyJsonTemplating(inputJson, frame);
-
     ParseUtil::ThrowIfNotJsonObject(json);
 
     const bool enforceVersion = !rendererVersion.empty();
@@ -197,17 +186,10 @@ std::shared_ptr<ParseResult> AdaptiveCard::DeserializeFromString(
 std::shared_ptr<ParseResult> AdaptiveCard::DeserializeFromString(const std::string& jsonString,
                                                                  std::string rendererVersion,
                                                                  std::shared_ptr<ElementParserRegistration> elementParserRegistration,
-                                                                 std::shared_ptr<ActionParserRegistration> actionParserRegistration,
-                                                                 const std::string& jsonFrame)
+                                                                 std::shared_ptr<ActionParserRegistration> actionParserRegistration)
 #endif // __ANDROID__
 {
-    Json::Value frame;
-    if (!jsonFrame.empty())
-    {
-        frame = ParseUtil::GetJsonValueFromString(jsonFrame);
-    }
-
-    return AdaptiveCard::Deserialize(ParseUtil::GetJsonValueFromString(jsonString), frame, rendererVersion, elementParserRegistration, actionParserRegistration);
+    return AdaptiveCard::Deserialize(ParseUtil::GetJsonValueFromString(jsonString), rendererVersion, elementParserRegistration, actionParserRegistration);
 }
 
 Json::Value AdaptiveCard::SerializeToJsonValue() const

--- a/source/shared/cpp/ObjectModel/SharedAdaptiveCard.h
+++ b/source/shared/cpp/ObjectModel/SharedAdaptiveCard.h
@@ -84,11 +84,9 @@ namespace AdaptiveSharedNamespace
         static std::shared_ptr<ParseResult> DeserializeFromFile(const std::string& jsonFile,
                                                                 std::string rendererVersion,
                                                                 std::shared_ptr<ElementParserRegistration> elementParserRegistration = nullptr,
-                                                                std::shared_ptr<ActionParserRegistration> actionParserRegistration = nullptr,
-                                                                const std::string& = nullptr);
+                                                                std::shared_ptr<ActionParserRegistration> actionParserRegistration = nullptr);
 
         static std::shared_ptr<ParseResult> Deserialize(const Json::Value& json,
-                                                        const Json::Value& frame,
                                                         std::string rendererVersion,
                                                         std::shared_ptr<ElementParserRegistration> elementParserRegistration = nullptr,
                                                         std::shared_ptr<ActionParserRegistration> actionParserRegistration = nullptr);
@@ -97,8 +95,7 @@ namespace AdaptiveSharedNamespace
         DeserializeFromString(const std::string& jsonString,
                               std::string rendererVersion,
                               std::shared_ptr<ElementParserRegistration> elementParserRegistration = nullptr,
-                              std::shared_ptr<ActionParserRegistration> actionParserRegistration = nullptr,
-                              const std::string& = nullptr);
+                              std::shared_ptr<ActionParserRegistration> actionParserRegistration = nullptr);
 
         static std::shared_ptr<AdaptiveCard> MakeFallbackTextCard(const std::string& fallbackText,
                                                                   const std::string& language,

--- a/source/shared/cpp/ObjectModel/ShowCardAction.cpp
+++ b/source/shared/cpp/ObjectModel/ShowCardAction.cpp
@@ -47,9 +47,8 @@ std::shared_ptr<BaseActionElement> ShowCardActionParser::Deserialize(std::shared
 
     std::string propertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Card);
 
-    Json::Value frame;
     auto parseResult =
-        AdaptiveCard::Deserialize(json.get(propertyName, Json::Value()), frame, "", elementParserRegistration, actionParserRegistration);
+        AdaptiveCard::Deserialize(json.get(propertyName, Json::Value()), "", elementParserRegistration, actionParserRegistration);
 
     auto showCardWarnings = parseResult->GetWarnings();
     auto warningsEnd = warnings.insert(warnings.end(), showCardWarnings.begin(), showCardWarnings.end());

--- a/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj
+++ b/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj
@@ -162,6 +162,7 @@
     <ClInclude Include="lib\AdaptiveRenderArgs.h" />
     <ClInclude Include="lib\AdaptiveRenderContext.h" />
     <ClInclude Include="lib\AdaptiveSeparator.h" />
+    <ClInclude Include="lib\AdaptiveTemplater.h" />
     <ClInclude Include="lib\AdaptiveTextBlockRenderer.h" />
     <ClInclude Include="lib\AdaptiveTextInputRenderer.h" />
     <ClInclude Include="lib\AdaptiveTimeInputRenderer.h" />
@@ -222,9 +223,10 @@
     <ClCompile Include="lib\AdaptiveMediaSource.cpp" />
     <ClCompile Include="lib\AdaptiveMediaEventArgs.cpp" />
     <ClCompile Include="lib\AdaptiveRemoteResourceInformation.cpp" />
+    <ClCompile Include="lib\AdaptiveTemplater.cpp" />
     <ClCompile Include="lib\MediaHelpers.cpp" />
     <ClCompile Include="lib\AdaptiveActionSet.cpp" />
-    <ClCompile Include="lib\AdaptiveActionSetRenderer.cpp" />    
+    <ClCompile Include="lib\AdaptiveActionSetRenderer.cpp" />
     <ClCompile Include="lib\pch.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>

--- a/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj.filters
+++ b/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj.filters
@@ -90,7 +90,8 @@
     <ClCompile Include="lib\AdaptiveMediaEventArgs.cpp" />
     <ClCompile Include="lib\AdaptiveRemoteResourceInformation.cpp" />
     <ClCompile Include="lib\AdaptiveActionSet.cpp" />
-    <ClCompile Include="lib\AdaptiveActionSetRenderer.cpp" />    
+    <ClCompile Include="lib\AdaptiveActionSetRenderer.cpp" />
+    <ClCompile Include="lib\AdaptiveTemplater.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="lib\AdaptiveCard.h" />
@@ -188,7 +189,8 @@
     <ClInclude Include="lib\AdaptiveMediaEventArgs.h" />
     <ClInclude Include="lib\AdaptiveRemoteResourceInformation.h" />
     <ClInclude Include="lib\AdaptiveActionSet.h" />
-    <ClInclude Include="lib\AdaptiveActionSetRenderer.h" />    
+    <ClInclude Include="lib\AdaptiveActionSetRenderer.h" />
+    <ClInclude Include="lib\AdaptiveTemplater.h" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="idl\AdaptiveCards.Rendering.Uwp.idl" />

--- a/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
+++ b/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
@@ -102,6 +102,7 @@ AdaptiveNamespaceStart
     runtimeclass AdaptiveRemoteResourceInformation;
 
     runtimeclass WholeItemsPanel;
+    runtimeclass AdaptiveJsonTemplater;
 
     interface IAdaptiveCardResourceResolvers;
     interface IAdaptiveCardResourceResolver;
@@ -474,6 +475,38 @@ AdaptiveNamespaceStart
 
     [
         version(NTDDI_WIN10_RS1),
+        exclusiveto(AdaptiveJsonTemplater),
+#ifdef ADAPTIVE_CARDS_WINDOWS
+        uuid(072DB60B-F1A5-45B5-BA46-78245DB43FAA),
+        contract(InternalContract, 1),
+        internal
+#else
+        uuid(81DFB727-8CC7-49F1-AE95-6B97ABD84C3A)
+#endif
+    ]
+    interface IAdaptiveJsonTemplaterStatics : IInspectable
+    {
+        HRESULT ApplyJsonTemplating(
+            [in] Windows.Data.Json.JsonObject* card,
+            [in] Windows.Data.Json.JsonObject* frame,
+            [out, retval] Windows.Data.Json.JsonObject** value);
+    };
+
+    [
+        version(NTDDI_WIN10_RS1),
+        static(IAdaptiveJsonTemplaterStatics, NTDDI_WIN10_RS1),
+#ifdef ADAPTIVE_CARDS_WINDOWS
+        static(IAdaptiveJsonTemplaterStatics, InternalContract, 1),
+        contract(InternalContract, 1),
+        internal,
+#endif        
+    ]
+    runtimeclass AdaptiveJsonTemplater 
+    { 
+    };
+
+    [
+        version(NTDDI_WIN10_RS1),
 #ifdef ADAPTIVE_CARDS_WINDOWS
         uuid(21f8aa32-e8ca-41cb-b571-d7d234173a88),
         contract(InternalContract, 1),
@@ -823,14 +856,6 @@ AdaptiveNamespaceStart
             [in] AdaptiveActionParserRegistration* actionRegistration,
             [out, retval] AdaptiveCardParseResult** card);
 
-        [overload("FromJson")] 
-        HRESULT FromJsonWithParserRegistrationAndFrame(
-            [in] Windows.Data.Json.JsonObject * adaptiveJson,
-            [in] AdaptiveElementParserRegistration * elementRegistration,
-            [in] AdaptiveActionParserRegistration * actionRegistration,
-            [in] Windows.Data.Json.JsonObject * adaptiveFrame,
-            [out, retval] AdaptiveCardParseResult * *card);
-
         [overload("FromJsonString")]
         HRESULT FromJsonString(
             [in] HSTRING adaptiveJson,
@@ -842,14 +867,6 @@ AdaptiveNamespaceStart
             [in] AdaptiveElementParserRegistration* elementRegistration,
             [in] AdaptiveActionParserRegistration* actionRegistration,
             [out, retval] AdaptiveCardParseResult** card);
-
-        [overload("FromJsonString")] 
-        HRESULT FromJsonStringWithParserRegistrationAndFrame(
-            [in] HSTRING adaptiveJson,
-            [in] AdaptiveElementParserRegistration * elementRegistration,
-            [in] AdaptiveActionParserRegistration * actionRegistration,
-            [in] HSTRING adaptiveFrame,
-            [out, retval] AdaptiveCardParseResult * *card);
     };
 
     [

--- a/source/uwp/Renderer/lib/AdaptiveCard.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveCard.cpp
@@ -26,7 +26,7 @@ namespace AdaptiveNamespace
     _Use_decl_annotations_ HRESULT AdaptiveCardStaticsImpl::FromJson(IJsonObject* adaptiveJson,
                                                                      IAdaptiveCardParseResult** parseResult) noexcept try
     {
-        return FromJsonWithParserRegistrationAndFrame(adaptiveJson, nullptr, nullptr, nullptr, parseResult);
+        return FromJsonWithParserRegistration(adaptiveJson, nullptr, nullptr, parseResult);
     }
     CATCH_RETURN;
 
@@ -38,33 +38,17 @@ namespace AdaptiveNamespace
     {
         *parseResult = nullptr;
 
-        return FromJsonWithParserRegistrationAndFrame(adaptiveJson, elementParserRegistration, actionParserRegistration, nullptr, parseResult);
-    }
-    CATCH_RETURN;
-
-    _Use_decl_annotations_ HRESULT AdaptiveCardStaticsImpl::FromJsonWithParserRegistrationAndFrame(
-        IJsonObject* adaptiveJson,
-        IAdaptiveElementParserRegistration* elementParserRegistration,
-        IAdaptiveActionParserRegistration* actionParserRegistration,
-        IJsonObject* adaptiveFrame,
-        IAdaptiveCardParseResult** parseResult) noexcept try
-    {
-        *parseResult = nullptr;
-
         std::string adaptiveJsonString;
         RETURN_IF_FAILED(JsonObjectToString(adaptiveJson, adaptiveJsonString));
 
-        std::string adaptiveFrameString;
-        RETURN_IF_FAILED(JsonObjectToString(adaptiveFrame, adaptiveFrameString));
-
-        return FromJsonHelper(adaptiveJsonString, elementParserRegistration, actionParserRegistration, adaptiveFrameString, parseResult);
+        return FromJsonHelper(adaptiveJsonString, elementParserRegistration, actionParserRegistration, parseResult);
     }
     CATCH_RETURN;
 
     _Use_decl_annotations_ HRESULT AdaptiveCardStaticsImpl::FromJsonString(HSTRING adaptiveJson,
                                                                            IAdaptiveCardParseResult** parseResult) noexcept try
     {
-        return FromJsonStringWithParserRegistrationAndFrame(adaptiveJson, nullptr, nullptr, nullptr, parseResult);
+        return FromJsonStringWithParserRegistration(adaptiveJson, nullptr, nullptr, parseResult);
     }
     CATCH_RETURN;
 
@@ -76,27 +60,13 @@ namespace AdaptiveNamespace
     {
         *parseResult = nullptr;
 
-        return FromJsonStringWithParserRegistrationAndFrame(adaptiveJson, elementParserRegistration, actionParserRegistration, nullptr, parseResult);
-    }
-    CATCH_RETURN;
-
-    _Use_decl_annotations_ HRESULT AdaptiveCardStaticsImpl::FromJsonStringWithParserRegistrationAndFrame(
-        HSTRING adaptiveJson,
-        IAdaptiveElementParserRegistration* elementParserRegistration,
-        IAdaptiveActionParserRegistration* actionParserRegistration,
-        HSTRING adaptiveFrame,
-        IAdaptiveCardParseResult** parseResult) noexcept try
-    {
-        *parseResult = nullptr;
-
-        return FromJsonHelper(HStringToUTF8(adaptiveJson), elementParserRegistration, actionParserRegistration, HStringToUTF8(adaptiveFrame), parseResult);
+        return FromJsonHelper(HStringToUTF8(adaptiveJson), elementParserRegistration, actionParserRegistration, parseResult);
     }
     CATCH_RETURN;
 
     _Use_decl_annotations_ HRESULT AdaptiveCardStaticsImpl::FromJsonHelper(const std::string jsonString,
                                                                            IAdaptiveElementParserRegistration* elementParserRegistration,
                                                                            IAdaptiveActionParserRegistration* actionParserRegistration,
-                                                                           const std::string jsonFrame,
                                                                            IAdaptiveCardParseResult** parseResult)
     {
         std::shared_ptr<ElementParserRegistration> sharedModelElementParserRegistration;
@@ -127,7 +97,7 @@ namespace AdaptiveNamespace
         {
             const std::string c_rendererVersion = "2.0";
             std::shared_ptr<::AdaptiveCards::ParseResult> sharedParseResult = ::AdaptiveCards::AdaptiveCard::DeserializeFromString(
-                jsonString, c_rendererVersion, sharedModelElementParserRegistration, sharedModelActionParserRegistration, jsonFrame);
+                jsonString, c_rendererVersion, sharedModelElementParserRegistration, sharedModelActionParserRegistration);
 
             ComPtr<IAdaptiveCard> adaptiveCard;
             RETURN_IF_FAILED(MakeAndInitialize<AdaptiveCard>(&adaptiveCard, sharedParseResult->GetAdaptiveCard()));

--- a/source/uwp/Renderer/lib/AdaptiveCard.h
+++ b/source/uwp/Renderer/lib/AdaptiveCard.h
@@ -98,13 +98,6 @@ namespace AdaptiveNamespace
                                                       ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParserRegistration,
                                                       _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardParseResult** parseResult) noexcept;
 
-        IFACEMETHODIMP FromJsonWithParserRegistrationAndFrame(
-            _In_ ABI::Windows::Data::Json::IJsonObject* adaptiveJson,
-            ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration* elementParserRegistration,
-            ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParserRegistration,
-            _In_ ABI::Windows::Data::Json::IJsonObject* adaptiveFrame,
-            _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardParseResult** parseResult) noexcept;
-
         IFACEMETHODIMP FromJsonString(_In_ HSTRING adaptiveJson,
                                       _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardParseResult** parseResult) noexcept;
 
@@ -114,18 +107,10 @@ namespace AdaptiveNamespace
             ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParserRegistration,
             _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardParseResult** parseResult) noexcept;
 
-        IFACEMETHODIMP FromJsonStringWithParserRegistrationAndFrame(
-            _In_ HSTRING adaptiveJson,
-            ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration* elementParserRegistration,
-            ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParserRegistration,
-            _In_ HSTRING adaptiveFrame,
-            _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardParseResult** parseResult) noexcept;
-
     private:
         HRESULT FromJsonHelper(_In_ const std::string jsonString,
                                ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration* elementParserRegistration,
                                ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParserRegistration,
-                               _In_ const std::string jsonFrame,
                                _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardParseResult** parseResult);
     };
 

--- a/source/uwp/Renderer/lib/AdaptiveTemplater.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTemplater.cpp
@@ -1,0 +1,35 @@
+#include "pch.h"
+#include "AdaptiveTemplater.h"
+#include "FrameTranslator.h"
+
+namespace AdaptiveNamespace
+{
+    HRESULT AdaptiveJsonTemplaterStaticsImpl::ApplyJsonTemplating(ABI::Windows::Data::Json::IJsonObject* adaptiveJson,
+                                                                  ABI::Windows::Data::Json::IJsonObject* adaptiveFrame,
+                                                                  ABI::Windows::Data::Json::IJsonObject** result) noexcept try
+    {
+        std::string adaptiveJsonString;
+        RETURN_IF_FAILED(JsonObjectToString(adaptiveJson, adaptiveJsonString));
+
+        Json::Value json;
+        if (!adaptiveJsonString.empty())
+        {
+            json = ParseUtil::GetJsonValueFromString(adaptiveJsonString);
+        }
+
+        Json::Value frame;
+        if (adaptiveFrame)
+        {
+            std::string adaptiveFrameString;
+            RETURN_IF_FAILED(JsonObjectToString(adaptiveFrame, adaptiveFrameString));
+            frame = ParseUtil::GetJsonValueFromString(adaptiveFrameString);
+        }
+
+        Json::Value jsonCppResult = ::ApplyJsonTemplating(json, frame);
+
+        Json::FastWriter writer;
+        std::string resultString = writer.write(jsonCppResult);
+        return StringToJsonObject(resultString, result);
+    }
+    CATCH_RETURN;
+}

--- a/source/uwp/Renderer/lib/AdaptiveTemplater.h
+++ b/source/uwp/Renderer/lib/AdaptiveTemplater.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "AdaptiveCards.Rendering.Uwp.h"
+#include "SharedAdaptiveCard.h"
+
+namespace AdaptiveNamespace
+{
+    class AdaptiveJsonTemplaterStaticsImpl WrlFinal
+        : public Microsoft::WRL::AgileActivationFactory<ABI::AdaptiveNamespace::IAdaptiveJsonTemplaterStatics>
+    {
+        AdaptiveRuntimeStatic(AdaptiveJsonTemplater);
+
+        IFACEMETHODIMP ApplyJsonTemplating(_In_ ABI::Windows::Data::Json::IJsonObject* adaptiveJson,
+                                           _In_ ABI::Windows::Data::Json::IJsonObject* adaptiveFrame,
+                                           _COM_Outptr_ ABI::Windows::Data::Json::IJsonObject** result) noexcept;
+    };
+
+    ActivatableStaticOnlyFactory(AdaptiveJsonTemplaterStaticsImpl);
+}

--- a/source/uwp/UWPTestLibrary/RenderTestHelpers.cs
+++ b/source/uwp/UWPTestLibrary/RenderTestHelpers.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;
+using Windows.Data.Json;
 using Windows.Graphics.Imaging;
 using Windows.Storage;
 using Windows.UI;
@@ -67,7 +68,9 @@ namespace UWPTestLibrary
 
                 else
                 {
-                    AdaptiveCard card = AdaptiveCard.FromJsonString(cardFile.Contents).AdaptiveCard;
+                    JsonObject templatedJson = AdaptiveJsonTemplater.ApplyJsonTemplating(JsonObject.Parse(cardFile.Contents), null);
+
+                    AdaptiveCard card = AdaptiveCard.FromJson(templatedJson).AdaptiveCard;
 
                     if (card == null)
                     {

--- a/source/uwp/Visualizer/DocumentView.xaml
+++ b/source/uwp/Visualizer/DocumentView.xaml
@@ -14,15 +14,32 @@
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="*"/>
             <ColumnDefinition Width="350"/>
         </Grid.ColumnDefinitions>
 
         <!--Editor and errors-->
         <local:GenericDocumentView />
 
-        <!--Preview-->
         <Grid
             Grid.Column="1">
+            <TextBlock Text="{Binding TemplatedJson}" TextWrapping="WrapWholeWords" IsTextSelectionEnabled="True" Margin="20"/>
+        </Grid>
+
+        <toolkitControls:GridSplitter
+            Width="11"
+            Background="{ThemeResource SystemControlBackgroundAccentBrush}"
+            GripperCursor="Default"
+            HorizontalAlignment="Left"
+            Grid.Column="1"
+            ResizeDirection="Auto"
+            ResizeBehavior="BasedOnAlignment"
+            CursorBehavior="ChangeOnSplitterHover"
+            GripperForeground="White"/>        
+        
+        <!--Preview-->
+        <Grid
+            Grid.Column="2">
             <ScrollViewer VerticalScrollBarVisibility="Auto" Margin="11,0,0,0" Background="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}">
                 <Border
                     x:Name="AdaptiveCardHostContainer"
@@ -45,7 +62,7 @@
             Background="{ThemeResource SystemControlBackgroundAccentBrush}"
             GripperCursor="Default"
             HorizontalAlignment="Left"
-            Grid.Column="1"
+            Grid.Column="2"
             ResizeDirection="Auto"
             ResizeBehavior="BasedOnAlignment"
             CursorBehavior="ChangeOnSplitterHover"

--- a/source/uwp/Visualizer/ViewModel/DocumentViewModel.cs
+++ b/source/uwp/Visualizer/ViewModel/DocumentViewModel.cs
@@ -33,6 +33,13 @@ namespace AdaptiveCardVisualizer.ViewModel
             private set { SetProperty(ref _renderedCard, value); }
         }
 
+        private String _templatedJson;
+        public String TemplatedJson
+        {
+            get { return _templatedJson; }
+            private set { SetProperty(ref _templatedJson, value); }
+        }
+
         public static async Task<DocumentViewModel> LoadFromFileAsync(MainPageViewModel mainPageViewModel, IStorageFile file, string token)
         {
             var answer = new DocumentViewModel(mainPageViewModel);
@@ -82,7 +89,12 @@ namespace AdaptiveCardVisualizer.ViewModel
                 {
                     JsonObject jsonFrame;
                     JsonObject.TryParse(MainPageViewModel.FrameEditor.Frame, out jsonFrame);
-                    AdaptiveCardParseResult parseResult = AdaptiveCard.FromJson(jsonObject, null, null, jsonFrame);
+
+                    JsonObject templateResult = AdaptiveJsonTemplater.ApplyJsonTemplating(jsonObject, jsonFrame);
+                    dynamic parsedJson = JsonConvert.DeserializeObject(templateResult.ToString());
+                    TemplatedJson = JsonConvert.SerializeObject(parsedJson, Formatting.Indented);
+
+                    AdaptiveCardParseResult parseResult = AdaptiveCard.FromJson(templateResult);
 
                     RenderedAdaptiveCard renderResult = _renderer.RenderAdaptiveCard(parseResult.AdaptiveCard);
                     if (renderResult.FrameworkElement != null)


### PR DESCRIPTION
Separate templating from parsing at the API layer, and add an additional panel to the visualizer to show the result of applying templating.