### PR TITLE
custom image renderer check removed

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRenderer.mm
@@ -77,15 +77,13 @@ using namespace AdaptiveCards;
                                                                          hostConfig:config];
     }
 
-    if(![[ACRRegistration getInstance] isElementRendererOverriden:[ACRImageRenderer elemType]]){
-        if(!adaptiveCard->GetBackgroundImage().empty()) {
+    if(!adaptiveCard->GetBackgroundImage().empty()) {
             [rootView loadImage:adaptiveCard->GetBackgroundImage()];
-        }
-        if(![config getHostConfig]->media.playButton.empty()) {
-            [rootView loadImage:[config getHostConfig]->media.playButton];
-        }
     }
-
+    if(![config getHostConfig]->media.playButton.empty()) {
+            [rootView loadImage:[config getHostConfig]->media.playButton];
+    }
+    
     ACRContainerStyle style = ([config getHostConfig]->adaptiveCard.allowCustomStyle)? (ACRContainerStyle)adaptiveCard->GetStyle() : ACRDefault;
     style = (style == ACRNone)? ACRDefault : style;
     [verticalView setStyle:style];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm
@@ -96,10 +96,8 @@ typedef UIImage* (^ImageLoadBlock)(NSURL *url);
     if([key length]){
         UIView *imgView = nil;
         UIImage *img = nil;
-        if(![[ACRRegistration getInstance] isElementRendererOverriden:[ACRImageRenderer elemType]]){
-            img = _imageViewMap[key];
-            imgView = [[ACRUIImageView alloc] initWithImage:img];
-        }
+        img = _imageViewMap[key];
+        imgView = [[ACRUIImageView alloc] initWithImage:img];
         if(img) {
             imgView.translatesAutoresizingMaskIntoConstraints = NO;
             imgView.contentMode = UIViewContentModeScaleAspectFill;


### PR DESCRIPTION
This PR is a fix for issue : https://github.com/Microsoft/AdaptiveCards/issues/2138
Root Cause :- If a custom image renderer is implemented , than the code for background image setting was disabled.
Fix :- Removed the check for CustomImageRenderer implementation.
