### PR TITLE
[WPF] Fix text alignment issue

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveTextBlockRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveTextBlockRenderer.cs
@@ -122,9 +122,9 @@ namespace AdaptiveCards.Rendering.Wpf
 
             if (textBlock.HorizontalAlignment != AdaptiveHorizontalAlignment.Left)
             {
-                System.Windows.HorizontalAlignment alignment;
-                if (Enum.TryParse<System.Windows.HorizontalAlignment>(textBlock.HorizontalAlignment.ToString(), out alignment))
-                    uiTextBlock.HorizontalAlignment = alignment;
+                System.Windows.TextAlignment alignment;
+                if (Enum.TryParse<System.Windows.TextAlignment>(textBlock.HorizontalAlignment.ToString(), out alignment))
+                    uiTextBlock.TextAlignment = alignment;
             }
 
             if (textBlock.Wrap)


### PR DESCRIPTION
It looks like we were changing the HorizontalAlignment property which defines the positioning of the element (https://docs.microsoft.com/en-us/dotnet/framework/wpf/advanced/alignment-margins-and-padding-overview) instead of changing the text position

Fixes this: https://github.com/Microsoft/AdaptiveCards/issues/1009