### PR TITLE
[UWP][TestApp] Reliability fixes

### DIFF
--- a/source/uwp/AdaptiveCardTestApp/Pages/RunningTestsPage.xaml
+++ b/source/uwp/AdaptiveCardTestApp/Pages/RunningTestsPage.xaml
@@ -12,24 +12,24 @@
         <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Disabled">
             <StackPanel Margin="24" Orientation="Horizontal">
 
-                <StackPanel>
-                    <TextBlock
-                        Text="Running tests..."
-                        Style="{ThemeResource TitleTextBlockStyle}"/>
-
-                    <TextBlock
-                        Text="Current test"
-                        Style="{ThemeResource BaseTextBlockStyle}"
-                        Margin="0,24,0,0"/>
-                    <TextBlock
-                        Text="{Binding CurrentHostConfig}"/>
-                    <TextBlock
-                        Text="{Binding CurrentCard}"/>
-                    <Border
-                        Child="{Binding CurrentCardVisual}"
-                        Width="{Binding CurrentCardVisualWidth}"/>
-                </StackPanel>
-
+                <ScrollViewer>
+                    <StackPanel>
+                        <TextBlock
+                            Text="Running tests..."
+                            Style="{ThemeResource TitleTextBlockStyle}"/>
+                        <TextBlock
+                            Text="Current test"
+                            Style="{ThemeResource BaseTextBlockStyle}"
+                            Margin="0,24,0,0"/>
+                        <TextBlock
+                            Text="{Binding CurrentHostConfig}"/>
+                        <TextBlock
+                            Text="{Binding CurrentCard}"/>
+                        <Border
+                            Child="{Binding CurrentCardVisual}"
+                            Width="{Binding CurrentCardVisualWidth}"/>
+                    </StackPanel>
+                </ScrollViewer>
                 <ListView
                     Margin="12,0,0,0"
                     Width="300"

--- a/source/uwp/UWPUnitTests/UnitTest.cs
+++ b/source/uwp/UWPUnitTests/UnitTest.cs
@@ -115,49 +115,71 @@ namespace UWPUnitTests
 
         async public Task TestCard(FileViewModel hostConfigFile, FileViewModel cardFile)
         {
-            var renderResult = await UWPTestLibrary.RenderTestHelpers.RenderCard(cardFile, hostConfigFile, new Dictionary<string, AdaptiveCards.Rendering.Uwp.IAdaptiveCardResourceResolver>());
+            uint reruns = 0;
+            TestResultViewModel result = null;
+            bool retryImage = true;
+            bool testPass = false;
 
-            if (renderResult.Tree != null)
+            while (retryImage)
             {
-                UWPTestLibrary.ImageWaiter imageWaiter = new ImageWaiter(renderResult.Tree);
+                var renderResult = await UWPTestLibrary.RenderTestHelpers.RenderCard(cardFile, hostConfigFile, new Dictionary<string, AdaptiveCards.Rendering.Uwp.IAdaptiveCardResourceResolver>());
 
-                StackPanel stackPanel = new StackPanel();
-                stackPanel.Children.Add(renderResult.Tree);
+                if (renderResult.Tree != null)
+                {
+                    UWPTestLibrary.ImageWaiter imageWaiter = new ImageWaiter(renderResult.Tree);
 
-                Border border = new Border();
-                border.Width = renderResult.CardWidth;
-                border.Child = stackPanel;
-                (Window.Current.Content as Frame).Content = border;
+                    StackPanel stackPanel = new StackPanel();
+                    stackPanel.Children.Add(renderResult.Tree);
 
-                await imageWaiter.WaitOnAllImagesAsync();
+                    Border border = new Border();
+                    border.Width = renderResult.CardWidth;
+                    border.Child = stackPanel;
 
+                    ScrollViewer scrollViewer = new ScrollViewer();
+                    scrollViewer.Content = border;
+
+                    (Window.Current.Content as Frame).Content = scrollViewer;
+
+                    await imageWaiter.WaitOnAllImagesAsync();
+
+                }
+
+                StorageFile imageResultFile = null;
+                StorageFile jsonResultFile = null;
+                if (renderResult.Error == null)
+                {
+                    imageResultFile = await _tempResultsFolder.CreateFileAsync("Result.png", CreationCollisionOption.GenerateUniqueName);
+                    jsonResultFile = await _tempResultsFolder.CreateFileAsync("Result.json", CreationCollisionOption.GenerateUniqueName);
+
+                    await UWPTestLibrary.RenderTestHelpers.ResultsToFile(imageResultFile, jsonResultFile, renderResult.RoundTrippedJSON, renderResult.Tree);
+                }
+
+                await Task.Delay(10);
+
+                result = await TestResultViewModel.CreateAsync(
+                    cardFile: cardFile,
+                    hostConfigFile: hostConfigFile,
+                    renderedTestResult: renderResult,
+                    actualImageFile: imageResultFile,
+                    actualJsonFile: jsonResultFile,
+                    expectedFolder: _expectedFolder,
+                    sourceHostConfigsFolder: _sourceHostConfigsFolder,
+                    sourceCardsFolder: _sourceCardsFolder);
+
+                testPass = result.Status.IsPassingStatus() && result.Status.OriginalMatched;
+
+                if(!testPass)
+                {
+                    // Retry if we failed on image matching for an unchanged card to allow for
+                    // occasional differences in image rendering
+                    retryImage = result.Status.OriginalMatched && !result.Status.ImageMatched && (reruns < 3);
+                    reruns++;
+                }
+                else
+                {
+                    retryImage = false;
+                }
             }
-
-            StorageFile imageResultFile = null;
-            StorageFile jsonResultFile = null;
-            if (renderResult.Error == null)
-            {
-                imageResultFile = await _tempResultsFolder.CreateFileAsync("Result.png", CreationCollisionOption.GenerateUniqueName);
-                jsonResultFile = await _tempResultsFolder.CreateFileAsync("Result.json", CreationCollisionOption.GenerateUniqueName);
-
-                await UWPTestLibrary.RenderTestHelpers.ResultsToFile(imageResultFile, jsonResultFile, renderResult.RoundTrippedJSON, renderResult.Tree);
-            }
-
-            await Task.Delay(10);
-
-            var result = await TestResultViewModel.CreateAsync(
-                cardFile: cardFile,
-                hostConfigFile: hostConfigFile,
-                renderedTestResult: renderResult,
-                actualImageFile: imageResultFile,
-                actualJsonFile: jsonResultFile,
-                expectedFolder: _expectedFolder,
-                sourceHostConfigsFolder: _sourceHostConfigsFolder,
-                sourceCardsFolder: _sourceCardsFolder);
-
-            // We pass if it's not a new or changed card, and if either the image and json match or they match via error 
-            bool testPass = !result.Status.NewCard && !result.Status.OriginalMatched &&
-                ((result.Status.ImageMatched && result.Status.JsonRoundTripMatched) || result.Status.MatchedViaError);
 
             if (!testPass)
             {


### PR DESCRIPTION
Two main fixes to improve test app reliability:

- Scroll bar for test result. Sometimes images that were below the fold wouldn't fully load, leading to test failures. Adding a ScrollViewer control causes those images to load consistently.
- Reruns on failure. Rerun a failed test to allow for occasional image inconsistencies.

With these changes, all test app files are passing consistently for me (please let me know if you are seeing failures).

Fixes #3047 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3069)