### PR TITLE
Add maxWidth parameter for image loader to support vector images on Android.

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/AdaptiveCardRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/AdaptiveCardRenderer.java
@@ -51,9 +51,9 @@ public class AdaptiveCardRenderer
         private Context m_context;
         private LinearLayout m_layout;
 
-        public BackgroundImageLoaderAsync(RenderedAdaptiveCard renderedCard, Context context, LinearLayout layout, String imageBaseUrl)
+        public BackgroundImageLoaderAsync(RenderedAdaptiveCard renderedCard, Context context, LinearLayout layout, String imageBaseUrl, int maxWidth)
         {
-            super(renderedCard, imageBaseUrl);
+            super(renderedCard, imageBaseUrl, maxWidth);
 
             m_context = context;
             m_layout = layout;
@@ -206,7 +206,12 @@ public class AdaptiveCardRenderer
         String imageUrl = adaptiveCard.GetBackgroundImage();
         if (!imageUrl.isEmpty())
         {
-            BackgroundImageLoaderAsync loaderAsync = new BackgroundImageLoaderAsync(renderedCard, context, layout, hostConfig.GetImageBaseUrl());
+            BackgroundImageLoaderAsync loaderAsync = new BackgroundImageLoaderAsync(
+                    renderedCard,
+                    context,
+                    layout,
+                    hostConfig.GetImageBaseUrl(),
+                    context.getResources().getDisplayMetrics().widthPixels);
 
             IOnlineImageLoader onlineImageLoader = CardRendererRegistration.getInstance().getOnlineImageLoader();
             if(onlineImageLoader != null)

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/GenericImageLoaderAsync.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/GenericImageLoaderAsync.java
@@ -24,11 +24,18 @@ public abstract class GenericImageLoaderAsync extends AsyncTask<String, Void, Ht
     String m_imageBaseUrl;
     IOnlineImageLoader m_onlineImageLoader = null;
     IDataUriImageLoader m_dataUriImageLoader = null;
+    int m_maxWidth;
 
     GenericImageLoaderAsync(RenderedAdaptiveCard renderedCard, String imageBaseUrl)
     {
+        this(renderedCard, imageBaseUrl, -1);
+    }
+
+    GenericImageLoaderAsync(RenderedAdaptiveCard renderedCard, String imageBaseUrl, int maxWidth)
+    {
         m_renderedCard = renderedCard;
         m_imageBaseUrl = imageBaseUrl;
+        m_maxWidth = maxWidth;
     }
 
     // Main function to try different ways to load an image
@@ -43,7 +50,15 @@ public abstract class GenericImageLoaderAsync extends AsyncTask<String, Void, Ht
             {
                 if( m_dataUriImageLoader != null )
                 {
-                    return m_dataUriImageLoader.loadDataUriImage(path, this);
+                    if (m_maxWidth != -1)
+                    {
+                        return m_dataUriImageLoader.loadDataUriImage(path, this, m_maxWidth);
+                    }
+                    else
+                    {
+                        return m_dataUriImageLoader.loadDataUriImage(path, this);
+                    }
+
                 }
                 else
                 {

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/IDataUriImageLoader.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/IDataUriImageLoader.java
@@ -7,4 +7,5 @@ import io.adaptivecards.renderer.http.HttpRequestResult;
 public interface IDataUriImageLoader
 {
     HttpRequestResult<Bitmap> loadDataUriImage(String url, GenericImageLoaderAsync loader) throws Exception;
+    HttpRequestResult<Bitmap> loadDataUriImage(String url, GenericImageLoaderAsync loader, int maxWidth) throws Exception;
 }

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/InnerImageLoaderAsync.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/InnerImageLoaderAsync.java
@@ -11,7 +11,12 @@ public abstract class InnerImageLoaderAsync extends GenericImageLoaderAsync
 
     public InnerImageLoaderAsync(RenderedAdaptiveCard renderedCard, View containerView, String imageBaseUrl)
     {
-        super(renderedCard, imageBaseUrl);
+        this(renderedCard, containerView, imageBaseUrl, -1);
+    }
+
+    public InnerImageLoaderAsync(RenderedAdaptiveCard renderedCard, View containerView, String imageBaseUrl, int maxWidth)
+    {
+        super(renderedCard, imageBaseUrl, maxWidth);
 
         m_view = containerView;
     }

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/action/ActionElementRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/action/ActionElementRenderer.java
@@ -182,7 +182,7 @@ public class ActionElementRenderer implements IBaseActionElementRenderer
 
         protected ActionElementRendererIconImageLoaderAsync(RenderedAdaptiveCard renderedCard, View containerView, String imageBaseUrl, IconPlacement iconPlacement, long iconSize)
         {
-            super(renderedCard, containerView, imageBaseUrl);
+            super(renderedCard, containerView, imageBaseUrl, containerView.getResources().getDisplayMetrics().widthPixels);
             m_iconPlacement = iconPlacement;
             m_iconSize = iconSize;
         }

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/TextInputRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/TextInputRenderer.java
@@ -122,7 +122,7 @@ public class TextInputRenderer extends BaseCardElementRenderer
             m_renderedAdaptiveCard = renderedCard;
             m_action = action;
         }
-        
+
         @Override
         public boolean onKey(View view, int i, KeyEvent keyEvent) {
             if(view.getTag() == m_tag) {
@@ -380,7 +380,7 @@ public class TextInputRenderer extends BaseCardElementRenderer
 
         protected InlineActionIconImageLoaderAsync(RenderedAdaptiveCard renderedCard, View containerView, String url, EditText editText)
         {
-            super(renderedCard, containerView, url);
+            super(renderedCard, containerView, url, containerView.getResources().getDisplayMetrics().widthPixels);
             m_editText = editText;
         }
 

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ImageRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ImageRenderer.java
@@ -58,9 +58,25 @@ public class ImageRenderer extends BaseCardElementRenderer
 
     private class ImageRendererImageLoaderAsync extends InnerImageLoaderAsync
     {
-        ImageRendererImageLoaderAsync(RenderedAdaptiveCard renderedCard, ImageView imageView, String imageBaseUrl, ImageStyle imageStyle, int backgroundColor)
+        ImageRendererImageLoaderAsync(
+            RenderedAdaptiveCard renderedCard,
+            ImageView imageView,
+            String imageBaseUrl,
+            ImageStyle imageStyle,
+            int backgroundColor)
         {
-            super(renderedCard, imageView, imageBaseUrl);
+            this(renderedCard, imageView, imageBaseUrl, imageStyle, backgroundColor, -1);
+        }
+
+        ImageRendererImageLoaderAsync(
+            RenderedAdaptiveCard renderedCard,
+            ImageView imageView,
+            String imageBaseUrl,
+            ImageStyle imageStyle,
+            int backgroundColor,
+            int maxWidth)
+        {
+            super(renderedCard, imageView, imageBaseUrl, maxWidth);
             m_imageStyle = imageStyle;
             m_backgroundColor = backgroundColor;
         }
@@ -96,6 +112,20 @@ public class ImageRenderer extends BaseCardElementRenderer
 
         private ImageStyle m_imageStyle;
         private int m_backgroundColor;
+    }
+
+    private static int getImageSizeLimit(Context context, ImageSize imageSize, ImageSizesConfig imageSizesConfig) {
+        int imageSizeLimit = context.getResources().getDisplayMetrics().widthPixels;
+
+        if (imageSize == ImageSize.Small) {
+            imageSizeLimit = Util.dpToPixels(context, imageSizesConfig.getSmallSize());
+        } else if (imageSize == ImageSize.Medium) {
+            imageSizeLimit = Util.dpToPixels(context, imageSizesConfig.getMediumSize());
+        } else if (imageSize == ImageSize.Large) {
+            imageSizeLimit = Util.dpToPixels(context, imageSizesConfig.getLargeSize());
+        }
+
+        return imageSizeLimit;
     }
 
     private static void setImageSize(Context context, ImageView imageView, ImageSize imageSize, ImageSizesConfig imageSizesConfig) {
@@ -169,7 +199,14 @@ public class ImageRenderer extends BaseCardElementRenderer
             imageView.setBackgroundColor(backgroundColor);
         }
 
-        ImageRendererImageLoaderAsync imageLoaderAsync = new ImageRendererImageLoaderAsync(renderedCard, imageView, hostConfig.GetImageBaseUrl(), image.GetImageStyle(), backgroundColor);
+        int imageSizeLimit = getImageSizeLimit(context, image.GetImageSize(), hostConfig.GetImageSizes());
+        ImageRendererImageLoaderAsync imageLoaderAsync = new ImageRendererImageLoaderAsync(
+            renderedCard,
+            imageView,
+            hostConfig.GetImageBaseUrl(),
+            image.GetImageStyle(),
+            backgroundColor,
+            imageSizeLimit);
 
         IOnlineImageLoader onlineImageLoader = CardRendererRegistration.getInstance().getOnlineImageLoader();
         if (onlineImageLoader != null)

--- a/source/android/mobile/build.gradle
+++ b/source/android/mobile/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     })
     implementation 'com.android.support:appcompat-v7:26.1.0'
     implementation 'com.android.support:design:26.1.0'
+    implementation 'com.pixplicity.sharp:library:1.1.0'
     testImplementation 'junit:junit:4.12'
     implementation project(':adaptivecards')
 }

--- a/source/android/mobile/samples/v1.1/Scenarios/Image.SvgDataUri.json
+++ b/source/android/mobile/samples/v1.1/Scenarios/Image.SvgDataUri.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+	"type": "AdaptiveCard",
+	"version": "1.0",
+	"body": [
+		{
+			"type": "Image",
+			"url": "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath d='M224%20387.814V512L32 320l192-192v126.912C447.375 260.152 437.794 103.016 380.93 0 521.287 151.707 491.48 394.785 224 387.814z'/%3E%3C/svg%3E"
+		}
+	]
+}

--- a/source/android/mobile/src/main/java/io/adaptivecards/adaptivecardssample/ImageUtil.java
+++ b/source/android/mobile/src/main/java/io/adaptivecards/adaptivecardssample/ImageUtil.java
@@ -1,0 +1,26 @@
+package io.adaptivecards.adaptivecardssample;
+
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
+
+public class ImageUtil
+{
+    public static Bitmap drawableToBitmap(Drawable drawable, int maxWidth)
+    {
+        if (drawable instanceof BitmapDrawable)
+        {
+            return ((BitmapDrawable)drawable).getBitmap();
+        }
+        else
+        {
+            int height = (int)((float)maxWidth * ((float)drawable.getIntrinsicHeight() / (float)drawable.getIntrinsicWidth()));
+            Bitmap bitmap = Bitmap.createBitmap(maxWidth, height, Bitmap.Config.ARGB_8888);
+            Canvas canvas = new Canvas(bitmap);
+            drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
+            drawable.draw(canvas);
+            return bitmap;
+        }
+    }
+}


### PR DESCRIPTION
We want to support svg images, so we need a width parameter sent to image loader to decide the size of the svg image.