### PR TITLE
[.NET] Fix separation strong issue

### DIFF
--- a/source/dotnet/Library/AdaptiveCards/AdaptiveElement.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveElement.cs
@@ -54,7 +54,7 @@ namespace AdaptiveCards
                         return AdaptiveSeparationStyle.None;
 
                     case AdaptiveSpacing.Large:
-                        return AdaptiveSeparationStyle.Strong;
+                        return Separator ? AdaptiveSeparationStyle.Strong : AdaptiveSeparationStyle.Default;
 
                     default:
                         return AdaptiveSeparationStyle.Default;

--- a/source/dotnet/Test/AdaptiveCards.Test/SeparatorSpacingTests.cs
+++ b/source/dotnet/Test/AdaptiveCards.Test/SeparatorSpacingTests.cs
@@ -132,20 +132,15 @@ namespace AdaptiveCards.Test
         [TestMethod]
         public void TestLargeSpacing()
         {
-            AdaptiveCard card = new AdaptiveCard();
+            AdaptiveCard card = new AdaptiveCard(new AdaptiveSchemaVersion("1.0"));
             AdaptiveTextBlock block = new AdaptiveTextBlock();
             block.Text = "Hi this is textblock";
-            // block.Separation = AdaptiveSeparationStyle.Strong;
-            // block.Separator = true;
             block.Spacing = AdaptiveSpacing.Large;
 
-            card.Body.Add(block);
             card.Body.Add(block);
 
             string s = card.ToJson();
             Assert.IsFalse(s.Contains("separation"));
-
-            //Assert.AreEqual(true, card.Body[0].Separator);
         }
 
         [TestMethod]

--- a/source/dotnet/Test/AdaptiveCards.Test/SeparatorSpacingTests.cs
+++ b/source/dotnet/Test/AdaptiveCards.Test/SeparatorSpacingTests.cs
@@ -130,6 +130,25 @@ namespace AdaptiveCards.Test
         }
 
         [TestMethod]
+        public void TestLargeSpacing()
+        {
+            AdaptiveCard card = new AdaptiveCard();
+            AdaptiveTextBlock block = new AdaptiveTextBlock();
+            block.Text = "Hi this is textblock";
+            // block.Separation = AdaptiveSeparationStyle.Strong;
+            // block.Separator = true;
+            block.Spacing = AdaptiveSpacing.Large;
+
+            card.Body.Add(block);
+            card.Body.Add(block);
+
+            string s = card.ToJson();
+            Assert.IsFalse(s.Contains("separation"));
+
+            //Assert.AreEqual(true, card.Body[0].Separator);
+        }
+
+        [TestMethod]
         public void TestSerializingLegacySeparation()
         {
             var inputJson = @"{


### PR DESCRIPTION
Changes the requisite for writing the separation as Strong by requiring spacing to be large and separator to be true, this doesnt modify the general behaviour for spacing so it isnt a breaking change

Fixes this: https://github.com/Microsoft/AdaptiveCards/issues/2037