### PR TITLE
[UWP] Remove image comparison from unit tests

### DIFF
--- a/source/uwp/UWPTestLibrary/TestResultViewModel.cs
+++ b/source/uwp/UWPTestLibrary/TestResultViewModel.cs
@@ -490,7 +490,7 @@ namespace UWPTestLibrary
             {
                 return "Passed";
             }
-            else if (NewCard == true)
+            else if (NewCard)
             {
                 if (Error == null)
                 {

--- a/source/uwp/UWPTestLibrary/TestResultViewModel.cs
+++ b/source/uwp/UWPTestLibrary/TestResultViewModel.cs
@@ -199,6 +199,8 @@ namespace UWPTestLibrary
                     }
                 }
 
+                answer.Status.Error = answer.TestResult.Error;
+
                 // If both had error, compare via the error
                 if (answer.ExpectedError != null && answer.TestResult.Error != null)
                 {
@@ -463,6 +465,8 @@ namespace UWPTestLibrary
         /// <summary> This is a new card</summary>
         public bool NewCard { get; set; } = false;
 
+        public string Error;
+
         /// <summary> Set the status to a passing result</summary>
         public void SetToPassingStatus(bool matchedViaError)
         {
@@ -488,7 +492,14 @@ namespace UWPTestLibrary
             }
             else if (NewCard == true)
             {
-                return "New Card Added";
+                if (Error == null)
+                {
+                    return "New Card Added";
+                }
+                else
+                {
+                    return "Error in new card";
+                }
             }
             else if (!OriginalMatched && ((!ImageMatched || !JsonRoundTripMatched) && !MatchedViaError))
             {


### PR DESCRIPTION
## Related Issue
Fixes: #3719

## Description
Updated the unit tests that runs all files to not require image comparisons to match. Image comparison is not stable enough to run as an automated blocking test at this time, and this change decouples stabilizing the test app from getting a basic rendering pass of all files into CI.

A file will pass for the unit test if it 
1. Is expected to fail, and does
2. It is expected to succeed and does, and the expected round tripped json is unchanged
3. It is a new file, and renders successfully.

## How Verified
Unit test suite passes consistently

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3724)