### PR TITLE
Add missing exclusivetos to UWP API

### DIFF
--- a/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
+++ b/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
@@ -48,6 +48,9 @@ AdaptiveNamespaceStart
     runtimeclass AdaptiveTimeInput;
     runtimeclass AdaptiveToggleInput;
     runtimeclass AdaptiveSeparator;
+    runtimeclass AdaptiveOpenUrlAction;
+    runtimeclass AdaptiveShowCardAction;
+    runtimeclass AdaptiveSubmitAction;
     runtimeclass AdaptiveToggleVisibilityAction;
 
     runtimeclass AdaptiveFontSizesConfig;
@@ -484,17 +487,18 @@ AdaptiveNamespaceStart
     {
         interface Windows.Foundation.Collections.IVector<IAdaptiveCardElement*>;
         interface Windows.Foundation.Collections.IVector<IAdaptiveActionElement*>;
-        interface Windows.Foundation.Collections.IVector<IAdaptiveColumn*>;
-        interface Windows.Foundation.Collections.IVector<IAdaptiveFact*>;
-        interface Windows.Foundation.Collections.IVector<IAdaptiveChoiceInput*>;
-        interface Windows.Foundation.Collections.IVector<IAdaptiveError*>;
-        interface Windows.Foundation.Collections.IVector<IAdaptiveWarning*>;
+        interface Windows.Foundation.Collections.IVector<AdaptiveColumn*>;
+        interface Windows.Foundation.Collections.IVector<AdaptiveFact*>;
+        interface Windows.Foundation.Collections.IVector<AdaptiveChoiceInput*>;
+        interface Windows.Foundation.Collections.IVector<AdaptiveError*>;
+        interface Windows.Foundation.Collections.IVector<AdaptiveWarning*>;
         interface Windows.Foundation.Collections.IObservableVector<IAdaptiveCardElement*>;
-        interface Windows.Foundation.Collections.IObservableVector<IAdaptiveColumn*>;
+        interface Windows.Foundation.Collections.IObservableVector<AdaptiveColumn*>;
         interface Windows.Foundation.IAsyncOperation<RenderedAdaptiveCard*>;
         interface Windows.Foundation.Collections.IVector<AdaptiveMediaSource*>;
         interface Windows.Foundation.Collections.IVector<AdaptiveRemoteResourceInformation*>;
         interface Windows.Foundation.Collections.IVector<AdaptiveToggleVisibilityTarget*>;
+        interface Windows.Foundation.Collections.IVector<AdaptiveImage*>;
     }
 
     [
@@ -811,8 +815,8 @@ AdaptiveNamespaceStart
     interface IAdaptiveCardParseResult : IInspectable
     {
         [propget] HRESULT AdaptiveCard([out, retval] AdaptiveCard** value);
-        [propget] HRESULT Errors([out, retval] Windows.Foundation.Collections.IVector<IAdaptiveError*>** value);
-        [propget] HRESULT Warnings([out, retval] Windows.Foundation.Collections.IVector<IAdaptiveWarning*>** value);
+        [propget] HRESULT Errors([out, retval] Windows.Foundation.Collections.IVector<AdaptiveError*>** value);
+        [propget] HRESULT Warnings([out, retval] Windows.Foundation.Collections.IVector<AdaptiveWarning*>** value);
     };
 
     [
@@ -885,6 +889,7 @@ AdaptiveNamespaceStart
 
     [
         version(NTDDI_WIN10_RS1),
+        exclusiveto(AdaptiveImage),
 #ifdef ADAPTIVE_CARDS_WINDOWS
         uuid(3b0830aa-a03a-46c4-9204-32c051e34982),
         contract(InternalContract, 1),
@@ -951,7 +956,7 @@ AdaptiveNamespaceStart
     ]
     interface IAdaptiveImageSet : IInspectable
     {
-        [propget] HRESULT Images([out, retval] Windows.Foundation.Collections.IVector<IAdaptiveImage*>** value);
+        [propget] HRESULT Images([out, retval] Windows.Foundation.Collections.IVector<AdaptiveImage*>** value);
 
         [propget] HRESULT ImageSize([out, retval] ImageSize* value);
         [propput] HRESULT ImageSize([in] ImageSize value);
@@ -990,6 +995,7 @@ AdaptiveNamespaceStart
 
     [
         version(NTDDI_WIN10_RS1),
+        exclusiveto(AdaptiveChoiceInput),
 #ifdef ADAPTIVE_CARDS_WINDOWS
         uuid(ace5f894-2109-4c57-bde6-7e69069242a9),
         contract(InternalContract, 1),
@@ -1025,6 +1031,7 @@ AdaptiveNamespaceStart
 
     [
         version(NTDDI_WIN10_RS1),
+        exclusiveto(AdaptiveChoiceSetInput),
 #ifdef ADAPTIVE_CARDS_WINDOWS
         uuid(9fa2984c-a65e-4886-92b0-379ca242e955),
         contract(InternalContract, 1),
@@ -1045,7 +1052,7 @@ AdaptiveNamespaceStart
         [propget] HRESULT ChoiceSetStyle([out, retval] ChoiceSetStyle* value);
         [propput] HRESULT ChoiceSetStyle([in] ChoiceSetStyle value);
 
-        [propget] HRESULT Choices([out, retval] Windows.Foundation.Collections.IVector<IAdaptiveChoiceInput*>** value);
+        [propget] HRESULT Choices([out, retval] Windows.Foundation.Collections.IVector<AdaptiveChoiceInput*>** value);
     };
 
     [
@@ -1285,6 +1292,7 @@ AdaptiveNamespaceStart
 
     [
         version(NTDDI_WIN10_RS1),
+        exclusiveto(AdaptiveContainer),
 #ifdef ADAPTIVE_CARDS_WINDOWS
         uuid(60554c5a-32db-4130-8613-d39737ced7c4),
         contract(InternalContract, 1),
@@ -1324,6 +1332,7 @@ AdaptiveNamespaceStart
 
     [
         version(NTDDI_WIN10_RS1),
+        exclusiveto(AdaptiveColumn),
 #ifdef ADAPTIVE_CARDS_WINDOWS
         uuid(fe3a3792-d916-4b9d-b54c-eb1e1b5c23b4),
         contract(InternalContract, 1),
@@ -1379,7 +1388,7 @@ AdaptiveNamespaceStart
     ]
     interface IAdaptiveColumnSet : IInspectable
     {
-        [propget] HRESULT Columns([out, retval] Windows.Foundation.Collections.IVector<IAdaptiveColumn*>** value);
+        [propget] HRESULT Columns([out, retval] Windows.Foundation.Collections.IVector<AdaptiveColumn*>** value);
 
         [propget] HRESULT SelectAction([out, retval] IAdaptiveActionElement** value);
         [propput] HRESULT SelectAction([in] IAdaptiveActionElement* value);
@@ -1403,6 +1412,7 @@ AdaptiveNamespaceStart
 
     [
         version(NTDDI_WIN10_RS1),
+        exclusiveto(AdaptiveFact),
 #ifdef ADAPTIVE_CARDS_WINDOWS
         uuid(d06f4235-e32a-4bba-9802-49a8e2d2c3b7),
         contract(InternalContract, 1),
@@ -1452,7 +1462,7 @@ AdaptiveNamespaceStart
     ]
     interface IAdaptiveFactSet : IInspectable
     {
-        [propget] HRESULT Facts([out, retval] Windows.Foundation.Collections.IVector<IAdaptiveFact*>** value);
+        [propget] HRESULT Facts([out, retval] Windows.Foundation.Collections.IVector<AdaptiveFact*>** value);
     };
 
     [
@@ -2381,7 +2391,7 @@ AdaptiveNamespaceStart
     interface IAdaptiveHostConfigParseResult : IInspectable
     {
         [propget] HRESULT HostConfig([out, retval] AdaptiveHostConfig** value);
-        [propget] HRESULT Errors([out, retval] Windows.Foundation.Collections.IVector<IAdaptiveError*>** value);
+        [propget] HRESULT Errors([out, retval] Windows.Foundation.Collections.IVector<AdaptiveError*>** value);
     };
 
     [
@@ -2466,6 +2476,7 @@ AdaptiveNamespaceStart
 
     [
         version(NTDDI_WIN10_RS1),
+        exclusiveto(AdaptiveOpenUrlAction),
 #ifdef ADAPTIVE_CARDS_WINDOWS
         uuid(8a7f7888-f53b-4fdb-8f3c-968da4352031),
         contract(InternalContract, 1),
@@ -2497,6 +2508,7 @@ AdaptiveNamespaceStart
 
     [
         version(NTDDI_WIN10_RS1),
+        exclusiveto(AdaptiveShowCardAction),
 #ifdef ADAPTIVE_CARDS_WINDOWS
         uuid(201859e9-1179-4c2b-91fa-3f561210a7f6),
         contract(InternalContract, 1),
@@ -2528,6 +2540,7 @@ AdaptiveNamespaceStart
 
     [
         version(NTDDI_WIN10_RS1),
+        exclusiveto(AdaptiveSubmitAction),
 #ifdef ADAPTIVE_CARDS_WINDOWS
         uuid(c89015c8-1a8e-4819-8e93-d5fed276efc5),
         contract(InternalContract, 1),
@@ -2735,9 +2748,9 @@ AdaptiveNamespaceStart
 
         [propget] HRESULT UserInputs([out, retval] AdaptiveInputs** value);
 
-        [propget] HRESULT Errors([out, retval] Windows.Foundation.Collections.IVector<IAdaptiveError*>** value);
+        [propget] HRESULT Errors([out, retval] Windows.Foundation.Collections.IVector<AdaptiveError*>** value);
 
-        [propget] HRESULT Warnings([out, retval] Windows.Foundation.Collections.IVector<IAdaptiveWarning*>** value);
+        [propget] HRESULT Warnings([out, retval] Windows.Foundation.Collections.IVector<AdaptiveWarning*>** value);
 
         [eventadd] HRESULT Action([in] Windows.Foundation.TypedEventHandler<RenderedAdaptiveCard*, AdaptiveActionEventArgs*>* pHandler, [out][retval] EventRegistrationToken* pToken);
         [eventremove] HRESULT Action([in] EventRegistrationToken token);
@@ -2807,7 +2820,7 @@ AdaptiveNamespaceStart
             [in] Windows.Data.Json.JsonObject* inputJson,
             [in] AdaptiveElementParserRegistration* elementParsers,
             [in] AdaptiveActionParserRegistration* actionParsers,
-            [in] Windows.Foundation.Collections.IVector<IAdaptiveWarning*>* warnings,
+            [in] Windows.Foundation.Collections.IVector<AdaptiveWarning*>* warnings,
             [out, retval] IAdaptiveCardElement** result);
     };
 
@@ -2891,7 +2904,7 @@ AdaptiveNamespaceStart
             [in] Windows.Data.Json.JsonObject* inputJson,
             [in] AdaptiveElementParserRegistration* elementParsers,
             [in] AdaptiveActionParserRegistration* actionParsers,
-            [in] Windows.Foundation.Collections.IVector<IAdaptiveWarning*>* warnings,
+            [in] Windows.Foundation.Collections.IVector<AdaptiveWarning*>* warnings,
             [out, retval] IAdaptiveActionElement** result);
     };
 
@@ -3325,6 +3338,7 @@ AdaptiveNamespaceStart
 
     [
         version(NTDDI_WIN10_RS1),
+        exclusiveto(AdaptiveError),
 #ifdef ADAPTIVE_CARDS_WINDOWS
         uuid(f3c95797-25ad-4ee1-a4ad-0fafb986213f),
         contract(InternalContract, 1),
@@ -3356,6 +3370,7 @@ AdaptiveNamespaceStart
 
     [
         version(NTDDI_WIN10_RS1),
+        exclusiveto(AdaptiveWarning),
 #ifdef ADAPTIVE_CARDS_WINDOWS
         uuid(d978d794-6585-4e97-b602-9e6a2ffa3948),
         contract(InternalContract, 1),

--- a/source/uwp/Renderer/lib/AdaptiveActionParserRegistration.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveActionParserRegistration.cpp
@@ -93,8 +93,8 @@ namespace AdaptiveNamespace
                                                                                context.actionParserRegistration);
 
         ComPtr<IAdaptiveActionElement> actionElement;
-        ComPtr<ABI::Windows::Foundation::Collections::IVector<IAdaptiveWarning*>> adaptiveWarnings =
-            Make<Vector<IAdaptiveWarning*>>();
+        ComPtr<ABI::Windows::Foundation::Collections::IVector<AdaptiveWarning*>> adaptiveWarnings =
+            Make<Vector<AdaptiveWarning*>>();
         THROW_IF_FAILED(parser->FromJson(jsonObject.Get(),
                                          adaptiveElementParserRegistration.Get(),
                                          adaptiveActionParserRegistration.Get(),

--- a/source/uwp/Renderer/lib/AdaptiveCard.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveCard.cpp
@@ -104,7 +104,7 @@ namespace AdaptiveNamespace
             RETURN_IF_FAILED(MakeAndInitialize<AdaptiveCard>(&adaptiveCard, sharedParseResult->GetAdaptiveCard()));
             RETURN_IF_FAILED(adaptiveParseResult->put_AdaptiveCard(adaptiveCard.Get()));
 
-            ComPtr<IVector<IAdaptiveWarning*>> warnings;
+            ComPtr<IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>> warnings;
             RETURN_IF_FAILED(adaptiveParseResult->get_Warnings(&warnings));
 
             RETURN_IF_FAILED(SharedWarningsToAdaptiveWarnings(sharedParseResult->GetWarnings(), warnings.Get()));
@@ -113,7 +113,7 @@ namespace AdaptiveNamespace
         }
         catch (const AdaptiveCardParseException& e)
         {
-            ComPtr<IVector<IAdaptiveError*>> errors;
+            ComPtr<IVector<ABI::AdaptiveNamespace::AdaptiveError*>> errors;
             RETURN_IF_FAILED(adaptiveParseResult->get_Errors(&errors));
             HString errorMessage;
             ABI::AdaptiveNamespace::ErrorStatusCode statusCode =

--- a/source/uwp/Renderer/lib/AdaptiveCardParseResult.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveCardParseResult.cpp
@@ -25,8 +25,8 @@ namespace AdaptiveNamespace
 
     HRESULT AdaptiveCardParseResult::RuntimeClassInitialize()
     {
-        m_errors = Make<Vector<IAdaptiveError*>>();
-        m_warnings = Make<Vector<IAdaptiveWarning*>>();
+        m_errors = Make<Vector<AdaptiveError*>>();
+        m_warnings = Make<Vector<AdaptiveWarning*>>();
         return S_OK;
     }
 
@@ -42,13 +42,13 @@ namespace AdaptiveNamespace
     }
 
     HRESULT AdaptiveCardParseResult::get_Errors(
-        _COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveError*>** value)
+        _COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveError*>** value)
     {
         return m_errors.CopyTo(value);
     }
 
     HRESULT AdaptiveCardParseResult::get_Warnings(
-        _COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>** value)
+        _COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>** value)
     {
         return m_warnings.CopyTo(value);
     }

--- a/source/uwp/Renderer/lib/AdaptiveCardParseResult.h
+++ b/source/uwp/Renderer/lib/AdaptiveCardParseResult.h
@@ -20,14 +20,14 @@ namespace AdaptiveNamespace
         IFACEMETHODIMP get_AdaptiveCard(_COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCard** value);
         HRESULT put_AdaptiveCard(_In_ ABI::AdaptiveNamespace::IAdaptiveCard* value);
 
-        IFACEMETHODIMP get_Errors(_COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveError*>** value);
+        IFACEMETHODIMP get_Errors(_COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveError*>** value);
         IFACEMETHODIMP get_Warnings(
-            _COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>** value);
+            _COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>** value);
 
     private:
         Microsoft::WRL::ComPtr<ABI::AdaptiveNamespace::IAdaptiveCard> m_adaptiveCard;
-        Microsoft::WRL::ComPtr<ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveError*>> m_errors;
-        Microsoft::WRL::ComPtr<ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>> m_warnings;
+        Microsoft::WRL::ComPtr<ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveError*>> m_errors;
+        Microsoft::WRL::ComPtr<ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>> m_warnings;
     };
 
     ActivatableClass(AdaptiveCardParseResult);

--- a/source/uwp/Renderer/lib/AdaptiveCardRendererComponent.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveCardRendererComponent.cpp
@@ -160,11 +160,11 @@ namespace AdaptiveNamespace
         RETURN_IF_FAILED(adaptiveCardParseResult->get_AdaptiveCard(&parsedCard));
         if (parsedCard == nullptr)
         {
-            ComPtr<IVector<IAdaptiveError*>> renderResultErrors;
+            ComPtr<IVector<AdaptiveError*>> renderResultErrors;
             RETURN_IF_FAILED(renderedCard->get_Errors(&renderResultErrors));
-            ComPtr<IVector<IAdaptiveError*>> parseErrors;
+            ComPtr<IVector<AdaptiveError*>> parseErrors;
             RETURN_IF_FAILED(adaptiveCardParseResult->get_Errors(&parseErrors));
-            XamlHelpers::IterateOverVector<IAdaptiveError>(parseErrors.Get(), [&](IAdaptiveError* error) {
+            XamlHelpers::IterateOverVector<AdaptiveError, IAdaptiveError>(parseErrors.Get(), [&](IAdaptiveError* error) {
                 ComPtr<IAdaptiveError> localError(error);
                 return renderResultErrors->Append(localError.Get());
             });

--- a/source/uwp/Renderer/lib/AdaptiveChoiceSetInput.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceSetInput.cpp
@@ -16,7 +16,7 @@ namespace AdaptiveNamespace
 {
     AdaptiveChoiceSetInput::AdaptiveChoiceSetInput()
     {
-        m_choices = Microsoft::WRL::Make<Vector<IAdaptiveChoiceInput*>>();
+        m_choices = Microsoft::WRL::Make<Vector<AdaptiveChoiceInput*>>();
     }
 
     HRESULT AdaptiveChoiceSetInput::RuntimeClassInitialize() noexcept try
@@ -82,7 +82,7 @@ namespace AdaptiveNamespace
         return S_OK;
     }
 
-    HRESULT AdaptiveChoiceSetInput::get_Choices(_COM_Outptr_ IVector<IAdaptiveChoiceInput*>** choices)
+    HRESULT AdaptiveChoiceSetInput::get_Choices(_COM_Outptr_ IVector<AdaptiveChoiceInput*>** choices)
     {
         return m_choices.CopyTo(choices);
     }

--- a/source/uwp/Renderer/lib/AdaptiveChoiceSetInput.h
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceSetInput.h
@@ -39,7 +39,7 @@ namespace AdaptiveNamespace
         IFACEMETHODIMP put_ChoiceSetStyle(ABI::AdaptiveNamespace::ChoiceSetStyle choiceSetStyle);
 
         IFACEMETHODIMP get_Choices(
-            _COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveChoiceInput*>** columns);
+            _COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveChoiceInput*>** columns);
 
         // IAdaptiveInputElement
         IFACEMETHODIMP get_IsRequired(_Out_ boolean* isRequired)
@@ -112,7 +112,7 @@ namespace AdaptiveNamespace
         void* PeekAt(REFIID riid) override { return PeekHelper(riid, this); }
 
     private:
-        Microsoft::WRL::ComPtr<ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveChoiceInput*>> m_choices;
+        Microsoft::WRL::ComPtr<ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveChoiceInput*>> m_choices;
         boolean m_wrap;
         boolean m_isMultiSelect;
         ABI::AdaptiveNamespace::ChoiceSetStyle m_choiceSetStyle;

--- a/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.cpp
@@ -33,7 +33,7 @@ namespace AdaptiveNamespace
         _In_ ABI::Windows::Data::Json::IJsonObject* jsonObject,
         _In_ ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration* elementParserRegistration,
         _In_ ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParserRegistration,
-        _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>* adaptiveWarnings,
+        _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* adaptiveWarnings,
         _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardElement** element)
     {
         return AdaptiveNamespace::FromJson<AdaptiveNamespace::AdaptiveChoiceSetInput, AdaptiveSharedNamespace::ChoiceSetInput, AdaptiveSharedNamespace::ChoiceSetInputParser>(

--- a/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.h
@@ -24,7 +24,7 @@ namespace AdaptiveNamespace
         IFACEMETHODIMP FromJson(_In_ ABI::Windows::Data::Json::IJsonObject*,
                                 _In_ ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration* elementParsers,
                                 _In_ ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParsers,
-                                _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>* adaptiveWarnings,
+                                _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* adaptiveWarnings,
                                 _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardElement** element) override;
     };
 

--- a/source/uwp/Renderer/lib/AdaptiveColumnSet.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveColumnSet.cpp
@@ -16,7 +16,7 @@ using namespace ABI::Windows::UI::Xaml::Controls;
 
 namespace AdaptiveNamespace
 {
-    AdaptiveColumnSet::AdaptiveColumnSet() { m_columns = Microsoft::WRL::Make<Vector<IAdaptiveColumn*>>(); }
+    AdaptiveColumnSet::AdaptiveColumnSet() { m_columns = Microsoft::WRL::Make<Vector<ABI::AdaptiveNamespace::AdaptiveColumn*>>(); }
 
     HRESULT AdaptiveColumnSet::RuntimeClassInitialize() noexcept try
     {
@@ -41,7 +41,7 @@ namespace AdaptiveNamespace
     }
     CATCH_RETURN;
 
-    IFACEMETHODIMP AdaptiveColumnSet::get_Columns(_COM_Outptr_ IVector<IAdaptiveColumn*>** columns)
+    IFACEMETHODIMP AdaptiveColumnSet::get_Columns(_COM_Outptr_ IVector<ABI::AdaptiveNamespace::AdaptiveColumn*>** columns)
     {
         return m_columns.CopyTo(columns);
     }
@@ -75,7 +75,7 @@ namespace AdaptiveNamespace
             columnSet->SetSelectAction(sharedAction);
         }
 
-        XamlHelpers::IterateOverVector<IAdaptiveColumn>(m_columns.Get(), [&](IAdaptiveColumn* column) {
+        XamlHelpers::IterateOverVector<ABI::AdaptiveNamespace::AdaptiveColumn, IAdaptiveColumn>(m_columns.Get(), [&](IAdaptiveColumn* column) {
             ComPtr<AdaptiveNamespace::AdaptiveColumn> columnImpl = PeekInnards<AdaptiveNamespace::AdaptiveColumn>(column);
 
             std::shared_ptr<BaseCardElement> sharedColumnBaseElement;

--- a/source/uwp/Renderer/lib/AdaptiveColumnSet.h
+++ b/source/uwp/Renderer/lib/AdaptiveColumnSet.h
@@ -23,7 +23,7 @@ namespace AdaptiveNamespace
         HRESULT RuntimeClassInitialize(const std::shared_ptr<AdaptiveSharedNamespace::ColumnSet>& sharedColumnSet);
 
         // IAdaptiveColumnSet
-        IFACEMETHODIMP get_Columns(_COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveColumn*>** columns);
+        IFACEMETHODIMP get_Columns(_COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveColumn*>** columns);
 
         IFACEMETHODIMP get_SelectAction(_COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveActionElement** action);
         IFACEMETHODIMP put_SelectAction(_In_ ABI::AdaptiveNamespace::IAdaptiveActionElement* action);
@@ -89,7 +89,7 @@ namespace AdaptiveNamespace
         void* PeekAt(REFIID riid) override { return PeekHelper(riid, this); }
 
     private:
-        Microsoft::WRL::ComPtr<ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveColumn*>> m_columns;
+        Microsoft::WRL::ComPtr<ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveColumn*>> m_columns;
         Microsoft::WRL::ComPtr<ABI::AdaptiveNamespace::IAdaptiveActionElement> m_selectAction;
     };
 

--- a/source/uwp/Renderer/lib/AdaptiveColumnSetRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveColumnSetRenderer.cpp
@@ -33,7 +33,7 @@ namespace AdaptiveNamespace
         _In_ ABI::Windows::Data::Json::IJsonObject* jsonObject,
         _In_ ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration* elementParserRegistration,
         _In_ ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParserRegistration,
-        _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>* adaptiveWarnings,
+        _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* adaptiveWarnings,
         _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardElement** element)
     {
         return AdaptiveNamespace::FromJson<AdaptiveNamespace::AdaptiveColumnSet, AdaptiveSharedNamespace::ColumnSet, AdaptiveSharedNamespace::ColumnSetParser>(

--- a/source/uwp/Renderer/lib/AdaptiveColumnSetRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveColumnSetRenderer.h
@@ -24,7 +24,7 @@ namespace AdaptiveNamespace
         IFACEMETHODIMP FromJson(_In_ ABI::Windows::Data::Json::IJsonObject*,
                                 _In_ ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration* elementParsers,
                                 _In_ ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParsers,
-                                _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>* adaptiveWarnings,
+                                _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* adaptiveWarnings,
                                 _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardElement** element) override;
     };
 

--- a/source/uwp/Renderer/lib/AdaptiveContainerRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveContainerRenderer.cpp
@@ -33,7 +33,7 @@ namespace AdaptiveNamespace
         _In_ ABI::Windows::Data::Json::IJsonObject* jsonObject,
         _In_ ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration* elementParserRegistration,
         _In_ ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParserRegistration,
-        _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>* adaptiveWarnings,
+        _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* adaptiveWarnings,
         _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardElement** element)
     {
         return AdaptiveNamespace::FromJson<AdaptiveNamespace::AdaptiveContainer, AdaptiveSharedNamespace::Container, AdaptiveSharedNamespace::ContainerParser>(

--- a/source/uwp/Renderer/lib/AdaptiveContainerRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveContainerRenderer.h
@@ -24,7 +24,7 @@ namespace AdaptiveNamespace
         IFACEMETHODIMP FromJson(_In_ ABI::Windows::Data::Json::IJsonObject*,
                                 _In_ ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration* elementParsers,
                                 _In_ ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParsers,
-                                _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>* adaptiveWarnings,
+                                _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* adaptiveWarnings,
                                 _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardElement** element) override;
     };
 

--- a/source/uwp/Renderer/lib/AdaptiveDateInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveDateInputRenderer.cpp
@@ -33,7 +33,7 @@ namespace AdaptiveNamespace
         _In_ ABI::Windows::Data::Json::IJsonObject* jsonObject,
         _In_ ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration* elementParserRegistration,
         _In_ ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParserRegistration,
-        _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>* adaptiveWarnings,
+        _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* adaptiveWarnings,
         _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardElement** element)
     {
         return AdaptiveNamespace::FromJson<AdaptiveNamespace::AdaptiveDateInput, AdaptiveSharedNamespace::DateInput, AdaptiveSharedNamespace::DateInputParser>(

--- a/source/uwp/Renderer/lib/AdaptiveDateInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveDateInputRenderer.h
@@ -24,7 +24,7 @@ namespace AdaptiveNamespace
         IFACEMETHODIMP FromJson(_In_ ABI::Windows::Data::Json::IJsonObject*,
                                 _In_ ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration* elementParsers,
                                 _In_ ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParsers,
-                                _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>* adaptiveWarnings,
+                                _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* adaptiveWarnings,
                                 _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardElement** element) override;
     };
 

--- a/source/uwp/Renderer/lib/AdaptiveElementParserRegistration.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveElementParserRegistration.cpp
@@ -99,8 +99,8 @@ namespace AdaptiveNamespace
                                                                                context.actionParserRegistration);
 
         ComPtr<IAdaptiveCardElement> cardElement;
-        ComPtr<ABI::Windows::Foundation::Collections::IVector<IAdaptiveWarning*>> adaptiveWarnings =
-            Make<Vector<IAdaptiveWarning*>>();
+        ComPtr<ABI::Windows::Foundation::Collections::IVector<AdaptiveWarning*>> adaptiveWarnings =
+            Make<Vector<AdaptiveWarning*>>();
         THROW_IF_FAILED(parser->FromJson(jsonObject.Get(),
                                          adaptiveElementParserRegistration.Get(),
                                          adaptiveActionParserRegistration.Get(),

--- a/source/uwp/Renderer/lib/AdaptiveElementParserRegistration.h
+++ b/source/uwp/Renderer/lib/AdaptiveElementParserRegistration.h
@@ -58,7 +58,7 @@ namespace AdaptiveNamespace
     HRESULT FromJson(_In_ ABI::Windows::Data::Json::IJsonObject* jsonObject,
                      _In_ ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration* elementParserRegistration,
                      _In_ ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParserRegistration,
-                     _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>* adaptiveWarnings,
+                     _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* adaptiveWarnings,
                      _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardElement** element)
     {
         std::string jsonString;

--- a/source/uwp/Renderer/lib/AdaptiveFactSet.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveFactSet.cpp
@@ -14,7 +14,7 @@ using namespace ABI::Windows::UI::Xaml::Controls;
 
 namespace AdaptiveNamespace
 {
-    AdaptiveFactSet::AdaptiveFactSet() { m_facts = Microsoft::WRL::Make<Vector<IAdaptiveFact*>>(); }
+    AdaptiveFactSet::AdaptiveFactSet() { m_facts = Microsoft::WRL::Make<Vector<AdaptiveFact*>>(); }
 
     HRESULT AdaptiveFactSet::RuntimeClassInitialize() noexcept try
     {
@@ -37,7 +37,7 @@ namespace AdaptiveNamespace
     }
     CATCH_RETURN;
 
-    IFACEMETHODIMP AdaptiveFactSet::get_Facts(_COM_Outptr_ IVector<IAdaptiveFact*>** facts)
+    IFACEMETHODIMP AdaptiveFactSet::get_Facts(_COM_Outptr_ IVector<AdaptiveFact*>** facts)
     {
         return m_facts.CopyTo(facts);
     }

--- a/source/uwp/Renderer/lib/AdaptiveFactSet.h
+++ b/source/uwp/Renderer/lib/AdaptiveFactSet.h
@@ -24,7 +24,7 @@ namespace AdaptiveNamespace
         HRESULT RuntimeClassInitialize(const std::shared_ptr<AdaptiveSharedNamespace::FactSet>& sharedFactSet);
 
         // IAdaptiveFactSet
-        IFACEMETHODIMP get_Facts(_COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveFact*>** facts);
+        IFACEMETHODIMP get_Facts(_COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveFact*>** facts);
 
         // IAdaptiveCardElement
         IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveNamespace::ElementType* elementType);
@@ -87,7 +87,7 @@ namespace AdaptiveNamespace
         void* PeekAt(REFIID riid) override { return PeekHelper(riid, this); }
 
     private:
-        Microsoft::WRL::ComPtr<ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveFact*>> m_facts;
+        Microsoft::WRL::ComPtr<ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveFact*>> m_facts;
     };
 
     ActivatableClass(AdaptiveFactSet);

--- a/source/uwp/Renderer/lib/AdaptiveFactSetRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveFactSetRenderer.cpp
@@ -33,7 +33,7 @@ namespace AdaptiveNamespace
         _In_ ABI::Windows::Data::Json::IJsonObject* jsonObject,
         _In_ ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration* elementParserRegistration,
         _In_ ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParserRegistration,
-        _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>* adaptiveWarnings,
+        _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* adaptiveWarnings,
         _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardElement** element)
     {
         return AdaptiveNamespace::FromJson<AdaptiveNamespace::AdaptiveFactSet, AdaptiveSharedNamespace::FactSet, AdaptiveSharedNamespace::FactSetParser>(

--- a/source/uwp/Renderer/lib/AdaptiveFactSetRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveFactSetRenderer.h
@@ -24,7 +24,7 @@ namespace AdaptiveNamespace
         IFACEMETHODIMP FromJson(_In_ ABI::Windows::Data::Json::IJsonObject*,
                                 _In_ ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration* elementParsers,
                                 _In_ ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParsers,
-                                _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>* adaptiveWarnings,
+                                _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* adaptiveWarnings,
                                 _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardElement** element);
     };
 

--- a/source/uwp/Renderer/lib/AdaptiveHostConfigParseResult.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveHostConfigParseResult.cpp
@@ -25,7 +25,7 @@ namespace AdaptiveNamespace
 
     HRESULT AdaptiveHostConfigParseResult::RuntimeClassInitialize()
     {
-        m_errors = Make<Vector<IAdaptiveError*>>();
+        m_errors = Make<Vector<AdaptiveError*>>();
         return S_OK;
     }
 
@@ -41,7 +41,7 @@ namespace AdaptiveNamespace
     }
 
     HRESULT AdaptiveHostConfigParseResult::get_Errors(
-        _COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveError*>** value)
+        _COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveError*>** value)
     {
         return m_errors.CopyTo(value);
     }

--- a/source/uwp/Renderer/lib/AdaptiveHostConfigParseResult.h
+++ b/source/uwp/Renderer/lib/AdaptiveHostConfigParseResult.h
@@ -19,11 +19,11 @@ namespace AdaptiveNamespace
         // IAdaptiveHostConfigParseResult
         IFACEMETHODIMP get_HostConfig(_COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveHostConfig** value);
 
-        IFACEMETHODIMP get_Errors(_COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveError*>** value);
+        IFACEMETHODIMP get_Errors(_COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveError*>** value);
 
     private:
         Microsoft::WRL::ComPtr<ABI::AdaptiveNamespace::IAdaptiveHostConfig> m_hostConfig;
-        Microsoft::WRL::ComPtr<ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveError*>> m_errors;
+        Microsoft::WRL::ComPtr<ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveError*>> m_errors;
     };
 
     ActivatableClass(AdaptiveHostConfigParseResult);

--- a/source/uwp/Renderer/lib/AdaptiveImageRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImageRenderer.cpp
@@ -38,7 +38,7 @@ namespace AdaptiveNamespace
         _In_ ABI::Windows::Data::Json::IJsonObject* jsonObject,
         _In_ ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration* elementParserRegistration,
         _In_ ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParserRegistration,
-        _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>* adaptiveWarnings,
+        _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* adaptiveWarnings,
         _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardElement** element)
     {
         return AdaptiveNamespace::FromJson<AdaptiveNamespace::AdaptiveImage, AdaptiveSharedNamespace::Image, AdaptiveSharedNamespace::ImageParser>(

--- a/source/uwp/Renderer/lib/AdaptiveImageRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveImageRenderer.h
@@ -27,7 +27,7 @@ namespace AdaptiveNamespace
         IFACEMETHODIMP FromJson(_In_ ABI::Windows::Data::Json::IJsonObject*,
                                 _In_ ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration* elementParsers,
                                 _In_ ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParsers,
-                                _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>* adaptiveWarnings,
+                                _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* adaptiveWarnings,
                                 _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardElement** element) override;
 
     private:

--- a/source/uwp/Renderer/lib/AdaptiveImageSet.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImageSet.cpp
@@ -14,7 +14,7 @@ using namespace ABI::Windows::UI::Xaml::Controls;
 
 namespace AdaptiveNamespace
 {
-    AdaptiveImageSet::AdaptiveImageSet() { m_images = Microsoft::WRL::Make<Vector<IAdaptiveImage*>>(); }
+    AdaptiveImageSet::AdaptiveImageSet() { m_images = Microsoft::WRL::Make<Vector<AdaptiveImage*>>(); }
 
     HRESULT AdaptiveImageSet::RuntimeClassInitialize() noexcept try
     {
@@ -39,7 +39,7 @@ namespace AdaptiveNamespace
     }
     CATCH_RETURN;
 
-    IFACEMETHODIMP AdaptiveImageSet::get_Images(_COM_Outptr_ IVector<IAdaptiveImage*>** images)
+    IFACEMETHODIMP AdaptiveImageSet::get_Images(_COM_Outptr_ IVector<AdaptiveImage*>** images)
     {
         return m_images.CopyTo(images);
     }

--- a/source/uwp/Renderer/lib/AdaptiveImageSet.h
+++ b/source/uwp/Renderer/lib/AdaptiveImageSet.h
@@ -24,7 +24,7 @@ namespace AdaptiveNamespace
         HRESULT RuntimeClassInitialize(const std::shared_ptr<AdaptiveSharedNamespace::ImageSet>& sharedImageSet);
 
         // IAdaptiveImageSet
-        IFACEMETHODIMP get_Images(_COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveImage*>** columns);
+        IFACEMETHODIMP get_Images(_COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveImage*>** columns);
 
         IFACEMETHODIMP get_ImageSize(_Out_ ABI::AdaptiveNamespace::ImageSize* imageSize);
         IFACEMETHODIMP put_ImageSize(ABI::AdaptiveNamespace::ImageSize imageSize);
@@ -90,7 +90,7 @@ namespace AdaptiveNamespace
         void* PeekAt(REFIID riid) override { return PeekHelper(riid, this); }
 
     private:
-        Microsoft::WRL::ComPtr<ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveImage*>> m_images;
+        Microsoft::WRL::ComPtr<ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveImage*>> m_images;
         ABI::AdaptiveNamespace::ImageSize m_imageSize;
     };
 

--- a/source/uwp/Renderer/lib/AdaptiveImageSetRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImageSetRenderer.cpp
@@ -33,7 +33,7 @@ namespace AdaptiveNamespace
         _In_ ABI::Windows::Data::Json::IJsonObject* jsonObject,
         _In_ ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration* elementParserRegistration,
         _In_ ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParserRegistration,
-        _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>* adaptiveWarnings,
+        _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* adaptiveWarnings,
         _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardElement** element)
     {
         return AdaptiveNamespace::FromJson<AdaptiveNamespace::AdaptiveImageSet, AdaptiveSharedNamespace::ImageSet, AdaptiveSharedNamespace::ImageSetParser>(

--- a/source/uwp/Renderer/lib/AdaptiveImageSetRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveImageSetRenderer.h
@@ -24,7 +24,7 @@ namespace AdaptiveNamespace
         IFACEMETHODIMP FromJson(_In_ ABI::Windows::Data::Json::IJsonObject*,
                                 _In_ ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration* elementParsers,
                                 _In_ ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParsers,
-                                _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>* adaptiveWarnings,
+                                _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* adaptiveWarnings,
                                 _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardElement** element) override;
     };
 

--- a/source/uwp/Renderer/lib/AdaptiveMediaRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveMediaRenderer.cpp
@@ -29,7 +29,7 @@ namespace AdaptiveNamespace
         _In_ ABI::Windows::Data::Json::IJsonObject* jsonObject,
         _In_ ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration* elementParserRegistration,
         _In_ ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParserRegistration,
-        _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>* adaptiveWarnings,
+        _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* adaptiveWarnings,
         _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardElement** element)
     {
         return AdaptiveNamespace::FromJson<AdaptiveNamespace::AdaptiveMedia, AdaptiveSharedNamespace::Media, AdaptiveSharedNamespace::MediaParser>(

--- a/source/uwp/Renderer/lib/AdaptiveMediaRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveMediaRenderer.h
@@ -20,7 +20,7 @@ namespace AdaptiveNamespace
         IFACEMETHODIMP FromJson(_In_ ABI::Windows::Data::Json::IJsonObject*,
                                 _In_ ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration* elementParsers,
                                 _In_ ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParsers,
-                                _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>* adaptiveWarnings,
+                                _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* adaptiveWarnings,
                                 _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardElement** element) override;
     };
 

--- a/source/uwp/Renderer/lib/AdaptiveNumberInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveNumberInputRenderer.cpp
@@ -33,7 +33,7 @@ namespace AdaptiveNamespace
         _In_ ABI::Windows::Data::Json::IJsonObject* jsonObject,
         _In_ ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration* elementParserRegistration,
         _In_ ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParserRegistration,
-        _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>* adaptiveWarnings,
+        _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* adaptiveWarnings,
         _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardElement** element)
     {
         return AdaptiveNamespace::FromJson<AdaptiveNamespace::AdaptiveNumberInput, AdaptiveSharedNamespace::NumberInput, AdaptiveSharedNamespace::NumberInputParser>(

--- a/source/uwp/Renderer/lib/AdaptiveNumberInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveNumberInputRenderer.h
@@ -24,7 +24,7 @@ namespace AdaptiveNamespace
         IFACEMETHODIMP FromJson(_In_ ABI::Windows::Data::Json::IJsonObject*,
                                 _In_ ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration* elementParsers,
                                 _In_ ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParsers,
-                                _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>* adaptiveWarnings,
+                                _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* adaptiveWarnings,
                                 _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardElement** element);
     };
 

--- a/source/uwp/Renderer/lib/AdaptiveRenderContext.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveRenderContext.cpp
@@ -72,7 +72,7 @@ namespace AdaptiveNamespace
     {
         ComPtr<AdaptiveError> error;
         RETURN_IF_FAILED(MakeAndInitialize<AdaptiveError>(&error, statusCode, message));
-        ComPtr<IVector<ABI::AdaptiveNamespace::IAdaptiveError*>> errors;
+        ComPtr<IVector<ABI::AdaptiveNamespace::AdaptiveError*>> errors;
         RETURN_IF_FAILED(m_renderResult->get_Errors(&errors));
         return (errors->Append(error.Detach()));
     }
@@ -81,7 +81,7 @@ namespace AdaptiveNamespace
     {
         ComPtr<AdaptiveWarning> warning;
         RETURN_IF_FAILED(MakeAndInitialize<AdaptiveWarning>(&warning, statusCode, message));
-        ComPtr<IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>> warnings;
+        ComPtr<IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>> warnings;
         RETURN_IF_FAILED(m_renderResult->get_Warnings(&warnings));
         return (warnings->Append(warning.Detach()));
     }

--- a/source/uwp/Renderer/lib/AdaptiveTextBlockRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTextBlockRenderer.cpp
@@ -33,7 +33,7 @@ namespace AdaptiveNamespace
         _In_ ABI::Windows::Data::Json::IJsonObject* jsonObject,
         _In_ ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration* elementParserRegistration,
         _In_ ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParserRegistration,
-        _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>* adaptiveWarnings,
+        _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* adaptiveWarnings,
         _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardElement** element)
     {
         return AdaptiveNamespace::FromJson<AdaptiveNamespace::AdaptiveTextBlock, AdaptiveSharedNamespace::TextBlock, AdaptiveSharedNamespace::TextBlockParser>(

--- a/source/uwp/Renderer/lib/AdaptiveTextBlockRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveTextBlockRenderer.h
@@ -24,7 +24,7 @@ namespace AdaptiveNamespace
         IFACEMETHODIMP FromJson(_In_ ABI::Windows::Data::Json::IJsonObject*,
                                 _In_ ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration* elementParsers,
                                 _In_ ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParsers,
-                                _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>* adaptiveWarnings,
+                                _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* adaptiveWarnings,
                                 _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardElement** element) override;
     };
 

--- a/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.cpp
@@ -33,7 +33,7 @@ namespace AdaptiveNamespace
         _In_ ABI::Windows::Data::Json::IJsonObject* jsonObject,
         _In_ ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration* elementParserRegistration,
         _In_ ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParserRegistration,
-        _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>* adaptiveWarnings,
+        _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* adaptiveWarnings,
         _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardElement** element)
     {
         return AdaptiveNamespace::FromJson<AdaptiveNamespace::AdaptiveTextInput, AdaptiveSharedNamespace::TextInput, AdaptiveSharedNamespace::TextInputParser>(

--- a/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.h
@@ -24,7 +24,7 @@ namespace AdaptiveNamespace
         IFACEMETHODIMP FromJson(_In_ ABI::Windows::Data::Json::IJsonObject*,
                                 _In_ ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration* elementParsers,
                                 _In_ ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParsers,
-                                _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>* adaptiveWarnings,
+                                _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* adaptiveWarnings,
                                 _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardElement** element) override;
     };
 

--- a/source/uwp/Renderer/lib/AdaptiveTimeInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTimeInputRenderer.cpp
@@ -33,7 +33,7 @@ namespace AdaptiveNamespace
         _In_ ABI::Windows::Data::Json::IJsonObject* jsonObject,
         _In_ ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration* elementParserRegistration,
         _In_ ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParserRegistration,
-        _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>* adaptiveWarnings,
+        _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* adaptiveWarnings,
         _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardElement** element)
     {
         return AdaptiveNamespace::FromJson<AdaptiveNamespace::AdaptiveTimeInput, AdaptiveSharedNamespace::TimeInput, AdaptiveSharedNamespace::TimeInputParser>(

--- a/source/uwp/Renderer/lib/AdaptiveTimeInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveTimeInputRenderer.h
@@ -24,7 +24,7 @@ namespace AdaptiveNamespace
         IFACEMETHODIMP FromJson(_In_ ABI::Windows::Data::Json::IJsonObject*,
                                 _In_ ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration* elementParsers,
                                 _In_ ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParsers,
-                                _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>* adaptiveWarnings,
+                                _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* adaptiveWarnings,
                                 _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardElement** element) override;
     };
 

--- a/source/uwp/Renderer/lib/AdaptiveToggleInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveToggleInputRenderer.cpp
@@ -33,7 +33,7 @@ namespace AdaptiveNamespace
         _In_ ABI::Windows::Data::Json::IJsonObject* jsonObject,
         _In_ ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration* elementParserRegistration,
         _In_ ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParserRegistration,
-        _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>* adaptiveWarnings,
+        _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* adaptiveWarnings,
         _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardElement** element)
     {
         return AdaptiveNamespace::FromJson<AdaptiveNamespace::AdaptiveToggleInput, AdaptiveSharedNamespace::ToggleInput, AdaptiveSharedNamespace::ToggleInputParser>(

--- a/source/uwp/Renderer/lib/AdaptiveToggleInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveToggleInputRenderer.h
@@ -24,7 +24,7 @@ namespace AdaptiveNamespace
         IFACEMETHODIMP FromJson(_In_ ABI::Windows::Data::Json::IJsonObject*,
                                 _In_ ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration* elementParsers,
                                 _In_ ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParsers,
-                                _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>* adaptiveWarnings,
+                                _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* adaptiveWarnings,
                                 _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardElement** element) override;
     };
 

--- a/source/uwp/Renderer/lib/InputValue.cpp
+++ b/source/uwp/Renderer/lib/InputValue.cpp
@@ -109,7 +109,7 @@ std::string InputValue::GetChoiceValue(_In_ IAdaptiveChoiceSetInput* choiceInput
 {
     if (selectedIndex != -1)
     {
-        ComPtr<IVector<IAdaptiveChoiceInput*>> choices;
+        ComPtr<IVector<AdaptiveChoiceInput*>> choices;
         THROW_IF_FAILED(choiceInput->get_Choices(&choices));
 
         ComPtr<IAdaptiveChoiceInput> choice;

--- a/source/uwp/Renderer/lib/RenderedAdaptiveCard.cpp
+++ b/source/uwp/Renderer/lib/RenderedAdaptiveCard.cpp
@@ -29,14 +29,15 @@ namespace AdaptiveNamespace
 
     HRESULT RenderedAdaptiveCard::RuntimeClassInitialize()
     {
-        RETURN_IF_FAILED(RenderedAdaptiveCard::RuntimeClassInitialize(Make<Vector<IAdaptiveError*>>().Get(),
-                                                                      Make<Vector<IAdaptiveWarning*>>().Get()));
+        RETURN_IF_FAILED(
+            RenderedAdaptiveCard::RuntimeClassInitialize(Make<Vector<ABI::AdaptiveNamespace::AdaptiveError*>>().Get(),
+                                                         Make<Vector<ABI::AdaptiveNamespace::AdaptiveWarning*>>().Get()));
         return S_OK;
     }
 
     HRESULT RenderedAdaptiveCard::RuntimeClassInitialize(
-        _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveError*>* errors,
-        _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>* warnings)
+        _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveError*>* errors,
+        _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* warnings)
     {
         m_errors = errors;
         m_warnings = warnings;
@@ -83,13 +84,13 @@ namespace AdaptiveNamespace
     }
 
     HRESULT RenderedAdaptiveCard::get_Errors(
-        _COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveError*>** value)
+        _COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveError*>** value)
     {
         return m_errors.CopyTo(value);
     }
 
     HRESULT RenderedAdaptiveCard::get_Warnings(
-        _COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>** value)
+        _COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>** value)
     {
         return m_warnings.CopyTo(value);
     }

--- a/source/uwp/Renderer/lib/RenderedAdaptiveCard.h
+++ b/source/uwp/Renderer/lib/RenderedAdaptiveCard.h
@@ -18,8 +18,8 @@ namespace AdaptiveNamespace
 
         HRESULT RuntimeClassInitialize();
         HRESULT RuntimeClassInitialize(
-            _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveError*>* errors,
-            _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>* warnings);
+            _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveError*>* errors,
+            _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* warnings);
 
         // IRenderedAdaptiveCard
         IFACEMETHODIMP get_OriginatingCard(_COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCard** value);
@@ -35,9 +35,9 @@ namespace AdaptiveNamespace
             _Out_ EventRegistrationToken* token);
         IFACEMETHODIMP remove_MediaClicked(EventRegistrationToken token);
 
-        IFACEMETHODIMP get_Errors(_COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveError*>** value);
+        IFACEMETHODIMP get_Errors(_COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveError*>** value);
         IFACEMETHODIMP get_Warnings(
-            _COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>** value);
+            _COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>** value);
 
         HRESULT AddInputValue(_In_ ABI::AdaptiveNamespace::IAdaptiveInputValue* inputValue);
         void SetFrameworkElement(_In_ ABI::Windows::UI::Xaml::IFrameworkElement* value);
@@ -49,8 +49,8 @@ namespace AdaptiveNamespace
         Microsoft::WRL::ComPtr<ABI::AdaptiveNamespace::IAdaptiveCard> m_originatingCard;
         Microsoft::WRL::ComPtr<AdaptiveNamespace::AdaptiveInputs> m_inputs;
         Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IFrameworkElement> m_frameworkElement;
-        Microsoft::WRL::ComPtr<ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveError*>> m_errors;
-        Microsoft::WRL::ComPtr<ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>> m_warnings;
+        Microsoft::WRL::ComPtr<ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveError*>> m_errors;
+        Microsoft::WRL::ComPtr<ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>> m_warnings;
         std::shared_ptr<ActionEventSource> m_actionEvents;
         std::shared_ptr<MediaEventSource> m_mediaClickedEvents;
     };

--- a/source/uwp/Renderer/lib/Util.cpp
+++ b/source/uwp/Renderer/lib/Util.cpp
@@ -241,12 +241,13 @@ HRESULT GenerateSharedActions(_In_ ABI::Windows::Foundation::Collections::IVecto
     return S_OK;
 }
 
-HRESULT GenerateSharedImages(_In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveImage*>* images,
+HRESULT GenerateSharedImages(_In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveImage*>* images,
                              std::vector<std::shared_ptr<AdaptiveSharedNamespace::Image>>& containedElements)
 {
     containedElements.clear();
 
-    XamlHelpers::IterateOverVector<ABI::AdaptiveNamespace::IAdaptiveImage>(images, [&](ABI::AdaptiveNamespace::IAdaptiveImage* image) {
+    XamlHelpers::IterateOverVector<ABI::AdaptiveNamespace::AdaptiveImage,
+                                   ABI::AdaptiveNamespace::IAdaptiveImage>(images, [&](ABI::AdaptiveNamespace::IAdaptiveImage* image) {
         ComPtr<ABI::AdaptiveNamespace::IAdaptiveImage> localImage = image;
         ComPtr<ABI::AdaptiveNamespace::IAdaptiveCardElement> imageAsElement;
         localImage.As(&imageAsElement);
@@ -262,12 +263,13 @@ HRESULT GenerateSharedImages(_In_ ABI::Windows::Foundation::Collections::IVector
     return S_OK;
 }
 
-HRESULT GenerateSharedFacts(_In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveFact*>* facts,
+HRESULT GenerateSharedFacts(_In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveFact*>* facts,
                             std::vector<std::shared_ptr<AdaptiveSharedNamespace::Fact>>& containedElements)
 {
     containedElements.clear();
 
-    XamlHelpers::IterateOverVector<ABI::AdaptiveNamespace::IAdaptiveFact>(facts, [&](ABI::AdaptiveNamespace::IAdaptiveFact* fact) {
+    XamlHelpers::IterateOverVector<ABI::AdaptiveNamespace::AdaptiveFact, ABI::AdaptiveNamespace::IAdaptiveFact>(
+        facts, [&](ABI::AdaptiveNamespace::IAdaptiveFact* fact) {
         ComPtr<AdaptiveNamespace::AdaptiveFact> adaptiveElement = PeekInnards<AdaptiveNamespace::AdaptiveFact>(fact);
         if (adaptiveElement == nullptr)
         {
@@ -283,12 +285,13 @@ HRESULT GenerateSharedFacts(_In_ ABI::Windows::Foundation::Collections::IVector<
     return S_OK;
 }
 
-HRESULT GenerateSharedChoices(_In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveChoiceInput*>* choices,
+HRESULT GenerateSharedChoices(_In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveChoiceInput*>* choices,
                               std::vector<std::shared_ptr<AdaptiveSharedNamespace::ChoiceInput>>& containedElements)
 {
     containedElements.clear();
 
-    XamlHelpers::IterateOverVector<ABI::AdaptiveNamespace::IAdaptiveChoiceInput>(choices, [&](ABI::AdaptiveNamespace::IAdaptiveChoiceInput* choice) {
+    XamlHelpers::IterateOverVector <ABI::AdaptiveNamespace::AdaptiveChoiceInput, ABI::AdaptiveNamespace::IAdaptiveChoiceInput >
+        (choices, [&](ABI::AdaptiveNamespace::IAdaptiveChoiceInput* choice) {
         ComPtr<AdaptiveNamespace::AdaptiveChoiceInput> adaptiveElement =
             PeekInnards<AdaptiveNamespace::AdaptiveChoiceInput>(choice);
         if (adaptiveElement == nullptr)
@@ -510,7 +513,7 @@ HRESULT GenerateActionProjection(const std::shared_ptr<AdaptiveSharedNamespace::
 CATCH_RETURN;
 
 HRESULT GenerateColumnsProjection(const std::vector<std::shared_ptr<AdaptiveSharedNamespace::Column>>& containedElements,
-                                  _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveColumn*>* projectedParentContainer) noexcept try
+                                  _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveColumn*>* projectedParentContainer) noexcept try
 {
     for (auto& containedElement : containedElements)
     {
@@ -525,7 +528,7 @@ HRESULT GenerateColumnsProjection(const std::vector<std::shared_ptr<AdaptiveShar
 CATCH_RETURN;
 
 HRESULT GenerateFactsProjection(const std::vector<std::shared_ptr<AdaptiveSharedNamespace::Fact>>& containedElements,
-                                _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveFact*>* projectedParentContainer) noexcept try
+                                _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveFact*>* projectedParentContainer) noexcept try
 {
     for (auto& containedElement : containedElements)
     {
@@ -540,7 +543,7 @@ HRESULT GenerateFactsProjection(const std::vector<std::shared_ptr<AdaptiveShared
 CATCH_RETURN;
 
 HRESULT GenerateImagesProjection(const std::vector<std::shared_ptr<AdaptiveSharedNamespace::Image>>& containedElements,
-                                 _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveImage*>* projectedParentContainer) noexcept try
+                                 _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveImage*>* projectedParentContainer) noexcept try
 {
     for (auto& containedElement : containedElements)
     {
@@ -556,7 +559,7 @@ CATCH_RETURN;
 
 HRESULT GenerateInputChoicesProjection(
     const std::vector<std::shared_ptr<AdaptiveSharedNamespace::ChoiceInput>>& containedElements,
-    _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveChoiceInput*>* projectedParentContainer) noexcept try
+    _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveChoiceInput*>* projectedParentContainer) noexcept try
 {
     for (auto& containedElement : containedElements)
     {
@@ -1224,7 +1227,7 @@ void GetUrlFromString(_In_ ABI::AdaptiveNamespace::IAdaptiveHostConfig* hostConf
 }
 
 HRESULT SharedWarningsToAdaptiveWarnings(std::vector<std::shared_ptr<AdaptiveCardParseWarning>> sharedWarnings,
-                                         _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>* adaptiveWarnings)
+                                         _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* adaptiveWarnings)
 {
     for (auto sharedWarning : sharedWarnings)
     {
@@ -1243,14 +1246,14 @@ HRESULT SharedWarningsToAdaptiveWarnings(std::vector<std::shared_ptr<AdaptiveCar
     return S_OK;
 }
 
-HRESULT AdaptiveWarningsToSharedWarnings(_In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>* adaptiveWarnings,
+HRESULT AdaptiveWarningsToSharedWarnings(_In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* adaptiveWarnings,
                                          std::vector<std::shared_ptr<AdaptiveCardParseWarning>> sharedWarnings)
 {
-    ComPtr<ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>> localAdaptiveWarnings{adaptiveWarnings};
-    ComPtr<IIterable<ABI::AdaptiveNamespace::IAdaptiveWarning*>> vectorIterable;
-    RETURN_IF_FAILED(localAdaptiveWarnings.As<IIterable<ABI::AdaptiveNamespace::IAdaptiveWarning*>>(&vectorIterable));
+    ComPtr<ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>> localAdaptiveWarnings{adaptiveWarnings};
+    ComPtr<IIterable<ABI::AdaptiveNamespace::AdaptiveWarning*>> vectorIterable;
+    RETURN_IF_FAILED(localAdaptiveWarnings.As<IIterable<ABI::AdaptiveNamespace::AdaptiveWarning*>>(&vectorIterable));
 
-    Microsoft::WRL::ComPtr<IIterator<ABI::AdaptiveNamespace::IAdaptiveWarning*>> vectorIterator;
+    Microsoft::WRL::ComPtr<IIterator<ABI::AdaptiveNamespace::AdaptiveWarning*>> vectorIterator;
     HRESULT hr = vectorIterable->First(&vectorIterator);
 
     boolean hasCurrent;

--- a/source/uwp/Renderer/lib/Util.h
+++ b/source/uwp/Renderer/lib/Util.h
@@ -101,13 +101,13 @@ HRESULT GenerateSharedAction(_In_ ABI::AdaptiveNamespace::IAdaptiveActionElement
 HRESULT GenerateSharedActions(_In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveActionElement*>* items,
                               std::vector<std::shared_ptr<AdaptiveSharedNamespace::BaseActionElement>>& containedElements);
 
-HRESULT GenerateSharedImages(_In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveImage*>* items,
+HRESULT GenerateSharedImages(_In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveImage*>* items,
                              std::vector<std::shared_ptr<AdaptiveSharedNamespace::Image>>& containedElements);
 
-HRESULT GenerateSharedFacts(_In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveFact*>* items,
+HRESULT GenerateSharedFacts(_In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveFact*>* items,
                             std::vector<std::shared_ptr<AdaptiveSharedNamespace::Fact>>& containedElements);
 
-HRESULT GenerateSharedChoices(_In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveChoiceInput*>* items,
+HRESULT GenerateSharedChoices(_In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveChoiceInput*>* items,
                               std::vector<std::shared_ptr<AdaptiveSharedNamespace::ChoiceInput>>& containedElements);
 
 HRESULT GenerateSharedMediaSources(_In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveMediaSource*>* items,
@@ -129,17 +129,17 @@ HRESULT GenerateActionProjection(const std::shared_ptr<AdaptiveSharedNamespace::
                                  _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveActionElement** projectedAction) noexcept;
 
 HRESULT GenerateColumnsProjection(const std::vector<std::shared_ptr<AdaptiveSharedNamespace::Column>>& containedElements,
-                                  _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveColumn*>* projectedParentContainer) noexcept;
+                                  _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveColumn*>* projectedParentContainer) noexcept;
 
 HRESULT GenerateFactsProjection(const std::vector<std::shared_ptr<AdaptiveSharedNamespace::Fact>>& containedElements,
-                                _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveFact*>* projectedParentContainer) noexcept;
+                                _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveFact*>* projectedParentContainer) noexcept;
 
 HRESULT GenerateImagesProjection(const std::vector<std::shared_ptr<AdaptiveSharedNamespace::Image>>& containedElements,
-                                 _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveImage*>* projectedParentContainer) noexcept;
+                                 _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveImage*>* projectedParentContainer) noexcept;
 
 HRESULT GenerateInputChoicesProjection(
     const std::vector<std::shared_ptr<AdaptiveSharedNamespace::ChoiceInput>>& containedElements,
-    _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveChoiceInput*>* projectedParentContainer) noexcept;
+    _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveChoiceInput*>* projectedParentContainer) noexcept;
 
 HRESULT GenerateMediaSourcesProjection(
     const std::vector<std::shared_ptr<AdaptiveSharedNamespace::MediaSource>>& containedElements,
@@ -205,9 +205,9 @@ void GetUrlFromString(_In_ ABI::AdaptiveNamespace::IAdaptiveHostConfig* hostConf
 
 HRESULT SharedWarningsToAdaptiveWarnings(
     std::vector<std::shared_ptr<AdaptiveSharedNamespace::AdaptiveCardParseWarning>> sharedWarnings,
-    _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>* adaptiveWarnings);
+    _In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* adaptiveWarnings);
 
-HRESULT AdaptiveWarningsToSharedWarnings(_In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>* adaptiveWarnings,
+HRESULT AdaptiveWarningsToSharedWarnings(_In_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* adaptiveWarnings,
                                          std::vector<std::shared_ptr<AdaptiveSharedNamespace::AdaptiveCardParseWarning>> sharedWarnings);
 
 ABI::Windows::UI::Color GenerateLighterColor(const ABI::Windows::UI::Color& originalColor);

--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -2369,7 +2369,7 @@ namespace AdaptiveNamespace
         ComPtr<IGridStatics> gridStatics;
         THROW_IF_FAILED(GetActivationFactory(HStringReference(RuntimeClass_Windows_UI_Xaml_Controls_Grid).Get(), &gridStatics));
 
-        ComPtr<IVector<IAdaptiveColumn*>> columns;
+        ComPtr<IVector<AdaptiveColumn*>> columns;
         THROW_IF_FAILED(adaptiveColumnSet->get_Columns(&columns));
         int currentColumn{};
         ComPtr<IAdaptiveElementRendererRegistration> elementRenderers;
@@ -2388,7 +2388,7 @@ namespace AdaptiveNamespace
         ComPtr<IAdaptiveHostConfig> hostConfig;
         THROW_IF_FAILED(renderContext->get_HostConfig(&hostConfig));
 
-        XamlHelpers::IterateOverVector<IAdaptiveColumn>(
+        XamlHelpers::IterateOverVector<AdaptiveColumn, IAdaptiveColumn>(
             columns.Get(),
             [xamlGrid, gridStatics, &currentColumn, renderContext, renderArgs, columnRenderer, hostConfig](IAdaptiveColumn* column) {
                 ComPtr<IAdaptiveCardElement> columnAsCardElement;
@@ -2559,10 +2559,10 @@ namespace AdaptiveNamespace
             factSetGridHeight = {1, GridUnitType::GridUnitType_Star};
         }
 
-        ComPtr<IVector<IAdaptiveFact*>> facts;
+        ComPtr<IVector<AdaptiveFact*>> facts;
         THROW_IF_FAILED(adaptiveFactSet->get_Facts(&facts));
         int currentFact = 0;
-        XamlHelpers::IterateOverVector<IAdaptiveFact>(
+        XamlHelpers::IterateOverVector<AdaptiveFact, IAdaptiveFact>(
             facts.Get(), [xamlGrid, gridStatics, factSetGridHeight, &currentFact, renderContext, renderArgs](IAdaptiveFact* fact) {
                 ComPtr<IRowDefinition> factRow = XamlHelpers::CreateXamlClass<IRowDefinition>(
                     HStringReference(RuntimeClass_Windows_UI_Xaml_Controls_RowDefinition));
@@ -2673,7 +2673,7 @@ namespace AdaptiveNamespace
 
         THROW_IF_FAILED(xamlGrid->put_Orientation(Orientation_Horizontal));
 
-        ComPtr<IVector<IAdaptiveImage*>> images;
+        ComPtr<IVector<ABI::AdaptiveNamespace::AdaptiveImage*>> images;
         THROW_IF_FAILED(adaptiveImageSet->get_Images(&images));
 
         ComPtr<IAdaptiveHostConfig> hostConfig;
@@ -2701,7 +2701,7 @@ namespace AdaptiveNamespace
             ComPtr<AdaptiveRenderArgs> childRenderArgs;
             THROW_IF_FAILED(MakeAndInitialize<AdaptiveRenderArgs>(&childRenderArgs, containerStyle, xamlGrid.Get()));
 
-            XamlHelpers::IterateOverVector<IAdaptiveImage>(
+            XamlHelpers::IterateOverVector<ABI::AdaptiveNamespace::AdaptiveImage, ABI::AdaptiveNamespace::IAdaptiveImage>(
                 images.Get(),
                 [imageSize, xamlGrid, renderContext, childRenderArgs, imageRenderer, imageSetConfig](IAdaptiveImage* adaptiveImage) {
                     ComPtr<IUIElement> uiImage;
@@ -2788,7 +2788,7 @@ namespace AdaptiveNamespace
         ComPtr<IVector<IInspectable*>> itemsVector;
         THROW_IF_FAILED(items.As(&itemsVector));
 
-        ComPtr<IVector<IAdaptiveChoiceInput*>> choices;
+        ComPtr<IVector<ABI::AdaptiveNamespace::AdaptiveChoiceInput*>> choices;
         THROW_IF_FAILED(adaptiveChoiceSetInput->get_Choices(&choices));
 
         std::vector<std::string> values = GetChoiceSetValueVector(adaptiveChoiceSetInput);
@@ -2797,7 +2797,7 @@ namespace AdaptiveNamespace
 
         int currentIndex = 0;
         int selectedIndex = -1;
-        XamlHelpers::IterateOverVector<IAdaptiveChoiceInput>(
+        XamlHelpers::IterateOverVector<ABI::AdaptiveNamespace::AdaptiveChoiceInput, IAdaptiveChoiceInput>(
             choices.Get(), [&currentIndex, &selectedIndex, itemsVector, values, wrap](IAdaptiveChoiceInput* adaptiveChoiceInput) {
                 HString title;
                 THROW_IF_FAILED(adaptiveChoiceInput->get_Title(title.GetAddressOf()));
@@ -2838,7 +2838,7 @@ namespace AdaptiveNamespace
                                                   boolean isMultiSelect,
                                                   _Outptr_ IUIElement** choiceInputSet)
     {
-        ComPtr<IVector<IAdaptiveChoiceInput*>> choices;
+        ComPtr<IVector<AdaptiveChoiceInput*>> choices;
         THROW_IF_FAILED(adaptiveChoiceSetInput->get_Choices(&choices));
 
         ComPtr<IStackPanel> stackPanel =
@@ -2853,7 +2853,8 @@ namespace AdaptiveNamespace
         boolean wrap;
         adaptiveChoiceSetInput->get_Wrap(&wrap);
 
-        XamlHelpers::IterateOverVector<IAdaptiveChoiceInput>(choices.Get(), [panel, isMultiSelect, renderContext, values, wrap](IAdaptiveChoiceInput* adaptiveChoiceInput) {
+        XamlHelpers::IterateOverVector<AdaptiveChoiceInput, IAdaptiveChoiceInput>(
+            choices.Get(), [panel, isMultiSelect, renderContext, values, wrap](IAdaptiveChoiceInput* adaptiveChoiceInput) {
             ComPtr<IUIElement> choiceItem;
             if (isMultiSelect)
             {

--- a/source/uwp/Renderer/lib/XamlHelpers.h
+++ b/source/uwp/Renderer/lib/XamlHelpers.h
@@ -19,7 +19,7 @@ namespace AdaptiveNamespace
             return result;
         }
 
-        template<typename T, typename C>
+        template<typename T, typename TInterface, typename C>
         static void IterateOverVector(_In_ ABI::Windows::Foundation::Collections::IVector<T*>* vector, C iterationCallback)
         {
             Microsoft::WRL::ComPtr<ABI::Windows::Foundation::Collections::IVector<T*>> localVector(vector);
@@ -36,8 +36,8 @@ namespace AdaptiveNamespace
             HRESULT hr = vectorIterator->get_HasCurrent(&hasCurrent);
             while (SUCCEEDED(hr) && hasCurrent)
             {
-                Microsoft::WRL::ComPtr<T> current = nullptr;
-                hr = vectorIterator->get_Current(&current);
+                Microsoft::WRL::ComPtr<TInterface> current = nullptr;
+                hr = vectorIterator->get_Current(current.GetAddressOf());
                 if (FAILED(hr))
                 {
                     break;
@@ -46,6 +46,12 @@ namespace AdaptiveNamespace
                 iterationCallback(current.Get());
                 hr = vectorIterator->MoveNext(&hasCurrent);
             }
+        }
+
+        template<typename T, typename C>
+        static void IterateOverVector(_In_ ABI::Windows::Foundation::Collections::IVector<T*>* vector, C iterationCallback)
+        {
+            IterateOverVector<T, T, C>(vector, iterationCallback);
         }
 
         template<typename T>

--- a/source/uwp/UWPUnitTests/ObjectModelTests.cs
+++ b/source/uwp/UWPUnitTests/ObjectModelTests.cs
@@ -318,8 +318,8 @@ namespace UWPUnitTests
             columnSet.Columns.Add(column1);
             columnSet.Columns.Add(column2);
 
-            Assert.AreEqual("ColumnId", (columnSet.Columns[0] as AdaptiveColumn).Id);
-            Assert.AreEqual("Column2Id", (columnSet.Columns[1] as AdaptiveColumn).Id);
+            Assert.AreEqual("ColumnId", columnSet.Columns[0].Id);
+            Assert.AreEqual("Column2Id", columnSet.Columns[1].Id);
 
             var jsonString = columnSet.ToJson().ToString();
             Assert.AreEqual("{\"columns\":[{\"height\":\"Stretch\",\"id\":\"ColumnId\",\"isVisible\":false,\"items\":[{\"text\":\"This is a text block\",\"type\":\"TextBlock\"},{\"text\":\"This is another text block\",\"type\":\"TextBlock\"}],\"selectAction\":{\"data\":\"null\",\"id\":\"\",\"title\":\"Select Action\",\"type\":\"Action.Submit\"},\"separator\":true,\"spacing\":\"small\",\"style\":\"Emphasis\",\"type\":\"Column\",\"verticalContentAlignment\":\"Bottom\",\"width\":\"auto\"},{\"id\":\"Column2Id\",\"items\":[{\"text\":\"This is a text block\",\"type\":\"TextBlock\"}],\"type\":\"Column\",\"width\":\"auto\"}],\"height\":\"Stretch\",\"id\":\"ColumnSetId\",\"isVisible\":false,\"separator\":true,\"spacing\":\"small\",\"type\":\"ColumnSet\"}", jsonString);
@@ -397,8 +397,8 @@ namespace UWPUnitTests
             imageSet.Images.Add(image1);
             imageSet.Images.Add(image2);
 
-            Assert.AreEqual("Image1Id", (imageSet.Images[0] as AdaptiveImage).Id);
-            Assert.AreEqual("Image2Id", (imageSet.Images[1] as AdaptiveImage).Id);
+            Assert.AreEqual("Image1Id", imageSet.Images[0].Id);
+            Assert.AreEqual("Image2Id", imageSet.Images[1].Id);
 
             var jsonString = imageSet.ToJson().ToString();
             Assert.AreEqual("{\"height\":\"Stretch\",\"id\":\"ImageSetId\",\"imageSize\":\"Small\",\"images\":[{\"id\":\"Image1Id\",\"type\":\"Image\",\"url\":\"https://www.stuff.com/picture.jpg\"},{\"id\":\"Image2Id\",\"type\":\"Image\",\"url\":\"https://www.stuff.com/picture2.jpg\"}],\"isVisible\":false,\"separator\":true,\"spacing\":\"medium\",\"type\":\"ImageSet\"}", jsonString);


### PR DESCRIPTION
When the UWP code was originally written, we were using a vector implementation that couldn't handle vectors of RuntimeClasses. Because you can't declare a vector of interfaces that are exclusive to a runtimeclass (only vectors of that runtime class) some of our interfaces were not marked as exclusiveto when they should have been. This leads to some awkward API usage in the projected languages. We've long since fixed the vector issue, so updated our API to correctly mark interfaces as exclusiveto.