### PR TITLE
removed play icon from hostconfig

### DIFF
--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/resources/sample.json
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/resources/sample.json
@@ -246,7 +246,6 @@
 		"spacing": 5
 	},
 	"media": {
-		"playButton" :"https://www.shareicon.net/download/64x64/2017/04/08/883361_media_512x512.png",
 		"allowInlinePlayback" : true
 	}
 }


### PR DESCRIPTION
fixes ios ci issue
the ios unit test pull down media icon from https://www.shareicon.net/ for each test.
lately, we seemed to hit their rate limit, and download speed from unit tests was severely limited.
removed the url from unit test host config.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3126)