### PR TITLE
Add tabindex attribute to select actions to enable keyboard naviagtion.

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Rendering.Html/AdaptiveCardRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Html/AdaptiveCardRenderer.cs
@@ -112,7 +112,8 @@ namespace AdaptiveCards.Rendering.Html
         {
             tag.AddClass(GetActionCssClass(action))
                 .Attr("role", "button")
-                .Attr("aria-label", action.Title ?? "");
+                .Attr("aria-label", action.Title ?? "")
+                .Attr("tabindex","0");
 
             ActionTransformers.Apply(action, tag, context);
 


### PR DESCRIPTION
By adding the tabindex attribute to selectActions, they can now be navigated through with the keyboard.