### PR TITLE
Remove hardcoded color in input text

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/TextInputRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/TextInputRenderer.java
@@ -155,7 +155,6 @@ public class TextInputRenderer extends BaseCardElementRenderer
         EditText editText = new EditText(context);
         textInputHandler.setView(editText);
         editText.setTag(textInputHandler);
-        editText.setTextColor(Color.BLACK);
         renderedCard.registerInputHandler(textInputHandler);
 
         if (!TextUtils.isEmpty(value))


### PR DESCRIPTION
The color of input text color is hardcoded as black and cannot be changed by the client . 
Fixes the issue [2245](https://github.com/Microsoft/AdaptiveCards/issues/2245)