### PR TITLE
[Android] Add support for new lines in TextBlock

### DIFF
--- a/samples/v1.2/Tests/newline_card.json
+++ b/samples/v1.2/Tests/newline_card.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.0",
+  "body": [
+    {
+      "type": "Container",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "Publish Adaptive Card schema",
+          "weight": "bolder",
+          "size": "medium"
+        },
+        {
+          "type": "ColumnSet",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "auto",
+              "items": [
+                {
+                  "size": "small",
+                  "style": "person",
+                  "type": "Image",
+                  "url": "https://pbs.twimg.com/profile_images/3647943215/d7f12830b3c17a5a9e4afcc370e3a37e_400x400.jpeg"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "Matt Hidinger",
+                  "weight": "bolder",
+                  "wrap": true
+                },
+                {
+                  "type": "TextBlock",
+                  "spacing": "none",
+                  "text": "Created {{DATE(2017-02-14T06:08:39Z, SHORT)}}",
+                  "isSubtle": true,
+                  "wrap": true
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "Hi Team,\n\n2 things: \n\n1) @Micheal gave me some great feedback to start sharing my research trips more broadly to the desktop folks. I will be sharing research trips and insights to everyone and not just the team I travel with. So get ready to learn more about our users 🙂\n\n2) I recently visited customers in London with @Meghan Stockdale to research Somethings+SomeOtherThing+something. I wanted to share some insights from the trip that Meghan put together! For context this information is based off 4 companies and 85 customers. (full deck here: Modern Collaboration_ Content and Comms System feedback.pptx)",
+          "wrap": true
+        },
+        {
+          "type": "FactSet",
+          "facts": [
+            {
+              "title": "Board:",
+              "value": "Adaptive Card"
+            },
+            {
+              "title": "List:",
+              "value": "Backlog"
+            },
+            {
+              "title": "Assigned to:",
+              "value": "Matt Hidinger"
+            },
+            {
+              "title": "Due date:",
+              "value": "Not set"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "actions": [
+    {
+      "type": "Action.ShowCard",
+      "title": "Set due date",
+      "card": {
+        "type": "AdaptiveCard",
+        "version": "1.0",
+        "body": [
+          {
+            "type": "Input.Date",
+            "id": "dueDate"
+          }
+        ],
+        "actions": [
+          {
+            "type": "Action.Submit",
+            "title": "OK"
+          }
+        ]
+      }
+    },
+    {
+      "type": "Action.ShowCard",
+      "title": "Comment",
+      "card": {
+        "type": "AdaptiveCard",
+        "version": "1.0",
+        "body": [
+          {
+            "type": "Input.Text",
+            "id": "comment",
+            "isMultiline": true,
+            "placeholder": "Enter your comment"
+          }
+        ],
+        "actions": [
+          {
+            "type": "Action.Submit",
+            "title": "OK"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/samples/v1.2/Tests/newline_card_r.json
+++ b/samples/v1.2/Tests/newline_card_r.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.0",
+  "body": [
+    {
+      "type": "Container",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "Publish Adaptive Card schema",
+          "weight": "bolder",
+          "size": "medium"
+        },
+        {
+          "type": "ColumnSet",
+          "columns": [
+            {
+              "type": "Column",
+              "width": "auto",
+              "items": [
+                {
+                  "size": "small",
+                  "style": "person",
+                  "type": "Image",
+                  "url": "https://pbs.twimg.com/profile_images/3647943215/d7f12830b3c17a5a9e4afcc370e3a37e_400x400.jpeg"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "width": "stretch",
+              "items": [
+                {
+                  "type": "TextBlock",
+                  "text": "Matt Hidinger",
+                  "weight": "bolder",
+                  "wrap": true
+                },
+                {
+                  "type": "TextBlock",
+                  "spacing": "none",
+                  "text": "Created {{DATE(2017-02-14T06:08:39Z, SHORT)}}",
+                  "isSubtle": true,
+                  "wrap": true
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "Hi Team,\r\r2 things: \r\r1) @Micheal gave me some great feedback to start sharing my research trips more broadly to the desktop folks. I will be sharing research trips and insights to everyone and not just the team I travel with. So get ready to learn more about our users 🙂\r\r2) I recently visited customers in London with @Meghan Stockdale to research Somethings+SomeOtherThing+something. I wanted to share some insights from the trip that Meghan put together! For context this information is based off 4 companies and 85 customers. (full deck here: Modern Collaboration_ Content and Comms System feedback.pptx)",
+          "wrap": true
+        },
+        {
+          "type": "FactSet",
+          "facts": [
+            {
+              "title": "Board:",
+              "value": "Adaptive Card"
+            },
+            {
+              "title": "List:",
+              "value": "Backlog"
+            },
+            {
+              "title": "Assigned to:",
+              "value": "Matt Hidinger"
+            },
+            {
+              "title": "Due date:",
+              "value": "Not set"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "actions": [
+    {
+      "type": "Action.ShowCard",
+      "title": "Set due date",
+      "card": {
+        "type": "AdaptiveCard",
+        "version": "1.0",
+        "body": [
+          {
+            "type": "Input.Date",
+            "id": "dueDate"
+          }
+        ],
+        "actions": [
+          {
+            "type": "Action.Submit",
+            "title": "OK"
+          }
+        ]
+      }
+    },
+    {
+      "type": "Action.ShowCard",
+      "title": "Comment",
+      "card": {
+        "type": "AdaptiveCard",
+        "version": "1.0",
+        "body": [
+          {
+            "type": "Input.Text",
+            "id": "comment",
+            "isMultiline": true,
+            "placeholder": "Enter your comment"
+          }
+        ],
+        "actions": [
+          {
+            "type": "Action.Submit",
+            "title": "OK"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/source/android/adaptivecards/src/androidTest/java/io/adaptivecards/objectmodel/TextBlockPropertiesTest.java
+++ b/source/android/adaptivecards/src/androidTest/java/io/adaptivecards/objectmodel/TextBlockPropertiesTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 package io.adaptivecards.objectmodel;
 
 import android.util.Pair;
@@ -315,7 +317,22 @@ public class TextBlockPropertiesTest
         final String textWithNewLines = "This is some string\nAnd this is another line\r";
         // This looks counter intuitive but without the replacement of '\n\r' for "<br/>" the
         // output will only contain a blank space where '\n' is expected
-        final String expectedHtml = "This is some string\nAnd this is another line ";
+        final String expectedHtml = "This is some string\nAnd this is another line";
+
+        // "(\n\r, \r\n, \r, \n)" are all considered line breaks that are converted to \n
+        // The last line breaks are also removed in the handleSpecialText function
+        String html = RendererUtil.handleSpecialText(textWithNewLines).toString();
+
+        Assert.assertEquals(expectedHtml, html);
+    }
+
+    @Test
+    public void TestNumberedList () throws Exception
+    {
+        final String textWithNewLines = "1. Green\r2. Orange\r3. Blue";
+        // This looks counter intuitive but without the replacement of '\n\r' for "<br/>" the
+        // output will only contain a blank space where '\n' is expected
+        final String expectedHtml = "1. Green\n2. Orange\n3. Blue";
 
         String html = RendererUtil.handleSpecialText(textWithNewLines).toString();
 

--- a/source/android/adaptivecards/src/androidTest/java/io/adaptivecards/objectmodel/TextBlockPropertiesTest.java
+++ b/source/android/adaptivecards/src/androidTest/java/io/adaptivecards/objectmodel/TextBlockPropertiesTest.java
@@ -8,6 +8,8 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 
+import io.adaptivecards.renderer.readonly.RendererUtil;
+
 public class TextBlockPropertiesTest
 {
     static {
@@ -305,6 +307,19 @@ public class TextBlockPropertiesTest
             TextBlock parsedTextBlock = TestUtil.castToTextBlock(result.GetAdaptiveCard().GetBody().get(0));
             Assert.assertEquals((boolean)testTuple.first, parsedTextBlock.GetWrap());
         }
+    }
+
+    @Test
+    public void TestLineBreaks () throws Exception
+    {
+        final String textWithNewLines = "This is some string\nAnd this is another line\r";
+        // This looks counter intuitive but without the replacement of '\n\r' for "<br/>" the
+        // output will only contain a blank space where '\n' is expected
+        final String expectedHtml = "This is some string\nAnd this is another line ";
+
+        String html = RendererUtil.handleSpecialText(textWithNewLines).toString();
+
+        Assert.assertEquals(expectedHtml, html);
     }
 
     // This string is the result for an empty textblock or a textblock with all default values

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/RendererUtil.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/RendererUtil.java
@@ -55,7 +55,7 @@ public class RendererUtil
 
         // preprocess string to change <li> to <listItem> so we get a chance to handle them
         textString = textString.replace("<li>", "<listItem>");
-        textString = textString.replace(System.lineSeparator(), "<br/>");
+        textString = textString.replaceAll("(" + System.lineSeparator() + "|\r\n|\n\r|\r|\n)", "<br/>");
 
         Spanned htmlString;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/RendererUtil.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/RendererUtil.java
@@ -55,6 +55,7 @@ public class RendererUtil
 
         // preprocess string to change <li> to <listItem> so we get a chance to handle them
         textString = textString.replace("<li>", "<listItem>");
+        textString = textString.replace(System.lineSeparator(), "<br/>");
 
         Spanned htmlString;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)


### PR DESCRIPTION
## Related Issue
Fixes #3531 

## Description
Due to some preprocessing done in Android to support Markdown we translate the text strings into HTML, this causes \n or \r to be ignored. For this solution, \n and \r are replaced by <br/> as that's HTML's the new line 

## How Verified
Manual testing was performed with the provided card and this is the result

![Screenshot_20191112-135423_AdaptiveCards Visualizer](https://user-images.githubusercontent.com/35784165/68701043-d5b6f200-053a-11ea-8970-e4b79e4f0474.jpg)

As the TextBlock.Markdown card also contained /r the card was also tested 

![Screenshot_20191112-135409_AdaptiveCards Visualizer](https://user-images.githubusercontent.com/35784165/68701057-d8194c00-053a-11ea-82cf-26feb67e01c7.jpg)

A unit test was also added to check the correct management of '\n' characters during preprocessing

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3599)