### PR TITLE
[UWP] Add accessible names to all action buttons

### DIFF
--- a/source/uwp/Renderer/lib/ActionHelpers.cpp
+++ b/source/uwp/Renderer/lib/ActionHelpers.cpp
@@ -57,6 +57,12 @@ namespace AdaptiveNamespace::ActionHelpers
         THROW_IF_FAILED(action->get_IconUrl(iconUrl.GetAddressOf()));
 
         ComPtr<IButton> localButton(button);
+        ComPtr<IAutomationPropertiesStatics> automationProperties;
+        THROW_IF_FAILED(GetActivationFactory(
+            HStringReference(RuntimeClass_Windows_UI_Xaml_Automation_AutomationProperties).Get(), &automationProperties));
+        ComPtr<IDependencyObject> buttonAsDependencyObject;
+        THROW_IF_FAILED(localButton.As(&buttonAsDependencyObject));
+        THROW_IF_FAILED(automationProperties->SetName(buttonAsDependencyObject.Get(), title.Get()));
 
         // Check if the button has an iconUrl
         if (iconUrl != nullptr)


### PR DESCRIPTION
## Related Issue
Fixes #3527

## Description
While investigating alternatives for a partner team, I noticed that ActionSet buttons lack appropriate accessibility information, particularly when an `iconUrl` is present. Most accessibility tools will decide that if there's a single text child of a button, that the text child must be the name. However, if there's >1 child, it gives up. Consider this:

```json
{
    "type": "AdaptiveCard",
    "version": "1.1",
    "body": [
        {
            "type": "ActionSet",
            "actions": [
                {
                    "type": "Action.Submit",
                    "title": "action!",
                    "iconUrl": "data:image/png;base64,[...]="
                }
            ]
        }
    ]
}
```

Accessibility Insights will show this as not having a name. Similarly, Narrator will read it simply as "button".

![image](https://user-images.githubusercontent.com/16614499/67131074-1d569200-f1b8-11e9-88e6-d7e586a310bb.png)

The fix is to explicitly add the action title as the accessible name for the button control when it's built.

## How Verified
Verified with Accessibility Insights and Narrator

![image](https://user-images.githubusercontent.com/16614499/67131278-da48ee80-f1b8-11e9-8b53-d585c46555c6.png)

Narrator now says the name before saying button (e.g. before it would just say "button", now it might say something like "Microsoft To Do - button").

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3528)