### PR TITLE
Update adaptivecards-controls package version

### DIFF
--- a/source/nodejs/adaptivecards-controls/package-lock.json
+++ b/source/nodejs/adaptivecards-controls/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "adaptivecards-controls",
-	"version": "0.1.7",
+	"version": "0.3.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/source/nodejs/adaptivecards-controls/package.json
+++ b/source/nodejs/adaptivecards-controls/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "adaptivecards-controls",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"description": "A library of pure JS/HTML controls designed for use with Adaptive Cards.",
 	"author": "Microsoft",
 	"license": "MIT",

--- a/source/nodejs/adaptivecards-designer-app/package-lock.json
+++ b/source/nodejs/adaptivecards-designer-app/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "adaptivecards-designer-app",
-	"version": "0.1.4",
+	"version": "0.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -254,22 +254,22 @@
 			}
 		},
 		"adaptivecards": {
-			"version": "1.2.0-beta1",
-			"resolved": "https://registry.npmjs.org/adaptivecards/-/adaptivecards-1.2.0-beta1.tgz",
-			"integrity": "sha512-y7CMbFameCNtG8C6kgl/WShJ1ZRojdykGXFbtP+rsCEjcyGBv5zhH/2Kdw26rRmHiwWAZrp2+xqdTvH5RwvjpQ=="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/adaptivecards/-/adaptivecards-1.2.0.tgz",
+			"integrity": "sha512-rfB3dr2/yNMgJHiGCFH247RtLXkKcNwhGbI1GrXSITfyqfo12esTWDLkRLe62b0oGZxPKJZo5187BY9xORZYsg=="
 		},
 		"adaptivecards-controls": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/adaptivecards-controls/-/adaptivecards-controls-0.1.7.tgz",
-			"integrity": "sha512-kDzWotztlJkBWAUl1mUNMSdV/KS8FN3pq7znFEMC2xspTPKhSHaYkB4rbdxTMdhIOQRXEVFG9E/6yOQ02c0L/Q=="
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/adaptivecards-controls/-/adaptivecards-controls-0.2.0.tgz",
+			"integrity": "sha512-LfmE76Chi6hfNnxp7olyEF25t2Jmbm7b9pqVa+RXrTR48Klj4KHGrMrXsVQKhEznAVordYiwLliBMDlbsiJ7Fw=="
 		},
 		"adaptivecards-designer": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/adaptivecards-designer/-/adaptivecards-designer-0.5.0.tgz",
-			"integrity": "sha512-4ph7gV0FRKx5cVBv9IrIa9nL9wtdBEqFmboLr2RfS/ogM1yxhjGJ0pYewT50AD+4OEl54/U0T63FsRtSplqQfg==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/adaptivecards-designer/-/adaptivecards-designer-0.6.0.tgz",
+			"integrity": "sha512-PC/bnwnjT9YxUZAvUlGI0x4t9ytgED+mpJZRhK4TpjkzCZu7MvxDRgRu9tkZK0qsNRafMFQAK9vvbLt2RP9lNA==",
 			"requires": {
-				"adaptivecards": "^1.2.0-beta1",
-				"adaptivecards-controls": "^0.1.7",
+				"adaptivecards": "^1.2.0",
+				"adaptivecards-controls": "^0.2.0",
 				"clipboard": "^2.0.1",
 				"monaco-editor": "^0.15.6"
 			}

--- a/source/nodejs/adaptivecards-designer/package-lock.json
+++ b/source/nodejs/adaptivecards-designer/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "adaptivecards-designer",
-	"version": "0.5.0",
+	"version": "0.6.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -230,14 +230,14 @@
 			}
 		},
 		"adaptivecards": {
-			"version": "1.2.0-beta1",
-			"resolved": "https://registry.npmjs.org/adaptivecards/-/adaptivecards-1.2.0-beta1.tgz",
-			"integrity": "sha512-y7CMbFameCNtG8C6kgl/WShJ1ZRojdykGXFbtP+rsCEjcyGBv5zhH/2Kdw26rRmHiwWAZrp2+xqdTvH5RwvjpQ=="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/adaptivecards/-/adaptivecards-1.2.0.tgz",
+			"integrity": "sha512-rfB3dr2/yNMgJHiGCFH247RtLXkKcNwhGbI1GrXSITfyqfo12esTWDLkRLe62b0oGZxPKJZo5187BY9xORZYsg=="
 		},
 		"adaptivecards-controls": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/adaptivecards-controls/-/adaptivecards-controls-0.1.7.tgz",
-			"integrity": "sha512-kDzWotztlJkBWAUl1mUNMSdV/KS8FN3pq7znFEMC2xspTPKhSHaYkB4rbdxTMdhIOQRXEVFG9E/6yOQ02c0L/Q=="
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/adaptivecards-controls/-/adaptivecards-controls-0.2.0.tgz",
+			"integrity": "sha512-LfmE76Chi6hfNnxp7olyEF25t2Jmbm7b9pqVa+RXrTR48Klj4KHGrMrXsVQKhEznAVordYiwLliBMDlbsiJ7Fw=="
 		},
 		"ajv": {
 			"version": "6.6.2",

--- a/source/nodejs/adaptivecards-visualizer/package-lock.json
+++ b/source/nodejs/adaptivecards-visualizer/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "adaptivecards-visualizer",
-	"version": "1.1.6",
+	"version": "1.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -214,9 +214,9 @@
 			}
 		},
 		"adaptivecards": {
-			"version": "1.2.0-beta1",
-			"resolved": "https://registry.npmjs.org/adaptivecards/-/adaptivecards-1.2.0-beta1.tgz",
-			"integrity": "sha512-y7CMbFameCNtG8C6kgl/WShJ1ZRojdykGXFbtP+rsCEjcyGBv5zhH/2Kdw26rRmHiwWAZrp2+xqdTvH5RwvjpQ=="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/adaptivecards/-/adaptivecards-1.2.0.tgz",
+			"integrity": "sha512-rfB3dr2/yNMgJHiGCFH247RtLXkKcNwhGbI1GrXSITfyqfo12esTWDLkRLe62b0oGZxPKJZo5187BY9xORZYsg=="
 		},
 		"ajv": {
 			"version": "6.6.2",

--- a/source/nodejs/adaptivecards/package-lock.json
+++ b/source/nodejs/adaptivecards/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "adaptivecards",
-	"version": "1.2.0-beta1",
+	"version": "1.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/source/nodejs/package-lock.json
+++ b/source/nodejs/package-lock.json
@@ -1866,7 +1866,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
@@ -2638,7 +2638,7 @@
     },
     "callsites": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
       "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
       "dev": true
     },
@@ -5068,7 +5068,6 @@
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5271,8 +5270,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5362,8 +5360,7 @@
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -5929,7 +5926,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
@@ -7634,7 +7631,7 @@
     },
     "jsesc": {
       "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+      "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
       "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
       "dev": true
     },
@@ -10003,7 +10000,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -10928,7 +10925,7 @@
         },
         "readable-stream": {
           "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
           "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
           "dev": true,
           "requires": {


### PR DESCRIPTION
Current `master` branch builds of nodejs fail since we shipped a new version of `adaptivecards-controls`. This is due to how we handle versioning on our internal package feed. The fix is to move master to the next minor version (`release/1.2` is still at `0.2.0`).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3023)