### PR TITLE
for some reason this file is "unable to parse" in the build server

### DIFF
--- a/source/tools/hostConfig/json-to-scss/package-lock.json
+++ b/source/tools/hostConfig/json-to-scss/package-lock.json
@@ -1,14 +1,14 @@
 {
-  "name": "microsoft-adaptivecards-json-to-scss",
-  "version": "1.0.0",
-  "lockfileVersion": 1,
-  "requires": true,
-  "dependencies": {
-    "typescript": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.1.5.tgz",
-      "integrity": "sha1-b+lHngDgGFUkfOohbnVhuvzbzUo=",
-      "dev": true
-    }
-  }
+	"name": "microsoft-adaptivecards-json-to-scss",
+	"version": "1.0.0",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"typescript": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.1.5.tgz",
+			"integrity": "sha1-b+lHngDgGFUkfOohbnVhuvzbzUo=",
+			"dev": true
+		}
+	}
 }


### PR DESCRIPTION
Build server is reporting a failure in this file, but I'm not sure why. Seeing if this helps

##[warning]Could not parse Jtokens from C:\BA\7861\s\source\tools\hostConfig\json-to-scss\package-lock.json file.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3667)