### PR TITLE
[.NET] Remove netstandard 1.3 from signconfig.xml

### DIFF
--- a/source/dotnet/Build/SignConfig.xml
+++ b/source/dotnet/Build/SignConfig.xml
@@ -8,11 +8,9 @@
   <job platform="AnyCPU" configuration="release" dest="__RELBINPATH__\..\..\..\s\signed" jobname="Adaptive Cards .NET" approvers="">
     <!-- AdaptiveCards -->
     <file src="__RELBINPATH__\..\..\..\s\tosign\AdaptiveCards\net4.5.2\AdaptiveCards.dll" signType="Both" dest="__RELBINPATH__\..\..\..\s\signed\AdaptiveCards\net4.5.2\AdaptiveCards.dll" />
-    <file src="__RELBINPATH__\..\..\..\s\tosign\AdaptiveCards\netstandard1.3\AdaptiveCardsnetstandard1.3.dll" signType="Both" dest="__RELBINPATH__\..\..\..\s\signed\AdaptiveCards\netstandard1.3\AdaptiveCardsnetstandard1.3.dll" />
     <file src="__RELBINPATH__\..\..\..\s\tosign\AdaptiveCards\netstandard2.0\AdaptiveCardsnetstandard2.0.dll" signType="Both" dest="__RELBINPATH__\..\..\..\s\signed\AdaptiveCards\netstandard2.0\AdaptiveCardsnetstandard2.0.dll" />
     <!-- AdaptiveCards.Html -->
     <file src="__RELBINPATH__\..\..\..\s\tosign\AdaptiveCards.Rendering.Html\net4.5.2\AdaptiveCards.Rendering.Html.dll" signType="Both" dest="__RELBINPATH__\..\..\..\s\signed\AdaptiveCards.Rendering.Html\net4.5.2\AdaptiveCards.Rendering.Html.dll" />
-    <file src="__RELBINPATH__\..\..\..\s\tosign\AdaptiveCards.Rendering.Html\netstandard1.3\AdaptiveCards.Rendering.Htmlnetstandard1.3.dll" signType="Both" dest="__RELBINPATH__\..\..\..\s\signed\AdaptiveCards.Rendering.Html\netstandard1.3\AdaptiveCards.Rendering.Htmlnetstandard1.3.dll" />
     <file src="__RELBINPATH__\..\..\..\s\tosign\AdaptiveCards.Rendering.Html\netstandard2.0\AdaptiveCards.Rendering.Htmlnetstandard2.0.dll" signType="Both" dest="__RELBINPATH__\..\..\..\s\signed\AdaptiveCards.Rendering.Html\netstandard2.0\AdaptiveCards.Rendering.Htmlnetstandard2.0.dll" />
     <!-- AdaptiveCards.Wpf-->
     <file src="__RELBINPATH__\..\..\..\s\tosign\AdaptiveCards.Rendering.Wpf\net4.5.2\AdaptiveCards.Rendering.Wpf.dll" signType="Both" dest="__RELBINPATH__\..\..\..\s\signed\AdaptiveCards.Rendering.Wpf\net4.5.2\AdaptiveCards.Rendering.Wpf.dll" />


### PR DESCRIPTION


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3290)