### PR TITLE
[UWP][Accessability] Use element tag instead of access key for internal tracking

### DIFF
--- a/source/uwp/Renderer/lib/ElementTagContent.cpp
+++ b/source/uwp/Renderer/lib/ElementTagContent.cpp
@@ -11,6 +11,8 @@ using namespace ABI::Windows::UI::Xaml::Controls;
 
 namespace AdaptiveNamespace
 {
+    HRESULT ElementTagContent::RuntimeClassInitialize() { return S_OK; }
+
     HRESULT ElementTagContent::RuntimeClassInitialize(_In_ IAdaptiveCardElement* cardElement,
                                                       _In_ IPanel* parentPanel,
                                                       _In_ IUIElement* separator,

--- a/source/uwp/Renderer/lib/ElementTagContent.cpp
+++ b/source/uwp/Renderer/lib/ElementTagContent.cpp
@@ -15,15 +15,20 @@ namespace AdaptiveNamespace
                                                       _In_ IPanel* parentPanel,
                                                       _In_ IUIElement* separator,
                                                       _In_ IColumnDefinition* columnDefinition,
-                                                      _In_ boolean expectedVisibility)
+                                                      boolean expectedVisibility,
+                                                      boolean isStretchable)
     {
-        ComPtr<IPanel> localParentPanel(parentPanel);
-        RETURN_IF_FAILED(localParentPanel.AsWeak(&m_parentPanel));
+        if (parentPanel != nullptr)
+        {
+            ComPtr<IPanel> localParentPanel(parentPanel);
+            RETURN_IF_FAILED(localParentPanel.AsWeak(&m_parentPanel));
+        }
 
         m_columnDefinition = columnDefinition;
         m_separator = separator;
         m_cardElement = cardElement;
         m_expectedVisibility = expectedVisibility;
+        m_isStretchable = isStretchable;
         return S_OK;
     }
 
@@ -56,6 +61,16 @@ namespace AdaptiveNamespace
     HRESULT ElementTagContent::set_ExpectedVisibility(boolean expectedVisibility)
     {
         m_expectedVisibility = expectedVisibility;
+        return S_OK;
+    }
+    HRESULT ElementTagContent::get_IsStretchable(boolean* isStretchable)
+    {
+        *isStretchable = m_isStretchable;
+        return S_OK;
+    }
+    HRESULT ElementTagContent::put_IsStretchable(boolean isStretchable)
+    {
+        m_isStretchable = isStretchable;
         return S_OK;
     }
 }

--- a/source/uwp/Renderer/lib/ElementTagContent.h
+++ b/source/uwp/Renderer/lib/ElementTagContent.h
@@ -25,6 +25,10 @@ namespace AdaptiveNamespace
         : public Microsoft::WRL::RuntimeClass<Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>, IElementTagContent>
     {
     public:
+        ElementTagContent() : m_expectedVisibility (true), m_isStretchable(false) {}
+
+        HRESULT RuntimeClassInitialize();
+
         HRESULT RuntimeClassInitialize(_In_ ABI::AdaptiveNamespace::IAdaptiveCardElement* cardElement,
                                        _In_ ABI::Windows::UI::Xaml::Controls::IPanel* parentPanel,
                                        _In_ ABI::Windows::UI::Xaml::IUIElement* separator,

--- a/source/uwp/Renderer/lib/ElementTagContent.h
+++ b/source/uwp/Renderer/lib/ElementTagContent.h
@@ -16,7 +16,9 @@ namespace AdaptiveNamespace
         // visible so the best way to track the intended visibility of the element and its separator is keeping this
         // flag to avoid comparing against the rendered visibility
         virtual HRESULT get_ExpectedVisibility(_Outptr_ boolean * expectedVisibility) = 0;
-        virtual HRESULT set_ExpectedVisibility(_In_ boolean expectedVisibility) = 0;
+        virtual HRESULT set_ExpectedVisibility(boolean expectedVisibility) = 0;
+        virtual HRESULT get_IsStretchable(_Outptr_ boolean * isStretchable) = 0;
+        virtual HRESULT put_IsStretchable(boolean isStretchable) = 0;
     };
 
     class ElementTagContent
@@ -27,7 +29,8 @@ namespace AdaptiveNamespace
                                        _In_ ABI::Windows::UI::Xaml::Controls::IPanel* parentPanel,
                                        _In_ ABI::Windows::UI::Xaml::IUIElement* separator,
                                        _In_ ABI::Windows::UI::Xaml::Controls::IColumnDefinition* columnDefinition,
-                                       _In_ boolean expectedVisibility);
+                                       boolean expectedVisibility,
+                                       boolean isStretchable);
 
         virtual HRESULT get_ColumnDefinition(_COM_Outptr_ ABI::Windows::UI::Xaml::Controls::IColumnDefinition** columnDefinition) override;
         virtual HRESULT get_AdaptiveCardElement(_COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardElement** cardElement) override;
@@ -35,6 +38,8 @@ namespace AdaptiveNamespace
         virtual HRESULT get_ParentPanel(_COM_Outptr_ ABI::Windows::UI::Xaml::Controls::IPanel** parentPanel) override;
         virtual HRESULT get_ExpectedVisibility(_Outptr_ boolean* expectedVisibility) override;
         virtual HRESULT set_ExpectedVisibility(_In_ boolean expectedVisibility) override;
+        virtual HRESULT get_IsStretchable(_Outptr_ boolean* isStretchable) override;
+        virtual HRESULT put_IsStretchable(boolean isStretchable) override;
 
     private:
         Microsoft::WRL::ComPtr<ABI::AdaptiveNamespace::IAdaptiveCardElement> m_cardElement;
@@ -42,5 +47,6 @@ namespace AdaptiveNamespace
         Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IUIElement> m_separator;
         Microsoft::WRL::WeakRef m_parentPanel;
         boolean m_expectedVisibility;
+        boolean m_isStretchable;
     };
 }

--- a/source/uwp/Renderer/lib/WholeItemsPanel.cpp
+++ b/source/uwp/Renderer/lib/WholeItemsPanel.cpp
@@ -408,16 +408,18 @@ namespace AdaptiveNamespace
         ComPtr<IElementTagContent> elementTagContent;
         if (tagAsInspectable != nullptr)
         {
-            tagAsInspectable.As(&elementTagContent);
-            elementTagContent->put_IsStretchable(true);
+            THROW_IF_FAILED(tagAsInspectable.As(&elementTagContent));
+            THROW_IF_FAILED(elementTagContent->put_IsStretchable(true));
         }
         else
         {
             ComPtr<IElementTagContent> tagContent;
-            THROW_IF_FAILED(MakeAndInitialize<ElementTagContent>(&tagContent, nullptr, nullptr, nullptr, nullptr, false, true));
+            THROW_IF_FAILED(MakeAndInitialize<ElementTagContent>(&tagContent));
 
-            tagContent.As(&tagAsInspectable);
-            elementAsFrameworkElement->put_Tag(tagAsInspectable.Get());
+            THROW_IF_FAILED(tagContent->put_IsStretchable(true));
+
+            THROW_IF_FAILED(tagContent.As(&tagAsInspectable));
+            THROW_IF_FAILED(elementAsFrameworkElement->put_Tag(tagAsInspectable.Get()));
         }
 
         ++m_stretchableItemCount;

--- a/source/uwp/Renderer/lib/WholeItemsPanel.cpp
+++ b/source/uwp/Renderer/lib/WholeItemsPanel.cpp
@@ -6,6 +6,7 @@
 #include "pch.h"
 #include "WholeItemsPanel.h"
 #include "XamlHelpers.h"
+#include "ElementTagContent.h"
 
 using namespace std;
 using namespace Microsoft::WRL;
@@ -251,12 +252,11 @@ namespace AdaptiveNamespace
         RETURN_IF_FAILED(children->get_Size(&m_measuredCount));
 
         float extraPaddingPerItem{};
-        if (!m_stretchableItems.empty())
+        if (m_stretchableItemCount != 0)
         {
-            extraPaddingPerItem = floor((finalSize.Height - m_calculatedSize) / m_stretchableItems.size());
+            extraPaddingPerItem = floor((finalSize.Height - m_calculatedSize) / m_stretchableItemCount);
         }
-
-        if (m_stretchableItems.empty())
+        else
         {
             if (m_verticalContentAlignment == ABI::AdaptiveNamespace::VerticalContentAlignment::Center)
             {
@@ -399,35 +399,48 @@ namespace AdaptiveNamespace
     void WholeItemsPanel::AddElementToStretchablesList(_In_ IUIElement* element)
     {
         ComPtr<IUIElement> localElement(element);
-        ComPtr<IUIElement4> elementWithAccessKey;
-        if (SUCCEEDED(localElement.As(&elementWithAccessKey)))
-        {
-            std::string elementAccessKey = std::to_string(m_accessKeyCount);
-            ++m_accessKeyCount;
+        ComPtr<IFrameworkElement> elementAsFrameworkElement;
+        THROW_IF_FAILED(localElement.As(&elementAsFrameworkElement));
 
-            HString accessKey;
-            if (SUCCEEDED(UTF8ToHString(elementAccessKey, accessKey.GetAddressOf())))
-            {
-                elementWithAccessKey->put_AccessKey(accessKey.Get());
-                m_stretchableItems.insert(std::move(elementAccessKey));
-            }
+        ComPtr<IInspectable> tagAsInspectable;
+        THROW_IF_FAILED(elementAsFrameworkElement->get_Tag(&tagAsInspectable));
+
+        ComPtr<IElementTagContent> elementTagContent;
+        if (tagAsInspectable != nullptr)
+        {
+            tagAsInspectable.As(&elementTagContent);
+            elementTagContent->put_IsStretchable(true);
         }
+        else
+        {
+            ComPtr<IElementTagContent> tagContent;
+            THROW_IF_FAILED(MakeAndInitialize<ElementTagContent>(&tagContent, nullptr, nullptr, nullptr, nullptr, false, true));
+
+            tagContent.As(&tagAsInspectable);
+            elementAsFrameworkElement->put_Tag(tagAsInspectable.Get());
+        }
+
+        ++m_stretchableItemCount;
     }
 
     bool WholeItemsPanel::IsUIElementInStretchableList(_In_ IUIElement* element)
     {
-        ComPtr<IUIElement> localElement(element);
-        ComPtr<IUIElement4> elementWithAccessKey;
-        if (SUCCEEDED(localElement.As(&elementWithAccessKey)))
+        ComPtr<IUIElement> localUIElement(element);
+        ComPtr<IFrameworkElement> uiElementAsFrameworkElement;
+        THROW_IF_FAILED(localUIElement.As(&uiElementAsFrameworkElement));
+
+        ComPtr<IInspectable> tagAsInspectable;
+        THROW_IF_FAILED(uiElementAsFrameworkElement->get_Tag(&tagAsInspectable));
+
+        boolean isStretchable = false;
+        if (tagAsInspectable != nullptr)
         {
-            HString elementAccessKey;
-            if (SUCCEEDED(elementWithAccessKey->get_AccessKey(elementAccessKey.GetAddressOf())))
-            {
-                return (m_stretchableItems.find(HStringToUTF8(elementAccessKey.Get())) != m_stretchableItems.end());
-            }
+            ComPtr<AdaptiveNamespace::IElementTagContent> tagContent;
+            THROW_IF_FAILED(tagAsInspectable.As(&tagContent));
+            THROW_IF_FAILED(tagContent->get_IsStretchable(&isStretchable));
         }
 
-        return false; // Couldn't get access key, weird, so it wasnt found
+        return isStretchable;
     }
 
     void WholeItemsPanel::SetVerticalContentAlignment(_In_ ABI::AdaptiveNamespace::VerticalContentAlignment verticalContentAlignment)

--- a/source/uwp/Renderer/lib/WholeItemsPanel.h
+++ b/source/uwp/Renderer/lib/WholeItemsPanel.h
@@ -54,10 +54,9 @@ namespace AdaptiveNamespace
         unsigned int m_visibleCount{};
         unsigned int m_measuredCount{};
 
-        unsigned int m_accessKeyCount{};
+        unsigned int m_stretchableItemCount{};
         float m_calculatedSize{};
         bool m_allElementsRendered{};
-        std::set<std::string> m_stretchableItems;
         ABI::AdaptiveNamespace::VerticalContentAlignment m_verticalContentAlignment{};
 
         // true if this represents the mainPanel.

--- a/source/uwp/Renderer/lib/XamlHelpers.cpp
+++ b/source/uwp/Renderer/lib/XamlHelpers.cpp
@@ -532,12 +532,14 @@ namespace AdaptiveNamespace::XamlHelpers
                 RETURN_IF_FAILED(newControlAsFrameworkElement->put_Name(id.Get()));
             }
 
-            ComPtr<ElementTagContent> tagContent;
-            RETURN_IF_FAILED(MakeAndInitialize<ElementTagContent>(&tagContent, element, parentPanel, separator, columnDefinition, isVisible));
-            RETURN_IF_FAILED(newControlAsFrameworkElement->put_Tag(tagContent.Get()));
-
             ABI::AdaptiveNamespace::HeightType heightType{};
             RETURN_IF_FAILED(element->get_Height(&heightType));
+
+            ComPtr<ElementTagContent> tagContent;
+            RETURN_IF_FAILED(MakeAndInitialize<ElementTagContent>(
+                &tagContent, element, parentPanel, separator, columnDefinition, isVisible, heightType == HeightType_Stretch));
+            RETURN_IF_FAILED(newControlAsFrameworkElement->put_Tag(tagContent.Get()));
+
             XamlHelpers::AppendXamlElementToPanel(newControl, parentPanel, heightType);
 
             childCreatedCallback(newControl);


### PR DESCRIPTION
## Related Issue
Fixes #3819

## Description
The WholeItemsPanel keeps track of which items have been marked as `"height":"stretch"` in order to render them properly. In order to do this, the code was stashing an identifier in the `AccessKey` property of the xaml elements (#1377). Unfortunately, that was causing access keys to show up in the UI when the user presses 'Alt'.

![image](https://user-images.githubusercontent.com/9091833/75936681-b1f42080-5e37-11ea-8fd8-7bed8f21282a.png)

Updated the code to use the `Tag` property to handle this internal tracking, as that is a place for custom data that won't have a UI impact. Because we're already using the Tag property for a variety of purposes, added the `IsStretchable` property to the existing `ElementTagContent` type.

## How Verified
Confirmed that the card from bug #3819 no longer generates an access key. Verified existing VerticalStretch cards still render correctly.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3820)