### PR TITLE
[UWP] Fix for 2400 - Images not obeying parent container width constraints

### DIFF
--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -2138,7 +2138,7 @@ namespace AdaptiveNamespace
             ComPtr<IEllipse> backgroundEllipse =
                 XamlHelpers::CreateXamlClass<IEllipse>(HStringReference(RuntimeClass_Windows_UI_Xaml_Shapes_Ellipse));
 
-			Stretch imageStretch = (isAspectRatioNeeded) ? Stretch::Stretch_Fill : Stretch::Stretch_UniformToFill;
+            Stretch imageStretch = (isAspectRatioNeeded) ? Stretch::Stretch_Fill : Stretch::Stretch_UniformToFill;
             bool mustHideElement{true};
 
             ComPtr<IInspectable> parentElement;

--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -2138,7 +2138,7 @@ namespace AdaptiveNamespace
             ComPtr<IEllipse> backgroundEllipse =
                 XamlHelpers::CreateXamlClass<IEllipse>(HStringReference(RuntimeClass_Windows_UI_Xaml_Shapes_Ellipse));
 
-            Stretch stretch = (isAspectRatioNeeded) ? Stretch::Stretch_Fill : Stretch::Stretch_UniformToFill;
+			Stretch imageStretch = (isAspectRatioNeeded) ? Stretch::Stretch_Fill : Stretch::Stretch_UniformToFill;
             bool mustHideElement{true};
 
             ComPtr<IInspectable> parentElement;
@@ -2155,18 +2155,16 @@ namespace AdaptiveNamespace
                                 ellipseAsShape.Get(),
                                 isVisible,
                                 &mustHideElement,
-                                stretch);
+								imageStretch);
 
             ComPtr<IShape> backgroundEllipseAsShape;
             THROW_IF_FAILED(backgroundEllipse.As(&backgroundEllipseAsShape));
 
-            // Set Auto, None, and Stretch to Stretch_UniformToFill. An ellipse set to Stretch_Uniform ends up with size 0.
-            if (size == ABI::AdaptiveNamespace::ImageSize::None || size == ABI::AdaptiveNamespace::ImageSize::Stretch ||
-                size == ABI::AdaptiveNamespace::ImageSize::Auto || hasExplicitMeasurements)
-            {
-                THROW_IF_FAILED(ellipseAsShape->put_Stretch(stretch));
-                THROW_IF_FAILED(backgroundEllipseAsShape->put_Stretch(stretch));
-            }
+			// Set the stretch for the ellipse - this is different to the stretch used for the image brush above.
+			// This will force the ellipse to conform to fit within the confines of its parent.
+			Stretch ellipseStretch = Stretch::Stretch_UniformToFill;
+			THROW_IF_FAILED(ellipseAsShape->put_Stretch(ellipseStretch));
+			THROW_IF_FAILED(backgroundEllipseAsShape->put_Stretch(ellipseStretch));
 
             if (backgroundColor != nullptr)
             {
@@ -2200,7 +2198,7 @@ namespace AdaptiveNamespace
 
             if (backgroundColor != nullptr)
             {
-                // Create a surronding border with solid color background to contain the image
+				// Create a surrounding border with solid color background to contain the image
                 ComPtr<IBorder> border =
                     XamlHelpers::CreateXamlClass<IBorder>(HStringReference(RuntimeClass_Windows_UI_Xaml_Controls_Border));
 
@@ -2246,12 +2244,12 @@ namespace AdaptiveNamespace
         {
             if (pixelWidth)
             {
-                THROW_IF_FAILED(frameworkElement->put_Width(pixelWidth));
+                THROW_IF_FAILED(frameworkElement->put_MaxWidth(pixelWidth));
             }
 
             if (pixelHeight)
             {
-                THROW_IF_FAILED(frameworkElement->put_Height(pixelHeight));
+                THROW_IF_FAILED(frameworkElement->put_MaxHeight(pixelHeight));
             }
         }
         else
@@ -2263,8 +2261,13 @@ namespace AdaptiveNamespace
                 UINT32 imageSize;
                 THROW_IF_FAILED(sizeOptions->get_Small(&imageSize));
 
-                THROW_IF_FAILED(frameworkElement->put_Width(imageSize));
-                THROW_IF_FAILED(frameworkElement->put_Height(imageSize));
+                THROW_IF_FAILED(frameworkElement->put_MaxWidth(imageSize));
+
+				// We don't want to set a max height on the person ellipse as ellipses do not understand preserving aspect ratio when constrained on both axes.
+				// In adaptive cards person images will always be 1:1 aspect ratio and will always be width constrained (as you can't limit heights in adaptive cards) so only setting MaxWidth is ok.
+				if (imageStyle != ImageStyle_Person)
+					THROW_IF_FAILED(frameworkElement->put_MaxHeight(imageSize));
+
                 break;
             }
 
@@ -2273,9 +2276,14 @@ namespace AdaptiveNamespace
                 UINT32 imageSize;
                 THROW_IF_FAILED(sizeOptions->get_Medium(&imageSize));
 
-                THROW_IF_FAILED(frameworkElement->put_Width(imageSize));
-                THROW_IF_FAILED(frameworkElement->put_Height(imageSize));
-                break;
+                THROW_IF_FAILED(frameworkElement->put_MaxWidth(imageSize));
+
+				// We don't want to set a max height on the person ellipse as ellipses do not understand preserving aspect ratio when constrained on both axes.
+				// In adaptive cards person images will always be 1:1 aspect ratio and will always be width constrained (as you can't limit heights in adaptive cards) so only setting MaxWidth is ok.
+				if (imageStyle != ImageStyle_Person)
+					THROW_IF_FAILED(frameworkElement->put_MaxHeight(imageSize));
+
+				break;
             }
 
             case ABI::AdaptiveNamespace::ImageSize::Large:
@@ -2283,8 +2291,13 @@ namespace AdaptiveNamespace
                 UINT32 imageSize;
                 THROW_IF_FAILED(sizeOptions->get_Large(&imageSize));
 
-                THROW_IF_FAILED(frameworkElement->put_Width(imageSize));
-                THROW_IF_FAILED(frameworkElement->put_Height(imageSize));
+                THROW_IF_FAILED(frameworkElement->put_MaxWidth(imageSize));
+
+				// We don't want to set a max height on the person ellipse as ellipses do not understand preserving aspect ratio when constrained on both axes.
+				// In adaptive cards person images will always be 1:1 aspect ratio and will always be width constrained (as you can't limit heights in adaptive cards) so only setting MaxWidth is ok.
+				if (imageStyle != ImageStyle_Person)
+					THROW_IF_FAILED(frameworkElement->put_MaxHeight(imageSize));
+
                 break;
             }
             }

--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -1392,7 +1392,11 @@ namespace AdaptiveNamespace
                         ComPtr<IAdaptiveCard> showCard;
                         THROW_IF_FAILED(showCardAction->get_Card(&showCard));
 
-                        BuildShowCard(showCard.Get(), renderContext, renderArgs, (adaptiveActionSet == nullptr), uiShowCard.GetAddressOf());
+                        BuildShowCard(showCard.Get(),
+                                      renderContext,
+                                      renderArgs,
+                                      (adaptiveActionSet == nullptr),
+                                      uiShowCard.GetAddressOf());
 
                         ComPtr<IPanel> showCardsPanel;
                         THROW_IF_FAILED(showCardsStackPanel.As(&showCardsPanel));
@@ -2155,16 +2159,16 @@ namespace AdaptiveNamespace
                                 ellipseAsShape.Get(),
                                 isVisible,
                                 &mustHideElement,
-								imageStretch);
+                                imageStretch);
 
             ComPtr<IShape> backgroundEllipseAsShape;
             THROW_IF_FAILED(backgroundEllipse.As(&backgroundEllipseAsShape));
 
-			// Set the stretch for the ellipse - this is different to the stretch used for the image brush above.
-			// This will force the ellipse to conform to fit within the confines of its parent.
-			Stretch ellipseStretch = Stretch::Stretch_UniformToFill;
-			THROW_IF_FAILED(ellipseAsShape->put_Stretch(ellipseStretch));
-			THROW_IF_FAILED(backgroundEllipseAsShape->put_Stretch(ellipseStretch));
+            // Set the stretch for the ellipse - this is different to the stretch used for the image brush above.
+            // This will force the ellipse to conform to fit within the confines of its parent.
+            Stretch ellipseStretch = Stretch::Stretch_UniformToFill;
+            THROW_IF_FAILED(ellipseAsShape->put_Stretch(ellipseStretch));
+            THROW_IF_FAILED(backgroundEllipseAsShape->put_Stretch(ellipseStretch));
 
             if (backgroundColor != nullptr)
             {
@@ -2198,7 +2202,7 @@ namespace AdaptiveNamespace
 
             if (backgroundColor != nullptr)
             {
-				// Create a surrounding border with solid color background to contain the image
+                // Create a surrounding border with solid color background to contain the image
                 ComPtr<IBorder> border =
                     XamlHelpers::CreateXamlClass<IBorder>(HStringReference(RuntimeClass_Windows_UI_Xaml_Controls_Border));
 
@@ -2263,10 +2267,12 @@ namespace AdaptiveNamespace
 
                 THROW_IF_FAILED(frameworkElement->put_MaxWidth(imageSize));
 
-				// We don't want to set a max height on the person ellipse as ellipses do not understand preserving aspect ratio when constrained on both axes.
-				// In adaptive cards person images will always be 1:1 aspect ratio and will always be width constrained (as you can't limit heights in adaptive cards) so only setting MaxWidth is ok.
-				if (imageStyle != ImageStyle_Person)
-					THROW_IF_FAILED(frameworkElement->put_MaxHeight(imageSize));
+                // We don't want to set a max height on the person ellipse as ellipses do not understand preserving
+                // aspect ratio when constrained on both axes. In adaptive cards person images will always be 1:1 aspect
+                // ratio and will always be width constrained (as you can't limit heights in adaptive cards) so only
+                // setting MaxWidth is ok.
+                if (imageStyle != ImageStyle_Person)
+                    THROW_IF_FAILED(frameworkElement->put_MaxHeight(imageSize));
 
                 break;
             }
@@ -2278,12 +2284,14 @@ namespace AdaptiveNamespace
 
                 THROW_IF_FAILED(frameworkElement->put_MaxWidth(imageSize));
 
-				// We don't want to set a max height on the person ellipse as ellipses do not understand preserving aspect ratio when constrained on both axes.
-				// In adaptive cards person images will always be 1:1 aspect ratio and will always be width constrained (as you can't limit heights in adaptive cards) so only setting MaxWidth is ok.
-				if (imageStyle != ImageStyle_Person)
-					THROW_IF_FAILED(frameworkElement->put_MaxHeight(imageSize));
+                // We don't want to set a max height on the person ellipse as ellipses do not understand preserving
+                // aspect ratio when constrained on both axes. In adaptive cards person images will always be 1:1 aspect
+                // ratio and will always be width constrained (as you can't limit heights in adaptive cards) so only
+                // setting MaxWidth is ok.
+                if (imageStyle != ImageStyle_Person)
+                    THROW_IF_FAILED(frameworkElement->put_MaxHeight(imageSize));
 
-				break;
+                break;
             }
 
             case ABI::AdaptiveNamespace::ImageSize::Large:
@@ -2293,10 +2301,12 @@ namespace AdaptiveNamespace
 
                 THROW_IF_FAILED(frameworkElement->put_MaxWidth(imageSize));
 
-				// We don't want to set a max height on the person ellipse as ellipses do not understand preserving aspect ratio when constrained on both axes.
-				// In adaptive cards person images will always be 1:1 aspect ratio and will always be width constrained (as you can't limit heights in adaptive cards) so only setting MaxWidth is ok.
-				if (imageStyle != ImageStyle_Person)
-					THROW_IF_FAILED(frameworkElement->put_MaxHeight(imageSize));
+                // We don't want to set a max height on the person ellipse as ellipses do not understand preserving
+                // aspect ratio when constrained on both axes. In adaptive cards person images will always be 1:1 aspect
+                // ratio and will always be width constrained (as you can't limit heights in adaptive cards) so only
+                // setting MaxWidth is ok.
+                if (imageStyle != ImageStyle_Person)
+                    THROW_IF_FAILED(frameworkElement->put_MaxHeight(imageSize));
 
                 break;
             }
@@ -3244,7 +3254,6 @@ namespace AdaptiveNamespace
         THROW_IF_FAILED(datePickerAsFrameworkElement->put_VerticalAlignment(ABI::Windows::UI::Xaml::VerticalAlignment_Top));
 
         THROW_IF_FAILED(datePicker.CopyTo(dateInputControl));
-
 
         // Value
         HString hstringValue;


### PR DESCRIPTION
Addresses UWP issue #2400 where images are not obeying the constraints of the parent container.
This causes problems where images within columns with set widths extend outside of the column bounds and get clipped.