### PR TITLE
[UWP] Fix RendererRegistration error handling and fix inheritance issue with WholeItemsPanel

### DIFF
--- a/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
+++ b/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
@@ -2123,8 +2123,8 @@ AdaptiveNamespaceStart
         contract(InternalContract, 1),
         internal
 #endif
-    ]
-    runtimeclass WholeItemsPanel
+    ] 
+    runtimeclass WholeItemsPanel : Windows.UI.Xaml.Controls.Panel
     {
         String GetAltText();
         Boolean IsAllContentClippedOut();


### PR DESCRIPTION
## Related Issue
Fixes #3709 

## Description
Two issues here:

1) The renderer needs to run on the UI thread rather than the main test thread, so the test happens in a dispatcher. Unfortunately, exceptions thrown there cause the UWP test infrastructure to abort the test. Updated the test to catch the exception and throw it on the main test thread so it is reported properly as a test failure. Also updated other tests with the same pattern.

2) A bug in the update to modern idl caused WholeItemsPanel to lose it's inheritance from Panel. This broke the test function GetAllDescendants, because that function casts all elements in the tree as UIElement, and WholeItemsPanel no longer successfully cast. Added that inheritance back.

## How Verified
RendererRegistration tests now pass successfully.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3710)