### PR TITLE
Fixes compact ChoiceSet with wrap to dynamically update cell height

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSourceCompactStyle.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSourceCompactStyle.mm
@@ -147,13 +147,11 @@ static NSString *pickerCell = @"pickerCell";
 {
     UITableViewCell *cell = [tableView.dataSource tableView:tableView cellForRowAtIndexPath:indexPath];
     if(indexPath.row == 0) {
-        if(!_compactViewHeight || ![_textInCompactView isEqualToString:cell.textLabel.text]) {
             CGSize labelStringSize = [cell.textLabel.text boundingRectWithSize:CGSizeMake(cell.contentView.frame.size.width - accessoryViewWidth, CGFLOAT_MAX)
                                                                 options:NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading
                                                              attributes:@{NSFontAttributeName:cell.textLabel.font}
                                                                 context:nil].size;
             _compactViewHeight = labelStringSize.height;
-        }
         return _compactViewHeight + padding;
     } else {
         return _showPickerView ? _pickerViewHeight : 0.0f;


### PR DESCRIPTION
## Related Issue
Fixes #3299

## Description
When compact ChoiceSet has wrap property set, it will try to wrap the text in cell. Once the cell height is fixed by default cell selection, cell height did not dynamically adjust its cell height.

## How Verified
Using the test json in #3299, run the permutations of possible user selections to verify that cell height adjust to new text.