### PR TITLE
[.NET] Bring signing changes over in prep for 1.2.2

### DIFF
--- a/custom.props
+++ b/custom.props
@@ -4,7 +4,7 @@
     <VersionMajor>1</VersionMajor>
     <VersionMinor>2</VersionMinor>
     <!-- The nuget package version should be incremented when we produce QFEs -->
-    <NuGetPackVersion>1.2.1</NuGetPackVersion>
+    <NuGetPackVersion>1.2.2</NuGetPackVersion>
     <VersionInfoProductName>AdaptiveCards</VersionInfoProductName>
   </PropertyGroup>
 </Project>

--- a/source/dotnet/Build/CopySignFiles.cmd
+++ b/source/dotnet/Build/CopySignFiles.cmd
@@ -7,6 +7,7 @@ set ACHTML=AdaptiveCards.Rendering.Html
 set ACWPF=AdaptiveCards.Rendering.Wpf
 set ACWPFX=AdaptiveCards.Rendering.Wpf.Xceed
 set ACNET=net4.5.2
+set ACSTANDARD13=netstandard1.3
 set ACSTANDARD20=netstandard2.0
 
 REM setting path variables
@@ -17,6 +18,7 @@ set ACWPFPATH=AdaptiveCards.Rendering.Wpf\
 set ACWPFXPATH=AdaptiveCards.Rendering.Wpf.Xceed\
 set BINPATH=bin\Release\
 set ACNETPATH=net4.5.2\
+set ACSTANDARD13PATH=netstandard1.3\
 set ACSTANDARD20PATH=netstandard2.0\
 
 if "%2" == "" goto :usage
@@ -31,10 +33,12 @@ pushd "%2"
 REM AdaptiveCards
 echo %ACPATH%
 mkdir tosign\%ACPATH%%ACNETPATH%
+mkdir tosign\%ACPATH%%ACSTANDARD13PATH%
 mkdir tosign\%ACPATH%%ACSTANDARD20PATH%
 
 REM AdaptiveCards.Html
 mkdir tosign\%ACHTMLPATH%%ACNETPATH%
+mkdir tosign\%ACHTMLPATH%%ACSTANDARD13PATH%
 mkdir tosign\%ACHTMLPATH%%ACSTANDARD20PATH%
 
 REM AdaptiveCards.Rendering.Wpf
@@ -46,10 +50,12 @@ mkdir tosign\%ACWPFXPATH%%ACNETPATH%
 
 REM AdaptiveCards
 call :checkedCopy %ACROOT%%ACPATH%%BINPATH%%ACNETPATH%%AC%.dll tosign\%ACPATH%%ACNETPATH%%AC%.dll
+call :checkedCopy %ACROOT%%ACPATH%%BINPATH%%ACSTANDARD13PATH%%AC%.dll tosign\%ACPATH%%ACSTANDARD13PATH%%AC%%ACSTANDARD13%.dll
 call :checkedCopy %ACROOT%%ACPATH%%BINPATH%%ACSTANDARD20PATH%%AC%.dll tosign\%ACPATH%%ACSTANDARD20PATH%%AC%%ACSTANDARD20%.dll
 
 REM AdaptiveCards.Html
 call :checkedCopy %ACROOT%%ACHTMLPATH%%BINPATH%%ACNETPATH%%ACHTML%.dll tosign\%ACHTMLPATH%%ACNETPATH%%ACHTML%.dll      
+call :checkedCopy %ACROOT%%ACHTMLPATH%%BINPATH%%ACSTANDARD13PATH%%ACHTML%.dll tosign\%ACHTMLPATH%%ACSTANDARD13PATH%%ACHTML%%ACSTANDARD13%.dll
 call :checkedCopy %ACROOT%%ACHTMLPATH%%BINPATH%%ACSTANDARD20PATH%%ACHTML%.dll tosign\%ACHTMLPATH%%ACSTANDARD20PATH%%ACHTML%%ACSTANDARD20%.dll
 
 REM AdaptiveCards.Rendering.Wpf
@@ -66,10 +72,12 @@ pushd "%2"
 
 REM AdaptiveCards
 call :checkedCopy signed\%ACPATH%%ACNETPATH%%AC%.dll %ACROOT%%ACPATH%%BINPATH%%ACNETPATH%%AC%.dll                         
+call :checkedCopy signed\%ACPATH%%ACSTANDARD13PATH%%AC%%ACSTANDARD13%.dll %ACROOT%%ACPATH%%BINPATH%%ACSTANDARD13PATH%%AC%.dll                         
 call :checkedCopy signed\%ACPATH%%ACSTANDARD20PATH%%AC%%ACSTANDARD20%.dll %ACROOT%%ACPATH%%BINPATH%%ACSTANDARD20PATH%%AC%.dll                         
 
 REM AdaptiveCards.Html
 call :checkedCopy signed\%ACHTMLPATH%%ACNETPATH%%ACHTML%.dll %ACROOT%%ACHTMLPATH%%BINPATH%%ACNETPATH%%ACHTML%.dll                         
+call :checkedCopy signed\%ACHTMLPATH%%ACSTANDARD13PATH%%ACHTML%%ACSTANDARD13%.dll %ACROOT%%ACHTMLPATH%%BINPATH%%ACSTANDARD13PATH%%ACHTML%.dll                         
 call :checkedCopy signed\%ACHTMLPATH%%ACSTANDARD20PATH%%ACHTML%%ACSTANDARD20%.dll %ACROOT%%ACHTMLPATH%%BINPATH%%ACSTANDARD20PATH%%ACHTML%.dll                         
 
 REM AdaptiveCards.Rendering.Wpf

--- a/source/dotnet/Build/SignConfig.xml
+++ b/source/dotnet/Build/SignConfig.xml
@@ -7,14 +7,16 @@
   <!-- Release sign job -->
   <job platform="AnyCPU" configuration="release" dest="__RELBINPATH__\..\..\..\s\signed" jobname="Adaptive Cards .NET" approvers="">
     <!-- AdaptiveCards -->
-    <file src="__RELBINPATH__\..\..\..\s\tosign\AdaptiveCards\net4.5.2\AdaptiveCards.dll" signType="Both" dest="__RELBINPATH__\..\..\..\s\signed\AdaptiveCards\net4.5.2\AdaptiveCards.dll" />
-    <file src="__RELBINPATH__\..\..\..\s\tosign\AdaptiveCards\netstandard2.0\AdaptiveCardsnetstandard2.0.dll" signType="Both" dest="__RELBINPATH__\..\..\..\s\signed\AdaptiveCards\netstandard2.0\AdaptiveCardsnetstandard2.0.dll" />
+    <file src="__RELBINPATH__\..\..\..\s\tosign\AdaptiveCards\net4.5.2\AdaptiveCards.dll" signType="BothDual" dest="__RELBINPATH__\..\..\..\s\signed\AdaptiveCards\net4.5.2\AdaptiveCards.dll" />
+    <file src="__RELBINPATH__\..\..\..\s\tosign\AdaptiveCards\netstandard1.3\AdaptiveCardsnetstandard1.3.dll" signType="BothDual" dest="__RELBINPATH__\..\..\..\s\signed\AdaptiveCards\netstandard1.3\AdaptiveCardsnetstandard1.3.dll" />
+    <file src="__RELBINPATH__\..\..\..\s\tosign\AdaptiveCards\netstandard2.0\AdaptiveCardsnetstandard2.0.dll" signType="BothDual" dest="__RELBINPATH__\..\..\..\s\signed\AdaptiveCards\netstandard2.0\AdaptiveCardsnetstandard2.0.dll" />
     <!-- AdaptiveCards.Html -->
-    <file src="__RELBINPATH__\..\..\..\s\tosign\AdaptiveCards.Rendering.Html\net4.5.2\AdaptiveCards.Rendering.Html.dll" signType="Both" dest="__RELBINPATH__\..\..\..\s\signed\AdaptiveCards.Rendering.Html\net4.5.2\AdaptiveCards.Rendering.Html.dll" />
-    <file src="__RELBINPATH__\..\..\..\s\tosign\AdaptiveCards.Rendering.Html\netstandard2.0\AdaptiveCards.Rendering.Htmlnetstandard2.0.dll" signType="Both" dest="__RELBINPATH__\..\..\..\s\signed\AdaptiveCards.Rendering.Html\netstandard2.0\AdaptiveCards.Rendering.Htmlnetstandard2.0.dll" />
+    <file src="__RELBINPATH__\..\..\..\s\tosign\AdaptiveCards.Rendering.Html\net4.5.2\AdaptiveCards.Rendering.Html.dll" signType="BothDual" dest="__RELBINPATH__\..\..\..\s\signed\AdaptiveCards.Rendering.Html\net4.5.2\AdaptiveCards.Rendering.Html.dll" />
+    <file src="__RELBINPATH__\..\..\..\s\tosign\AdaptiveCards.Rendering.Html\netstandard1.3\AdaptiveCards.Rendering.Htmlnetstandard1.3.dll" signType="BothDual" dest="__RELBINPATH__\..\..\..\s\signed\AdaptiveCards.Rendering.Html\netstandard1.3\AdaptiveCards.Rendering.Htmlnetstandard1.3.dll" />
+    <file src="__RELBINPATH__\..\..\..\s\tosign\AdaptiveCards.Rendering.Html\netstandard2.0\AdaptiveCards.Rendering.Htmlnetstandard2.0.dll" signType="BothDual" dest="__RELBINPATH__\..\..\..\s\signed\AdaptiveCards.Rendering.Html\netstandard2.0\AdaptiveCards.Rendering.Htmlnetstandard2.0.dll" />
     <!-- AdaptiveCards.Wpf-->
-    <file src="__RELBINPATH__\..\..\..\s\tosign\AdaptiveCards.Rendering.Wpf\net4.5.2\AdaptiveCards.Rendering.Wpf.dll" signType="Both" dest="__RELBINPATH__\..\..\..\s\signed\AdaptiveCards.Rendering.Wpf\net4.5.2\AdaptiveCards.Rendering.Wpf.dll" />
+    <file src="__RELBINPATH__\..\..\..\s\tosign\AdaptiveCards.Rendering.Wpf\net4.5.2\AdaptiveCards.Rendering.Wpf.dll" signType="BothDual" dest="__RELBINPATH__\..\..\..\s\signed\AdaptiveCards.Rendering.Wpf\net4.5.2\AdaptiveCards.Rendering.Wpf.dll" />
     <!-- AdaptiveCards.Wpf.Xceed-->
-    <file src="__RELBINPATH__\..\..\..\s\tosign\AdaptiveCards.Rendering.Wpf.Xceed\net4.5.2\AdaptiveCards.Rendering.Wpf.Xceed.dll" signType="Both" dest="__RELBINPATH__\..\..\..\s\signed\AdaptiveCards.Rendering.Wpf.Xceed\net4.5.2\AdaptiveCards.Rendering.Wpf.Xceed.dll" />
+    <file src="__RELBINPATH__\..\..\..\s\tosign\AdaptiveCards.Rendering.Wpf.Xceed\net4.5.2\AdaptiveCards.Rendering.Wpf.Xceed.dll" signType="BothDual" dest="__RELBINPATH__\..\..\..\s\signed\AdaptiveCards.Rendering.Wpf.Xceed\net4.5.2\AdaptiveCards.Rendering.Wpf.Xceed.dll" />
   </job>
 </SignConfigXML>

--- a/source/dotnet/Samples/AdaptiveCards.Sample.Html/Program.cs
+++ b/source/dotnet/Samples/AdaptiveCards.Sample.Html/Program.cs
@@ -321,10 +321,10 @@ namespace AdaptiveCards.Sample.Html
 
                             <!-- if element is not visible -> skip (The separator was hidden in the previous step) -->
                             if(child.style.display == 'none'){{
-                                continue;	
+                                continue;
                             }}
 
-                            const childSeparatorId = child.dataset.acSeparatorid;		
+                            const childSeparatorId = child.dataset.acSeparatorid;
                             var childSeparator = document.getElementById(childSeparatorId);
 
                             if(isFirstElement){{

--- a/source/uwp/Build/SignConfig.xml
+++ b/source/uwp/Build/SignConfig.xml
@@ -7,15 +7,15 @@
   <!-- Release sign job -->
   <job platform="x64" configuration="release" dest="__RELBINPATH__\..\..\..\s\signed" jobname="Adaptive Cards UWP" approvers="">
     <!-- AdaptiveCards winmd -->
-    <file src="__RELBINPATH__\..\..\..\s\tosign\AdaptiveCardRenderer\AdaptiveCards.Rendering.Uwp.winmd" signType="Authenticode" dest="__RELBINPATH__\..\..\..\s\signed\AdaptiveCardRenderer\AdaptiveCards.Rendering.winmd" />
+    <file src="__RELBINPATH__\..\..\..\s\tosign\AdaptiveCardRenderer\AdaptiveCards.Rendering.Uwp.winmd" signType="AuthenticodeFormer" dest="__RELBINPATH__\..\..\..\s\signed\AdaptiveCardRenderer\AdaptiveCards.Rendering.winmd" />
 
     <!-- Win32 -->
-    <file src="__RELBINPATH__\..\..\..\s\tosign\AdaptiveCardRenderer\win32\AdaptiveCards.Rendering.Uwp.dll" signType="Authenticode" dest="__RELBINPATH__\..\..\..\s\signed\AdaptiveCardRenderer\win32\AdaptiveCards.Rendering.Uwp.dll" />
+    <file src="__RELBINPATH__\..\..\..\s\tosign\AdaptiveCardRenderer\win32\AdaptiveCards.Rendering.Uwp.dll" signType="AuthenticodeFormer" dest="__RELBINPATH__\..\..\..\s\signed\AdaptiveCardRenderer\win32\AdaptiveCards.Rendering.Uwp.dll" />
     <!-- x64 -->
-    <file src="__RELBINPATH__\..\..\..\s\tosign\AdaptiveCardRenderer\x64\AdaptiveCards.Rendering.Uwp.dll" signType="Authenticode" dest="__RELBINPATH__\..\..\..\s\signed\AdaptiveCardRenderer\x64\AdaptiveCards.Rendering.Uwp.dll" />
+    <file src="__RELBINPATH__\..\..\..\s\tosign\AdaptiveCardRenderer\x64\AdaptiveCards.Rendering.Uwp.dll" signType="AuthenticodeFormer" dest="__RELBINPATH__\..\..\..\s\signed\AdaptiveCardRenderer\x64\AdaptiveCards.Rendering.Uwp.dll" />
     <!-- ARM -->
-    <file src="__RELBINPATH__\..\..\..\s\tosign\AdaptiveCardRenderer\ARM\AdaptiveCards.Rendering.Uwp.dll" signType="Authenticode" dest="__RELBINPATH__\..\..\..\s\signed\AdaptiveCardRenderer\ARM\AdaptiveCards.Rendering.Uwp.dll" />
+    <file src="__RELBINPATH__\..\..\..\s\tosign\AdaptiveCardRenderer\ARM\AdaptiveCards.Rendering.Uwp.dll" signType="AuthenticodeFormer" dest="__RELBINPATH__\..\..\..\s\signed\AdaptiveCardRenderer\ARM\AdaptiveCards.Rendering.Uwp.dll" />
     <!-- ARM64 -->
-    <file src="__RELBINPATH__\..\..\..\s\tosign\AdaptiveCardRenderer\ARM64\AdaptiveCards.Rendering.Uwp.dll" signType="Authenticode" dest="__RELBINPATH__\..\..\..\s\signed\AdaptiveCardRenderer\ARM64\AdaptiveCards.Rendering.Uwp.dll" />
+    <file src="__RELBINPATH__\..\..\..\s\tosign\AdaptiveCardRenderer\ARM64\AdaptiveCards.Rendering.Uwp.dll" signType="AuthenticodeFormer" dest="__RELBINPATH__\..\..\..\s\signed\AdaptiveCardRenderer\ARM64\AdaptiveCards.Rendering.Uwp.dll" />
   </job>
 </SignConfigXML>


### PR DESCRIPTION
Cherry-pick signing fixes and bump version.

Verified by running release pipeline without publishing

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3327)