### PR TITLE
[iOS] Fix clipped text in non-compact ChoiceSet

### DIFF
--- a/samples/v1.2/Tests/ChoiceSet.UnclippedText.json
+++ b/samples/v1.2/Tests/ChoiceSet.UnclippedText.json
@@ -1,0 +1,28 @@
+{
+    "type": "AdaptiveCard",
+    "version": "1.2"
+    "body": [
+        {
+            "type": "Container",
+            "style": "emphasis",
+            "items": [
+                {
+                    "type": "Input.ChoiceSet",
+                    "id": "0",
+                    "style": "expanded",
+                    "wrap": true,
+                    "choices": [
+                        {
+                            "title": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. End.",
+                            "value": "0"
+                        },
+                        {
+                            "title": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. End.",
+                            "value": "1"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/samples/v1.2/Tests/ChoiceSet.UnclippedText.json
+++ b/samples/v1.2/Tests/ChoiceSet.UnclippedText.json
@@ -1,6 +1,6 @@
 {
     "type": "AdaptiveCard",
-    "version": "1.2"
+    "version": "1.2",
     "body": [
         {
             "type": "Container",

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSource.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSource.h
@@ -32,4 +32,6 @@ extern NSString *uncheckedRadioButtonReuseID;
 
 - (NSString *)getTitlesOfChoices;
 
+- (float)getNonInputWidth:(UITableViewCell *)cell;
+
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSource.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSource.mm
@@ -190,13 +190,6 @@ const CGFloat accessoryViewWidth = 50.0f;
     }
 }
 
-/*
-- (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
-{
-    return UITableViewAutomaticDimension;
-}
-*/
- 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
 {
     UITableViewCell *cell = [tableView.dataSource tableView:tableView cellForRowAtIndexPath:indexPath];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSource.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSource.mm
@@ -55,6 +55,7 @@ const CGFloat accessoryViewWidth = 50.0f;
     NSArray *_defaultValuesArray;
     BOOL _shouldWrap;
     std::shared_ptr<HostConfig> _config;
+    CGSize _contentSize;
 }
 
 - (instancetype)initWithInputChoiceSet:(std::shared_ptr<AdaptiveCards::ChoiceSetInput> const &)choiceSet WithHostConfig:(std::shared_ptr<AdaptiveCards::HostConfig> const &)hostConfig;
@@ -189,6 +190,13 @@ const CGFloat accessoryViewWidth = 50.0f;
     }
 }
 
+/*
+- (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    return UITableViewAutomaticDimension;
+}
+*/
+ 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
 {
     UITableViewCell *cell = [tableView.dataSource tableView:tableView cellForRowAtIndexPath:indexPath];
@@ -199,12 +207,22 @@ const CGFloat accessoryViewWidth = 50.0f;
     } else {
         textString = cell.textLabel.text;
     }
+    
+    if (_contentSize.width == 0 && tableView.contentSize.width && tableView.frame.size.height)
+    {
+        _contentSize = tableView.contentSize;
+        [tableView invalidateIntrinsicContentSize];
+    }
+    
     CGSize labelStringSize =
-        [textString boundingRectWithSize:CGSizeMake(cell.contentView.frame.size.width - accessoryViewWidth, CGFLOAT_MAX)
+        [textString boundingRectWithSize:CGSizeMake(tableView.contentSize.width - [self getNonInputWidth:cell], CGFLOAT_MAX)
                                  options:NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading
                               attributes:@{NSFontAttributeName : cell.textLabel.font}
                                  context:nil]
             .size;
+    
+    [tableView layoutIfNeeded];
+    
     return labelStringSize.height + padding;
 }
 
@@ -250,6 +268,11 @@ const CGFloat accessoryViewWidth = 50.0f;
         return nil;
     }
     return [values componentsJoinedByString:@", "];
+}
+
+- (float)getNonInputWidth:(UITableViewCell *)cell
+{
+    return padding * 3 + cell.imageView.image.size.width;
 }
 
 @end


### PR DESCRIPTION
## Related Issue
Fixes https://github.com/microsoft/AdaptiveCards/issues/3804

## Description
Fixes height calculation for text labels in choice sets which allows text not to be clipped any more. 

## How Verified
The fix was verified manually and the test json was added to the test folder, below the result can be seen:

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-02-27 at 17 47 57](https://user-images.githubusercontent.com/35784165/75503056-7665dc00-5989-11ea-89fb-5bab63fb180c.png)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3809)