### PR TITLE
Add px to Column.width and some other schema description updates

### DIFF
--- a/schemas/1.2.0/adaptive-card.json
+++ b/schemas/1.2.0/adaptive-card.json
@@ -351,7 +351,7 @@
         },
         "minHeight": {
           "type": "string",
-          "description": "Specifies the minimum height of the column.",
+          "description": "Specifies the minimum height of the column in pixels, like `\"80px\"`.",
           "examples": [
             "50px"
           ],
@@ -399,7 +399,7 @@
               "type": "number"
             }
           ],
-          "description": "`\"auto\"`, `\"stretch\"`, or a number representing relative width of the column in the column group."
+          "description": "`\"auto\"`, `\"stretch\"`, a number representing relative width of the column in the column group, or in version 1.1 and higher, a specific pixel width, like `\"50px\"`."
         },
         "id": {},
         "isVisible": {},
@@ -470,7 +470,7 @@
         },
         "minHeight": {
           "type": "string",
-          "description": "Specifies the minimum height of the column set.",
+          "description": "Specifies the minimum height of the column set in pixels, like `\"80px\"`.",
           "examples": [
             "50px"
           ],
@@ -557,7 +557,7 @@
         },
         "minHeight": {
           "type": "string",
-          "description": "Specifies the minimum height of the container.",
+          "description": "Specifies the minimum height of the container in pixels, like `\"80px\"`.",
           "examples": [
             "50px"
           ],

--- a/schemas/src/elements/Column.json
+++ b/schemas/src/elements/Column.json
@@ -67,7 +67,7 @@
     },
     "width": {
       "type": "string|number",
-      "description": "`\"auto\"`, `\"stretch\"`, or a number representing relative width of the column in the column group."
+      "description": "`\"auto\"`, `\"stretch\"`, a number representing relative width of the column in the column group, or in version 1.1 and higher, a specific pixel width, like `\"50px\"`."
     }
   }
 }

--- a/schemas/src/elements/Column.json
+++ b/schemas/src/elements/Column.json
@@ -33,7 +33,7 @@
     },
     "minHeight": {
       "type": "string",
-      "description": "Specifies the minimum height of the column.",
+      "description": "Specifies the minimum height of the column in pixels, like `\"80px\"`.",
       "examples": [
         "50px"
       ],

--- a/schemas/src/elements/ColumnSet.json
+++ b/schemas/src/elements/ColumnSet.json
@@ -38,7 +38,7 @@
     },
     "minHeight": {
       "type": "string",
-      "description": "Specifies the minimum height of the column set.",
+      "description": "Specifies the minimum height of the column set in pixels, like `\"80px\"`.",
       "examples": [
         "50px"
       ],

--- a/schemas/src/elements/Container.json
+++ b/schemas/src/elements/Container.json
@@ -44,7 +44,7 @@
     },
     "minHeight": {
       "type": "string",
-      "description": "Specifies the minimum height of the container.",
+      "description": "Specifies the minimum height of the container in pixels, like `\"80px\"`.",
       "examples": [
         "50px"
       ],


### PR DESCRIPTION
Our schema description for `Column.width` was missing stating that you can use pixel widths in the columns. Fixes #3073

Also, our property descriptions of `minHeight` didn't show an example of the pixel string format in the description.

Both of these updates were made to the existing `1.2.0` schema rather than incrementing version number since these updates are strictly limited to the descriptions, and therefore won't affect anyone using the schema as CI testing

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3080)