### PR TITLE
[.NET] Apply ContainerStyle Foreground Colors + default Foreground Colors

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Rendering.Html/AdaptiveCardRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Html/AdaptiveCardRenderer.cs
@@ -596,12 +596,14 @@ namespace AdaptiveCards.Rendering.Html
                 .Style("flex", "1 1 100%");
             }
 
+            // Keep track of ContainerStyle.ForegroundColors before Container is rendered
             var outerStyle = context.ForegroundColors;
             if (container.Style != null)
             {
                 // Apply background color
                 ContainerStyleConfig containerStyle = context.Config.ContainerStyles.GetContainerStyleConfig(container.Style);
                 uiContainer.Style("background-color", context.GetRGBColor(containerStyle.BackgroundColor));
+
                 context.ForegroundColors = containerStyle.ForegroundColors;
             }
 
@@ -623,6 +625,7 @@ namespace AdaptiveCards.Rendering.Html
 
             AddSelectAction(uiContainer, container.SelectAction, context);
 
+            // Revert context's value to that of outside the Container
             context.ForegroundColors = outerStyle;
             return uiContainer;
         }

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Html/AdaptiveCardRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Html/AdaptiveCardRenderer.cs
@@ -596,11 +596,13 @@ namespace AdaptiveCards.Rendering.Html
                 .Style("flex", "1 1 100%");
             }
 
+            var outerStyle = context.ForegroundColors;
             if (container.Style != null)
             {
                 // Apply background color
                 ContainerStyleConfig containerStyle = context.Config.ContainerStyles.GetContainerStyleConfig(container.Style);
                 uiContainer.Style("background-color", context.GetRGBColor(containerStyle.BackgroundColor));
+                context.ForegroundColors = containerStyle.ForegroundColors;
             }
 
             switch (container.VerticalContentAlignment)
@@ -621,6 +623,7 @@ namespace AdaptiveCards.Rendering.Html
 
             AddSelectAction(uiContainer, container.SelectAction, context);
 
+            context.ForegroundColors = outerStyle;
             return uiContainer;
         }
 

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Html/AdaptiveRenderContext.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Html/AdaptiveRenderContext.cs
@@ -11,6 +11,7 @@ namespace AdaptiveCards.Rendering.Html
             // clone it
             Config = JsonConvert.DeserializeObject<AdaptiveHostConfig>(JsonConvert.SerializeObject(hostConfig));
             ElementRenderers = elementRenderers;
+            ForegroundColors = Config.ContainerStyles.Default.ForegroundColors;
         }
 
         public AdaptiveHostConfig Config { get; set; }
@@ -51,25 +52,25 @@ namespace AdaptiveCards.Rendering.Html
             switch (color)
             {
                 case AdaptiveTextColor.Accent:
-                    colorConfig = Config.ContainerStyles.Default.ForegroundColors.Accent;
+                    colorConfig = ForegroundColors.Accent;
                     break;
                 case AdaptiveTextColor.Good:
-                    colorConfig = Config.ContainerStyles.Default.ForegroundColors.Good;
+                    colorConfig = ForegroundColors.Good;
                     break;
                 case AdaptiveTextColor.Warning:
-                    colorConfig = Config.ContainerStyles.Default.ForegroundColors.Warning;
+                    colorConfig = ForegroundColors.Warning;
                     break;
                 case AdaptiveTextColor.Attention:
-                    colorConfig = Config.ContainerStyles.Default.ForegroundColors.Attention;
+                    colorConfig = ForegroundColors.Attention;
                     break;
                 case AdaptiveTextColor.Dark:
-                    colorConfig = Config.ContainerStyles.Default.ForegroundColors.Dark;
+                    colorConfig = ForegroundColors.Dark;
                     break;
                 case AdaptiveTextColor.Light:
-                    colorConfig = Config.ContainerStyles.Default.ForegroundColors.Light;
+                    colorConfig = ForegroundColors.Light;
                     break;
                 default:
-                    colorConfig = Config.ContainerStyles.Default.ForegroundColors.Default;
+                    colorConfig = ForegroundColors.Default;
                     break;
             }
             return GetRGBColor(isSubtle ? colorConfig.Subtle : colorConfig.Default);
@@ -91,5 +92,7 @@ namespace AdaptiveCards.Rendering.Html
         }
 
         public string Lang { get; set; }
+
+        public ForegroundColorsConfig ForegroundColors { get; set; }
     }
 }

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveCardRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveCardRenderer.cs
@@ -228,7 +228,8 @@ namespace AdaptiveCards.Rendering.Wpf
                 Config = HostConfig ?? new AdaptiveHostConfig(),
                 Resources = Resources,
                 ElementRenderers = ElementRenderers,
-                Lang = card.Lang
+                Lang = card.Lang,
+                ForegroundColors = (HostConfig == null) ? HostConfig.ContainerStyles.Default.ForegroundColors : new ContainerStylesConfig().Default.ForegroundColors
             };
 
             string accentColor = HostConfig.ContainerStyles.Default.ForegroundColors.Accent.Default;
@@ -283,7 +284,8 @@ namespace AdaptiveCards.Rendering.Wpf
                     Config = HostConfig ?? new AdaptiveHostConfig(),
                     Resources = Resources,
                     ElementRenderers = ElementRenderers,
-                    Lang = card.Lang
+                    Lang = card.Lang,
+                    ForegroundColors = (HostConfig == null) ? HostConfig.ContainerStyles.Default.ForegroundColors : new ContainerStylesConfig().Default.ForegroundColors
                 };
 
                 var stream = context.Render(card).RenderToImage(width);

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveCardRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveCardRenderer.cs
@@ -229,7 +229,7 @@ namespace AdaptiveCards.Rendering.Wpf
                 Resources = Resources,
                 ElementRenderers = ElementRenderers,
                 Lang = card.Lang,
-                ForegroundColors = (HostConfig == null) ? HostConfig.ContainerStyles.Default.ForegroundColors : new ContainerStylesConfig().Default.ForegroundColors
+                ForegroundColors = (HostConfig != null) ? HostConfig.ContainerStyles.Default.ForegroundColors : new ContainerStylesConfig().Default.ForegroundColors
             };
 
             string accentColor = HostConfig.ContainerStyles.Default.ForegroundColors.Accent.Default;
@@ -285,7 +285,7 @@ namespace AdaptiveCards.Rendering.Wpf
                     Resources = Resources,
                     ElementRenderers = ElementRenderers,
                     Lang = card.Lang,
-                    ForegroundColors = (HostConfig == null) ? HostConfig.ContainerStyles.Default.ForegroundColors : new ContainerStylesConfig().Default.ForegroundColors
+                    ForegroundColors = (HostConfig != null) ? HostConfig.ContainerStyles.Default.ForegroundColors : new ContainerStylesConfig().Default.ForegroundColors
                 };
 
                 var stream = context.Render(card).RenderToImage(width);

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveContainerRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveContainerRenderer.cs
@@ -13,12 +13,14 @@ namespace AdaptiveCards.Rendering.Wpf
             uiContainer.Style = context.GetStyle("Adaptive.Container");
             uiContainer.SetBackgroundSource(container.BackgroundImage, context);
 
+            // Keep track of ContainerStyle.ForegroundColors before Container is rendered
             var outerStyle = context.ForegroundColors;
             if (container.Style != null)
             {
                 // Apply background color
                 ContainerStyleConfig containerStyle = context.Config.ContainerStyles.GetContainerStyleConfig(container.Style);
                 uiContainer.SetBackgroundColor(containerStyle.BackgroundColor, context);
+
                 context.ForegroundColors = containerStyle.ForegroundColors;
             }
 
@@ -52,6 +54,7 @@ namespace AdaptiveCards.Rendering.Wpf
                 border.Visibility = Visibility.Collapsed;
             }
 
+            // Revert context's value to that of outside the Container
             context.ForegroundColors = outerStyle;
             return border;
         }

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveContainerRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveContainerRenderer.cs
@@ -13,11 +13,13 @@ namespace AdaptiveCards.Rendering.Wpf
             uiContainer.Style = context.GetStyle("Adaptive.Container");
             uiContainer.SetBackgroundSource(container.BackgroundImage, context);
 
+            var outerStyle = context.ForegroundColors;
             if (container.Style != null)
             {
                 // Apply background color
                 ContainerStyleConfig containerStyle = context.Config.ContainerStyles.GetContainerStyleConfig(container.Style);
                 uiContainer.SetBackgroundColor(containerStyle.BackgroundColor, context);
+                context.ForegroundColors = containerStyle.ForegroundColors;
             }
 
             switch (container.VerticalContentAlignment)
@@ -50,6 +52,7 @@ namespace AdaptiveCards.Rendering.Wpf
                 border.Visibility = Visibility.Collapsed;
             }
 
+            context.ForegroundColors = outerStyle;
             return border;
         }
 

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveRenderContext.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveRenderContext.cs
@@ -195,5 +195,7 @@ namespace AdaptiveCards.Rendering.Wpf
         public string Lang { get; set; }
 
         public FrameworkElement CardRoot { get; set; }
+
+        public ForegroundColorsConfig ForegroundColors { get; set; }
     }
 }

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveTextBlockRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveTextBlockRenderer.cs
@@ -21,26 +21,26 @@ namespace AdaptiveCards.Rendering.Wpf
             switch (textBlock.Color)
             {
                 case AdaptiveTextColor.Accent:
-                    colorOption = context.Config.ContainerStyles.Default.ForegroundColors.Accent;
+                    colorOption = context.ForegroundColors.Accent;
                     break;
                 case AdaptiveTextColor.Attention:
-                    colorOption = context.Config.ContainerStyles.Default.ForegroundColors.Attention;
+                    colorOption = context.ForegroundColors.Attention;
                     break;
                 case AdaptiveTextColor.Dark:
-                    colorOption = context.Config.ContainerStyles.Default.ForegroundColors.Dark;
+                    colorOption = context.ForegroundColors.Dark;
                     break;
                 case AdaptiveTextColor.Good:
-                    colorOption = context.Config.ContainerStyles.Default.ForegroundColors.Good;
+                    colorOption = context.ForegroundColors.Good;
                     break;
                 case AdaptiveTextColor.Light:
-                    colorOption = context.Config.ContainerStyles.Default.ForegroundColors.Light;
+                    colorOption = context.ForegroundColors.Light;
                     break;
                 case AdaptiveTextColor.Warning:
-                    colorOption = context.Config.ContainerStyles.Default.ForegroundColors.Warning;
+                    colorOption = context.ForegroundColors.Warning;
                     break;
                 case AdaptiveTextColor.Default:
                 default:
-                    colorOption = context.Config.ContainerStyles.Default.ForegroundColors.Default;
+                    colorOption = context.ForegroundColors.Default;
                     break;
             }
 

--- a/source/dotnet/Library/AdaptiveCards/Rendering/ContainerStylesConfig.cs
+++ b/source/dotnet/Library/AdaptiveCards/Rendering/ContainerStylesConfig.cs
@@ -10,19 +10,43 @@ namespace AdaptiveCards.Rendering
         public ContainerStyleConfig Default { get; set; } = new ContainerStyleConfig();
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public ContainerStyleConfig Emphasis { get; set; } = new ContainerStyleConfig() { };
+        public ContainerStyleConfig Emphasis { get; set; } = new ContainerStyleConfig()
+        {
+            BackgroundColor = "#08000000"
+        };
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public ContainerStyleConfig Good { get; set; } = new ContainerStyleConfig() { };
+        public ContainerStyleConfig Good { get; set; } = new ContainerStyleConfig()
+        {
+            BackgroundColor = "#ffd5f0dd",
+            ForegroundColors = alternateForegroundColors
+        };
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public ContainerStyleConfig Warning { get; set; } = new ContainerStyleConfig() { };
+        public ContainerStyleConfig Warning { get; set; } = new ContainerStyleConfig()
+        {
+            BackgroundColor = "#f7f7df",
+            ForegroundColors = alternateForegroundColors
+        };
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public ContainerStyleConfig Attention { get; set; } = new ContainerStyleConfig() { };
+        public ContainerStyleConfig Attention { get; set; } = new ContainerStyleConfig()
+        {
+            BackgroundColor = "#f7e9e9",
+            ForegroundColors = alternateForegroundColors
+        };
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public ContainerStyleConfig Accent { get; set; } = new ContainerStyleConfig() { };
+        public ContainerStyleConfig Accent { get; set; } = new ContainerStyleConfig()
+        {
+            BackgroundColor = "#dce5f7",
+            ForegroundColors = alternateForegroundColors
+        };
+
+        private static readonly ForegroundColorsConfig alternateForegroundColors = new ForegroundColorsConfig()
+        {
+            Warning = new FontColorConfig("#ffa600", "#B2ffa600")
+        };
 
         public ContainerStyleConfig GetContainerStyleConfig(AdaptiveContainerStyle? style)
         {

--- a/source/dotnet/Test/AdaptiveCards.Rendering.Html.Test/HtmlRendererTests.cs
+++ b/source/dotnet/Test/AdaptiveCards.Rendering.Html.Test/HtmlRendererTests.cs
@@ -27,7 +27,61 @@ namespace AdaptiveCards.Rendering.Html.Test
                 generatedHtml);
         }
 
+        [TestMethod]
+        public void ContainerStyleForegroundColors()
+        {
+            var hostConfig = new AdaptiveHostConfig();
+            hostConfig.ContainerStyles.Emphasis.ForegroundColors = new ForegroundColorsConfig()
+            {
+                Default = new FontColorConfig("#FFcc3300")
+            };
 
+            var card = new AdaptiveCard("1.2")
+            {
+                Body = new System.Collections.Generic.List<AdaptiveElement>()
+                {
+                    new AdaptiveContainer()
+                    {
+                        Style = AdaptiveContainerStyle.Emphasis,
+                        Items = new System.Collections.Generic.List<AdaptiveElement>()
+                        {
+                            new AdaptiveTextBlock()
+                            {
+                                Text = "container 1 -- emphasis style text"
+                            },
+                            new AdaptiveContainer()
+                            {
+                                Style = AdaptiveContainerStyle.Accent,
+                                Items = new System.Collections.Generic.List<AdaptiveElement>()
+                                {
+                                    new AdaptiveTextBlock()
+                                    {
+                                        Text = "container 1.1 -- accent style text"
+                                    }
+                                }
+                            },
+                            new AdaptiveTextBlock()
+                            {
+                                Text = "container 1 -- emphasis style text"
+                            }
+                        }
+                    },
+                    new AdaptiveTextBlock()
+                    {
+                        Text = "default style text"
+                    }
+                }
+            };
+
+            var renderer = new AdaptiveCardRenderer(hostConfig);
+            var result = renderer.RenderCard(card);
+            var generatedHtml = result.Html.ToString();
+
+            // Generated HTML should have two <p> tags, with appropriate styles set.
+            Assert.AreEqual(
+                "<div class='ac-adaptivecard' style='width: 100%;background-color: rgba(255, 255, 255, 1.00);padding: 15px;box-sizing: border-box;justify-content: flex-start;'><div class='ac-container' style='background-color: rgba(0, 0, 0, 0.03);justify-content: flex-start;'><div class='ac-textblock' style='box-sizing: border-box;text-align: left;color: rgba(204, 51, 0, 1.00);line-height: 18.62px;font-size: 14px;font-weight: 400;white-space: nowrap;'><p style='margin-top: 0px;margin-bottom: 0px;width: 100%;text-overflow: ellipsis;overflow: hidden;'>container 1 -- emphasis style text</p></div><div class='ac-separator' style='height: 8px;'></div><div class='ac-container' style='background-color: #dce5f7;justify-content: flex-start;'><div class='ac-textblock' style='box-sizing: border-box;text-align: left;color: rgba(0, 0, 0, 1.00);line-height: 18.62px;font-size: 14px;font-weight: 400;white-space: nowrap;'><p style='margin-top: 0px;margin-bottom: 0px;width: 100%;text-overflow: ellipsis;overflow: hidden;'>container 1.1 -- accent style text</p></div></div><div class='ac-separator' style='height: 8px;'></div><div class='ac-textblock' style='box-sizing: border-box;text-align: left;color: rgba(204, 51, 0, 1.00);line-height: 18.62px;font-size: 14px;font-weight: 400;white-space: nowrap;'><p style='margin-top: 0px;margin-bottom: 0px;width: 100%;text-overflow: ellipsis;overflow: hidden;'>container 1 -- emphasis style text</p></div></div><div class='ac-separator' style='height: 8px;'></div><div class='ac-textblock' style='box-sizing: border-box;text-align: left;color: rgba(0, 0, 0, 1.00);line-height: 18.62px;font-size: 14px;font-weight: 400;white-space: nowrap;'><p style='margin-top: 0px;margin-bottom: 0px;width: 100%;text-overflow: ellipsis;overflow: hidden;'>default style text</p></div></div>",
+                generatedHtml);
+        }
 
         private class TestHtmlRenderer : AdaptiveCardRenderer
         {


### PR DESCRIPTION
Bugfix for #2285 .

`AdaptiveRenderContext` was modified to keep track of the container style. When TextBlock text is being rendered, it now reads the value in `AdaptiveRenderContext` and bases it off that.

`ContainerStylesConfig` now has appropriate default values that match up with SharedModel.

Test for HTML was created. There is no way to make a test for WPF.