### PR TITLE
[UWP] Fix cirucular reference in element tag

### DIFF
--- a/source/uwp/Renderer/lib/ElementTagContent.cpp
+++ b/source/uwp/Renderer/lib/ElementTagContent.cpp
@@ -4,6 +4,7 @@
 #include "pch.h"
 #include "ElementTagContent.h"
 
+using namespace Microsoft::WRL;
 using namespace ABI::AdaptiveNamespace;
 using namespace ABI::Windows::UI::Xaml;
 using namespace ABI::Windows::UI::Xaml::Controls;
@@ -16,8 +17,10 @@ namespace AdaptiveNamespace
                                                       _In_ IColumnDefinition* columnDefinition,
                                                       _In_ boolean expectedVisibility)
     {
+        ComPtr<IPanel> localParentPanel(parentPanel);
+        RETURN_IF_FAILED(localParentPanel.AsWeak(&m_parentPanel));
+
         m_columnDefinition = columnDefinition;
-        m_parentPanel = parentPanel;
         m_separator = separator;
         m_cardElement = cardElement;
         m_expectedVisibility = expectedVisibility;

--- a/source/uwp/Renderer/lib/ElementTagContent.h
+++ b/source/uwp/Renderer/lib/ElementTagContent.h
@@ -40,7 +40,7 @@ namespace AdaptiveNamespace
         Microsoft::WRL::ComPtr<ABI::AdaptiveNamespace::IAdaptiveCardElement> m_cardElement;
         Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::Controls::IColumnDefinition> m_columnDefinition;
         Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IUIElement> m_separator;
-        Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::Controls::IPanel> m_parentPanel;
+        Microsoft::WRL::WeakRef m_parentPanel;
         boolean m_expectedVisibility;
     };
 }

--- a/source/uwp/Renderer/lib/RenderedAdaptiveCard.cpp
+++ b/source/uwp/Renderer/lib/RenderedAdaptiveCard.cpp
@@ -240,7 +240,10 @@ namespace AdaptiveNamespace
 
         for (auto parentPanel : parentPanels)
         {
-            XamlHelpers::SetSeparatorVisibility(parentPanel);
+            if (parentPanel)
+            {
+                XamlHelpers::SetSeparatorVisibility(parentPanel);
+            }
         }
 
         return S_OK;


### PR DESCRIPTION
## Related Issue
Found during investigation of #3425 but doesn't fully fix that issue.

## Description
Storing the parent element in the element tag leads to the following circular reference:
ParentElement->ChildElement->ElementTag->ParentElement

Fixed this issue by storing a weak reference to the parent element in the tag. 

## How Verified
Ran UWP test app and unit tests. Repro on a locally modified version of code showed that this used to cause a leak and now doesn't.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3496)