### PR TITLE
Fix Null value handling for Min, Max, and Value in AdaptiveNumberInput

### DIFF
--- a/source/dotnet/Library/AdaptiveCards/AdaptiveNumberInput.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveNumberInput.cs
@@ -33,7 +33,8 @@ namespace AdaptiveCards
 
         /// <summary>
         ///     The initial value for the field
-        /// </summary>
+        /// </summary>'
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
 #if !NETSTANDARD1_3
         [XmlAttribute]
 #endif
@@ -43,6 +44,7 @@ namespace AdaptiveCards
         /// <summary>
         ///     hint of minimum value(may be ignored by some clients)
         /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
 #if !NETSTANDARD1_3
         [XmlAttribute]
 #endif
@@ -52,6 +54,7 @@ namespace AdaptiveCards
         /// <summary>
         ///     hint of maximum value(may be ignored by some clients)
         /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
 #if !NETSTANDARD1_3
         [XmlAttribute]
 #endif

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveNumberInput.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveNumberInput.cs
@@ -33,7 +33,7 @@ namespace AdaptiveCards
 
         /// <summary>
         ///     The initial value for the field
-        /// </summary>'
+        /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
 #if !NETSTANDARD1_3
         [XmlAttribute]

--- a/source/dotnet/Test/AdaptiveCards.Test/AdaptiveNumberInputTests.cs
+++ b/source/dotnet/Test/AdaptiveCards.Test/AdaptiveNumberInputTests.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+
+namespace AdaptiveCards.Test
+{
+    [TestClass]
+    public class AdaptiveNumberInputTests
+    {
+        [TestMethod]
+        public void TestThatSerializationWorks()
+        {
+            var json = @"{
+  ""type"": ""AdaptiveCard"",
+  ""version"": ""1.0"",
+  ""body"": [
+    {
+      ""type"": ""Input.Number"",
+      ""id"": ""number"",
+      ""placeholder"": ""Pick a number"",
+      ""value"": 5.0,
+      ""min"": 1.0,
+      ""max"": 22.0
+    }
+  ]
+}";
+
+            // Test deserialization
+            var cardResult = AdaptiveCard.FromJson(json);
+            var card = cardResult.Card;
+
+            var inputElement = card?.Body?.FirstOrDefault() as AdaptiveNumberInput;
+            Assert.IsNotNull(inputElement);
+            Assert.AreEqual("Pick a number", inputElement.Placeholder);
+            Assert.AreEqual(1, inputElement.Min);
+            Assert.AreEqual(5, inputElement.Value);
+            Assert.AreEqual(22, inputElement.Max);
+            Assert.AreEqual("number", inputElement.Id);
+
+            // Test serialization
+            var resultJson = card?.ToJson();
+            Assert.AreEqual(json, resultJson);
+        }
+
+        [TestMethod]
+        public void TestThatNaNValueIsDroppedOnSerialization()
+        {
+            var json = @"{
+  ""type"": ""AdaptiveCard"",
+  ""version"": ""1.0"",
+  ""body"": [
+    {
+      ""type"": ""Input.Number"",
+      ""id"": ""number"",
+      ""placeholder"": ""Pick a number"",
+      ""min"": 1.0,
+      ""max"": 22.0
+    }
+  ]
+}";
+
+            // Test deserialization
+            var cardResult = AdaptiveCard.FromJson(json);
+            var card = cardResult.Card;
+            var inputElement = card.Body.FirstOrDefault() as AdaptiveNumberInput;
+            Assert.IsNotNull(inputElement);
+            Assert.AreEqual(double.NaN, inputElement.Value);
+
+            // Test serialization
+            var resultJson = card.ToJson();
+            Assert.IsFalse(resultJson.Contains("\"value\""));
+            Assert.AreEqual(json, resultJson);
+        }
+
+        [TestMethod]
+        public void TestThatNaNMinIsDroppedOnSerialization()
+        {
+            var json = @"{
+  ""type"": ""AdaptiveCard"",
+  ""version"": ""1.0"",
+  ""body"": [
+    {
+      ""type"": ""Input.Number"",
+      ""id"": ""number"",
+      ""placeholder"": ""Pick a number"",
+      ""value"": 5.0,
+      ""max"": 22.0
+    }
+  ]
+}";
+
+            // Test deserialization
+            var cardResult = AdaptiveCard.FromJson(json);
+            var card = cardResult.Card;
+            var inputElement = card.Body.FirstOrDefault() as AdaptiveNumberInput;
+            Assert.IsNotNull(inputElement);
+            Assert.AreEqual(double.NaN, inputElement.Min);
+
+            // Test serialization
+            var resultJson = card.ToJson();
+            Assert.IsFalse(resultJson.Contains("\"min\""));
+            Assert.AreEqual(json, resultJson);
+        }
+
+        [TestMethod]
+        public void TestThatNaNMaxIsDroppedOnSerialization()
+        {
+            var json = @"{
+  ""type"": ""AdaptiveCard"",
+  ""version"": ""1.0"",
+  ""body"": [
+    {
+      ""type"": ""Input.Number"",
+      ""id"": ""number"",
+      ""placeholder"": ""Pick a number"",
+      ""value"": 5.0,
+      ""min"": 1.0
+    }
+  ]
+}";
+
+            // Test deserialization
+            var cardResult = AdaptiveCard.FromJson(json);
+            var card = cardResult.Card;
+            var inputElement = card.Body.FirstOrDefault() as AdaptiveNumberInput;
+            Assert.IsNotNull(inputElement);
+            Assert.AreEqual(double.NaN, inputElement.Max);
+
+            // Test serialization
+            var resultJson = card.ToJson();
+            Assert.IsFalse(resultJson.Contains("\"max\""));
+            Assert.AreEqual(json, resultJson);
+        }
+    }
+}


### PR DESCRIPTION
Fix with tests to this issue: https://github.com/Microsoft/AdaptiveCards/issues/2478