### PR TITLE
[UWP] Build perf improvements

### DIFF
--- a/source/uwp/AdaptiveCards.sln
+++ b/source/uwp/AdaptiveCards.sln
@@ -7,7 +7,6 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AdaptiveCardVisualizer", "Visualizer\AdaptiveCardVisualizer.csproj", "{B5DECA6E-D9EA-476D-9B7E-34D3B3044CD8}"
 	ProjectSection(ProjectDependencies) = postProject
 		{CF169157-F487-420C-8B9B-CA3ABE2BB209} = {CF169157-F487-420C-8B9B-CA3ABE2BB209}
-		{2D040C7D-757A-4292-BB59-62BC53A83C9F} = {2D040C7D-757A-4292-BB59-62BC53A83C9F}
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ObjectModelProjection", "ObjectModelProjection\ObjectModelProjection.vcxproj", "{2D040C7D-757A-4292-BB59-62BC53A83C9F}"

--- a/source/uwp/UWPUnitTests/UWPUnitTests.csproj
+++ b/source/uwp/UWPUnitTests/UWPUnitTests.csproj
@@ -109,7 +109,7 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
-    <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
+    <UseDotNetNativeToolchain>false</UseDotNetNativeToolchain>
   </PropertyGroup>
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>


### PR DESCRIPTION
A couple small changes:

* Remove unneeded dependency between `AdaptiveCardsVisualizer` and `ObjectModelProjection`, since it already depends on `AdaptiveCardRenderer`
* Move `UWPUnitTests` off of the .NET Native toolchain since it's just tests

This dropped builds down by 3-4 minutes of execution time :)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3004)