### PR TITLE
Handle invalid Image.SelectAction

### DIFF
--- a/source/dotnet/Library/AdaptiveCards/AdaptiveTypedElementConverter.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveTypedElementConverter.cs
@@ -100,7 +100,14 @@ namespace AdaptiveCards
                     throw new AdaptiveSerializationException($"Required property 'id' not found on '{typeName}'");
 
                 var result = (AdaptiveTypedElement)Activator.CreateInstance(type);
-                serializer.Populate(jObject.CreateReader(), result);
+                try
+                {
+                    serializer.Populate(jObject.CreateReader(), result);
+                }
+                catch (JsonSerializationException)
+                {
+                    return result;
+                }
 
                 HandleAdditionalProperties(result);
                 return result;

--- a/source/dotnet/Test/AdaptiveCards.Test/AdaptiveActionTests.cs
+++ b/source/dotnet/Test/AdaptiveCards.Test/AdaptiveActionTests.cs
@@ -30,6 +30,39 @@ namespace AdaptiveCards.Test
         }
 
         [TestMethod]
+        public void ParseInvalidAction()
+        {
+            string url = "http://adaptivecards.io/content/cats/1.png";
+            var json = @"{
+	""$schema"": ""http://adaptivecards.io/schemas/adaptive-card.json"",
+	""type"": ""AdaptiveCard"",
+	""version"": ""1.0"",
+	""body"": [
+		{
+			""type"": ""Image"",
+			""url"": """+ url + @""",
+			""selectAction"": {
+				""type"": ""Invalid Action"",
+				""url"": ""https://www.youtube.com/watch?v=dQw4w9WgXcQ""
+			}
+		}
+	]
+}";
+
+            var result = AdaptiveCard.FromJson(json);
+
+            var card = result.Card;
+            Assert.IsNotNull(card);
+
+            Assert.IsTrue(result.Warnings.Count == 1);
+
+            AdaptiveImage image = (AdaptiveImage) card.Body[0];
+            Assert.AreEqual(image.Url, url);
+            Assert.IsNull(image.SelectAction);
+
+        }
+
+        [TestMethod]
         public void ParseSentiment()
         {
             var json = @"{


### PR DESCRIPTION
Bugfix for #2104.

## Explanation of Issue
For whatever reason, Json.net mishandles passing `null` up to an `object` (Image) expecting an `object` (SelectAction). This is because the `JsonReader` expects more tokens, but is handed an unhandled `EndObject` token and just throws an error. This all happens in `JsonSerializerInternalReader` when trying to set the properties of the `Image`.

## Fix
Since we can't control anything other than the `contract` and the `converter`, it looks like the best we can do is catch the exception thrown when deserializing the Image. Then just pass up what we were able to deserialize of the Image so far.

## Side Effect
Unfortunately, anything written after the faulty `SelectAction` is lost. This means that the following two JSON would return different AdaptiveCards. This is still different behavior from the SharedModel and JavaScript because those platforms would output Card 1's result, regardless of which JSON is passed.

---Card 1---
![image](https://user-images.githubusercontent.com/11050425/48291144-32646600-e42a-11e8-98d9-eb99b5fd9e6b.png)
```
{
  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
  "type": "AdaptiveCard",
  "version": "1.0",
  "body": [
    {
      "type": "Image",
      "url": "http://adaptivecards.io/content/cats/1.png",
      "selectAction": {
        "type": "INVALID ACTION",
        "title": "cool link",
        "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
      },
    }
  ]
}
```

---Card 2---
![image](https://user-images.githubusercontent.com/11050425/48291185-5a53c980-e42a-11e8-99cc-f99efbdcd274.png)
```
{
  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
  "type": "AdaptiveCard",
  "version": "1.0",
  "body": [
    {
      "type": "Image",
      "selectAction": {
        "type": "INVALID ACTION",
        "title": "cool link",
        "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
      },
      "url": "http://adaptivecards.io/content/cats/1.png"
    }
  ]
}
```

Both cards throw the proper warning:
![image](https://user-images.githubusercontent.com/11050425/48291207-76f00180-e42a-11e8-9b6c-5b60f25350a6.png)