### PR TITLE
Add class to validate and parse colors

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Rendering.Html/AdaptiveCardRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Html/AdaptiveCardRenderer.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using Newtonsoft.Json;
+using AdaptiveCards;
 
 namespace AdaptiveCards.Rendering.Html
 {
@@ -132,7 +133,7 @@ namespace AdaptiveCards.Rendering.Html
                 {
                     case AdaptiveSentiment.Positive:
                         string accentColor = context.Config.ContainerStyles.Default.ForegroundColors.Accent.Default;
-                        string lighterAccentColor = context.GenerateLighterColor(accentColor);
+                        string lighterAccentColor = ColorUtil.GenerateLighterColor(accentColor);
                         buttonElement.Style("background-color", context.GetRGBColor(accentColor));
                         buttonElement.Attr("onMouseOver", "this.style.backgroundColor='" + context.GetRGBColor(lighterAccentColor) + "'");
                         buttonElement.Attr("onMouseOut", "this.style.backgroundColor='" + context.GetRGBColor(accentColor) + "'");
@@ -141,7 +142,7 @@ namespace AdaptiveCards.Rendering.Html
                         break;
                     case AdaptiveSentiment.Destructive:
                         string attentionColor = context.Config.ContainerStyles.Default.ForegroundColors.Attention.Default;
-                        string lighterAttentionColor = context.GenerateLighterColor(attentionColor);
+                        string lighterAttentionColor = ColorUtil.GenerateLighterColor(attentionColor);
                         buttonElement.Style("color", context.GetRGBColor(attentionColor));
                         buttonElement.Attr("onMouseOver", "this.style.color='" + context.GetRGBColor(lighterAttentionColor) + "'");
                         buttonElement.Attr("onMouseOut", "this.style.color='" + context.GetRGBColor(attentionColor) + "'");

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Html/AdaptiveRenderContext.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Html/AdaptiveRenderContext.cs
@@ -90,24 +90,6 @@ namespace AdaptiveCards.Rendering.Html
             return color;
         }
 
-        public string GenerateLighterColor(string hexColor)
-        {
-            int color = int.Parse(hexColor.Substring(1), System.Globalization.NumberStyles.HexNumber);
-
-            const double colorIncrement = 0.25;
-            int originalR = (color & 0xFF0000) >> 16;
-            int originalG = (color & 0x00FF00) >> 8;
-            int originalB = (color & 0x0000FF);
-
-            int newColorR = originalR + (int)((255 - originalR) * colorIncrement);
-            int newColorG = originalG + (int)((255 - originalG) * colorIncrement);
-            int newColorB = originalB + (int)((255 - originalB) * colorIncrement);
-
-            int newColor = ((newColorR << 16) | (newColorG << 8) | (newColorB));
-
-            return "#" + newColor.ToString("X");
-        }
-
         public string Lang { get; set; }
     }
 }

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveCardRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveCardRenderer.cs
@@ -197,24 +197,6 @@ namespace AdaptiveCards.Rendering.Wpf
             return outerGrid;
         }
 
-        private string GenerateLighterColor(string hexColor)
-        {
-            int color = int.Parse(hexColor.Substring(1), System.Globalization.NumberStyles.HexNumber);
-
-            const double colorIncrement = 0.25;
-            int originalR = (color & 0x00FF0000) >> 16;
-            int originalG = (color & 0x0000FF00) >> 8;
-            int originalB = (color & 0x000000FF);
-
-            int newColorR = originalR + (int)((255 - originalR) * colorIncrement);
-            int newColorG = originalG + (int)((255 - originalG) * colorIncrement);
-            int newColorB = originalB + (int)((255 - originalB) * colorIncrement);
-
-            int newColor = ((newColorR << 16) | (newColorG << 8) | (newColorB));
-
-            return "#" + newColor.ToString("X");
-        }
-
         /// <summary>
         /// Renders an adaptive card.
         /// </summary>
@@ -245,9 +227,9 @@ namespace AdaptiveCards.Rendering.Wpf
             };
 
             string accentColor = HostConfig.ContainerStyles.Default.ForegroundColors.Accent.Default;
-            string lighterAccentColor = GenerateLighterColor(accentColor);
+            string lighterAccentColor = ColorUtil.GenerateLighterColor(accentColor);
             string attentionColor = HostConfig.ContainerStyles.Default.ForegroundColors.Attention.Default;
-            string lighterAttentionColor = GenerateLighterColor(attentionColor);
+            string lighterAttentionColor = ColorUtil.GenerateLighterColor(attentionColor);
 
             Resources["Adaptive.Action.Positive.Button.Static.Background"] = context.GetColorBrush(accentColor);
             Resources["Adaptive.Action.Positive.Button.MouseOver.Background"] = context.GetColorBrush(lighterAccentColor);

--- a/source/dotnet/Library/AdaptiveCards/ColorUtil.cs
+++ b/source/dotnet/Library/AdaptiveCards/ColorUtil.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AdaptiveCards
+{
+    public class ColorUtil
+    {
+        // We need to have a string in the format #AARRGGBB or #RRGGBB  
+        public static bool IsValidColor(string color)
+        {
+            if (!string.IsNullOrEmpty(color) && (color.Length == 7 || color.Length == 9) && color[0] == '#')
+            {
+                // Verify that each character is a proper hex digit
+                for (int i = 1; i < color.Length; i++)
+                {
+                    if (!color[i].IsHexDigit())
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
+
+            return false;
+        }
+
+        public static bool TryParseColor(string color, out int result)
+        {
+            result = 0;
+
+            if(IsValidColor(color))
+            {
+                result = int.Parse(color.Substring(1), System.Globalization.NumberStyles.HexNumber);
+                return true;
+            }
+
+            return false;
+        }
+
+        public static string GenerateLighterColor(string hexColor)
+        {
+            int color;
+            if(TryParseColor(hexColor, out color))
+            {
+                const double colorIncrement = 0.25;
+                int originalR = (color & 0xFF0000) >> 16;
+                int originalG = (color & 0x00FF00) >> 8;
+                int originalB = (color & 0x0000FF);
+
+                int newColorR = originalR + (int)((255 - originalR) * colorIncrement);
+                int newColorG = originalG + (int)((255 - originalG) * colorIncrement);
+                int newColorB = originalB + (int)((255 - originalB) * colorIncrement);
+
+                int newColor = ((newColorR << 16) | (newColorG << 8) | (newColorB));
+
+                return "#" + newColor.ToString("X");
+            }
+            else
+            {
+                // Reset to black as original color was not valid
+                return "#FF000000";
+            }           
+        }
+
+    }
+}

--- a/source/dotnet/Library/AdaptiveCards/HashColorConverter.cs
+++ b/source/dotnet/Library/AdaptiveCards/HashColorConverter.cs
@@ -18,34 +18,20 @@ namespace AdaptiveCards
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            bool fValidString = true;
             if (reader.TokenType == JsonToken.String)
             {
                 var colorString = defaultSerializer.Deserialize(reader, objectType) as string;
-                // We need to have a string in the format #AARRGGBB or #RRGGBB
-                if (!string.IsNullOrEmpty(colorString) && (colorString.Length == 7 || colorString.Length == 9) && colorString[0] == '#')
+                // We need to have a string in the format #AARRGGBB or #RRGGBB               
+                if (ColorUtil.IsValidColor(colorString))
                 {
-                    // Verify that each character is a proper hex digit
-                    for (int i = 1; i < colorString.Length; i++)
-                    {
-                        if (!colorString[i].IsHexDigit())
-                        {
-                            fValidString = false;
-                            break;
-                        }
-                    }
-
                     // We have the right format, and all the digits are hex, return the string
-                    if (fValidString)
+                    if (colorString.Length == 7)
                     {
-                        if (colorString.Length == 7)
-                        {
-                            return $"#FF{colorString.Substring(1).ToUpperInvariant()}";
-                        }
-                        else
-                        {
-                            return colorString.ToUpperInvariant();
-                        }
+                        return $"#FF{colorString.Substring(1).ToUpperInvariant()}";
+                    }
+                    else
+                    {
+                        return colorString.ToUpperInvariant();
                     }
                 }
             }


### PR DESCRIPTION
Merges the two methods for .NET into a shared one. The added class also includes the color validation used by the parsing process.

Fixes this: https://github.com/microsoft/adaptivecards/issues/2120