### PR TITLE
Fix iOS build break

### DIFF
--- a/source/shared/cpp/ObjectModel/BaseCardElement.h
+++ b/source/shared/cpp/ObjectModel/BaseCardElement.h
@@ -8,6 +8,9 @@
 #include "RemoteResourceInformation.h"
 #include "Util.h"
 
+int ParseSizeForPixelSize(const std::string& sizeString,
+                          std::vector<std::shared_ptr<AdaptiveSharedNamespace::AdaptiveCardParseWarning>>* warnings);
+
 void HandleUnknownProperties(const Json::Value& json, const std::unordered_set<std::string>& knownProperties, Json::Value& unknownProperties);
 
 namespace AdaptiveSharedNamespace
@@ -46,7 +49,9 @@ namespace AdaptiveSharedNamespace
 
         template<typename T> static std::shared_ptr<T> Deserialize(ParseContext& context, const Json::Value& json);
 
-        static void ParseJsonObject(AdaptiveSharedNamespace::ParseContext& context, const Json::Value& json, std::shared_ptr<BaseElement>& element);
+        static void ParseJsonObject(AdaptiveSharedNamespace::ParseContext& context,
+                                    const Json::Value& json,
+                                    std::shared_ptr<BaseElement>& element);
 
     protected:
         static Json::Value SerializeSelectAction(const std::shared_ptr<BaseActionElement> selectAction);

--- a/source/shared/cpp/ObjectModel/Util.h
+++ b/source/shared/cpp/ObjectModel/Util.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "BaseCardElement.h"
 #include "AdaptiveCardParseWarning.h"
 
 std::string ValidateColor(const std::string& backgroundColor,


### PR DESCRIPTION
Fix iOS break due to commit 41796ba. Not the happiest person with this fix -- it's a little unclear why the `#include "util.h"` isn't working. Don't have access to xcode currently to find a better fix, though.