### PR TITLE
Create a new issue template for Bug Reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Create a bug report to help us improve
+title: "[Platform][Broad Issue Category if applicable (eg Accessibility)] [Bug Title]"
+labels: Bug
+assignees: ''
+
+---
+
+# Platform
+
+What platform is your issue or question related to? (Delete other platforms).
+
+* .NET HTML
+* .NET WPF
+* Android
+* iOS
+* JavaScript
+* UWP
+
+# Author or host
+
+Are you an author (like sending something to Outlook), or a host that is rendering your own cards? If host, please specify the corresponding host (app) name.
+
+If you're an author, who are you sending cards to?
+
+# Version of SDK
+
+What version are you using? Ex: NuGet 1.0.2, or latest master, etc...
+
+# Details
+
+Explain your issue. If you just have a question, please post [on StackOverflow instead](https://stackoverflow.com/questions/tagged/adaptive-cards).


### PR DESCRIPTION
- Follows the newer template workflow which allows for separate templates for bugs and tasks
- Allows for automatically labeling the issues as "Bugs" to kick off the internal fabric bot github workflow to get this visible on our project boards

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3351)