### PR TITLE
Remove symbols nuget package signing reference

### DIFF
--- a/source/uwp/Build/SignNugetConfig.xml
+++ b/source/uwp/Build/SignNugetConfig.xml
@@ -8,6 +8,5 @@
   <job platform="x64" configuration="release" dest="__RELBINPATH__\..\..\..\a\signed" jobname="Adaptive Cards UWP Nuget" approvers="">
     <!-- AdaptiveCards -->
     <file src="__RELBINPATH__\..\..\..\a\AdaptiveCards.*.nupkg" signType="Nuget"  />
-    <file src="__RELBINPATH__\..\..\..\a\AdaptiveCards.*.symbols.nupkg" signType="Nuget"  />
   </job>
 </SignConfigXML>


### PR DESCRIPTION
#3595  Related Issue
[UWP] Symbols incorrectly published for UWP.

## Description
The UWP renderer is native code which is unsupported by the nuget symbol server. Currently the release process nuget packs with the Symbols flag to generate a separate symbols.nupkg that is uploaded to that server.

If we remove that from the pipeline, this config file still expects to find it. So we need to remove this reference.

## How Verified
How you verified the fix, including one or all of the following: 
1. n/a.
2. n/a
3. n/a, need to make this change before changing the pipeline.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3596)