### PR TITLE
Cherry picking a couple of .NET fixes for 1.1

### DIFF
--- a/source/dotnet/Library/AdaptiveCards/AdaptiveCard.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveCard.cs
@@ -54,7 +54,8 @@ namespace AdaptiveCards
         /// <summary>
         /// Creates an AdaptiveCard using the <see cref="F:AdaptiveCards.AdaptiveCard.KnownSchemaVersion" /> of this library
         /// </summary>
-        public AdaptiveCard() : this(KnownSchemaVersion) { }
+        [Obsolete("Please use the overload that accepts a version parameter and specify the version your card requires")]
+        public AdaptiveCard() : this(new AdaptiveSchemaVersion(1, 0)) { }
 
         /// <summary>
         /// The Body elements for this card

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveElement.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveElement.cs
@@ -54,7 +54,7 @@ namespace AdaptiveCards
                         return AdaptiveSeparationStyle.None;
 
                     case AdaptiveSpacing.Large:
-                        return AdaptiveSeparationStyle.Strong;
+                        return Separator ? AdaptiveSeparationStyle.Strong : AdaptiveSeparationStyle.Default;
 
                     default:
                         return AdaptiveSeparationStyle.Default;

--- a/source/dotnet/Test/AdaptiveCards.Test/AdaptiveCardApiTests.cs
+++ b/source/dotnet/Test/AdaptiveCards.Test/AdaptiveCardApiTests.cs
@@ -12,7 +12,10 @@ namespace AdaptiveCards.Test
         [TestMethod]
         public void TestAssigningVersion()
         {
-            AdaptiveCard card = new AdaptiveCard();
+            AdaptiveCard card = new AdaptiveCard("1.0");
+
+            Assert.AreEqual(1, card.Version.Major);
+            Assert.AreEqual(0, card.Version.Minor);
             card.Version = new AdaptiveSchemaVersion(4, 5);
 
             Assert.AreEqual(4, card.Version.Major);
@@ -22,7 +25,7 @@ namespace AdaptiveCards.Test
         [TestMethod]
         public void TestAssigningVersionAsString()
         {
-            AdaptiveCard card = new AdaptiveCard();
+            AdaptiveCard card = new AdaptiveCard("1.0");
             card.Version = "4.5";
 
             Assert.AreEqual(4, card.Version.Major);
@@ -89,8 +92,7 @@ namespace AdaptiveCards.Test
     }
   ]
 }";
-            // TODO: No longer throwing on this exception to work around bot framework integration issues. Revisit later
-            //Assert.ThrowsException<AdaptiveSerializationException>(() => AdaptiveCard.FromJson(json));
+            Assert.ThrowsException<AdaptiveSerializationException>(() => AdaptiveCard.FromJson(json));
         }
 
         [TestMethod]

--- a/source/dotnet/Test/AdaptiveCards.Test/ChoiceSetInputTests.cs
+++ b/source/dotnet/Test/AdaptiveCards.Test/ChoiceSetInputTests.cs
@@ -10,7 +10,7 @@ namespace AdaptiveCards.Test
         [TestMethod]
         public void TestChoiceSetExpanded()
         {
-            var card = new AdaptiveCard
+            var card = new AdaptiveCard("1.0")
             {
                 Body = new List<AdaptiveElement>()
                 {

--- a/source/dotnet/Test/AdaptiveCards.Test/SeparatorSpacingTests.cs
+++ b/source/dotnet/Test/AdaptiveCards.Test/SeparatorSpacingTests.cs
@@ -130,6 +130,20 @@ namespace AdaptiveCards.Test
         }
 
         [TestMethod]
+        public void TestLargeSpacing()
+        {
+            AdaptiveCard card = new AdaptiveCard(new AdaptiveSchemaVersion("1.0"));
+            AdaptiveTextBlock block = new AdaptiveTextBlock();
+            block.Text = "Hi this is textblock";
+            block.Spacing = AdaptiveSpacing.Large;
+
+            card.Body.Add(block);
+
+            string s = card.ToJson();
+            Assert.IsFalse(s.Contains("separation"));
+        }
+
+        [TestMethod]
         public void TestSerializingLegacySeparation()
         {
             var inputJson = @"{

--- a/source/dotnet/Test/AdaptiveCards.Test/SerializationTests.cs
+++ b/source/dotnet/Test/AdaptiveCards.Test/SerializationTests.cs
@@ -14,7 +14,9 @@ namespace AdaptiveCards.Test
         [TestMethod]
         public void TestCardsSerializeInTheCorrectOrder()
         {
+#pragma warning disable 0618
             var card = new AdaptiveCard();
+#pragma warning restore 0618
             card.Version = "1.0";
             card.FallbackText = "Fallback Text";
             card.Speak = "Speak";
@@ -84,7 +86,10 @@ namespace AdaptiveCards.Test
         [TestMethod]
         public void TestSerializingAdditionalData()
         {
-            var card = new AdaptiveCard
+            // Disable this warning since we want to make sure that
+            // the obsoleted constructor also outputs the right version
+#pragma warning disable 0618
+            var card = new AdaptiveCard()
             {
                 Id = "myCard",
                 Body =
@@ -109,10 +114,11 @@ namespace AdaptiveCards.Test
                     ["-ms-test"] = "Card extension data"
                 }
             };
+#pragma warning restore 0618
 
             var expected = @"{
   ""type"": ""AdaptiveCard"",
-  ""version"": ""1.1"",
+  ""version"": ""1.0"",
   ""id"": ""myCard"",
   ""body"": [
     {
@@ -137,7 +143,7 @@ namespace AdaptiveCards.Test
         [TestMethod]
         public void TestDefaultValuesAreNotSerialized()
         {
-            var card = new AdaptiveCard
+            var card = new AdaptiveCard("1.0")
             {
                 Body =
                 {
@@ -148,7 +154,7 @@ namespace AdaptiveCards.Test
 
             var expected = @"{
   ""type"": ""AdaptiveCard"",
-  ""version"": ""1.1"",
+  ""version"": ""1.0"",
   ""body"": [
     {
       ""type"": ""TextBlock"",
@@ -231,7 +237,7 @@ namespace AdaptiveCards.Test
         [TestMethod]
         public void TestSerializingTextBlock()
         {
-            var card = new AdaptiveCard()
+            var card = new AdaptiveCard("1.0")
             {
                 Body =
                 {
@@ -258,7 +264,7 @@ namespace AdaptiveCards.Test
         [TestMethod]
         public void TestShowCardActionSerialization()
         {
-            var card = new AdaptiveCard()
+            var card = new AdaptiveCard("1.0")
             {
                 Body =
                 {
@@ -272,7 +278,7 @@ namespace AdaptiveCards.Test
                     new AdaptiveShowCardAction
                     {
                         Title = "Show Card",
-                        Card = new AdaptiveCard
+                        Card = new AdaptiveCard("1.0")
                         {
                             Version = null,
                             Body =
@@ -536,7 +542,7 @@ namespace AdaptiveCards.Test
   ]
 }";
 
-            var card = new AdaptiveCard
+            var card = new AdaptiveCard("1.1")
             {
                 Id = "myCard",
                 Body =


### PR DESCRIPTION
[.NET] Fix separation strong issue (#2200)
Obsolete the default AdaptiveCard constructor in favor of specifying … (#2188)