### PR TITLE
Move release/1.2 branch to 1.2.5

### DIFF
--- a/custom.props
+++ b/custom.props
@@ -4,7 +4,7 @@
     <VersionMajor>1</VersionMajor>
     <VersionMinor>2</VersionMinor>
     <!-- The nuget package version should be incremented when we produce QFEs -->
-    <NuGetPackVersion>1.2.4</NuGetPackVersion>
+    <NuGetPackVersion>1.2.5</NuGetPackVersion>
     <VersionInfoProductName>AdaptiveCards</VersionInfoProductName>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Update `release/1.2` branch version to 1.2.5 in prep for next patch.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3603)