### PR TITLE
[UWP][TestApp] Usability Improvements

### DIFF
--- a/source/uwp/AdaptiveCardTestApp/Pages/RunningTestsPage.xaml.cs
+++ b/source/uwp/AdaptiveCardTestApp/Pages/RunningTestsPage.xaml.cs
@@ -60,23 +60,21 @@ namespace AdaptiveCardTestApp.Pages
 
             Color indicatorColor;
             Symbol symbol;
-            switch (status)
+
+            if (status.IsPassingStatus())
             {
-                case TestStatus.Passed:
-                case TestStatus.PassedButSourceWasChanged:
-                    indicatorColor = Colors.Green;
-                    symbol = Symbol.Accept;
-                    break;
-
-                case TestStatus.New:
-                    indicatorColor = Color.FromArgb(255, 65, 159, 254); // A nice blue color
-                    symbol = Symbol.Add;
-                    break;
-
-                default:
-                    indicatorColor = Colors.Red;
-                    symbol = Symbol.Cancel;
-                    break;
+                indicatorColor = Colors.Green;
+                symbol = Symbol.Accept;
+            }
+            else if (status.NewCard)
+            {
+                indicatorColor = Color.FromArgb(255, 65, 159, 254); // A nice blue color
+                symbol = Symbol.Add;
+            }
+            else
+            {
+                indicatorColor = Colors.Red;
+                symbol = Symbol.Cancel;
             }
 
             visual.Children.Add(new Ellipse()

--- a/source/uwp/AdaptiveCardTestApp/Pages/TestResultsPage.xaml
+++ b/source/uwp/AdaptiveCardTestApp/Pages/TestResultsPage.xaml
@@ -36,13 +36,38 @@
                         HorizontalAlignment="Stretch"
                         Click="ButtonStartOver_Click"/>
                     <Button
-                        x:Name="ButtonAcceptAll"
-                        Content="Accept all"
+                        x:Name="ButtonUpdateOriginals"
                         RelativePanel.RightOf="ButtonStartOver"
                         Style="{ThemeResource AccentButtonStyle}"
                         Margin="2,2,2,2"
                         HorizontalAlignment="Stretch"
+                        Content="Accept all new sources"
                         Click="ButtonAcceptAll_Click"/>
+                    <Button
+                        x:Name="ButtonUpdateJson"
+                        RelativePanel.RightOf="ButtonUpdateOriginals"
+                        Style="{ThemeResource AccentButtonStyle}"
+                        Margin="2,2,2,2"
+                        HorizontalAlignment="Stretch"
+                        Content="Accept all new json"
+                        Click="ButtonAcceptAll_Click"/>
+                    <Button
+                        x:Name="ButtonUpdateImage"
+                        RelativePanel.RightOf="ButtonUpdateJson"
+                        Style="{ThemeResource AccentButtonStyle}"
+                        Margin="2,2,2,2"
+                        HorizontalAlignment="Stretch"
+                        Content="Accept all new images"
+                        Click="ButtonAcceptAll_Click"/>
+                    <Button
+                        x:Name="ButtonUpdateAll"
+                        RelativePanel.RightOf="ButtonUpdateImage"
+                        Style="{ThemeResource AccentButtonStyle}"
+                        Margin="2,2,2,2"
+                        HorizontalAlignment="Stretch"
+                        Content="Accept all changes"
+                        Click="ButtonAcceptAll_Click"/>
+
                 </RelativePanel>
             </ListView.Header>
             <ListView.ItemTemplate>

--- a/source/uwp/AdaptiveCardTestApp/Pages/TestResultsPage.xaml.cs
+++ b/source/uwp/AdaptiveCardTestApp/Pages/TestResultsPage.xaml.cs
@@ -119,19 +119,19 @@ namespace AdaptiveCardTestApp.Pages
             bool updateJson = false;
 
             Button buttonSender = sender as Button;
-            if (buttonSender.Name == "ButtonUpdateOriginals")
+            if (buttonSender == ButtonUpdateOriginals)
             {
                 updateOriginals = true;
             }
-            else if (buttonSender.Name == "ButtonUpdateJson")
+            else if (buttonSender == ButtonUpdateJson)
             {
                 updateJson = true;
             }
-            else if (buttonSender.Name == "ButtonUpdateImage")
+            else if (buttonSender == ButtonUpdateImage)
             {
                 updateImage = true;
             }
-            else if (buttonSender.Name == "ButtonUpdateAll")
+            else if (buttonSender == ButtonUpdateAll)
             {
                 updateOriginals = updateJson = updateImage = true;
             }

--- a/source/uwp/AdaptiveCardTestApp/Pages/TestResultsPage.xaml.cs
+++ b/source/uwp/AdaptiveCardTestApp/Pages/TestResultsPage.xaml.cs
@@ -42,11 +42,8 @@ namespace AdaptiveCardTestApp.Pages
             ListViewCategories.ItemsSource = new TestResultsCategoryViewModel[]
             {
                 model.Passed,
-                model.Failed,
-                model.JsonFailed,
-                model.ImageAndJsonFailed,
-                model.FailedButSourceWasChanged,
                 model.PassedButSourceWasChanged,
+                model.Failed,
                 model.Leaked,
                 model.New,
             };
@@ -54,21 +51,6 @@ namespace AdaptiveCardTestApp.Pages
             if (model.Failed.Results.Count > 0)
             {
                 ListViewCategories.SelectedItem = model.Failed;
-            }
-
-            else if (model.JsonFailed.Results.Count > 0)
-            {
-                ListViewCategories.SelectedItem = model.JsonFailed;
-            }
-
-            else if (model.ImageAndJsonFailed.Results.Count > 0)
-            {
-                ListViewCategories.SelectedItem = model.ImageAndJsonFailed;
-            }
-
-            else if (model.FailedButSourceWasChanged.Results.Count > 0)
-            {
-                ListViewCategories.SelectedItem = model.FailedButSourceWasChanged;
             }
 
             else if (model.PassedButSourceWasChanged.Results.Count > 0)
@@ -97,19 +79,66 @@ namespace AdaptiveCardTestApp.Pages
         private void ListViewCategories_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             var model = DataContext as TestResultsViewModel;
-            ButtonAcceptAll.Visibility = Visibility.Visible;
+            ButtonUpdateAll.Visibility = Visibility.Visible;
 
             var category = ListViewCategories.SelectedItem as TestResultsCategoryViewModel;
 
             ListViewResults.ItemsSource = category?.Results;
-            ButtonAcceptAll.Visibility = (category == model.Passed) ? Visibility.Collapsed : Visibility.Visible;
+
+            if (category == model.Passed)
+            {
+                // For passed files, no update buttons are necessary
+                ButtonUpdateAll.Visibility = Visibility.Collapsed;
+                ButtonUpdateImage.Visibility = Visibility.Collapsed;
+                ButtonUpdateJson.Visibility = Visibility.Collapsed;
+                ButtonUpdateOriginals.Visibility = Visibility.Collapsed;
+            }
+            else if (category == model.PassedButSourceWasChanged)
+            {
+                // For the case of passing files with changed source, only the button for updating
+                // originals is present 
+                ButtonUpdateAll.Visibility = Visibility.Collapsed;
+                ButtonUpdateImage.Visibility = Visibility.Collapsed;
+                ButtonUpdateJson.Visibility = Visibility.Collapsed;
+            }
+            else if (category == model.New)
+            {
+                // For new files, only let them accept all
+                ButtonUpdateImage.Visibility = Visibility.Collapsed;
+                ButtonUpdateJson.Visibility = Visibility.Collapsed;
+                ButtonUpdateOriginals.Visibility = Visibility.Collapsed;
+            }
+
+            ButtonUpdateAll.Visibility = (category == model.Passed) ? Visibility.Collapsed : Visibility.Visible;
         }
 
         private async void ButtonAcceptAll_Click(object sender, RoutedEventArgs e)
         {
+            bool updateOriginals = false;
+            bool updateImage = false;
+            bool updateJson = false;
+
+            Button buttonSender = sender as Button;
+            if (buttonSender.Name == "ButtonUpdateOriginals")
+            {
+                updateOriginals = true;
+            }
+            else if (buttonSender.Name == "ButtonUpdateJson")
+            {
+                updateJson = true;
+            }
+            else if (buttonSender.Name == "ButtonUpdateImage")
+            {
+                updateImage = true;
+            }
+            else if (buttonSender.Name == "ButtonUpdateAll")
+            {
+                updateOriginals = updateJson = updateImage = true;
+            }
+
             foreach (var item in ((ListViewResults.ItemsSource as IEnumerable).OfType<TestResultViewModel>()).ToArray())
             {
-                await item.SaveAsNewExpectedAsync();
+                await item.SaveAsNewExpectedAsync(updateOriginals, updateJson, updateImage); 
             }
         }
 

--- a/source/uwp/AdaptiveCardTestApp/ViewModels/TestResultsViewModel.cs
+++ b/source/uwp/AdaptiveCardTestApp/ViewModels/TestResultsViewModel.cs
@@ -11,23 +11,17 @@ namespace AdaptiveCardTestApp.ViewModels
     {
         public TestResultsCategoryViewModel Passed { get; }
         public TestResultsCategoryViewModel Failed { get; }
-        public TestResultsCategoryViewModel ImageAndJsonFailed { get; }
-        public TestResultsCategoryViewModel JsonFailed { get; }
-        public TestResultsCategoryViewModel FailedButSourceWasChanged { get; }
         public TestResultsCategoryViewModel PassedButSourceWasChanged { get; }
         public TestResultsCategoryViewModel New { get; }
         public TestResultsCategoryViewModel Leaked { get; }
 
         public TestResultsViewModel(IEnumerable<TestResultViewModel> results)
         {
-            Passed = new TestResultsCategoryViewModel("Passed", results.Where(i => i.Status == TestStatus.Passed));
-            Failed = new TestResultsCategoryViewModel("Image Comparison Failed", results.Where(i => i.Status == TestStatus.Failed));
-            JsonFailed = new TestResultsCategoryViewModel("Json Roundtrip Failed", results.Where(i => i.Status == TestStatus.JsonFailed));
-            ImageAndJsonFailed = new TestResultsCategoryViewModel("Image Comparison and Json Roundtrip Failed", results.Where(i => i.Status == TestStatus.ImageAndJsonFailed));
-            FailedButSourceWasChanged = new TestResultsCategoryViewModel("Failed/source changed", results.Where(i => i.Status == TestStatus.FailedButSourceWasChanged));
-            PassedButSourceWasChanged = new TestResultsCategoryViewModel("Passed/source changed", results.Where(i => i.Status == TestStatus.PassedButSourceWasChanged));
+            Passed = new TestResultsCategoryViewModel("Passed", results.Where(i => i.Status.IsPassingStatus() && i.Status.OriginalMatched));
+            PassedButSourceWasChanged = new TestResultsCategoryViewModel("Passed (source changed)", results.Where(i => i.Status.IsPassingStatus() && !i.Status.OriginalMatched));
+            Failed = new TestResultsCategoryViewModel("Failed", results.Where(i => !i.Status.IsPassingStatus() && !i.Status.NewCard));
             Leaked = new TestResultsCategoryViewModel("Leaked", results.Where(i => i.TestResult.IsLeaked == true));
-            New = new TestResultsCategoryViewModel("New", results.Where(i => i.Status == TestStatus.New));
+            New = new TestResultsCategoryViewModel("New", results.Where(i => i.Status.NewCard));
 
             foreach (var r in results)
             {
@@ -43,18 +37,21 @@ namespace AdaptiveCardTestApp.ViewModels
             {
                 Passed.Results.Remove(item);
                 Failed.Results.Remove(item);
-                JsonFailed.Results.Remove(item);
-                ImageAndJsonFailed.Results.Remove(item);
-                FailedButSourceWasChanged.Results.Remove(item);
                 PassedButSourceWasChanged.Results.Remove(item);
                 New.Results.Remove(item);
                 Leaked.Results.Remove(item);
 
-                switch (item.Status)
+                if (item.Status.IsPassingStatus() && item.Status.OriginalMatched)
                 {
-                    case TestStatus.Passed:
-                        Passed.Results.Add(item);
-                        break;
+                    Passed.Results.Add(item);
+                }
+                else if (item.Status.IsPassingStatus() && !item.Status.OriginalMatched)
+                {
+                    PassedButSourceWasChanged.Results.Add(item);
+                }
+                else
+                {
+                    Failed.Results.Add(item);
                 }
             }
         }

--- a/source/uwp/AdaptiveCardTestApp/Views/TestResultView.xaml
+++ b/source/uwp/AdaptiveCardTestApp/Views/TestResultView.xaml
@@ -27,6 +27,32 @@
                 Text="{Binding HostConfigName}"/>
             <TextBlock
                 Text="{Binding CardName}"/>
+            <RichTextBlock>
+                <Paragraph/>
+                <Paragraph>
+                    <Span>
+                        <Run Text="Source Json "/>
+                        <Run Foreground="{Binding OriginalResultBrush}" Text="{Binding OriginalResult}"/>
+                    </Span>
+                </Paragraph>
+            </RichTextBlock>            
+            <RichTextBlock>
+                <Paragraph>
+                    <Span>
+                        <Run Text="Json Comparsion "/>
+                        <Run Foreground="{Binding JsonResultBrush}" Text="{Binding JsonResult}"/>
+                    </Span>
+                </Paragraph>
+            </RichTextBlock>
+            <RichTextBlock>
+                <Paragraph>
+                    <Span>
+                        <Run Text="Image Comparsion "/>
+                        <Run Foreground="{Binding ImageResultBrush}" Text="{Binding ImageResult}"/>
+                    </Span>
+                </Paragraph>
+                <Paragraph/>
+            </RichTextBlock>
         </StackPanel>
 
         <Grid Grid.Row="1">
@@ -67,16 +93,19 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
+                <StackPanel>
                 <TextBlock
                     Text="Actual"
                     Style="{ThemeResource BaseTextBlockStyle}"
                     Margin="0,6,0,6"/>
-                <Image
-                    Grid.Row="1"
-                    x:Name="ImageResult"
-                    Source="{Binding ActualImageFile, Converter={StaticResource StorageFileToImageSourceConverter}}"
-                    Stretch="Uniform"
-                    VerticalAlignment="Top"/>
+                <Border BorderThickness="2" BorderBrush="{Binding ImageResultBrush}">
+                    <Image
+                        Grid.Row="1"
+                        x:Name="ImageResult"
+                        Source="{Binding ActualImageFile, Converter={StaticResource StorageFileToImageSourceConverter}}"
+                        Stretch="Uniform"
+                        VerticalAlignment="Top"/>
+                </Border>
                 <TextBlock
                     Grid.Row="1"
                     x:Name="TextBlockError"
@@ -84,6 +113,7 @@
                     Style="{ThemeResource BaseTextBlockStyle}"
                     Foreground="Red"
                     MaxHeight="150"/>
+                </StackPanel>
             </Grid>
             <Grid Grid.Column="4">
                 <Grid.RowDefinitions>
@@ -119,11 +149,30 @@
                 Content="Compare round tripped json"
                 Click="ButtonRoundTrippedJson_Click"/>
             <Button
-                x:Name="ButtonSaveAsExpected"
-                Margin="0,12,0,0"
-                Content="Set as expected"
+                x:Name="ButtonUpdateOriginals"
+                Margin="0,12,6,0"
+                Content="Accept new source"
                 Style="{ThemeResource AccentButtonStyle}"
                 Click="ButtonSaveAsExpected_Click"/>
+            <Button
+                x:Name="ButtonUpdateJson"
+                Margin="0,12,6,0"
+                Content="Accept new json"
+                Style="{ThemeResource AccentButtonStyle}"
+                Click="ButtonSaveAsExpected_Click"/>
+            <Button
+                x:Name="ButtonUpdateImage"
+                Margin="0,12,6,0"
+                Content="Accept new image"
+                Style="{ThemeResource AccentButtonStyle}"
+                Click="ButtonSaveAsExpected_Click"/>
+            <Button
+                x:Name="ButtonUpdateAll"
+                Margin="0,12,6,0"
+                Content="Accept all changes"
+                Style="{ThemeResource AccentButtonStyle}"
+                Click="ButtonSaveAsExpected_Click"/>
+
         </StackPanel>
     </Grid>
 </UserControl>

--- a/source/uwp/AdaptiveCardTestApp/Views/TestResultView.xaml.cs
+++ b/source/uwp/AdaptiveCardTestApp/Views/TestResultView.xaml.cs
@@ -25,47 +25,46 @@ namespace AdaptiveCardTestApp.Views
             {
                 _currModel = model;
 
+                ButtonUpdateImage.Visibility = Visibility.Collapsed;
+                ButtonUpdateJson.Visibility = Visibility.Collapsed;
+                ButtonUpdateOriginals.Visibility = Visibility.Collapsed;
+                ButtonUpdateAll.Visibility = Visibility.Collapsed;
+
                 if (model.Status.NewCard)
                 {
                     // For a new card, only let them update "all"
-                    ButtonUpdateImage.Visibility = Visibility.Collapsed;
-                    ButtonUpdateJson.Visibility = Visibility.Collapsed;
-                    ButtonUpdateOriginals.Visibility = Visibility.Collapsed;
                     ButtonUpdateAll.Visibility = Visibility.Visible;
 
                 }
-                if (model.Status.MatchedViaError)
+                else if (model.Status.MatchedViaError)
                 {
                     // If they matched via error nothing to update except possibly the original
-                    ButtonUpdateImage.Visibility = Visibility.Collapsed;
-                    ButtonUpdateJson.Visibility = Visibility.Collapsed;
-                    ButtonUpdateAll.Visibility = Visibility.Collapsed;
                     ButtonUpdateOriginals.Visibility = model.Status.OriginalMatched ? Visibility.Collapsed : Visibility.Visible;
                 }
                 else
                 {
                     // Provide the appropriate buttons to update as needed
-                    uint buttonsShown = 3;
-                    if (model.Status.ImageMatched)
+                    uint buttonsShown = 0;
+                    if (!model.Status.ImageMatched)
                     {
-                        ButtonUpdateImage.Visibility = Visibility.Collapsed;
-                        buttonsShown--;
+                        ButtonUpdateImage.Visibility = Visibility.Visible;
+                        buttonsShown++;
                     }
-                    if (model.Status.JsonRoundTripMatched)
+                    if (!model.Status.JsonRoundTripMatched)
                     {
-                        ButtonUpdateJson.Visibility = Visibility.Collapsed;
-                        buttonsShown--;
+                        ButtonUpdateJson.Visibility = Visibility.Visible;
+                        buttonsShown++;
                     }
-                    if (model.Status.OriginalMatched)
+                    if (!model.Status.OriginalMatched)
                     {
-                        ButtonUpdateOriginals.Visibility = Visibility.Collapsed;
-                        buttonsShown--;
+                        ButtonUpdateOriginals.Visibility = Visibility.Visible;
+                        buttonsShown++;
                     }
 
                     // Only show the update all button if we have more than one thing to update
-                    if (buttonsShown < 2)
+                    if (buttonsShown > 1)
                     {
-                        ButtonUpdateAll.Visibility = Visibility.Collapsed;
+                        ButtonUpdateAll.Visibility = Visibility.Visible;
                     }
                 }
 
@@ -82,19 +81,19 @@ namespace AdaptiveCardTestApp.Views
             bool updateJson = false;
 
             Button buttonSender = sender as Button;
-            if (buttonSender.Name == "ButtonUpdateOriginals")
+            if (buttonSender == ButtonUpdateOriginals)
             {
                 updateOriginals = true;
             }
-            else if (buttonSender.Name == "ButtonUpdateJson")
+            else if (buttonSender == ButtonUpdateJson)
             {
                 updateJson = true;
             }
-            else if (buttonSender.Name == "ButtonUpdateImage")
+            else if (buttonSender == ButtonUpdateImage)
             {
                 updateImage = true;
             }
-            else if (buttonSender.Name == "ButtonUpdateAll")
+            else if (buttonSender == ButtonUpdateAll)
             {
                 updateOriginals = updateJson = updateImage = true;
             }

--- a/source/uwp/UWPTestLibrary/TestResultViewModel.cs
+++ b/source/uwp/UWPTestLibrary/TestResultViewModel.cs
@@ -6,16 +6,119 @@ using Windows.Graphics.Imaging;
 using Windows.Storage;
 using Windows.UI.Popups;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Media;
 
 namespace UWPTestLibrary
 {
     public class TestResultViewModel : BindableBase
     {
+        public TestResultViewModel()
+        {
+            _status = new TestStatus();
+        }
+
         public string CardName { get; set; }
         public FileViewModel CardFile { get; set; }
 
         public string HostConfigName { get; set; }
         public FileViewModel HostConfigFile { get; set; }
+
+        private Brush GetBrushForResult(bool image)
+        {
+            if (Status.MatchedViaError)
+            {
+                return new SolidColorBrush(Windows.UI.Colors.Black);
+            }
+            else if (Status.NewCard)
+            {
+                return new SolidColorBrush(Windows.UI.Color.FromArgb(255, 65, 159, 254));
+            }
+            else if (image && Status.ImageMatched ||
+                     !image && Status.JsonRoundTripMatched)
+            {
+                return new SolidColorBrush(Windows.UI.Colors.LimeGreen);
+            }
+            else
+            {
+                return new SolidColorBrush(Windows.UI.Colors.Red);
+            }
+        }
+
+        private string GetStringForResult(bool image)
+        {
+            if (Status.MatchedViaError)
+            {
+                return "N/A";
+            }
+            else if (Status.NewCard)
+            {
+                return "New";
+            }
+            else if (image && Status.ImageMatched ||
+                     !image && Status.JsonRoundTripMatched)
+            {
+                return "Passed";
+            }
+            else
+            {
+                return "Failed";
+            }
+        }
+
+        public string ImageResult
+        {
+            get { return GetStringForResult(true); }
+        }
+        public Brush ImageResultBrush
+        {
+            get { return GetBrushForResult(true); }
+        }
+        public string JsonResult
+        {
+            get { return GetStringForResult(false); }
+        }
+        public Brush JsonResultBrush
+        {
+            get { return GetBrushForResult(false); }
+        }
+
+        public string OriginalResult
+        {
+            get
+            {
+                if (Status.NewCard)
+                {
+                    return "New";
+                }
+                else if (Status.OriginalMatched)
+                {
+                    return "Unchanged";
+                }
+                else
+                {
+                    return "Changed";
+                }
+            }
+        }
+
+        public Brush OriginalResultBrush
+        {
+            get
+            {
+                if (Status.NewCard)
+                {
+                    return new SolidColorBrush(Windows.UI.Color.FromArgb(255, 65, 159, 254));
+                }
+                else if (Status.OriginalMatched)
+                {
+                    return new SolidColorBrush(Windows.UI.Colors.LimeGreen);
+                }
+                else
+                {
+                    return new SolidColorBrush(Windows.UI.Colors.Red);
+                }
+            }
+        }
 
         public FileViewModel RoundtrippedJsonModel { get; set; }
         public FileViewModel ExpectedRoundtrippedJsonModel { get; set; }
@@ -78,7 +181,7 @@ namespace UWPTestLibrary
                 var storedInfo = await StoredTestResultInfo.DeserializeFromFileAsync(expectedFolder, answer._expectedFileNameWithoutExtension);
                 if (storedInfo == null)
                 {
-                    answer.Status = TestStatus.New;
+                    answer.Status.NewCard = true;
                 }
                 else
                 {
@@ -101,11 +204,7 @@ namespace UWPTestLibrary
                 {
                     if (answer.ExpectedError == answer.TestResult.Error)
                     {
-                        answer.Status = TestStatus.Passed;
-                    }
-                    else
-                    {
-                        answer.Status = TestStatus.Failed;
+                        answer.Status.MatchedViaError = true;
                     }
                 }
 
@@ -117,45 +216,31 @@ namespace UWPTestLibrary
 
                     if (ImageBytesAreTheSame(oldBytes, newBytes))
                     {
-                        answer.Status = TestStatus.Passed;
-                    }
-                    else
-                    {
-                        answer.Status = TestStatus.Failed;
+                        answer.Status.ImageMatched = true;
                     }
 
                     // Check if the round tripped json is the same
                     answer.ExpectedRoundtrippedJsonModel = await FileViewModel.LoadAsync(answer.ExpectedRoundtrippedJsonFile);
                     answer.RoundtrippedJsonModel = await FileViewModel.LoadAsync(answer.ActualRoundTrippedJsonFile);
-                    if (answer.DidRoundtrippedJsonChange)
+                    if (!answer.DidRoundtrippedJsonChange)
                     {
-                        answer.Status = (answer.Status == TestStatus.Passed) ? TestStatus.JsonFailed : TestStatus.ImageAndJsonFailed;
+                        answer.Status.JsonRoundTripMatched = true;
                     }
-                }
-
-                // Otherwise one had image and one had error, so fail
-                else
-                {
-                    answer.Status = TestStatus.Failed;
                 }
 
                 // See if the source chagned by checking
                 // if the hashes have changed since the stored info
-                if (storedInfo.HostConfigHash != hostConfigFile.Hash
-                    || storedInfo.CardHash != cardFile.Hash)
+                if (storedInfo.HostConfigHash == hostConfigFile.Hash &&
+                    storedInfo.CardHash == cardFile.Hash)
                 {
-                    answer.Status = (answer.Status == TestStatus.Failed ||
-                                     answer.Status == TestStatus.ImageAndJsonFailed ||
-                                     answer.Status == TestStatus.JsonFailed) ?
-                        TestStatus.FailedButSourceWasChanged :
-                        TestStatus.PassedButSourceWasChanged;
+                    answer.Status.OriginalMatched = true;
                 }
             }
             catch
             {
                 // Any exceptions being thrown get reported as "New", typically this results from file
                 // not found of an expected file, which means it genuinely is new
-                answer.Status = TestStatus.New;
+                answer.Status.NewCard = true;
             }
 
             return answer;
@@ -246,12 +331,17 @@ namespace UWPTestLibrary
             return name.Replace('\\', '.');
         }
 
-        public async Task SaveAsNewExpectedAsync()
+        public async Task SaveAsNewExpectedAsync(bool updateOriginals, bool updateJson, bool updateImage)
         {
             try
             {
+                if (!updateOriginals && !updateJson && !updateImage)
+                {
+                    return;
+                }
+
                 // If actual has error and existing did NOT have error, delete existing image
-                if (TestResult.Error != null && ExpectedImageFile != null)
+                if (TestResult.Error != null && ExpectedImageFile != null && updateImage)
                 {
                     try
                     {
@@ -263,47 +353,86 @@ namespace UWPTestLibrary
                 // Save the updated info
                 await new StoredTestResultInfo()
                 {
-                    HostConfigHash = HostConfigFile.Hash,
-                    CardHash = CardFile.Hash,
-                    Error = TestResult.Error
+                    HostConfigHash = updateOriginals ? HostConfigFile.Hash : _oldHostConfigHash,
+                    CardHash = updateOriginals ? CardFile.Hash : _oldCardHash,
+                    Error = (updateJson || updateImage) ? TestResult.Error : ExpectedError
                 }.SaveToFileAsync(_expectedFolder, _expectedFileNameWithoutExtension);
 
                 // Make sure the source files are saved (we use FailIfExists and try/catch since if file already exists no need to update it)
-                try
+                if (updateOriginals)
                 {
-                    var sourceHostConfigFile = await _sourceHostConfigsFolder.CreateFileAsync(GetStoredSourceFileName(HostConfigFile.Name, HostConfigFile.Hash), CreationCollisionOption.FailIfExists);
-                    await FileIO.WriteTextAsync(sourceHostConfigFile, HostConfigFile.Contents);
+                    try
+                    {
+                        var sourceHostConfigFile = await _sourceHostConfigsFolder.CreateFileAsync(GetStoredSourceFileName(HostConfigFile.Name, HostConfigFile.Hash), CreationCollisionOption.OpenIfExists);
+                        await FileIO.WriteTextAsync(sourceHostConfigFile, HostConfigFile.Contents);
 
-                    var oldSourceHostConfigFile = await _sourceHostConfigsFolder.CreateFileAsync(GetStoredSourceFileName(HostConfigFile.Name, _oldHostConfigHash), CreationCollisionOption.OpenIfExists);
-                    await oldSourceHostConfigFile.DeleteAsync(StorageDeleteOption.PermanentDelete);
-                }
-                catch { }
-                try
-                {
-                    var sourceCardFile = await _sourceCardsFolder.CreateFileAsync(GetStoredSourceFileName(CardFile.Name, CardFile.Hash), CreationCollisionOption.FailIfExists);
-                    await FileIO.WriteTextAsync(sourceCardFile, CardFile.Contents);
+                        var oldSourceHostConfigFile = await _sourceHostConfigsFolder.CreateFileAsync(GetStoredSourceFileName(HostConfigFile.Name, _oldHostConfigHash), CreationCollisionOption.OpenIfExists);
+                        await oldSourceHostConfigFile.DeleteAsync(StorageDeleteOption.PermanentDelete);
+                    }
+                    catch { }
+                    try
+                    {
+                        var sourceCardFile = await _sourceCardsFolder.CreateFileAsync(GetStoredSourceFileName(CardFile.Name, CardFile.Hash), CreationCollisionOption.OpenIfExists);
+                        await FileIO.WriteTextAsync(sourceCardFile, CardFile.Contents);
 
-                    var oldSourceCardFile = await _sourceCardsFolder.CreateFileAsync(GetStoredSourceFileName(CardFile.Name, _oldCardHash), CreationCollisionOption.OpenIfExists);
-                    await oldSourceCardFile.DeleteAsync(StorageDeleteOption.PermanentDelete);
+                        var oldSourceCardFile = await _sourceCardsFolder.CreateFileAsync(GetStoredSourceFileName(CardFile.Name, _oldCardHash), CreationCollisionOption.OpenIfExists);
+                        await oldSourceCardFile.DeleteAsync(StorageDeleteOption.PermanentDelete);
+                    }
+                    catch { }
                 }
-                catch { }
 
                 // If no error, update the image file
                 if (TestResult.Error == null)
                 {
-                    var expectedFile = await _expectedFolder.CreateFileAsync(_expectedFileNameWithoutExtension + ".png", CreationCollisionOption.ReplaceExisting);
-                    await ActualImageFile.CopyAndReplaceAsync(expectedFile);
-
-                    var expectedJsonFile = await _expectedFolder.CreateFileAsync(GetStrippedFileName(CardFile) + "ToJson.json", CreationCollisionOption.ReplaceExisting);
-                    await ActualRoundTrippedJsonFile.CopyAndReplaceAsync(expectedJsonFile);
+                    if (updateImage)
+                    {
+                        var expectedFile = await _expectedFolder.CreateFileAsync(_expectedFileNameWithoutExtension + ".png", CreationCollisionOption.ReplaceExisting);
+                        await ActualImageFile.CopyAndReplaceAsync(expectedFile);
+                    }
+                    if (updateJson)
+                    {
+                        var expectedJsonFile = await _expectedFolder.CreateFileAsync(GetStrippedFileName(CardFile) + "ToJson.json", CreationCollisionOption.ReplaceExisting);
+                        await ActualRoundTrippedJsonFile.CopyAndReplaceAsync(expectedJsonFile);
+                    }
                 }
 
-                // Update the status
-                ExpectedError = TestResult.Error;
-                ExpectedImageFile = ActualImageFile;
-                _oldHostConfigHash = HostConfigFile.Hash;
-                _oldCardHash = CardFile.Hash;
-                Status = TestStatus.Passed;
+                // Create a new status with the values set to the current values
+                TestStatus newStatus = new TestStatus();
+                newStatus.ImageMatched = Status.ImageMatched;
+                newStatus.JsonRoundTripMatched = Status.JsonRoundTripMatched;
+                newStatus.MatchedViaError = Status.MatchedViaError;
+                newStatus.NewCard = Status.NewCard;
+                newStatus.OriginalMatched = Status.OriginalMatched;
+
+                // Update based on the changes
+                if ((TestResult.Error != null) && (updateImage || updateJson))
+                {
+                    newStatus.MatchedViaError = true;
+                    ExpectedError = TestResult.Error;
+                }
+                else
+                {
+
+                    if (updateImage)
+                    {
+                        newStatus.ImageMatched = true;
+                        ExpectedImageFile = ActualImageFile;
+                    }
+                    if (updateJson)
+                    {
+                        newStatus.JsonRoundTripMatched = true;
+                    }
+                }
+
+                if (updateOriginals)
+                {
+                    _oldHostConfigHash = HostConfigFile.Hash;
+                    _oldCardHash = CardFile.Hash;
+                    newStatus.OriginalMatched = true;
+                    newStatus.NewCard = false;
+                }
+
+                Status = newStatus;
             }
             catch (Exception ex)
             {
@@ -317,41 +446,70 @@ namespace UWPTestLibrary
         }
     }
 
-    public enum TestStatus
+    public class TestStatus
     {
-        /// <summary>
-        /// Visual identically matched
-        /// </summary>
-        Passed,
+        // The error results match (either both pass or both fail with the same result)
+        public bool MatchedViaError { get; set; } = false;
 
-        /// <summary>
-        /// Visual did match, but source files (payload and host config) changed, so changes are possibly expected
-        /// </summary>
-        PassedButSourceWasChanged,
+        // The original card and host config json matches
+        public bool OriginalMatched { get; set; } = false;
 
-        /// <summary>
-        /// Visual did NOT match, and source files (payload and host config) were identical, Json round tripping matches
-        /// </summary>
-        Failed,
+        // The rendered image matches
+        public bool ImageMatched { get; set; } = false;
 
-        /// <summary>
-        /// Visual did NOT match, and source files (payload and host config) were identical, Json round tripping doesn't match
-        /// </summary>
-        ImageAndJsonFailed,
+        // The round tripped json matches
+        public bool JsonRoundTripMatched { get; set; } = false;
 
-        /// <summary>
-        /// Visual identically matched, Roundtripped json did not match, and source files (payload and host config) were identical
-        /// </summary>
-        JsonFailed,
+        // This is a new card
+        public bool NewCard { get; set; } = false;
 
-        /// <summary>
-        /// Visual did NOT match, but source files (payload and host config) changed, so changes are possibly expected
-        /// </summary>
-        FailedButSourceWasChanged,
+        // Set the status to a passing result
+        public void SetToPassingStatus(bool matchedViaError)
+        {
+            NewCard = false;
+            OriginalMatched = true;
 
-        /// <summary>
-        /// New test, no existing Expected
-        /// </summary>
-        New
+            ImageMatched = !matchedViaError;
+            JsonRoundTripMatched = !matchedViaError;
+            MatchedViaError = matchedViaError;
+        }
+
+        // Determine if this status is a passing result
+        public bool IsPassingStatus()
+        {
+            return MatchedViaError || (ImageMatched && JsonRoundTripMatched);
+        }
+
+        public override string ToString()
+        {
+            if (IsPassingStatus())
+            {
+                return "Passed";
+            }
+            else if (NewCard == true)
+            {
+                return "New Card Added";
+            }
+            else if (!OriginalMatched && ((!ImageMatched || !JsonRoundTripMatched) && !MatchedViaError))
+            {
+                return "Failure with original changed";
+            }
+            else if (!ImageMatched && JsonRoundTripMatched)
+            {
+                return "Image comparison failed";
+            }
+            else if (ImageMatched && !JsonRoundTripMatched)
+            {
+                return "Json round trip failed";
+            }
+            else if (!ImageMatched && !JsonRoundTripMatched)
+            {
+                return "Json round trip and image comparison failed";
+            }
+            else
+            {
+                return base.ToString();
+            }
+        }
     }
 }

--- a/source/uwp/UWPTestLibrary/TestResultViewModel.cs
+++ b/source/uwp/UWPTestLibrary/TestResultViewModel.cs
@@ -448,22 +448,22 @@ namespace UWPTestLibrary
 
     public class TestStatus
     {
-        // The error results match (either both pass or both fail with the same result)
+        /// <summary>The error results match (either both pass or both fail with the same result)</summary>
         public bool MatchedViaError { get; set; } = false;
 
-        // The original card and host config json matches
+        /// <summary> The original card and host config json matches </summary>
         public bool OriginalMatched { get; set; } = false;
 
-        // The rendered image matches
+        /// <summary> The rendered image matches</summary>
         public bool ImageMatched { get; set; } = false;
 
-        // The round tripped json matches
+        /// <summary> The round tripped json matches</summary>
         public bool JsonRoundTripMatched { get; set; } = false;
 
-        // This is a new card
+        /// <summary> This is a new card</summary>
         public bool NewCard { get; set; } = false;
 
-        // Set the status to a passing result
+        /// <summary> Set the status to a passing result</summary>
         public void SetToPassingStatus(bool matchedViaError)
         {
             NewCard = false;

--- a/source/uwp/UWPUnitTests/UnitTest.cs
+++ b/source/uwp/UWPUnitTests/UnitTest.cs
@@ -155,8 +155,11 @@ namespace UWPUnitTests
                 sourceHostConfigsFolder: _sourceHostConfigsFolder,
                 sourceCardsFolder: _sourceCardsFolder);
 
-            if ((result.Status != TestStatus.Passed) &&
-                (result.Status != TestStatus.PassedButSourceWasChanged))
+            // We pass if it's not a new or changed card, and if either the image and json match or they match via error 
+            bool testPass = !result.Status.NewCard && !result.Status.OriginalMatched &&
+                ((result.Status.ImageMatched && result.Status.JsonRoundTripMatched) || result.Status.MatchedViaError);
+
+            if (!testPass)
             {
                 throw new Exception(result.Status.ToString() + ": " + result.HostConfigName + "\\" + result.CardName);
             }


### PR DESCRIPTION
Several improvements to the UWP test app.

- More information in test results. Specifically, calling out the results of original comparison, json round tripping and image comparison. In addition, added a colored border to call out whether the image comparison failed:

![image](https://user-images.githubusercontent.com/9091833/59224894-4d47b600-8b84-11e9-920a-85adc94c169d.png)

- Ability to accept originals, jsons, or images independently, both per card and for the entire list:

![image](https://user-images.githubusercontent.com/9091833/59225100-bb8c7880-8b84-11e9-85c7-a599f730244f.png)
![image](https://user-images.githubusercontent.com/9091833/59225167-e37bdc00-8b84-11e9-8b70-fc331ea609ba.png)

- As a result of those changes, we no longer need all of the combinations of tabs on the side. Simplified that list:

![image](https://user-images.githubusercontent.com/9091833/59225591-f93dd100-8b85-11e9-8a51-6daea62e0966.png)

- To support these changes, changed the TestStatus from an enum to class, and updated the code accordingly.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3046)

Fixes #3045