### PR TITLE
[.NET] Add manual versioned references to System.Net.Http 4.3.1

### DIFF
--- a/source/dotnet/Samples/AdaptiveCards.Sample.Html/AdaptiveCards.Sample.Html.csproj
+++ b/source/dotnet/Samples/AdaptiveCards.Sample.Html/AdaptiveCards.Sample.Html.csproj
@@ -10,6 +10,7 @@
     <ProjectReference Include="..\..\Library\AdaptiveCards.Rendering.Html\AdaptiveCards.Rendering.Html.csproj" />
     <ProjectReference Include="..\..\Library\AdaptiveCards\AdaptiveCards.csproj" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
+    <PackageReference Include="System.Net.Http" Version="4.3.1" />
   </ItemGroup>
 
 </Project>

--- a/source/dotnet/Samples/AdaptiveCards.Sample.ImageRender/AdaptiveCards.Sample.ImageRender.csproj
+++ b/source/dotnet/Samples/AdaptiveCards.Sample.ImageRender/AdaptiveCards.Sample.ImageRender.csproj
@@ -10,6 +10,7 @@
     <ProjectReference Include="..\..\Library\AdaptiveCards.Rendering.Wpf\AdaptiveCards.Rendering.Wpf.csproj" />
     <ProjectReference Include="..\..\Library\AdaptiveCards\AdaptiveCards.csproj" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
+    <PackageReference Include="System.Net.Http" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/dotnet/Samples/ImageRendererServer/ImageRendererServer.csproj
+++ b/source/dotnet/Samples/ImageRendererServer/ImageRendererServer.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Library\AdaptiveCards.Rendering.Wpf\AdaptiveCards.Rendering.Wpf.csproj" />
     <ProjectReference Include="..\..\Library\AdaptiveCards\AdaptiveCards.csproj" />
+    <PackageReference Include="System.Net.Http" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/dotnet/Test/AdaptiveCards.Rendering.Html.Test/AdaptiveCards.Rendering.Html.Test.csproj
+++ b/source/dotnet/Test/AdaptiveCards.Rendering.Html.Test/AdaptiveCards.Rendering.Html.Test.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Library\AdaptiveCards.Rendering.Html\AdaptiveCards.Rendering.Html.csproj" />
     <ProjectReference Include="..\..\Library\AdaptiveCards\AdaptiveCards.csproj" />
+    <PackageReference Include="System.Net.Http" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/dotnet/Test/AdaptiveCards.Test/AdaptiveCards.Test.csproj
+++ b/source/dotnet/Test/AdaptiveCards.Test/AdaptiveCards.Test.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
These version revs had to be manually added (outside of VS), which is why they were missed.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3268)