### PR TITLE
Adding the proper copyright for .NET packages (#2277)

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Rendering.Html/AdaptiveCards.Rendering.Html.csproj
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Html/AdaptiveCards.Rendering.Html.csproj
@@ -12,6 +12,7 @@
     <RepositoryUrl>https://github.com/Microsoft/AdaptiveCards</RepositoryUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/Microsoft/AdaptiveCards/master/LICENSE</PackageLicenseUrl>
     <DefineConstants>$(DefineConstants);$(AdditionalConstants)</DefineConstants>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <GenerateAssemblyInfo Condition="$(Tfs_PackageVersionNumber) != ''">false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf.Xceed/AdaptiveCards.Rendering.Wpf.Xceed.csproj
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf.Xceed/AdaptiveCards.Rendering.Wpf.Xceed.csproj
@@ -13,6 +13,7 @@
     <PackageLicenseUrl>https://raw.githubusercontent.com/Microsoft/AdaptiveCards/master/LICENSE</PackageLicenseUrl>
     <RootNamespace>AdaptiveCards.Rendering.Wpf</RootNamespace>
     <DefineConstants>WPF;$(DefineConstants);$(AdditionalConstants)</DefineConstants>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <GenerateAssemblyInfo Condition="$(Tfs_PackageVersionNumber) != ''">false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveCards.Rendering.Wpf.csproj
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveCards.Rendering.Wpf.csproj
@@ -12,6 +12,7 @@
     <RepositoryUrl>https://github.com/Microsoft/AdaptiveCards</RepositoryUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/Microsoft/AdaptiveCards/master/LICENSE</PackageLicenseUrl>
     <DefineConstants>WPF;$(DefineConstants);$(AdditionalConstants)</DefineConstants>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <GenerateAssemblyInfo Condition="$(Tfs_PackageVersionNumber) != ''">false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveCards.csproj
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveCards.csproj
@@ -13,6 +13,7 @@
     <PackageLicenseUrl>https://raw.githubusercontent.com/Microsoft/AdaptiveCards/master/LICENSE</PackageLicenseUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <DefineConstants>$(DefineConstants);$(AdditionalConstants)</DefineConstants>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <GenerateAssemblyInfo Condition="$(Tfs_PackageVersionNumber) != ''">false</GenerateAssemblyInfo>
   </PropertyGroup>
 


### PR DESCRIPTION
Cherry-picking the change from 1.1 so that new (1.2) packages don't have the issue.