### PR TITLE
[.NET] Add new OnDeserializingMissingVersion callback

### DIFF
--- a/source/dotnet/Library/AdaptiveCards/AdaptiveCard.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveCard.cs
@@ -218,6 +218,14 @@ namespace AdaptiveCards
         public bool ShouldSerializeHeight() => this.Height?.ShouldSerializeAdaptiveHeight() == true;
 
         /// <summary>
+        ///     Callback that will be invoked should a null or empty version string is encountered. The callback may return an alternate version to use for parsing.
+        /// </summary>
+        /// <example>
+        ///     AdaptiveCard.OnDeserializingMissingVersion = () => new AdaptiveSchemaVersion(0, 5);
+        /// </example>
+        public static Func<AdaptiveSchemaVersion> OnDeserializingMissingVersion { get; set; }
+
+        /// <summary>
         /// Parse an AdaptiveCard from a JSON string
         /// </summary>
         /// <param name="json">A JSON-serialized Adaptive Card</param>

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveCardConverter.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveCardConverter.cs
@@ -20,29 +20,52 @@ namespace AdaptiveCards
 
         public override bool CanWrite => false;
 
+        private void ValidateJsonVersion(ref JObject jObject)
+        {
+            string exceptionMessage = "";
+            if (jObject.Value<string>("version") == null)
+            {
+                exceptionMessage = "Could not parse required key: version. It was not found.";
+            }
+
+            // If this is the root AdaptiveCard and missing a version we fail parsing.
+            // The depth checks that cards within a Action.ShowCard don't require the version
+            if (jObject.Value<string>("version") == "")
+            {
+                exceptionMessage = "Property is required but was found empty: version";
+            }
+
+            if (!String.IsNullOrEmpty(exceptionMessage))
+            {
+                if (AdaptiveCard.OnDeserializingMissingVersion == null)
+                {
+                    // no handler registered for dealing with missing/empty version. best just throw...
+                    throw new AdaptiveSerializationException(exceptionMessage);
+                }
+                else
+                {
+                    // caller wants to override version semantics
+                    var overriddenVersion = AdaptiveCard.OnDeserializingMissingVersion();
+                    jObject["version"] = overriddenVersion.ToString();
+                }
+            }
+        }
+
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
             var jObject = JObject.Load(reader);
 
             if (jObject.Value<string>("type") != AdaptiveCard.TypeName)
+            {
                 throw new AdaptiveSerializationException($"Property 'type' must be '{AdaptiveCard.TypeName}'");
+            }
 
             if (reader.Depth == 0)
             {
                 // Needed for ID collision detection after fallback was introduced
                 ParseContext.Initialize();
 
-                if (jObject.Value<string>("version") == null)
-                {
-                    throw new AdaptiveSerializationException("Could not parse required key: version. It was not found.");
-                }
-
-                // If this is the root AdaptiveCard and missing a version we fail parsing.
-                // The depth checks that cards within a Action.ShowCard don't require the version
-                if (jObject.Value<string>("version") == "")
-                {
-                    throw new AdaptiveSerializationException("Property is required but was found empty: version");
-                }
+                ValidateJsonVersion(ref jObject);
 
                 if (new AdaptiveSchemaVersion(jObject.Value<string>("version")) > AdaptiveCard.KnownSchemaVersion)
                 {

--- a/source/dotnet/Samples/WPFVisualizer/MainWindow.xaml.cs
+++ b/source/dotnet/Samples/WPFVisualizer/MainWindow.xaml.cs
@@ -67,7 +67,6 @@ namespace WpfVisualizer
                 });
             }
 
-
             Renderer = new AdaptiveCardRenderer()
             {
                 Resources = Resources
@@ -122,7 +121,6 @@ namespace WpfVisualizer
 
             try
             {
-
                 AdaptiveCardParseResult parseResult = AdaptiveCard.FromJson(CardPayload);
 
                 AdaptiveCard card = parseResult.Card;

--- a/source/dotnet/Test/AdaptiveCards.Test/AdaptiveCardApiTests.cs
+++ b/source/dotnet/Test/AdaptiveCards.Test/AdaptiveCardApiTests.cs
@@ -94,7 +94,18 @@ namespace AdaptiveCards.Test
     }
   ]
 }";
+            // By default we should be throwing an exception when no version present.
             Assert.ThrowsException<AdaptiveSerializationException>(() => AdaptiveCard.FromJson(json));
+
+            // Or we can supply a replacement version to use
+            AdaptiveCard.OnDeserializingMissingVersion = () => new AdaptiveSchemaVersion(0, 5);
+            var card = AdaptiveCard.FromJson(json);
+            Assert.AreEqual(new AdaptiveSchemaVersion(0, 5), card.Card.Version);
+
+            // But make sure that if the callback throws an exception that it is allowed through
+            AdaptiveCard.OnDeserializingMissingVersion = () => throw new Exception("test exception");
+            Assert.ThrowsException<Exception>(() => AdaptiveCard.FromJson(json));
+            AdaptiveCard.OnDeserializingMissingVersion = null;
         }
 
         [TestMethod]

--- a/source/dotnet/Test/AdaptiveCards.Test/AdaptiveCardApiTests.cs
+++ b/source/dotnet/Test/AdaptiveCards.Test/AdaptiveCardApiTests.cs
@@ -95,7 +95,8 @@ namespace AdaptiveCards.Test
   ]
 }";
             // By default we should be throwing an exception when no version present.
-            Assert.ThrowsException<AdaptiveSerializationException>(() => AdaptiveCard.FromJson(json));
+            Assert.ThrowsException<AdaptiveSerializationException>(() => AdaptiveCard.FromJson(json),
+                                                                   "Having no version tag should cause an exception to be thrown.");
 
             // Or we can supply a replacement version to use
             AdaptiveCard.OnDeserializingMissingVersion = () => new AdaptiveSchemaVersion(0, 5);
@@ -103,8 +104,9 @@ namespace AdaptiveCards.Test
             Assert.AreEqual(new AdaptiveSchemaVersion(0, 5), card.Card.Version);
 
             // But make sure that if the callback throws an exception that it is allowed through
-            AdaptiveCard.OnDeserializingMissingVersion = () => throw new Exception("test exception");
-            Assert.ThrowsException<Exception>(() => AdaptiveCard.FromJson(json));
+            AdaptiveCard.OnDeserializingMissingVersion = () => throw new Exception();
+            Assert.ThrowsException<Exception>(() => AdaptiveCard.FromJson(json),
+                                              "An exception thrown from an OnDeserializingMissingVersion handler should be allowed to propagate out.");
             AdaptiveCard.OnDeserializingMissingVersion = null;
         }
 


### PR DESCRIPTION
## Related Issue
Fixes #3376

## Description
Allows .NET folks to supply a callback to run when a missing or empty `version` field is encountered. The callback takes no parameters and must return an `AdaptiveSchemaVersion`, which represents the version to use for parsing.

## How Verified
Manual validation with Visualizer through debugger. New unit tests.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3462)