### PR TITLE
[Android] Fix background image repeat behaviours

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/BackgroundImageLoaderAsync.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/BackgroundImageLoaderAsync.java
@@ -44,8 +44,6 @@ public class BackgroundImageLoaderAsync extends GenericImageLoaderAsync
 
     void onSuccessfulPostExecute(Bitmap bitmap)
     {
-        int originalWidth = m_layout.getWidth();
-        int originalHeight = m_layout.getHeight();
         BitmapDrawable background = new BackgroundImageDrawable(m_context.getResources(), bitmap, m_backgroundImageProperties);
         m_layout.setBackground(background);
         m_layout.bringChildToFront(m_layout.getChildAt(0));
@@ -71,8 +69,7 @@ public class BackgroundImageLoaderAsync extends GenericImageLoaderAsync
             switch (m_backgroundImageProperties.GetFillMode())
             {
                 case Repeat:
-                    setTileModeXY(Shader.TileMode.REPEAT, Shader.TileMode.REPEAT);
-                    super.draw(canvas);
+                    tileHorizontallyAndVertically(canvas);
                     break;
                 case RepeatVertically:
                     tileVertically(canvas);
@@ -185,7 +182,7 @@ public class BackgroundImageLoaderAsync extends GenericImageLoaderAsync
                     int imageHeight = bitmap.getHeight();
                     canvas.drawBitmap(bitmap,
                                         new Rect(0, 0, remainingWidth, imageHeight),
-                                        new Rect(x, (int)verticalOffset, canvasWidth, imageHeight),
+                                        new Rect(x, (int)verticalOffset, canvasWidth, (int)verticalOffset + imageHeight),
                                         getPaint());
                 }
             }
@@ -224,8 +221,42 @@ public class BackgroundImageLoaderAsync extends GenericImageLoaderAsync
                     int imageWidth = bitmap.getWidth();
                     canvas.drawBitmap(bitmap,
                         new Rect(0, 0, imageWidth, remainingHeight),
-                        new Rect((int)horizontalOffset, y, imageWidth, canvasHeight),
+                        new Rect((int)horizontalOffset, y, (int)horizontalOffset + imageWidth, canvasHeight),
                         getPaint());
+                }
+            }
+        }
+
+        private void tileHorizontallyAndVertically(Canvas canvas)
+        {
+            Bitmap bitmap = m_bitmap;
+
+            int imageHeight = bitmap.getHeight();
+            int imageWidth  = bitmap.getWidth();
+            int canvasHeight = canvas.getHeight();
+            int canvasWidth = canvas.getWidth();
+            for (int y = 0; y < canvasHeight; y += imageHeight)
+            {
+                int remainingHeight = canvasHeight - y;
+                for (int x = 0; x < canvasWidth; x += imageWidth)
+                {
+                    int remainingWidth = canvasWidth - x;
+                    // If the image can be drawn completely, then do it
+                    if (imageWidth <= remainingWidth && imageHeight <= remainingHeight)
+                    {
+                        canvas.drawBitmap(bitmap, x, y, getPaint());
+                    }
+                    else
+                    {
+                        // If the image can't be drawn completely, then draw as much of the image as possible
+                        int drawableWidth = Math.min(remainingWidth, imageWidth);
+                        int drawableHeight = Math.min(remainingHeight, imageHeight);
+
+                        canvas.drawBitmap(bitmap,
+                            new Rect(0, 0, drawableWidth, drawableHeight),
+                            new Rect(x, y, x + drawableWidth, y + drawableHeight),
+                            getPaint());
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes https://github.com/microsoft/AdaptiveCards/issues/2947

The issue came with the "hackish" trick to avoid containers to grow if a background image was specified even if the background was smaller, there I was adding an empty image of size 1x1 but that overrode the repeat behaviour that was using the actual set background image

Also found out that the incomplete images were not being drawn so I fixed that too

### How verified 

The mobile app was run and this are the results

AdaptiveCard.BackgroundImage.FillMode.json
![Screenshot_2019-05-21-11-01-18](https://user-images.githubusercontent.com/35784165/58115762-a2a92c80-7baf-11e9-8ef4-25fa81df3305.png)

AdaptiveCard.BackgroundImage.FillMode.Repeat.json
![Screenshot_2019-05-21-11-01-23](https://user-images.githubusercontent.com/35784165/58115771-a50b8680-7baf-11e9-9583-5e7aeb6eabc6.png)

AdaptiveCard.BackgroundImage.FillMode.RepeatHorizontally.json
![Screenshot_2019-05-21-11-01-35](https://user-images.githubusercontent.com/35784165/58115773-a8067700-7baf-11e9-85ff-1e2f5ba833b7.png)

AdaptiveCard.BackgroundImage.FillMode.RepeatVertically.json
![Screenshot_2019-05-21-11-01-44](https://user-images.githubusercontent.com/35784165/58115780-aa68d100-7baf-11e9-80d1-72f3ba2b7d21.png)

Column.BackgroundImage.json
![Screenshot_2019-05-21-11-02-12](https://user-images.githubusercontent.com/35784165/58115794-b18fdf00-7baf-11e9-8daa-7c94192e8589.png)

Container.BackgroundImage.json
![Screenshot_2019-05-21-11-02-31](https://user-images.githubusercontent.com/35784165/58115801-b5236600-7baf-11e9-9777-77d4e1090545.png)