### PR TITLE
[Template] Don't drop card if $when fails to eval

### DIFF
--- a/source/nodejs/adaptivecards-designer-app/src/app.ts
+++ b/source/nodejs/adaptivecards-designer-app/src/app.ts
@@ -3,6 +3,7 @@
 import * as monaco from "monaco-editor";
 import * as markdownit from "markdown-it";
 import * as ACDesigner from "adaptivecards-designer";
+import * as ACTemplating from "adaptivecards-templating";
 import * as Adaptive from "adaptivecards";
 import "adaptivecards-designer/dist/adaptivecards-designer.css";
 import "./app.css";
@@ -11,7 +12,8 @@ import "./app.css";
 // import "adaptivecards-designer/dist/adaptivecards-defaulthost.css";
 
 window.onload = function() {
-    // Uncomment to enabled preview features such as data binding
+    ACTemplating.GlobalSettings.undefinedExpressionValueSubstitutionString = "<undefined value>";
+
     ACDesigner.GlobalSettings.showVersionPicker = true;
     ACDesigner.GlobalSettings.enableDataBindingSupport = true;
     // Note the below two flags are ignored if enableDataBindingSupport is set to false
@@ -27,8 +29,6 @@ window.onload = function() {
     ACDesigner.Strings.toolboxes.sampleDataEditor.title = "Custom title";
     ACDesigner.Strings.toolboxes.toolPalette.title = "Custom title";
     */
-
-
 
 	ACDesigner.CardDesigner.onProcessMarkdown = (text: string, result: { didProcess: boolean, outputHtml: string }) => {
 		result.outputHtml = new markdownit().render(text);

--- a/source/nodejs/adaptivecards-templating/src/adaptivecards-templating.ts
+++ b/source/nodejs/adaptivecards-templating/src/adaptivecards-templating.ts
@@ -2,3 +2,4 @@
 // Licensed under the MIT License.
 export * from "./expression-parser";
 export * from "./template-engine";
+export * from "./shared";

--- a/source/nodejs/adaptivecards-templating/src/expression-parser.ts
+++ b/source/nodejs/adaptivecards-templating/src/expression-parser.ts
@@ -105,11 +105,11 @@ class Tokenizer {
                         throw new Error("A tokenizer rule matched more than one group.");
                     }
 
-                    if (rule.tokenType != undefined) {
+                    if (rule.tokenType !== undefined) {
                         result.push(
                             {
                                 type: rule.tokenType,
-                                value: matches[matches.length == 1 ? 0 : 1],
+                                value: matches[matches.length === 1 ? 0 : 1],
                                 originalPosition: i
                             }
                         )
@@ -367,7 +367,7 @@ export class EvaluationContext {
     }
 
     restoreLastState() {
-        if (this._stateStack.length == 0) {
+        if (this._stateStack.length === 0) {
             throw new Error("There is no evaluation context state to restore.");
         }
 
@@ -378,7 +378,7 @@ export class EvaluationContext {
     }
 
     get currentDataContext(): any {
-        return this.$data != undefined ? this.$data : this.$root;
+        return this.$data !== undefined ? this.$data : this.$root;
     }
 }
 
@@ -444,10 +444,10 @@ class ExpressionNode extends EvaluationNode {
 
                     switch (node.operator) {
                         case "==":
-                            result = left == right;
+                            result = left === right;
                             break;
                         case "!=":
-                            result = left != right;
+                            result = left !== right;
                             break;
                         case "<":
                             result = left < right;
@@ -501,7 +501,7 @@ class FunctionCallNode extends EvaluationNode {
     evaluate(context: EvaluationContext): LiteralValue {
         let callback = context.getFunction(this.functionName);
 
-        if (callback != undefined) {
+        if (callback !== undefined) {
             let evaluatedParams = [];
 
             for (let param of this.parameters) {
@@ -548,7 +548,7 @@ class PathNode extends EvaluationNode {
             let part = this.parts[index];
 
             try {
-                if (part instanceof IdentifierNode && index == 0) {
+                if (part instanceof IdentifierNode && index === 0) {
                     switch (part.identifier) {
                         case "$root":
                             result = context.$root;
@@ -571,7 +571,7 @@ class PathNode extends EvaluationNode {
                 else {
                     let partValue = part.evaluate(context);
 
-                    if (index == 0) {
+                    if (index === 0) {
                         result = partValue;
                     }
                     else {
@@ -698,7 +698,7 @@ export class ExpressionParser {
 
             switch (this.current.type) {
                 case "(":
-                    if (result.parts.length == 0) {
+                    if (result.parts.length === 0) {
                         this.moveNext();
     
                         result.parts.push(this.parseExpression());
@@ -713,7 +713,7 @@ export class ExpressionParser {
                                 this.unexpectedToken();
                             }
 
-                            if (functionName != "") {
+                            if (functionName !== "") {
                                 functionName += ".";
                             }
 
@@ -761,7 +761,7 @@ export class ExpressionParser {
 
         while (!this.eoe) {
             if (expectedNextTokenTypes.indexOf(this.current.type) < 0) {
-                if (result.nodes.length == 0) {
+                if (result.nodes.length === 0) {
                     this.unexpectedToken();
                 }
 
@@ -779,10 +779,10 @@ export class ExpressionParser {
                 case "string":
                 case "number":
                 case "boolean":
-                    if (this.current.type == "string") {
+                    if (this.current.type === "string") {
                         result.nodes.push(new LiteralNode(this.current.value));
                     }
-                    else if (this.current.type == "number") {
+                    else if (this.current.type === "number") {
                         result.nodes.push(new LiteralNode(parseFloat(this.current.value)));
                     }
                     else {
@@ -795,7 +795,7 @@ export class ExpressionParser {
 
                     break;
                 case "-":
-                    if (result.nodes.length == 0) {
+                    if (result.nodes.length === 0) {
                         result.nodes.push(new LiteralNode(-1));
                         result.nodes.push(new OperatorNode("*"));
 
@@ -811,7 +811,7 @@ export class ExpressionParser {
 
                     break;
                 case "+":
-                    if (result.nodes.length == 0) {
+                    if (result.nodes.length === 0) {
                         expectedNextTokenTypes = literals.concat("(");
                     }
                     else {
@@ -854,8 +854,8 @@ export class ExpressionParser {
         return this._tokens[this._index];
     }
 
-    static parseBinding(bindingExpression: string): Binding {
-        let parser = new ExpressionParser(Tokenizer.parse(bindingExpression));
+    static parseBinding(expressionString: string): Binding {
+        let parser = new ExpressionParser(Tokenizer.parse(expressionString));
         parser.parseToken("{");
 
         let allowNull = !parser.parseOptionalToken("?#");
@@ -863,7 +863,7 @@ export class ExpressionParser {
 
         parser.parseToken("}");
 
-        return new Binding(expression, allowNull);
+        return new Binding(expressionString, expression, allowNull);
     }
 
     constructor(tokens: Token[]) {
@@ -872,7 +872,7 @@ export class ExpressionParser {
 }
 
 export class Binding {
-    constructor(private readonly expression: EvaluationNode, readonly allowNull: boolean = true) {}
+    constructor(readonly expressionString: string, private readonly expression: EvaluationNode, readonly allowNull: boolean = true) {}
 
     evaluate(context: EvaluationContext): LiteralValue {
         return this.expression.evaluate(context);

--- a/source/nodejs/adaptivecards-templating/src/shared.ts
+++ b/source/nodejs/adaptivecards-templating/src/shared.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+export class GlobalSettings {
+    static undefinedExpressionValueSubstitutionString?: string = undefined;
+}

--- a/source/nodejs/adaptivecards-templating/src/template-engine.ts
+++ b/source/nodejs/adaptivecards-templating/src/template-engine.ts
@@ -205,11 +205,22 @@ export class Template {
             let when = node["$when"];
 
             if (when instanceof TemplatizedString) {
-                let whenValue = when.evaluate(this._context);
+                let whenValue: any;
+                
+                try {
+                    whenValue = when.evaluate(this._context);
 
-                if (typeof whenValue === "boolean") {
-                    dropObject = !whenValue;
+                    // If $when doesn't evaluate to a boolean, consider it is false
+                    if (typeof whenValue !== "boolean") {
+                        whenValue = false;
+                    }
                 }
+                catch {
+                    // If we hit an exception, consider $when to be false
+                    whenValue = false;
+                }
+
+                dropObject = !whenValue;
             }
 
             if (!dropObject) {

--- a/source/nodejs/adaptivecards-templating/src/template-engine.ts
+++ b/source/nodejs/adaptivecards-templating/src/template-engine.ts
@@ -111,7 +111,7 @@ class TemplatizedString {
                     let evaluatedPart = this.evalExpression(<Binding>part, context);
 
                     if (evaluatedPart === undefined) {
-                        evaluatedPart = Shared.GlobalSettings.undefinedExpressionValueSubstitutionString ?? (<Binding>part).expressionString;
+                        evaluatedPart = Shared.GlobalSettings.undefinedExpressionValueSubstitutionString ? Shared.GlobalSettings.undefinedExpressionValueSubstitutionString : (<Binding>part).expressionString;
                     }
 
                     s += evaluatedPart;

--- a/source/nodejs/adaptivecards-templating/src/template-engine.ts
+++ b/source/nodejs/adaptivecards-templating/src/template-engine.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Binding, ExpressionParser, EvaluationContext } from "./expression-parser";
+import * as Shared from "./shared";
 
 class TemplatizedString {
     private _parts: Array<string | Binding> = [];
@@ -20,7 +21,7 @@ class TemplatizedString {
                 start = s.indexOf("{", start);
 
                 if (start >= 0) {
-                    if (start + 1 < s.length && s[start + 1] == "{") {
+                    if (start + 1 < s.length && s[start + 1] === "{") {
                         start += 2;
 
                         loop = true;
@@ -61,7 +62,7 @@ class TemplatizedString {
             }
         } while (i < s.length);
 
-        if (result._parts.length == 1 && typeof result._parts[0] === "string") {
+        if (result._parts.length === 1 && typeof result._parts[0] === "string") {
             return <string>result._parts[0];
         }
         else {
@@ -74,7 +75,7 @@ class TemplatizedString {
     private evalExpression(bindingExpression: Binding, context: EvaluationContext): any {
         let result = bindingExpression.evaluate(context);
 
-        if (result == undefined) {
+        if (result === undefined) {
             this._shouldDropOwner = this._shouldDropOwner || !bindingExpression.allowNull;
         }
 
@@ -82,10 +83,12 @@ class TemplatizedString {
     }
 
     private internalEvaluate(context: EvaluationContext): any {
-        if (this._parts.length == 0) {
+        if (this._parts.length === 0) {
             return undefined;
         }
-        else if (this._parts.length == 1) {
+        else if (this._parts.length === 1) {
+            // If the templatized string only has 1 part, we want it to evaluate
+            // to same the type as produced by the expression
             if (typeof this._parts[0] === "string") {
                 return this._parts[0];
             }
@@ -94,6 +97,10 @@ class TemplatizedString {
             }
         }
         else {
+            // If the templatized string has multiple parts, we want it to evaluate
+            // to a string. In that context, each part that evaluates to undefined
+            // gets replaced by the original expression by default or by a resource
+            // string provided by the application
             let s = "";
 
             for (let part of this._parts) {
@@ -101,7 +108,13 @@ class TemplatizedString {
                     s += part;
                 }
                 else {
-                    s += this.evalExpression(<Binding>part, context);
+                    let evaluatedPart = this.evalExpression(<Binding>part, context);
+
+                    if (evaluatedPart === undefined) {
+                        evaluatedPart = Shared.GlobalSettings.undefinedExpressionValueSubstitutionString ? Shared.GlobalSettings.undefinedExpressionValueSubstitutionString : (<Binding>part).expressionString;
+                    }
+
+                    s += evaluatedPart;
                 }
             }
 
@@ -125,7 +138,7 @@ export class Template {
         if (typeof node === "string") {
             return TemplatizedString.parse(node);
         }
-        else if (typeof node === "object" && node != null) {
+        else if (typeof node === "object" && node !== null) {
             if (Array.isArray(node)) {
                 let result: any[] = [];
 
@@ -161,7 +174,7 @@ export class Template {
             if (!this._context.isReservedField(key)) {
                 let value = this.internalExpand(node[key]);
 
-                if (value != undefined) {
+                if (value !== undefined) {
                     result[key] = value;
                 }
             }
@@ -181,7 +194,7 @@ export class Template {
             for (let item of node) {
                 let expandedItem = this.internalExpand(item);
 
-                if (expandedItem != null) {
+                if (expandedItem !== null) {
                     if (Array.isArray(expandedItem)) {
                         itemArray = itemArray.concat(expandedItem);
                     }
@@ -200,7 +213,7 @@ export class Template {
                 result = null;
             }
         }
-        else if (typeof node === "object" && node != null) {
+        else if (typeof node === "object" && node !== null) {
             let dropObject = false;
             let when = node["$when"];
 
@@ -226,7 +239,7 @@ export class Template {
             if (!dropObject) {
                 let dataContext = node["$data"];
 
-                if (dataContext != undefined) {
+                if (dataContext !== undefined) {
                     if (dataContext instanceof TemplatizedString) {
                         dataContext = dataContext.evaluate(this._context);
                     }
@@ -240,7 +253,7 @@ export class Template {
 
                             let expandedObject = this.expandSingleObject(node);
 
-                            if (expandedObject != null) {
+                            if (expandedObject !== null) {
                                 result.push(expandedObject);
                             }
                         }

--- a/source/nodejs/adaptivecards-templating/src/template-engine.ts
+++ b/source/nodejs/adaptivecards-templating/src/template-engine.ts
@@ -111,7 +111,7 @@ class TemplatizedString {
                     let evaluatedPart = this.evalExpression(<Binding>part, context);
 
                     if (evaluatedPart === undefined) {
-                        evaluatedPart = Shared.GlobalSettings.undefinedExpressionValueSubstitutionString ? Shared.GlobalSettings.undefinedExpressionValueSubstitutionString : (<Binding>part).expressionString;
+                        evaluatedPart = Shared.GlobalSettings.undefinedExpressionValueSubstitutionString ?? (<Binding>part).expressionString;
                     }
 
                     s += evaluatedPart;


### PR DESCRIPTION
## Related Issue
Fixes https://github.com/microsoft/AdaptiveCards/issues/3688

## Description
### $when clause handling change
Currently, two things happen:
- When the `$when` clause fails to evaluate, an exception is thrown which causes the whole card to not render
- When the `$when` clause evaluates to a non-boolean value, it is considered to be `true`

With this PR, the behavior becomes:
- When the `$when` clause fails to evaluate, it is considered to be `false`
- When the `$when` clause evaluates to a non-boolean value, it is considered to be `false`

In turn this means that an invalid $when clause will now cause the element on which it is defined to be dropped, but the card will still render.

### Handling of templatized strings containing expressions that evaluate to undefined
Currently, when an expression refers to a field that isn't defined (doesn't have a value) in the data context, it often evaluates to `undefined` and the string "undefined" gets emitted in the output card, and eventually displayed on screen That behavior is less than optimal.

With this PR:
- Such expressions will still evaluate to `undefined` but the display result (e.g. what ends up in the card) will be the original expression string. For instance "{title}"
- Applications can override that behavior by providing their own default string. For instance:

```typescript
ACTemplating.GlobalSettings.undefinedExpressionValueSubstitutionString = "<undefined value>";
```
 
## How Verified
Verified manually in adaptivecards-designer-app

## Test payloads
### For $when clause handling
```json
{
    "type": "AdaptiveCard",
    "version": "1.0",
    "body": [
        {
            "type": "TextBlock",
            "text": "{title}",
            "$when": "{title!=\"\"}"
        }
    ],
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json"
}

```

### For expressions evaluating to undefined
```json
{
    "type": "AdaptiveCard",
    "version": "1.0",
    "body": [
        {
            "type": "TextBlock",
            "text": "[{title}]({titleUrl})",
            "color": "Accent",
            "size": "Medium",
            "weight": "Bolder"
        }
    ],
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
    "$data": {
        "titleUrl": "https://modernacdesigner.azurewebsites.net"
    }
}
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3823)