### PR TITLE
[JavaScript] Logger for Telemetry

### DIFF
--- a/source/nodejs/adaptivecards-designer-app/package-lock.json
+++ b/source/nodejs/adaptivecards-designer-app/package-lock.json
@@ -253,35 +253,6 @@
 				"acorn": "^5.0.0"
 			}
 		},
-		"adaptivecards": {
-			"version": "1.3.0-alpha1",
-			"resolved": "https://registry.npmjs.org/adaptivecards/-/adaptivecards-1.3.0-alpha1.tgz",
-			"integrity": "sha512-V6dOox+Kzpu0NUb14FErW5JGBDLtxL3JimdA9D2scIP5O2g9t5eO/auD2RTFaag2pzBLGKBKbe06koeh1ml9RA==",
-			"dev": true
-		},
-		"adaptivecards-controls": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/adaptivecards-controls/-/adaptivecards-controls-0.3.1.tgz",
-			"integrity": "sha512-VgCTlABUA31GdIT7KPWsykm0EL5yxYiHra6KN4NCbR4qXxfpaEoBRajAICfZPijz/jP7JWTucACfl0mln94GcQ==",
-			"dev": true
-		},
-		"adaptivecards-designer": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/adaptivecards-designer/-/adaptivecards-designer-0.7.1.tgz",
-			"integrity": "sha512-wrZ0TyvIqkBAvUj2HnPUDvFgeR5D9fKynCyR8C5CPuSHpu4hfDcxm4gXh2/qYt/JHxfFK94PiduI6HvLX351CA==",
-			"dev": true,
-			"requires": {
-				"adaptivecards": "^1.3.0-alpha.2",
-				"adaptivecards-controls": "^0.3.1",
-				"adaptivecards-templating": "^0.1.0-alpha.1",
-				"clipboard": "^2.0.1"
-			}
-		},
-		"adaptivecards-templating": {
-			"version": "0.1.0-alpha.1",
-			"resolved": "https://registry.npmjs.org/adaptivecards-templating/-/adaptivecards-templating-0.1.0-alpha.1.tgz",
-			"integrity": "sha512-C5YiUqiOcwlG27aaAEaOQSNAVQK3vBZMJ8ZFa3bCHZktMbbH0EeZZeM/CMu2B+SD0cfIL1tcRr789Ou6lCKrHA=="
-		},
 		"ajv": {
 			"version": "6.6.2",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
@@ -875,17 +846,6 @@
 				}
 			}
 		},
-		"clipboard": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.4.tgz",
-			"integrity": "sha512-Vw26VSLRpJfBofiVaFb/I8PVfdI1OxKcYShe6fm0sP/DtmiWQNCjhM/okTvdCo0G+lMMm1rMYbk4IK4x1X+kgQ==",
-			"dev": true,
-			"requires": {
-				"good-listener": "^1.2.2",
-				"select": "^1.1.2",
-				"tiny-emitter": "^2.0.0"
-			}
-		},
 		"cliui": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
@@ -1231,12 +1191,6 @@
 				"pify": "^3.0.0",
 				"rimraf": "^2.2.8"
 			}
-		},
-		"delegate": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-			"integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-			"dev": true
 		},
 		"depd": {
 			"version": "1.1.2",
@@ -2423,15 +2377,6 @@
 					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
 					"dev": true
 				}
-			}
-		},
-		"good-listener": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-			"integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-			"dev": true,
-			"requires": {
-				"delegate": "^3.1.2"
 			}
 		},
 		"graceful-fs": {
@@ -4037,12 +3982,6 @@
 				"ajv-keywords": "^3.1.0"
 			}
 		},
-		"select": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-			"integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
-			"dev": true
-		},
 		"select-hose": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -4694,12 +4633,6 @@
 			"requires": {
 				"setimmediate": "^1.0.4"
 			}
-		},
-		"tiny-emitter": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-			"integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-			"dev": true
 		},
 		"to-arraybuffer": {
 			"version": "1.0.1",

--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/package-lock.json
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/package-lock.json
@@ -2142,7 +2142,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -2163,12 +2164,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -2183,17 +2186,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -2310,7 +2316,8 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -2322,6 +2329,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -2336,6 +2344,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -2343,12 +2352,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -2367,6 +2378,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -2447,7 +2459,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -2459,6 +2472,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -2544,7 +2558,8 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -2580,6 +2595,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -2599,6 +2615,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -2642,12 +2659,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},

--- a/source/nodejs/adaptivecards-visualizer/package-lock.json
+++ b/source/nodejs/adaptivecards-visualizer/package-lock.json
@@ -213,12 +213,6 @@
 				"acorn": "^5.0.0"
 			}
 		},
-		"adaptivecards": {
-			"version": "1.3.0-alpha1",
-			"resolved": "https://registry.npmjs.org/adaptivecards/-/adaptivecards-1.3.0-alpha1.tgz",
-			"integrity": "sha512-V6dOox+Kzpu0NUb14FErW5JGBDLtxL3JimdA9D2scIP5O2g9t5eO/auD2RTFaag2pzBLGKBKbe06koeh1ml9RA==",
-			"dev": true
-		},
 		"ajv": {
 			"version": "6.6.2",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",

--- a/source/nodejs/adaptivecards/example.html
+++ b/source/nodejs/adaptivecards/example.html
@@ -9,7 +9,17 @@
 
 	<style type="text/css">
 		#exampleDiv {
-			width: 250px;
+			width: 1000px;
+			border: solid 1px black;
+		}
+
+		#exampleDiv2 {
+			width: 1000px;
+			border: solid 1px black;
+		}
+
+		#exampleDiv3 {
+			width: 1000px;
 			border: solid 1px black;
 		}
 	</style>
@@ -20,30 +30,69 @@
 			// author a card
 			// in practice you'll probably get this from a service
 			// see http://adaptivecards.io/samples/ for inspiration
+
+			// this card specifically demos the Input.Rating control
 			var card = {
-				"type": "AdaptiveCard",
-				"version": "1.0",
-				"body": [{
-						"type": "Image",
-						"url": "http://adaptivecards.io/content/adaptive-card-50.png"
-					},
-					{
-						"type": "TextBlock",
-						"text": "Hello **Adaptive Cards!**"
-					}
-				],
-				"actions": [{
-						"type": "Action.OpenUrl",
-						"title": "Learn more",
-						"url": "http://adaptivecards.io"
-					},
-					{
-						"type": "Action.OpenUrl",
-						"title": "GitHub",
-						"url": "http://github.com/Microsoft/AdaptiveCards"
-					}
-				]
-			};
+	"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+	"type": "AdaptiveCard",
+	"version": "1.0",
+	"body": [
+	{
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "width": 2,
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "PIZZA"
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "Tom's Pie",
+                            "weight": "Bolder",
+                            "size": "ExtraLarge",
+                            "spacing": "None"
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "**Matt H. said** \"I'm compelled to give this place 5 stars due to the number of times I've chosen to eat here this past year!\"",
+                            "size": "Small",
+                            "wrap": true
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": 1,
+                    "items": [
+                        {
+                            "type": "Image",
+                            "url": "https://picsum.photos/300?image=882",
+                            "size": "auto"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "TextBlock",
+            "text": "Would you mind rating our restaurant?",
+            "size": "Medium"
+        },
+        {
+			"type": "Input.Rating",
+			"id": "UserProvidedRating"
+		}
+    ],
+  			"actions": [
+      	  	{
+				"type": "Action.Submit",
+				"title": "Submit Rating"
+        	}
+		]
+};
 
 			// Create an AdaptiveCard instance
 			var adaptiveCard = new AdaptiveCards.AdaptiveCard();
@@ -70,26 +119,149 @@
 
 			// And finally insert it in the page:
 			document.getElementById('exampleDiv').appendChild(renderedCard);
+
+			var card2 = {
+    "type": "AdaptiveCard",
+    "body": [
+        {
+            "type": "Input.ChoiceSet",
+            "id": "as",
+            "placeholder": "Placeholder text",
+            "choices": [
+                {
+                    "title": "Spicy Tuna",
+                    "value": "opt1"
+                },
+                {
+                    "title": "Spicy Salmon",
+                    "value": "Choice 2"
+                },
+                {
+                    "title": "Unagi",
+                    "value": "roe"
+                }
+            ],
+            "style": "expanded"
+        },
+        {
+            "type": "TextBlock",
+            "id": "e",
+            "text": "Please choose an option from above."
+        },
+        {
+            "type": "ActionSet",
+            "actions": [
+                {
+                    "type": "Action.Submit",
+                    "title": "Action.Submit"
+                },
+                {
+                    "type": "Action.ShowCard",
+                    "title": "Action.ShowCard",
+                    "card": {
+                        "type": "AdaptiveCard",
+                        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json"
+                    }
+                }
+            ]
+        }
+    ],
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.0"
+};
+
+			// Create an AdaptiveCard instance
+			var adaptiveCard2 = new AdaptiveCards.AdaptiveCard();
+
+			// Set its hostConfig property unless you want to use the default Host Config
+			// Host Config defines the style and behavior of a card
+			adaptiveCard2.hostConfig = new AdaptiveCards.HostConfig({
+				fontFamily: "Segoe UI, Helvetica Neue, sans-serif"
+				// More host config options
+				// You can find example configs here: https://github.com/microsoft/AdaptiveCards/tree/master/samples/HostConfig
+			});
+
+			// Set the adaptive card's event handlers. onExecuteAction is invoked
+			// whenever an action is clicked in the card
+			adaptiveCard2.onExecuteAction = function (action) {
+				alert("Ow!");
+			}
+
+			// Parse the card payload
+			adaptiveCard2.parse(card2);
+
+			// Render the card to an HTML element:
+			var renderedCard2 = adaptiveCard2.render();
+
+			// And finally insert it in the page:
+			document.getElementById('exampleDiv2').appendChild(renderedCard2);
+
+			var card3 = {
+				"type": "AdaptiveCard",
+				"version": "1.0",
+				"body": [{
+						"type": "Image",
+						"url": "http://adaptivecards.io/content/adaptive-card-50.png"
+					},
+					{
+						"type": "TextBlock",
+						"text": "Hello **Adaptive Cards!**"
+					},
+					{
+			"type": "Input.Rating",
+			"id": "UserProvidedRating"
+		}
+				],
+				"actions": [{
+						"type": "Action.Submit",
+						"title": "Learn more"
+					},
+					{
+						"type": "Action.OpenUrl",
+						"title": "GitHub",
+						"url": "http://github.com/Microsoft/AdaptiveCards"
+					}
+				]
+			};
+
+			// Create an AdaptiveCard instance
+			var adaptiveCard3 = new AdaptiveCards.AdaptiveCard();
+
+			// Set its hostConfig property unless you want to use the default Host Config
+			// Host Config defines the style and behavior of a card
+			adaptiveCard3.hostConfig = new AdaptiveCards.HostConfig({
+				fontFamily: "Segoe UI, Helvetica Neue, sans-serif"
+				// More host config options
+				// You can find example configs here: https://github.com/microsoft/AdaptiveCards/tree/master/samples/HostConfig
+			});
+
+			// Set the adaptive card's event handlers. onExecuteAction is invoked
+			// whenever an action is clicked in the card
+			adaptiveCard3.onExecuteAction = function (action) {
+				alert("Submitted.");
+			}
+
+			// Parse the card payload
+			adaptiveCard3.parse(card3);
+
+			// Render the card to an HTML element:
+			var renderedCard3 = adaptiveCard3.render();
+
+			// And finally insert it in the page:
+			document.getElementById('exampleDiv3').appendChild(renderedCard3);
 		}
 	</script>
 
 </head>
 
 <body onload="renderCard()">
-	<h1>Adaptive Cards Example</h1>
-
-	<p>This example requires a build of the Adaptive Cards library.</p>
-
-	<h3>To run:</h3>
-	<code>
-		<pre>$ npm install</pre>
-		<pre>$ npm run build</pre>
-		<pre>Refresh this page</pre>
-	</code>
-
-	<h3>A card will render below</h3>
+	<h1>Adaptive Cards Telemetry Demo</h1>
 
 	<div id="exampleDiv"></div>
+	<br>
+	<div id="exampleDiv2"></div>
+	<br>
+	<div id="exampleDiv3"></div>
 
 </body>
 

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -6863,7 +6863,7 @@ export class AdaptiveCard extends ContainerWithActions {
 	}
 	
 	/**
-	 * A method that creates an IACLogger and enables event logging to the respective providers.
+	 * A method that enables logging if certain requirements are met (e.g., an Input.Rating element is present)
 	 * 
 	 * @param json - The JSON object that is being parsed
 	 */
@@ -6871,26 +6871,19 @@ export class AdaptiveCard extends ContainerWithActions {
 
 		if (json[this.getItemsCollectionPropertyName()] != null) {
 
-			let items = json[this.getItemsCollectionPropertyName()] as Array<any>;
-
-			// only telemetry for card with Input.Rating is collected
-            let hasRating: boolean = false;
+            let items = json[this.getItemsCollectionPropertyName()] as Array<any>;
             
             let guidHelper: GUIDHelper = GUIDHelper.getOrCreate();
 			// generate a new GUID each time a new card is parsed
 			guidHelper.createGUID();
 
+			// only telemetry for card with Input.Rating is collected
 			for (let i = 0; i < items.length; i++) {
 				if (items[i]["type"] === "Input.Rating") {
-                    hasRating = true;
+                    guidHelper.trackGUID(); // start tracking GUID for telemetry
 					break;
 				}
             }
-            
-            if (hasRating) {
-                GUIDHelper.getOrCreate().getGUID();
-            }
-
 		}
 	}
 

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -3841,21 +3841,19 @@ class ActionButton {
 
 class ActionButtonWithTelemetry extends ActionButton {
 	
-	render(alignment: Enums.ActionAlignment) {
-
-		var useGUID = GUIDHelper.getOrCreate().isGUIDtracked();
-		var guid = GUIDHelper.getOrCreate().getGUID().toString();
+    render(alignment: Enums.ActionAlignment) {
+        let useGUID = GUIDHelper.getOrCreate().isGUIDtracked();
+        let guid = GUIDHelper.getOrCreate().getGUID().toString();
 
         this.action.render();
         this.action.renderedElement.style.flex = alignment === Enums.ActionAlignment.Stretch ? "0 1 100%" : "0 1 auto";
         this.action.renderedElement.onclick = (e) => {
             e.preventDefault();
-			e.cancelBubble = true;
+            e.cancelBubble = true;
 			
-			if (this.action instanceof SubmitAction && useGUID) {
-				ACLogger.getOrCreate().logEvent("SubmitAction", "Action.Submit", guid);
-			}
-			
+            if (this.action instanceof SubmitAction && useGUID) {
+                ACLogger.getOrCreate().logEvent("SubmitAction", "Action.Submit", guid);
+            }
 
             this.click();
         };
@@ -6866,7 +6864,7 @@ export class AdaptiveCard extends ContainerWithActions {
 			let items = json[this.getItemsCollectionPropertyName()] as Array<any>;
 
 			// only telemetry for card with Input.Rating is collected
-			var hasRating: boolean = false;
+			let hasRating: boolean = false;
 
 			for (let i = 0; i < items.length; i++) {
 				if (items[i]["type"] === "Input.Rating") {
@@ -6875,24 +6873,24 @@ export class AdaptiveCard extends ContainerWithActions {
 				}
 			}
 			
-			var guidHelper: GUIDHelper = GUIDHelper.getOrCreate();
+			let guidHelper: GUIDHelper = GUIDHelper.getOrCreate();
 			// generate a new GUID each time a new card is parsed
 			guidHelper.createGUID();
 
 			if (hasRating) {
 
-				var logger: IACLogger = ACLogger.getOrCreate();
+				let logger: IACLogger = ACLogger.getOrCreate();
 
 				// only call getGUID() if we want to track the GUID
 				// (has a rating control)
-				var guid: string = guidHelper.getGUID().toString();
+				let guid: string = guidHelper.getGUID().toString();
 				
 
 				for (let i = 0; i < items.length; i++) {
-					var itemType = items[i]["type"];
+					let itemType = items[i]["type"];
 
 					if (itemType === "Input.Rating") {
-						var valueSet = {};
+						let valueSet = {};
 
 						valueSet["defaultScale"] = (items[i]["maxValue"]) ? false : true;
 
@@ -6944,7 +6942,7 @@ export class AdaptiveCard extends ContainerWithActions {
 	 * @param itemSchemaName Name of the item according to the Adaptive Cards schema
 	 */
 	private logSubItems(item: any, subItemName: string, itemSchemaName: string): void {
-		var subItems = item[subItemName];
+		let subItems = item[subItemName];
 
 		if (subItems) {
 

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -8,7 +8,6 @@ import * as TextFormatters from "./text-formatters";
 import { ACLogger } from "./logging/ACLogger";
 import { GUIDHelper } from "./logging/GUIDHelper";
 import { IACLogger } from "./logging/IACLogger";
-import { ConsoleProvider } from "./logging/ConsoleProvider";
 
 function invokeSetCollection(action: Action, collection: ActionCollection) {
     if (action) {
@@ -6847,7 +6846,6 @@ export class AdaptiveCard extends ContainerWithActions {
 		
 		// uncomment line below to enable sending of telemetry
 		// ACLogger.getOrCreate().configureCustomProviders( { add providers here } );
-		ACLogger.getOrCreate().configureCustomProviders(new ConsoleProvider());
 
 		if (ACLogger.getOrCreate().isTelemetryEnabled()) {
 			this.renderCardTelemetry(json);

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -689,7 +689,7 @@ export abstract class CardElement extends CardObject {
     render(): HTMLElement {
         // do not log on source AdaptiveCard
         if (GUIDHelper.getOrCreate().isGUIDtracked() && this.getJsonTypeName() !== "AdaptiveCard") {
-            ACLogger.getOrCreate().logEvent("RenderCard", this.getJsonTypeName(), GUIDHelper.getOrCreate().getGUID().toString());
+            AdaptiveCard.logger.logEvent("RenderCard", this.getJsonTypeName(), GUIDHelper.getOrCreate().getGUID().toString());
         }
         
         this._renderedElement = this.overrideInternalRender();
@@ -1725,7 +1725,7 @@ export class FactSet extends CardElement {
 
         if (GUIDHelper.getOrCreate().isGUIDtracked()) {
             for (let i = 0; i < this.facts.length; i++) {
-                ACLogger.getOrCreate().logEvent("RenderCard", "Fact", GUIDHelper.getOrCreate().getGUID().toString());
+                AdaptiveCard.logger.logEvent("RenderCard", "Fact", GUIDHelper.getOrCreate().getGUID().toString());
             }
         }
 
@@ -3276,7 +3276,7 @@ export class ChoiceSetInput extends Input {
     protected internalRender(): HTMLElement {
         if (GUIDHelper.getOrCreate().isGUIDtracked()) {
             for (let i = 0; i < this.choices.length; i++) {
-                ACLogger.getOrCreate().logEvent("RenderCard", "Choice", GUIDHelper.getOrCreate().getGUID().toString());
+                AdaptiveCard.logger.logEvent("RenderCard", "Choice", GUIDHelper.getOrCreate().getGUID().toString());
             }
         }
 
@@ -3927,7 +3927,7 @@ export abstract class Action extends CardObject {
             // store guid at render time to correlate events
             this._guid = GUIDHelper.getOrCreate().getGUID().toString();
 
-            ACLogger.getOrCreate().logEvent("RenderCard", this.getJsonTypeName(), this._guid);
+            AdaptiveCard.logger.logEvent("RenderCard", this.getJsonTypeName(), this._guid);
         }
 
         // Cache hostConfig for perf
@@ -4003,7 +4003,7 @@ export abstract class Action extends CardObject {
 
         // logging is only scoped to Action.Submit events
         if (this.getJsonTypeName() === "Action.Submit" && this._guid !== null) {
-            ACLogger.getOrCreate().logEvent("SubmitButtonClicked", this.getJsonTypeName(), this._guid);
+            AdaptiveCard.logger.logEvent("SubmitButtonClicked", this.getJsonTypeName(), this._guid);
         }
 
         raiseExecuteActionEvent(this);
@@ -6656,6 +6656,8 @@ export class AdaptiveCard extends ContainerWithActions {
     static onParseError: (error: HostConfig.IValidationError) => void = null;
     static onProcessMarkdown: (text: string, result: IMarkdownProcessingResult) => void = null;
 
+    static readonly logger: IACLogger = ACLogger.getOrCreate();
+
     static get processMarkdown(): (text: string) => string {
         throw new Error("The processMarkdown event has been removed. Please update your code and set onProcessMarkdown instead.")
     }
@@ -6850,10 +6852,10 @@ export class AdaptiveCard extends ContainerWithActions {
 		}
 		
 		// uncomment line below to enable sending of telemetry
-        // ACLogger.getOrCreate().configureCustomProviders( { add providers here } );
-        ACLogger.getOrCreate().configureCustomProviders(new ConsoleProvider());
+        // AdaptiveCard.logger.configureCustomProviders( { add providers here } );
+        AdaptiveCard.logger.configureCustomProviders(new ConsoleProvider());
 
-		if (ACLogger.getOrCreate().isTelemetryEnabled()) {
+		if (AdaptiveCard.logger.isTelemetryEnabled()) {
 			this.renderCardTelemetry(json);
 		}
 

--- a/source/nodejs/adaptivecards/src/logging/ACLogger.ts
+++ b/source/nodejs/adaptivecards/src/logging/ACLogger.ts
@@ -8,8 +8,8 @@ import { IACLogger } from "./IACLogger";
 */
 export class ACLogger implements IACLogger {
 
-	private static instance: IACLogger;
-	private providers: IACProvider[];
+	private static _instance: IACLogger;
+	private _providers: IACProvider[];
 
 	// singleton method requires a private constructor
 	private constructor() {	}
@@ -17,12 +17,12 @@ export class ACLogger implements IACLogger {
 	private log(level: LogLevel, message: string): void {
 
 		// if providers have not yet been configured, then exit
-		if (!this.providers) {
+		if (!this._providers) {
 			console.log("ERROR: Providers have not yet been configured!");
 			return;
 		}
 
-		var stringLevel: string = "";
+		let stringLevel: string = "";
 		switch (level) {
 			case LogLevel.Warn:
 				stringLevel = "warn";
@@ -41,7 +41,7 @@ export class ACLogger implements IACLogger {
 				return;
 		}
 
-		for (var provider of this.providers) {
+		for (let provider of this._providers) {
 			try {
 				provider.sendLogData(stringLevel, message);
 			} catch (e) {
@@ -67,7 +67,7 @@ export class ACLogger implements IACLogger {
 	}
 	
 	logEvent(event: string, eventSourceName: string, correlationID?: string, valueSet?: object): void {
-		for (var provider of this.providers) {
+		for (let provider of this._providers) {
 			try {
 				provider.sendData(event, eventSourceName, correlationID, valueSet);
 			} catch (e) {
@@ -82,11 +82,11 @@ export class ACLogger implements IACLogger {
 	 * then returned.
 	 */
 	static getOrCreate(): IACLogger {
-		if (!this.instance) {
-			this.instance = new ACLogger();
+		if (!this._instance) {
+			this._instance = new ACLogger();
 		}
 
-		return this.instance;
+		return this._instance;
 	}
 	
 
@@ -96,29 +96,29 @@ export class ACLogger implements IACLogger {
 			return;
 		}
 
-		if (!this.providers) {
-			this.providers = [];
+		if (!this._providers) {
+			this._providers = [];
 		}
 
-		for (var i = 0; i < providers.length; i++) {
-			var hasProvider: boolean = false;
-			var newProviderName: string = Object.getPrototypeOf(providers[i]).constructor.name;
+		for (let i = 0; i < providers.length; i++) {
+			let hasProvider: boolean = false;
+			let newProviderName: string = Object.getPrototypeOf(providers[i]).constructor.name;
 
 			// check if new provider is already configured
-			this.providers.forEach(function(currentProvider: IACProvider) {
+			this._providers.forEach(function(currentProvider: IACProvider) {
 				if (newProviderName === Object.getPrototypeOf(currentProvider).constructor.name) {
 					hasProvider = true;
 				}
 			});
 
 			if (!hasProvider) {
-				this.providers.push(providers[i]);
+				this._providers.push(providers[i]);
 			}
 		}
 	}
 
 	isTelemetryEnabled(): boolean {
-		return this.providers ? true : false;
+		return this._providers ? true : false;
 	}
 
 }

--- a/source/nodejs/adaptivecards/src/logging/ACLogger.ts
+++ b/source/nodejs/adaptivecards/src/logging/ACLogger.ts
@@ -1,0 +1,124 @@
+import { IACProvider } from "./IACProvider";
+import { LogLevel } from "./log-enums";
+import { IACLogger } from "./IACLogger";
+
+/*
+	The implementation of the IACLogger to be used within the
+	Adaptive Cards JS renderer.
+*/
+export class ACLogger implements IACLogger {
+
+	private static instance: IACLogger;
+	private providers: IACProvider[];
+
+	// singleton method requires a private constructor
+	private constructor() {	}
+
+	private log(level: LogLevel, message: string): void {
+
+		// if providers have not yet been configured, then exit
+		if (!this.providers) {
+			console.log("ERROR: Providers have not yet been configured!");
+			return;
+		}
+
+		var stringLevel: string = "";
+		switch (level) {
+			case LogLevel.Warn:
+				stringLevel = "warn";
+				break;
+			case LogLevel.Error:
+				stringLevel = "error";
+				break;
+			case LogLevel.Verbose:
+				stringLevel = "verbose";
+				break;
+			case LogLevel.Info:
+				stringLevel = "info";
+				break;
+			default:
+				console.log("ERROR: LogLevel undefined.");
+				return;
+		}
+
+		for (var provider of this.providers) {
+			try {
+				provider.sendLogData(stringLevel, message);
+			} catch (e) {
+				console.log("ERROR: Error logging to provider " + Object.getPrototypeOf(provider).constructor.name + " - " + e);
+			}
+		}
+	}
+
+	logWarn(message: string): void {
+		this.log(LogLevel.Warn, message);
+	}
+
+	logError(message: string): void {
+		this.log(LogLevel.Error, message);
+	}
+
+	logVerbose(message: string): void {
+		this.log(LogLevel.Verbose, message);
+	}
+
+	logInfo(message: string): void {
+		this.log(LogLevel.Info, message);
+	}
+	
+	logEvent(event: string, eventSourceName: string, correlationID?: string, valueSet?: object): void {
+		for (var provider of this.providers) {
+			try {
+				provider.sendData(event, eventSourceName, correlationID, valueSet);
+			} catch (e) {
+				console.log("ERROR: Error logging to provider " + Object.getPrototypeOf(provider).constructor.name + " - " + e);
+			}
+		}
+	}
+
+	/**
+	 * Returns the singleton instance of the ACLogger.
+	 * If the instance has not yet been created, then the instance is created,
+	 * then returned.
+	 */
+	static getOrCreate(): IACLogger {
+		if (!this.instance) {
+			this.instance = new ACLogger();
+		}
+
+		return this.instance;
+	}
+	
+
+	configureCustomProviders(...providers: IACProvider[]): void {
+
+		if (providers === undefined || providers.length == 0) {
+			return;
+		}
+
+		if (!this.providers) {
+			this.providers = [];
+		}
+
+		for (var i = 0; i < providers.length; i++) {
+			var hasProvider: boolean = false;
+			var newProviderName: string = Object.getPrototypeOf(providers[i]).constructor.name;
+
+			// check if new provider is already configured
+			this.providers.forEach(function(currentProvider: IACProvider) {
+				if (newProviderName === Object.getPrototypeOf(currentProvider).constructor.name) {
+					hasProvider = true;
+				}
+			});
+
+			if (!hasProvider) {
+				this.providers.push(providers[i]);
+			}
+		}
+	}
+
+	isTelemetryEnabled(): boolean {
+		return this.providers ? true : false;
+	}
+
+}

--- a/source/nodejs/adaptivecards/src/logging/ConsoleProvider.ts
+++ b/source/nodejs/adaptivecards/src/logging/ConsoleProvider.ts
@@ -1,0 +1,18 @@
+/*
+	A console logging implementation of the IACProvider.
+	Allows for all logging from an IACLogger to be output to the console.
+*/
+import { IACProvider } from "./IACProvider";
+
+export class ConsoleProvider implements IACProvider {
+
+	sendLogData(level: string, message: string) {
+		console.log("Log" + level.toUpperCase() + ": " + message);
+	}
+
+	sendData(event: any, eventSourceName: any, correlationID?: any, valueSet?: any) {
+		console.log("LogEvent: " + event + "\nSource: " + eventSourceName + 
+		"\nCorrelationID: " + correlationID + "\n" + "valueSet: " + valueSet);
+	}
+
+}

--- a/source/nodejs/adaptivecards/src/logging/GUIDHelper.ts
+++ b/source/nodejs/adaptivecards/src/logging/GUIDHelper.ts
@@ -5,9 +5,9 @@ A helper class to generate, keep track of, and return a unique GUID
 to correlate events throughout a unique card's life cycle.
 */
 export class GUIDHelper {
-	private guid: number;
-	private static instance: GUIDHelper;
-	private hasRating: boolean;
+	private _guid: number;
+	private static _instance: GUIDHelper;
+	private _hasRating: boolean;
 
 	private constructor() { }
 
@@ -19,11 +19,11 @@ export class GUIDHelper {
 	 * @returns Singleton instance of GUIDHelper
 	 */
 	static getOrCreate(): GUIDHelper {
-		if (this.instance) {
-			return this.instance;
+		if (this._instance) {
+			return this._instance;
 		} else {
-			this.instance = new GUIDHelper();
-			return this.instance;
+			this._instance = new GUIDHelper();
+			return this._instance;
 		}
 	}
 
@@ -31,8 +31,8 @@ export class GUIDHelper {
 	 * Creates a new unique GUID and resets tracking
 	 */
 	createGUID(): void {
-		this.guid = uuidv4();
-		this.hasRating = false;
+		this._guid = uuidv4();
+		this._hasRating = false;
 	}
 
 	/**
@@ -46,8 +46,8 @@ export class GUIDHelper {
 	 * @returns GUID. If createGUID() has not yet been called, then an undefined object will be returned
 	 */
 	getGUID(): number {
-		this.hasRating = true;
-		return this.guid;
+		this._hasRating = true;
+		return this._guid;
 	}
 
 	/**
@@ -57,6 +57,6 @@ export class GUIDHelper {
 	 * @returns true if future events should be tracked, false otherwise
 	 */
 	isGUIDtracked(): boolean {
-		return this.hasRating;
+		return this._hasRating;
 	}
 }

--- a/source/nodejs/adaptivecards/src/logging/GUIDHelper.ts
+++ b/source/nodejs/adaptivecards/src/logging/GUIDHelper.ts
@@ -1,0 +1,62 @@
+const uuidv4 = require('uuid/v4');
+
+/*
+A helper class to generate, keep track of, and return a unique GUID
+to correlate events throughout a unique card's life cycle.
+*/
+export class GUIDHelper {
+	private guid: number;
+	private static instance: GUIDHelper;
+	private hasRating: boolean;
+
+	private constructor() { }
+
+	/**
+	 * Returns the singleton instance of the GUIDHelper.
+	 * If the instance has not yet been created, then the instance is created,
+	 * then returned.
+	 * 
+	 * @returns Singleton instance of GUIDHelper
+	 */
+	static getOrCreate(): GUIDHelper {
+		if (this.instance) {
+			return this.instance;
+		} else {
+			this.instance = new GUIDHelper();
+			return this.instance;
+		}
+	}
+
+	/**
+	 * Creates a new unique GUID and resets tracking
+	 */
+	createGUID(): void {
+		this.guid = uuidv4();
+		this.hasRating = false;
+	}
+
+	/**
+	 * Retrieves the unique GUID corresponding to the class
+	 * 
+	 * @remarks
+	 * When this method is called, the class begins tracking
+	 * the corresponding GUID to convey that certain events
+	 * be tracked in a card's future (e.g., SubmitButtonClicked)
+	 * 
+	 * @returns GUID. If createGUID() has not yet been called, then an undefined object will be returned
+	 */
+	getGUID(): number {
+		this.hasRating = true;
+		return this.guid;
+	}
+
+	/**
+	 * Returns a boolean indicating whether or not events corresponding to a unique card's GUID
+	 * should be tracked in the future (e.g., SubmitButtonClicked)
+	 * 
+	 * @returns true if future events should be tracked, false otherwise
+	 */
+	isGUIDtracked(): boolean {
+		return this.hasRating;
+	}
+}

--- a/source/nodejs/adaptivecards/src/logging/GUIDHelper.ts
+++ b/source/nodejs/adaptivecards/src/logging/GUIDHelper.ts
@@ -46,8 +46,15 @@ export class GUIDHelper {
 	 * @returns GUID. If createGUID() has not yet been called, then an undefined object will be returned
 	 */
 	getGUID(): number {
-		this._hasRating = true;
 		return this._guid;
+	}
+
+	/**
+	 * When called, indicates that logging calls should occur for a specific card
+	 * in the future and GUIDs should be correlated
+	 */
+	trackGUID(): void {
+		this._hasRating = true;
 	}
 
 	/**

--- a/source/nodejs/adaptivecards/src/logging/IACLogger.ts
+++ b/source/nodejs/adaptivecards/src/logging/IACLogger.ts
@@ -1,0 +1,68 @@
+import { IACProvider } from "./IACProvider";
+
+/*
+	The IACLogger interface. All logger implementations in Adaptive Cards must follow this interface.
+*/
+export interface IACLogger {
+
+	/**
+	 * Logs a warning message to all providers configured to the IACLogger.
+	 * 
+	 * @param message - The message to be logged
+	 */
+	logWarn(message: string): void; 
+	
+	/**
+	 * Logs an error message to all providers configured to the IACLogger.
+	 * 
+	 * @param message - The message to be logged
+	 */
+	logError(message: string): void; 
+	
+	/**
+	 * Logs a verbose message to all providers configured to the IACLogger.
+	 * 
+	 * @param message - The message to be logged
+	 */
+	logVerbose(message: string): void; 
+	
+	/**
+	 * Logs an info message to all providers configured to the IACLogger.
+	 * 
+	 * @param message - The message to be logged
+	 */
+	logInfo(message: string): void; 
+	
+	/**
+	 * Logs an event to all providers configured to the IACLogger.
+	 * 
+	 * @param event - The name of the event to be logged (e.g., RenderCard)
+	 * @param eventSourceName - The name of the source element corresponding to the event (e.g., TextBlock)
+	 * @param correlationID - (optional) The unique correlation identifier to correlate events relating to the same Adaptive Card 
+	 * @param valueSet - (optional) An object containing key-value pairs corresponding to data for telemetry metrics (e.g., { defaultIconUsed: true })
+	 */
+	logEvent(event: string, eventSourceName: string, correlationID?: string, valueSet?: object): void;
+
+	/**
+	 * Configures the IACLogger to log to the instances of the providers specified in the parameters.
+	 * 
+	 * @remarks
+	 * If an IACLogger is not configured before logging, then an error will be output to the console and no event/message will be logged.
+	 * 
+	 * @param providers - The custom instances of providers that IACLogger will log to, in comma-separated form. If no providers
+	 * are given in the parameters, then no providers will be configured.
+	 */
+	configureCustomProviders(...providers: IACProvider[]): void;
+
+	/**
+	 * Returns whether or not telemetry is enabled for the logger.
+	 * 
+	 * @remarks
+	 * This function determines status according to the state of the providers; if providers are empty,
+	 * then telemetry is not enabled, and vice versa
+	 * 
+	 * @returns true if telemetry is enabled, else false
+	 */
+	isTelemetryEnabled(): boolean;
+
+}

--- a/source/nodejs/adaptivecards/src/logging/IACProvider.ts
+++ b/source/nodejs/adaptivecards/src/logging/IACProvider.ts
@@ -1,0 +1,31 @@
+/*
+	The IACProvider interface. All provider implementations must follow this interface
+	in order to be used by the IACLogger.
+*/
+export interface IACProvider {
+
+	/**
+	 * Sends a log message to the telemetry provider.
+	 * 
+	 * @remarks
+	 * Any errors originating from the telemetry platform will be logged to the console.
+	 * 
+	 * @param level - The level of the message to be logged
+	 * @param message - The message to be logged
+	 */
+	sendLogData(level: string, message: string): void;
+
+	/**
+	 * Sends an event to the telemetry provider.
+	 * 
+	 * @remarks
+	 * Any errors originating from the telemetry platform will be logged to the console.
+	 * 
+	 * @param event - The name of the event to be logged (e.g., RenderCard)
+	 * @param eventSourceName - The name of the source element corresponding to the event (e.g., TextBlock)
+	 * @param correlationID - (optional) The unique correlation identifier to correlate events relating to the same Adaptive Card 
+	 * @param valueSet - (optional) An object containing key-value pairs corresponding to data for telemetry metrics (e.g., { defaultIconUsed: true })
+	 */
+	sendData(event: string, eventSourceName: string, correlationID?: string, valueSet?: object): void;
+
+}

--- a/source/nodejs/adaptivecards/src/logging/README.md
+++ b/source/nodejs/adaptivecards/src/logging/README.md
@@ -1,0 +1,41 @@
+# Logging in Adaptive Cards
+
+Adaptive Cards supports logging to various platforms, including telemetry platforms such as Microsoft 1DS.
+
+## Logging API
+
+A developer can log both messages and events to the platform(s) she specifies. The ACLogger API is as follows (method descriptions are available in IACLogger.ts):
+
+```
+	logWarn(message: string): void; 
+
+	logError(message: string): void; 
+
+	logVerbose(message: string): void; 
+
+	logInfo(message: string): void; 
+	
+	logEvent(event: string, eventSourceName: string, correlationID?: string, valueSet?: object): void;
+
+	configureCustomProviders(...providers: IACProvider[]): void;
+
+	isTelemetryEnabled(): boolean;
+```
+
+## Enabling Logging
+
+Telemetry is disabled by default. To enable this feature, uncomment the appropriate line in the `parse()` method of the `AdaptiveCard` class in `AdaptiveCards/source/nodejs/adaptivecards/card-elements.ts`. Providers must then be included in the parameters of the method call, e.g.:
+
+`ACLogger.getOrCreate().configureCustomProviders(new ConsoleLogger(), new Microsoft1DSLogger());`
+
+## Extensibility
+
+The current logging architecture supports extension of both the base ACLogger as well as IACProviders. A ConsoleLogger and Microsoft1DSProvider is available with the base Adaptive Cards library.
+
+### Extending ACLogger
+
+Creating a new ACLogger requires implementing the IACLogger.ts interface and replacing all instantiations of the default logger in card-elements.ts to instantiations of the new logger implementation. While not required, it is recommended that any implementation of IACLogger retain the singleton pattern. This ensures the least amount of resources is used by the logger, and that the provider state is maintained.
+
+### Extending ACProvider
+
+New logging providers can be used by any class that implements the IACProvider interface. The new provider can be logged to by calling `configureCustomProviders()` and using the instantiated provider as a parameter before any logging calls.

--- a/source/nodejs/adaptivecards/src/logging/log-enums.ts
+++ b/source/nodejs/adaptivecards/src/logging/log-enums.ts
@@ -1,0 +1,7 @@
+export enum LogLevel {
+	Warn,
+	Error,
+	Verbose,
+	Info,
+	Event
+}

--- a/source/nodejs/package-lock.json
+++ b/source/nodejs/package-lock.json
@@ -13120,8 +13120,7 @@
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "dev": true
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "v8-compile-cache": {
       "version": "2.0.3",

--- a/source/nodejs/package.json
+++ b/source/nodejs/package.json
@@ -37,5 +37,8 @@
 		"webpack": "^4.38.0",
 		"webpack-cli": "^3.3.6",
 		"webpack-dev-server": "^3.7.2"
+	},
+	"dependencies": {
+		"uuid": "^3.3.2"
 	}
 }

--- a/source/nodejs/spec-generator/package-lock.json
+++ b/source/nodejs/spec-generator/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "spec-generator",
-	"version": "0.5.1",
+	"version": "0.5.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
Fixes #3058, implements dev spec in #3246 when combined with #3331

# Logging for Adaptive Cards

## Summary

This feature contains an extensible way to log events and messages to the console, the Microsoft 1DS telemetry platform, and any other logging/telemetry platform that implements the `IACProvider` interface. Logging is disabled by default. When enabled, log calls currently only occur when a card contains the `Input.Rating` element (see #3332).

![image](https://user-images.githubusercontent.com/42462906/62993862-1608b600-be0e-11e9-98ff-5aceb2a74738.png)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3333)