### PR TITLE
TS: Rename action.sentiment into action.style

### DIFF
--- a/source/nodejs/adaptivecards-designer-app/dist/containers/outlook-container.css
+++ b/source/nodejs/adaptivecards-designer-app/dist/containers/outlook-container.css
@@ -97,24 +97,24 @@ a.ac-anchor:visited:active {
     border: 1px solid #464B93;
 }
 
-.ac-pushButton.sentiment-positive {
+.ac-pushButton.style-positive {
     background-color: #0078D7;
     color: white;
     border: 1px solid #0078D7;
 }
 
-.ac-pushButton.sentiment-positive:hover, .ac-pushButton.sentiment-positive:active {
+.ac-pushButton.style-positive:hover, .ac-pushButton.style-positive:active {
     background-color: #006ABC;
     border: 1px solid #006ABC;
 }
 
-.ac-pushButton.sentiment-destructive {
+.ac-pushButton.style-destructive {
     background-color: #E50000;
     color: white;
     border: 1px solid #E50000;
 }
 
-.ac-pushButton.sentiment-destructive:hover, .ac-pushButton.sentiment-destructive:active {
+.ac-pushButton.style-destructive:hover, .ac-pushButton.style-destructive:active {
     background-color: #BF0000;
     border: 1px solid #BF0000;
 }

--- a/source/nodejs/adaptivecards-designer-app/dist/containers/webchat-container.css
+++ b/source/nodejs/adaptivecards-designer-app/dist/containers/webchat-container.css
@@ -94,20 +94,20 @@ a.ac-anchor:visited:active {
     background-color: #BABABA;
 }
 
-.ac-pushButton.sentiment-positive {
+.ac-pushButton.style-positive {
     background-color: #0078D7;
     color: white;
 }
 
-.ac-pushButton.sentiment-positive:hover, .ac-pushButton.sentiment-positive:active {
+.ac-pushButton.style-positive:hover, .ac-pushButton.style-positive:active {
     background-color: #006ABC;
 }
 
-.ac-pushButton.sentiment-destructive {
+.ac-pushButton.style-destructive {
     background-color: #E50000;
 }
 
-.ac-pushButton.sentiment-destructive:hover, .ac-pushButton.sentiment-destructive:active {
+.ac-pushButton.style-destructive:hover, .ac-pushButton.style-destructive:active {
     background-color: #BF0000;
 }
 

--- a/source/nodejs/adaptivecards-designer-app/dist/containers/webchat-container.css
+++ b/source/nodejs/adaptivecards-designer-app/dist/containers/webchat-container.css
@@ -105,6 +105,7 @@ a.ac-anchor:visited:active {
 
 .ac-pushButton.style-destructive {
     background-color: #E50000;
+    color: white;
 }
 
 .ac-pushButton.style-destructive:hover, .ac-pushButton.style-destructive:active {

--- a/source/nodejs/adaptivecards-designer/src/containers/outlook/outlook-container.css
+++ b/source/nodejs/adaptivecards-designer/src/containers/outlook/outlook-container.css
@@ -97,24 +97,24 @@ a.ac-anchor:visited:active {
     border: 1px solid #464B93;
 }
 
-.ac-pushButton.sentiment-positive {
+.ac-pushButton.style-positive {
     background-color: #0078D7;
     color: white;
     border: 1px solid #0078D7;
 }
 
-.ac-pushButton.sentiment-positive:hover, .ac-pushButton.sentiment-positive:active {
+.ac-pushButton.style-positive:hover, .ac-pushButton.style-positive:active {
     background-color: #006ABC;
     border: 1px solid #006ABC;
 }
 
-.ac-pushButton.sentiment-destructive {
+.ac-pushButton.style-destructive {
     background-color: #E50000;
     color: white;
     border: 1px solid #E50000;
 }
 
-.ac-pushButton.sentiment-destructive:hover, .ac-pushButton.sentiment-destructive:active {
+.ac-pushButton.style-destructive:hover, .ac-pushButton.style-destructive:active {
     background-color: #BF0000;
     border: 1px solid #BF0000;
 }

--- a/source/nodejs/adaptivecards-designer/src/containers/webchat/webchat-container.css
+++ b/source/nodejs/adaptivecards-designer/src/containers/webchat/webchat-container.css
@@ -94,20 +94,21 @@ a.ac-anchor:visited:active {
     background-color: #BABABA;
 }
 
-.ac-pushButton.sentiment-positive {
+.ac-pushButton.style-positive {
     background-color: #0078D7;
     color: white;
 }
 
-.ac-pushButton.sentiment-positive:hover, .ac-pushButton.sentiment-positive:active {
+.ac-pushButton.style-positive:hover, .ac-pushButton.style-positive:active {
     background-color: #006ABC;
 }
 
-.ac-pushButton.sentiment-destructive {
+.ac-pushButton.style-destructive {
     background-color: #E50000;
+    color: white;
 }
 
-.ac-pushButton.sentiment-destructive:hover, .ac-pushButton.sentiment-destructive:active {
+.ac-pushButton.style-destructive:hover, .ac-pushButton.style-destructive:active {
     background-color: #BF0000;
 }
 

--- a/source/nodejs/adaptivecards-designer/src/designer-peers.ts
+++ b/source/nodejs/adaptivecards-designer/src/designer-peers.ts
@@ -667,14 +667,14 @@ export class ActionPeer extends DesignerPeer {
             this.changed(false);
         }
 
-        let sentiment = addLabelAndInput(card, "Sentiment:", Adaptive.ChoiceSetInput);
-        sentiment.input.isCompact = true;
-        sentiment.input.choices.push(new Adaptive.Choice("Default", Adaptive.ActionSentiment.Default.toString()));
-        sentiment.input.choices.push(new Adaptive.Choice("Positive", Adaptive.ActionSentiment.Positive.toString()));
-        sentiment.input.choices.push(new Adaptive.Choice("Destructive", Adaptive.ActionSentiment.Destructive.toString()));
-        sentiment.input.defaultValue = this.action.sentiment.toString();
-        sentiment.input.onValueChanged = () => {
-            this.action.sentiment = <Adaptive.ActionSentiment>parseInt(sentiment.input.value);
+        let style = addLabelAndInput(card, "Style:", Adaptive.ChoiceSetInput);
+        style.input.isCompact = true;
+        style.input.choices.push(new Adaptive.Choice("Default", Adaptive.ActionStyle.Default));
+        style.input.choices.push(new Adaptive.Choice("Positive", Adaptive.ActionStyle.Positive));
+        style.input.choices.push(new Adaptive.Choice("Destructive", Adaptive.ActionStyle.Destructive));
+        style.input.defaultValue = this.action.style;
+        style.input.onValueChanged = () => {
+            this.action.style = style.input.value;
 
             this.changed(false);
         }

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -3722,15 +3722,14 @@ class ActionButton {
                 break;
         }
 
-        switch (this.action.sentiment) {
-            case Enums.ActionSentiment.Positive:
-                this.action.renderedElement.classList.add(...hostConfig.makeCssClassNames("primary", "sentiment-positive"));
-                break;
-            case Enums.ActionSentiment.Destructive:
-                this.action.renderedElement.classList.add(...hostConfig.makeCssClassNames("sentiment-destructive"));
-                break;
+        if (!Utils.isNullOrEmpty(this.action.style)) {
+            if (this.action.style === Enums.ActionStyle.Positive) {
+                this.action.renderedElement.classList.add(...hostConfig.makeCssClassNames("primary", "style-positive"));
+            }
+            else {
+                this.action.renderedElement.classList.add(...hostConfig.makeCssClassNames("style-" + this.action.style.toLowerCase()));
+             }
         }
-
     }
 
     readonly action: Action;
@@ -3816,7 +3815,7 @@ export abstract class Action extends CardObject {
 
     title: string;
     iconUrl: string;
-    sentiment: Enums.ActionSentiment = Enums.ActionSentiment.Default;
+    style: string = Enums.ActionStyle.Default;
 
     onExecute: (sender: Action) => void;
 
@@ -3830,7 +3829,7 @@ export abstract class Action extends CardObject {
         Utils.setProperty(result, "type", this.getJsonTypeName());
         Utils.setProperty(result, "title", this.title);
         Utils.setProperty(result, "iconUrl", this.iconUrl);
-        Utils.setEnumProperty(Enums.ActionSentiment, result, "sentiment", this.sentiment, Enums.ActionSentiment.Default);
+        Utils.setProperty(result, "style", this.style, Enums.ActionStyle.Default);
 
         return result;
     }
@@ -3941,7 +3940,7 @@ export abstract class Action extends CardObject {
 
         this.title = Utils.getStringValue(json["title"]);
         this.iconUrl = Utils.getStringValue(json["iconUrl"]);
-        this.sentiment = Utils.getEnumValue(Enums.ActionSentiment, json["sentiment"], this.sentiment);
+        this.style = Utils.getStringValue(json["style"], this.style);
     }
 
     remove(): boolean {
@@ -3984,16 +3983,16 @@ export abstract class Action extends CardObject {
     }
 
     get isPrimary(): boolean {
-        return this.sentiment == Enums.ActionSentiment.Positive;
+        return this.style == Enums.ActionStyle.Positive;
     }
 
     set isPrimary(value: boolean) {
         if (value) {
-            this.sentiment = Enums.ActionSentiment.Positive;
+            this.style = Enums.ActionStyle.Positive;
         }
         else {
-            if (this.sentiment == Enums.ActionSentiment.Positive) {
-                this.sentiment = Enums.ActionSentiment.Default;
+            if (this.style == Enums.ActionStyle.Positive) {
+                this.style = Enums.ActionStyle.Default;
             }
         }
     }

--- a/source/nodejs/adaptivecards/src/enums.ts
+++ b/source/nodejs/adaptivecards/src/enums.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-export enum ActionSentiment {
-    Default,
-    Positive,
-    Destructive
+export class ActionStyle {
+    static readonly Default = "default";
+    static readonly Positive = "positive";
+    static readonly Destructive = "destructive";
 }
 
 export enum Size {


### PR DESCRIPTION
Also makes the `style` property a string for extensibility.

Hosts that want to use custom styles should declare an `.ac-pushButton.style-<custom style name>` class in their CSS file. Example:

```css
.ac-pushButton.style-myCustomStyle {
    background-color: green;
    color: white;
}
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/2981)