### PR TITLE
[UWP] Ensure correct parser registrations are passed to custom parsers

### DIFF
--- a/source/uwp/Renderer/lib/AdaptiveActionParserRegistration.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveActionParserRegistration.cpp
@@ -18,25 +18,22 @@ using namespace ABI::Windows::UI;
 
 namespace AdaptiveNamespace
 {
+    const char* c_upwActionParserRegistration = "AB3CC8B0-FF27-4859-A2AA-BCE2E729805";
+
     AdaptiveActionParserRegistration::AdaptiveActionParserRegistration() {}
 
     HRESULT AdaptiveActionParserRegistration::RuntimeClassInitialize() noexcept try
     {
-        std::shared_ptr<ActionParserRegistration> sharedParserRegistration = std::make_shared<ActionParserRegistration>();
-        RuntimeClassInitialize(sharedParserRegistration);
-
-        return S_OK;
-    }
-    CATCH_RETURN;
-
-    HRESULT AdaptiveActionParserRegistration::RuntimeClassInitialize(
-        std::shared_ptr<AdaptiveSharedNamespace::ActionParserRegistration> sharedParserRegistration) noexcept try
-    {
         m_registration = std::make_shared<RegistrationMap>();
-        m_sharedParserRegistration = sharedParserRegistration;
+        m_sharedParserRegistration = std::make_shared<ActionParserRegistration>();
 
         m_isInitializing = true;
         RegisterDefaultActionRenderers(this);
+
+        // Register this (UWP) registration with a well known guid string in the shared model
+        // registration so we can get it back again
+        m_sharedParserRegistration->AddParser(c_upwActionParserRegistration, std::make_shared<SharedModelActionParser>(this));
+
         m_isInitializing = false;
 
         return S_OK;
@@ -89,6 +86,12 @@ namespace AdaptiveNamespace
         return m_sharedParserRegistration;
     }
 
+    SharedModelActionParser::SharedModelActionParser(AdaptiveNamespace::AdaptiveActionParserRegistration* parserRegistration)
+    {
+        ComPtr<AdaptiveActionParserRegistration> localParserRegistration(parserRegistration);
+        localParserRegistration.AsWeak(&m_parserRegistration);
+    }
+
     std::shared_ptr<BaseActionElement> SharedModelActionParser::Deserialize(ParseContext& context, const Json::Value& value)
     {
         std::string type = ParseUtil::GetTypeAsString(value);
@@ -96,19 +99,19 @@ namespace AdaptiveNamespace
         HString typeAsHstring;
         THROW_IF_FAILED(UTF8ToHString(type, typeAsHstring.GetAddressOf()));
 
+        ComPtr<IAdaptiveActionParserRegistration> adaptiveActionParserRegistration;
+        THROW_IF_FAILED(GetAdaptiveParserRegistration(&adaptiveActionParserRegistration));
+
         ComPtr<IAdaptiveActionParser> parser;
-        THROW_IF_FAILED(m_parserRegistration->Get(typeAsHstring.Get(), &parser));
+        THROW_IF_FAILED(adaptiveActionParserRegistration->Get(typeAsHstring.Get(), &parser));
 
         ComPtr<ABI::Windows::Data::Json::IJsonObject> jsonObject;
         THROW_IF_FAILED(JsonCppToJsonObject(value, &jsonObject));
 
+        // Get the element parser registration from the shared model
         ComPtr<IAdaptiveElementParserRegistration> adaptiveElementParserRegistration;
-        MakeAndInitialize<AdaptiveNamespace::AdaptiveElementParserRegistration>(&adaptiveElementParserRegistration,
-                                                                                context.elementParserRegistration);
-
-        ComPtr<IAdaptiveActionParserRegistration> adaptiveActionParserRegistration;
-        MakeAndInitialize<AdaptiveNamespace::AdaptiveActionParserRegistration>(&adaptiveActionParserRegistration,
-                                                                               context.actionParserRegistration);
+        THROW_IF_FAILED(GetAdaptiveElementParserRegistrationFromSharedModel(context.elementParserRegistration,
+                                                                            &adaptiveElementParserRegistration));
 
         ComPtr<IAdaptiveActionElement> actionElement;
         ComPtr<ABI::Windows::Foundation::Collections::IVector<AdaptiveWarning*>> adaptiveWarnings =
@@ -128,5 +131,14 @@ namespace AdaptiveNamespace
     std::shared_ptr<BaseActionElement> SharedModelActionParser::DeserializeFromString(ParseContext& context, const std::string& jsonString)
     {
         return Deserialize(context, ParseUtil::GetJsonValueFromString(jsonString));
+    }
+
+    HRESULT SharedModelActionParser::GetAdaptiveParserRegistration(_COM_Outptr_ IAdaptiveActionParserRegistration** actionParserRegistration)
+    {
+        ComPtr<IAdaptiveActionParserRegistration> parserRegistration;
+        RETURN_IF_FAILED(m_parserRegistration.As(&parserRegistration));
+        RETURN_IF_FAILED(parserRegistration.CopyTo(actionParserRegistration));
+
+        return S_OK;
     }
 }

--- a/source/uwp/Renderer/lib/AdaptiveActionParserRegistration.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveActionParserRegistration.cpp
@@ -18,8 +18,6 @@ using namespace ABI::Windows::UI;
 
 namespace AdaptiveNamespace
 {
-    const char* c_upwActionParserRegistration = "AB3CC8B0-FF27-4859-A2AA-BCE2E729805";
-
     AdaptiveActionParserRegistration::AdaptiveActionParserRegistration() {}
 
     HRESULT AdaptiveActionParserRegistration::RuntimeClassInitialize() noexcept try
@@ -135,10 +133,6 @@ namespace AdaptiveNamespace
 
     HRESULT SharedModelActionParser::GetAdaptiveParserRegistration(_COM_Outptr_ IAdaptiveActionParserRegistration** actionParserRegistration)
     {
-        ComPtr<IAdaptiveActionParserRegistration> parserRegistration;
-        RETURN_IF_FAILED(m_parserRegistration.As(&parserRegistration));
-        RETURN_IF_FAILED(parserRegistration.CopyTo(actionParserRegistration));
-
-        return S_OK;
+        return m_parserRegistration.CopyTo<IAdaptiveActionParserRegistration>(actionParserRegistration);
     }
 }

--- a/source/uwp/Renderer/lib/AdaptiveActionParserRegistration.h
+++ b/source/uwp/Renderer/lib/AdaptiveActionParserRegistration.h
@@ -3,10 +3,10 @@
 #pragma once
 
 #include "AdaptiveCards.Rendering.Uwp.h"
-
+ 
 namespace AdaptiveNamespace
 {
-    extern const char* c_upwActionParserRegistration;
+    constexpr char* c_upwActionParserRegistration = "AB3CC8B0-FF27-4859-A2AA-BCE2E729805";
 
     class DECLSPEC_UUID("fc95029a-9ec0-4d93-b170-09c99876db20") AdaptiveActionParserRegistration
         : public Microsoft::WRL::RuntimeClass<Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,

--- a/source/uwp/Renderer/lib/AdaptiveActionParserRegistration.h
+++ b/source/uwp/Renderer/lib/AdaptiveActionParserRegistration.h
@@ -6,6 +6,8 @@
 
 namespace AdaptiveNamespace
 {
+    extern const char* c_upwActionParserRegistration;
+
     class DECLSPEC_UUID("fc95029a-9ec0-4d93-b170-09c99876db20") AdaptiveActionParserRegistration
         : public Microsoft::WRL::RuntimeClass<Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
                                               Microsoft::WRL::Implements<ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration>,
@@ -42,16 +44,22 @@ namespace AdaptiveNamespace
     class SharedModelActionParser : public AdaptiveSharedNamespace::ActionElementParser
     {
     public:
-        SharedModelActionParser(_In_ AdaptiveNamespace::AdaptiveActionParserRegistration* parserRegistration) :
-            m_parserRegistration(parserRegistration)
-        {
-        }
+        SharedModelActionParser(_In_ AdaptiveNamespace::AdaptiveActionParserRegistration* parserRegistration);
 
         // AdaptiveSharedNamespace::ActionElementParser
         std::shared_ptr<BaseActionElement> Deserialize(ParseContext& context, const Json::Value& value) override;
         std::shared_ptr<BaseActionElement> DeserializeFromString(ParseContext& context, const std::string& jsonString) override;
 
+        HRESULT GetAdaptiveParserRegistration(_COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration** actionParserRegistration);
+
     private:
-        Microsoft::WRL::ComPtr<AdaptiveNamespace::AdaptiveActionParserRegistration> m_parserRegistration;
+        // This a a weak reference to the UWP level AdaptiveActionParserRegistration for this parse. Store as a weak
+        // reference to avoid circular references:
+        //
+        // SharedModelActionParser(This Object)->
+        //      m_parserRegistration(AdaptiveActionParserRegistration)->
+        //          m_sharedParserRegistration(ActionParserRegistration)->
+        //              m_cardElementParsers (Contains this object)
+        Microsoft::WRL::WeakRef m_parserRegistration;
     };
 }

--- a/source/uwp/Renderer/lib/AdaptiveElementParserRegistration.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveElementParserRegistration.cpp
@@ -33,8 +33,6 @@ using namespace ABI::Windows::UI;
 
 namespace AdaptiveNamespace
 {
-    const char* c_upwElementParserRegistration = "447C3D76-CAAD-405F-B929-E3201F1537AB";
-
     AdaptiveElementParserRegistration::AdaptiveElementParserRegistration() {}
 
     HRESULT AdaptiveElementParserRegistration::RuntimeClassInitialize() noexcept try
@@ -47,7 +45,7 @@ namespace AdaptiveNamespace
 
         // Register this (UWP) registration with a well known guid string in the shared model
         // registration so we can get it back again
-        m_sharedParserRegistration->AddParser(c_upwElementParserRegistration, std::make_shared<SharedModelElementParser>(this));
+        m_sharedParserRegistration->AddParser(c_uwpElementParserRegistration, std::make_shared<SharedModelElementParser>(this));
 
         m_isInitializing = false;
         return S_OK;
@@ -150,10 +148,6 @@ namespace AdaptiveNamespace
 
     HRESULT SharedModelElementParser::GetAdaptiveParserRegistration(_COM_Outptr_ IAdaptiveElementParserRegistration** elementParserRegistration)
     {
-        ComPtr<IAdaptiveElementParserRegistration> parserRegistration;
-        RETURN_IF_FAILED(m_parserRegistration.As(&parserRegistration));
-        RETURN_IF_FAILED(parserRegistration.CopyTo(elementParserRegistration));
-
-        return S_OK;
+        return m_parserRegistration.CopyTo<IAdaptiveElementParserRegistration>(elementParserRegistration);
     }
 }

--- a/source/uwp/Renderer/lib/AdaptiveElementParserRegistration.h
+++ b/source/uwp/Renderer/lib/AdaptiveElementParserRegistration.h
@@ -8,6 +8,8 @@
 
 namespace AdaptiveNamespace
 {
+    extern const char* c_upwElementParserRegistration;
+
     class DECLSPEC_UUID("fdf8457d-639f-4bbd-9e32-26c14bac3813") AdaptiveElementParserRegistration
         : public Microsoft::WRL::RuntimeClass<Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,
                                               Microsoft::WRL::Implements<ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration>,
@@ -21,7 +23,6 @@ namespace AdaptiveNamespace
     public:
         AdaptiveElementParserRegistration();
         HRESULT RuntimeClassInitialize() noexcept;
-        HRESULT RuntimeClassInitialize(std::shared_ptr<AdaptiveSharedNamespace::ElementParserRegistration> sharedParserRegistration) noexcept;
 
         // IAdaptiveElementParserRegistration
         IFACEMETHODIMP Set(_In_ HSTRING type, _In_ ABI::AdaptiveNamespace::IAdaptiveElementParser* Parser) noexcept;
@@ -44,17 +45,23 @@ namespace AdaptiveNamespace
     class SharedModelElementParser : public AdaptiveSharedNamespace::BaseCardElementParser
     {
     public:
-        SharedModelElementParser(_In_ AdaptiveNamespace::AdaptiveElementParserRegistration* parserRegistration) :
-            m_parserRegistration(parserRegistration)
-        {
-        }
+        SharedModelElementParser(_In_ AdaptiveNamespace::AdaptiveElementParserRegistration* parserRegistration);
 
         // AdaptiveSharedNamespace::BaseCardElementParser
         std::shared_ptr<BaseCardElement> Deserialize(ParseContext& context, const Json::Value& value) override;
         std::shared_ptr<BaseCardElement> DeserializeFromString(ParseContext& context, const std::string& jsonString) override;
 
+        HRESULT GetAdaptiveParserRegistration(_COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration** elementParserRegistration);
+
     private:
-        Microsoft::WRL::ComPtr<AdaptiveNamespace::AdaptiveElementParserRegistration> m_parserRegistration;
+        // This a a weak reference to the UWP level AdaptiveElementParserRegistration for this parse. Store as a weak
+        // reference to avoid circular references:
+        //
+        // SharedModelElementParser(This Object)->
+        //      m_parserRegistration(AdaptiveElementParserRegistration)->
+        //          m_sharedParserRegistration(ElementParserRegistration)->
+        //              m_cardElementParsers (Contains this object)
+        Microsoft::WRL::WeakRef m_parserRegistration;
     };
 
     template<typename TAdaptiveCardElement, typename TSharedModelElement, typename TSharedModelParser, typename TAdaptiveElementInterface>

--- a/source/uwp/Renderer/lib/AdaptiveElementParserRegistration.h
+++ b/source/uwp/Renderer/lib/AdaptiveElementParserRegistration.h
@@ -8,7 +8,7 @@
 
 namespace AdaptiveNamespace
 {
-    extern const char* c_upwElementParserRegistration;
+    constexpr char* c_uwpElementParserRegistration = "447C3D76-CAAD-405F-B929-E3201F1537AB";
 
     class DECLSPEC_UUID("fdf8457d-639f-4bbd-9e32-26c14bac3813") AdaptiveElementParserRegistration
         : public Microsoft::WRL::RuntimeClass<Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>,

--- a/source/uwp/Renderer/lib/Util.cpp
+++ b/source/uwp/Renderer/lib/Util.cpp
@@ -1721,7 +1721,7 @@ HRESULT GetAdaptiveElementParserRegistrationFromSharedModel(
 {
     // Look up the well known Element parser registration to see if we've got a custom Element registration to pass
     std::shared_ptr<BaseCardElementParser> sharedElementParser =
-        sharedElementParserRegistration->GetParser(c_upwElementParserRegistration);
+        sharedElementParserRegistration->GetParser(c_uwpElementParserRegistration);
 
     if (sharedElementParser != nullptr)
     {

--- a/source/uwp/Renderer/lib/Util.cpp
+++ b/source/uwp/Renderer/lib/Util.cpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <regex>
 
+#include "AdaptiveActionParserRegistration.h"
 #include "AdaptiveActionSet.h"
 #include "AdaptiveColumn.h"
 #include "AdaptiveColumnSet.h"
@@ -11,6 +12,7 @@
 #include "AdaptiveChoiceInput.h"
 #include "AdaptiveChoiceSetInput.h"
 #include "AdaptiveDateInput.h"
+#include "AdaptiveElementParserRegistration.h"
 #include "AdaptiveFact.h"
 #include "AdaptiveFactSet.h"
 #include "AdaptiveFeatureRegistration.h"
@@ -1682,5 +1684,61 @@ HRESULT CopyTextElement(_In_ ABI::AdaptiveNamespace::IAdaptiveTextElement* textE
     RETURN_IF_FAILED(localCopiedTextElement->put_Text(text.Get()));
 
     RETURN_IF_FAILED(localCopiedTextElement.CopyTo(copiedTextElement));
+    return S_OK;
+}
+
+HRESULT GetAdaptiveActionParserRegistrationFromSharedModel(
+    const std::shared_ptr<ActionParserRegistration>& sharedActionParserRegistration,
+    _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration** adaptiveActionParserRegistration)
+{
+    // Look up the well known action parser registration to see if we've got a custom action registration to pass
+    std::shared_ptr<ActionElementParser> sharedActionParser =
+        sharedActionParserRegistration->GetParser(c_upwActionParserRegistration);
+
+    if (sharedActionParser != nullptr)
+    {
+        // The shared model wraps the passed in parsers. Get our SharedModelActionParser from it so we can retrieve the
+        // IAdaptiveActionParserRegistration
+        std::shared_ptr<ActionElementParserWrapper> parserWrapper =
+            std::static_pointer_cast<ActionElementParserWrapper>(sharedActionParser);
+
+        std::shared_ptr<SharedModelActionParser> sharedModelParser =
+            std::static_pointer_cast<SharedModelActionParser>(parserWrapper->GetActualParser());
+
+        RETURN_IF_FAILED(sharedModelParser->GetAdaptiveParserRegistration(adaptiveActionParserRegistration));
+    }
+    else
+    {
+        RETURN_IF_FAILED(MakeAndInitialize<AdaptiveNamespace::AdaptiveActionParserRegistration>(adaptiveActionParserRegistration));
+    }
+
+    return S_OK;
+}
+
+HRESULT GetAdaptiveElementParserRegistrationFromSharedModel(
+    const std::shared_ptr<ElementParserRegistration>& sharedElementParserRegistration,
+    _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration** adaptiveElementParserRegistration)
+{
+    // Look up the well known Element parser registration to see if we've got a custom Element registration to pass
+    std::shared_ptr<BaseCardElementParser> sharedElementParser =
+        sharedElementParserRegistration->GetParser(c_upwElementParserRegistration);
+
+    if (sharedElementParser != nullptr)
+    {
+        // The shared model wraps the passed in parsers. Get our SharedModelElementParser from it so we can retrieve the
+        // IAdaptiveElementParserRegistration
+        std::shared_ptr<BaseCardElementParserWrapper> parserWrapper =
+            std::static_pointer_cast<BaseCardElementParserWrapper>(sharedElementParser);
+
+        std::shared_ptr<SharedModelElementParser> sharedModelParser =
+            std::static_pointer_cast<SharedModelElementParser>(parserWrapper->GetActualParser());
+
+        RETURN_IF_FAILED(sharedModelParser->GetAdaptiveParserRegistration(adaptiveElementParserRegistration));
+    }
+    else
+    {
+        RETURN_IF_FAILED(MakeAndInitialize<AdaptiveNamespace::AdaptiveElementParserRegistration>(adaptiveElementParserRegistration));
+    }
+
     return S_OK;
 }

--- a/source/uwp/Renderer/lib/Util.h
+++ b/source/uwp/Renderer/lib/Util.h
@@ -270,6 +270,14 @@ AdaptiveSharedNamespace::FallbackType MapUwpFallbackTypeToShared(const ABI::Adap
 HRESULT CopyTextElement(_In_ ABI::AdaptiveNamespace::IAdaptiveTextElement* textElement,
                         _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveTextElement** copiedTextElement);
 
+HRESULT GetAdaptiveActionParserRegistrationFromSharedModel(
+    const std::shared_ptr<AdaptiveSharedNamespace::ActionParserRegistration>& sharedActionParserRegistration,
+    _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveActionParserRegistration** adaptiveActionParserRegistration);
+
+HRESULT GetAdaptiveElementParserRegistrationFromSharedModel(
+    const std::shared_ptr<AdaptiveSharedNamespace::ElementParserRegistration>& sharedElementParserRegistration,
+    _COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveElementParserRegistration** adaptiveElementParserRegistration);
+
 namespace AdaptiveNamespace
 {
     class XamlBuilder;

--- a/source/uwp/UWPUnitTests/ParserRegistration.cs
+++ b/source/uwp/UWPUnitTests/ParserRegistration.cs
@@ -224,7 +224,6 @@ namespace UWPUnitTests
         {
             AdaptiveActionParserRegistration actionParserRegistration = new AdaptiveActionParserRegistration();
             AdaptiveElementParserRegistration elementParserRegistration = new AdaptiveElementParserRegistration();
-            List<AdaptiveWarning> warnings = new List<AdaptiveWarning>();
 
             actionParserRegistration.Set("TestCustomAction", new TestActionParser());
             elementParserRegistration.Set("TestCustomElement", new TestElementParser());

--- a/source/uwp/UWPUnitTests/ParserRegistration.cs
+++ b/source/uwp/UWPUnitTests/ParserRegistration.cs
@@ -97,6 +97,10 @@ namespace UWPUnitTests
         {
             public IAdaptiveCardElement FromJson(JsonObject inputJson, AdaptiveElementParserRegistration elementParsers, AdaptiveActionParserRegistration actionParsers, IList<AdaptiveWarning> warnings)
             {
+                // Validate that the registrations we were passed include the custom parsers
+                Assert.IsNotNull(elementParsers.Get("TestCustomElement"));
+                Assert.IsNotNull(actionParsers.Get("TestActionElement"));
+
                 JsonObject jsonTextBlock = inputJson.GetNamedObject("internalTextBlock");
                 var textBlockParser = elementParsers.Get("TextBlock");
 
@@ -110,8 +114,8 @@ namespace UWPUnitTests
         {
             AdaptiveActionParserRegistration actionParserRegistration = new AdaptiveActionParserRegistration();
             AdaptiveElementParserRegistration elementParserRegistration = new AdaptiveElementParserRegistration();
-            List<AdaptiveWarning> warnings = new List<AdaptiveWarning>();
 
+            actionParserRegistration.Set("TestActionElement", new TestActionParser());
             elementParserRegistration.Set("TestCustomElement", new TestElementParser());
             IAdaptiveElementParser testElementParserRetrieved = elementParserRegistration.Get("TestCustomElement");
             Assert.IsNotNull(testElementParserRetrieved);
@@ -203,6 +207,10 @@ namespace UWPUnitTests
         {
             public IAdaptiveActionElement FromJson(JsonObject inputJson, AdaptiveElementParserRegistration elementParsers, AdaptiveActionParserRegistration actionParsers, IList<AdaptiveWarning> warnings)
             {
+                // Validate that the registrations we were passed include the custom parsers
+                Assert.IsNotNull(elementParsers.Get("TestCustomElement"));
+                Assert.IsNotNull(actionParsers.Get("TestCustomAction"));
+
                 JsonObject jsonSubmitAction = inputJson.GetNamedObject("internalSubmitAction");
                 var submitActionParser = actionParsers.Get("Action.Submit");
 
@@ -219,6 +227,7 @@ namespace UWPUnitTests
             List<AdaptiveWarning> warnings = new List<AdaptiveWarning>();
 
             actionParserRegistration.Set("TestCustomAction", new TestActionParser());
+            elementParserRegistration.Set("TestCustomElement", new TestElementParser());
             IAdaptiveActionParser testActionParserRetrieved = actionParserRegistration.Get("TestCustomAction");
             Assert.IsNotNull(testActionParserRetrieved);
             Assert.IsNotNull(testActionParserRetrieved as TestActionParser);


### PR DESCRIPTION
## Related Issue
Fixes #3427

## Description
### Problem
In order to store custom parsers from UWP callers in the shared model, a wrapper class (```SharedModelElementParser```) is used to implement the shared model parser base class (```BaseCardElementParser```). This wrapper class holds a pointer to the UWP level parser registration for the wrapped type (either action or element).

The bug was that when this wrapper class was called back, instead of using the existing UWP level parser registration, it created a new one to pass to the UWP custom parser. This new registration did not include the UWP level parser registrations, and so it appeared to the callback as if the custom registrations were missing.

### Fixes
- Registered the element and action parsers with the shared model under a known guid. This allows the callback in the UWP interface level to find the correctly populated UWP parser registrations from the shared model registration. The new methods ```GetAdaptiveActionParserRegistrationFromSharedModel``` and ```GetAdaptiveElementParserRegistrationFromSharedModel``` use this to retrieve the appropriate registration from the callback.

- Removed the UWP ```AdaptiveElementParserRegistration```/```AdaptiveActionParserRegistration         RuntimeClassInitialize``` methods that take the shared model registration as input. The existence of this method implied that the UWP interface could be initialized based on the shared model. That would require more code to walk the shared model registration and get out the corresponding UWP parsers, which does not exist and would add more complexity.

- Changed the ```m_parserRegistration``` in ```SharedModelElementParser``` and ```SharedModelActionParser``` to a weak reference. While white boarding the current design i realized that the fact that the shared model registration has a reference to the UWP registration and the UWP registration has a reference to the shared model registration creates a circular reference. Added a WeakRef to break the cycle.

## How Verified
Updated existing ```ElementParserRegistraton_CustomElementTest``` and ```ActionParserRegistraton_CustomActionTest``` unit tests to verify that the custom renderers are in the renderer registrations passed to the custom parsing callback.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3429)