### PR TITLE
Change RenderResults to be WeakReferences

### DIFF
--- a/source/uwp/Renderer/lib/AdaptiveActionInvoker.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveActionInvoker.cpp
@@ -15,14 +15,18 @@ namespace AdaptiveNamespace
 
     HRESULT AdaptiveActionInvoker::RuntimeClassInitialize(_In_ RenderedAdaptiveCard* renderResult) noexcept try
     {
-        m_renderResult = renderResult;
-        return S_OK;
-    }
-    CATCH_RETURN;
+        ComPtr<IRenderedAdaptiveCard> strongRenderResult = renderResult;
+        return strongRenderResult.AsWeak(&m_weakRenderResult);
+    } CATCH_RETURN;
 
     HRESULT AdaptiveActionInvoker::SendActionEvent(_In_ IAdaptiveActionElement* actionElement)
     {
-        return m_renderResult->SendActionEvent(actionElement);
+        ComPtr<IRenderedAdaptiveCard> strongRenderResult;
+        RETURN_IF_FAILED(m_weakRenderResult.As(&strongRenderResult));
+        RETURN_IF_FAILED(strongRenderResult == nullptr ? E_FAIL : S_OK);
+        ComPtr<RenderedAdaptiveCard> renderResult = PeekInnards<RenderedAdaptiveCard>(strongRenderResult);
+        RETURN_IF_FAILED(renderResult == nullptr ? E_FAIL : S_OK);
+        RETURN_IF_FAILED(renderResult->SendActionEvent(actionElement));
+        return S_OK;
     }
-
 }

--- a/source/uwp/Renderer/lib/AdaptiveActionInvoker.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveActionInvoker.cpp
@@ -15,9 +15,10 @@ namespace AdaptiveNamespace
 
     HRESULT AdaptiveActionInvoker::RuntimeClassInitialize(_In_ RenderedAdaptiveCard* renderResult) noexcept try
     {
-        ComPtr<IRenderedAdaptiveCard> strongRenderResult = renderResult;
+        ComPtr<RenderedAdaptiveCard> strongRenderResult = renderResult;
         return strongRenderResult.AsWeak(&m_weakRenderResult);
-    } CATCH_RETURN;
+    }
+    CATCH_RETURN;
 
     HRESULT AdaptiveActionInvoker::SendActionEvent(_In_ IAdaptiveActionElement* actionElement)
     {

--- a/source/uwp/Renderer/lib/AdaptiveActionInvoker.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveActionInvoker.cpp
@@ -23,10 +23,14 @@ namespace AdaptiveNamespace
     {
         ComPtr<IRenderedAdaptiveCard> strongRenderResult;
         RETURN_IF_FAILED(m_weakRenderResult.As(&strongRenderResult));
-        RETURN_IF_FAILED(strongRenderResult == nullptr ? E_FAIL : S_OK);
-        ComPtr<RenderedAdaptiveCard> renderResult = PeekInnards<RenderedAdaptiveCard>(strongRenderResult);
-        RETURN_IF_FAILED(renderResult == nullptr ? E_FAIL : S_OK);
-        RETURN_IF_FAILED(renderResult->SendActionEvent(actionElement));
+        if (strongRenderResult != nullptr)
+        {
+            ComPtr<RenderedAdaptiveCard> renderResult = PeekInnards<RenderedAdaptiveCard>(strongRenderResult);
+            if (renderResult != nullptr)
+            {
+                RETURN_IF_FAILED(renderResult->SendActionEvent(actionElement));
+            }
+        }
         return S_OK;
     }
 }

--- a/source/uwp/Renderer/lib/AdaptiveActionInvoker.h
+++ b/source/uwp/Renderer/lib/AdaptiveActionInvoker.h
@@ -18,7 +18,7 @@ namespace AdaptiveNamespace
         IFACEMETHODIMP SendActionEvent(_In_ ABI::AdaptiveNamespace::IAdaptiveActionElement* actionElement);
 
     private:
-        Microsoft::WRL::ComPtr<AdaptiveNamespace::RenderedAdaptiveCard> m_renderResult;
+        Microsoft::WRL::WeakRef m_weakRenderResult;
     };
 
     ActivatableClass(AdaptiveActionInvoker);

--- a/source/uwp/Renderer/lib/AdaptiveMediaEventInvoker.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveMediaEventInvoker.cpp
@@ -15,13 +15,19 @@ namespace AdaptiveNamespace
 
     HRESULT AdaptiveMediaEventInvoker::RuntimeClassInitialize(_In_ RenderedAdaptiveCard* renderResult) noexcept try
     {
-        m_renderResult = renderResult;
-        return S_OK;
+        ComPtr<IRenderedAdaptiveCard> strongRenderResult = renderResult;
+        return strongRenderResult.AsWeak(&m_weakRenderResult);
     }
     CATCH_RETURN;
 
     HRESULT AdaptiveMediaEventInvoker::SendMediaClickedEvent(_In_ IAdaptiveMedia* mediaElement)
     {
-        return m_renderResult->SendMediaClickedEvent(mediaElement);
+        ComPtr<IRenderedAdaptiveCard> strongRenderResult;
+        RETURN_IF_FAILED(m_weakRenderResult.As(&strongRenderResult));
+        RETURN_IF_FAILED(strongRenderResult == nullptr ? E_FAIL : S_OK);
+        ComPtr<RenderedAdaptiveCard> renderResult = PeekInnards<RenderedAdaptiveCard>(strongRenderResult);
+        RETURN_IF_FAILED(renderResult == nullptr ? E_FAIL : S_OK);
+        RETURN_IF_FAILED(renderResult->SendMediaClickedEvent(mediaElement));
+        return S_OK;
     }
 }

--- a/source/uwp/Renderer/lib/AdaptiveMediaEventInvoker.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveMediaEventInvoker.cpp
@@ -15,7 +15,7 @@ namespace AdaptiveNamespace
 
     HRESULT AdaptiveMediaEventInvoker::RuntimeClassInitialize(_In_ RenderedAdaptiveCard* renderResult) noexcept try
     {
-        ComPtr<IRenderedAdaptiveCard> strongRenderResult = renderResult;
+        ComPtr<RenderedAdaptiveCard> strongRenderResult = renderResult;
         return strongRenderResult.AsWeak(&m_weakRenderResult);
     }
     CATCH_RETURN;

--- a/source/uwp/Renderer/lib/AdaptiveMediaEventInvoker.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveMediaEventInvoker.cpp
@@ -24,10 +24,14 @@ namespace AdaptiveNamespace
     {
         ComPtr<IRenderedAdaptiveCard> strongRenderResult;
         RETURN_IF_FAILED(m_weakRenderResult.As(&strongRenderResult));
-        RETURN_IF_FAILED(strongRenderResult == nullptr ? E_FAIL : S_OK);
-        ComPtr<RenderedAdaptiveCard> renderResult = PeekInnards<RenderedAdaptiveCard>(strongRenderResult);
-        RETURN_IF_FAILED(renderResult == nullptr ? E_FAIL : S_OK);
-        RETURN_IF_FAILED(renderResult->SendMediaClickedEvent(mediaElement));
+        if (strongRenderResult != nullptr)
+        {
+            ComPtr<RenderedAdaptiveCard> renderResult = PeekInnards<RenderedAdaptiveCard>(strongRenderResult);
+            if (renderResult != nullptr)
+            {
+                RETURN_IF_FAILED(renderResult->SendMediaClickedEvent(mediaElement));
+            }
+        }
         return S_OK;
     }
 }

--- a/source/uwp/Renderer/lib/AdaptiveMediaEventInvoker.h
+++ b/source/uwp/Renderer/lib/AdaptiveMediaEventInvoker.h
@@ -18,7 +18,7 @@ namespace AdaptiveNamespace
         IFACEMETHODIMP SendMediaClickedEvent(_In_ ABI::AdaptiveNamespace::IAdaptiveMedia* mediaElement);
 
     private:
-        Microsoft::WRL::ComPtr<AdaptiveNamespace::RenderedAdaptiveCard> m_renderResult;
+        Microsoft::WRL::WeakRef m_weakRenderResult;
     };
 
     ActivatableClass(AdaptiveMediaEventInvoker);

--- a/source/uwp/Renderer/lib/AdaptiveRenderContext.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveRenderContext.cpp
@@ -26,10 +26,12 @@ namespace AdaptiveNamespace
     {
         m_hostConfig = hostConfig;
         m_elementRendererRegistration = elementRendererRegistration;
-        m_renderResult = renderResult;
         m_resourceResolvers = resourceResolvers;
         m_overrideDictionary = overrideDictionary;
         m_actionSentimentDefaultDictionary = defaultActionSentimentStyles;
+
+        ComPtr<IRenderedAdaptiveCard> strongRenderResult = renderResult;
+        RETURN_IF_FAILED(strongRenderResult.AsWeak(&m_weakRenderResult));
 
         RETURN_IF_FAILED(MakeAndInitialize<AdaptiveActionInvoker>(&m_actionInvoker, renderResult));
         RETURN_IF_FAILED(MakeAndInitialize<AdaptiveMediaEventInvoker>(&m_mediaEventInvoker, renderResult));
@@ -72,8 +74,10 @@ namespace AdaptiveNamespace
     {
         ComPtr<AdaptiveError> error;
         RETURN_IF_FAILED(MakeAndInitialize<AdaptiveError>(&error, statusCode, message));
-        ComPtr<IVector<ABI::AdaptiveNamespace::AdaptiveError*>> errors;
-        RETURN_IF_FAILED(m_renderResult->get_Errors(&errors));
+        ComPtr<IVector<ABI::AdaptiveNamespace::IAdaptiveError*>> errors;
+        ComPtr<IRenderedAdaptiveCard> renderResult;
+        RETURN_IF_FAILED(GetRenderResult(renderResult.GetAddressOf()));
+        RETURN_IF_FAILED(renderResult->get_Errors(&errors));
         return (errors->Append(error.Detach()));
     }
 
@@ -81,8 +85,10 @@ namespace AdaptiveNamespace
     {
         ComPtr<AdaptiveWarning> warning;
         RETURN_IF_FAILED(MakeAndInitialize<AdaptiveWarning>(&warning, statusCode, message));
-        ComPtr<IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>> warnings;
-        RETURN_IF_FAILED(m_renderResult->get_Warnings(&warnings));
+        ComPtr<IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>> warnings;
+        ComPtr<IRenderedAdaptiveCard> renderResult;
+        RETURN_IF_FAILED(GetRenderResult(renderResult.GetAddressOf()));
+        RETURN_IF_FAILED(renderResult->get_Warnings(&warnings));
         return (warnings->Append(warning.Detach()));
     }
 
@@ -99,11 +105,23 @@ namespace AdaptiveNamespace
 
     HRESULT AdaptiveRenderContext::AddInputValue(_In_ IAdaptiveInputValue* inputValue)
     {
-        return m_renderResult->AddInputValue(inputValue);
+        ComPtr<IRenderedAdaptiveCard> renderResult;
+        RETURN_IF_FAILED(GetRenderResult(renderResult.GetAddressOf()));
+        ComPtr<RenderedAdaptiveCard> renderedAdaptiveCard = PeekInnards<RenderedAdaptiveCard>(renderResult);
+        RETURN_IF_FAILED(renderedAdaptiveCard == nullptr ? E_NOINTERFACE : S_OK);
+        return renderedAdaptiveCard->AddInputValue(inputValue);
     }
 
     Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IResourceDictionary> AdaptiveRenderContext::GetDefaultActionSentimentDictionary()
     {
         return m_actionSentimentDefaultDictionary;
+    }
+
+    HRESULT AdaptiveRenderContext::GetRenderResult(IRenderedAdaptiveCard** renderResult)
+    {
+        ComPtr<IRenderedAdaptiveCard> strongRenderResult;
+        RETURN_IF_FAILED(m_weakRenderResult.As(&strongRenderResult));
+        RETURN_IF_FAILED(strongRenderResult == nullptr ? E_FAIL : S_OK);
+        return strongRenderResult.CopyTo(renderResult);
     }
 }

--- a/source/uwp/Renderer/lib/AdaptiveRenderContext.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveRenderContext.cpp
@@ -30,7 +30,7 @@ namespace AdaptiveNamespace
         m_overrideDictionary = overrideDictionary;
         m_actionSentimentDefaultDictionary = defaultActionSentimentStyles;
 
-        ComPtr<IRenderedAdaptiveCard> strongRenderResult = renderResult;
+        ComPtr<RenderedAdaptiveCard> strongRenderResult = renderResult;
         RETURN_IF_FAILED(strongRenderResult.AsWeak(&m_weakRenderResult));
 
         RETURN_IF_FAILED(MakeAndInitialize<AdaptiveActionInvoker>(&m_actionInvoker, renderResult));
@@ -74,8 +74,8 @@ namespace AdaptiveNamespace
     {
         ComPtr<AdaptiveError> error;
         RETURN_IF_FAILED(MakeAndInitialize<AdaptiveError>(&error, statusCode, message));
-        ComPtr<IVector<ABI::AdaptiveNamespace::IAdaptiveError*>> errors;
-        ComPtr<IRenderedAdaptiveCard> renderResult;
+        ComPtr<IVector<ABI::AdaptiveNamespace::AdaptiveError*>> errors;
+        ComPtr<RenderedAdaptiveCard> renderResult;
         RETURN_IF_FAILED(GetRenderResult(renderResult.GetAddressOf()));
         RETURN_IF_FAILED(renderResult->get_Errors(&errors));
         return (errors->Append(error.Detach()));
@@ -85,8 +85,8 @@ namespace AdaptiveNamespace
     {
         ComPtr<AdaptiveWarning> warning;
         RETURN_IF_FAILED(MakeAndInitialize<AdaptiveWarning>(&warning, statusCode, message));
-        ComPtr<IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>> warnings;
-        ComPtr<IRenderedAdaptiveCard> renderResult;
+        ComPtr<IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>> warnings;
+        ComPtr<RenderedAdaptiveCard> renderResult;
         RETURN_IF_FAILED(GetRenderResult(renderResult.GetAddressOf()));
         RETURN_IF_FAILED(renderResult->get_Warnings(&warnings));
         return (warnings->Append(warning.Detach()));
@@ -105,11 +105,10 @@ namespace AdaptiveNamespace
 
     HRESULT AdaptiveRenderContext::AddInputValue(_In_ IAdaptiveInputValue* inputValue)
     {
-        ComPtr<IRenderedAdaptiveCard> renderResult;
+        ComPtr<RenderedAdaptiveCard> renderResult;
         RETURN_IF_FAILED(GetRenderResult(renderResult.GetAddressOf()));
-        ComPtr<RenderedAdaptiveCard> renderedAdaptiveCard = PeekInnards<RenderedAdaptiveCard>(renderResult);
-        RETURN_IF_FAILED(renderedAdaptiveCard == nullptr ? E_NOINTERFACE : S_OK);
-        return renderedAdaptiveCard->AddInputValue(inputValue);
+        RETURN_IF_FAILED(renderResult == nullptr ? E_NOINTERFACE : S_OK);
+        return renderResult->AddInputValue(inputValue);
     }
 
     Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IResourceDictionary> AdaptiveRenderContext::GetDefaultActionSentimentDictionary()
@@ -117,11 +116,13 @@ namespace AdaptiveNamespace
         return m_actionSentimentDefaultDictionary;
     }
 
-    HRESULT AdaptiveRenderContext::GetRenderResult(IRenderedAdaptiveCard** renderResult)
+    HRESULT AdaptiveRenderContext::GetRenderResult(AdaptiveCards::Rendering::Uwp::RenderedAdaptiveCard** renderResult)
     {
         ComPtr<IRenderedAdaptiveCard> strongRenderResult;
         RETURN_IF_FAILED(m_weakRenderResult.As(&strongRenderResult));
         RETURN_IF_FAILED(strongRenderResult == nullptr ? E_FAIL : S_OK);
-        return strongRenderResult.CopyTo(renderResult);
+        ComPtr<RenderedAdaptiveCard> renderResultObject = PeekInnards<RenderedAdaptiveCard>(strongRenderResult);
+        RETURN_IF_FAILED(renderResultObject == nullptr ? E_FAIL : S_OK);
+        return renderResultObject.CopyTo(renderResult);
     }
 }

--- a/source/uwp/Renderer/lib/AdaptiveRenderContext.h
+++ b/source/uwp/Renderer/lib/AdaptiveRenderContext.h
@@ -9,6 +9,7 @@ namespace AdaptiveNamespace
 {
     class DECLSPEC_UUID("F29649FF-C718-4F94-8F39-2415C86BE77E") AdaptiveRenderContext
         : public Microsoft::WRL::RuntimeClass<Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
+                                              Microsoft::WRL::Implements<IWeakReferenceSource>,
                                               ABI::AdaptiveNamespace::IAdaptiveRenderContext,
                                               Microsoft::WRL::CloakedIid<ITypePeek>>
     {
@@ -37,6 +38,7 @@ namespace AdaptiveNamespace
 
         HRESULT put_CardFrameworkElement(_In_ ABI::Windows::UI::Xaml::IFrameworkElement* value);
 
+        HRESULT GetRenderResult(_COM_Outptr_ ABI::AdaptiveNamespace::IRenderedAdaptiveCard** renderResult);
         Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IResourceDictionary> GetDefaultActionSentimentDictionary();
 
         // ITypePeek method
@@ -45,7 +47,7 @@ namespace AdaptiveNamespace
     private:
         Microsoft::WRL::ComPtr<ABI::AdaptiveNamespace::IAdaptiveHostConfig> m_hostConfig;
         Microsoft::WRL::ComPtr<ABI::AdaptiveNamespace::IAdaptiveElementRendererRegistration> m_elementRendererRegistration;
-        Microsoft::WRL::ComPtr<AdaptiveNamespace::RenderedAdaptiveCard> m_renderResult;
+        Microsoft::WRL::WeakRef m_weakRenderResult;
         Microsoft::WRL::ComPtr<AdaptiveNamespace::AdaptiveActionInvoker> m_actionInvoker;
         Microsoft::WRL::ComPtr<AdaptiveNamespace::AdaptiveMediaEventInvoker> m_mediaEventInvoker;
         Microsoft::WRL::ComPtr<ABI::AdaptiveNamespace::IAdaptiveCardResourceResolvers> m_resourceResolvers;

--- a/source/uwp/Renderer/lib/AdaptiveRenderContext.h
+++ b/source/uwp/Renderer/lib/AdaptiveRenderContext.h
@@ -38,7 +38,7 @@ namespace AdaptiveNamespace
 
         HRESULT put_CardFrameworkElement(_In_ ABI::Windows::UI::Xaml::IFrameworkElement* value);
 
-        HRESULT GetRenderResult(_COM_Outptr_ ABI::AdaptiveNamespace::IRenderedAdaptiveCard** renderResult);
+        HRESULT GetRenderResult(_COM_Outptr_ AdaptiveNamespace::RenderedAdaptiveCard** renderResult);
         Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IResourceDictionary> GetDefaultActionSentimentDictionary();
 
         // ITypePeek method

--- a/source/uwp/Renderer/lib/RenderedAdaptiveCard.h
+++ b/source/uwp/Renderer/lib/RenderedAdaptiveCard.h
@@ -7,8 +7,10 @@
 
 namespace AdaptiveNamespace
 {
-    class RenderedAdaptiveCard
+    class DECLSPEC_UUID("F25E0D36-0B5B-4398-AFC8-F84105EC46A2") RenderedAdaptiveCard
         : public Microsoft::WRL::RuntimeClass<Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
+                                              Microsoft::WRL::Implements<IWeakReferenceSource>,
+                                              Microsoft::WRL::CloakedIid<ITypePeek>,
                                               Microsoft::WRL::Implements<ABI::AdaptiveNamespace::IRenderedAdaptiveCard>>
     {
         AdaptiveRuntime(RenderedAdaptiveCard);
@@ -39,11 +41,17 @@ namespace AdaptiveNamespace
         IFACEMETHODIMP get_Warnings(
             _COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>** value);
 
-        HRESULT AddInputValue(_In_ ABI::AdaptiveNamespace::IAdaptiveInputValue* inputValue);
-        void SetFrameworkElement(_In_ ABI::Windows::UI::Xaml::IFrameworkElement* value);
-        void SetOriginatingCard(_In_ ABI::AdaptiveNamespace::IAdaptiveCard* value);
-        HRESULT SendActionEvent(_In_ ABI::AdaptiveNamespace::IAdaptiveActionElement* eventArgs);
-        HRESULT SendMediaClickedEvent(_In_ ABI::AdaptiveNamespace::IAdaptiveMedia* eventArgs);
+        // ITypePeek method
+        void *PeekAt(REFIID riid) override
+        {
+            return PeekHelper(riid, this);
+        }
+
+        HRESULT AddInputValue(ABI::AdaptiveNamespace::IAdaptiveInputValue* inputValue);
+        void SetFrameworkElement(ABI::Windows::UI::Xaml::IFrameworkElement* value);
+        void SetOriginatingCard(ABI::AdaptiveNamespace::IAdaptiveCard* value);
+        HRESULT SendActionEvent(ABI::AdaptiveNamespace::IAdaptiveActionElement* eventArgs);
+        HRESULT SendMediaClickedEvent(ABI::AdaptiveNamespace::IAdaptiveMedia* eventArgs);
 
     private:
         Microsoft::WRL::ComPtr<ABI::AdaptiveNamespace::IAdaptiveCard> m_originatingCard;


### PR DESCRIPTION
Because the RenderedAdaptiveCard holds on to the root of the tree.
The ClickHandler for the action button hangs on to the ActionInvoker.
This creates a cycle causing the whole AdaptiveCard and XAML tree to leak.
By switching to a WeakRef on the ActionInvoker, this will allow the RenderedAdaptiveCard to be released and the whole tree to go away.
Also setting the RenderContext to use a weakRef on the RenderedAdaptiveCard to prevent another leak.

With the change #2249, we are now leak free in the AdaptiveCardTestApp.
