### PR TITLE
Fix toggle input default values for valueOn and valueOff

### DIFF
--- a/source/shared/cpp/ObjectModel/ToggleInput.cpp
+++ b/source/shared/cpp/ObjectModel/ToggleInput.cpp
@@ -29,12 +29,12 @@ Json::Value ToggleInput::SerializeToJsonValue() const
         root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Value)] = m_value;
     }
 
-    if (!m_valueOff.empty())
+    if (m_valueOff != "false")
     {
         root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::ValueOff)] = m_valueOff;
     }
 
-    if (!m_valueOn.empty())
+    if (m_valueOn != "true")
     {
         root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::ValueOn)] = m_valueOn;
     }

--- a/source/shared/cpp/ObjectModel/ToggleInput.cpp
+++ b/source/shared/cpp/ObjectModel/ToggleInput.cpp
@@ -100,18 +100,8 @@ std::shared_ptr<BaseCardElement> ToggleInputParser::Deserialize(ParseContext& co
     toggleInput->SetTitle(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Title, true));
     toggleInput->SetValue(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Value));
     toggleInput->SetWrap(ParseUtil::GetBool(json, AdaptiveCardSchemaKey::Wrap, false, false));
-
-    std::string valueOff = ParseUtil::GetString(json, AdaptiveCardSchemaKey::ValueOff);
-    if (valueOff != "")
-    {
-        toggleInput->SetValueOff(valueOff);
-    }
-
-    std::string valueOn = ParseUtil::GetString(json, AdaptiveCardSchemaKey::ValueOn);
-    if (valueOn != "")
-    {
-        toggleInput->SetValueOn(valueOn);
-    }
+    toggleInput->SetValueOff(ParseUtil::GetString(json, AdaptiveCardSchemaKey::ValueOff, std::string("false")));
+    toggleInput->SetValueOn(ParseUtil::GetString(json, AdaptiveCardSchemaKey::ValueOn, std::string("true")));
 
     return toggleInput;
 }


### PR DESCRIPTION
Fixes #3224

Changes the serialize and deserialize methods for input.toggle to handle the default values for valueOn and valueOff correctly.

**This is required for the android unit tests**

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3227)