### PR TITLE
[UWP] Fix min height/rich text block build break

### DIFF
--- a/source/uwp/Renderer/lib/AdaptiveRichTextBlock.h
+++ b/source/uwp/Renderer/lib/AdaptiveRichTextBlock.h
@@ -109,6 +109,11 @@ namespace AdaptiveNamespace
         {
             return AdaptiveCardElementBase::put_Height(height);
         }
+        IFACEMETHODIMP get_MinHeight(_Out_ UINT32* minHeight)
+        {
+            return AdaptiveCardElementBase::get_MinHeight(minHeight);
+        }
+        IFACEMETHODIMP put_MinHeight(UINT32 minHeight) { return AdaptiveCardElementBase::put_MinHeight(minHeight); }
 
         // ITypePeek method
         void* PeekAt(REFIID riid) override { return PeekHelper(riid, this); }


### PR DESCRIPTION
Fix build break caused by the conflict between the min height and the rich text block changes