### PR TITLE
[UWP] Exposing user inputs through render context

### DIFF
--- a/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
+++ b/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
@@ -3275,6 +3275,8 @@ AdaptiveNamespaceStart
 
         [propget] HRESULT OverrideStyles([out, retval] Windows.UI.Xaml.ResourceDictionary** overrideDictionary);
 
+        [propget] HRESULT UserInputs([out, retval] AdaptiveInputs * *value);
+
         HRESULT AddInputValue([in] IAdaptiveInputValue* inputValue);
 
         HRESULT AddInlineShowCard([in] AdaptiveActionSet * inputValue,

--- a/source/uwp/Renderer/lib/AdaptiveRenderContext.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveRenderContext.cpp
@@ -77,6 +77,13 @@ namespace AdaptiveNamespace
         return m_overrideDictionary.CopyTo(overrideDictionary);
     }
 
+    HRESULT AdaptiveRenderContext::get_UserInputs(_COM_Outptr_ IAdaptiveInputs** value)
+    {
+        ComPtr<RenderedAdaptiveCard> renderResult;
+        RETURN_IF_FAILED(GetRenderResult(renderResult.GetAddressOf()));
+        return renderResult->get_UserInputs(value);
+    }
+
     HRESULT AdaptiveRenderContext::AddError(ABI::AdaptiveNamespace::ErrorStatusCode statusCode, _In_ HSTRING message)
     {
         ComPtr<AdaptiveError> error;

--- a/source/uwp/Renderer/lib/AdaptiveRenderContext.h
+++ b/source/uwp/Renderer/lib/AdaptiveRenderContext.h
@@ -31,7 +31,7 @@ namespace AdaptiveNamespace
         IFACEMETHODIMP get_ActionRenderers(_COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveActionRendererRegistration** value) override;
         IFACEMETHODIMP get_ActionInvoker(_COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveActionInvoker** value) override;
         IFACEMETHODIMP get_MediaEventInvoker(_COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveMediaEventInvoker** value) override;
-        IFACEMETHODIMP get_UserInputs(ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveInputs** value) override;
+        IFACEMETHODIMP get_UserInputs(_COM_Outptr_ ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveInputs** value) override;
         IFACEMETHODIMP AddInputValue(_In_ ABI::AdaptiveNamespace::IAdaptiveInputValue* inputValue) override;
         IFACEMETHODIMP AddInlineShowCard(_In_opt_ ABI::AdaptiveNamespace::IAdaptiveActionSet* actionSet,
                                          _In_ ABI::AdaptiveNamespace::IAdaptiveShowCardAction* showCardAction,

--- a/source/uwp/Renderer/lib/AdaptiveRenderContext.h
+++ b/source/uwp/Renderer/lib/AdaptiveRenderContext.h
@@ -31,6 +31,7 @@ namespace AdaptiveNamespace
         IFACEMETHODIMP get_ActionRenderers(_COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveActionRendererRegistration** value) override;
         IFACEMETHODIMP get_ActionInvoker(_COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveActionInvoker** value) override;
         IFACEMETHODIMP get_MediaEventInvoker(_COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveMediaEventInvoker** value) override;
+        IFACEMETHODIMP get_UserInputs(ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveInputs** value) override;
         IFACEMETHODIMP AddInputValue(_In_ ABI::AdaptiveNamespace::IAdaptiveInputValue* inputValue) override;
         IFACEMETHODIMP AddInlineShowCard(_In_opt_ ABI::AdaptiveNamespace::IAdaptiveActionSet* actionSet,
                                          _In_ ABI::AdaptiveNamespace::IAdaptiveShowCardAction* showCardAction,


### PR DESCRIPTION
[Link to bug item](https://github.com/Microsoft/AdaptiveCards/issues/2532 )

Exposing the user input values from any input elements in the adaptive card through the Render Context.
This is useful for custom renderers which need to know the input values of other elements in the card as a whole.

Fixes #2532