### PR TITLE
update web.config to serve static font files

### DIFF
--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/source/web.config
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/source/web.config
@@ -8,7 +8,6 @@
 		</httpProtocol>
 		<staticContent>
 			<mimeMap fileExtension=".json" mimeType="application/json" />
-			<mimeMap fileExtension=".json" mimeType="application/json" />
 			<mimeMap fileExtension=".woff" mimeType="application/font-woff" />
 			<mimeMap fileExtension=".woff2" mimeType="application/font-woff" /> 
 			<mimeMap fileExtension=".ttf" mimeType="application/octet-stream" />

--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/source/web.config
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/source/web.config
@@ -12,6 +12,7 @@
 			<mimeMap fileExtension=".woff2" mimeType="application/font-woff" /> 
 			<mimeMap fileExtension=".ttf" mimeType="application/octet-stream" />
 			<mimeMap fileExtension=".svg" mimeType="image/svg+xml" />
+			<mimeMap fileExtension=".eot" mimeType="application/vnd.ms-fontobject" />
 		</staticContent>
 		<rewrite>
 			<rules>

--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/source/web.config
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/source/web.config
@@ -8,6 +8,11 @@
 		</httpProtocol>
 		<staticContent>
 			<mimeMap fileExtension=".json" mimeType="application/json" />
+			<mimeMap fileExtension=".json" mimeType="application/json" />
+			<mimeMap fileExtension=".woff" mimeType="application/font-woff" />
+			<mimeMap fileExtension=".woff2" mimeType="application/font-woff" /> 
+			<mimeMap fileExtension=".ttf" mimeType="application/octet-stream" />
+			<mimeMap fileExtension=".svg" mimeType="image/svg+xml" />
 		</staticContent>
 		<rewrite>
 			<rules>


### PR DESCRIPTION
Fixes #3588

This is necessary so that Azure serves our static font files (for font-awesome). I updated the web.config on the CI server directly and confirmed this resolves the errors seen at https://adaptivecards.io

![image](https://user-images.githubusercontent.com/1432195/68693446-27a44b80-052c-11ea-8fcc-18c4135b7c13.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3597)