### PR TITLE
[UWP] Fix leaking cards

### DIFF
--- a/source/uwp/AdaptiveCardTestApp/Pages/TestResultsPage.xaml.cs
+++ b/source/uwp/AdaptiveCardTestApp/Pages/TestResultsPage.xaml.cs
@@ -22,13 +22,17 @@ namespace AdaptiveCardTestApp.Pages
             this.InitializeComponent();
         }
 
-        protected override void OnNavigatedTo(NavigationEventArgs e)
+        protected override async void OnNavigatedTo(NavigationEventArgs e)
         {
             var runningTestsViewModel = e.Parameter as RunningTestsViewModel;
             if (runningTestsViewModel == null)
             {
                 throw new InvalidOperationException("Running tests view model not provided");
             }
+
+            // Force a Garbage Collection to make sure that the WeakReferences as invalidated.
+            GC.Collect(GC.MaxGeneration, GCCollectionMode.Default, blocking: true);
+            await System.Threading.Tasks.Task.Delay(1000);
 
             var model = new TestResultsViewModel(runningTestsViewModel.Results);
             DataContext = model;
@@ -41,7 +45,8 @@ namespace AdaptiveCardTestApp.Pages
                 model.ImageAndJsonFailed,
                 model.FailedButSourceWasChanged,
                 model.PassedButSourceWasChanged,
-                model.New
+                model.Leaked,
+                model.New,
             };
 
             if (model.Failed.Results.Count > 0)
@@ -67,6 +72,11 @@ namespace AdaptiveCardTestApp.Pages
             else if (model.PassedButSourceWasChanged.Results.Count > 0)
             {
                 ListViewCategories.SelectedItem = model.PassedButSourceWasChanged;
+            }
+
+            else if (model.Leaked.Results.Count > 0)
+            {
+                ListViewCategories.SelectedItem = model.Leaked;
             }
 
             else if (model.New.Results.Count > 0)

--- a/source/uwp/AdaptiveCardTestApp/ViewModels/TestResultsViewModel.cs
+++ b/source/uwp/AdaptiveCardTestApp/ViewModels/TestResultsViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using UWPTestLibrary;
 
@@ -13,6 +13,7 @@ namespace AdaptiveCardTestApp.ViewModels
         public TestResultsCategoryViewModel FailedButSourceWasChanged { get; }
         public TestResultsCategoryViewModel PassedButSourceWasChanged { get; }
         public TestResultsCategoryViewModel New { get; }
+        public TestResultsCategoryViewModel Leaked { get; }
 
         public TestResultsViewModel(IEnumerable<TestResultViewModel> results)
         {
@@ -22,6 +23,7 @@ namespace AdaptiveCardTestApp.ViewModels
             ImageAndJsonFailed = new TestResultsCategoryViewModel("Image Comparison and Json Roundtrip Failed", results.Where(i => i.Status == TestStatus.ImageAndJsonFailed));
             FailedButSourceWasChanged = new TestResultsCategoryViewModel("Failed/source changed", results.Where(i => i.Status == TestStatus.FailedButSourceWasChanged));
             PassedButSourceWasChanged = new TestResultsCategoryViewModel("Passed/source changed", results.Where(i => i.Status == TestStatus.PassedButSourceWasChanged));
+            Leaked = new TestResultsCategoryViewModel("Leaked", results.Where(i => i.TestResult.IsLeaked == true));
             New = new TestResultsCategoryViewModel("New", results.Where(i => i.Status == TestStatus.New));
 
             foreach (var r in results)
@@ -43,6 +45,7 @@ namespace AdaptiveCardTestApp.ViewModels
                 FailedButSourceWasChanged.Results.Remove(item);
                 PassedButSourceWasChanged.Results.Remove(item);
                 New.Results.Remove(item);
+                Leaked.Results.Remove(item);
 
                 switch (item.Status)
                 {

--- a/source/uwp/Renderer/lib/AdaptiveActionInvoker.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveActionInvoker.cpp
@@ -18,14 +18,25 @@ AdaptiveNamespaceStart
     HRESULT AdaptiveActionInvoker::RuntimeClassInitialize(
         RenderedAdaptiveCard* renderResult) noexcept try
     {
-        m_renderResult = renderResult;
-        return S_OK;
-    } CATCH_RETURN;
+        ComPtr<RenderedAdaptiveCard> strongRenderResult = renderResult;
+        return strongRenderResult.AsWeak(&m_weakRenderResult);
+    }
+    CATCH_RETURN;
 
     _Use_decl_annotations_
     HRESULT AdaptiveActionInvoker::SendActionEvent(IAdaptiveActionElement* actionElement)
     {
-        return m_renderResult->SendActionEvent(actionElement);
+        ComPtr<IRenderedAdaptiveCard> strongRenderResult;
+        RETURN_IF_FAILED(m_weakRenderResult.As(&strongRenderResult));
+        if (strongRenderResult != nullptr)
+        {
+            ComPtr<RenderedAdaptiveCard> renderResult = PeekInnards<RenderedAdaptiveCard>(strongRenderResult);
+            if (renderResult != nullptr)
+            {
+                RETURN_IF_FAILED(renderResult->SendActionEvent(actionElement));
+            }
+        }
+        return S_OK;
     }
 
 AdaptiveNamespaceEnd

--- a/source/uwp/Renderer/lib/AdaptiveActionInvoker.h
+++ b/source/uwp/Renderer/lib/AdaptiveActionInvoker.h
@@ -19,7 +19,7 @@ AdaptiveNamespaceStart
         IFACEMETHODIMP SendActionEvent(_In_ ABI::AdaptiveNamespace::IAdaptiveActionElement* actionElement);
 
     private:
-        Microsoft::WRL::ComPtr<AdaptiveNamespace::RenderedAdaptiveCard> m_renderResult;
+        Microsoft::WRL::WeakRef m_weakRenderResult;
     };
 
     ActivatableClass(AdaptiveActionInvoker);

--- a/source/uwp/Renderer/lib/AdaptiveMediaEventInvoker.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveMediaEventInvoker.cpp
@@ -18,14 +18,25 @@ AdaptiveNamespaceStart
     HRESULT AdaptiveMediaEventInvoker::RuntimeClassInitialize(
         RenderedAdaptiveCard* renderResult) noexcept try
     {
-        m_renderResult = renderResult;
-        return S_OK;
-    } CATCH_RETURN;
+        ComPtr<RenderedAdaptiveCard> strongRenderResult = renderResult;
+        return strongRenderResult.AsWeak(&m_weakRenderResult);
+    }
+    CATCH_RETURN;
 
     _Use_decl_annotations_
     HRESULT AdaptiveMediaEventInvoker::SendMediaClickedEvent(IAdaptiveMedia* mediaElement)
     {
-        return m_renderResult->SendMediaClickedEvent(mediaElement);
+        ComPtr<IRenderedAdaptiveCard> strongRenderResult;
+        RETURN_IF_FAILED(m_weakRenderResult.As(&strongRenderResult));
+        if (strongRenderResult != nullptr)
+        {
+            ComPtr<RenderedAdaptiveCard> renderResult = PeekInnards<RenderedAdaptiveCard>(strongRenderResult);
+            if (renderResult != nullptr)
+            {
+                RETURN_IF_FAILED(renderResult->SendMediaClickedEvent(mediaElement));
+            }
+        }
+        return S_OK;
     }
 
 AdaptiveNamespaceEnd

--- a/source/uwp/Renderer/lib/AdaptiveMediaEventInvoker.h
+++ b/source/uwp/Renderer/lib/AdaptiveMediaEventInvoker.h
@@ -19,7 +19,7 @@ AdaptiveNamespaceStart
         IFACEMETHODIMP SendMediaClickedEvent(_In_ ABI::AdaptiveNamespace::IAdaptiveMedia* mediaElement);
 
     private:
-        Microsoft::WRL::ComPtr<AdaptiveNamespace::RenderedAdaptiveCard> m_renderResult;
+        Microsoft::WRL::WeakRef m_weakRenderResult;
     };
 
     ActivatableClass(AdaptiveMediaEventInvoker);

--- a/source/uwp/Renderer/lib/AdaptiveRenderContext.h
+++ b/source/uwp/Renderer/lib/AdaptiveRenderContext.h
@@ -6,10 +6,12 @@
 #include "AdaptiveMediaEventInvoker.h"
 
 AdaptiveNamespaceStart
-    class AdaptiveRenderContext :
+    class DECLSPEC_UUID("F29649FF-C718-4F94-8F39-2415C86BE77E") AdaptiveRenderContext :
         public Microsoft::WRL::RuntimeClass<
         Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
-        ABI::AdaptiveNamespace::IAdaptiveRenderContext>
+        Microsoft::WRL::Implements<IWeakReferenceSource>,
+        ABI::AdaptiveNamespace::IAdaptiveRenderContext,
+        Microsoft::WRL::CloakedIid<ITypePeek>>
     {
         AdaptiveRuntime(AdaptiveRenderContext)
 
@@ -33,10 +35,15 @@ AdaptiveNamespaceStart
         IFACEMETHODIMP AddError(_In_ ABI::AdaptiveNamespace::ErrorStatusCode statusCode, _In_ HSTRING message);
         IFACEMETHODIMP AddWarning(_In_ ABI::AdaptiveNamespace::WarningStatusCode statusCode, _In_ HSTRING message);
 
+        HRESULT GetRenderResult(_COM_Outptr_ AdaptiveNamespace::RenderedAdaptiveCard** renderResult);
+
+        // ITypePeek method
+        void* PeekAt(REFIID riid) override { return PeekHelper(riid, this); }
+
     private:
         Microsoft::WRL::ComPtr<ABI::AdaptiveNamespace::IAdaptiveHostConfig> m_hostConfig;
         Microsoft::WRL::ComPtr<ABI::AdaptiveNamespace::IAdaptiveElementRendererRegistration> m_elementRendererRegistration;
-        Microsoft::WRL::ComPtr<AdaptiveNamespace::RenderedAdaptiveCard> m_renderResult;
+        Microsoft::WRL::WeakRef m_weakRenderResult;
         Microsoft::WRL::ComPtr<AdaptiveNamespace::AdaptiveActionInvoker> m_actionInvoker;
         Microsoft::WRL::ComPtr<AdaptiveNamespace::AdaptiveMediaEventInvoker> m_mediaEventInvoker;
         Microsoft::WRL::ComPtr<ABI::AdaptiveNamespace::IAdaptiveCardResourceResolvers> m_resourceResolvers;

--- a/source/uwp/Renderer/lib/RenderedAdaptiveCard.h
+++ b/source/uwp/Renderer/lib/RenderedAdaptiveCard.h
@@ -6,9 +6,11 @@
 #include "AdaptiveInputs.h"
 
 AdaptiveNamespaceStart
-    class RenderedAdaptiveCard :
+    class DECLSPEC_UUID("F25E0D36-0B5B-4398-AFC8-F84105EC46A2") RenderedAdaptiveCard :
         public Microsoft::WRL::RuntimeClass<
             Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
+            Microsoft::WRL::Implements<IWeakReferenceSource>,
+            Microsoft::WRL::CloakedIid<ITypePeek>,
             Microsoft::WRL::Implements<ABI::AdaptiveNamespace::IRenderedAdaptiveCard>>
     {
         AdaptiveRuntime(RenderedAdaptiveCard)
@@ -41,6 +43,12 @@ AdaptiveNamespaceStart
 
         IFACEMETHODIMP get_Errors(_COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveError*>** value);
         IFACEMETHODIMP get_Warnings(_COM_Outptr_ ABI::Windows::Foundation::Collections::IVector<ABI::AdaptiveNamespace::IAdaptiveWarning*>** value);
+
+        // ITypePeek method
+        void *PeekAt(REFIID riid) override
+        {
+            return PeekHelper(riid, this);
+        }
 
         HRESULT AddInputValue(ABI::AdaptiveNamespace::IAdaptiveInputValue* inputValue);
         void SetFrameworkElement(ABI::Windows::UI::Xaml::IFrameworkElement* value);

--- a/source/uwp/UWPTestLibrary/RenderTestHelpers.cs
+++ b/source/uwp/UWPTestLibrary/RenderTestHelpers.cs
@@ -56,6 +56,7 @@ namespace UWPTestLibrary
             FrameworkElement xaml = null;
             double cardWidth = 400;
             WeakReference weakRefCard = null;
+
             try
             {
                 AdaptiveHostConfig hostConfig = AdaptiveHostConfig.FromJsonString(hostConfigFile.Contents).HostConfig;

--- a/source/uwp/UWPTestLibrary/RenderedTestResult.cs
+++ b/source/uwp/UWPTestLibrary/RenderedTestResult.cs
@@ -1,4 +1,3 @@
-﻿using AdaptiveCards.Rendering.Uwp;
 using System;
 using Windows.UI.Xaml;
 

--- a/source/uwp/UWPTestLibrary/TestResultViewModel.cs
+++ b/source/uwp/UWPTestLibrary/TestResultViewModel.cs
@@ -31,11 +31,10 @@ namespace UWPTestLibrary
         public StorageFile ExpectedRoundtrippedJsonFile { get; set; }
 
         public string ActualError { get; set; }
-
         public StorageFile ActualImageFile { get; set; }
         public StorageFile ActualRoundTrippedJsonFile { get; set; }
         public RenderedTestResult TestResult { get; set; }
-        public UIElement XamlCard { get; set; }
+        public UIElement XamlCard { get { return TestResult?.Tree; } }
 
         public bool DidHostConfigChange => _oldHostConfigHash != null && _oldHostConfigHash != HostConfigFile.Hash;
         public bool DidCardPayloadChange => _oldCardHash != null && _oldCardHash != CardFile.Hash;

--- a/source/uwp/Visualizer/ViewModel/DocumentViewModel.cs
+++ b/source/uwp/Visualizer/ViewModel/DocumentViewModel.cs
@@ -25,6 +25,7 @@ namespace AdaptiveCardVisualizer.ViewModel
 
         private DocumentViewModel(MainPageViewModel mainPageViewModel) : base(mainPageViewModel) { }
 
+        private RenderedAdaptiveCard _renderedAdaptiveCard;
         private UIElement _renderedCard;
         public UIElement RenderedCard
         {
@@ -81,11 +82,11 @@ namespace AdaptiveCardVisualizer.ViewModel
                 {
                     AdaptiveCardParseResult parseResult = AdaptiveCard.FromJson(jsonObject);
 
-                    RenderedAdaptiveCard renderResult = _renderer.RenderAdaptiveCard(parseResult.AdaptiveCard);
-                    if (renderResult.FrameworkElement != null)
+                    _renderedAdaptiveCard = _renderer.RenderAdaptiveCard(parseResult.AdaptiveCard);
+                    if (_renderedAdaptiveCard.FrameworkElement != null)
                     {
-                        RenderedCard = renderResult.FrameworkElement;
-                        renderResult.Action += async (sender, e) =>
+                        RenderedCard = _renderedAdaptiveCard.FrameworkElement;
+                        _renderedAdaptiveCard.Action += async (sender, e) =>
                         {
                             var m_actionDialog = new ContentDialog();
 
@@ -110,7 +111,7 @@ namespace AdaptiveCardVisualizer.ViewModel
 
                         if (!MainPageViewModel.HostConfigEditor.HostConfig.Media.AllowInlinePlayback)
                         {
-                            renderResult.MediaClicked += async (sender, e) =>
+                            _renderedAdaptiveCard.MediaClicked += async (sender, e) =>
                             {
                                 var onPlayDialog = new ContentDialog();
                                 onPlayDialog.Content = "MediaClickedEvent:";
@@ -142,7 +143,7 @@ namespace AdaptiveCardVisualizer.ViewModel
                             Type = ErrorViewModelType.Error
                         });
                     }
-                    foreach (var error in renderResult.Errors)
+                    foreach (var error in _renderedAdaptiveCard.Errors)
                     {
                         newErrors.Add(new ErrorViewModel()
                         {
@@ -159,7 +160,7 @@ namespace AdaptiveCardVisualizer.ViewModel
                         });
                     }
 
-                    foreach (var error in renderResult.Warnings)
+                    foreach (var error in _renderedAdaptiveCard.Warnings)
                     {
                         newErrors.Add(new ErrorViewModel()
                         {
@@ -203,7 +204,7 @@ namespace AdaptiveCardVisualizer.ViewModel
 
             if (args.Action is AdaptiveSubmitAction)
             {
-                answer += "\nData: " + (args.Action as AdaptiveSubmitAction).DataJson.Stringify();
+                answer += "\nData: " + (args.Action as AdaptiveSubmitAction).DataJson?.Stringify();
             }
             else if (args.Action is AdaptiveOpenUrlAction)
             {


### PR DESCRIPTION
***This is a minor breaking change***

There is reference cycle between the `RenderedAdaptiveCard`, the root `FrameworkElement`, the `ActionInvokers` and the `RenderContexts` causing the whole chain to leak.

In order to avoid this, the `ActionInvokers` and the `RenderContexts` will have a `WeakReference` to the `RenderedAdaptiveCard`.

For clients this means that the host needs to hold on to their `RenderedAdaptiveCard` if they need their actions to be invoked while the card is active. It's good practice anyway but this is forcing it.
