### PR TITLE
[UWP] Make "Add to Timeline" checkbox align to bottom

### DIFF
--- a/source/uwp/AdaptiveCardTestApp/Pages/StartPage.xaml
+++ b/source/uwp/AdaptiveCardTestApp/Pages/StartPage.xaml
@@ -45,6 +45,7 @@
             <CheckBox 
                 x:Name="TimelineCheckBox"
                 Content="Add to Timeline"
+                VerticalAlignment="Bottom"
                 Checked="TimelineCheckBox_Checked"
                 Unchecked="TimelineCheckBox_Checked"/>
         </Grid>


### PR DESCRIPTION
We have more hostconfigs in the mix now, so we end up with overlapping controls. For now, just move the checkbox to the bottom.