### PR TITLE
Adding /profile linker option

### DIFF
--- a/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj
+++ b/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj
@@ -93,6 +93,7 @@
         user32.lib;
         %(AdditionalDependencies);
       </AdditionalDependencies>
+      <AdditionalOptions>/profile %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <CustomBuildStep>
       <Command>mdmerge -partial -i "$(OutDir)$(TargetName).winmd" -o "$(OutDir)Output" -metadata_dir "$(WindowsSDK_MetadataFoundationPath)" -metadata_dir "$(WindowsSDK_MetadataPathVersioned)\Windows.Foundation.UniversalApiContract\8.0.0.0" &amp;&amp; copy /y "$(OutDir)Output\*" "$(OutDir)"</Command>


### PR DESCRIPTION
For this issue: https://github.com/microsoft/AdaptiveCards/issues/3606

This flag is needed for mandatory static analysis as part of our process.

## Related Issue
Fixes #3606 

## Description
Our compliance process requires binaries to be built with /profile to generate additional context for mandatory static analysis.

This should not change our dll from its existing state [Documented here](https://docs.microsoft.com/en-us/cpp/build/reference/profile-performance-tools-profiler?view=vs-2019)

Note: The documentation specifies that the program image will be affected by a "relocation section"- however this is caused by the implied /FIXED:NO flag. /FIXED:NO is the default for msbuild, so we were generating that anyway.

## How Verified
No unit testing. I built locally with this flag and passed it through the static analysis tool and where before it had errors it now passes.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3607)