### PR TITLE
Fix alwaysBleedSeparators half broken after recent changes.

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -135,17 +135,6 @@ export abstract class CardElement implements ICardObject {
 			},
 			this.separatorOrientation);
 
-		if (AdaptiveCard.alwaysBleedSeparators && renderedSeparator && this.separatorOrientation == Enums.Orientation.Horizontal) {
-			let parentContainer = this.getParentContainer();
-
-			if (parentContainer && parentContainer.getEffectivePadding()) {
-				let parentPhysicalPadding = this.hostConfig.paddingDefinitionToSpacingDefinition(parentContainer.getEffectivePadding());
-
-				renderedSeparator.style.marginLeft = "-" + parentPhysicalPadding.left + "px";
-				renderedSeparator.style.marginRight = "-" + parentPhysicalPadding.right + "px";
-			}
-		}
-
 		return renderedSeparator;
 	}
 
@@ -241,6 +230,25 @@ export abstract class CardElement implements ICardObject {
 
 	protected abstract internalRender(): HTMLElement;
 
+	protected applyPadding() {
+		if (this.separatorElement) {
+			if (AdaptiveCard.alwaysBleedSeparators && this.separatorOrientation == Enums.Orientation.Horizontal && !this.isBleeding()) {
+				let padding = new Shared.PaddingDefinition();
+
+				this.getImmediateSurroundingPadding(padding);
+		
+				let physiaclPadding = this.hostConfig.paddingDefinitionToSpacingDefinition(padding);
+	
+				this.separatorElement.style.marginLeft = "-" + physiaclPadding.left + "px";
+				this.separatorElement.style.marginRight = "-" + physiaclPadding.right + "px";
+			}
+			else {
+				this.separatorElement.style.marginRight = "0";
+				this.separatorElement.style.marginLeft = "0";
+			}
+		}
+	}
+
     /*
      * Called when this element overflows the bottom of the card.
      * maxHeight will be the amount of space still available on the card (0 if
@@ -305,6 +313,10 @@ export abstract class CardElement implements ICardObject {
 
 	abstract getJsonTypeName(): string;
 	abstract renderSpeech(): string;
+
+	isBleeding(): boolean {
+		return false;
+	}
 
 	toJSON() {
 		let result = {};
@@ -499,6 +511,7 @@ export abstract class CardElement implements ICardObject {
 
 	updateLayout(processChildren: boolean = true) {
 		this.updateRenderedElementVisibility();
+		this.applyPadding();
 	}
 
 	indexOf(cardElement: CardElement): number {
@@ -1669,7 +1682,25 @@ export abstract class CardElementContainer extends CardElement {
 	private _selectAction: Action = null;
 
 	protected applyPadding() {
-		// Do nothing in base implementation
+		super.applyPadding();
+
+		if (!this.renderedElement) {
+			return;
+		}
+
+		let physicalPadding = new Shared.SpacingDefinition();
+
+		if (this.getEffectivePadding()) {
+			physicalPadding = this.hostConfig.paddingDefinitionToSpacingDefinition(this.getEffectivePadding());
+		}
+
+		this.renderedElement.style.paddingTop = physicalPadding.top + "px";
+		this.renderedElement.style.paddingRight = physicalPadding.right + "px";
+		this.renderedElement.style.paddingBottom = physicalPadding.bottom + "px";
+		this.renderedElement.style.paddingLeft = physicalPadding.left + "px";
+
+		this.renderedElement.style.marginRight = "0";
+		this.renderedElement.style.marginLeft = "0";
 	}
 
 	protected getSelectAction(): Action {
@@ -1761,8 +1792,6 @@ export abstract class CardElementContainer extends CardElement {
 
 	updateLayout(processChildren: boolean = true) {
 		super.updateLayout(processChildren);
-
-		this.applyPadding();
 
 		if (processChildren) {
 			for (var i = 0; i < this.getItemCount(); i++) {
@@ -4071,20 +4100,11 @@ export abstract class StylableCardElementContainer extends CardElementContainer 
 	}
 
 	protected applyPadding() {
+		super.applyPadding();
+
 		if (!this.renderedElement) {
 			return;
 		}
-
-		let physicalPadding = new Shared.SpacingDefinition();
-
-		if (this.getEffectivePadding()) {
-			physicalPadding = this.hostConfig.paddingDefinitionToSpacingDefinition(this.getEffectivePadding());
-		}
-
-		this.renderedElement.style.paddingTop = physicalPadding.top + "px";
-		this.renderedElement.style.paddingRight = physicalPadding.right + "px";
-		this.renderedElement.style.paddingBottom = physicalPadding.bottom + "px";
-		this.renderedElement.style.paddingLeft = physicalPadding.left + "px";
 
 		if (this.isBleeding()) {
 			// Bleed into the first parent that does have padding
@@ -4100,15 +4120,6 @@ export abstract class StylableCardElementContainer extends CardElementContainer 
 			if (this.separatorElement && this.separatorOrientation == Enums.Orientation.Horizontal) {
 				this.separatorElement.style.marginLeft = "-" + physicalPadding.left + "px";
 				this.separatorElement.style.marginRight = "-" + physicalPadding.right + "px";
-			}
-		}
-		else {
-			this.renderedElement.style.marginRight = "0";
-			this.renderedElement.style.marginLeft = "0";
-
-			if (this.separatorElement) {
-				this.separatorElement.style.marginRight = "0";
-				this.separatorElement.style.marginLeft = "0";
 			}
 		}
 

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -5721,10 +5721,6 @@ export class AdaptiveCard extends ContainerWithActions {
 		return false;
 	}
 
-	protected get allowCustomPadding(): boolean {
-		return false;
-	}
-
 	protected get allowCustomStyle() {
 		return this.hostConfig.adaptiveCard && this.hostConfig.adaptiveCard.allowCustomStyle;
 	}

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -237,10 +237,10 @@ export abstract class CardElement implements ICardObject {
 
 				this.getImmediateSurroundingPadding(padding);
 		
-				let physiaclPadding = this.hostConfig.paddingDefinitionToSpacingDefinition(padding);
+				let physicalPadding = this.hostConfig.paddingDefinitionToSpacingDefinition(padding);
 	
-				this.separatorElement.style.marginLeft = "-" + physiaclPadding.left + "px";
-				this.separatorElement.style.marginRight = "-" + physiaclPadding.right + "px";
+				this.separatorElement.style.marginLeft = "-" + physicalPadding.left + "px";
+				this.separatorElement.style.marginRight = "-" + physicalPadding.right + "px";
 			}
 			else {
 				this.separatorElement.style.marginRight = "0";

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -44,7 +44,7 @@ function createCardObjectInstance<T extends ICardObject>(
 		}
 		else {
 			result.setParent(parent);
-			result.parse(json);
+			result.parse(json, errors);
 
 			tryToFallback = result.shouldFallback();
 		}
@@ -109,7 +109,7 @@ export function createElementInstance(
 export interface ICardObject {
 	shouldFallback(): boolean;
 	setParent(parent: CardElement);
-	parse(json: any);
+	parse(json: any, errors?: Array<HostConfig.IValidationError>);
 }
 
 export type CardElementHeight = "auto" | "stretch";
@@ -3477,7 +3477,20 @@ export class ShowCardAction extends Action {
 	parse(json: any, errors?: Array<HostConfig.IValidationError>) {
 		super.parse(json, errors);
 
-		this.card.parse(json["card"], errors);
+		let jsonCard = json["card"];
+
+		if (jsonCard) {
+			this.card.parse(jsonCard, errors);
+		}
+		else {
+			raiseParseError(
+				{
+					error: Enums.ValidationError.PropertyCantBeNull,
+					message: "An Action.ShowCard must have its \"card\" property set to a valid AdaptiveCard object."
+				},
+				errors
+			);
+		}
 	}
 
 	setParent(value: CardElement) {
@@ -5449,7 +5462,7 @@ export abstract class ContainerWithActions extends Container {
 	parse(json: any, errors?: Array<HostConfig.IValidationError>) {
 		super.parse(json, errors);
 
-		this._actionCollection.parse(json["actions"]);
+		this._actionCollection.parse(json["actions"], errors);
 	}
 
 	validate(): Array<HostConfig.IValidationError> {

--- a/source/nodejs/adaptivecards/src/utils.ts
+++ b/source/nodejs/adaptivecards/src/utils.ts
@@ -84,6 +84,7 @@ export function parseHostConfigEnum(targetEnum: { [s: number]: string }, value: 
 export function renderSeparation(separationDefinition: Shared.ISeparationDefinition, orientation: Enums.Orientation): HTMLElement {
 	if (separationDefinition.spacing > 0 || separationDefinition.lineThickness > 0) {
 		let separator = document.createElement("div");
+		separator.className = "ac-" + (orientation == Enums.Orientation.Horizontal ? "horizontal" : "vertical") + "-separator";
 
 		if (orientation == Enums.Orientation.Horizontal) {
 			if (separationDefinition.lineThickness) {


### PR DESCRIPTION
Fix a regression introduced by full bleeding support. Works better than before though thanks to the full bleeding implementation: now separators will bleed into the first parent that has padding instead of only into their direct parent. This produces more predictable results.

Try this payload:
```
{
	"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
	"type": "AdaptiveCard",
	"version": "1.0",
	"body": [
		{
			"type": "TextBlock",
            "text": "First element of the card"
        },
		{
			"type": "TextBlock",
            "separator": true,
            "text": "Second element of the card"
        },
        {
            "type": "Container",
            "separator": true,
			"items": [
				{
					"type": "TextBlock",
					"text": "First element in the Container with default style"
				},
				{
					"type": "TextBlock",
                    "separator": true,
					"text": "Second element in the Container with default style"
				}
			]
		},
        {
            "type": "Container",
            "style": "emphasis",
            "separator": true,
			"items": [
				{
					"type": "TextBlock",
					"text": "First element in the Container with emphasis style"
				},
				{
					"type": "TextBlock",
                    "separator": true,
					"text": "Second element in the Container with emphasis style"
				}
			]
		},
        {
            "type": "ColumnSet",
            "separator": true,
            "style": "emphasis",
            "columns": [
                {
                    "width": 1,
                    "items": [
                        {
                            "type": "TextBlock",
                            "text": "First"
                        },
                        {
                            "type": "TextBlock",
                            "separator": true,
                            "text": "Second"
                        }
                    ]
                },
                {
                    "width": 1,
                    "items": [
                        {
                            "type": "TextBlock",
                            "text": "First"
                        },
                        {
                            "type": "TextBlock",
                            "text": "Second"
                        }
                    ]
                }
            ]
        }
	]
}
```

It will render as follows:
![image](https://user-images.githubusercontent.com/1334689/51626530-95777c00-1ef4-11e9-80e4-7e94138b0d6a.png)
