### PR TITLE
Adding width and height anchor for separator

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRSeparator.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRSeparator.mm
@@ -87,6 +87,7 @@ using namespace AdaptiveCards;
         [self setContentCompressionResistancePriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisHorizontal];
         [self setContentHuggingPriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisVertical];
         [self setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisVertical];
+        [self.heightAnchor constraintEqualToConstant:height].active = YES;
     }
     else
     {
@@ -94,6 +95,7 @@ using namespace AdaptiveCards;
         [self setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
         [self setContentHuggingPriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisVertical];
         [self setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisVertical];
+        [self.widthAnchor constraintEqualToConstant:width].active = YES;
     }
     return constraint;
 }


### PR DESCRIPTION
This PR is a fix for [#2286](https://github.com/Microsoft/AdaptiveCards/issues/2286) 
Issue:
The intrinsicContentSize is passed for ACRSeparator but for some reason it is not applied, and the separator becomes small.
Fix:
We are anyways using intrinsicContentSize and setting contentCompressionResistancePriority for respective Axis which means we want it to apply the same size.
Fixing by setting a width and height constraint for the respective Axis so that separator size does not reduce.


