### PR TITLE
Obsolete the default AdaptiveCard constructor in favor of specifying …

### DIFF
--- a/source/dotnet/Library/AdaptiveCards/AdaptiveCard.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveCard.cs
@@ -54,7 +54,8 @@ namespace AdaptiveCards
         /// <summary>
         /// Creates an AdaptiveCard using the <see cref="F:AdaptiveCards.AdaptiveCard.KnownSchemaVersion" /> of this library
         /// </summary>
-        public AdaptiveCard() : this(KnownSchemaVersion) { }
+        [Obsolete("Please use the overload that accepts a version parameter and specify the version your card requires")]
+        public AdaptiveCard() : this(new AdaptiveSchemaVersion(1, 0)) { }
 
         /// <summary>
         /// The Body elements for this card

--- a/source/dotnet/Test/AdaptiveCards.Test/AdaptiveCardApiTests.cs
+++ b/source/dotnet/Test/AdaptiveCards.Test/AdaptiveCardApiTests.cs
@@ -12,7 +12,10 @@ namespace AdaptiveCards.Test
         [TestMethod]
         public void TestAssigningVersion()
         {
-            AdaptiveCard card = new AdaptiveCard();
+            AdaptiveCard card = new AdaptiveCard("1.0");
+
+            Assert.AreEqual(1, card.Version.Major);
+            Assert.AreEqual(0, card.Version.Minor);
             card.Version = new AdaptiveSchemaVersion(4, 5);
 
             Assert.AreEqual(4, card.Version.Major);

--- a/source/dotnet/Test/AdaptiveCards.Test/SerializationTests.cs
+++ b/source/dotnet/Test/AdaptiveCards.Test/SerializationTests.cs
@@ -112,7 +112,7 @@ namespace AdaptiveCards.Test
 
             var expected = @"{
   ""type"": ""AdaptiveCard"",
-  ""version"": ""1.2"",
+  ""version"": ""1.0"",
   ""id"": ""myCard"",
   ""body"": [
     {
@@ -148,7 +148,7 @@ namespace AdaptiveCards.Test
 
             var expected = @"{
   ""type"": ""AdaptiveCard"",
-  ""version"": ""1.2"",
+  ""version"": ""1.0"",
   ""body"": [
     {
       ""type"": ""TextBlock"",
@@ -536,7 +536,7 @@ namespace AdaptiveCards.Test
   ]
 }";
 
-            var card = new AdaptiveCard
+            var card = new AdaptiveCard("1.2")
             {
                 Id = "myCard",
                 Body =


### PR DESCRIPTION
…a version number.

When users generate cards we want to force them to make the conscious decision of the version of the card that they want to produce.