### PR TITLE
[.NET] Change Auto and Stretch to lower case versions 

### DIFF
--- a/source/dotnet/Library/AdaptiveCards/AdaptiveColumnWidth.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveColumnWidth.cs
@@ -8,11 +8,11 @@ namespace AdaptiveCards
         /// <summary>
         ///     The width of the Column is optimally chosen depending on the space available in the element's container
         /// </summary>
-        public const string Auto = "Auto";
+        public const string Auto = "auto";
 
         /// <summary>
         ///     The width of the Column adjusts to match that of its container
         /// </summary>
-        public const string Stretch = "Stretch";
+        public const string Stretch = "stretch";
     }
 }


### PR DESCRIPTION
Change of Stretch and Auto strings for column width to the lower versions for consistency as the other enums are actually returned as lower case values.

Fixes this: https://github.com/Microsoft/AdaptiveCards/issues/1058