### PR TITLE
Parse Context Update

### DIFF
--- a/source/dotnet/Library/AdaptiveCards/AdaptiveCard.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveCard.cs
@@ -238,7 +238,7 @@ namespace AdaptiveCards
             {
                 parseResult.Card = JsonConvert.DeserializeObject<AdaptiveCard>(json, new JsonSerializerSettings
                 {
-                    ContractResolver = new WarningLoggingContractResolver(parseResult),
+                    ContractResolver = new WarningLoggingContractResolver(parseResult, new ParseContext()),
                     Converters = { new StrictIntConverter() }
                 });
             }

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveCardConverter.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveCardConverter.cs
@@ -9,7 +9,7 @@ using Newtonsoft.Json.Linq;
 
 namespace AdaptiveCards
 {
-    public class AdaptiveCardConverter : JsonConverter, ILogWarnings
+    public class AdaptiveCardConverter : AdaptiveTypedBaseElementConverter, ILogWarnings
     {
         public List<AdaptiveWarning> Warnings { get; set; } = new List<AdaptiveWarning>();
 

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveCardConverter.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveCardConverter.cs
@@ -62,16 +62,6 @@ namespace AdaptiveCards
 
             if (reader.Depth == 0)
             {
-                // Needed for ID collision detection after fallback was introduced
-                if (ParseContext == null)
-                {
-                    ParseContext = new ParseContext();
-                }
-                else
-                {
-                    ParseContext.Initialize();
-                }
-
                 ValidateJsonVersion(ref jObject);
 
                 if (new AdaptiveSchemaVersion(jObject.Value<string>("version")) > AdaptiveCard.KnownSchemaVersion)
@@ -79,6 +69,14 @@ namespace AdaptiveCards
                     return MakeFallbackTextCard(jObject);
                 }
             }
+
+            /// this is needed when client calls Deserailizer method, we need this contract resolver,
+            /// so we can pass ParseContext
+            if (!(serializer.ContractResolver is WarningLoggingContractResolver))
+            {
+                serializer.ContractResolver = new WarningLoggingContractResolver(new AdaptiveCardParseResult(), new ParseContext()); 
+            }
+
             var typedElementConverter = serializer.ContractResolver.ResolveContract(typeof(AdaptiveTypedElement)).Converter;
 
             var card = (AdaptiveCard)typedElementConverter.ReadJson(jObject.CreateReader(), objectType, existingValue, serializer);

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveCardConverter.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveCardConverter.cs
@@ -70,7 +70,7 @@ namespace AdaptiveCards
                 }
             }
 
-            /// this is needed when client calls Deserailizer method, we need this contract resolver,
+            /// this is needed when client calls JsonConvert.Deserializer method, we need this contract resolver,
             /// so we can pass ParseContext
             if (!(serializer.ContractResolver is WarningLoggingContractResolver))
             {

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveCardConverter.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveCardConverter.cs
@@ -63,7 +63,14 @@ namespace AdaptiveCards
             if (reader.Depth == 0)
             {
                 // Needed for ID collision detection after fallback was introduced
-                ParseContext.Initialize();
+                if (ParseContext == null)
+                {
+                    ParseContext = new ParseContext();
+                }
+                else
+                {
+                    ParseContext.Initialize();
+                }
 
                 ValidateJsonVersion(ref jObject);
 

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveFallbackConverter.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveFallbackConverter.cs
@@ -2,7 +2,6 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 namespace AdaptiveCards
 {

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveFallbackConverter.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveFallbackConverter.cs
@@ -2,10 +2,11 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace AdaptiveCards
 {
-    public class AdaptiveFallbackConverter : JsonConverter, ILogWarnings
+    public class AdaptiveFallbackConverter : AdaptiveTypedBaseElementConverter, ILogWarnings
     {
         public List<AdaptiveWarning> Warnings { get; set; } = new List<AdaptiveWarning>();
 
@@ -103,7 +104,7 @@ namespace AdaptiveCards
             return result;
         }
 
-        public static AdaptiveFallbackElement ParseFallback(JToken fallbackJSON, JsonSerializer serializer, string objectId, AdaptiveInternalID internalId)
+        public AdaptiveFallbackElement ParseFallback(JToken fallbackJSON, JsonSerializer serializer, string objectId, AdaptiveInternalID internalId)
         {
             // Handle fallback as a string ("drop")
             if (fallbackJSON.Type == JTokenType.String)

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveInlinesConverter.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveInlinesConverter.cs
@@ -8,7 +8,7 @@ using System.Reflection;
 
 namespace AdaptiveCards
 {
-    class AdaptiveInlinesConverter : JsonConverter
+    class AdaptiveInlinesConverter : AdaptiveTypedBaseElementConverter 
     {
         public override bool CanRead => true;
 
@@ -40,12 +40,16 @@ namespace AdaptiveCards
                         throw new AdaptiveSerializationException($"Property 'type' must be '{AdaptiveTextRun.TypeName}'");
                     }
 
+                    if(ParseContext == null) {
+                        ParseContext = new ParseContext();
+                    }
+
                     var adaptiveInline = JsonConvert.DeserializeObject<AdaptiveTextRun>(jobj.ToString(), new JsonSerializerSettings
                     {
-                        ContractResolver = new WarningLoggingContractResolver(new AdaptiveCardParseResult(), new ParseContext()),
+                        ContractResolver = new WarningLoggingContractResolver(new AdaptiveCardParseResult(), ParseContext),
                         Converters = { new StrictIntConverter() }
                     });
-                    arrayList.Add((AdaptiveInline)adaptiveInline);
+                    arrayList.Add(adaptiveInline);
                 }
             }
             return arrayList;

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveInlinesConverter.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveInlinesConverter.cs
@@ -39,7 +39,13 @@ namespace AdaptiveCards
                     {
                         throw new AdaptiveSerializationException($"Property 'type' must be '{AdaptiveTextRun.TypeName}'");
                     }
-                    arrayList.Add((AdaptiveInline)jobj.ToObject(typeof(AdaptiveTextRun)));
+                    //arrayList.Add((AdaptiveInline)jobj.ToObject(typeof(AdaptiveTextRun)));
+                    var adaptiveInline = JsonConvert.DeserializeObject<AdaptiveTextRun>(jobj.ToString(), new JsonSerializerSettings
+                    {
+                        ContractResolver = new WarningLoggingContractResolver(new AdaptiveCardParseResult(), new ParseContext()),
+                        Converters = { new StrictIntConverter() }
+                    });
+                    arrayList.Add((AdaptiveInline)adaptiveInline);
                 }
             }
             return arrayList;

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveInlinesConverter.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveInlinesConverter.cs
@@ -39,7 +39,7 @@ namespace AdaptiveCards
                     {
                         throw new AdaptiveSerializationException($"Property 'type' must be '{AdaptiveTextRun.TypeName}'");
                     }
-                    //arrayList.Add((AdaptiveInline)jobj.ToObject(typeof(AdaptiveTextRun)));
+
                     var adaptiveInline = JsonConvert.DeserializeObject<AdaptiveTextRun>(jobj.ToString(), new JsonSerializerSettings
                     {
                         ContractResolver = new WarningLoggingContractResolver(new AdaptiveCardParseResult(), new ParseContext()),

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveTypedBaseElementConverter.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveTypedBaseElementConverter.cs
@@ -1,0 +1,22 @@
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AdaptiveCards
+{
+    public abstract class AdaptiveTypedBaseElementConverter : JsonConverter
+    {
+        protected ParseContext parseContext;
+        public ParseContext ParseContext
+        {
+            get => parseContext;
+            set
+            {
+                parseContext = value;
+            }
+        }
+    }
+}

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveTypedBaseElementConverter.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveTypedBaseElementConverter.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveTypedElement.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveTypedElement.cs
@@ -46,7 +46,7 @@ namespace AdaptiveCards
         public AdaptiveFallbackElement Fallback { get; set; }
 
         [JsonIgnore]
-        public AdaptiveInternalID InternalID { get; } = ParseContext.PeekElement();
+        public AdaptiveInternalID InternalID { get; }// = ParseContext.PeekElement();
 
         /// <summary>
         /// A unique ID associated with the element. For Inputs the ID will be used as the key for Action.Submit response

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveTypedElement.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveTypedElement.cs
@@ -46,7 +46,7 @@ namespace AdaptiveCards
         public AdaptiveFallbackElement Fallback { get; set; }
 
         [JsonIgnore]
-        public AdaptiveInternalID InternalID { get; }// = ParseContext.PeekElement();
+        public AdaptiveInternalID InternalID { get; set; }
 
         /// <summary>
         /// A unique ID associated with the element. For Inputs the ID will be used as the key for Action.Submit response

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveTypedElementConverter.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveTypedElementConverter.cs
@@ -98,6 +98,7 @@ namespace AdaptiveCards
                 try
                 {
                     serializer.Populate(jObject.CreateReader(), result);
+                    result.InternalID = internalID;
                 }
                 catch (JsonSerializationException) { }
 

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveTypedElementConverter.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveTypedElementConverter.cs
@@ -12,7 +12,7 @@ namespace AdaptiveCards
     /// <summary>
     ///     This handles using type field to instantiate strongly typed object on deserialization
     /// </summary>
-    public class AdaptiveTypedElementConverter : JsonConverter, ILogWarnings
+    public class AdaptiveTypedElementConverter : AdaptiveTypedBaseElementConverter, ILogWarnings
     {
         public List<AdaptiveWarning> Warnings { get; set; } = new List<AdaptiveWarning>();
 

--- a/source/dotnet/Library/AdaptiveCards/IgnoreEmptyItemsConverter.cs
+++ b/source/dotnet/Library/AdaptiveCards/IgnoreEmptyItemsConverter.cs
@@ -9,7 +9,7 @@ using Newtonsoft.Json.Linq;
 
 namespace AdaptiveCards
 {
-    public class IgnoreEmptyItemsConverter<T> : JsonConverter
+    public class IgnoreEmptyItemsConverter<T> : AdaptiveTypedBaseElementConverter 
     {
         public override bool CanConvert(Type objectType)
         {

--- a/source/dotnet/Library/AdaptiveCards/ParseContext.cs
+++ b/source/dotnet/Library/AdaptiveCards/ParseContext.cs
@@ -15,7 +15,7 @@ namespace AdaptiveCards
 
         public enum ContextType { Element, Action };
 
-        public static ContextType Type { get; set; }
+        public ContextType Type { get; set; }
 
         private IDictionary<string, List<AdaptiveInternalID>> elementIds = new Dictionary<string, List<AdaptiveInternalID>>();
 

--- a/source/dotnet/Library/AdaptiveCards/ParseContext.cs
+++ b/source/dotnet/Library/AdaptiveCards/ParseContext.cs
@@ -5,9 +5,9 @@ using Newtonsoft.Json;
 
 namespace AdaptiveCards
 {
-    static class ParseContext
+    public class ParseContext
     {
-        public static void Initialize()
+        public void Initialize()
         {
             elementIds = new Dictionary<string, List<AdaptiveInternalID>>();
             idStack = new Stack<Tuple<string, AdaptiveInternalID, bool>>();
@@ -17,12 +17,12 @@ namespace AdaptiveCards
 
         public static ContextType Type { get; set; }
 
-        private static IDictionary<string, List<AdaptiveInternalID>> elementIds = new Dictionary<string, List<AdaptiveInternalID>>();
+        private IDictionary<string, List<AdaptiveInternalID>> elementIds = new Dictionary<string, List<AdaptiveInternalID>>();
 
-        private static Stack<Tuple<string, AdaptiveInternalID, bool>> idStack = new Stack<Tuple<string, AdaptiveInternalID, bool>>();
+        private Stack<Tuple<string, AdaptiveInternalID, bool>> idStack = new Stack<Tuple<string, AdaptiveInternalID, bool>>();
 
         // Push the provided state on to our ID stack
-        public static void PushElement(string idJsonProperty, AdaptiveInternalID internalId)
+        public void PushElement(string idJsonProperty, AdaptiveInternalID internalId)
         {
             if (internalId.Equals(AdaptiveInternalID.Invalid))
             {
@@ -31,7 +31,7 @@ namespace AdaptiveCards
             idStack.Push(new Tuple<string, AdaptiveInternalID, bool>(idJsonProperty, internalId, AdaptiveFallbackConverter.IsInFallback));
         }
 
-        public static AdaptiveInternalID PeekElement()
+        public AdaptiveInternalID PeekElement()
         {
             if (idStack.Count == 0)
             {
@@ -42,7 +42,7 @@ namespace AdaptiveCards
         }
 
         // Pop the last id off our stack and perform validation 
-        public static void PopElement()
+        public void PopElement()
         {
             // about to pop an element off the stack. perform collision list maintenance and detection.
             var idsToPop = idStack.Peek();
@@ -121,7 +121,7 @@ namespace AdaptiveCards
 
         // Walk stack looking for first element to be marked fallback (which isn't the ID we're supposed to skip), then
         // return its internal ID. If none, return an invalid ID. (see comment above)
-        public static AdaptiveInternalID GetNearestFallbackID(AdaptiveInternalID skipID)
+        public AdaptiveInternalID GetNearestFallbackID(AdaptiveInternalID skipID)
         {
             foreach (var curElement in idStack)
             {

--- a/source/dotnet/Library/AdaptiveCards/ParseContext.cs
+++ b/source/dotnet/Library/AdaptiveCards/ParseContext.cs
@@ -7,12 +7,6 @@ namespace AdaptiveCards
 {
     public class ParseContext
     {
-        public void Initialize()
-        {
-            elementIds = new Dictionary<string, List<AdaptiveInternalID>>();
-            idStack = new Stack<Tuple<string, AdaptiveInternalID, bool>>();
-        }
-
         public enum ContextType { Element, Action };
 
         public ContextType Type { get; set; }

--- a/source/dotnet/Library/AdaptiveCards/WarningLoggingContractResolver.cs
+++ b/source/dotnet/Library/AdaptiveCards/WarningLoggingContractResolver.cs
@@ -25,9 +25,9 @@ namespace AdaptiveCards
         {
             var converter = base.ResolveContractConverter(type);
 
-            if (converter is AdaptiveTypedBaseElementConverter)
+            if (converter is AdaptiveTypedBaseElementConverter converterWithContext)
             {
-                ((AdaptiveTypedBaseElementConverter)converter).ParseContext = _parseContext;
+                converterWithContext.ParseContext = _parseContext;
             }
 
             if (converter is ILogWarnings logWarnings)
@@ -51,6 +51,11 @@ namespace AdaptiveCards
             if (property?.Converter is ILogWarnings converter)
             {
                 converter.Warnings = _parseResult.Warnings;
+            }
+
+            if (property?.Converter is AdaptiveTypedBaseElementConverter converterWithContext)
+            {
+                converterWithContext.ParseContext = _parseContext;
             }
 
             if (property?.MemberConverter is ILogWarnings memberConverter)

--- a/source/dotnet/Library/AdaptiveCards/WarningLoggingContractResolver.cs
+++ b/source/dotnet/Library/AdaptiveCards/WarningLoggingContractResolver.cs
@@ -13,15 +13,22 @@ namespace AdaptiveCards
     internal class WarningLoggingContractResolver : DefaultContractResolver
     {
         private readonly AdaptiveCardParseResult _parseResult;
+        private ParseContext _parseContext;
 
-        public WarningLoggingContractResolver(AdaptiveCardParseResult parseResult)
+        public WarningLoggingContractResolver(AdaptiveCardParseResult parseResult, ParseContext parseContext)
         {
             _parseResult = parseResult;
+            _parseContext = parseContext;
         }
 
         protected override JsonConverter ResolveContractConverter(Type type)
         {
             var converter = base.ResolveContractConverter(type);
+
+            if (converter is AdaptiveTypedBaseElementConverter)
+            {
+                ((AdaptiveTypedBaseElementConverter)converter).ParseContext = _parseContext;
+            }
 
             if (converter is ILogWarnings logWarnings)
             {

--- a/source/dotnet/Test/AdaptiveCards.Test/AdaptiveCardApiTests.cs
+++ b/source/dotnet/Test/AdaptiveCards.Test/AdaptiveCardApiTests.cs
@@ -1245,9 +1245,13 @@ namespace AdaptiveCards.Test
 
             StringAssert.Contains(ex.Message, "Property 'type' must be 'TextRun'");
         }
-                void RenderCardTask(string payload)
+        void RenderCardTask(string payload)
         {
             AdaptiveCardParseResult parseResult = AdaptiveCard.FromJson(payload);
+            if (parseResult.Warnings.Count != 0)
+            {
+                throw new Exception("parse failed");
+            }
         }
 
         [TestMethod]

--- a/source/dotnet/Test/AdaptiveCards.Test/AdaptiveCardApiTests.cs
+++ b/source/dotnet/Test/AdaptiveCards.Test/AdaptiveCardApiTests.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Newtonsoft.Json;
+using System.Threading.Tasks;
 
 namespace AdaptiveCards.Test
 {
@@ -1244,6 +1244,152 @@ namespace AdaptiveCards.Test
 
 
             StringAssert.Contains(ex.Message, "Property 'type' must be 'TextRun'");
+        }
+                void RenderCardTask(string payload)
+        {
+            AdaptiveCardParseResult parseResult = AdaptiveCard.FromJson(payload);
+        }
+
+        [TestMethod]
+        public void TestConcurrentParsing()
+        {
+            // card with invalid inline type
+            var adaptiveCard =
+@"{
+    ""$schema"": ""http://adaptivecards.io/schemas/adaptive-card.json"",
+    ""type"": ""AdaptiveCard"",
+    ""version"": ""1.0"",
+    ""body"": [
+        {
+            ""type"": ""TextBlock"",
+            ""text"": ""Publish Adaptive Card schema"",
+            ""weight"": ""bolder"",
+            ""size"": ""medium""
+        },
+        {
+            ""type"": ""ColumnSet"",
+            ""columns"": [
+                {
+                    ""type"": ""Column"",
+                    ""width"": ""auto"",
+                    ""items"": [
+                        {
+                            ""type"": ""Image"",
+                            ""url"": ""https://pbs.twimg.com/profile_images/3647943215/d7f12830b3c17a5a9e4afcc370e3a37e_400x400.jpeg"",
+                            ""size"": ""small"",
+                            ""style"": ""person""
+                        }
+                    ]
+                },
+                {
+                    ""type"": ""Column"",
+                    ""width"": ""stretch"",
+                    ""items"": [
+                        {
+                            ""type"": ""TextBlock"",
+                            ""text"": ""Matt Hidinger"",
+                            ""weight"": ""bolder"",
+                            ""wrap"": true
+                        },
+                        {
+                            ""type"": ""TextBlock"",
+                            ""spacing"": ""none"",
+                            ""text"": ""Created {{DATE(2017-02-14T06:08:39Z, SHORT)}}"",
+                            ""isSubtle"": true,
+                            ""wrap"": true
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            ""type"": ""TextBlock"",
+            ""text"": ""Now that we have defined the main rules and features of the format, we need to produce a schema and publish it to GitHub. The schema will be the starting point of our reference documentation."",
+            ""wrap"": true
+        },
+        {
+            ""type"": ""FactSet"",
+            ""facts"": [
+                {
+                    ""title"": ""Board:"",
+                    ""value"": ""Adaptive Card""
+                },
+                {
+                    ""title"": ""List:"",
+                    ""value"": ""Backlog""
+                },
+                {
+                    ""title"": ""Assigned to:"",
+                    ""value"": ""Matt Hidinger""
+                },
+                {
+                    ""title"": ""Due date:"",
+                    ""value"": ""Not set""
+                }
+            ]
+        }
+    ],
+    ""actions"": [
+        {
+            ""type"": ""Action.ShowCard"",
+            ""title"": ""Set due date"",
+            ""card"": {
+                ""type"": ""AdaptiveCard"",
+                ""body"": [
+                    {
+                        ""type"": ""Input.Date"",
+                        ""id"": ""dueDate""
+                    }
+                ],
+                ""actions"": [
+                    {
+                        ""type"": ""Action.Submit"",
+                        ""title"": ""OK""
+                    }
+                ]
+            }
+        },
+        {
+            ""type"": ""Action.ShowCard"",
+            ""title"": ""Comment"",
+            ""card"": {
+                ""type"": ""AdaptiveCard"",
+                ""body"": [
+                    {
+                        ""type"": ""Input.Text"",
+                        ""id"": ""comment"",
+                        ""isMultiline"": true,
+                        ""placeholder"": ""Enter your comment""
+                    }
+                ],
+                ""actions"": [
+                    {
+                        ""type"": ""Action.Submit"",
+                        ""title"": ""OK""
+                    }
+                ]
+            }
+        }
+    ]
+}";
+            List<Task> tasks = new List<Task>();
+            for (var i = 0; i < 10; i++)
+            {
+                var payload = adaptiveCard;
+                var task = Task.Run(() => { RenderCardTask(payload); });
+                tasks.Add(task);
+            }
+
+            try
+            {
+                Task.WaitAll(tasks.ToArray());
+            }
+            catch
+            {
+                // it's perfectly fine card. if there is exception, it is due to concurreny
+                // as it's the only variable.
+                Assert.Fail();
+            }
         }
     }
 }


### PR DESCRIPTION
## Related Issue
fixes #3509, fixes #3541 

## Description
ParseContext was a static class, and it caused synchronization issue during parsing in multi-threaded environments.

- this changes include:
1. Made ParseContext non static class
2. Added an instance of ParseContext to WarningLoggingContractResolver.
- so client's custom Json contract resolver may not work.
- we already don't allow custom Json contract resolver if FromJson() API is used
3. Fixed the issue where internalIds are not being set for elements
4. Added concurrency unit test for parsing


## How Verified
1. Concurrency unit tests were added and verified it.
2. All existing unit tests were passed
3. Run all of the fallback json tests cards and ran some of the relevant cards such as showcard

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3548)