### PR TITLE
ActionSet refactoring & Extra View Removal.

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionSetRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionSetRenderer.mm
@@ -30,11 +30,19 @@
     return singletonInstance;
 }
 
-- (UIView *)render:(UIView<ACRIContentHoldingView> *)viewGroup rootView:(ACRView *)rootView inputs:(NSArray *)inputs baseCardElement:(ACOBaseCardElement *)acoElem hostConfig:(ACOHostConfig *)acoConfig
+- (UIView *)render:(UIView<ACRIContentHoldingView> *)viewGroup
+           rootView:(ACRView *)rootView
+             inputs:(NSArray *)inputs
+    baseCardElement:(ACOBaseCardElement *)acoElem
+         hostConfig:(ACOHostConfig *)acoConfig
 {
     std::shared_ptr<BaseCardElement> elem = [acoElem element];
     std::shared_ptr<ActionSet> actionSetElem = std::dynamic_pointer_cast<ActionSet>(elem);
-    return [self renderButtons:rootView inputs:(NSMutableArray *)inputs superview:viewGroup elems:actionSetElem->GetActions() hostConfig:acoConfig];
+    return [self renderButtons:rootView
+                        inputs:(NSMutableArray *)inputs
+                     superview:viewGroup
+                         elems:actionSetElem->GetActions()
+                    hostConfig:acoConfig];
 }
 
 - (UIView *)renderButtons:(ACRView *)rootView
@@ -60,24 +68,30 @@
     ACRRegistration *reg = [ACRRegistration getInstance];
     ACOFeatureRegistration *featureReg = [ACOFeatureRegistration getInstance];
 
-    UIView<ACRIContentHoldingView> *childview = nil;
+    UIStackView *childview = [[UIStackView alloc] init];
+    childview.distribution = UIStackViewDistributionFillProportionally;
     AdaptiveCards::ActionsConfig adaptiveActionConfig = [config getHostConfig] -> GetActions();
-    NSDictionary<NSString *, NSNumber *> *attributes =
-        @{@"spacing" : [NSNumber numberWithInt:adaptiveActionConfig.buttonSpacing],
-          @"distribution" : [NSNumber numberWithInt:UIStackViewDistributionFillProportionally]};
 
     if (ActionsOrientation::Horizontal == adaptiveActionConfig.actionsOrientation) {
-        childview = [[ACRColumnSetView alloc] initWithFrame:CGRectMake(0, 0, superview.frame.size.width, superview.frame.size.height) attributes:attributes];
-        ((ACRColumnSetView *)childview).isActionSet = YES;
+        childview.axis = UILayoutConstraintAxisHorizontal;
     } else {
-        childview = [[ACRColumnView alloc] initWithFrame:CGRectMake(0, 0, superview.frame.size.width, superview.frame.size.height) attributes:attributes];
-        ((ACRColumnView *)childview).isActionSet = YES;
+        childview.axis = UILayoutConstraintAxisVertical;
     }
 
     ACOBaseActionElement *acoElem = [[ACOBaseActionElement alloc] init];
+    // set width
     ACRContentHoldingUIScrollView *containingView = [[ACRContentHoldingUIScrollView alloc] init];
     [superview addArrangedSubview:containingView];
-    float accumulatedWidth = 0, accumulatedHeight = 0, spacing = adaptiveActionConfig.buttonSpacing, maxWidth = 0, maxHeight = 0;
+    [containingView.widthAnchor constraintLessThanOrEqualToAnchor:superview.widthAnchor
+                                                       multiplier:1.0
+                                                         constant:0]
+        .active = YES;
+
+    float accumulatedWidth = 0, accumulatedHeight = 0, spacing = adaptiveActionConfig.buttonSpacing,
+          maxWidth = 0, maxHeight = 0;
+    childview.spacing = spacing;
+    childview.translatesAutoresizingMaskIntoConstraints = NO;
+
     if (elems.empty()) {
         return containingView;
     }
@@ -85,7 +99,9 @@
     unsigned long uMaxActionsToRender = MIN(adaptiveActionConfig.maxActions, elems.size());
 
     if (uMaxActionsToRender < elems.size()) {
-        [rootView addWarnings:ACRWarningStatusCode::ACRMaxActionsExceeded mesage:@"Some actions were not rendered due to exceeding the maximum number of actions allowed"];
+        [rootView addWarnings:ACRWarningStatusCode::ACRMaxActionsExceeded
+                       mesage:@"Some actions were not rendered due to exceeding the maximum number "
+                              @"of actions allowed"];
     }
 
     for (auto i = 0; i < uMaxActionsToRender; i++) {
@@ -100,7 +116,7 @@
 
         [acoElem setElem:elem];
 
-        NSUInteger numElem = [childview subviewsCounts];
+        NSUInteger numElem = [[childview arrangedSubviews] count];
 
         UIButton *button = nil;
 
@@ -108,19 +124,18 @@
             if ([acoElem meetsRequirements:featureReg] == NO) {
                 @throw [ACOFallbackException fallbackException];
             }
-            button = [actionRenderer renderButton:rootView inputs:inputs superview:superview baseActionElement:acoElem hostConfig:config];
+            button = [actionRenderer renderButton:rootView
+                                           inputs:inputs
+                                        superview:superview
+                                baseActionElement:acoElem
+                                       hostConfig:config];
             [childview addArrangedSubview:button];
         } @catch (ACOFallbackException *exception) {
-            handleActionFallbackException(exception,
-                                          superview,
-                                          rootView,
-                                          inputs,
-                                          acoElem,
-                                          config,
+            handleActionFallbackException(exception, superview, rootView, inputs, acoElem, config,
                                           childview);
-            NSUInteger count = [childview subviewsCounts];
+            NSUInteger count = [childview.arrangedSubviews count];
             if (count > numElem) {
-                UIView *view = [childview getLastSubview];
+                UIView *view = [childview.arrangedSubviews lastObject];
                 if (view && [view isKindOfClass:[UIButton class]]) {
                     button = (UIButton *)view;
                 }
@@ -133,48 +148,58 @@
         maxHeight = MAX(maxHeight, [button intrinsicContentSize].height);
     }
 
-    float contentWidth = accumulatedWidth, contentHeight = accumulatedHeight;
-    [childview adjustHuggingForLastElement];
+    float contentWidth = accumulatedWidth;
     if (ActionsOrientation::Horizontal == adaptiveActionConfig.actionsOrientation) {
         contentWidth += (elems.size() - 1) * spacing;
-        contentHeight = maxHeight;
     } else {
-        contentHeight += (elems.size() - 1) * spacing;
         contentWidth = maxWidth;
     }
-    childview.frame = CGRectMake(0, 0, contentWidth, contentHeight);
-    containingView.frame = CGRectMake(0, 0, superview.frame.size.width, contentHeight);
-    containingView.translatesAutoresizingMaskIntoConstraints = NO;
-    [containingView addSubview:childview];
-    [NSLayoutConstraint constraintWithItem:containingView attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:childview attribute:NSLayoutAttributeTop multiplier:1.0 constant:0].active = YES;
-    [NSLayoutConstraint constraintWithItem:containingView attribute:NSLayoutAttributeBottom relatedBy:NSLayoutRelationEqual toItem:childview attribute:NSLayoutAttributeBottom multiplier:1.0 constant:0].active = YES;
-    [NSLayoutConstraint constraintWithItem:containingView attribute:NSLayoutAttributeLeading relatedBy:NSLayoutRelationEqual toItem:childview attribute:NSLayoutAttributeLeading multiplier:1.0 constant:0].active = YES;
-    [NSLayoutConstraint constraintWithItem:containingView attribute:NSLayoutAttributeTrailing relatedBy:NSLayoutRelationEqual toItem:childview attribute:NSLayoutAttributeTrailing multiplier:1.0 constant:0].active = YES;
-    NSLayoutConstraint *hConstraint = [NSLayoutConstraint constraintWithItem:childview attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationEqual toItem:containingView attribute:NSLayoutAttributeWidth multiplier:1.0 constant:0];
-    NSLayoutConstraint *vConstraint = [NSLayoutConstraint constraintWithItem:childview attribute:NSLayoutAttributeHeight relatedBy:NSLayoutRelationEqual toItem:containingView attribute:NSLayoutAttributeHeight multiplier:1.0 constant:0];
 
-    hConstraint.active = YES;
-    vConstraint.active = YES;
+    [containingView addSubview:childview];
+
+    containingView.contentview = childview;
+    containingView.contentWidth = contentWidth;
+
+    [containingView.heightAnchor constraintEqualToAnchor:childview.heightAnchor multiplier:1.0].active = YES;
+    containingView.translatesAutoresizingMaskIntoConstraints = NO;
+
+    [NSLayoutConstraint constraintWithItem:containingView
+                                 attribute:NSLayoutAttributeTop
+                                 relatedBy:NSLayoutRelationEqual
+                                    toItem:childview
+                                 attribute:NSLayoutAttributeTop
+                                multiplier:1.0
+                                  constant:0]
+        .active = YES;
+    [NSLayoutConstraint constraintWithItem:containingView
+                                 attribute:NSLayoutAttributeBottom
+                                 relatedBy:NSLayoutRelationEqual
+                                    toItem:childview
+                                 attribute:NSLayoutAttributeBottom
+                                multiplier:1.0
+                                  constant:0]
+        .active = YES;
+    [NSLayoutConstraint constraintWithItem:containingView
+                                 attribute:NSLayoutAttributeLeading
+                                 relatedBy:NSLayoutRelationEqual
+                                    toItem:childview
+                                 attribute:NSLayoutAttributeLeading
+                                multiplier:1.0
+                                  constant:0]
+        .active = YES;
+    [NSLayoutConstraint constraintWithItem:containingView
+                                 attribute:NSLayoutAttributeTrailing
+                                 relatedBy:NSLayoutRelationEqual
+                                    toItem:childview
+                                 attribute:NSLayoutAttributeTrailing
+                                multiplier:1.0
+                                  constant:0]
+        .active = YES;
 
     if (ActionsOrientation::Horizontal == adaptiveActionConfig.actionsOrientation) {
-        hConstraint.priority = UILayoutPriorityDefaultLow;
-        if (contentWidth > superview.frame.size.width) {
-            containingView.showsHorizontalScrollIndicator = YES;
-        } else {
-            if (adaptiveActionConfig.actionAlignment == ActionAlignment::Stretch) {
-                [NSLayoutConstraint constraintWithItem:containingView
-                                             attribute:NSLayoutAttributeWidth
-                                             relatedBy:NSLayoutRelationEqual
-                                                toItem:childview
-                                             attribute:NSLayoutAttributeWidth
-                                            multiplier:1.0
-                                              constant:0]
-                    .active = YES;
-            }
-        }
-    } else {
-        vConstraint.priority = UILayoutPriorityDefaultLow;
+        containingView.stretch = true;
     }
+
     return containingView;
 }
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentHoldingUIScrollView.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentHoldingUIScrollView.h
@@ -9,4 +9,8 @@
 
 @interface ACRContentHoldingUIScrollView : UIScrollView
 
+@property bool stretch;
+@property UIView *contentview;
+@property CGFloat contentWidth;
+
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentHoldingUIScrollView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentHoldingUIScrollView.mm
@@ -9,9 +9,18 @@
 
 @implementation ACRContentHoldingUIScrollView
 
-- (CGSize)intrinsicContentSize
-{
-    return self.frame.size;
+- (CGSize)intrinsicContentSize {
+    return [super intrinsicContentSize];
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+
+    if (self.contentview && self.frame.size.width > self.contentWidth && self.stretch) {
+        [self.contentview.widthAnchor constraintEqualToAnchor:self.widthAnchor multiplier:1.0]
+            .active = YES;
+        [self.contentview setNeedsUpdateConstraints];
+    }
 }
 
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRenderer.mm
@@ -131,20 +131,13 @@ using namespace AdaptiveCards;
 
     [rootView waitForAsyncTasksToFinish];
 
-    UIView *leadingBlankSpace = nil, *trailingBlankSpace = nil;
+    UIView *leadingBlankSpace = nil;
     if (adaptiveCard->GetVerticalContentAlignment() == VerticalContentAlignment::Center ||
         adaptiveCard->GetVerticalContentAlignment() == VerticalContentAlignment::Bottom) {
         leadingBlankSpace = [verticalView addPaddingSpace];
     }
 
     [ACRRenderer render:verticalView rootView:rootView inputs:inputs withCardElems:body andHostConfig:config];
-
-    // Dont add the trailing space if the vertical content alignment is top/default
-    if ((adaptiveCard->GetVerticalContentAlignment() == VerticalContentAlignment::Center) ||
-        (adaptiveCard->GetVerticalContentAlignment() == VerticalContentAlignment::Top &&
-         !(verticalView.hasStretchableView))) {
-        trailingBlankSpace = [verticalView addPaddingSpace];
-    }
 
     [[rootView card] setInputs:inputs];
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.h
@@ -49,7 +49,7 @@ void handleActionFallbackException(ACOFallbackException *exception,
                                    UIView<ACRIContentHoldingView> *view, ACRView *rootView,
                                    NSMutableArray *inputs, ACOBaseActionElement *acoElem,
                                    ACOHostConfig *config,
-                                   UIView<ACRIContentHoldingView> *actionSet);
+                                   UIStackView *actionSet);
 
 void removeLastViewFromCollectionView(const CardElementType elemType,
                                       UIView<ACRIContentHoldingView> *view);

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
@@ -303,7 +303,7 @@ void applyBackgroundImageConstraints(const BackgroundImage *backgroundImagePrope
                 isDeficientInHeight = YES;
             }
 
-            if (isDeficientInWidth and isDeficientInWidth) {
+            if (isDeficientInWidth and isDeficientInHeight) {
                 CGFloat widthDeficiencyRaito = targetViewSize.width / sourceSize.width;
                 CGFloat heightDifficiencyRaito = targetViewSize.height / sourceSize.height;
                 // we choose one with bigger difficienty in ratio, and by increasing the
@@ -497,7 +497,7 @@ void handleActionFallbackException(ACOFallbackException *exception,
                                    UIView<ACRIContentHoldingView> *view, ACRView *rootView,
                                    NSMutableArray *inputs, ACOBaseActionElement *acoElem,
                                    ACOHostConfig *config,
-                                   UIView<ACRIContentHoldingView> *actionSet)
+                                   UIStackView *actionSet)
 {
     std::shared_ptr<BaseElement> fallbackBaseElement = nullptr;
     std::shared_ptr<BaseActionElement> elem = acoElem.element;


### PR DESCRIPTION
Fixed ActionSet having extra height.
This is a back port from release/1.2 branch.
## Related Issue
fixed #3784 

## Description
There was an extra view between base elements and actions causing the view's expansion.

## How Verified
Verified that extra view was removed.
Worked with the Teams mobile to confirm it.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3818)