### PR TITLE
[Android] Change styleBitmap accesibility in ImageLoaders to public

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/GenericImageLoaderAsync.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/GenericImageLoaderAsync.java
@@ -244,7 +244,7 @@ public abstract class GenericImageLoaderAsync extends AsyncTask<String, Void, Ht
     }
 
     // By default, this function keeps the bitmap as is
-    protected Bitmap styleBitmap(Bitmap bitmap)
+    public Bitmap styleBitmap(Bitmap bitmap)
     {
         return bitmap;
     }

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/action/ActionElementRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/action/ActionElementRenderer.java
@@ -82,7 +82,7 @@ public class ActionElementRenderer extends BaseActionElementRenderer
         }
 
         @Override
-        protected Bitmap styleBitmap(Bitmap bitmap)
+        public Bitmap styleBitmap(Bitmap bitmap)
         {
             Button button = (Button) super.m_view;
 

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ImageRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ImageRenderer.java
@@ -83,7 +83,7 @@ public class ImageRenderer extends BaseCardElementRenderer
         }
 
         @Override
-        protected Bitmap styleBitmap(Bitmap bitmap)
+        public Bitmap styleBitmap(Bitmap bitmap)
         {
             if (bitmap != null && m_imageStyle == ImageStyle.Person)
             {

--- a/source/android/mobile/src/main/java/io/adaptivecards/adaptivecardssample/CustomObjects/Media/CustomImageLoaderForButtons.java
+++ b/source/android/mobile/src/main/java/io/adaptivecards/adaptivecardssample/CustomObjects/Media/CustomImageLoaderForButtons.java
@@ -1,0 +1,45 @@
+package io.adaptivecards.adaptivecardssample.CustomObjects.Media;
+
+import android.graphics.Bitmap;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import android.graphics.BitmapFactory;
+
+import java.net.URISyntaxException;
+
+import io.adaptivecards.renderer.GenericImageLoaderAsync;
+import io.adaptivecards.renderer.IResourceResolver;
+import io.adaptivecards.renderer.http.HttpRequestHelper;
+import io.adaptivecards.renderer.http.HttpRequestResult;
+
+public class CustomImageLoaderForButtons implements IResourceResolver
+{
+    @Override
+    public HttpRequestResult<Bitmap> resolveImageResource(String s, GenericImageLoaderAsync genericImageLoaderAsync) throws IOException, URISyntaxException
+    {
+        byte[] bytes = HttpRequestHelper.get(s);
+        if (bytes == null)
+        {
+            throw new IOException("Failed to retrieve content from " + s);
+        }
+
+        Bitmap bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
+        bitmap = genericImageLoaderAsync.styleBitmap(bitmap);
+
+        if (bitmap == null)
+        {
+            throw new IOException("Failed to convert content to bitmap: " + new String(bytes));
+        }
+
+        return new HttpRequestResult<>(bitmap);
+    }
+
+    @Override
+    public HttpRequestResult<Bitmap> resolveImageResource(String s, GenericImageLoaderAsync genericImageLoaderAsync, int i) throws IOException, URISyntaxException
+    {
+        return resolveImageResource(s, genericImageLoaderAsync);
+    }
+}

--- a/source/android/mobile/src/main/java/io/adaptivecards/adaptivecardssample/MainActivityAdaptiveCardsSample.java
+++ b/source/android/mobile/src/main/java/io/adaptivecards/adaptivecardssample/MainActivityAdaptiveCardsSample.java
@@ -96,6 +96,8 @@ public class MainActivityAdaptiveCardsSample extends FragmentActivity
         m_jsonEditText = (EditText) findViewById(R.id.jsonAdaptiveCard);
         m_configEditText = (EditText) findViewById(R.id.hostConfig);
 
+        CardRendererRegistration.getInstance().registerResourceResolver("http", new CustomImageLoaderForButtons());
+
         TextWatcher watcher = new TextWatcher()
         {
             @Override

--- a/source/android/mobile/src/main/java/io/adaptivecards/adaptivecardssample/MainActivityAdaptiveCardsSample.java
+++ b/source/android/mobile/src/main/java/io/adaptivecards/adaptivecardssample/MainActivityAdaptiveCardsSample.java
@@ -78,6 +78,7 @@ public class MainActivityAdaptiveCardsSample extends FragmentActivity
     private Switch m_customImageLoader;
     private Switch m_customMediaLoader;
     private Switch m_onlineImageLoader;
+    private Switch m_httpResourceResolver;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -95,8 +96,6 @@ public class MainActivityAdaptiveCardsSample extends FragmentActivity
         // Add text change handler
         m_jsonEditText = (EditText) findViewById(R.id.jsonAdaptiveCard);
         m_configEditText = (EditText) findViewById(R.id.hostConfig);
-
-        CardRendererRegistration.getInstance().registerResourceResolver("http", new CustomImageLoaderForButtons());
 
         TextWatcher watcher = new TextWatcher()
         {
@@ -173,6 +172,9 @@ public class MainActivityAdaptiveCardsSample extends FragmentActivity
 
         m_onlineImageLoader = (Switch) findViewById(R.id.onlineImageLoader);
         m_onlineImageLoader.setOnCheckedChangeListener(new SwitchListener(findViewById(R.id.cardsCustomOnlineImageLoader)));
+
+        m_httpResourceResolver = (Switch) findViewById(R.id.httpResourceResolver);
+        m_httpResourceResolver.setOnCheckedChangeListener(new SwitchListener(findViewById(R.id.cardsHttpResourceResolver)));
     }
 
     private void renderAdaptiveCardAfterDelay(boolean showErrorToast)
@@ -235,6 +237,13 @@ public class MainActivityAdaptiveCardsSample extends FragmentActivity
             svgImageLoader = new SvgImageLoader();
         }
         CardRendererRegistration.getInstance().registerResourceResolver("data", svgImageLoader);
+
+        CustomImageLoaderForButtons httpResourceResolver = null;
+        if (m_httpResourceResolver.isChecked())
+        {
+            httpResourceResolver = new CustomImageLoaderForButtons();
+        }
+        CardRendererRegistration.getInstance().registerResourceResolver("http", httpResourceResolver);
     }
 
     private void registerCustomMediaLoaders()

--- a/source/android/mobile/src/main/res/layout/content_main_activity_adaptive_cards_sample.xml
+++ b/source/android/mobile/src/main/res/layout/content_main_activity_adaptive_cards_sample.xml
@@ -295,6 +295,21 @@
                                 android:paddingLeft="15dp"
                                 android:text="Image.json"
                                 android:visibility="gone" />
+
+                            <Switch
+                                android:id="@+id/httpResourceResolver"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:text="ResourceResolver for all http
+                                images" />
+
+                            <TextView
+                                android:id="@+id/cardsHttpResourceResolver"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:paddingLeft="15dp"
+                                android:text="Action.OpenUrl.IconUrl.json"
+                                android:visibility="gone" />-
                         </LinearLayout>
                     </ScrollView>
                 </LinearLayout>


### PR DESCRIPTION
## Related Issue
Fixes #3775 

## Description
Changes the accessibility of the styleBitmap method to be usable by anyone using a resource resolver to load images and style them accordingly to the context where the images are renderered. 

## How Verified
Custom rendered was added to the Sample Application. Picture below

![Screenshot_20200218-152517_AdaptiveCards Visualizer](https://user-images.githubusercontent.com/35784165/74775123-e7024f80-5249-11ea-8633-6a229befc2d1.jpg)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3791)