### PR TITLE
fixes issue #3104

### DIFF
--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/resources/sample.json
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/resources/sample.json
@@ -246,6 +246,7 @@
 		"spacing": 5
 	},
 	"media": {
+        "playButton" : "http://adaptivecards.io/content/adaptive-card-50.png",
 		"allowInlinePlayback" : true
 	}
 }

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRMediaRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRMediaRenderer.mm
@@ -50,10 +50,10 @@
     ACRContentHoldingUIView *contentholdingview = nil;
 
     // if poster is available, restrict the image size to the width of superview, and adjust the height accordingly
-    if(img) {
+    if (img) {
         view = [[UIImageView alloc] initWithImage:img];
 
-        if(img.size.width > 0) {
+        if (img.size.width > 0) {
             heightToWidthRatio = img.size.height / img.size.width;
         }
         contentholdingview = [[ACRContentHoldingUIView alloc] init];
@@ -63,12 +63,12 @@
         NSNumber *number = [NSNumber numberWithUnsignedLongLong:(unsigned long long)mediaElem.get()];
         NSString *key = [number stringValue];
         contentholdingview = (ACRContentHoldingUIView *)[rootView getImageView:key];
-        if(contentholdingview) {
+        if (contentholdingview) {
             view = contentholdingview.subviews[0];
         }
     }
 
-    if(!view) {
+    if (!view) {
         // if poster is not availabl, create a 4:3 blank black backgroudn poster view; 16:9 won't provide enough height in case the media is 4:3
         view = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, viewGroup.frame.size.width, viewGroup.frame.size.width * .75)];
         view.backgroundColor = UIColor.blackColor;
@@ -85,44 +85,44 @@
     NSString *piikey = [NSString stringWithCString:[acoConfig getHostConfig]->GetMedia().playButton.c_str() encoding:[NSString defaultCStringEncoding]];
     UIImage *playIconImage = imageViewMap[piikey];
     UIImageView *playIconImageView = nil;
-    BOOL drawDefaultPlayIcon = YES;
+    BOOL hideDefaultPlayIcon = NO;
 
-    if(!playIconImage) {
-        playIconImageView  = [rootView getImageView:@"playIconImage"];
-    }else {
+    if (!playIconImage) {
+        NSNumber *number = [NSNumber numberWithUnsignedLongLong:(unsigned long long)elem.get()];
+        NSString *key = [NSString stringWithFormat:@"%@_%@", [number stringValue], @"playIcon" ];
+        playIconImageView  = [rootView getImageView:key];
+    } else {
         playIconImageView = [[UIImageView alloc] initWithImage:playIconImage];
     }
 
-    if(playIconImageView) {
-        drawDefaultPlayIcon = NO;
+    if (playIconImageView) {
+        hideDefaultPlayIcon = YES;
         playIconImageView.tag = playIconTag;
         playIconImageView.translatesAutoresizingMaskIntoConstraints = NO;
     }
 
     view.tag = posterTag;
     // if play icon is provided from hostconfig, disable play icon drawing in its sublayer, and invalidate the current sublayer, so it will be updated in the next drawring cycle
-    if(!drawDefaultPlayIcon) {
-        contentholdingview.hidePlayIcon = YES;
+    if (hideDefaultPlayIcon) {
         [contentholdingview setNeedsLayout];
         [view addSubview:playIconImageView];
         [NSLayoutConstraint constraintWithItem:playIconImageView attribute:NSLayoutAttributeCenterX relatedBy:NSLayoutRelationEqual toItem:view attribute:NSLayoutAttributeCenterX multiplier:1.0 constant:0].active = YES;
         [NSLayoutConstraint constraintWithItem:playIconImageView attribute:NSLayoutAttributeCenterY relatedBy:NSLayoutRelationEqual toItem:view attribute:NSLayoutAttributeCenterY multiplier:1.0 constant:0].active = YES;
-
     }
 
-    contentholdingview.hidePlayIcon = YES;
+    contentholdingview.hidePlayIcon = hideDefaultPlayIcon;
 
     [viewGroup addArrangedSubview:contentholdingview];
 
-    if([acoConfig getHostConfig]->GetSupportsInteractivity()){
+    if ([acoConfig getHostConfig]->GetSupportsInteractivity()){
         ACRMediaTarget *mediaTarget = nil;
         ACOMediaEvent *mediaEvent = [[ACOMediaEvent alloc] initWithMedia:mediaElem];
-        if(!mediaEvent.isValid) {
+        if (!mediaEvent.isValid) {
             NSLog(@"warning: invalid mimetype detected, and media element is dropped");
             return nil;
         }
         // create target for gesture recongnizer;
-        if(![acoConfig getHostConfig]->GetMedia().allowInlinePlayback) {
+        if (![acoConfig getHostConfig]->GetMedia().allowInlinePlayback) {
             mediaTarget = [[ACRMediaTarget alloc] initWithMediaEvent:mediaEvent rootView:rootView config:acoConfig];
         } else {
             mediaTarget = [[ACRMediaTarget alloc] initWithMediaEvent:mediaEvent rootView:rootView config:acoConfig containingview:contentholdingview];
@@ -153,7 +153,6 @@
     }
 
     contentholdingview.frame = imageView.frame;
-    contentholdingview.hidePlayIcon = NO;
 
     [NSLayoutConstraint constraintWithItem:imageView attribute:NSLayoutAttributeCenterX relatedBy:NSLayoutRelationEqual toItem:contentholdingview attribute:NSLayoutAttributeCenterX multiplier:1.0 constant:0].active = YES;
     [NSLayoutConstraint constraintWithItem:imageView attribute:NSLayoutAttributeCenterY relatedBy:NSLayoutRelationEqual toItem:contentholdingview attribute:NSLayoutAttributeCenterY multiplier:1.0 constant:0].active = YES;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRMediaRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRMediaRenderer.mm
@@ -88,8 +88,7 @@
     BOOL hideDefaultPlayIcon = NO;
 
     if (!playIconImage) {
-        NSNumber *number = [NSNumber numberWithUnsignedLongLong:(unsigned long long)elem.get()];
-        NSString *key = [NSString stringWithFormat:@"%@_%@", [number stringValue], @"playIcon" ];
+        NSString *key = [NSString stringWithFormat:@"%llu_playIcon", (unsigned long long)elem.get()];
         playIconImageView  = [rootView getImageView:key];
     } else {
         playIconImageView = [[UIImageView alloc] initWithImage:playIconImage];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRenderer.mm
@@ -113,24 +113,6 @@ using namespace AdaptiveCards;
         [rootView loadBackgroundImageAccordingToResourceResolverIF:backgroundImageProperties key:@"backgroundImage" observerAction:observerAction];
     }
 
-    if(![config getHostConfig]->GetMedia().playButton.empty()) {
-        ObserverActionBlock observerAction =
-        ^(NSObject<ACOIResourceResolver>* imageResourceResolver, NSString* key, std::shared_ptr<BaseCardElement> const &elem, NSURL* url, ACRView* rootView) {
-            UIImageView *view = [imageResourceResolver resolveImageViewResource:url];
-            if(view) {
-                [view addObserver:rootView forKeyPath:@"image"
-                          options:NSKeyValueObservingOptionNew
-                          context:nil];
-
-                // store the image view for easy retrieval in ACRView::observeValueForKeyPath
-                [rootView setImageView:key view:view];
-            }
-        };
-        [rootView
-            loadImageAccordingToResourceResolverIFFromString:[config getHostConfig]->GetMedia().playButton
-            key:@"playIconImage" observerAction:observerAction];
-    }
-
     ACRContainerStyle style = ([config getHostConfig]->GetAdaptiveCard().allowCustomStyle)? (ACRContainerStyle)adaptiveCard->GetStyle() : ACRDefault;
     style = (style == ACRNone)? ACRDefault : style;
     [verticalView setStyle:style];


### PR DESCRIPTION
Fixes issue #3104 

there were two issues;

1. logic for disabling playIcon was properly adjusted after resource resolver changes.
2. the new resource resolver changes require new instances of UIImageViews, as UIImageView is a container of UIImage, and can't be duped. 


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3105)