### PR TITLE
Upgrade to new gradle version to fix NDK break

### DIFF
--- a/source/android/adaptivecards/build.gradle
+++ b/source/android/adaptivecards/build.gradle
@@ -4,11 +4,11 @@ apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 26
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -140,10 +140,10 @@ uploadArchives {
     }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    testCompile 'junit:junit:4.12'
+    implementation 'com.android.support:appcompat-v7:26.1.0'
+    testImplementation 'junit:junit:4.12'
 }

--- a/source/android/build.gradle
+++ b/source/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0'
+        classpath 'com.android.tools.build:gradle:3.2.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/source/android/build.gradle
+++ b/source/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.2.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/source/android/gradle/wrapper/gradle-wrapper.properties
+++ b/source/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/source/android/mobile/build.gradle
+++ b/source/android/mobile/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 26
     defaultConfig {
         applicationId "io.adaptivecards.adaptivecardssample"
         minSdkVersion 19
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 2
         versionName "1.0.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -19,12 +19,12 @@ android {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.android.support:design:25.3.1'
-    testCompile 'junit:junit:4.12'
-    compile project(':adaptivecards')
+    implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation 'com.android.support:design:26.1.0'
+    testImplementation 'junit:junit:4.12'
+    implementation project(':adaptivecards')
 }

--- a/source/android/mobile/src/main/java/io/adaptivecards/adaptivecardssample/MainActivityAdaptiveCardsSample.java
+++ b/source/android/mobile/src/main/java/io/adaptivecards/adaptivecardssample/MainActivityAdaptiveCardsSample.java
@@ -353,7 +353,9 @@ public class MainActivityAdaptiveCardsSample extends FragmentActivity
             CardRendererRegistration.getInstance().registerRenderer("blah", new CustomBlahRenderer());
 
             // Example on how a custom OnlineMediaLoader should be registered
-            CardRendererRegistration.getInstance().registerOnlineMediaLoader(new OnlineMediaLoader());
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                CardRendererRegistration.getInstance().registerOnlineMediaLoader(new OnlineMediaLoader());
+            }
 
             ParseResult parseResult = AdaptiveCard.DeserializeFromString(jsonText, AdaptiveCardRenderer.VERSION, elementParserRegistration);
             LinearLayout layout = (LinearLayout) findViewById(R.id.visualAdaptiveCardLayout);

--- a/source/android/mobilechatapp/build.gradle
+++ b/source/android/mobilechatapp/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    compile project(path: ':adaptivecards')
+    implementation project(path: ':adaptivecards')
 }
 
 task copyTestFiles(type: Copy)


### PR DESCRIPTION
Updates to the NDK cause build breaks in older versions of gradle. The only way to get us building is for users to downgrade the NDK version, which isn't optimal. This change upgrades us to a newer version of gradle which doesn't have problems with the newer NDK version.