### PR TITLE
[Shared] Improve DateTimePreparser perf

### DIFF
--- a/source/shared/cpp/ObjectModel/DateTimePreparser.cpp
+++ b/source/shared/cpp/ObjectModel/DateTimePreparser.cpp
@@ -103,167 +103,172 @@ constexpr time_t IntToTimeT(int timeToConvert)
 #pragma warning(pop)
 }
 
-void DateTimePreparser::ParseDateTime(std::string const& in)
+void DateTimePreparser::ParseDateTime(const std::string& in)
 {
-    std::vector<DateTimePreparsedToken> sections;
-
-    static const std::regex pattern(
-        "\\{\\{((DATE)|(TIME))\\((\\d{4})-{1}(\\d{2})-{1}(\\d{2})T(\\d{2}):{1}(\\d{2}):{1}(\\d{2})(Z|(([+-])(\\d{2}):{1}(\\d{2})))((((, ?SHORT)|(, ?LONG))|(, ?COMPACT))|)\\)\\}\\}");
-    std::smatch matches;
-    std::string text = in;
-    enum MatchIndex
+    if (in.find("{{") != std::string::npos)
     {
-        IsDate = 2,
-        Year = 4,
-        Month,
-        Day,
-        Hour,
-        Min,
-        Sec,
-        TimeZone = 12,
-        TZHr,
-        TZMn,
-        Format,
-        Style,
-    };
-    std::vector<int> indexer = {Year, Month, Day, Hour, Min, Sec, TZHr, TZMn};
-
-    while (std::regex_search(text, matches, pattern))
-    {
-        int formatStyle{};
-        // Date is matched
-        const bool isDate = matches[IsDate].matched;
-        int hours{}, minutes{};
-        struct tm parsedTm
+        static const std::regex pattern(
+            "\\{\\{((DATE)|(TIME))\\((\\d{4})-{1}(\\d{2})-{1}(\\d{2})T(\\d{2}):{1}(\\d{2}):{1}(\\d{2})(Z|(([+-])(\\d{2}):{1}(\\d{2})))((((, ?SHORT)|(, ?LONG))|(, ?COMPACT))|)\\)\\}\\}");
+        std::smatch matches;
+        std::string text = in;
+        enum MatchIndex
         {
+            IsDate = 2,
+            Year = 4,
+            Month,
+            Day,
+            Hour,
+            Min,
+            Sec,
+            TimeZone = 12,
+            TZHr,
+            TZMn,
+            Format,
+            Style,
         };
-        std::vector<int*> addrs = {
-            &parsedTm.tm_year, &parsedTm.tm_mon, &parsedTm.tm_mday, &parsedTm.tm_hour, &parsedTm.tm_min, &parsedTm.tm_sec, &hours, &minutes};
+        std::vector<int> indexer = {Year, Month, Day, Hour, Min, Sec, TZHr, TZMn};
 
-        if (matches[Style].matched)
+        while (std::regex_search(text, matches, pattern))
         {
-            // match for long/short/compact
-            bool formatHasSpace = matches[Format].str().at(1) == ' ';
-            const int formatStartIndex = formatHasSpace ? 2 : 1;
-            formatStyle = matches[Format].str().at(formatStartIndex);
-        }
-
-        AddTextToken(matches.prefix().str(), DateTimePreparsedTokenFormat::RegularString);
-
-        if (!isDate && formatStyle)
-        {
-            AddTextToken(matches[0].str(), DateTimePreparsedTokenFormat::RegularString);
-            text = matches.suffix().str();
-            continue;
-        }
-
-        for (unsigned int idx = 0; idx < indexer.size(); idx++)
-        {
-            if (matches[indexer.at(idx)].matched)
+            int formatStyle{};
+            // Date is matched
+            const bool isDate = matches[IsDate].matched;
+            int hours{}, minutes{};
+            struct tm parsedTm
             {
-                // get indexes for time attributes to index into corresponding matches
-                // and convert it to string
-                *(addrs.at(idx)) = stoi(matches[indexer.at(idx)]);
+            };
+            std::vector<int*> addrs = {
+                &parsedTm.tm_year, &parsedTm.tm_mon, &parsedTm.tm_mday, &parsedTm.tm_hour, &parsedTm.tm_min, &parsedTm.tm_sec, &hours, &minutes};
+
+            if (matches[Style].matched)
+            {
+                // match for long/short/compact
+                bool formatHasSpace = matches[Format].str().at(1) == ' ';
+                const int formatStartIndex = formatHasSpace ? 2 : 1;
+                formatStyle = matches[Format].str().at(formatStartIndex);
             }
-        }
 
-        // check for date and time validation
-        if (IsValidTimeAndDate(parsedTm, hours, minutes))
-        {
-            time_t offset{};
-            // maches offset sign,
-            // Z == UTC,
-            // + == time added from UTC
-            // - == time subtracted from UTC
-            if (matches[TimeZone].matched)
+            AddTextToken(matches.prefix().str(), DateTimePreparsedTokenFormat::RegularString);
+
+            if (!isDate && formatStyle)
             {
-                // converts to seconds
-                hours *= 3600;
-                minutes *= 60;
-                offset = IntToTimeT(hours) + IntToTimeT(minutes);
+                AddTextToken(matches[0].str(), DateTimePreparsedTokenFormat::RegularString);
+                text = matches.suffix().str();
+                continue;
+            }
 
-                wchar_t zone = matches[TimeZone].str().at(0);
-                // time zone offset calculation
-                if (zone == '+')
+            for (unsigned int idx = 0; idx < indexer.size(); idx++)
+            {
+                if (matches[indexer.at(idx)].matched)
                 {
-                    offset *= -1;
+                    // get indexes for time attributes to index into corresponding matches
+                    // and convert it to string
+                    *(addrs.at(idx)) = stoi(matches[indexer.at(idx)]);
                 }
             }
 
-            // measured from year 1900
-            parsedTm.tm_year -= 1900;
-            parsedTm.tm_mon -= 1;
-
-            time_t utc{};
-            // converts to ticks in UTC
-            utc = mktime(&parsedTm);
-            if (utc == -1)
+            // check for date and time validation
+            if (IsValidTimeAndDate(parsedTm, hours, minutes))
             {
-                AddTextToken(matches[0], DateTimePreparsedTokenFormat::RegularString);
-            }
+                time_t offset{};
+                // maches offset sign,
+                // Z == UTC,
+                // + == time added from UTC
+                // - == time subtracted from UTC
+                if (matches[TimeZone].matched)
+                {
+                    // converts to seconds
+                    hours *= 3600;
+                    minutes *= 60;
+                    offset = IntToTimeT(hours) + IntToTimeT(minutes);
+
+                    wchar_t zone = matches[TimeZone].str().at(0);
+                    // time zone offset calculation
+                    if (zone == '+')
+                    {
+                        offset *= -1;
+                    }
+                }
+
+                // measured from year 1900
+                parsedTm.tm_year -= 1900;
+                parsedTm.tm_mon -= 1;
+
+                time_t utc{};
+                // converts to ticks in UTC
+                utc = mktime(&parsedTm);
+                if (utc == -1)
+                {
+                    AddTextToken(matches[0], DateTimePreparsedTokenFormat::RegularString);
+                }
 
 // Disable "array to pointer decay" check for tzOffsetBuff since we can't change strftime's signature
 #pragma warning(push)
 #pragma warning(disable : 26485)
-            char tzOffsetBuff[6]{};
-            // gets local time zone offset
-            strftime(tzOffsetBuff, 6, "%z", &parsedTm);
-            std::string localTimeZoneOffsetStr(tzOffsetBuff);
-            const time_t nTzOffset = IntToTimeT(std::stoi(localTimeZoneOffsetStr));
-            offset += ((nTzOffset / 100) * 3600 + (nTzOffset % 100) * 60);
-            // add offset to utc
-            utc += offset;
-            struct tm result
-            {
-            };
+                char tzOffsetBuff[6]{};
+                // gets local time zone offset
+                strftime(tzOffsetBuff, 6, "%z", &parsedTm);
+                std::string localTimeZoneOffsetStr(tzOffsetBuff);
+                const time_t nTzOffset = IntToTimeT(std::stoi(localTimeZoneOffsetStr));
+                offset += ((nTzOffset / 100) * 3600 + (nTzOffset % 100) * 60);
+                // add offset to utc
+                utc += offset;
+                struct tm result
+                {
+                };
 #pragma warning(pop)
 
-            // converts to local time from utc
-            if (!LOCALTIME(&result, &utc))
-            {
-                // localtime() set dst, put_time adjusts time accordingly which is not what we want since
-                // we have already taken cared of it in our calculation
-                if (result.tm_isdst == 1)
+                // converts to local time from utc
+                if (!LOCALTIME(&result, &utc))
                 {
-                    result.tm_hour -= 1;
-                }
-
-                if (isDate)
-                {
-                    switch (formatStyle)
+                    // localtime() set dst, put_time adjusts time accordingly which is not what we want since
+                    // we have already taken cared of it in our calculation
+                    if (result.tm_isdst == 1)
                     {
-                    // SHORT Style
-                    case 'S':
-                        AddDateToken(matches[0].str(), result, DateTimePreparsedTokenFormat::DateShort);
-                        break;
-                    // LONG Style
-                    case 'L':
-                        AddDateToken(matches[0].str(), result, DateTimePreparsedTokenFormat::DateLong);
-                        break;
-                    // COMPACT or DEFAULT Style
-                    case 'C':
-                    default:
-                        AddDateToken(matches[0].str(), result, DateTimePreparsedTokenFormat::DateCompact);
-                        break;
+                        result.tm_hour -= 1;
+                    }
+
+                    if (isDate)
+                    {
+                        switch (formatStyle)
+                        {
+                        // SHORT Style
+                        case 'S':
+                            AddDateToken(matches[0].str(), result, DateTimePreparsedTokenFormat::DateShort);
+                            break;
+                        // LONG Style
+                        case 'L':
+                            AddDateToken(matches[0].str(), result, DateTimePreparsedTokenFormat::DateLong);
+                            break;
+                        // COMPACT or DEFAULT Style
+                        case 'C':
+                        default:
+                            AddDateToken(matches[0].str(), result, DateTimePreparsedTokenFormat::DateCompact);
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        std::ostringstream parsedTime;
+                        parsedTime << std::put_time(&result, "%I:%M %p");
+                        AddTextToken(parsedTime.str(), DateTimePreparsedTokenFormat::RegularString);
                     }
                 }
-                else
-                {
-                    std::ostringstream parsedTime;
-                    parsedTime << std::put_time(&result, "%I:%M %p");
-                    AddTextToken(parsedTime.str(), DateTimePreparsedTokenFormat::RegularString);
-                }
             }
-        }
-        else
-        {
-            AddTextToken(matches[0].str(), DateTimePreparsedTokenFormat::RegularString);
+            else
+            {
+                AddTextToken(matches[0].str(), DateTimePreparsedTokenFormat::RegularString);
+            }
+
+            text = matches.suffix().str();
         }
 
-        text = matches.suffix().str();
+        AddTextToken(text, DateTimePreparsedTokenFormat::RegularString);
     }
-
-    AddTextToken(text, DateTimePreparsedTokenFormat::RegularString);
+    else
+    {
+        AddTextToken(in, DateTimePreparsedTokenFormat::RegularString);
+    }
 }
 
 // Parses a time of the form HH:MM


### PR DESCRIPTION
Fixes #3378

Instead of running our regex against every line processed by `DateTimePreparser`, first do a quick check to see if the text contains `{{`.

## How Verified
Unit tests & UWP visualizer

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3379)