### PR TITLE
[Shared][UWP][Android] Add setDataJson(string) method

### DIFF
--- a/source/android/adaptivecards/build.gradle
+++ b/source/android/adaptivecards/build.gradle
@@ -140,10 +140,10 @@ uploadArchives {
     }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    testCompile 'junit:junit:4.12'
+    implementation 'com.android.support:appcompat-v7:25.3.1'
+    testImplementation 'junit:junit:4.12'
 }

--- a/source/android/adaptivecards/src/main/cpp/objectmodel_wrap.cpp
+++ b/source/android/adaptivecards/src/main/cpp/objectmodel_wrap.cpp
@@ -11977,7 +11977,7 @@ SWIGEXPORT jlong JNICALL Java_io_adaptivecards_objectmodel_AdaptiveCardObjectMod
 }
 
 
-SWIGEXPORT void JNICALL Java_io_adaptivecards_objectmodel_AdaptiveCardObjectModelJNI_SubmitAction_1SetDataJson(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jlong jarg2, jobject jarg2_) {
+SWIGEXPORT void JNICALL Java_io_adaptivecards_objectmodel_AdaptiveCardObjectModelJNI_SubmitAction_1SetDataJson_1_1SWIG_10(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jlong jarg2, jobject jarg2_) {
   AdaptiveCards::SubmitAction *arg1 = (AdaptiveCards::SubmitAction *) 0 ;
   Json::Value *arg2 = 0 ;
   std::shared_ptr< AdaptiveCards::SubmitAction > *smartarg1 = 0 ;
@@ -11995,6 +11995,29 @@ SWIGEXPORT void JNICALL Java_io_adaptivecards_objectmodel_AdaptiveCardObjectMode
     return ;
   } 
   (arg1)->SetDataJson((Json::Value const &)*arg2);
+}
+
+
+SWIGEXPORT void JNICALL Java_io_adaptivecards_objectmodel_AdaptiveCardObjectModelJNI_SubmitAction_1SetDataJson_1_1SWIG_11(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jstring jarg2) {
+  AdaptiveCards::SubmitAction *arg1 = (AdaptiveCards::SubmitAction *) 0 ;
+  std::string arg2 ;
+  std::shared_ptr< AdaptiveCards::SubmitAction > *smartarg1 = 0 ;
+  
+  (void)jenv;
+  (void)jcls;
+  (void)jarg1_;
+  
+  smartarg1 = *(std::shared_ptr<  AdaptiveCards::SubmitAction > **)&jarg1;
+  arg1 = (AdaptiveCards::SubmitAction *)(smartarg1 ? smartarg1->get() : 0); 
+  if(!jarg2) {
+    SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null string");
+    return ;
+  } 
+  const char *arg2_pstr = (const char *)jenv->GetStringUTFChars(jarg2, 0); 
+  if (!arg2_pstr) return ;
+  (&arg2)->assign(arg2_pstr);
+  jenv->ReleaseStringUTFChars(jarg2, arg2_pstr); 
+  (arg1)->SetDataJson(arg2);
 }
 
 

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/objectmodel/AdaptiveCardObjectModelJNI.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/objectmodel/AdaptiveCardObjectModelJNI.java
@@ -549,7 +549,8 @@ public class AdaptiveCardObjectModelJNI {
   public final static native long new_SubmitAction();
   public final static native String SubmitAction_GetDataJson(long jarg1, SubmitAction jarg1_);
   public final static native long SubmitAction_GetDataJsonAsValue(long jarg1, SubmitAction jarg1_);
-  public final static native void SubmitAction_SetDataJson(long jarg1, SubmitAction jarg1_, long jarg2, JsonValue jarg2_);
+  public final static native void SubmitAction_SetDataJson__SWIG_0(long jarg1, SubmitAction jarg1_, long jarg2, JsonValue jarg2_);
+  public final static native void SubmitAction_SetDataJson__SWIG_1(long jarg1, SubmitAction jarg1_, String jarg2);
   public final static native long SubmitAction_SerializeToJsonValue(long jarg1, SubmitAction jarg1_);
   public final static native long SubmitAction_dynamic_cast(long jarg1, BaseActionElement jarg1_);
   public final static native void delete_SubmitAction(long jarg1);

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/objectmodel/SubmitAction.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/objectmodel/SubmitAction.java
@@ -50,7 +50,11 @@ public class SubmitAction extends BaseActionElement {
   }
 
   public void SetDataJson(JsonValue value) {
-    AdaptiveCardObjectModelJNI.SubmitAction_SetDataJson(swigCPtr, this, JsonValue.getCPtr(value), value);
+    AdaptiveCardObjectModelJNI.SubmitAction_SetDataJson__SWIG_0(swigCPtr, this, JsonValue.getCPtr(value), value);
+  }
+
+  public void SetDataJson(String value) {
+    AdaptiveCardObjectModelJNI.SubmitAction_SetDataJson__SWIG_1(swigCPtr, this, value);
   }
 
   public JsonValue SerializeToJsonValue() {

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/objectmodel/WarningStatusCode.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/objectmodel/WarningStatusCode.java
@@ -20,7 +20,8 @@ public enum WarningStatusCode {
   UnsupportedMediaType,
   InvalidMediaMix,
   InvalidColorFormat,
-  InvalidDimensionSpecified;
+  InvalidDimensionSpecified,
+  InvalidLanguage;
 
   public final int swigValue() {
     return swigValue;

--- a/source/android/mobile/build.gradle
+++ b/source/android/mobile/build.gradle
@@ -19,12 +19,12 @@ android {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.android.support:design:25.3.1'
-    testCompile 'junit:junit:4.12'
-    compile project(':adaptivecards')
+    implementation 'com.android.support:appcompat-v7:25.3.1'
+    implementation 'com.android.support:design:25.3.1'
+    testImplementation 'junit:junit:4.12'
+    implementation project(':adaptivecards')
 }

--- a/source/android/mobilechatapp/build.gradle
+++ b/source/android/mobilechatapp/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    compile project(path: ':adaptivecards')
+    implementation project(path: ':adaptivecards')
 }
 
 task copyTestFiles(type: Copy)

--- a/source/shared/cpp/ObjectModel/SubmitAction.cpp
+++ b/source/shared/cpp/ObjectModel/SubmitAction.cpp
@@ -26,6 +26,11 @@ Json::Value SubmitAction::GetDataJsonAsValue() const
     return m_dataJson;
 }
 
+void SubmitAction::SetDataJson(const std::string value)
+{
+    SetDataJson(ParseUtil::GetJsonValueFromString(value));
+}
+
 void SubmitAction::SetDataJson(const Json::Value &value)
 {
     m_dataJson = value;

--- a/source/shared/cpp/ObjectModel/SubmitAction.h
+++ b/source/shared/cpp/ObjectModel/SubmitAction.h
@@ -14,6 +14,7 @@ public:
     std::string GetDataJson() const;
     Json::Value GetDataJsonAsValue() const;
     void SetDataJson(const Json::Value &value);
+    void SetDataJson(const std::string value);
 
     Json::Value SerializeToJsonValue() const override;
 

--- a/source/uwp/Renderer/lib/AdaptiveSubmitAction.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveSubmitAction.cpp
@@ -21,7 +21,12 @@ AdaptiveNamespaceStart
             return E_INVALIDARG;
         }
 
-        RETURN_IF_FAILED(StringToJsonValue(sharedSubmitAction->GetDataJson(), &m_dataJson));
+        auto sharedJson = sharedSubmitAction->GetDataJson();
+        if (!sharedJson.empty())
+        {
+            RETURN_IF_FAILED(StringToJsonValue(sharedSubmitAction->GetDataJson(), &m_dataJson));
+        }
+        
         InitializeBaseElement(std::static_pointer_cast<AdaptiveSharedNamespace::BaseActionElement>(sharedSubmitAction));
         return S_OK;
     } CATCH_RETURN;
@@ -52,8 +57,11 @@ AdaptiveNamespaceStart
         RETURN_IF_FAILED(SetSharedElementProperties(std::static_pointer_cast<AdaptiveSharedNamespace::BaseActionElement>(submitAction)));
 
         std::string jsonAsString;
-        RETURN_IF_FAILED(JsonValueToString(m_dataJson.Get(), jsonAsString));
-        submitAction->SetDataJson(jsonAsString);
+        if (m_dataJson != nullptr)
+        {
+            RETURN_IF_FAILED(JsonValueToString(m_dataJson.Get(), jsonAsString));
+            submitAction->SetDataJson(jsonAsString);
+        }
 
         sharedModel = submitAction;
         return S_OK;


### PR DESCRIPTION
Completes this issue: https://github.com/Microsoft/AdaptiveCards/issues/2381

It looks like the original method was removed and then re-added. I couldn't cherrypick the fix as @RebeccaAnne made it as it included the ChoiceSetInput wrap property. 

This PR also contains the fix for the gradle files as the keyword 'compile' and it's derivatives are now obsolete and they must be changed for 'implementation' and its derivatives