### PR TITLE
[UWP] Fix AdaptiveColumn width

### DIFF
--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/ElementTest.cpp
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/ElementTest.cpp
@@ -18,12 +18,22 @@ namespace AdaptiveCardsSharedModelUnitTest
             auto columnTest = std::make_shared<AdaptiveCards::Column>();
             Assert::AreEqual(0, columnTest->GetPixelWidth());
             Assert::AreEqual("Auto"s, columnTest->GetWidth());
+            Assert::AreEqual("{\"items\":[],\"type\":\"Column\",\"width\":\"Auto\"}\n"s, columnTest->Serialize());
+
             columnTest->SetWidth("20px"s);
             Assert::AreEqual(20, columnTest->GetPixelWidth());
             Assert::AreEqual("20px"s, columnTest->GetWidth());
+            Assert::AreEqual("{\"items\":[],\"type\":\"Column\",\"width\":\"20px\"}\n"s, columnTest->Serialize());
+
             columnTest->SetPixelWidth(40);
             Assert::AreEqual(40, columnTest->GetPixelWidth());
             Assert::AreEqual("40px"s, columnTest->GetWidth());
+            Assert::AreEqual("{\"items\":[],\"type\":\"Column\",\"width\":\"40px\"}\n"s, columnTest->Serialize());
+
+            columnTest->SetWidth("Stretch");
+            Assert::AreEqual(0, columnTest->GetPixelWidth());
+            Assert::AreEqual("stretch"s, columnTest->GetWidth());
+            Assert::AreEqual("{\"items\":[],\"type\":\"Column\",\"width\":\"stretch\"}\n"s, columnTest->Serialize());
         }
     };
 }

--- a/source/uwp/Renderer/lib/AdaptiveColumn.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveColumn.cpp
@@ -164,8 +164,16 @@ namespace AdaptiveNamespace
 
         column->SetStyle(static_cast<AdaptiveSharedNamespace::ContainerStyle>(m_style));
         column->SetVerticalContentAlignment(static_cast<AdaptiveSharedNamespace::VerticalContentAlignment>(m_verticalAlignment));
-        column->SetWidth(HStringToUTF8(m_width.Get()));
-        column->SetPixelWidth(m_pixelWidth);
+
+        if (m_pixelWidth)
+        {
+            column->SetPixelWidth(m_pixelWidth);
+        }
+        else
+        {
+            column->SetWidth(HStringToUTF8(m_width.Get()));
+        }
+
         column->SetMinHeight(m_minHeight);
         column->SetBleed(m_bleed);
 


### PR DESCRIPTION
With change fee0c03191cd212ad004d16be9ae2a533589d433, pixel width and string width in the shared model are now last-writer-wins. Update `AdaptiveColumn::GetSharedModel()` to account for that. I made sure that there are no other dependencies on calling order exist in our codebase (that I can find), and marked the original bug for the shared model change as breaking. I also added missing serialization verification to shared model unit tests.

Fixes #3339.

Verified with test app

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3340)