### PR TITLE
[TS] Change declaration of static readonly fields

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -4076,7 +4076,9 @@ export abstract class Action extends CardObject {
 }
 
 export class SubmitAction extends Action {
-    static readonly JsonTypeName = "Action.Submit";
+    // Note the "weird" way this field is declared is to work around a breaking
+    // change introduced in TS 3.1 wrt d.ts generation. DO NOT CHANGE
+    static readonly JsonTypeName: "Action.Submit" = "Action.Submit";
 
     private _isPrepared: boolean = false;
     private _originalData: Object;
@@ -4151,7 +4153,9 @@ export class SubmitAction extends Action {
 }
 
 export class OpenUrlAction extends Action {
-    static readonly JsonTypeName = "Action.OpenUrl";
+    // Note the "weird" way this field is declared is to work around a breaking
+    // change introduced in TS 3.1 wrt d.ts generation. DO NOT CHANGE
+    static readonly JsonTypeName: "Action.OpenUrl" = "Action.OpenUrl";
 
     url: string;
 
@@ -4192,7 +4196,9 @@ export class OpenUrlAction extends Action {
 }
 
 export class ToggleVisibilityAction extends Action {
-    static readonly JsonTypeName = "Action.ToggleVisibility";
+    // Note the "weird" way this field is declared is to work around a breaking
+    // change introduced in TS 3.1 wrt d.ts generation. DO NOT CHANGE
+    static readonly JsonTypeName: "Action.ToggleVisibility" = "Action.ToggleVisibility";
 
     targetElements = {}
 
@@ -4317,7 +4323,9 @@ export class HttpHeader extends SerializableObject {
 }
 
 export class HttpAction extends Action {
-    static readonly JsonTypeName = "Action.Http";
+    // Note the "weird" way this field is declared is to work around a breaking
+    // change introduced in TS 3.1 wrt d.ts generation. DO NOT CHANGE
+    static readonly JsonTypeName: "Action.Http" = "Action.Http";
 
     private _url = new Shared.StringWithSubstitutions();
     private _body = new Shared.StringWithSubstitutions();
@@ -4367,17 +4375,6 @@ export class HttpAction extends Action {
         Utils.setProperty(result, "url", this._url.getOriginal());
         Utils.setProperty(result, "body", this._body.getOriginal());
         Utils.setProperty(result, "ignoreInputValidation", this.ignoreInputValidation, false);
-
-        /*
-        let headers = [];
-
-        for (let header of this.headers) {
-            headers.push(header.toJSON());
-        }
-
-        Utils.setProperty(result, "headers", headers);
-        */
-
         Utils.setArrayProperty(result, "headers", this.headers);
 
         return result;
@@ -4463,7 +4460,9 @@ export class HttpAction extends Action {
 }
 
 export class ShowCardAction extends Action {
-    static readonly JsonTypeName = "Action.ShowCard";
+    // Note the "weird" way this field is declared is to work around a breaking
+    // change introduced in TS 3.1 wrt d.ts generation. DO NOT CHANGE
+    static readonly JsonTypeName: "Action.ShowCard" = "Action.ShowCard";
 
     protected addCssClasses(element: HTMLElement) {
         super.addCssClasses(element);

--- a/source/nodejs/adaptivecards/src/enums.ts
+++ b/source/nodejs/adaptivecards/src/enums.ts
@@ -1,9 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
+// Note the "weird" way these readonly fields are declared is to work around
+// a breaking change introduced in TS 3.1 wrt d.ts generation. DO NOT CHANGE
+// and adopt this syntax for all other static readonly fields.
 export class ActionStyle {
-    static readonly Default = "default";
-    static readonly Positive = "positive";
-    static readonly Destructive = "destructive";
+    static readonly Default: "default" = "default";
+    static readonly Positive: "positive" = "positive";
+    static readonly Destructive: "destructive" = "destructive";
 }
 
 export enum Size {
@@ -129,14 +133,18 @@ export enum InputValidationNecessity {
     recent enough to understand string enums. This is
     a compatible construct that does not require using
     a more recent version of TypeScript.
+
+    Also note the "weird" way these readonly fields are declared is to work around
+    a breaking change introduced in TS 3.1 wrt d.ts generation. DO NOT CHANGE
+    and adopt this syntax for all other static readonly fields.
 */
 export class ContainerStyle {
-    static readonly Default = "default";
-    static readonly Emphasis = "emphasis";
-    static readonly Accent = "accent";
-    static readonly Good = "good";
-    static readonly Attention = "attention";
-    static readonly Warning = "warning";
+    static readonly Default: "default" = "default";
+    static readonly Emphasis: "emphasis" = "emphasis";
+    static readonly Accent: "accent" = "accent";
+    static readonly Good: "good" = "good";
+    static readonly Attention: "attention" = "attention";
+    static readonly Warning: "warning" = "warning";
 }
 
 export enum ValidationError {


### PR DESCRIPTION
## Related Issue
Fixes [#3406 [TS] initialized static readonly fields cause compile time errors when using TS 3.0 or earlier](https://github.com/microsoft/AdaptiveCards/issues/3406)

## Description
Please refer to the issue for a full description of the problem.

This fix adopts a syntax for declaring static readonly fields that works around the problem while remaining 100% backward compatible.

This fix is important for MS Teams who is currently integrating the latest version of the TS library and is hitting compilation errors for they have not yet moved to TS 3.1 or later and cannot do it now.

Create a [descriptive title and provide all of the relevant details in the description](https://chris.beams.io/posts/git-commit/). 
This information lives with the code and will help future readers (***including yourself***) and will serve as documentation.

## How Verified
Verified manually.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3407)