### PR TITLE
Add leak testing for the AdaptiveCardTestApp.

### DIFF
--- a/source/uwp/AdaptiveCardTestApp/Pages/TestResultsPage.xaml.cs
+++ b/source/uwp/AdaptiveCardTestApp/Pages/TestResultsPage.xaml.cs
@@ -41,7 +41,8 @@ namespace AdaptiveCardTestApp.Pages
                 model.ImageAndJsonFailed,
                 model.FailedButSourceWasChanged,
                 model.PassedButSourceWasChanged,
-                model.New
+                model.Leaked,
+                model.New,
             };
 
             if (model.Failed.Results.Count > 0)
@@ -67,6 +68,11 @@ namespace AdaptiveCardTestApp.Pages
             else if (model.PassedButSourceWasChanged.Results.Count > 0)
             {
                 ListViewCategories.SelectedItem = model.PassedButSourceWasChanged;
+            }
+
+            else if (model.Leaked.Results.Count > 0)
+            {
+                ListViewCategories.SelectedItem = model.Leaked;
             }
 
             else if (model.New.Results.Count > 0)

--- a/source/uwp/AdaptiveCardTestApp/Pages/TestResultsPage.xaml.cs
+++ b/source/uwp/AdaptiveCardTestApp/Pages/TestResultsPage.xaml.cs
@@ -22,13 +22,17 @@ namespace AdaptiveCardTestApp.Pages
             this.InitializeComponent();
         }
 
-        protected override void OnNavigatedTo(NavigationEventArgs e)
+        protected override async void OnNavigatedTo(NavigationEventArgs e)
         {
             var runningTestsViewModel = e.Parameter as RunningTestsViewModel;
             if (runningTestsViewModel == null)
             {
                 throw new InvalidOperationException("Running tests view model not provided");
             }
+
+            // Force a Garbage Collection to make sure that the WeakReferences as invalidated.
+            GC.Collect(GC.MaxGeneration, GCCollectionMode.Default, blocking: true);
+            await System.Threading.Tasks.Task.Delay(1000);
 
             var model = new TestResultsViewModel(runningTestsViewModel.Results);
             DataContext = model;

--- a/source/uwp/AdaptiveCardTestApp/ViewModels/RunningTestsViewModel.cs
+++ b/source/uwp/AdaptiveCardTestApp/ViewModels/RunningTestsViewModel.cs
@@ -156,10 +156,9 @@ namespace AdaptiveCardTestApp.ViewModels
             var result = await TestResultViewModel.CreateAsync(
                 cardFile: cardFile,
                 hostConfigFile: hostConfigFile,
-                actualError: renderResult.Item1,
+                renderedTestResult: renderResult.Item1,
                 actualImageFile: renderResult.Item2,
                 actualJsonFile: renderResult.Item3,
-                xamlCard: renderResult.Item4,
                 expectedFolder: _expectedFolder,
                 sourceHostConfigsFolder: _sourceHostConfigsFolder,
                 sourceCardsFolder: _sourceCardsFolder);
@@ -168,28 +167,28 @@ namespace AdaptiveCardTestApp.ViewModels
             return result;
         }
 
-        private async Task<Tuple<string, StorageFile, StorageFile, UIElement>> RenderCard(FileViewModel cardFile, FileViewModel hostConfigFile)
+        private async Task<Tuple<RenderedTestResult, StorageFile, StorageFile>> RenderCard(FileViewModel cardFile, FileViewModel hostConfigFile)
         {
             var renderResult = await UWPTestLibrary.RenderTestHelpers.RenderCard(cardFile, hostConfigFile);
 
-            UWPTestLibrary.ImageWaiter imageWaiter = new ImageWaiter(renderResult.Item3);
+            UWPTestLibrary.ImageWaiter imageWaiter = new ImageWaiter(renderResult.Tree);
 
-            CurrentCardVisual = renderResult.Item3;
-            CurrentCardVisualWidth = renderResult.Item4;
+            CurrentCardVisual = renderResult.Tree;
+            CurrentCardVisualWidth = renderResult.CardWidth;
 
             await imageWaiter.WaitOnAllImagesAsync();
 
             StorageFile imageResultFile = null;
             StorageFile jsonResultFile = null;
-            if (renderResult.Item1 == null)
+            if (renderResult.Error == null)
             {
                 imageResultFile = await _tempResultsFolder.CreateFileAsync("Result.png", CreationCollisionOption.GenerateUniqueName);
                 jsonResultFile = await _tempResultsFolder.CreateFileAsync("Result.json", CreationCollisionOption.GenerateUniqueName);
 
-                await UWPTestLibrary.RenderTestHelpers.ResultsToFile(imageResultFile, jsonResultFile, renderResult.Item2, CurrentCardVisual);
+                await UWPTestLibrary.RenderTestHelpers.ResultsToFile(imageResultFile, jsonResultFile, renderResult.RoundTrippedJSON, CurrentCardVisual);
             }
 
-            return new Tuple<string, StorageFile, StorageFile, UIElement>(renderResult.Item1, imageResultFile, jsonResultFile, CurrentCardVisual);
+            return new Tuple<RenderedTestResult, StorageFile, StorageFile>(renderResult, imageResultFile, jsonResultFile);
         }
 
         private void GoToDoneState()

--- a/source/uwp/AdaptiveCardTestApp/ViewModels/TestResultsViewModel.cs
+++ b/source/uwp/AdaptiveCardTestApp/ViewModels/TestResultsViewModel.cs
@@ -18,16 +18,13 @@ namespace AdaptiveCardTestApp.ViewModels
 
         public TestResultsViewModel(IEnumerable<TestResultViewModel> results)
         {
-            // Force a Garbage Collection to make sure that the WeakReferences as invalidated.
-            GC.Collect();
-
             Passed = new TestResultsCategoryViewModel("Passed", results.Where(i => i.Status == TestStatus.Passed));
             Failed = new TestResultsCategoryViewModel("Image Comparison Failed", results.Where(i => i.Status == TestStatus.Failed));
             JsonFailed = new TestResultsCategoryViewModel("Json Roundtrip Failed", results.Where(i => i.Status == TestStatus.JsonFailed));
             ImageAndJsonFailed = new TestResultsCategoryViewModel("Image Comparison and Json Roundtrip Failed", results.Where(i => i.Status == TestStatus.ImageAndJsonFailed));
             FailedButSourceWasChanged = new TestResultsCategoryViewModel("Failed/source changed", results.Where(i => i.Status == TestStatus.FailedButSourceWasChanged));
             PassedButSourceWasChanged = new TestResultsCategoryViewModel("Passed/source changed", results.Where(i => i.Status == TestStatus.PassedButSourceWasChanged));
-            Leaked = new TestResultsCategoryViewModel("Leaked", results.Where(i => i.TestResult.WeakCard.IsAlive == true));
+            Leaked = new TestResultsCategoryViewModel("Leaked", results.Where(i => i.TestResult.IsLeaked == true));
             New = new TestResultsCategoryViewModel("New", results.Where(i => i.Status == TestStatus.New));
 
             foreach (var r in results)

--- a/source/uwp/AdaptiveCardTestApp/ViewModels/TestResultsViewModel.cs
+++ b/source/uwp/AdaptiveCardTestApp/ViewModels/TestResultsViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using UWPTestLibrary;
@@ -13,15 +14,20 @@ namespace AdaptiveCardTestApp.ViewModels
         public TestResultsCategoryViewModel FailedButSourceWasChanged { get; }
         public TestResultsCategoryViewModel PassedButSourceWasChanged { get; }
         public TestResultsCategoryViewModel New { get; }
+        public TestResultsCategoryViewModel Leaked { get; }
 
         public TestResultsViewModel(IEnumerable<TestResultViewModel> results)
         {
+            // Force a Garbage Collection to make sure that the WeakReferences as invalidated.
+            GC.Collect();
+
             Passed = new TestResultsCategoryViewModel("Passed", results.Where(i => i.Status == TestStatus.Passed));
             Failed = new TestResultsCategoryViewModel("Image Comparison Failed", results.Where(i => i.Status == TestStatus.Failed));
             JsonFailed = new TestResultsCategoryViewModel("Json Roundtrip Failed", results.Where(i => i.Status == TestStatus.JsonFailed));
             ImageAndJsonFailed = new TestResultsCategoryViewModel("Image Comparison and Json Roundtrip Failed", results.Where(i => i.Status == TestStatus.ImageAndJsonFailed));
             FailedButSourceWasChanged = new TestResultsCategoryViewModel("Failed/source changed", results.Where(i => i.Status == TestStatus.FailedButSourceWasChanged));
             PassedButSourceWasChanged = new TestResultsCategoryViewModel("Passed/source changed", results.Where(i => i.Status == TestStatus.PassedButSourceWasChanged));
+            Leaked = new TestResultsCategoryViewModel("Leaked", results.Where(i => i.TestResult.WeakCard.IsAlive == true));
             New = new TestResultsCategoryViewModel("New", results.Where(i => i.Status == TestStatus.New));
 
             foreach (var r in results)
@@ -43,6 +49,7 @@ namespace AdaptiveCardTestApp.ViewModels
                 FailedButSourceWasChanged.Results.Remove(item);
                 PassedButSourceWasChanged.Results.Remove(item);
                 New.Results.Remove(item);
+                Leaked.Results.Remove(item);
 
                 switch (item.Status)
                 {

--- a/source/uwp/UWPTestLibrary/RenderTestHelpers.cs
+++ b/source/uwp/UWPTestLibrary/RenderTestHelpers.cs
@@ -49,12 +49,13 @@ namespace UWPTestLibrary
             }
         }
 
-        public static async Task<Tuple<string, string, UIElement, double>> RenderCard(FileViewModel cardFile, FileViewModel hostConfigFile)
+        public static async Task<RenderedTestResult> RenderCard(FileViewModel cardFile, FileViewModel hostConfigFile)
         {
             string error = null;
             string roundTrippedJsonString = null;
             FrameworkElement xaml = null;
             double cardWidth = 400;
+            WeakReference weakRefCard = null;
 
             try
             {
@@ -95,7 +96,10 @@ namespace UWPTestLibrary
                             cardWidth = 310;
                         }
 
-                        xaml = renderer.RenderAdaptiveCard(card).FrameworkElement as FrameworkElement;
+                        RenderedAdaptiveCard renderedCard = renderer.RenderAdaptiveCard(card);
+                        weakRefCard = new WeakReference(renderedCard);
+
+                        xaml = renderedCard.FrameworkElement as FrameworkElement;
 
                         if (xaml == null)
                         {
@@ -129,7 +133,14 @@ namespace UWPTestLibrary
                 error = ex.ToString();
             }
 
-            return new Tuple<string, string, UIElement, double>(error, roundTrippedJsonString, xaml, cardWidth);
+            return new RenderedTestResult
+            {
+                Error = error,
+                RoundTrippedJSON = roundTrippedJsonString,
+                Tree = xaml,
+                CardWidth = cardWidth,
+                WeakCard = weakRefCard
+            };
         }
 
         public static async Task ResultsToFile(

--- a/source/uwp/UWPTestLibrary/RenderedTestResult.cs
+++ b/source/uwp/UWPTestLibrary/RenderedTestResult.cs
@@ -1,4 +1,4 @@
-﻿using AdaptiveCards.Rendering.Uwp;
+using AdaptiveCards.Rendering.Uwp;
 using System;
 using Windows.UI.Xaml;
 
@@ -8,11 +8,16 @@ namespace UWPTestLibrary
     {
         public string Error { get; set; }
         public string RoundTrippedJSON { get; set; }
-
         public UIElement Tree { get; set; }
-
         public double CardWidth { get; set; }
-
         public WeakReference WeakCard { get; set; }
+
+        public bool IsLeaked
+        {
+            get
+            {
+                return WeakCard != null ? WeakCard.Target != null : false;
+            }
+        }
     }
 }

--- a/source/uwp/UWPTestLibrary/RenderedTestResult.cs
+++ b/source/uwp/UWPTestLibrary/RenderedTestResult.cs
@@ -1,0 +1,18 @@
+﻿using AdaptiveCards.Rendering.Uwp;
+using System;
+using Windows.UI.Xaml;
+
+namespace UWPTestLibrary
+{
+    public class RenderedTestResult
+    {
+        public string Error { get; set; }
+        public string RoundTrippedJSON { get; set; }
+
+        public UIElement Tree { get; set; }
+
+        public double CardWidth { get; set; }
+
+        public WeakReference WeakCard { get; set; }
+    }
+}

--- a/source/uwp/UWPTestLibrary/TestResultViewModel.cs
+++ b/source/uwp/UWPTestLibrary/TestResultViewModel.cs
@@ -33,6 +33,7 @@ namespace UWPTestLibrary
         public StorageFile ActualImageFile { get; set; }
         public StorageFile ActualRoundTrippedJsonFile { get; set; }
         public RenderedTestResult TestResult { get; set; }
+        public UIElement XamlCard { get { return TestResult?.Tree; } }
 
         public bool DidHostConfigChange => _oldHostConfigHash != null && _oldHostConfigHash != HostConfigFile.Hash;
         public bool DidCardPayloadChange => _oldCardHash != null && _oldCardHash != CardFile.Hash;

--- a/source/uwp/UWPTestLibrary/TestResultViewModel.cs
+++ b/source/uwp/UWPTestLibrary/TestResultViewModel.cs
@@ -30,11 +30,9 @@ namespace UWPTestLibrary
         public StorageFile ExpectedImageFile { get; set; }
         public StorageFile ExpectedRoundtrippedJsonFile { get; set; }
 
-        public string ActualError { get; set; }
-
         public StorageFile ActualImageFile { get; set; }
         public StorageFile ActualRoundTrippedJsonFile { get; set; }
-        public UIElement XamlCard { get; set; }
+        public RenderedTestResult TestResult { get; set; }
 
         public bool DidHostConfigChange => _oldHostConfigHash != null && _oldHostConfigHash != HostConfigFile.Hash;
         public bool DidCardPayloadChange => _oldCardHash != null && _oldCardHash != CardFile.Hash;
@@ -50,22 +48,20 @@ namespace UWPTestLibrary
         public static async Task<TestResultViewModel> CreateAsync(
             FileViewModel cardFile,
             FileViewModel hostConfigFile,
-            string actualError,
+            RenderedTestResult renderedTestResult,
             StorageFile actualImageFile,
             StorageFile actualJsonFile,
             StorageFolder expectedFolder,
             StorageFolder sourceHostConfigsFolder,
-            StorageFolder sourceCardsFolder,
-            UIElement xamlCard)
+            StorageFolder sourceCardsFolder)
         {
             var answer = new TestResultViewModel()
             {
                 CardName = cardFile.Name,
                 CardFile = cardFile,
-                XamlCard = xamlCard,
+                TestResult = renderedTestResult,
                 HostConfigName = hostConfigFile.Name,
                 HostConfigFile = hostConfigFile,
-                ActualError = actualError,
                 ActualImageFile = actualImageFile,
                 ActualRoundTrippedJsonFile = actualJsonFile,
                 _expectedFolder = expectedFolder,
@@ -98,9 +94,9 @@ namespace UWPTestLibrary
                 }
 
                 // If both had error, compare via the error
-                if (answer.ExpectedError != null && answer.ActualError != null)
+                if (answer.ExpectedError != null && answer.TestResult.Error != null)
                 {
-                    if (answer.ExpectedError == answer.ActualError)
+                    if (answer.ExpectedError == answer.TestResult.Error)
                     {
                         answer.Status = TestStatus.Passed;
                     }
@@ -252,7 +248,7 @@ namespace UWPTestLibrary
             try
             {
                 // If actual has error and existing did NOT have error, delete existing image
-                if (ActualError != null && ExpectedImageFile != null)
+                if (TestResult.Error != null && ExpectedImageFile != null)
                 {
                     try
                     {
@@ -266,7 +262,7 @@ namespace UWPTestLibrary
                 {
                     HostConfigHash = HostConfigFile.Hash,
                     CardHash = CardFile.Hash,
-                    Error = ActualError
+                    Error = TestResult.Error
                 }.SaveToFileAsync(_expectedFolder, _expectedFileNameWithoutExtension);
 
                 // Make sure the source files are saved (we use FailIfExists and try/catch since if file already exists no need to update it)
@@ -290,7 +286,7 @@ namespace UWPTestLibrary
                 catch { }
 
                 // If no error, update the image file
-                if (ActualError == null)
+                if (TestResult.Error == null)
                 {
                     var expectedFile = await _expectedFolder.CreateFileAsync(_expectedFileNameWithoutExtension + ".png", CreationCollisionOption.ReplaceExisting);
                     await ActualImageFile.CopyAndReplaceAsync(expectedFile);
@@ -300,7 +296,7 @@ namespace UWPTestLibrary
                 }
 
                 // Update the status
-                ExpectedError = ActualError;
+                ExpectedError = TestResult.Error;
                 ExpectedImageFile = ActualImageFile;
                 _oldHostConfigHash = HostConfigFile.Hash;
                 _oldCardHash = CardFile.Hash;

--- a/source/uwp/UWPTestLibrary/UWPTestLibrary.csproj
+++ b/source/uwp/UWPTestLibrary/UWPTestLibrary.csproj
@@ -92,6 +92,7 @@
     <Compile Include="FileLoadHelpers.cs" />
     <Compile Include="FileViewModel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RenderedTestResult.cs" />
     <Compile Include="RenderTestHelpers.cs" />
     <Compile Include="StoredTestResultInfo.cs" />
     <Compile Include="TestResultViewModel.cs" />

--- a/source/uwp/UWPUnitTests/UnitTest.cs
+++ b/source/uwp/UWPUnitTests/UnitTest.cs
@@ -113,15 +113,15 @@ namespace UWPUnitTests
         {
             var renderResult = await UWPTestLibrary.RenderTestHelpers.RenderCard(cardFile, hostConfigFile);
 
-            if (renderResult.Item3 != null)
+            if (renderResult.Tree != null)
             {
-                UWPTestLibrary.ImageWaiter imageWaiter = new ImageWaiter(renderResult.Item3);
+                UWPTestLibrary.ImageWaiter imageWaiter = new ImageWaiter(renderResult.Tree);
 
                 StackPanel stackPanel = new StackPanel();
-                stackPanel.Children.Add(renderResult.Item3);
+                stackPanel.Children.Add(renderResult.Tree);
 
                 Border border = new Border();
-                border.Width = renderResult.Item4;
+                border.Width = renderResult.CardWidth;
                 border.Child = stackPanel;
                 (Window.Current.Content as Frame).Content = border;
 
@@ -131,12 +131,12 @@ namespace UWPUnitTests
 
             StorageFile imageResultFile = null;
             StorageFile jsonResultFile = null;
-            if (renderResult.Item1 == null)
+            if (renderResult.Error == null)
             {
                 imageResultFile = await _tempResultsFolder.CreateFileAsync("Result.png", CreationCollisionOption.GenerateUniqueName);
                 jsonResultFile = await _tempResultsFolder.CreateFileAsync("Result.json", CreationCollisionOption.GenerateUniqueName);
 
-                await UWPTestLibrary.RenderTestHelpers.ResultsToFile(imageResultFile, jsonResultFile, renderResult.Item2, renderResult.Item3);
+                await UWPTestLibrary.RenderTestHelpers.ResultsToFile(imageResultFile, jsonResultFile, renderResult.RoundTrippedJSON, renderResult.Tree);
             }
 
             await Task.Delay(10);
@@ -144,10 +144,9 @@ namespace UWPUnitTests
             var result = await TestResultViewModel.CreateAsync(
                 cardFile: cardFile,
                 hostConfigFile: hostConfigFile,
-                actualError: renderResult.Item1,
+                renderedTestResult: renderResult,
                 actualImageFile: imageResultFile,
                 actualJsonFile: jsonResultFile,
-                xamlCard: renderResult.Item3,
                 expectedFolder: _expectedFolder,
                 sourceHostConfigsFolder: _sourceHostConfigsFolder,
                 sourceCardsFolder: _sourceCardsFolder);


### PR DESCRIPTION
First step in addressing some leaks that were found.

Keep track of every RenderedAdaptiveCard that we've rendered and keep them as WeakReferences.
On exit check that they've all been cleaned up.

Current code now leaks 271 cards out of 924