### PR TITLE
[Android] Enhanced background image support

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/AdaptiveCardRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/AdaptiveCardRenderer.java
@@ -1,18 +1,13 @@
 package io.adaptivecards.renderer;
 
 import android.content.Context;
-import android.graphics.Bitmap;
 import android.graphics.Color;
-import android.graphics.drawable.BitmapDrawable;
 import android.support.v4.app.FragmentManager;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.HorizontalScrollView;
 import android.widget.LinearLayout;
 
-import io.adaptivecards.objectmodel.ActionAlignment;
-import io.adaptivecards.objectmodel.ActionsOrientation;
 import io.adaptivecards.objectmodel.AdaptiveCard;
 import io.adaptivecards.objectmodel.BackgroundImage;
 import io.adaptivecards.objectmodel.BaseActionElement;
@@ -21,12 +16,9 @@ import io.adaptivecards.objectmodel.BaseCardElementVector;
 import io.adaptivecards.objectmodel.ContainerStyle;
 import io.adaptivecards.objectmodel.HeightType;
 import io.adaptivecards.objectmodel.HostConfig;
-import io.adaptivecards.objectmodel.IconPlacement;
-import io.adaptivecards.objectmodel.Spacing;
 import io.adaptivecards.objectmodel.VerticalContentAlignment;
 import io.adaptivecards.renderer.action.ActionElementRenderer;
 import io.adaptivecards.renderer.actionhandler.ICardActionHandler;
-import io.adaptivecards.renderer.http.HttpRequestResult;
 import io.adaptivecards.renderer.registration.CardRendererRegistration;
 
 public class AdaptiveCardRenderer

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/AdaptiveCardRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/AdaptiveCardRenderer.java
@@ -47,37 +47,6 @@ public class AdaptiveCardRenderer
         return s_instance;
     }
 
-    private class BackgroundImageLoaderAsync extends GenericImageLoaderAsync
-    {
-        private Context m_context;
-        private LinearLayout m_layout;
-
-        public BackgroundImageLoaderAsync(RenderedAdaptiveCard renderedCard, Context context, LinearLayout layout, String imageBaseUrl)
-        {
-            super(renderedCard, imageBaseUrl);
-
-            m_context = context;
-            m_layout = layout;
-        }
-
-        @Override
-        protected HttpRequestResult<Bitmap> doInBackground(String... args)
-        {
-            if (args.length == 0)
-            {
-                return null;
-            }
-            return loadImage(args[0], m_context);
-        }
-
-        void onSuccessfulPostExecute(Bitmap bitmap)
-        {
-            BitmapDrawable background = new BitmapDrawable(m_context.getResources(), bitmap);
-            m_layout.setBackground(background);
-            m_layout.bringChildToFront(m_layout.getChildAt(0));
-        }
-    }
-
     public RenderedAdaptiveCard render(Context context, FragmentManager fragmentManager, AdaptiveCard adaptiveCard, ICardActionHandler cardActionHandler)
     {
         return render(context, fragmentManager, adaptiveCard, cardActionHandler, defaultHostConfig);
@@ -207,7 +176,7 @@ public class AdaptiveCardRenderer
         BackgroundImage backgroundImageProperties = adaptiveCard.GetBackgroundImage();
         if (backgroundImageProperties != null && !backgroundImageProperties.GetUrl().isEmpty())
         {
-            BackgroundImageLoaderAsync loaderAsync = new BackgroundImageLoaderAsync(renderedCard, context, layout, hostConfig.GetImageBaseUrl());
+            BackgroundImageLoaderAsync loaderAsync = new BackgroundImageLoaderAsync(renderedCard, context, layout, hostConfig.GetImageBaseUrl(), backgroundImageProperties);
 
             IOnlineImageLoader onlineImageLoader = CardRendererRegistration.getInstance().getOnlineImageLoader();
             if(onlineImageLoader != null)

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/BackgroundImageLoaderAsync.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/BackgroundImageLoaderAsync.java
@@ -1,0 +1,123 @@
+package io.adaptivecards.renderer;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Shader;
+import android.graphics.drawable.BitmapDrawable;
+import android.widget.LinearLayout;
+
+import io.adaptivecards.objectmodel.BackgroundImage;
+import io.adaptivecards.renderer.http.HttpRequestResult;
+
+public class BackgroundImageLoaderAsync extends GenericImageLoaderAsync
+{
+    private Context m_context;
+    private LinearLayout m_layout;
+    private BackgroundImage m_backgroundImageProperties;
+
+    public BackgroundImageLoaderAsync(RenderedAdaptiveCard renderedCard, Context context, LinearLayout layout, String imageBaseUrl, BackgroundImage backgroundImageProperties)
+    {
+        super(renderedCard, imageBaseUrl);
+
+        m_context = context;
+        m_layout = layout;
+        m_backgroundImageProperties = backgroundImageProperties;
+    }
+
+    @Override
+    protected HttpRequestResult<Bitmap> doInBackground(String... args)
+    {
+        if (args.length == 0)
+        {
+            return null;
+        }
+        return loadImage(args[0], m_context);
+    }
+
+    void onSuccessfulPostExecute(Bitmap bitmap)
+    {
+        BitmapDrawable background = new BackgroundImageDrawable(m_context.getResources(), bitmap, m_backgroundImageProperties);
+        m_layout.setBackground(background);
+    }
+
+    private class BackgroundImageDrawable extends BitmapDrawable
+    {
+        private BackgroundImage m_backgroundImageProperties;
+
+        public BackgroundImageDrawable(Resources resources, Bitmap bitmap, BackgroundImage backgroundImageProperties)
+        {
+            super(resources, bitmap);
+            m_backgroundImageProperties = backgroundImageProperties;
+        }
+
+        @Override
+        public void draw(Canvas canvas)
+        {
+            switch (m_backgroundImageProperties.GetMode())
+            {
+                case Repeat:
+                    setTileModeXY(Shader.TileMode.REPEAT, Shader.TileMode.REPEAT);
+                    super.draw(canvas);
+                    break;
+                case RepeatVertically:
+                    tileVertically(canvas);
+                    break;
+                case RepeatHorizontally:
+                    tileHorizontally(canvas);
+                    break;
+                case Stretch:
+                default:
+                    super.draw(canvas);
+                    break;
+            }
+        }
+
+        private void tileHorizontally(Canvas canvas)
+        {
+            float verticalOffset;
+            switch (m_backgroundImageProperties.GetVerticalAlignment())
+            {
+                case Bottom:
+                    verticalOffset = canvas.getHeight() - getBitmap().getHeight();
+                    break;
+                case Center:
+                    verticalOffset = (canvas.getHeight() - getBitmap().getHeight()) / (float) 2;
+                    break;
+                case Top:
+                default:
+                    verticalOffset = 0;
+                    break;
+            }
+
+            for (int x = 0; x < canvas.getWidth(); x += getBitmap().getWidth())
+            {
+                canvas.drawBitmap(getBitmap(), x, verticalOffset, getPaint());
+            }
+        }
+
+        private void tileVertically(Canvas canvas)
+        {
+            float horizontalOffset;
+            switch (m_backgroundImageProperties.GetHorizontalAlignment())
+            {
+                case Right:
+                    horizontalOffset = canvas.getWidth() - getBitmap().getWidth();
+                    break;
+                case Center:
+                    horizontalOffset = (canvas.getWidth() - getBitmap().getWidth()) / (float) 2;
+                    break;
+                case Left:
+                default:
+                    horizontalOffset = 0;
+                    break;
+            }
+
+            for (int y = 0; y < canvas.getHeight(); y += getBitmap().getHeight())
+            {
+                canvas.drawBitmap(getBitmap(), horizontalOffset, y, getPaint());
+            }
+        }
+    }
+}

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ColumnRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ColumnRenderer.java
@@ -11,7 +11,6 @@ import android.widget.LinearLayout;
 
 import io.adaptivecards.objectmodel.BackgroundImage;
 import io.adaptivecards.objectmodel.ContainerStyle;
-import io.adaptivecards.objectmodel.HeightType;
 import io.adaptivecards.objectmodel.VerticalContentAlignment;
 import io.adaptivecards.renderer.BackgroundImageLoaderAsync;
 import io.adaptivecards.renderer.IDataUriImageLoader;
@@ -20,14 +19,12 @@ import io.adaptivecards.renderer.RenderedAdaptiveCard;
 import io.adaptivecards.renderer.Util;
 import io.adaptivecards.renderer.action.ActionElementRenderer;
 import io.adaptivecards.renderer.actionhandler.ICardActionHandler;
-import io.adaptivecards.renderer.inputhandler.IInputHandler;
 import io.adaptivecards.objectmodel.BaseCardElement;
 import io.adaptivecards.objectmodel.HostConfig;
 import io.adaptivecards.objectmodel.Column;
 import io.adaptivecards.renderer.BaseCardElementRenderer;
 import io.adaptivecards.renderer.registration.CardRendererRegistration;
 
-import java.util.Vector;
 import java.util.Locale;
 
 public class ColumnRenderer extends BaseCardElementRenderer
@@ -79,7 +76,7 @@ public class ColumnRenderer extends BaseCardElementRenderer
         verticalContentAlignmentLayout.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
 
         VerticalContentAlignment contentAlignment = column.GetVerticalContentAlignment();
-        switch(contentAlignment)
+        switch (contentAlignment)
         {
             case Center:
                 verticalContentAlignmentLayout.setGravity(Gravity.CENTER_VERTICAL);
@@ -114,13 +111,13 @@ public class ColumnRenderer extends BaseCardElementRenderer
             BackgroundImageLoaderAsync loaderAsync = new BackgroundImageLoaderAsync(renderedCard, context, returnedView, hostConfig.GetImageBaseUrl(), backgroundImageProperties);
 
             IOnlineImageLoader onlineImageLoader = CardRendererRegistration.getInstance().getOnlineImageLoader();
-            if(onlineImageLoader != null)
+            if (onlineImageLoader != null)
             {
                 loaderAsync.registerCustomOnlineImageLoader(onlineImageLoader);
             }
 
             IDataUriImageLoader dataUriImageLoader = CardRendererRegistration.getInstance().getDataUriImageLoader();
-            if(dataUriImageLoader != null)
+            if (dataUriImageLoader != null)
             {
                 loaderAsync.registerCustomDataUriImageLoader(dataUriImageLoader);
             }

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ColumnRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ColumnRenderer.java
@@ -9,9 +9,13 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
 
+import io.adaptivecards.objectmodel.BackgroundImage;
 import io.adaptivecards.objectmodel.ContainerStyle;
 import io.adaptivecards.objectmodel.HeightType;
 import io.adaptivecards.objectmodel.VerticalContentAlignment;
+import io.adaptivecards.renderer.BackgroundImageLoaderAsync;
+import io.adaptivecards.renderer.IDataUriImageLoader;
+import io.adaptivecards.renderer.IOnlineImageLoader;
 import io.adaptivecards.renderer.RenderedAdaptiveCard;
 import io.adaptivecards.renderer.Util;
 import io.adaptivecards.renderer.action.ActionElementRenderer;
@@ -102,6 +106,26 @@ public class ColumnRenderer extends BaseCardElementRenderer
                     hostConfig.GetContainerStyles().getEmphasisPalette().getBackgroundColor() :
                     hostConfig.GetContainerStyles().getDefaultPalette().getBackgroundColor();
             returnedView.setBackgroundColor(Color.parseColor(color));
+        }
+
+        BackgroundImage backgroundImageProperties = column.GetBackgroundImage();
+        if (backgroundImageProperties != null && !backgroundImageProperties.GetUrl().isEmpty())
+        {
+            BackgroundImageLoaderAsync loaderAsync = new BackgroundImageLoaderAsync(renderedCard, context, returnedView, hostConfig.GetImageBaseUrl(), backgroundImageProperties);
+
+            IOnlineImageLoader onlineImageLoader = CardRendererRegistration.getInstance().getOnlineImageLoader();
+            if(onlineImageLoader != null)
+            {
+                loaderAsync.registerCustomOnlineImageLoader(onlineImageLoader);
+            }
+
+            IDataUriImageLoader dataUriImageLoader = CardRendererRegistration.getInstance().getDataUriImageLoader();
+            if(dataUriImageLoader != null)
+            {
+                loaderAsync.registerCustomDataUriImageLoader(dataUriImageLoader);
+            }
+
+            loaderAsync.execute(backgroundImageProperties.GetUrl());
         }
 
         String columnSize = column.GetWidth().toLowerCase(Locale.getDefault());

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ContainerRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ContainerRenderer.java
@@ -19,14 +19,11 @@ import io.adaptivecards.renderer.RenderedAdaptiveCard;
 import io.adaptivecards.renderer.Util;
 import io.adaptivecards.renderer.action.ActionElementRenderer;
 import io.adaptivecards.renderer.actionhandler.ICardActionHandler;
-import io.adaptivecards.renderer.inputhandler.IInputHandler;
 import io.adaptivecards.objectmodel.BaseCardElement;
 import io.adaptivecards.objectmodel.Container;
 import io.adaptivecards.objectmodel.HostConfig;
 import io.adaptivecards.renderer.BaseCardElementRenderer;
 import io.adaptivecards.renderer.registration.CardRendererRegistration;
-
-import java.util.Vector;
 
 public class ContainerRenderer extends BaseCardElementRenderer
 {
@@ -70,7 +67,7 @@ public class ContainerRenderer extends BaseCardElementRenderer
         LinearLayout containerView = new LinearLayout(context);
 
         containerView.setOrientation(LinearLayout.VERTICAL);
-        if(container.GetHeight() == HeightType.Stretch)
+        if (container.GetHeight() == HeightType.Stretch)
         {
             containerView.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT, 1));
         }
@@ -80,7 +77,7 @@ public class ContainerRenderer extends BaseCardElementRenderer
         }
 
         VerticalContentAlignment contentAlignment = container.GetVerticalContentAlignment();
-        switch(contentAlignment)
+        switch (contentAlignment)
         {
             case Center:
                 containerView.setGravity(Gravity.CENTER_VERTICAL);
@@ -114,13 +111,13 @@ public class ContainerRenderer extends BaseCardElementRenderer
             BackgroundImageLoaderAsync loaderAsync = new BackgroundImageLoaderAsync(renderedCard, context, containerView, hostConfig.GetImageBaseUrl(), backgroundImageProperties);
 
             IOnlineImageLoader onlineImageLoader = CardRendererRegistration.getInstance().getOnlineImageLoader();
-            if(onlineImageLoader != null)
+            if (onlineImageLoader != null)
             {
                 loaderAsync.registerCustomOnlineImageLoader(onlineImageLoader);
             }
 
             IDataUriImageLoader dataUriImageLoader = CardRendererRegistration.getInstance().getDataUriImageLoader();
-            if(dataUriImageLoader != null)
+            if (dataUriImageLoader != null)
             {
                 loaderAsync.registerCustomDataUriImageLoader(dataUriImageLoader);
             }

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ContainerRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ContainerRenderer.java
@@ -8,9 +8,13 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
 
+import io.adaptivecards.objectmodel.BackgroundImage;
 import io.adaptivecards.objectmodel.ContainerStyle;
 import io.adaptivecards.objectmodel.HeightType;
 import io.adaptivecards.objectmodel.VerticalContentAlignment;
+import io.adaptivecards.renderer.BackgroundImageLoaderAsync;
+import io.adaptivecards.renderer.IDataUriImageLoader;
+import io.adaptivecards.renderer.IOnlineImageLoader;
 import io.adaptivecards.renderer.RenderedAdaptiveCard;
 import io.adaptivecards.renderer.Util;
 import io.adaptivecards.renderer.action.ActionElementRenderer;
@@ -102,6 +106,26 @@ public class ContainerRenderer extends BaseCardElementRenderer
                     hostConfig.GetContainerStyles().getEmphasisPalette().getBackgroundColor() :
                     hostConfig.GetContainerStyles().getDefaultPalette().getBackgroundColor();
             containerView.setBackgroundColor(Color.parseColor(color));
+        }
+
+        BackgroundImage backgroundImageProperties = container.GetBackgroundImage();
+        if (backgroundImageProperties != null && !backgroundImageProperties.GetUrl().isEmpty())
+        {
+            BackgroundImageLoaderAsync loaderAsync = new BackgroundImageLoaderAsync(renderedCard, context, containerView, hostConfig.GetImageBaseUrl(), backgroundImageProperties);
+
+            IOnlineImageLoader onlineImageLoader = CardRendererRegistration.getInstance().getOnlineImageLoader();
+            if(onlineImageLoader != null)
+            {
+                loaderAsync.registerCustomOnlineImageLoader(onlineImageLoader);
+            }
+
+            IDataUriImageLoader dataUriImageLoader = CardRendererRegistration.getInstance().getDataUriImageLoader();
+            if(dataUriImageLoader != null)
+            {
+                loaderAsync.registerCustomDataUriImageLoader(dataUriImageLoader);
+            }
+
+            loaderAsync.execute(backgroundImageProperties.GetUrl());
         }
 
         if (container.GetSelectAction() != null)


### PR DESCRIPTION
Allows background image to be repeated along the x and/or y axis. Also added background image support to containers and columns.

PR for #1292 
Spec: #477 

* Moved `BackgroundImageLoaderAsync` to its own file for public access (needed for container/column).
* Added `BackgroundImageLoaderAsync` usage in container/column
* Created `BackgroundImageDrawable` within`BackgroundImageLoaderAsync`:
  * added `tileVertically` and `tileHorizontally` to handle tiling image along one axis
  * overrode `draw(Canvas)` to draw background image appropriately based on background image properties (mode and vertical/horizontal alignment).
