### PR TITLE
Make `compact` the default Input.ChoiceSet style

### DIFF
--- a/source/dotnet/Library/AdaptiveCards/AdaptiveChoiceInputStyle.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveChoiceInputStyle.cs
@@ -7,13 +7,13 @@ namespace AdaptiveCards
     public enum AdaptiveChoiceInputStyle
     {
         /// <summary>
-        ///     choices are prefered to be displayed for easy input. Example: Checkbox or Radio buttons
-        /// </summary>
-        Expanded,
-
-        /// <summary>
         ///     choices are prefered to be compactly displayed. Example: ComboBox
         /// </summary>
-        Compact
+        Compact,
+
+        /// <summary>
+        ///     choices are prefered to be displayed for easy input. Example: Checkbox or Radio buttons
+        /// </summary>
+        Expanded
     }
 }

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveChoiceSetInput.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveChoiceSetInput.cs
@@ -40,6 +40,7 @@ namespace AdaptiveCards
 #if !NETSTANDARD1_3
         [XmlAttribute]
 #endif
+        [DefaultValue(typeof(AdaptiveChoiceInputStyle), "compact")]
         public AdaptiveChoiceInputStyle Style { get; set; }
 
         /// <summary>


### PR DESCRIPTION
(to align with other platforms)

Fixes #2446

## How verified
* existing unit tests
* sample card from linked issue in visualizers