### PR TITLE
Cumulative ColumnSet fixes from Bug bash

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -5878,6 +5878,7 @@ export class ColumnSet extends StylableCardElementContainer {
             let element = document.createElement("div");
             element.className = hostConfig.makeCssClassName("ac-columnSet");
             element.style.display = "flex";
+            element.style.overflowX = "hidden";
 
             if (AdaptiveCard.useAdvancedCardBottomTruncation) {
                 // See comment in Container.internalRender()

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -2223,7 +2223,7 @@ export abstract class CardElementContainer extends CardElement {
         let element = super.render();
         let hostConfig = this.hostConfig;
 
-        if (this.isSelectable && this._selectAction && hostConfig.supportsInteractivity) {
+        if (element && this.isSelectable && this._selectAction && hostConfig.supportsInteractivity) {
             element.classList.add(hostConfig.makeCssClassName("ac-selectable"));
             element.tabIndex = 0;
             element.setAttribute("role", "button");


### PR DESCRIPTION
Fixes #3007, #3009 
- Fix selectAction exception on empty ColumnSet (https://github.com/microsoft/AdaptiveCards/issues/3007)
- Hide horizontal overflow in ColumnSet (https://github.com/microsoft/AdaptiveCards/issues/3009)

Verified manually.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3008)