### PR TITLE
Add two events to designer

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/card-designer.ts
+++ b/source/nodejs/adaptivecards-designer/src/card-designer.ts
@@ -368,6 +368,10 @@ export class CardDesigner {
 
     private activeHostContainerChanged() {
         this.recreateDesignerSurface();
+
+        if (this.onActiveHostContainerChanged) {
+            this.onActiveHostContainerChanged(this);
+        }
     }
 
     private updateToolboxLayout(toolbox: Toolbox, hostPanelRect: ClientRect | DOMRect) {
@@ -402,11 +406,19 @@ export class CardDesigner {
     private updateLayoutTimer: any;
 
     private preventCardUpdate: boolean = false;
+
+    private cardPayloadChanged() {
+        if (this.onCardPayloadChanged) {
+            this.onCardPayloadChanged(this);
+        }
+    }
     
     private setCardPayload(payload: object) {
         if (this._isMonacoEditorLoaded) {
             this._cardEditor.setValue(JSON.stringify(payload, null, 4));
         }
+
+        this.cardPayloadChanged();
     }
 
     private setSampleDataPayload(payload: any) {
@@ -458,6 +470,8 @@ export class CardDesigner {
 
             if (!this.preventCardUpdate) {
                 this.designerSurface.setCardPayloadAsString(this.getCurrentCardEditorPayload());
+
+                this.cardPayloadChanged();
             }
         }
         finally {
@@ -1040,6 +1054,9 @@ export class CardDesigner {
     getCard(): object {
         return this.designerSurface.card.toJSON();
     }
+
+    onCardPayloadChanged: (designer: CardDesigner) => void;
+    onActiveHostContainerChanged: (designer: CardDesigner) => void;
 
     get currentTargetVersion(): Shared.TargetVersion {
         if (this._versionChoicePicker) {


### PR DESCRIPTION
## Related Issue
Fixes https://github.com/microsoft/AdaptiveCards/issues/3458

## Description
Please refer to the issue for a full description. Applications embedding the designer can now handle two new events:
- **onActiveHostContainerChanged**: triggered when the user selects another host application in the toolbar
- **onCardPayloadChanged**: triggered when the card has changed, whether via drag/drop or as the JSON is manually modified

## How Verified
Verified manually

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3459)