### PR TITLE
[UWP][Visualizer Accessibility] Tab Order Fixes

### DIFF
--- a/source/uwp/Visualizer/DocumentView.xaml
+++ b/source/uwp/Visualizer/DocumentView.xaml
@@ -19,7 +19,19 @@
         </Grid.ColumnDefinitions>
 
         <!--Editor and errors-->
-        <local:GenericDocumentView />
+        <local:GenericDocumentView x:Name="GenericDocumentViewName"/>
+
+        <!--Vertical draggable column splitter-->
+        <toolkitControls:GridSplitter
+            Width="11"
+            Background="{ThemeResource SystemControlBackgroundAccentBrush}"
+            GripperCursor="Default"
+            HorizontalAlignment="Left"
+            Grid.Column="1"
+            ResizeDirection="Auto"
+            ResizeBehavior="BasedOnAlignment"
+            CursorBehavior="ChangeOnSplitterHover"
+            GripperForeground="White"/>
 
         <!--Preview-->
         <Grid
@@ -39,17 +51,5 @@
                     Height="40"/>
             </Border>
         </Grid>
-
-        <!--Vertical draggable column splitter-->
-        <toolkitControls:GridSplitter
-            Width="11"
-            Background="{ThemeResource SystemControlBackgroundAccentBrush}"
-            GripperCursor="Default"
-            HorizontalAlignment="Left"
-            Grid.Column="1"
-            ResizeDirection="Auto"
-            ResizeBehavior="BasedOnAlignment"
-            CursorBehavior="ChangeOnSplitterHover"
-            GripperForeground="White"/>
     </Grid>
 </UserControl>

--- a/source/uwp/Visualizer/GenericDocumentView.xaml
+++ b/source/uwp/Visualizer/GenericDocumentView.xaml
@@ -39,7 +39,7 @@
         </ScrollViewer>
 
         <!--Error info-->
-        <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" MaxHeight="200">
+        <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" MaxHeight="200" IsEnabled="False">
             <ItemsControl ItemsSource="{Binding Errors}">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>

--- a/source/uwp/Visualizer/MainPage.xaml
+++ b/source/uwp/Visualizer/MainPage.xaml
@@ -118,34 +118,6 @@
             </Grid>
         </Grid>
 
-
-
-
-
-
-
-
-
-        <!-- JSON input panel-->
-        <!--<Grid Grid.Column="0">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="5"/>
-                <RowDefinition Height="*"/>
-            </Grid.RowDefinitions>
-            <TextBlock Text="JSON:" HorizontalAlignment="Left" VerticalAlignment="Bottom" Grid.Row="0"/>
-            <RichEditBox x:Name="adaptiveJson" Grid.Row="2"/>
-        </Grid>-->
-
-        <!-- Render outputs-->
-        <!--<Grid Grid.Column="2">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="*"/>
-            </Grid.RowDefinitions>
-            <TextBlock Text="Rendered As Xaml Output:" Grid.Row="0"/>
-            <ContentPresenter x:Name="renderedXamlPresenter" Grid.Row="1"/>
-        </Grid>-->
     </Grid>
     
 </Page>

--- a/source/uwp/Visualizer/ViewModel/GenericDocumentViewModel.cs
+++ b/source/uwp/Visualizer/ViewModel/GenericDocumentViewModel.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+using AdaptiveCardVisualizer.Helpers;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Windows.Storage;
 using Windows.UI.Popups;
-using AdaptiveCardVisualizer.Helpers;
 
 namespace AdaptiveCardVisualizer.ViewModel
 {


### PR DESCRIPTION
## Related Issue
Fixes #3771 
Fixes #3772

## Description
Two fixes related to tab order in the UWP visualizer:
1. Tab order went json panel->rendered card->grid splitter, when json panel->grid splitter->rendered card would be more appropriate. Changed the order of those two elements in xaml to update this ordering.
2. The error panel was included in the tab order even though it is not interactive. Set IsEnabled to false to indicate to xaml that the error panel should not have a tab stop.

## How Verified
Manually confirmed tab order now behaves as expected in these cases.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3773)