### PR TITLE
[UWP] Use platform character conversion functions instead of codecvt

### DIFF
--- a/source/uwp/Renderer/lib/AdaptiveOpenUrlAction.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveOpenUrlAction.cpp
@@ -28,11 +28,12 @@ namespace AdaptiveNamespace
 
         ComPtr<IUriRuntimeClassFactory> uriActivationFactory;
         RETURN_IF_FAILED(GetActivationFactory(HStringReference(RuntimeClass_Windows_Foundation_Uri).Get(), &uriActivationFactory));
-        std::wstring imageUri = StringToWstring(sharedOpenUrlAction->GetUrl());
+        HString asHstring;
+        RETURN_IF_FAILED(UTF8ToHString(sharedOpenUrlAction->GetUrl(), asHstring.GetAddressOf()));
 
-        if (!imageUri.empty())
+        if (asHstring.IsValid())
         {
-            RETURN_IF_FAILED(uriActivationFactory->CreateUri(HStringReference(imageUri.c_str()).Get(), m_url.GetAddressOf()));
+            RETURN_IF_FAILED(uriActivationFactory->CreateUri(asHstring.Get(), m_url.GetAddressOf()));
         }
 
         InitializeBaseElement(std::static_pointer_cast<AdaptiveSharedNamespace::BaseActionElement>(sharedOpenUrlAction));

--- a/source/uwp/Renderer/lib/DateTimeParser.h
+++ b/source/uwp/Renderer/lib/DateTimeParser.h
@@ -3,7 +3,6 @@
 #pragma once
 #include "DateTimePreparser.h"
 
-#include <codecvt>
 #include <string>
 
 namespace AdaptiveNamespace

--- a/source/uwp/Renderer/lib/Util.cpp
+++ b/source/uwp/Renderer/lib/Util.cpp
@@ -52,7 +52,7 @@ using namespace AdaptiveNamespace;
 using namespace ABI::Windows::Foundation;
 using namespace ABI::Windows::Foundation::Collections;
 
-HRESULT WStringToHString(const std::wstring_view& in, _Outptr_ HSTRING* out)
+HRESULT WStringToHString(const std::wstring_view& in, _Outptr_ HSTRING* out) noexcept try
 {
     if (out == nullptr)
     {
@@ -67,6 +67,7 @@ HRESULT WStringToHString(const std::wstring_view& in, _Outptr_ HSTRING* out)
         return WindowsCreateString(&in[0], static_cast<UINT32>(in.length()), out);
     }
 }
+CATCH_RETURN;
 
 std::string WstringToString(const std::wstring_view& in)
 {
@@ -104,7 +105,7 @@ std::wstring StringToWstring(const std::string_view& in)
     return L"";
 }
 
-HRESULT UTF8ToHString(const std::string_view& in, _Outptr_ HSTRING* out)
+HRESULT UTF8ToHString(const std::string_view& in, _Outptr_ HSTRING* out) noexcept try
 {
     if (out == nullptr)
     {
@@ -116,12 +117,14 @@ HRESULT UTF8ToHString(const std::string_view& in, _Outptr_ HSTRING* out)
         return WindowsCreateString(wide.c_str(), static_cast<UINT32>(wide.length()), out);
     }
 }
+CATCH_RETURN;
 
-HRESULT HStringToUTF8(const HSTRING& in, std::string& out)
+HRESULT HStringToUTF8(const HSTRING& in, std::string& out) noexcept try
 {
     out = WstringToString(WindowsGetStringRawBuffer(in, nullptr));
     return S_OK;
 }
+CATCH_RETURN;
 
 std::string HStringToUTF8(const HSTRING& in)
 {

--- a/source/uwp/Renderer/lib/Util.h
+++ b/source/uwp/Renderer/lib/Util.h
@@ -34,14 +34,14 @@ private:
     DWORD _dwErr;
 };
 
-HRESULT WStringToHString(const std::wstring& in, _Outptr_ HSTRING* out);
+HRESULT WStringToHString(const std::wstring_view& in, _Outptr_ HSTRING* out);
 
-std::string WstringToString(const std::wstring& in);
-std::wstring StringToWstring(const std::string& in);
+std::string WstringToString(const std::wstring_view& in);
+std::wstring StringToWstring(const std::string_view& in);
 
 // This function is needed to deal with the fact that non-windows platforms handle Unicode without the need for wchar_t.
 // (which has a platform specific implementation) It converts a std::string to an HSTRING.
-HRESULT UTF8ToHString(const std::string& in, _Outptr_ HSTRING* out);
+HRESULT UTF8ToHString(const std::string_view& in, _Outptr_ HSTRING* out);
 
 // This function is needed to deal with the fact that non-windows platforms handle Unicode without the need for wchar_t.
 // (which has a platform specific implementation) It converts from HSTRING to a standard std::string.

--- a/source/uwp/Renderer/lib/Util.h
+++ b/source/uwp/Renderer/lib/Util.h
@@ -25,6 +25,15 @@
 using namespace InternalNamespace;
 #endif
 
+class bad_string_conversion : public std::exception
+{
+public:
+    bad_string_conversion() : _dwErr(GetLastError()) {}
+
+private:
+    DWORD _dwErr;
+};
+
 HRESULT WStringToHString(const std::wstring& in, _Outptr_ HSTRING* out);
 
 std::string WstringToString(const std::wstring& in);

--- a/source/uwp/Renderer/lib/Util.h
+++ b/source/uwp/Renderer/lib/Util.h
@@ -34,24 +34,24 @@ private:
     DWORD _dwErr;
 };
 
-HRESULT WStringToHString(const std::wstring_view& in, _Outptr_ HSTRING* out);
+HRESULT WStringToHString(const std::wstring_view& in, _Outptr_ HSTRING* out) noexcept;
 
 std::string WstringToString(const std::wstring_view& in);
 std::wstring StringToWstring(const std::string_view& in);
 
 // This function is needed to deal with the fact that non-windows platforms handle Unicode without the need for wchar_t.
 // (which has a platform specific implementation) It converts a std::string to an HSTRING.
-HRESULT UTF8ToHString(const std::string_view& in, _Outptr_ HSTRING* out);
+HRESULT UTF8ToHString(const std::string_view& in, _Outptr_ HSTRING* out) noexcept;
 
 // This function is needed to deal with the fact that non-windows platforms handle Unicode without the need for wchar_t.
 // (which has a platform specific implementation) It converts from HSTRING to a standard std::string.
-HRESULT HStringToUTF8(const HSTRING& in, std::string& out);
+HRESULT HStringToUTF8(const HSTRING& in, std::string& out) noexcept;
 
 std::string HStringToUTF8(const HSTRING& in);
 
-inline bool Boolify(const boolean value)
+inline bool Boolify(const boolean value) noexcept
 {
-    return value > 0 ? true : false;
+    return (value > 0);
 }
 
 HRESULT GetColorFromString(const std::string& colorString, _Out_ ABI::Windows::UI::Color* color) noexcept;

--- a/source/uwp/Visualizer/ViewModel/DocumentViewModel.cs
+++ b/source/uwp/Visualizer/ViewModel/DocumentViewModel.cs
@@ -221,50 +221,38 @@ namespace AdaptiveCardVisualizer.ViewModel
 
         public static void InitializeRenderer(AdaptiveHostConfig hostConfig)
         {
-            try
+            _renderer = new AdaptiveCardRenderer();
+            if (hostConfig != null)
             {
-                _renderer = new AdaptiveCardRenderer();
-                if (hostConfig != null)
-                {
-                    _renderer.HostConfig = hostConfig;
-                }
-
-                // Add a feature representing this version of the visualizer. used for test cards.
-                _renderer.FeatureRegistration.Set("acTest", "1.0");
-
-                if (Settings.UseFixedDimensions)
-                {
-                    _renderer.SetFixedDimensions(320, 180);
-                }
-
-                // Custom resource resolvers
-                _renderer.ResourceResolvers.Set("symbol", new MySymbolResourceResolver());
-
-                /*
-                 *Example on how to override the Action Positive and Destructive styles
-                Style positiveStyle = new Style(typeof(Button));
-                positiveStyle.Setters.Add(new Setter(Button.BackgroundProperty, new SolidColorBrush(Windows.UI.Colors.LawnGreen)));
-                Style destructiveStyle = new Style(typeof(Button));
-                destructiveStyle.Setters.Add(new Setter(Button.BackgroundProperty, new SolidColorBrush(Windows.UI.Colors.Red)));
-                Style otherStyle = new Style(typeof(Button));
-                otherStyle.Setters.Add(new Setter(Button.BackgroundProperty, new SolidColorBrush(Windows.UI.Colors.Yellow)));
-                otherStyle.Setters.Add(new Setter(Button.ForegroundProperty, new SolidColorBrush(Windows.UI.Colors.DarkRed)));
-
-                _renderer.OverrideStyles = new ResourceDictionary();
-                _renderer.OverrideStyles.Add("Adaptive.Action.Positive", positiveStyle);
-                _renderer.OverrideStyles.Add("Adaptive.Action.Destructive", destructiveStyle);
-                _renderer.OverrideStyles.Add("Adaptive.Action.other", otherStyle);
-                */
-
+                _renderer.HostConfig = hostConfig;
             }
-            catch
+
+            // Add a feature representing this version of the visualizer. used for test cards.
+            _renderer.FeatureRegistration.Set("acTest", "1.0");
+
+            if (Settings.UseFixedDimensions)
             {
-                if (Debugger.IsAttached)
-                {
-                    Debugger.Break();
-                }
-                throw;
+                _renderer.SetFixedDimensions(320, 180);
             }
+
+            // Custom resource resolvers
+            _renderer.ResourceResolvers.Set("symbol", new MySymbolResourceResolver());
+
+            /*
+                *Example on how to override the Action Positive and Destructive styles
+            Style positiveStyle = new Style(typeof(Button));
+            positiveStyle.Setters.Add(new Setter(Button.BackgroundProperty, new SolidColorBrush(Windows.UI.Colors.LawnGreen)));
+            Style destructiveStyle = new Style(typeof(Button));
+            destructiveStyle.Setters.Add(new Setter(Button.BackgroundProperty, new SolidColorBrush(Windows.UI.Colors.Red)));
+            Style otherStyle = new Style(typeof(Button));
+            otherStyle.Setters.Add(new Setter(Button.BackgroundProperty, new SolidColorBrush(Windows.UI.Colors.Yellow)));
+            otherStyle.Setters.Add(new Setter(Button.ForegroundProperty, new SolidColorBrush(Windows.UI.Colors.DarkRed)));
+
+            _renderer.OverrideStyles = new ResourceDictionary();
+            _renderer.OverrideStyles.Add("Adaptive.Action.Positive", positiveStyle);
+            _renderer.OverrideStyles.Add("Adaptive.Action.Destructive", destructiveStyle);
+            _renderer.OverrideStyles.Add("Adaptive.Action.other", otherStyle);
+            */
         }
     }
 }


### PR DESCRIPTION
## Related Issue
Fixes #3398

## Description
The UWP renderer relies on the classes from stl's `codecvt` which have been deprecated. On top of that, `codecvt` is quite slow compared to platform APIs. With this change, we switch over to `MultiByteToWideChar()` and `WideCharToMultiByte()` for our charset conversion.

## How Verified
PerfApp and the test app. Between this change and the change that went in with #3379, we're seeing a pretty serious perf improvement:

### Before
![image](https://user-images.githubusercontent.com/16614499/63804403-f7092a00-c8cb-11e9-8f60-a82eab9716a8.png)

### After
![image](https://user-images.githubusercontent.com/16614499/63804411-fc667480-c8cb-11e9-9de0-de4aa983d901.png)

### Methodology

Measurements taken on my dev machine running an x64 release build of the PerfApp. The app was run without a debugger attached.

If you've never used the UWP PerfApp before, the above screenshots might be a little confusing. I chose 50 parse iterations and 1 render iteration per card. As implemented, this means that each card will be parsed and then rendered. This happens 50 times -- in other words, the number of parses and renders is equal (see [here](https://github.com/microsoft/AdaptiveCards/blob/ef004dbe74c58750b6d8da5577961510d2d828bd/source/uwp/PerfApp/MainPage.xaml.cpp#L95-L117)). I tested against the `source/samples/v1.0` folder.

"Ticks" according to PerfApp are the result of calling `GetTickCount64()` ([docs](https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-gettickcount64)). That is, each tick is a millisecond. The percentages listed after the average ticks is the percentage of the overall load time is taken by each process. Before our changes, cards took an average of 3ms to parse and they took 6ms to render, so 1/3 of the time was parse, and 2/3 spent on render. After our changes, parsing dropped (on average) to sub-millisecond times and rendering dropped to 2ms on average. You can see this improvement in the total render ticks as well, with the before figure being `27447` (27 seconds) and the after figure at `9208` (9 seconds).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3400)