### PR TITLE
[UWP] Fix debug build

### DIFF
--- a/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj
+++ b/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj
@@ -122,6 +122,7 @@
       <WarningLevel>Level4</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
       <ControlFlowGuard>Guard</ControlFlowGuard>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/source/uwp/Renderer/lib/RenderedAdaptiveCard.cpp
+++ b/source/uwp/Renderer/lib/RenderedAdaptiveCard.cpp
@@ -193,8 +193,6 @@ namespace AdaptiveNamespace
         default:
             return m_actionEvents->InvokeAll(this, eventArgs.Get());
         }
-
-        return m_actionEvents->InvokeAll(this, eventArgs.Get());
     }
 
     HRESULT RenderedAdaptiveCard::SendMediaClickedEvent(_In_ IAdaptiveMedia* mediaElement)

--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -801,6 +801,7 @@ namespace AdaptiveNamespace
                         ComPtr<IAsyncOperationWithProgress<UINT64, UINT64>> copyStreamOperation;
                         RETURN_IF_FAILED(m_randomAccessStreamStatics->CopyAsync(imageStream.Get(), outputStream.Get(), &copyStreamOperation));
 
+                        m_copyStreamOperations.push_back(copyStreamOperation);
                         return copyStreamOperation->put_Completed(
                             Callback<Implements<RuntimeClassFlags<WinRtClassicComMix>, IAsyncOperationWithProgressCompletedHandler<UINT64, UINT64>>>(
                                 [strongThis, this, bitmapSource, randomAccessStream, strongImageControl](
@@ -815,7 +816,6 @@ namespace AdaptiveNamespace
                                     return S_OK;
                                 })
                                 .Get());
-                        m_copyStreamOperations.push_back(copyStreamOperation);
                     }
                     else
                     {


### PR DESCRIPTION
Building UWP locally (x86/debug) I ran into the following error:
"'/ZI' and '/guard:cf' command-line options are incompatible"
Set DebugInformationFormat to ProgramDatabase (/Zi instead of /ZI) to avoid this conflict. 

Additionally, hit two warnings about unreachable code (now treated as errors) and fixed them.

How verified: UWP debug now builds correctly. No new test failures.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3153)