### PR TITLE
Fix Container layout issue on Android.

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ContainerRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ContainerRenderer.java
@@ -65,9 +65,14 @@ public class ContainerRenderer extends BaseCardElementRenderer
         ContainerStyle styleForThis = container.GetStyle().swigValue() == ContainerStyle.None.swigValue() ? containerStyle : container.GetStyle();
         LinearLayout containerView = new LinearLayout(context);
 
+        containerView.setOrientation(LinearLayout.VERTICAL);
         if(container.GetHeight() == HeightType.Stretch)
         {
-            containerView.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.MATCH_PARENT, 1));
+            containerView.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0, 1));
+        }
+        else
+        {
+            containerView.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
         }
 
         VerticalContentAlignment contentAlignment = container.GetVerticalContentAlignment();


### PR DESCRIPTION
On Android, LinearLayout's orientation is set as horizontal by default. However, for Container layout, we should set orientation as vertical. So in this PR, I try to set containerView's orientation to vertical explicitly.