### PR TITLE
Fix Input.ChoiceSet description

### DIFF
--- a/schemas/adaptive-card.json
+++ b/schemas/adaptive-card.json
@@ -686,7 +686,7 @@
 					"$ref": "#/definitions/ChoiceInputStyle"
 				},
 				"type": {
-					"description": "Must be `\"Input.ChoiceInput\"`.",
+					"description": "Must be `\"Input.ChoiceSet\"`.",
 					"enum": [
 						"Input.ChoiceSet"
 					],


### PR DESCRIPTION
I noticed a typo in adaptive-card.json. The description of the `type` property of `Input.ChoiceSet` was ``"Must be `\"Input.ChoiceInput\"`."`` instead of ``"Must be `\"Input.ChoiceSet\"`."``