### PR TITLE
Fix Null value handling for Min, Max, and Value in AdaptiveNumberInput (release/1.1)

### DIFF
--- a/custom.props
+++ b/custom.props
@@ -4,7 +4,7 @@
     <VersionMajor>1</VersionMajor>
     <VersionMinor>1</VersionMinor>
     <!-- The nuget package version should be incremented when we produce QFEs -->
-    <NuGetPackVersion>1.1.3</NuGetPackVersion>
+    <NuGetPackVersion>1.1.4</NuGetPackVersion>
     <VersionInfoProductName>AdaptiveCards</VersionInfoProductName>
   </PropertyGroup>
 </Project>

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Html/Properties/AssemblyInfo.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Html/Properties/AssemblyInfo.cs
@@ -2,6 +2,6 @@
 using System.Reflection;
 
 #if DELAY_SIGN
-[assembly: AssemblyKeyFileAttribute(@"\\cp1pd2cdscvlt01\Public\StrongNamePublicKeys\35MSSharedLib1024.snk")]
+[assembly: AssemblyKeyFileAttribute(@"\\cp1l4omt\StrongNamePublicKeys\35MSSharedLib1024.snk")]
 [assembly: AssemblyDelaySignAttribute(true)]
 #endif

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf.Xceed/Properties/AssemblyInfo.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf.Xceed/Properties/AssemblyInfo.cs
@@ -2,6 +2,6 @@
 using System.Reflection;
 
 #if DELAY_SIGN
-[assembly: AssemblyKeyFileAttribute(@"\\cp1pd2cdscvlt01\Public\StrongNamePublicKeys\35MSSharedLib1024.snk")]
+[assembly: AssemblyKeyFileAttribute(@"\\cp1l4omt\StrongNamePublicKeys\35MSSharedLib1024.snk")]
 [assembly: AssemblyDelaySignAttribute(true)]
 #endif

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/Properties/AssemblyInfo.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/Properties/AssemblyInfo.cs
@@ -2,6 +2,6 @@
 using System.Reflection;
 
 #if DELAY_SIGN
-[assembly: AssemblyKeyFileAttribute(@"\\cp1pd2cdscvlt01\Public\StrongNamePublicKeys\35MSSharedLib1024.snk")]
+[assembly: AssemblyKeyFileAttribute(@"\\cp1l4omt\StrongNamePublicKeys\35MSSharedLib1024.snk")]
 [assembly: AssemblyDelaySignAttribute(true)]
 #endif

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveNumberInput.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveNumberInput.cs
@@ -34,6 +34,7 @@ namespace AdaptiveCards
         /// <summary>
         ///     The initial value for the field
         /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
 #if !NETSTANDARD1_3
         [XmlAttribute]
 #endif
@@ -43,6 +44,7 @@ namespace AdaptiveCards
         /// <summary>
         ///     hint of minimum value(may be ignored by some clients)
         /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
 #if !NETSTANDARD1_3
         [XmlAttribute]
 #endif
@@ -52,6 +54,7 @@ namespace AdaptiveCards
         /// <summary>
         ///     hint of maximum value(may be ignored by some clients)
         /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
 #if !NETSTANDARD1_3
         [XmlAttribute]
 #endif

--- a/source/dotnet/Library/AdaptiveCards/Properties/AssemblyInfo.cs
+++ b/source/dotnet/Library/AdaptiveCards/Properties/AssemblyInfo.cs
@@ -2,6 +2,6 @@
 using System.Reflection;
 
 #if DELAY_SIGN
-[assembly: AssemblyKeyFileAttribute(@"\\cp1pd2cdscvlt01\Public\StrongNamePublicKeys\35MSSharedLib1024.snk")]
+[assembly: AssemblyKeyFileAttribute(@"\\cp1l4omt\StrongNamePublicKeys\35MSSharedLib1024.snk")]
 [assembly: AssemblyDelaySignAttribute(true)]
 #endif

--- a/source/dotnet/Test/AdaptiveCards.Test/AdaptiveNumberInputTests.cs
+++ b/source/dotnet/Test/AdaptiveCards.Test/AdaptiveNumberInputTests.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+
+namespace AdaptiveCards.Test
+{
+    [TestClass]
+    public class AdaptiveNumberInputTests
+    {
+        [TestMethod]
+        public void TestThatSerializationWorks()
+        {
+            var json = @"{
+  ""type"": ""AdaptiveCard"",
+  ""version"": ""1.0"",
+  ""body"": [
+    {
+      ""type"": ""Input.Number"",
+      ""id"": ""number"",
+      ""placeholder"": ""Pick a number"",
+      ""value"": 5.0,
+      ""min"": 1.0,
+      ""max"": 22.0
+    }
+  ]
+}";
+
+            // Test deserialization
+            var cardResult = AdaptiveCard.FromJson(json);
+            var card = cardResult.Card;
+
+            var inputElement = card?.Body?.FirstOrDefault() as AdaptiveNumberInput;
+            Assert.IsNotNull(inputElement);
+            Assert.AreEqual("Pick a number", inputElement.Placeholder);
+            Assert.AreEqual(1, inputElement.Min);
+            Assert.AreEqual(5, inputElement.Value);
+            Assert.AreEqual(22, inputElement.Max);
+            Assert.AreEqual("number", inputElement.Id);
+
+            // Test serialization
+            var resultJson = card?.ToJson();
+            Assert.AreEqual(json, resultJson);
+        }
+
+        [TestMethod]
+        public void TestThatNaNValueIsDroppedOnSerialization()
+        {
+            var json = @"{
+  ""type"": ""AdaptiveCard"",
+  ""version"": ""1.0"",
+  ""body"": [
+    {
+      ""type"": ""Input.Number"",
+      ""id"": ""number"",
+      ""placeholder"": ""Pick a number"",
+      ""min"": 1.0,
+      ""max"": 22.0
+    }
+  ]
+}";
+
+            // Test deserialization
+            var cardResult = AdaptiveCard.FromJson(json);
+            var card = cardResult.Card;
+            var inputElement = card.Body.FirstOrDefault() as AdaptiveNumberInput;
+            Assert.IsNotNull(inputElement);
+            Assert.AreEqual(double.NaN, inputElement.Value);
+
+            // Test serialization
+            var resultJson = card.ToJson();
+            Assert.IsFalse(resultJson.Contains("\"value\""));
+            Assert.AreEqual(json, resultJson);
+        }
+
+        [TestMethod]
+        public void TestThatNaNMinIsDroppedOnSerialization()
+        {
+            var json = @"{
+  ""type"": ""AdaptiveCard"",
+  ""version"": ""1.0"",
+  ""body"": [
+    {
+      ""type"": ""Input.Number"",
+      ""id"": ""number"",
+      ""placeholder"": ""Pick a number"",
+      ""value"": 5.0,
+      ""max"": 22.0
+    }
+  ]
+}";
+
+            // Test deserialization
+            var cardResult = AdaptiveCard.FromJson(json);
+            var card = cardResult.Card;
+            var inputElement = card.Body.FirstOrDefault() as AdaptiveNumberInput;
+            Assert.IsNotNull(inputElement);
+            Assert.AreEqual(double.NaN, inputElement.Min);
+
+            // Test serialization
+            var resultJson = card.ToJson();
+            Assert.IsFalse(resultJson.Contains("\"min\""));
+            Assert.AreEqual(json, resultJson);
+        }
+
+        [TestMethod]
+        public void TestThatNaNMaxIsDroppedOnSerialization()
+        {
+            var json = @"{
+  ""type"": ""AdaptiveCard"",
+  ""version"": ""1.0"",
+  ""body"": [
+    {
+      ""type"": ""Input.Number"",
+      ""id"": ""number"",
+      ""placeholder"": ""Pick a number"",
+      ""value"": 5.0,
+      ""min"": 1.0
+    }
+  ]
+}";
+
+            // Test deserialization
+            var cardResult = AdaptiveCard.FromJson(json);
+            var card = cardResult.Card;
+            var inputElement = card.Body.FirstOrDefault() as AdaptiveNumberInput;
+            Assert.IsNotNull(inputElement);
+            Assert.AreEqual(double.NaN, inputElement.Max);
+
+            // Test serialization
+            var resultJson = card.ToJson();
+            Assert.IsFalse(resultJson.Contains("\"max\""));
+            Assert.AreEqual(json, resultJson);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2480 in the 1.1 release

* Fix Null value handling for Min, Max, and Value in AdaptiveNumberInput

* address PR comments

(cherry picked from commit a5650dc)