### PR TITLE
[Android] Add empty options support for ChoiceSet

### DIFF
--- a/samples/v1.2/Tests/choice_default_value.json
+++ b/samples/v1.2/Tests/choice_default_value.json
@@ -1,0 +1,35 @@
+{
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "type": "AdaptiveCard",
+    "version": "1.0",
+    "body": [
+        {
+            "type": "TextBlock",
+            "text": "What color do you want? *(isMultiSelect:false, style:compact)*"
+        },
+        {
+            "type": "Input.ChoiceSet",
+            "id": "myColor",
+            "choices": [
+                {
+                    "title": "Red",
+                    "value": "1"
+                },
+                {
+                    "title": "Green",
+                    "value": "2"
+                },
+                {
+                    "title": "Blue",
+                    "value": "3"
+                }
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "type": "Action.Submit",
+            "title": "Submit"
+        }
+    ]
+}

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/ChoiceSetInputRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/ChoiceSetInputRenderer.java
@@ -47,28 +47,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
 
-class ItemSelectedListener implements AdapterView.OnItemSelectedListener
-{
-    public ItemSelectedListener(ComboBoxInputHandler comboBoxInputHandler)
-    {
-        m_InputHandler = comboBoxInputHandler;
-    }
-
-    @Override
-    public void onItemSelected(AdapterView<?> parent, View view, int position, long id)
-    {
-        CardRendererRegistration.getInstance().notifyInputChange(m_InputHandler.getId(), m_InputHandler.getInput());
-    }
-
-    @Override
-    public void onNothingSelected(AdapterView<?> parent)
-    {
-        CardRendererRegistration.getInstance().notifyInputChange(m_InputHandler.getId(), m_InputHandler.getInput());
-    }
-
-    private ComboBoxInputHandler m_InputHandler;
-}
-
 public class ChoiceSetInputRenderer extends BaseCardElementRenderer
 {
     protected ChoiceSetInputRenderer()
@@ -289,7 +267,20 @@ public class ChoiceSetInputRenderer extends BaseCardElementRenderer
         spinner.setAdapter(spinnerArrayAdapter);
 
         spinner.setSelection(selection);
-        spinner.setOnItemSelectedListener(new ItemSelectedListener(comboBoxInputHandler));
+        spinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener()
+        {
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int position, long id)
+            {
+                CardRendererRegistration.getInstance().notifyInputChange(comboBoxInputHandler.getId(), comboBoxInputHandler.getInput());
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> parent)
+            {
+                CardRendererRegistration.getInstance().notifyInputChange(comboBoxInputHandler.getId(), comboBoxInputHandler.getInput());
+            }
+        });
         return spinner;
     }
 


### PR DESCRIPTION
## Related Issue
Fixes #3605 

## Description
Overrides the base behaviour of the ArrayAdapter to handle default empty values in such a way where the empty option is the default value but it's not a selectable value afterwards

## How Verified
The scenario was tested manually using the attached payload yielding this result

On the first image we can see that the empty value is "selected"
![Screenshot_20191115-131748_AdaptiveCards Visualizer](https://user-images.githubusercontent.com/35784165/68966553-47897880-0793-11ea-9a40-bc30a4a98d6b.jpg)

On the second image we can see that the empty value is not an option
![Screenshot_20191115-131754_AdaptiveCards Visualizer](https://user-images.githubusercontent.com/35784165/68966560-49ebd280-0793-11ea-99c6-756989099e45.jpg)

On the third image we can see the selected non-empty element
![Screenshot_20191115-131805_AdaptiveCards Visualizer](https://user-images.githubusercontent.com/35784165/68966570-4d7f5980-0793-11ea-8a0c-8a1e399366c2.jpg)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3615)