### PR TITLE
[TS] Fix RichTextBlock rendering bug

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -1572,15 +1572,24 @@ export class RichTextBlock extends CardElement {
                     break;
             }
 
+            let renderedInlines: number = 0;
+
             for (let inline of this._inlines) {
-                element.appendChild(inline.render());
+                let renderedInline = inline.render();
+
+                if (renderedInline) {
+                    element.appendChild(renderedInline);
+
+                    renderedInlines++;
+                }
             }
 
-            return element;
+            if (renderedInlines > 0) {
+                return element;
+            }
         }
-        else {
-            return null;
-        }
+
+        return null;
     }
 
     asString(): string {


### PR DESCRIPTION
## Related Issue
Fixes https://github.com/microsoft/AdaptiveCards/issues/3523

## Description
When a `TextRun` in a `RichTextBlock` had an empty text property, its internal render code would output `null` (by design) but the RichTextBlock would fail to test for that and attempt to append null to its child collection, generating an uncaught exception that caused the card to fail to render.

Test payload:
```
{
    "type": "AdaptiveCard",
    "version": "1.0",
    "body": [
        {
            "type": "TextBlock",
            "text": "This text should be displayed"
        },
        {
            "type": "RichTextBlock",
            "inlines": [
                {
                    "type": "TextRun"
                }
            ]
        }
    ],
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json"
}
```

## How Verified
Verified manually in adaptivecards-designer-app as well as https://adaptivecardsci.z5.web.core.windows.net/pr/3645/designer

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3645)