### PR TITLE
[iOS] Added Custom Parsing and allowed signal to be passed to host app from…

### DIFF
--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/CustomActionNewType.mm
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/CustomActionNewType.mm
@@ -7,6 +7,7 @@
 
 #import "CustomActionNewType.h"
 #import <AdaptiveCards/ACOBaseActionElementPrivate.h>
+#import <AdaptiveCards/ACRAggregateTarget.h>
 #import <AdaptiveCards/SharedAdaptiveCard.h>
 
 @implementation CustomActionNewType
@@ -41,39 +42,6 @@
 
 @end
 
-@interface AlertTarget : NSObject
-
-@property (weak) ACRView *rootView;
-@property CustomActionNewType *action;
-
-- (instancetype)init:(ACRView *)rootView action:(CustomActionNewType *)action;
-
-- (IBAction)send:(UIButton *)sender;
-
-@end
-
-@implementation AlertTarget
-
-- (instancetype)init:(ACRView *)rootView action:(CustomActionNewType *)action
-{
-    self = [super init];
-    if (self) {
-        self.rootView = rootView;
-        self.action = action;
-    }
-    return self;
-}
-
-- (IBAction)send:(UIButton *)sender
-{
-    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:@"successfully rendered new button type" message:_action.alertMessage preferredStyle:UIAlertControllerStyleAlert];
-    [alertController addAction:[UIAlertAction actionWithTitle:@"Dismiss" style:UIAlertActionStyleDefault handler:nil]];
-    _action.alertController = alertController;
-    [_rootView.acrActionDelegate didFetchUserResponses:nil action:_action];
-}
-
-@end
-
 @implementation CustomActionNewTypeRenderer : ACRBaseActionElementRenderer
 
 + (CustomActionNewTypeRenderer *)getInstance
@@ -95,7 +63,8 @@
     button.backgroundColor = newType.color;
     button.layer.cornerRadius = newType.cornerradius;
 
-    AlertTarget *target = [[AlertTarget alloc] init:rootView action:newType];
+    // ACRAggregateTarget relays signal (event) back to host app via ACRActionDelegate
+    ACRAggregateTarget *target = [[ACRAggregateTarget alloc] initWithActionElement:newType rootView:rootView];
 
     [button addTarget:target action:@selector(send:) forControlEvents:UIControlEventTouchUpInside];
     [superview addTarget:target];

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ViewController.m
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ViewController.m
@@ -386,9 +386,10 @@ const CGFloat kAdaptiveCardsWidth = 330;
     } else if (action.type == ACRUnknownAction) {
         if ([action isKindOfClass:[CustomActionNewType class]]) {
             CustomActionNewType *newType = (CustomActionNewType *)action;
-            if (newType.alertController) {
-                [self presentViewController:newType.alertController animated:YES completion:nil];
-            }
+            UIAlertController *alertController = [UIAlertController alertControllerWithTitle:@"successfully rendered new button type" message:newType.alertMessage preferredStyle:UIAlertControllerStyleAlert];
+            [alertController addAction:[UIAlertAction actionWithTitle:@"Dismiss" style:UIAlertActionStyleDefault handler:nil]];
+            newType.alertController = alertController;
+            [self presentViewController:alertController animated:YES completion:nil];
         }
     }
 }

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizerTests/ADCIOSVisualizerTests.mm
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizerTests/ADCIOSVisualizerTests.mm
@@ -433,7 +433,7 @@
     }];
 }
 
-- (void)testSharedEnumsCompatabilityTest
+- (void)testSharedEnumsCompatabilityWithiOSSDKEnums
 {
     XCTAssertTrue(static_cast<int>(AdaptiveCards::CardElementType::ActionSet) == ACRActionSet);
     XCTAssertTrue(static_cast<int>(AdaptiveCards::CardElementType::AdaptiveCard) == ACRAdaptiveCard);

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizerTests/ADCIOSVisualizerTests.mm
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizerTests/ADCIOSVisualizerTests.mm
@@ -12,6 +12,7 @@
 #import "AdaptiveCards/ShowCardAction.h"
 #import "AdaptiveCards/TextBlock.h"
 #import "AdaptiveCards/UtiliOS.h"
+#import "CustomActionNewType.h"
 #import <AdaptiveCards/ACFramework.h>
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
@@ -455,6 +456,11 @@
     XCTAssertTrue(static_cast<int>(AdaptiveCards::CardElementType::ToggleInput) == ACRToggleInput);
     XCTAssertTrue(static_cast<int>(AdaptiveCards::CardElementType::Unknown) == ACRUnknown);
     XCTAssertTrue(static_cast<int>(AdaptiveCards::CardElementType::RichTextBlock) == ACRRichTextBlock);
+    XCTAssertTrue(static_cast<int>(AdaptiveCards::ActionType::ShowCard) == ACRShowCard);
+    XCTAssertTrue(static_cast<int>(AdaptiveCards::ActionType::Submit) == ACRSubmit);
+    XCTAssertTrue(static_cast<int>(AdaptiveCards::ActionType::OpenUrl) == ACROpenUrl);
+    XCTAssertTrue(static_cast<int>(AdaptiveCards::ActionType::ToggleVisibility) == ACRToggleVisibility);
+    XCTAssertTrue(static_cast<int>(AdaptiveCards::ActionType::UnknownAction) == ACRUnknownAction);
 }
 
 @end

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizerTests/ADCIOSVisualizerTests.mm
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizerTests/ADCIOSVisualizerTests.mm
@@ -435,6 +435,8 @@
 
 - (void)testSharedEnumsCompatabilityWithiOSSDKEnums
 {
+    // The below Enums from shared model's numeric values should be in sync with
+    // iOS SDK's enum.
     XCTAssertTrue(static_cast<int>(AdaptiveCards::CardElementType::ActionSet) == ACRActionSet);
     XCTAssertTrue(static_cast<int>(AdaptiveCards::CardElementType::AdaptiveCard) == ACRAdaptiveCard);
     XCTAssertTrue(static_cast<int>(AdaptiveCards::CardElementType::ChoiceInput) == ACRChoiceInput);

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOBaseActionElement.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOBaseActionElement.h
@@ -17,7 +17,7 @@ typedef NS_ENUM(NSInteger, ACRActionType) {
     ACRSubmit,
     ACROpenUrl,
     ACRToggleVisibility,
-    ACRUnknownAction,
+    ACRUnknownAction = 6,
 };
 
 typedef NS_ENUM(NSInteger, ACRIconPlacement) {

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRAggregateTarget.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRAggregateTarget.h
@@ -8,10 +8,9 @@
 #import "ACRIContentHoldingView.h"
 #import "ACRLongPressGestureRecognizerEventHandler.h"
 #import "ACRView.h"
-#import "HostConfig.h"
-#import "SharedAdaptiveCard.h"
 #import <UIKit/UIKit.h>
 
+// AggregateTraget is used to relay the signal back to host
 @interface ACRAggregateTarget : NSObject <ACRSelectActionDelegate>
 
 - (instancetype)initWithActionElement:(ACOBaseActionElement *)actionElement rootView:(ACRView *)rootView;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRAggregateTarget.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRAggregateTarget.mm
@@ -22,7 +22,7 @@
 {
     self = [super init];
     if (self) {
-        _actionElement = [[ACOBaseActionElement alloc] initWithBaseActionElement:[actionElement element]];
+        _actionElement = actionElement;
         _view = rootView;
     }
     return self;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRCustomActionRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRCustomActionRenderer.mm
@@ -14,8 +14,8 @@
 #import "UnknownAction.h"
 #import "UtiliOS.h"
 
-// this renderer is entry point to custom parsing and rendering registered with host
-// it will call custom parsing to deserialize json to object, then the object is renderred by calling
+// this is an entry point to custom parsing and rendering
+// it will call a registered custom parser to deserialize, then the deserialized object is rendered by calling
 // the appropriate custom renderer
 @implementation ACRCustomActionRenderer
 
@@ -37,7 +37,7 @@
                 hostConfig:(ACOHostConfig *)acoConfig;
 {
     std::shared_ptr<UnknownAction> unknownAction = std::dynamic_pointer_cast<UnknownAction>([acoElem element]);
-    // we get back deserialized action object back by running's host's registered parser
+    // we get back a deserialized action object by calling a custom parser registered via host
     ACOBaseActionElement *customAction = deserializeUnknowActionToCustomAction(unknownAction);
     if (customAction) {
         ACRRegistration *reg = [ACRRegistration getInstance];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRCustomActionRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRCustomActionRenderer.mm
@@ -38,7 +38,7 @@
 {
     std::shared_ptr<UnknownAction> unknownAction = std::dynamic_pointer_cast<UnknownAction>([acoElem element]);
     // we get back a deserialized action object by calling a custom parser registered via host
-    ACOBaseActionElement *customAction = deserializeUnknowActionToCustomAction(unknownAction);
+    ACOBaseActionElement *customAction = deserializeUnknownActionToCustomAction(unknownAction);
     if (customAction) {
         ACRRegistration *reg = [ACRRegistration getInstance];
         NSString *type = [NSString stringWithCString:unknownAction->GetElementTypeString().c_str() encoding:NSUTF8StringEncoding];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRCustomActionRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRCustomActionRenderer.mm
@@ -14,6 +14,9 @@
 #import "UnknownAction.h"
 #import "UtiliOS.h"
 
+// this renderer is entry point to custom parsing and rendering registered with host
+// it will call custom parsing to deserialize json to object, then the object is renderred by calling
+// the appropriate custom renderer
 @implementation ACRCustomActionRenderer
 
 + (ACRCustomActionRenderer *)getInstance
@@ -33,27 +36,18 @@
          baseActionElement:(ACOBaseActionElement *)acoElem
                 hostConfig:(ACOHostConfig *)acoConfig;
 {
-    std::shared_ptr<UnknownAction> customAction = std::dynamic_pointer_cast<UnknownAction>([acoElem element]);
+    std::shared_ptr<UnknownAction> unknownAction = std::dynamic_pointer_cast<UnknownAction>([acoElem element]);
+    // we get back deserialized action object back by running's host's registered parser
+    ACOBaseActionElement *customAction = deserializeUnknowActionToCustomAction(unknownAction);
+    if (customAction) {
+        ACRRegistration *reg = [ACRRegistration getInstance];
+        NSString *type = [NSString stringWithCString:unknownAction->GetElementTypeString().c_str() encoding:NSUTF8StringEncoding];
 
-    ACRRegistration *reg = [ACRRegistration getInstance];
-    if (reg) {
-        NSString *type = [NSString stringWithCString:customAction->GetElementTypeString().c_str() encoding:NSUTF8StringEncoding];
-        NSObject<ACOIBaseActionElementParser> *parser = [reg getCustomActionElementParser:type];
-        if (!parser) {
-            @throw [ACOFallbackException fallbackException];
-        }
-        Json::Value blob = customAction->GetAdditionalProperties();
-        Json::FastWriter fastWriter;
-        NSString *jsonString = [[NSString alloc] initWithCString:fastWriter.write(blob).c_str() encoding:NSUTF8StringEncoding];
-        if (jsonString.length > 0) {
-            NSData *jsonPayload = [jsonString dataUsingEncoding:NSUTF8StringEncoding];
-            ACOParseContext *context = [reg getParseContext];
-            ACOBaseActionElement *actionElement = [parser deserialize:jsonPayload parseContext:context];
-            ACRBaseActionElementRenderer *renderer = [reg getActionRenderer:[NSNumber numberWithLong:type.hash]];
-            ;
-            if (renderer) {
-                return [renderer renderButton:view inputs:inputs superview:superview baseActionElement:actionElement hostConfig:acoConfig];
-            }
+        ACRBaseActionElementRenderer *renderer = [reg getActionRenderer:[NSNumber numberWithLong:type.hash]];
+
+        if (renderer) {
+            // render a button by calling custom renderer
+            return [renderer renderButton:view inputs:inputs superview:superview baseActionElement:customAction hostConfig:acoConfig];
         }
     }
     return nil;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTargetBuilderDirector.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTargetBuilderDirector.mm
@@ -196,7 +196,7 @@
 {
     std::shared_ptr<UnknownAction> unknownAction = std::dynamic_pointer_cast<UnknownAction>(action);
     if (unknownAction) {
-        ACOBaseActionElement *customAction = deserializeUnknowActionToCustomAction(unknownAction);
+        ACOBaseActionElement *customAction = deserializeUnknownActionToCustomAction(unknownAction);
         return [[ACRAggregateTarget alloc] initWithActionElement:customAction rootView:director.rootView];
     }
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTargetBuilderDirector.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTargetBuilderDirector.mm
@@ -179,7 +179,7 @@
 
 @end
 
-// build target for unknow actions
+// build target for unknown actions
 @interface ACRUnknownActionTargetBuilder : ACRTargetBuilder
 @end
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.h
@@ -12,6 +12,7 @@
 #import "RichTextElementProperties.h"
 #import "TextBlock.h"
 #import "TextRun.h"
+#import "UnknownAction.h"
 #import <UIKit/UIKit.h>
 
 using namespace AdaptiveCards;
@@ -63,3 +64,5 @@ void TextBlockToRichTextElementProperties(const std::shared_ptr<TextBlock> &text
 void TextRunToRichTextElementProperties(const std::shared_ptr<TextRun> &textRun, RichTextElementProperties &textProp);
 
 void buildIntermediateResultForText(ACRView *rootView, ACOHostConfig *hostConfig, RichTextElementProperties const &textProperties, NSString *elementId);
+
+ACOBaseActionElement *deserializeUnknowActionToCustomAction(const std::shared_ptr<UnknownAction> action);

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.h
@@ -65,4 +65,4 @@ void TextRunToRichTextElementProperties(const std::shared_ptr<TextRun> &textRun,
 
 void buildIntermediateResultForText(ACRView *rootView, ACOHostConfig *hostConfig, RichTextElementProperties const &textProperties, NSString *elementId);
 
-ACOBaseActionElement *deserializeUnknowActionToCustomAction(const std::shared_ptr<UnknownAction> action);
+ACOBaseActionElement *deserializeUnknownActionToCustomAction(const std::shared_ptr<UnknownAction> action);

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
@@ -657,7 +657,7 @@ void TextRunToRichTextElementProperties(const std::shared_ptr<TextRun> &textRun,
     textProp.SetStrikethrough(textRun->GetStrikethrough());
 }
 
-ACOBaseActionElement *deserializeUnknowActionToCustomAction(const std::shared_ptr<UnknownAction> unknownAction)
+ACOBaseActionElement *deserializeUnknownActionToCustomAction(const std::shared_ptr<UnknownAction> unknownAction)
 {
     ACRRegistration *reg = [ACRRegistration getInstance];
     ACOBaseActionElement *customAction = nil;


### PR DESCRIPTION
## Related Issue
fixes #3519 

## Description
iOS lacked the ability to relay event raised from custom action in SelectAction context.
This change allows custom action to be parsed and passed onto host app via the adaptive card action delegate when the event is raised.

Sample Apps' usage was slightly changed. CustomRender no longer creates custom target, and the target is replaced by `ACRAggregateTarget`. `ACRAggregateTarget` is used to pass signal, and handling of the action is done in the host app's delegate using the action passed in.

Minor code clean-up & refactoring were performed.

## How Verified
test json was used to verify that custom action worked for both Actions and SelectAction context

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3526)