### PR TITLE
[TS] Fix collapsed ShowCard losing input values

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -4595,7 +4595,7 @@ class ActionCollection {
 
         (<InlineAdaptiveCard>action.card).suppressStyle = suppressStyle;
 
-        var renderedCard = action.card.render();
+        var renderedCard = action.card.renderedElement ? action.card.renderedElement : action.card.render();
 
         this._actionCard = renderedCard;
         this._expandedAction = action;


### PR DESCRIPTION
## Related Issue
Fixes https://github.com/microsoft/AdaptiveCards/issues/3617#event-2808512127

## Description
ShowCard was always re-rendered, losing the values in the `<input>` elements. This fix reuses the previously rendered ShowCard if possible.

## How Verified
Verified manually in adaptivecards-visualizer

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3621)