### PR TITLE
Ignore Max, Min, and Value from AdaptiveNumberInput on Serialization

### DIFF
--- a/source/dotnet/Library/AdaptiveCards/AdaptiveNumberInput.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveNumberInput.cs
@@ -34,6 +34,7 @@ namespace AdaptiveCards
         /// <summary>
         ///     The initial value for the field
         /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
 #if !NETSTANDARD1_3
         [XmlAttribute]
 #endif
@@ -43,6 +44,7 @@ namespace AdaptiveCards
         /// <summary>
         ///     hint of minimum value(may be ignored by some clients)
         /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
 #if !NETSTANDARD1_3
         [XmlAttribute]
 #endif
@@ -52,6 +54,7 @@ namespace AdaptiveCards
         /// <summary>
         ///     hint of maximum value(may be ignored by some clients)
         /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
 #if !NETSTANDARD1_3
         [XmlAttribute]
 #endif


### PR DESCRIPTION
proposed fix for this issue: https://github.com/Microsoft/AdaptiveCards/issues/2478