### PR TITLE
[Shared Model] [.NET] Allow images in image set to not specify element type

### DIFF
--- a/source/dotnet/Library/AdaptiveCards/AdaptiveImage.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveImage.cs
@@ -35,6 +35,7 @@ namespace AdaptiveCards
 #if !NETSTANDARD1_3
         [XmlIgnore]
 #endif
+        [JsonProperty(Required = Required.Default)]
         public override string Type { get; set; } = TypeName;
 
         /// <summary>

--- a/source/dotnet/Test/AdaptiveCards.Test/AdaptiveCardApiTests.cs
+++ b/source/dotnet/Test/AdaptiveCards.Test/AdaptiveCardApiTests.cs
@@ -228,31 +228,31 @@ namespace AdaptiveCards.Test
         public void TestDefaultValueHandling()
         {
             var json = @"{
-	            ""$schema"": ""http://adaptivecards.io/schemas/adaptive-card.json"",
-	            ""type"": ""AdaptiveCard"",
-	            ""version"": ""1.0"",
-	            ""body"": [
-		            {
-			            ""type"": ""Container"",
-			            ""style"": ""asdf"",
-			            ""spacing"": ""asdf"",
-			            ""items"": [
-				            {
-					            ""type"": ""TextBlock"",
-					            ""text"": ""Sample text"",
-					            ""color"": ""asdf"",
-					            ""size"": ""asdf"",
-					            ""weight"": ""asdf""
-				            },
-				            {
-					            ""type"": ""Image"",
-					            ""url"": ""http://adaptivecards.io/content/cats/1.png"",
-					            ""style"": ""asdf"",
-					            ""size"": ""asdf""
-				            }
-			            ]
-		            }
-	            ]
+                ""$schema"": ""http://adaptivecards.io/schemas/adaptive-card.json"",
+                ""type"": ""AdaptiveCard"",
+                ""version"": ""1.0"",
+                ""body"": [
+                    {
+                        ""type"": ""Container"",
+                        ""style"": ""asdf"",
+                        ""spacing"": ""asdf"",
+                        ""items"": [
+                            {
+                                ""type"": ""TextBlock"",
+                                ""text"": ""Sample text"",
+                                ""color"": ""asdf"",
+                                ""size"": ""asdf"",
+                                ""weight"": ""asdf""
+                            },
+                            {
+                                ""type"": ""Image"",
+                                ""url"": ""http://adaptivecards.io/content/cats/1.png"",
+                                ""style"": ""asdf"",
+                                ""size"": ""asdf""
+                            }
+                        ]
+                    }
+                ]
             }";
 
             var card = AdaptiveCard.FromJson(json).Card;

--- a/source/dotnet/Test/AdaptiveCards.Test/AdaptiveCardApiTests.cs
+++ b/source/dotnet/Test/AdaptiveCards.Test/AdaptiveCardApiTests.cs
@@ -258,9 +258,9 @@ namespace AdaptiveCards.Test
             var card = AdaptiveCard.FromJson(json).Card;
 
             // Contents of card for easier access
-            AdaptiveContainer container = (AdaptiveContainer) card.Body[0];
-            AdaptiveTextBlock textblock = (AdaptiveTextBlock) container.Items[0];
-            AdaptiveImage image = (AdaptiveImage) container.Items[1];
+            AdaptiveContainer container = (AdaptiveContainer)card.Body[0];
+            AdaptiveTextBlock textblock = (AdaptiveTextBlock)container.Items[0];
+            AdaptiveImage image = (AdaptiveImage)container.Items[1];
 
             // Container property tests
             Assert.IsNull(container.Style);
@@ -299,7 +299,7 @@ namespace AdaptiveCards.Test
             Assert.AreEqual(card.Body.Count, 1);
             var imageBlock = card.Body[0] as AdaptiveImage;
             Assert.AreEqual(0, result.Warnings.Count);
-            Assert.AreEqual(20U,imageBlock.PixelWidth);
+            Assert.AreEqual(20U, imageBlock.PixelWidth);
             Assert.AreEqual(50U, imageBlock.PixelHeight);
         }
 
@@ -518,7 +518,7 @@ namespace AdaptiveCards.Test
             Assert.AreEqual(columnSet.Height, AdaptiveHeight.Auto);
             Assert.AreEqual(columnSet.Columns.Count, 2);
 
-            foreach(var column in columnSet.Columns)
+            foreach (var column in columnSet.Columns)
             {
                 Assert.AreEqual(column.Items.Count, 1);
                 var columnContent = column.Items[0];
@@ -934,11 +934,11 @@ namespace AdaptiveCards.Test
 
             actionSet.Actions.Add(showCardAction);
 
-                AdaptiveToggleVisibilityAction toggleVisibilityAction = new AdaptiveToggleVisibilityAction
-                {
-                    Title = "Toggle",
-                    TargetElements = new List<AdaptiveTargetElement> { "test" }
-                };
+            AdaptiveToggleVisibilityAction toggleVisibilityAction = new AdaptiveToggleVisibilityAction
+            {
+                Title = "Toggle",
+                TargetElements = new List<AdaptiveTargetElement> { "test" }
+            };
             actionSet.Actions.Add(toggleVisibilityAction);
 
             // This lines are not indented so the comparisson doesn't fail due to extra spaces
@@ -1142,6 +1142,60 @@ namespace AdaptiveCards.Test
 }";
             var outputJson = card.ToJson();
             Assert.AreEqual(outputJson, expectedJson);
-}
+        }
+
+        [TestMethod]
+        public void TestImplicitImageType()
+        {
+            // Images set to type "Image" or with type unset should parse correctly within an image set
+            var imageTypeSetOrEmpty =
+            @"{
+                ""type"": ""AdaptiveCard"",
+                ""version"": ""1.2"",
+                ""body"": [
+                    {
+                        ""type"": ""ImageSet"",
+                        ""images"": [
+                            {
+                                ""type"": ""Image"",
+                                ""url"": ""http://adaptivecards.io/content/cats/1.png""
+                            },
+                            {
+                                ""url"": ""http://adaptivecards.io/content/cats/1.png""
+                            }
+                        ]
+                    }
+                ]
+            }";
+
+            // Images set to a bogus type should not parse correctly
+            var imageTypeInvalid =
+            @"{
+                ""type"": ""AdaptiveCard"",
+                ""version"": ""1.2"",
+                ""body"": [
+                    {
+                        ""type"": ""ImageSet"",
+                        ""images"": [
+                            {
+                                ""type"": ""Elephant"",
+                                ""url"": ""http://adaptivecards.io/content/cats/1.png""
+                            }
+                        ]
+                    }
+                ]
+            }";
+
+            var result = AdaptiveCard.FromJson(imageTypeSetOrEmpty);
+            Assert.IsNotNull(result.Card);
+            Assert.AreEqual(2, (result.Card.Body[0] as AdaptiveImageSet).Images.Count);
+
+            var ex = Assert.ThrowsException<ArgumentException>(() =>
+            {
+                AdaptiveCard.FromJson(imageTypeInvalid);
+            });
+
+            StringAssert.Contains(ex.Message, "The value \"AdaptiveCards.AdaptiveUnknownElement\" is not of type \"AdaptiveCards.AdaptiveImage\" and cannot be used in this generic collection.");
+        }
     }
 }

--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/ObjectModelTest.cpp
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/ObjectModelTest.cpp
@@ -1201,5 +1201,62 @@ namespace AdaptiveCardsSharedModelUnitTest
                 Assert::AreEqual("Unable to parse element of type Elephant", e.GetReason().c_str(), L"GetReason incorrect");
             }
         }
+
+        TEST_METHOD(ImplicitImageTypeInImageSetTest)
+        {
+            // Images set to type "Image" or with type unset should parse correctly within an image set
+            std::string imageTypeSetOrEmpty =
+            "{\
+                \"$schema\":\"http://adaptivecards.io/schemas/adaptive-card.json\",\
+                \"type\": \"AdaptiveCard\",\
+                \"version\": \"1.0\",\
+                \"body\": [\
+                    {\
+                        \"type\":\"ImageSet\",\
+                        \"images\": [\
+                            {\
+                                \"type\": \"Image\",\
+                                \"url\": \"http://adaptivecards.io/content/cats/1.png\"\
+                            },\
+                            {\
+                                \"url\": \"http://adaptivecards.io/content/cats/1.png\"\
+                            }\
+                        ]\
+                    }\
+                ]\
+            }";
+
+            // Images set to a bogus type should not parse correctly
+            std::string imageTypeInvalid =
+            "{\
+                \"$schema\":\"http://adaptivecards.io/schemas/adaptive-card.json\",\
+                \"type\": \"AdaptiveCard\",\
+                \"version\": \"1.0\",\
+                \"body\": [\
+                    {\
+                        \"type\":\"ImageSet\",\
+                        \"images\": [\
+                            {\
+                                \"type\": \"Elephant\",\
+                                \"url\": \"http://adaptivecards.io/content/cats/1.png\"\
+                            }\
+                        ]\
+                    }\
+                ]\
+            }";
+
+            std::shared_ptr<ParseResult> parseResult = AdaptiveCard::DeserializeFromString(imageTypeSetOrEmpty, "1.0");
+
+            try
+            {
+                parseResult = AdaptiveCard::DeserializeFromString(imageTypeInvalid, "1.0");
+                Assert::IsTrue(false, L"Deserializing should throw an exception");
+            }
+            catch (const AdaptiveCardParseException& e)
+            {
+                Assert::IsTrue(ErrorStatusCode::InvalidPropertyValue == e.GetStatusCode(), L"ErrorStatusCode incorrect");
+                Assert::AreEqual("Unable to parse element of type Elephant", e.GetReason().c_str(), L"GetReason incorrect");
+            }
+        }
     };
 }

--- a/source/shared/cpp/ObjectModel/ColumnSet.cpp
+++ b/source/shared/cpp/ObjectModel/ColumnSet.cpp
@@ -46,7 +46,7 @@ void ColumnSet::DeserializeChildren(ParseContext& context, const Json::Value& va
                                                         value,
                                                         AdaptiveCardSchemaKey::Columns,
                                                         false,     // isRequired
-                                                        "Column"); // impliedType
+                                                        CardElementTypeToString(CardElementType::Column)); // impliedType
 }
 
 void ColumnSet::PopulateKnownPropertiesSet()

--- a/source/shared/cpp/ObjectModel/ImageSet.cpp
+++ b/source/shared/cpp/ObjectModel/ImageSet.cpp
@@ -62,7 +62,8 @@ std::shared_ptr<BaseCardElement> ImageSetParser::Deserialize(ParseContext& conte
         ParseUtil::GetEnumValue<ImageSize>(value, AdaptiveCardSchemaKey::ImageSize, ImageSize::None, ImageSizeFromString);
 
     // Parse Images
-    auto images = ParseUtil::GetElementCollection<Image>(true, context, value, AdaptiveCardSchemaKey::Images, true);
+    auto images = ParseUtil::GetElementCollection<Image>(
+        true, context, value, AdaptiveCardSchemaKey::Images, true, CardElementTypeToString(CardElementType::Image));
 
     for (auto image : images)
     {


### PR DESCRIPTION
Update the shared model and .NET code to allow images within an image set to not explicitly specify their type.

How Verified: Ran Shared Model, UWP, and .NET tests. Added new case to shared model and .NET to cover this scenario. Manual verification in UWP and .NET visualizers.

Fixes #2848

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3109)