### PR TITLE
Do not mix ComPtr and std::shared_ptr on the same object (#2362)

### DIFF
--- a/custom.props
+++ b/custom.props
@@ -4,7 +4,7 @@
     <VersionMajor>1</VersionMajor>
     <VersionMinor>1</VersionMinor>
     <!-- The nuget package version should be incremented when we produce QFEs -->
-    <NuGetPackVersion>1.1.2</NuGetPackVersion>
+    <NuGetPackVersion>1.1.3</NuGetPackVersion>
     <VersionInfoProductName>AdaptiveCards</VersionInfoProductName>
   </PropertyGroup>
 </Project>

--- a/source/uwp/Renderer/lib/AdaptiveCardRendererComponent.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveCardRendererComponent.cpp
@@ -49,7 +49,7 @@ AdaptiveNamespaceStart
 
     HRESULT AdaptiveCardRenderer::RuntimeClassInitialize()
     {
-        m_xamlBuilder = std::make_shared<XamlBuilder>();
+        RETURN_IF_FAILED(MakeAndInitialize<XamlBuilder>(&m_xamlBuilder));
         RETURN_IF_FAILED(MakeAndInitialize<AdaptiveElementRendererRegistration>(&m_elementRendererRegistration));
         RETURN_IF_FAILED(RegisterDefaultElementRenderers());
         RETURN_IF_FAILED(MakeAndInitialize<AdaptiveHostConfig>(&m_hostConfig));
@@ -303,8 +303,5 @@ AdaptiveNamespaceStart
         return S_OK;
     }
 
-    std::shared_ptr<XamlBuilder> AdaptiveCardRenderer::GetXamlBuilder()
-    {
-        return m_xamlBuilder;
-    }
+    ComPtr<XamlBuilder> AdaptiveCardRenderer::GetXamlBuilder() { return m_xamlBuilder; }
 AdaptiveNamespaceEnd

--- a/source/uwp/Renderer/lib/AdaptiveCardRendererComponent.h
+++ b/source/uwp/Renderer/lib/AdaptiveCardRendererComponent.h
@@ -50,7 +50,7 @@ AdaptiveNamespaceStart
         ABI::AdaptiveNamespace::IAdaptiveHostConfig* GetHostConfig();
         Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IResourceDictionary> GetMergedDictionary();
         bool GetFixedDimensions(_Out_ UINT32* width, _Out_ UINT32* height);
-        std::shared_ptr<AdaptiveNamespace::XamlBuilder> GetXamlBuilder();
+        Microsoft::WRL::ComPtr<AdaptiveNamespace::XamlBuilder> GetXamlBuilder();
 
         IFACEMETHODIMP get_ResourceResolvers(
             _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardResourceResolvers** value);
@@ -63,7 +63,7 @@ AdaptiveNamespaceStart
         Microsoft::WRL::ComPtr<ABI::AdaptiveNamespace::IAdaptiveCardResourceResolvers> m_resourceResolvers;
         Microsoft::WRL::ComPtr<ABI::AdaptiveNamespace::IAdaptiveElementRendererRegistration> m_elementRendererRegistration;
 
-        std::shared_ptr<AdaptiveNamespace::XamlBuilder> m_xamlBuilder;
+        Microsoft::WRL::ComPtr<AdaptiveNamespace::XamlBuilder> m_xamlBuilder;
         bool m_explicitDimensions = false;
         UINT32 m_desiredWidth = 0;
         UINT32 m_desiredHeight = 0;

--- a/source/uwp/Renderer/lib/AdaptiveImageRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImageRenderer.cpp
@@ -12,17 +12,15 @@ using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::Foundation;
 
 AdaptiveNamespaceStart
-    AdaptiveImageRenderer::AdaptiveImageRenderer()
-    {
-        m_xamlBuilder = std::make_shared<XamlBuilder>();
-    }
+    AdaptiveImageRenderer::AdaptiveImageRenderer() {}
 
-    AdaptiveImageRenderer::AdaptiveImageRenderer(std::shared_ptr<XamlBuilder> xamlBuilder) : m_xamlBuilder(xamlBuilder)
+    AdaptiveImageRenderer::AdaptiveImageRenderer(ComPtr<XamlBuilder> xamlBuilder) : m_xamlBuilder(xamlBuilder)
     {
     }
 
     HRESULT AdaptiveImageRenderer::RuntimeClassInitialize() noexcept try
     {
+        RETURN_IF_FAILED(MakeAndInitialize<XamlBuilder>(&m_xamlBuilder));
         return S_OK;
     } CATCH_RETURN;
 

--- a/source/uwp/Renderer/lib/AdaptiveImageRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveImageRenderer.h
@@ -16,7 +16,7 @@ AdaptiveNamespaceStart
 
     public:
         AdaptiveImageRenderer();
-        AdaptiveImageRenderer(std::shared_ptr<AdaptiveNamespace::XamlBuilder> xamlBuilder);
+        AdaptiveImageRenderer(Microsoft::WRL::ComPtr<AdaptiveNamespace::XamlBuilder> xamlBuilder);
         HRESULT RuntimeClassInitialize() noexcept;
 
         IFACEMETHODIMP Render(
@@ -33,7 +33,7 @@ AdaptiveNamespaceStart
             ABI::AdaptiveNamespace::IAdaptiveCardElement** element) override;
 
     private:
-        std::shared_ptr<AdaptiveNamespace::XamlBuilder> m_xamlBuilder;
+        Microsoft::WRL::ComPtr<AdaptiveNamespace::XamlBuilder> m_xamlBuilder;
     };
 
     ActivatableClass(AdaptiveImageRenderer);

--- a/source/uwp/Renderer/lib/XamlBuilder.h
+++ b/source/uwp/Renderer/lib/XamlBuilder.h
@@ -18,10 +18,12 @@ AdaptiveNamespaceStart
         Microsoft::WRL::FtmBase,
         AdaptiveNamespace::IImageLoadTrackerListener>
     {
-        AdaptiveRuntimeStringClass(XamlBuilder)
-    public:
-        XamlBuilder();
+        friend HRESULT Microsoft::WRL::Details::MakeAndInitialize<AdaptiveNamespace::XamlBuilder, AdaptiveNamespace::XamlBuilder>(
+            AdaptiveNamespace::XamlBuilder**);
 
+        AdaptiveRuntimeStringClass(XamlBuilder);
+
+    public:
         // IImageLoadTrackerListener
         STDMETHODIMP AllImagesLoaded();
         STDMETHODIMP ImagesLoadingHadError();
@@ -123,6 +125,8 @@ AdaptiveNamespaceStart
         static Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::Media::IBrush> GetSolidColorBrush(_In_ ABI::Windows::UI::Color color);
 
     private:
+        XamlBuilder();
+
         ImageLoadTracker m_imageLoadTracker;
         std::set<Microsoft::WRL::ComPtr<IXamlBuilderListener>> m_listeners;
         Microsoft::WRL::ComPtr<ABI::Windows::Storage::Streams::IRandomAccessStreamStatics> m_randomAccessStreamStatics;


### PR DESCRIPTION
* Resolve issue #2341

We were tracking the references to the XamlBuilder through std::shared_ptr and ComPtr

We can only have 1 set of reference count, so consolidating to ComPtr.

Making the XamlBuilder constructor private to avoid this situation.