### PR TITLE
[UWP] Add implementations of factory classes for warnings and errors

### DIFF
--- a/source/uwp/Renderer/lib/AdaptiveError.h
+++ b/source/uwp/Renderer/lib/AdaptiveError.h
@@ -30,5 +30,15 @@ namespace AdaptiveNamespace
         ABI::AdaptiveNamespace::ErrorStatusCode m_statusCode;
     };
 
-    ActivatableClass(AdaptiveError);
+    class AdaptiveErrorFactory : public Microsoft::WRL::AgileActivationFactory<ABI::AdaptiveNamespace::IAdaptiveErrorFactory>
+    {
+        IFACEMETHODIMP CreateInstance(ABI::AdaptiveCards::Rendering::Uwp::ErrorStatusCode statusCode,
+                                      _In_ HSTRING message,
+                                      _COM_Outptr_ ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveError** result) override
+        {
+            return Microsoft::WRL::Details::MakeAndInitialize<AdaptiveError>(result, statusCode, message);
+        }
+    };
+
+    ActivatableClassWithFactory(AdaptiveError, AdaptiveErrorFactory);
 }

--- a/source/uwp/Renderer/lib/AdaptiveWarning.h
+++ b/source/uwp/Renderer/lib/AdaptiveWarning.h
@@ -29,5 +29,15 @@ namespace AdaptiveNamespace
         ABI::AdaptiveNamespace::WarningStatusCode m_statusCode;
     };
 
-    ActivatableClass(AdaptiveWarning);
+    class AdaptiveWarningFactory : public Microsoft::WRL::AgileActivationFactory<ABI::AdaptiveNamespace::IAdaptiveWarningFactory>
+    {
+        IFACEMETHODIMP CreateInstance(ABI::AdaptiveCards::Rendering::Uwp::WarningStatusCode statusCode,
+                                      _In_ HSTRING message,
+                                      _COM_Outptr_ ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveWarning** result) override
+        {
+            return Microsoft::WRL::Details::MakeAndInitialize<AdaptiveWarning>(result, statusCode, message);
+        }
+    };
+
+    ActivatableClassWithFactory(AdaptiveWarning, AdaptiveWarningFactory);
 }


### PR DESCRIPTION
## Related Issue
Regression from fix to #3373 in PR #3375.

## Description
I changed the default constructors for AdaptiveError and AdaptiveWarning to ones that take parameters. I forgot that this requires manually implementing the corresponding factory classes. This means that although calls to the new constructors built fine, they failed at runtime.

Fixed this by implementing factory classes for AdaptiveError and AdaptiveWarning.

## How Verified
Verified with local in progress custom rendering cases (for #2720).


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3385)