### PR TITLE
Updating the dotnet projects metadata to generate the nuget packages (#2010)

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Rendering.Html/AdaptiveCards.Rendering.Html.csproj
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Html/AdaptiveCards.Rendering.Html.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <TargetFrameworks>net4.5.2;netstandard1.3;netstandard2.0</TargetFrameworks>
-    <Authors>AdaptiveCards</Authors>
+    <Authors>Microsoft</Authors>
     <Summary>Adaptive Card renderer for generating HTML tags</Summary>
     <Description>This library provides the ability to render an Adaptive Card into HTML, typically used for server-side card rendering</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>adaptivecards;adaptive-cards</PackageTags>
-    <PackageProjectUrl>http://adaptivecards.io</PackageProjectUrl>
-    <PackageIconUrl>http://adaptivecards.io/content/icons_blue/blue-48.png</PackageIconUrl>
+    <PackageProjectUrl>https://adaptivecards.io</PackageProjectUrl>
+    <PackageIconUrl>https://adaptivecards.io/content/icons_blue/blue-48.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/Microsoft/AdaptiveCards</RepositoryUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/Microsoft/AdaptiveCards/master/LICENSE</PackageLicenseUrl>
     <DefineConstants>$(DefineConstants);$(AdditionalConstants)</DefineConstants>

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf.Xceed/AdaptiveCards.Rendering.Wpf.Xceed.csproj
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf.Xceed/AdaptiveCards.Rendering.Wpf.Xceed.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <TargetFramework>net4.5.2</TargetFramework>
-    <Authors>AdaptiveCards</Authors>
+    <Authors>Microsoft</Authors>
     <Summary>Adaptive Card renderer for WPF with enhanced input controls provided by the Xceed WPF toolkit</Summary>
     <Description>This library implements classes for rendering Adaptive Cards into WPF controls</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>adaptivecards;adaptive-cards</PackageTags>
-    <PackageProjectUrl>http://adaptivecards.io</PackageProjectUrl>
-    <PackageIconUrl>http://adaptivecards.io/content/icons_blue/blue-48.png</PackageIconUrl>
+    <PackageProjectUrl>https://adaptivecards.io</PackageProjectUrl>
+    <PackageIconUrl>https://adaptivecards.io/content/icons_blue/blue-48.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/Microsoft/AdaptiveCards</RepositoryUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/Microsoft/AdaptiveCards/master/LICENSE</PackageLicenseUrl>
     <RootNamespace>AdaptiveCards.Rendering.Wpf</RootNamespace>

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveCards.Rendering.Wpf.csproj
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveCards.Rendering.Wpf.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <TargetFramework>net4.5.2</TargetFramework>
-    <Authors>AdaptiveCards</Authors>
+    <Authors>Microsoft</Authors>
     <Summary>Adaptive Card renderer for WPF</Summary>
     <Description>This library implements classes for rendering Adaptive Cards into WPF controls</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>adaptivecards;adaptive-cards</PackageTags>
-    <PackageProjectUrl>http://adaptivecards.io</PackageProjectUrl>
-    <PackageIconUrl>http://adaptivecards.io/content/icons_blue/blue-48.png</PackageIconUrl>
+    <PackageProjectUrl>https://adaptivecards.io</PackageProjectUrl>
+    <PackageIconUrl>https://adaptivecards.io/content/icons_blue/blue-48.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/Microsoft/AdaptiveCards</RepositoryUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/Microsoft/AdaptiveCards/master/LICENSE</PackageLicenseUrl>
     <DefineConstants>WPF;$(DefineConstants);$(AdditionalConstants)</DefineConstants>

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveCards.csproj
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveCards.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <TargetFrameworks>net4.5.2;netstandard1.3;netstandard2.0</TargetFrameworks>
-    <Authors>AdaptiveCards</Authors>
+    <Authors>Microsoft</Authors>
     <Summary>Adaptive Card object model for .NET</Summary>
     <Description>This library implements classes for building and serializing adaptive card objects</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>adaptivecards;adaptive-cards</PackageTags>
-    <PackageProjectUrl>http://adaptivecards.io</PackageProjectUrl>
-    <PackageIconUrl>http://adaptivecards.io/content/icons_blue/blue-48.png</PackageIconUrl>
+    <PackageProjectUrl>https://adaptivecards.io</PackageProjectUrl>
+    <PackageIconUrl>https://adaptivecards.io/content/icons_blue/blue-48.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/Microsoft/AdaptiveCards</RepositoryUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/Microsoft/AdaptiveCards/master/LICENSE</PackageLicenseUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
Fixes #2010 in `release/1.0`

(cherry picked from commit f44d396ec66980446568c93870ab91868b1888ab)