### PR TITLE
Fixed Issue #3776, Crashing While Unwrapping Paragraph Tag

### DIFF
--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/MarkDownUnitTest.cpp
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/MarkDownUnitTest.cpp
@@ -17,6 +17,20 @@ namespace AdaptiveCardsSharedModelUnitTest
             Assert::AreEqual<bool>(false, parser.HasHtmlTags());
         }
 
+        TEST_METHOD(MarkDownBasicSanityTest_CanHandleEmphasisTest)
+        {
+            MarkDownParser parser("*");
+            Assert::AreEqual<std::string>("<p>*</p>", parser.TransformToHtml());
+            Assert::AreEqual<bool>(false, parser.HasHtmlTags());
+        }
+
+        TEST_METHOD(MarkDownBasicSanityTest_CanHandleStrongEmphasisTest)
+        {
+            MarkDownParser parser("**");
+            Assert::AreEqual<std::string>("<p>**</p>", parser.TransformToHtml());
+            Assert::AreEqual<bool>(false, parser.HasHtmlTags());
+        }
+
         TEST_METHOD(EmphasisLeftDelimiterTest_LeftDelimiterTest)
         {
             MarkDownParser parser("*foo bar*");

--- a/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownHtmlGenerator.cpp
@@ -95,6 +95,11 @@ void MarkDownEmphasisHtmlGenerator::PushBoldTag()
 
 std::string MarkDownLeftEmphasisHtmlGenerator::GenerateHtmlString()
 {
+    if (m_isHead)
+    {
+        html << "<p>";
+    }
+
     if (m_numberOfUnusedDelimiters)
     {
         const size_t startIdx = m_token.size() - m_numberOfUnusedDelimiters;
@@ -105,11 +110,6 @@ std::string MarkDownLeftEmphasisHtmlGenerator::GenerateHtmlString()
     for (auto itr = m_tags.rbegin(); itr != m_tags.rend(); ++itr)
     {
         html << *itr;
-    }
-
-    if (m_isHead)
-    {
-        return "<p>" + html.str();
     }
 
     if (m_isTail)
@@ -132,6 +132,11 @@ void MarkDownRightEmphasisHtmlGenerator::PushBoldTag()
 
 std::string MarkDownRightEmphasisHtmlGenerator::GenerateHtmlString()
 {
+    if (m_isHead)
+    {
+        html << "<p>";
+    }
+
     // append tags;
     for (auto itr = m_tags.begin(); itr != m_tags.end(); ++itr)
     {
@@ -143,11 +148,6 @@ std::string MarkDownRightEmphasisHtmlGenerator::GenerateHtmlString()
     {
         const size_t startIdx = m_token.size() - m_numberOfUnusedDelimiters;
         html << m_token.substr(startIdx, std::string::npos);
-    }
-
-    if (m_isHead)
-    {
-        return "<p>" + html.str();
     }
 
     if (m_isTail)


### PR DESCRIPTION
## Related Issue
Fixes #3776 

## Description
This PR fixes the crash reported by #3776. The crash happens while unwrapping ```<p>``` tags from the text. There was missing ```</p>``` tags. Fix was made to shared MarkDownParser code. The parser code returns immediately when it sees that a given token is marked as Head. This only happens to emphasis and strong emphasis tokens. If a string is a single emphasis (*) and strong emphasis (**), a token can be both head and tail, so returning from translation upon seeing the tag is marked head is a programming error. 

## How Verified

Added unit tests to cover those cases.
Inspected all codes to make sure that only emphasis and strong emphasis tokens exhibit this behavior.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3779)