### PR TITLE
[UWP] Use default Image renderer for background

### DIFF
--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -11,6 +11,7 @@
 #include "AdaptiveFeatureRegistration.h"
 #include "AdaptiveHostConfig.h"
 #include "AdaptiveImage.h"
+#include "AdaptiveImageRenderer.h"
 #include "AdaptiveRenderArgs.h"
 #include "AdaptiveShowCardAction.h"
 #include "AdaptiveTextRun.h"
@@ -487,9 +488,10 @@ namespace AdaptiveNamespace
         ComPtr<IAdaptiveElementRendererRegistration> elementRenderers;
         THROW_IF_FAILED(renderContext->get_ElementRenderers(&elementRenderers));
 
+        // For background image we use the default image renderer instead of custom image renderers
         ComPtr<IAdaptiveElementRenderer> elementRenderer;
-        THROW_IF_FAILED(elementRenderers->Get(HStringReference(L"Image").Get(), &elementRenderer));
-
+        THROW_IF_FAILED(MakeAndInitialize<AdaptiveNamespace::AdaptiveImageRenderer>(&elementRenderer));
+        
         ComPtr<IUIElement> background;
         if (elementRenderer != nullptr)
         {


### PR DESCRIPTION
Changes the ApplyBackgroundToRoot implementation to always use the default AdaptiveImageRenderer

This fixes: https://github.com/microsoft/AdaptiveCards/issues/2712

## How Verified

### Test 1

The test app was run and no card failed to render correctly

### Test 2

I added a custom mock Image renderer which only draws a cat image for all image elements, so the ActivityUpdate card looks like this  

![image](https://user-images.githubusercontent.com/35784165/60306239-55c61d80-98f4-11e9-9c59-d5779b9ebeb6.png)

The cards AdaptiveCard.BackgroundImage.FillMode.json and Column.BackgroundImage.json yielded this results

![image](https://user-images.githubusercontent.com/35784165/60306153-008a0c00-98f4-11e9-8a5f-97916f1d113e.png)

![image](https://user-images.githubusercontent.com/35784165/60306205-34653180-98f4-11e9-8956-01af55747a54.png)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3113)