### PR TITLE
Add two small features to the UWP test app

### DIFF
--- a/source/uwp/AdaptiveCardTestApp/Pages/StartPage.xaml
+++ b/source/uwp/AdaptiveCardTestApp/Pages/StartPage.xaml
@@ -23,18 +23,24 @@
 
             <ListView
                 x:Name="ListViewHostConfigs"
-                Header="Host configs"
                 SelectionMode="Multiple"
                 ItemsSource="{Binding HostConfigs}"
-                DisplayMemberPath="Name"/>
+                DisplayMemberPath="Name">
+                <ListView.Header>
+                    <Button Content="Host configs" Click="HostButton_Click"/>
+                </ListView.Header>
+            </ListView>
 
             <ListView
                 x:Name="ListViewCards"
                 Grid.Column="2"
-                Header="Cards"
                 SelectionMode="Multiple"
                 ItemsSource="{Binding Cards}"
-                DisplayMemberPath="Name"/>
+                DisplayMemberPath="Name">
+                <ListView.Header>
+                    <Button Content="Cards" Click="CardButton_Click"/>
+                </ListView.Header>
+            </ListView>
 
             <CheckBox 
                 x:Name="TimelineCheckBox"

--- a/source/uwp/AdaptiveCardTestApp/Pages/StartPage.xaml.cs
+++ b/source/uwp/AdaptiveCardTestApp/Pages/StartPage.xaml.cs
@@ -105,5 +105,40 @@ namespace AdaptiveCardTestApp.Pages
         {
             ViewModel.AddToTimeline = (TimelineCheckBox.IsChecked == true);
         }
+
+        private bool lastSelectedAllCards = true;
+
+        private void CardButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (lastSelectedAllCards)
+            {
+                foreach (var range in ListViewCards.SelectedRanges)
+                {
+                    ListViewCards.DeselectRange(range);
+                }
+            }
+            else
+            {
+                ListViewCards.SelectAll();
+            }
+            lastSelectedAllCards = !lastSelectedAllCards;
+        }
+
+        private bool lastSelectedAllHosts = true;
+        private void HostButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (lastSelectedAllHosts)
+            {
+                foreach (var range in ListViewHostConfigs.SelectedRanges)
+                {
+                    ListViewHostConfigs.DeselectRange(range);
+                }
+            }
+            else
+            {
+                ListViewHostConfigs.SelectAll();
+            }
+            lastSelectedAllHosts = !lastSelectedAllHosts;
+        }
     }
 }

--- a/source/uwp/AdaptiveCardTestApp/Pages/TestResultsPage.xaml
+++ b/source/uwp/AdaptiveCardTestApp/Pages/TestResultsPage.xaml
@@ -27,12 +27,22 @@
             SelectionMode="None"
             ItemContainerStyle="{StaticResource FullWidthListViewItem}">
             <ListView.Header>
-                <Button
-                    x:Name="ButtonAcceptAll"
-                    Content="Accept all"
-                    Style="{ThemeResource AccentButtonStyle}"
-                    HorizontalAlignment="Stretch"
-                    Click="ButtonAcceptAll_Click"/>
+                <RelativePanel HorizontalAlignment="Right">
+                    <Button
+                        x:Name="ButtonStartOver"
+                        Content="Start over"
+                        Margin="2,2,2,2"
+                        HorizontalAlignment="Stretch"
+                        Click="ButtonStartOver_Click"/>
+                    <Button
+                        x:Name="ButtonAcceptAll"
+                        Content="Accept all"
+                        RelativePanel.RightOf="ButtonStartOver"
+                        Style="{ThemeResource AccentButtonStyle}"
+                        Margin="2,2,2,2"
+                        HorizontalAlignment="Stretch"
+                        Click="ButtonAcceptAll_Click"/>
+                </RelativePanel>
             </ListView.Header>
             <ListView.ItemTemplate>
                 <DataTemplate>

--- a/source/uwp/AdaptiveCardTestApp/Pages/TestResultsPage.xaml.cs
+++ b/source/uwp/AdaptiveCardTestApp/Pages/TestResultsPage.xaml.cs
@@ -110,5 +110,10 @@ namespace AdaptiveCardTestApp.Pages
                 await item.SaveAsNewExpectedAsync();
             }
         }
+
+        private void ButtonStartOver_Click(object sender, RoutedEventArgs e)
+        {
+            Frame.Navigate(typeof(StartPage));
+        }
     }
 }


### PR DESCRIPTION
Make start page host config and test headers clickable to toggle selection. Also add a new button on the results page to allow users to start over again without having to relaunch app.