### PR TITLE
rename adaptive transformer, override accepting object

### DIFF
--- a/source/experimental/dotnet/AdaptiveCards.Templating/AdaptiveCards.Templating/AdaptiveCards.Templating.csproj
+++ b/source/experimental/dotnet/AdaptiveCards.Templating/AdaptiveCards.Templating/AdaptiveCards.Templating.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Jurassic" Version="3.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/experimental/dotnet/AdaptiveCards.Templating/AdaptiveCards.Templating/AdaptiveTransformer.cs
+++ b/source/experimental/dotnet/AdaptiveCards.Templating/AdaptiveCards.Templating/AdaptiveTransformer.cs
@@ -1,15 +1,16 @@
 using Jurassic;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace AdaptiveCards.Templating
 {
-    public class AdaptiveTransformer
+    public class AdaptiveTemplate
     {
         private ScriptEngine _scriptEngine;
 
-        public AdaptiveTransformer()
+        public AdaptiveTemplate()
         {
             _scriptEngine = new ScriptEngine();
 
@@ -42,9 +43,30 @@ namespace AdaptiveCards.Templating
             return _jsHelper;
         }
 
-        public string Transform(string jsonTemplate, string jsonData)
+        /// <summary>
+        /// Expand the template and bind the data
+        /// </summary>
+        /// <param name="jsonTemplate">Your Json Template</param>
+        /// <param name="jsonData">The Data to bind (Json Formatted)</param>
+        /// <returns></returns>
+        public string Expand(string jsonTemplate, string jsonData)
         {
-            return _scriptEngine.CallGlobalFunction<string>("transform", jsonTemplate, jsonData);
+            return _scriptEngine.CallGlobalFunction<string>("expand", jsonTemplate, jsonData);
         }
+
+
+        /// <summary>
+        /// Expand the template and bind the data
+        /// </summary>
+        /// <param name="jsonTemplate">Your Json Template</param>
+        /// <param name="jsonData">The Data to bind (Serializable Object)</param>
+        /// <returns></returns>
+        public string Expand(string jsonTemplate, object Data)
+        {
+            var jsonData = JsonConvert.SerializeObject(Data,
+                new JsonSerializerSettings() { ReferenceLoopHandling = ReferenceLoopHandling.Ignore });
+            return _scriptEngine.CallGlobalFunction<string>("expand", jsonTemplate, jsonData);
+        }
+
     }
 }

--- a/source/experimental/dotnet/AdaptiveCards.Templating/AdaptiveCards.Templating/AdaptiveTransformer.cs
+++ b/source/experimental/dotnet/AdaptiveCards.Templating/AdaptiveCards.Templating/AdaptiveTransformer.cs
@@ -57,14 +57,21 @@ namespace AdaptiveCards.Templating
 
         /// <summary>
         /// Expand the template and bind the data
+		/// Note that everything in your data object will be serialized to JSON.
+		/// To avoid performance issues only pass in the data required by your template
         /// </summary>
         /// <param name="jsonTemplate">Your Json Template</param>
-        /// <param name="jsonData">The Data to bind (Serializable Object)</param>
+        /// <param name="jsonData">The Data to bind (will be serialized internally)</param>
         /// <returns></returns>
-        public string Expand(string jsonTemplate, object Data)
+        public string Expand(string jsonTemplate, object Data, JsonSerializerSettings serializerSettings = null)
         {
-            var jsonData = JsonConvert.SerializeObject(Data,
-                new JsonSerializerSettings() { ReferenceLoopHandling = ReferenceLoopHandling.Ignore });
+            // Use passed serializer settings if null use internal defaults
+            var serializerSettingsToUse = serializerSettings != null ? serializerSettings :
+                new JsonSerializerSettings() {
+                    ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+                    DefaultValueHandling = DefaultValueHandling.Ignore};
+
+            var jsonData = JsonConvert.SerializeObject(Data, serializerSettingsToUse);
             return _scriptEngine.CallGlobalFunction<string>("expand", jsonTemplate, jsonData);
         }
 

--- a/source/experimental/dotnet/AdaptiveCards.Templating/AdaptiveCards.Templating/AdaptiveTransformer.cs
+++ b/source/experimental/dotnet/AdaptiveCards.Templating/AdaptiveCards.Templating/AdaptiveTransformer.cs
@@ -57,8 +57,8 @@ namespace AdaptiveCards.Templating
 
         /// <summary>
         /// Expand the template and bind the data
-		/// Note that everything in your data object will be serialized to JSON.
-		/// To avoid performance issues only pass in the data required by your template
+        /// Note that everything in your data object will be serialized to JSON.
+        /// To avoid performance issues only pass in the data required by your template
         /// </summary>
         /// <param name="jsonTemplate">Your Json Template</param>
         /// <param name="jsonData">The Data to bind (will be serialized internally)</param>

--- a/source/experimental/dotnet/AdaptiveCards.Templating/AdaptiveCards.Templating/js/script.js
+++ b/source/experimental/dotnet/AdaptiveCards.Templating/AdaptiveCards.Templating/js/script.js
@@ -1,4 +1,4 @@
-function transform(jsonTemplate, jsonData) {
+function expand(jsonTemplate, jsonData) {
     var template = new ACData.Template(JSON.parse(jsonTemplate));
 
     var context = new ACData.EvaluationContext();


### PR DESCRIPTION
## Description
* Added Newtonsoft.Json to support serialization
* Added a new override to expand accepting any object (serializes the object to json, object needs to be serializable)
* Renamed class to AdaptiveTemplate and transform to expand to be inline with JS SDK

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3620)