### PR TITLE
[UWP] Set background image tile control to IsEnabled false to avoid generating extraneous tab stops

### DIFF
--- a/source/uwp/Renderer/lib/XamlHelpers.cpp
+++ b/source/uwp/Renderer/lib/XamlHelpers.cpp
@@ -334,6 +334,12 @@ namespace AdaptiveNamespace::XamlHelpers
         // Creates the background image for all fill modes
         ComPtr<TileControl> tileControl;
         THROW_IF_FAILED(MakeAndInitialize<TileControl>(&tileControl));
+
+        // Set IsEnabled to false to avoid generating a tab stop for the background image tile control
+        ComPtr<IControl> tileControlAsControl;
+        THROW_IF_FAILED(tileControl.As(&tileControlAsControl));
+        THROW_IF_FAILED(tileControlAsControl->put_IsEnabled(false));
+
         THROW_IF_FAILED(tileControl->put_BackgroundImage(backgroundImage));
 
         ComPtr<IFrameworkElement> rootElement;


### PR DESCRIPTION
## Related Issue
Fixes #3777 

## Description
The additional tab stop is caused by the custom TileControl which hosts the background image. Because this is not intended as an interactive control, set IsEnabled to false to remove the tab stop.

## How Verified
Manually verified additional tab stop is no longer present using [AdaptiveCard.BackgroundImage.FillMode.Cover.json](https://github.com/microsoft/AdaptiveCards/blob/master/samples/v1.2/Elements/AdaptiveCard.BackgroundImage.FillMode.Cover.json)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3778)