### PR TITLE
[HTML] Add support for <mark> to highlight text in TextBlock

### DIFF
--- a/source/nodejs/adaptivecards-visualizer/src/containers/host-container.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/host-container.ts
@@ -113,6 +113,7 @@ export abstract class HostContainer {
         AdaptiveCard.actionTypeRegistry.reset();
         AdaptiveCard.useAutomaticContainerBleeding = false;
         AdaptiveCard.useMarkdownInRadioButtonAndCheckbox = true;
+        AdaptiveCard.allowMarkForTextHighlighting = false;
     }
 
     public parseElement(element: CardElement, json: any) {

--- a/source/nodejs/adaptivecards-visualizer/src/containers/outlook.ts
+++ b/source/nodejs/adaptivecards-visualizer/src/containers/outlook.ts
@@ -51,6 +51,7 @@ export class OutlookContainer extends HostContainer {
         Adaptive.AdaptiveCard.actionTypeRegistry.registerType("Action.ToggleVisibility", () => { return new ToggleVisibilityAction(); });
 
         Adaptive.AdaptiveCard.useMarkdownInRadioButtonAndCheckbox = false;
+        Adaptive.AdaptiveCard.allowMarkForTextHighlighting = true;
     }
 
     private parsePadding(json: any): Adaptive.PaddingDefinition {

--- a/source/nodejs/adaptivecards/src/host-config.ts
+++ b/source/nodejs/adaptivecards/src/host-config.ts
@@ -215,6 +215,9 @@ export class ContainerStyleDefinition {
         attention: new TextColorDefinition()
     };
 
+    highlightBackgroundColor?: string;
+    highlightForegroundColor?: string;
+
     parse(obj: any) {
         if (obj) {
             this.backgroundColor = obj["backgroundColor"];
@@ -228,6 +231,9 @@ export class ContainerStyleDefinition {
                 this.foregroundColors.warning = this.getTextColorDefinitionOrDefault(obj.foregroundColors["warning"], { default: "#E69500", subtle: "#DDE69500" });
                 this.foregroundColors.attention = this.getTextColorDefinitionOrDefault(obj.foregroundColors["attention"], { default: "#CC3300", subtle: "#DDCC3300" });
             }
+
+            this.highlightBackgroundColor = obj["highlightBackgroundColor"];
+            this.highlightForegroundColor = obj["highlightForegroundColor"];
         }
     }
 


### PR DESCRIPTION
This change allows the use of `<mark></mark>` in **TextBlock**.

This feature is disabled by default and needs to be explicitly turned by the host that needs it by setting `AdaptiveCard.allow.allowMarkForTextHighlighting = true`.

This feature is necessary to unblock an Outlook scenario. It will become unnecessary and will be deprecated when inline text runs are supported (https://github.com/Microsoft/AdaptiveCards/issues/1933)

This change also fixes a bug where the right foreground color would not always be applied.