### PR TITLE
Fixing references hardcoding the namespace to `AdaptiveCards::Rendering::Uwp`

### DIFF
--- a/source/uwp/Renderer/lib/AdaptiveActionSet.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveActionSet.cpp
@@ -7,7 +7,7 @@
 
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;
-using namespace ABI::AdaptiveCards::Rendering::Uwp;
+using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::Foundation::Collections;
 using namespace ABI::Windows::UI::Xaml;
 using namespace ABI::Windows::UI::Xaml::Controls;

--- a/source/uwp/Renderer/lib/AdaptiveActionSet.h
+++ b/source/uwp/Renderer/lib/AdaptiveActionSet.h
@@ -14,10 +14,10 @@ namespace AdaptiveCards
         {
             class DECLSPEC_UUID("d6031009-7039-4735-bd07-ab6d99b29f03") AdaptiveActionSet
                 : public Microsoft::WRL::RuntimeClass<Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
-                                                      ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveActionSet,
-                                                      ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement,
+                                                      ABI::AdaptiveNamespace::IAdaptiveActionSet,
+                                                      ABI::AdaptiveNamespace::IAdaptiveCardElement,
                                                       Microsoft::WRL::CloakedIid<ITypePeek>,
-                                                      Microsoft::WRL::CloakedIid<AdaptiveCards::Rendering::Uwp::AdaptiveCardElementBase>>
+                                                      Microsoft::WRL::CloakedIid<AdaptiveNamespace::AdaptiveCardElementBase>>
             {
                 InspectableClass(RuntimeClass_AdaptiveCards_Rendering_Uwp_AdaptiveActionSet, BaseTrust)
 
@@ -27,16 +27,16 @@ namespace AdaptiveCards
 
                 // IAdaptiveActionSet
                 IFACEMETHODIMP get_Actions(
-                    _COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveActionElement*>** items);
+                    _COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveActionElement*>** items);
 
                 // IAdaptiveCardElement
-                IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveCards::Rendering::Uwp::ElementType* elementType);
+                IFACEMETHODIMP get_ElementType(_Out_ ABI::AdaptiveNamespace::ElementType* elementType);
 
-                IFACEMETHODIMP get_Spacing(_Out_ ABI::AdaptiveCards::Rendering::Uwp::Spacing* spacing)
+                IFACEMETHODIMP get_Spacing(_Out_ ABI::AdaptiveNamespace::Spacing* spacing)
                 {
                     return AdaptiveCardElementBase::get_Spacing(spacing);
                 }
-                IFACEMETHODIMP put_Spacing(_In_ ABI::AdaptiveCards::Rendering::Uwp::Spacing spacing)
+                IFACEMETHODIMP put_Spacing(_In_ ABI::AdaptiveNamespace::Spacing spacing)
                 {
                     return AdaptiveCardElementBase::put_Spacing(spacing);
                 }
@@ -96,7 +96,7 @@ namespace AdaptiveCards
                 void* PeekAt(REFIID riid) override { return PeekHelper(riid, this); }
 
             private:
-                Microsoft::WRL::ComPtr<ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveActionElement*>> m_actions;
+                Microsoft::WRL::ComPtr<ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveActionElement*>> m_actions;
             };
 
             ActivatableClass(AdaptiveActionSet);

--- a/source/uwp/Renderer/lib/AdaptiveActionSetRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveActionSetRenderer.cpp
@@ -9,7 +9,7 @@
 
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;
-using namespace ABI::AdaptiveCards::Rendering::Uwp;
+using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::Foundation;
 
 namespace AdaptiveCards
@@ -36,10 +36,10 @@ namespace AdaptiveCards
 
             HRESULT AdaptiveActionSetRenderer::FromJson(
                 ABI::Windows::Data::Json::IJsonObject* jsonObject,
-                ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveElementParserRegistration* elementParserRegistration,
-                ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveActionParserRegistration* actionParserRegistration,
+                ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration* elementParserRegistration,
+                ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParserRegistration,
                 ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* adaptiveWarnings,
-                ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement** element) noexcept try
+                ABI::AdaptiveNamespace::IAdaptiveCardElement** element) noexcept try
             {
                 return AdaptiveNamespace::FromJson<AdaptiveNamespace::AdaptiveActionSet, AdaptiveSharedNamespace::ActionSet, AdaptiveSharedNamespace::ActionSetParser>(
                     jsonObject, elementParserRegistration, actionParserRegistration, adaptiveWarnings, element);

--- a/source/uwp/Renderer/lib/AdaptiveActionSetRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveActionSetRenderer.h
@@ -12,23 +12,23 @@ namespace AdaptiveCards
         {
             class AdaptiveActionSetRenderer
                 : public Microsoft::WRL::RuntimeClass<Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
-                                                      ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveElementRenderer,
-                                                      ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveElementParser>
+                                                      ABI::AdaptiveNamespace::IAdaptiveElementRenderer,
+                                                      ABI::AdaptiveNamespace::IAdaptiveElementParser>
             {
                 InspectableClass(RuntimeClass_AdaptiveCards_Rendering_Uwp_AdaptiveActionSetRenderer, BaseTrust)
 
                     public : HRESULT RuntimeClassInitialize() noexcept;
 
-                IFACEMETHODIMP Render(_In_ ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement* cardElement,
-                                      _In_ ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveRenderContext* renderContext,
-                                      _In_ ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveRenderArgs* renderArgs,
+                IFACEMETHODIMP Render(_In_ ABI::AdaptiveNamespace::IAdaptiveCardElement* cardElement,
+                                      _In_ ABI::AdaptiveNamespace::IAdaptiveRenderContext* renderContext,
+                                      _In_ ABI::AdaptiveNamespace::IAdaptiveRenderArgs* renderArgs,
                                       _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result) noexcept;
 
                 IFACEMETHODIMP FromJson(ABI::Windows::Data::Json::IJsonObject*,
-                                        ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveElementParserRegistration* elementParsers,
-                                        ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveActionParserRegistration* actionParsers,
+                                        ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration* elementParsers,
+                                        ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration* actionParsers,
                                         ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::AdaptiveWarning*>* adaptiveWarnings,
-                                        ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveCardElement** element) noexcept;
+                                        ABI::AdaptiveNamespace::IAdaptiveCardElement** element) noexcept;
             };
 
             ActivatableClass(AdaptiveActionSetRenderer);

--- a/source/uwp/Renderer/lib/AdaptiveCardRendererComponent.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveCardRendererComponent.cpp
@@ -127,7 +127,7 @@ namespace AdaptiveNamespace
             m_xamlBuilder->SetEnableXamlImageHandling(true);
             try
             {
-                AdaptiveCards::Rendering::Uwp::XamlBuilder::BuildXamlTreeFromAdaptiveCard(adaptiveCard,
+                AdaptiveNamespace::XamlBuilder::BuildXamlTreeFromAdaptiveCard(adaptiveCard,
                                                                                           &xamlTreeRoot,
                                                                                           renderContext.Get(),
                                                                                           m_xamlBuilder);

--- a/source/uwp/Renderer/lib/AsyncOperations.h
+++ b/source/uwp/Renderer/lib/AsyncOperations.h
@@ -95,7 +95,7 @@ protected:
                                                                                     actionSentimentDefaultDictionary.Get(),
                                                                                     m_renderResult.Get()));
 
-                    AdaptiveCards::Rendering::Uwp::XamlBuilder::BuildXamlTreeFromAdaptiveCard(m_card.Get(),
+                    AdaptiveNamespace::XamlBuilder::BuildXamlTreeFromAdaptiveCard(m_card.Get(),
                                                                                               &m_rootXamlElement,
                                                                                               renderContext.Get(),
                                                                                               m_renderer->GetXamlBuilder());

--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -2062,7 +2062,7 @@ namespace AdaptiveNamespace
             THROW_IF_FAILED(ellipse.As(&ellipseAsShape));
 
             SetImageOnUIElement(imageUrl.Get(), ellipse.Get(), resourceResolvers.Get(),
-                               (size == ABI::AdaptiveCards::Rendering::Uwp::ImageSize_Auto),
+                               (size == ABI::AdaptiveNamespace::ImageSize_Auto),
                                parentElement.Get(), ellipseAsShape.Get(), isVisible, &mustHideElement, stretch);
 
             ComPtr<IShape> backgroundEllipseAsShape;
@@ -2139,7 +2139,7 @@ namespace AdaptiveNamespace
 
             bool mustHideElement{true};
             SetImageOnUIElement(imageUrl.Get(), xamlImage.Get(), resourceResolvers.Get(),
-                                (size == ABI::AdaptiveCards::Rendering::Uwp::ImageSize_Auto),
+                                (size == ABI::AdaptiveNamespace::ImageSize_Auto),
                                 parentElement.Get(), frameworkElement.Get(), isVisible, &mustHideElement);
         }
 


### PR DESCRIPTION
Making sure that all references are done as `AdaptiveNamespace.`