### PR TITLE
Add UWP object model tests and fix bugs

### DIFF
--- a/source/uwp/Renderer/lib/AdaptiveOpenUrlAction.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveOpenUrlAction.cpp
@@ -27,7 +27,11 @@ namespace AdaptiveNamespace
         ComPtr<IUriRuntimeClassFactory> uriActivationFactory;
         RETURN_IF_FAILED(GetActivationFactory(HStringReference(RuntimeClass_Windows_Foundation_Uri).Get(), &uriActivationFactory));
         std::wstring imageUri = StringToWstring(sharedOpenUrlAction->GetUrl());
-        RETURN_IF_FAILED(uriActivationFactory->CreateUri(HStringReference(imageUri.c_str()).Get(), m_url.GetAddressOf()));
+
+        if (!imageUri.empty())
+        {
+            RETURN_IF_FAILED(uriActivationFactory->CreateUri(HStringReference(imageUri.c_str()).Get(), m_url.GetAddressOf()));
+        }
 
         InitializeBaseElement(std::static_pointer_cast<AdaptiveSharedNamespace::BaseActionElement>(sharedOpenUrlAction));
         return S_OK;

--- a/source/uwp/Renderer/lib/AdaptiveShowCardAction.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveShowCardAction.cpp
@@ -23,7 +23,11 @@ namespace AdaptiveNamespace
             return E_INVALIDARG;
         }
 
-        RETURN_IF_FAILED(MakeAndInitialize<AdaptiveCard>(&m_card, sharedShowCardAction->GetCard()));
+        std::shared_ptr<AdaptiveCards::AdaptiveCard> card = sharedShowCardAction->GetCard();
+        if (card != nullptr)
+        {
+            RETURN_IF_FAILED(MakeAndInitialize<AdaptiveCard>(&m_card, sharedShowCardAction->GetCard()));
+        }
 
         InitializeBaseElement(std::static_pointer_cast<AdaptiveSharedNamespace::BaseActionElement>(sharedShowCardAction));
         return S_OK;

--- a/source/uwp/UWPUnitTests/ObjectModelTests.cs
+++ b/source/uwp/UWPUnitTests/ObjectModelTests.cs
@@ -1,0 +1,712 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using AdaptiveCards.Rendering.Uwp;
+using Windows.Data.Json;
+
+
+namespace UWPUnitTests
+{
+    [TestClass]
+    public class ObjectModelTest
+    {
+        [TestMethod]
+        public void Card()
+        {
+            AdaptiveCard card = new AdaptiveCard
+            {
+                BackgroundImage = "https://www.stuff.com/background.jpg",
+                FallbackText = "Fallback Text",
+                Height = HeightType.Stretch,
+                Language = "en",
+                Speak = "This is a card",
+                Style = ContainerStyle.Emphasis,
+                Version = "1.3",
+                VerticalContentAlignment = VerticalContentAlignment.Center,
+            };
+
+            Assert.AreEqual("https://www.stuff.com/background.jpg", card.BackgroundImage);
+            Assert.AreEqual("Fallback Text", card.FallbackText);
+            Assert.AreEqual(HeightType.Stretch, card.Height);
+            Assert.AreEqual("en", card.Language);
+            Assert.AreEqual("This is a card", card.Speak);
+            Assert.AreEqual(ContainerStyle.Emphasis, card.Style);
+            Assert.AreEqual("1.3", card.Version);
+            Assert.AreEqual(VerticalContentAlignment.Center, card.VerticalContentAlignment);
+
+            card.SelectAction = new AdaptiveSubmitAction
+            {
+                Title = "Select Action"
+            };
+            Assert.IsNotNull(card.SelectAction);
+            Assert.AreEqual("Select Action", card.SelectAction.Title);
+
+            AdaptiveTextBlock textBlock = new AdaptiveTextBlock
+            {
+                Text = "This is a text block"
+            };
+            card.Body.Add(textBlock);
+
+            AdaptiveTextBlock textBlock2 = new AdaptiveTextBlock
+            {
+                Text = "This is another text block"
+            };
+            card.Body.Add(textBlock2);
+
+            Assert.AreEqual("This is a text block", (card.Body[0] as AdaptiveTextBlock).Text);
+            Assert.AreEqual("This is another text block", (card.Body[1] as AdaptiveTextBlock).Text);
+
+            AdaptiveSubmitAction submitAction = new AdaptiveSubmitAction
+            {
+                Title = "Submit One"
+            };
+            card.Actions.Add(submitAction);
+
+            AdaptiveSubmitAction submitAction2 = new AdaptiveSubmitAction
+            {
+                Title = "Submit Two"
+            };
+            card.Actions.Add(submitAction2);
+
+            Assert.AreEqual("Submit One", card.Actions[0].Title);
+            Assert.AreEqual("Submit Two", card.Actions[1].Title);
+
+            var jsonString = card.ToJson().ToString();
+            Assert.AreEqual("{\"actions\":[{\"data\":\"null\",\"id\":\"\",\"title\":\"Submit One\",\"type\":\"Action.Submit\"},{\"data\":\"null\",\"id\":\"\",\"title\":\"Submit Two\",\"type\":\"Action.Submit\"}],\"backgroundImage\":\"https://www.stuff.com/background.jpg\",\"body\":[{\"text\":\"This is a text block\",\"type\":\"TextBlock\"},{\"text\":\"This is another text block\",\"type\":\"TextBlock\"}],\"fallbackText\":\"Fallback Text\",\"height\":\"Stretch\",\"lang\":\"en\",\"speak\":\"This is a card\",\"style\":\"Emphasis\",\"type\":\"AdaptiveCard\",\"version\":\"1.3\",\"verticalContentAlignment\":\"Center\"}", jsonString);
+        }
+
+        public void ValidateBaseElementProperties(
+            IAdaptiveCardElement element,
+            string id,
+            bool isVisible,
+            bool separator,
+            Spacing spacing,
+            HeightType height)
+        {
+            Assert.AreEqual(id, element.Id);
+            Assert.AreEqual(isVisible, element.IsVisible);
+            Assert.AreEqual(separator, element.Separator);
+            Assert.AreEqual(spacing, element.Spacing);
+            Assert.AreEqual(height, element.Height);
+        }
+
+        [TestMethod]
+        public void TextBlock()
+        {
+            AdaptiveTextBlock textBlock = new AdaptiveTextBlock
+            {
+                Color = ForegroundColor.Accent,
+                FontStyle = FontStyle.Monospace,
+                Height = HeightType.Stretch,
+                HorizontalAlignment = HAlignment.Center,
+                Id = "TextBlockId",
+                IsSubtle = true,
+                IsVisible = false,
+                Language = "en",
+                MaxLines = 3,
+                Separator = true,
+                Size = TextSize.Large,
+                Spacing = Spacing.Large,
+                Text = "This is a text block",
+                Weight = TextWeight.Bolder,
+                Wrap = true
+            };
+
+            ValidateBaseElementProperties(textBlock, "TextBlockId", false, true, Spacing.Large, HeightType.Stretch);
+
+            Assert.AreEqual(ForegroundColor.Accent, textBlock.Color);
+            Assert.AreEqual(FontStyle.Monospace, textBlock.FontStyle);
+            Assert.AreEqual(HAlignment.Center, textBlock.HorizontalAlignment);
+            Assert.AreEqual(true, textBlock.IsSubtle);
+            Assert.AreEqual("en", textBlock.Language);
+            Assert.AreEqual<uint>(3, textBlock.MaxLines);
+            Assert.AreEqual(TextSize.Large, textBlock.Size);
+            Assert.AreEqual("This is a text block", textBlock.Text);
+            Assert.AreEqual(TextWeight.Bolder, textBlock.Weight);
+            Assert.AreEqual(true, textBlock.Wrap);
+
+            var jsonString = textBlock.ToJson().ToString();
+            Assert.AreEqual("{\"color\":\"Accent\",\"fontStyle\":\"Monospace\",\"height\":\"Stretch\",\"horizontalAlignment\":\"Center\",\"id\":\"TextBlockId\",\"isSubtle\":true,\"isVisible\":false,\"maxLines\":3,\"separator\":true,\"size\":\"Large\",\"spacing\":\"large\",\"text\":\"This is a text block\",\"type\":\"TextBlock\",\"weight\":\"Bolder\",\"wrap\":true}", jsonString);
+        }
+
+        [TestMethod]
+        public void Image()
+        {
+            AdaptiveImage image = new AdaptiveImage
+            {
+                AltText = "This is a picture",
+                BackgroundColor = "0xffffffff",
+                Height = HeightType.Stretch,
+                HorizontalAlignment = HAlignment.Center,
+                Id = "ImageId",
+                IsVisible = false,
+                PixelHeight = 50,
+                PixelWidth = 40,
+                Separator = true,
+                Size = ImageSize.Medium,
+                Spacing = Spacing.Large,
+                Style = ImageStyle.Person,
+                Url = "https://www.stuff.com/picture.jpg"
+            };
+
+            ValidateBaseElementProperties(image, "ImageId", false, true, Spacing.Large, HeightType.Stretch);
+
+            Assert.AreEqual("This is a picture", image.AltText);
+            Assert.AreEqual("0xffffffff", image.BackgroundColor);
+            Assert.AreEqual(HAlignment.Center, image.HorizontalAlignment);
+            Assert.AreEqual<uint>(50, image.PixelHeight);
+            Assert.AreEqual<uint>(40, image.PixelWidth);
+            Assert.AreEqual(ImageSize.Medium, image.Size);
+            Assert.AreEqual(ImageStyle.Person, image.Style);
+            Assert.AreEqual("https://www.stuff.com/picture.jpg", image.Url);
+
+            var jsonString = image.ToJson().ToString();
+            Assert.AreEqual("{\"altText\":\"This is a picture\",\"backgroundColor\":\"0xffffffff\",\"height\":\"50px\",\"horizontalAlignment\":\"Center\",\"id\":\"ImageId\",\"isVisible\":false,\"separator\":true,\"spacing\":\"large\",\"style\":\"person\",\"type\":\"Image\",\"url\":\"https://www.stuff.com/picture.jpg\",\"width\":\"40px\"}", jsonString);
+        }
+
+        [TestMethod]
+        public void Media()
+        {
+            AdaptiveMediaSource mediaSource1 = new AdaptiveMediaSource
+            {
+                MimeType = "audio/mp4",
+                Url = "https://www.stuff.com/media.mp4"
+            };
+
+            Assert.AreEqual("audio/mp4", mediaSource1.MimeType);
+            Assert.AreEqual("https://www.stuff.com/media.mp4", mediaSource1.Url);
+
+            AdaptiveMediaSource mediaSource2 = new AdaptiveMediaSource
+            {
+                MimeType = "audio/mpeg",
+                Url = "https://www.stuff.com/media.mp3"
+            };
+
+            Assert.AreEqual("audio/mpeg", mediaSource2.MimeType);
+            Assert.AreEqual("https://www.stuff.com/media.mp3", mediaSource2.Url);
+
+            AdaptiveMedia media = new AdaptiveMedia
+            {
+                AltText = "This is some audio",
+                Height = HeightType.Stretch,
+                Id = "MediaId",
+                IsVisible = false,
+                Poster = "https://www.stuff.com/poster.jpg",
+                Separator = true,
+                Spacing = Spacing.Large
+            };
+
+            ValidateBaseElementProperties(media, "MediaId", false, true, Spacing.Large, HeightType.Stretch);
+
+            Assert.AreEqual("This is some audio", media.AltText);
+            Assert.AreEqual("https://www.stuff.com/poster.jpg", media.Poster);
+
+            media.Sources.Add(mediaSource1);
+            media.Sources.Add(mediaSource2);
+
+            Assert.AreEqual("https://www.stuff.com/media.mp4", media.Sources[0].Url);
+            Assert.AreEqual("https://www.stuff.com/media.mp3", media.Sources[1].Url);
+
+            var jsonString = media.ToJson().ToString();
+            Assert.AreEqual("{\"altText\":\"This is some audio\",\"height\":\"Stretch\",\"id\":\"MediaId\",\"isVisible\":false,\"poster\":\"https://www.stuff.com/poster.jpg\",\"separator\":true,\"sources\":[{\"mimeType\":\"audio/mp4\",\"url\":\"https://www.stuff.com/media.mp4\"},{\"mimeType\":\"audio/mpeg\",\"url\":\"https://www.stuff.com/media.mp3\"}],\"spacing\":\"large\",\"type\":\"Media\"}", jsonString);
+        }
+
+        [TestMethod]
+        public void Container()
+        {
+            AdaptiveContainer container = new AdaptiveContainer
+            {
+                Height = HeightType.Stretch,
+                Id = "ContainerId",
+                IsVisible = false,
+                Separator = true,
+                Spacing = Spacing.ExtraLarge,
+                Style = ContainerStyle.Emphasis,
+                VerticalContentAlignment = VerticalContentAlignment.Bottom
+            };
+
+            ValidateBaseElementProperties(container, "ContainerId", false, true, Spacing.ExtraLarge, HeightType.Stretch);
+
+            Assert.AreEqual(ContainerStyle.Emphasis, container.Style);
+            Assert.AreEqual(VerticalContentAlignment.Bottom, container.VerticalContentAlignment);
+
+            container.SelectAction = new AdaptiveSubmitAction
+            {
+                Title = "Select Action"
+            };
+            Assert.IsNotNull(container.SelectAction);
+            Assert.AreEqual("Select Action", container.SelectAction.Title);
+
+            AdaptiveTextBlock textBlock = new AdaptiveTextBlock
+            {
+                Text = "This is a text block"
+            };
+            container.Items.Add(textBlock);
+
+            AdaptiveTextBlock textBlock2 = new AdaptiveTextBlock
+            {
+                Text = "This is another text block"
+            };
+            container.Items.Add(textBlock2);
+
+            Assert.AreEqual("This is a text block", (container.Items[0] as AdaptiveTextBlock).Text);
+            Assert.AreEqual("This is another text block", (container.Items[1] as AdaptiveTextBlock).Text);
+        }
+
+        [TestMethod]
+        public void ColumnSet()
+        {
+            AdaptiveColumn column1 = new AdaptiveColumn
+            {
+                Height = HeightType.Stretch,
+                Id = "ColumnId",
+                IsVisible = false,
+                PixelWidth = 50,
+                Separator = true,
+                Spacing = Spacing.Small,
+                Style = ContainerStyle.Emphasis,
+                VerticalContentAlignment = VerticalContentAlignment.Bottom,
+            };
+
+            ValidateBaseElementProperties(column1, "ColumnId", false, true, Spacing.Small, HeightType.Stretch);
+
+            Assert.AreEqual<uint>(50, column1.PixelWidth);
+            Assert.AreEqual(ContainerStyle.Emphasis, column1.Style);
+            Assert.AreEqual(VerticalContentAlignment.Bottom, column1.VerticalContentAlignment);
+
+            column1.SelectAction = new AdaptiveSubmitAction
+            {
+                Title = "Select Action"
+            };
+            Assert.IsNotNull(column1.SelectAction);
+            Assert.AreEqual("Select Action", column1.SelectAction.Title);
+
+            AdaptiveTextBlock textBlock = new AdaptiveTextBlock
+            {
+                Text = "This is a text block"
+            };
+            column1.Items.Add(textBlock);
+
+            AdaptiveTextBlock textBlock2 = new AdaptiveTextBlock
+            {
+                Text = "This is another text block"
+            };
+            column1.Items.Add(textBlock2);
+
+            Assert.AreEqual("This is a text block", (column1.Items[0] as AdaptiveTextBlock).Text);
+            Assert.AreEqual("This is another text block", (column1.Items[1] as AdaptiveTextBlock).Text);
+
+            AdaptiveColumn column2 = new AdaptiveColumn
+            {
+                Id = "Column2Id"
+            };
+            AdaptiveTextBlock textBlock3 = new AdaptiveTextBlock
+            {
+                Text = "This is a text block"
+            };
+            column2.Items.Add(textBlock3);
+
+            AdaptiveColumnSet columnSet = new AdaptiveColumnSet
+            {
+                Height = HeightType.Stretch,
+                Id = "ColumnSetId",
+                IsVisible = false,
+                Separator = true,
+                Spacing = Spacing.Small,
+            };
+
+            ValidateBaseElementProperties(columnSet, "ColumnSetId", false, true, Spacing.Small, HeightType.Stretch);
+
+            columnSet.Columns.Add(column1);
+            columnSet.Columns.Add(column2);
+
+            Assert.AreEqual("ColumnId", (columnSet.Columns[0] as AdaptiveColumn).Id);
+            Assert.AreEqual("Column2Id", (columnSet.Columns[1] as AdaptiveColumn).Id);
+
+            var jsonString = columnSet.ToJson().ToString();
+            Assert.AreEqual("{\"columns\":[{\"height\":\"Stretch\",\"id\":\"ColumnId\",\"isVisible\":false,\"items\":[{\"text\":\"This is a text block\",\"type\":\"TextBlock\"},{\"text\":\"This is another text block\",\"type\":\"TextBlock\"}],\"selectAction\":{\"data\":\"null\",\"id\":\"\",\"title\":\"Select Action\",\"type\":\"Action.Submit\"},\"separator\":true,\"spacing\":\"small\",\"style\":\"Emphasis\",\"type\":\"Column\",\"verticalContentAlignment\":\"Bottom\",\"width\":\"auto\"},{\"id\":\"Column2Id\",\"items\":[{\"text\":\"This is a text block\",\"type\":\"TextBlock\"}],\"type\":\"Column\",\"width\":\"auto\"}],\"height\":\"Stretch\",\"id\":\"ColumnSetId\",\"isVisible\":false,\"separator\":true,\"spacing\":\"small\",\"type\":\"ColumnSet\"}", jsonString);
+        }
+
+        [TestMethod]
+        public void FactSet()
+        {
+            AdaptiveFact fact1 = new AdaptiveFact
+            {
+                Title = "Title1",
+                Value = "Value1",
+                Language = "en"
+            };
+
+            Assert.AreEqual("Title1", fact1.Title);
+            Assert.AreEqual("Value1", fact1.Value);
+            Assert.AreEqual("en", fact1.Language);
+
+            AdaptiveFact fact2 = new AdaptiveFact
+            {
+                Title = "Title2",
+                Value = "Value2",
+            };
+
+            AdaptiveFactSet factSet = new AdaptiveFactSet
+            {
+                Height = HeightType.Stretch,
+                Id = "FactSetId",
+                IsVisible = false,
+                Separator = true,
+                Spacing = Spacing.Medium,
+            };
+
+            ValidateBaseElementProperties(factSet, "FactSetId", false, true, Spacing.Medium, HeightType.Stretch);
+
+            factSet.Facts.Add(fact1);
+            factSet.Facts.Add(fact2);
+
+            Assert.AreEqual("Value1", factSet.Facts[0].Value);
+            Assert.AreEqual("Value2", factSet.Facts[1].Value);
+
+            var jsonString = factSet.ToJson().ToString();
+            Assert.AreEqual("{\"facts\":[{\"title\":\"Title1\",\"value\":\"Value1\"},{\"title\":\"Title2\",\"value\":\"Value2\"}],\"height\":\"Stretch\",\"id\":\"FactSetId\",\"isVisible\":false,\"separator\":true,\"spacing\":\"medium\",\"type\":\"FactSet\"}", jsonString);
+        }
+
+        [TestMethod]
+        public void ImageSet()
+        {
+            AdaptiveImage image1 = new AdaptiveImage
+            {
+                Id = "Image1Id",
+                Url = "https://www.stuff.com/picture.jpg"
+            };
+
+            AdaptiveImage image2 = new AdaptiveImage
+            {
+                Id = "Image2Id",
+                Url = "https://www.stuff.com/picture2.jpg"
+            };
+
+            AdaptiveImageSet imageSet = new AdaptiveImageSet
+            {
+                ImageSize = ImageSize.Small,
+                Height = HeightType.Stretch,
+                Id = "ImageSetId",
+                IsVisible = false,
+                Separator = true,
+                Spacing = Spacing.Medium,
+            };
+
+            ValidateBaseElementProperties(imageSet, "ImageSetId", false, true, Spacing.Medium, HeightType.Stretch);
+            Assert.AreEqual(ImageSize.Small, imageSet.ImageSize);
+
+            imageSet.Images.Add(image1);
+            imageSet.Images.Add(image2);
+
+            Assert.AreEqual("Image1Id", (imageSet.Images[0] as AdaptiveImage).Id);
+            Assert.AreEqual("Image2Id", (imageSet.Images[1] as AdaptiveImage).Id);
+
+            var jsonString = imageSet.ToJson().ToString();
+            Assert.AreEqual("{\"height\":\"Stretch\",\"id\":\"ImageSetId\",\"imageSize\":\"Small\",\"images\":[{\"id\":\"Image1Id\",\"type\":\"Image\",\"url\":\"https://www.stuff.com/picture.jpg\"},{\"id\":\"Image2Id\",\"type\":\"Image\",\"url\":\"https://www.stuff.com/picture2.jpg\"}],\"isVisible\":false,\"separator\":true,\"spacing\":\"medium\",\"type\":\"ImageSet\"}", jsonString);
+        }
+
+        [TestMethod]
+        public void TextInput()
+        {
+            AdaptiveTextInput textInput = new AdaptiveTextInput
+            {
+                IsMultiline = true,
+                MaxLength = 5,
+                Placeholder = "Placeholder",
+                Value = "Value",
+                TextInputStyle = TextInputStyle.Email,
+                Height = HeightType.Stretch,
+                Id = "TextInputId",
+                IsVisible = false,
+                Separator = true,
+                Spacing = Spacing.Medium,
+            };
+
+            ValidateBaseElementProperties(textInput, "TextInputId", false, true, Spacing.Medium, HeightType.Stretch);
+
+            Assert.AreEqual(true, textInput.IsMultiline);
+            Assert.AreEqual<uint>(5, textInput.MaxLength);
+            Assert.AreEqual("Placeholder", textInput.Placeholder);
+            Assert.AreEqual("Value", textInput.Value);
+            Assert.AreEqual(TextInputStyle.Email, textInput.TextInputStyle);
+
+            var jsonString = textInput.ToJson().ToString();
+            Assert.AreEqual("{\"height\":\"Stretch\",\"id\":\"TextInputId\",\"isMultiline\":true,\"isRequired\":false,\"isVisible\":false,\"maxLength\":5,\"placeholder\":\"Placeholder\",\"separator\":true,\"spacing\":\"medium\",\"style\":\"Email\",\"type\":\"Input.Text\",\"value\":\"Value\"}", jsonString);
+
+            textInput.InlineAction = new AdaptiveSubmitAction
+            {
+                Title = "Inline Action"
+            };
+            Assert.IsNotNull(textInput.InlineAction);
+            Assert.AreEqual("Inline Action", textInput.InlineAction.Title);
+        }
+
+        [TestMethod]
+        public void NumberInput()
+        {
+            AdaptiveNumberInput numberInput = new AdaptiveNumberInput
+            {
+                Max = 50,
+                Min = 40,
+                Placeholder = "Placeholder",
+                Value = 42,
+                Height = HeightType.Stretch,
+                Id = "NumberInputId",
+                IsVisible = false,
+                Separator = true,
+                Spacing = Spacing.Medium,
+            };
+
+            ValidateBaseElementProperties(numberInput, "NumberInputId", false, true, Spacing.Medium, HeightType.Stretch);
+
+            Assert.AreEqual(50, numberInput.Max);
+            Assert.AreEqual(40, numberInput.Min);
+            Assert.AreEqual("Placeholder", numberInput.Placeholder);
+            Assert.AreEqual(42, numberInput.Value);
+
+            var jsonString = numberInput.ToJson().ToString();
+            Assert.AreEqual("{\"height\":\"Stretch\",\"id\":\"NumberInputId\",\"isRequired\":false,\"isVisible\":false,\"max\":50,\"min\":40,\"placeholder\":\"Placeholder\",\"separator\":true,\"spacing\":\"medium\",\"type\":\"Input.Number\",\"value\":42}", jsonString);
+        }
+
+        [TestMethod]
+        public void DateInput()
+        {
+            AdaptiveDateInput dateInput = new AdaptiveDateInput
+            {
+                Max = "2019-01-14",
+                Min = "2017-01-14",
+                Placeholder = "Placeholder",
+                Value = "2018-01-14",
+                Height = HeightType.Stretch,
+                Id = "DateInputId",
+                IsVisible = false,
+                Separator = true,
+                Spacing = Spacing.Medium,
+            };
+
+            ValidateBaseElementProperties(dateInput, "DateInputId", false, true, Spacing.Medium, HeightType.Stretch);
+
+            Assert.AreEqual("2019-01-14", dateInput.Max);
+            Assert.AreEqual("2017-01-14", dateInput.Min);
+            Assert.AreEqual("Placeholder", dateInput.Placeholder);
+            Assert.AreEqual("2018-01-14", dateInput.Value);
+
+            var jsonString = dateInput.ToJson().ToString();
+            Assert.AreEqual("{\"height\":\"Stretch\",\"id\":\"DateInputId\",\"isRequired\":false,\"isVisible\":false,\"max\":\"2019-01-14\",\"min\":\"2017-01-14\",\"placeholder\":\"Placeholder\",\"separator\":true,\"spacing\":\"medium\",\"type\":\"Input.Date\",\"value\":\"2018-01-14\"}", jsonString);
+        }
+
+        [TestMethod]
+        public void TimeInput()
+        {
+            AdaptiveTimeInput timeInput = new AdaptiveTimeInput
+            {
+                Max = "05:00",
+                Min = "01:00",
+                Placeholder = "Placeholder",
+                Value = "02:00",
+                Height = HeightType.Stretch,
+                Id = "TimeInputId",
+                IsVisible = false,
+                Separator = true,
+                Spacing = Spacing.Medium,
+            };
+
+            ValidateBaseElementProperties(timeInput, "TimeInputId", false, true, Spacing.Medium, HeightType.Stretch);
+
+            Assert.AreEqual("05:00", timeInput.Max);
+            Assert.AreEqual("01:00", timeInput.Min);
+            Assert.AreEqual("Placeholder", timeInput.Placeholder);
+            Assert.AreEqual("02:00", timeInput.Value);
+
+            var jsonString = timeInput.ToJson().ToString();
+        }
+
+        [TestMethod]
+        public void ToggleInput()
+        {
+            AdaptiveToggleInput toggleInput = new AdaptiveToggleInput
+            {
+                Title = "Title",
+                Value = "Value",
+                ValueOff = "ValueOff",
+                ValueOn = "ValueOn",
+                Wrap = true,
+                Height = HeightType.Stretch,
+                Id = "ToggleInputId",
+                IsVisible = false,
+                Separator = true,
+                Spacing = Spacing.Medium,
+            };
+
+            ValidateBaseElementProperties(toggleInput, "ToggleInputId", false, true, Spacing.Medium, HeightType.Stretch);
+
+            Assert.AreEqual("Title", toggleInput.Title);
+            Assert.AreEqual("Value", toggleInput.Value);
+            Assert.AreEqual("ValueOff", toggleInput.ValueOff);
+            Assert.AreEqual("ValueOn", toggleInput.ValueOn);
+            Assert.AreEqual(true, toggleInput.Wrap);
+
+            var jsonString = toggleInput.ToJson().ToString();
+            Assert.AreEqual("{\"height\":\"Stretch\",\"id\":\"ToggleInputId\",\"isRequired\":false,\"isVisible\":false,\"separator\":true,\"spacing\":\"medium\",\"title\":\"Title\",\"type\":\"Input.Toggle\",\"value\":\"Value\",\"valueOff\":\"ValueOff\",\"valueOn\":\"ValueOn\",\"wrap\":true}", jsonString);
+        }
+
+        [TestMethod]
+        public void ChoiceSetInput()
+        {
+            AdaptiveChoiceInput choice1 = new AdaptiveChoiceInput
+            {
+                Title = "Title1",
+                Value = "Value1",
+            };
+
+            Assert.AreEqual("Title1", choice1.Title);
+            Assert.AreEqual("Value1", choice1.Value);
+
+            AdaptiveChoiceInput choice2 = new AdaptiveChoiceInput
+            {
+                Title = "Title2",
+                Value = "Value2",
+            };
+
+            AdaptiveChoiceSetInput choiceSet = new AdaptiveChoiceSetInput
+            {
+                ChoiceSetStyle = ChoiceSetStyle.Expanded,
+                IsMultiSelect = true,
+                Value = "Value2",
+                Wrap = true,
+                Height = HeightType.Stretch,
+                Id = "ChoiceSetInputId",
+                IsVisible = false,
+                Separator = true,
+                Spacing = Spacing.Medium,
+            };
+
+            ValidateBaseElementProperties(choiceSet, "ChoiceSetInputId", false, true, Spacing.Medium, HeightType.Stretch);
+
+            Assert.AreEqual(ChoiceSetStyle.Expanded, choiceSet.ChoiceSetStyle);
+            Assert.AreEqual(true, choiceSet.IsMultiSelect);
+            Assert.AreEqual("Value2", choiceSet.Value);
+            Assert.AreEqual(true, choiceSet.Wrap);
+
+            choiceSet.Choices.Add(choice1);
+            choiceSet.Choices.Add(choice2);
+
+            Assert.AreEqual("Value1", choiceSet.Choices[0].Value);
+            Assert.AreEqual("Value2", choiceSet.Choices[1].Value);
+
+            var jsonString = choiceSet.ToJson().ToString();
+            Assert.AreEqual("{\"choices\":[{\"title\":\"Title1\",\"value\":\"Value1\"},{\"title\":\"Title2\",\"value\":\"Value2\"}],\"height\":\"Stretch\",\"id\":\"ChoiceSetInputId\",\"isMultiSelect\":true,\"isRequired\":false,\"isVisible\":false,\"separator\":true,\"spacing\":\"medium\",\"style\":\"Expanded\",\"type\":\"Input.ChoiceSet\",\"value\":\"Value2\",\"wrap\":true}", jsonString);
+        }
+
+        public void ValidateBaseActionProperties(
+            IAdaptiveActionElement element,
+            string iconUrl,
+            string id,
+            string title,
+            Sentiment sentiment)
+        {
+            Assert.AreEqual(iconUrl, element.IconUrl);
+            Assert.AreEqual(id, element.Id);
+            Assert.AreEqual(sentiment, element.Sentiment);
+            Assert.AreEqual(title, element.Title);
+        }
+
+        [TestMethod]
+        public void OpenUrlAction()
+        {
+            var url = new System.Uri("http://www.stuff.com");
+            AdaptiveOpenUrlAction openUrlAction = new AdaptiveOpenUrlAction
+            {
+                Url = url,
+                IconUrl = "http://www.stuff.com/icon.jpg",
+                Id = "OpenUrlId",
+                Sentiment = Sentiment.Destructive,
+                Title = "Title"
+            };
+
+            ValidateBaseActionProperties(openUrlAction, "http://www.stuff.com/icon.jpg", "OpenUrlId", "Title", Sentiment.Destructive);
+            Assert.AreEqual(url, openUrlAction.Url);
+
+            var jsonString = openUrlAction.ToJson().ToString();
+            Assert.AreEqual("{\"iconUrl\":\"http://www.stuff.com/icon.jpg\",\"id\":\"OpenUrlId\",\"sentiment\":\"Destructive\",\"title\":\"Title\",\"type\":\"Action.OpenUrl\",\"url\":\"http://www.stuff.com/\"}", jsonString);
+        }
+
+        [TestMethod]
+        public void SubmitAction()
+        {
+            JsonValue dataJson = JsonValue.CreateStringValue("foo");
+            AdaptiveSubmitAction submitAction = new AdaptiveSubmitAction
+            {
+                DataJson = dataJson,
+                IconUrl = "http://www.stuff.com/icon.jpg",
+                Id = "OpenUrlId",
+                Sentiment = Sentiment.Destructive,
+                Title = "Title"
+            };
+
+            ValidateBaseActionProperties(submitAction, "http://www.stuff.com/icon.jpg", "OpenUrlId", "Title", Sentiment.Destructive);
+            Assert.AreEqual(dataJson, submitAction.DataJson);
+
+            var jsonString = submitAction.ToJson().ToString();
+            Assert.AreEqual("{\"data\":\"\\\"foo\\\"\",\"iconUrl\":\"http://www.stuff.com/icon.jpg\",\"id\":\"OpenUrlId\",\"sentiment\":\"Destructive\",\"title\":\"Title\",\"type\":\"Action.Submit\"}", jsonString);
+        }
+
+        [TestMethod]
+        public void ShowCardAction()
+        {
+            AdaptiveShowCardAction showCardAction = new AdaptiveShowCardAction
+            {
+                IconUrl = "http://www.stuff.com/icon.jpg",
+                Id = "OpenUrlId",
+                Sentiment = Sentiment.Destructive,
+                Title = "Title"
+            };
+
+            ValidateBaseActionProperties(showCardAction, "http://www.stuff.com/icon.jpg", "OpenUrlId", "Title", Sentiment.Destructive);
+
+            AdaptiveCard card = new AdaptiveCard();
+            showCardAction.Card = card;
+            Assert.IsNotNull(showCardAction.Card);
+
+            var jsonString = showCardAction.ToJson().ToString();
+            Assert.AreEqual("{\"card\":{\"actions\":[],\"body\":[],\"type\":\"AdaptiveCard\",\"version\":\"1.0\"},\"iconUrl\":\"http://www.stuff.com/icon.jpg\",\"id\":\"OpenUrlId\",\"sentiment\":\"Destructive\",\"title\":\"Title\",\"type\":\"Action.ShowCard\"}", jsonString);
+        }
+
+        [TestMethod]
+        public void ToggleVisibilityAction()
+        {
+            AdaptiveToggleVisibilityTarget toggleTarget1 = new AdaptiveToggleVisibilityTarget
+            {
+                ElementId = "elementId",
+                IsVisible = IsVisible.IsVisibleToggle
+            };
+
+            Assert.AreEqual("elementId", toggleTarget1.ElementId);
+            Assert.AreEqual(IsVisible.IsVisibleToggle, toggleTarget1.IsVisible);
+
+            AdaptiveToggleVisibilityTarget toggleTarget2 = new AdaptiveToggleVisibilityTarget
+            {
+                ElementId = "element2Id",
+                IsVisible = IsVisible.IsVisibleTrue
+            };
+
+            AdaptiveToggleVisibilityAction toggleAction = new AdaptiveToggleVisibilityAction
+            {
+                IconUrl = "http://www.stuff.com/icon.jpg",
+                Id = "ToggleVisibilityId",
+                Sentiment = Sentiment.Destructive,
+                Title = "Title"
+            };
+
+            ValidateBaseActionProperties(toggleAction, "http://www.stuff.com/icon.jpg", "ToggleVisibilityId", "Title", Sentiment.Destructive);
+
+            toggleAction.TargetElements.Add(toggleTarget1);
+            toggleAction.TargetElements.Add(toggleTarget2);
+
+            Assert.AreEqual("elementId", toggleAction.TargetElements[0].ElementId);
+            Assert.AreEqual("element2Id", toggleAction.TargetElements[1].ElementId);
+
+            var jsonString = toggleAction.ToJson().ToString();
+            Assert.AreEqual("{\"iconUrl\":\"http://www.stuff.com/icon.jpg\",\"id\":\"ToggleVisibilityId\",\"sentiment\":\"Destructive\",\"targetElements\":[\"elementId\",{\"elementId\":\"element2Id\",\"isVisible\":true}],\"title\":\"Title\",\"type\":\"Action.ToggleVisibility\"}", jsonString);
+        }
+    }
+}

--- a/source/uwp/UWPUnitTests/UWPUnitTests.csproj
+++ b/source/uwp/UWPUnitTests/UWPUnitTests.csproj
@@ -95,6 +95,7 @@
     <SDKReference Include="TestPlatform.Universal, Version=$(UnitTestPlatformVersion)" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ObjectModelTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>


### PR DESCRIPTION
Added basic unit testing to the UWP object model. Constructed each type and set and validated properties. 

Fixed bugs in the constructors of OpenUrlAction and ShowCardAction that prevented these types from being constructed.