### PR TITLE
[UWP][Accessibility] Change toggle button to regular button

### DIFF
--- a/source/uwp/Visualizer/MainPage.xaml
+++ b/source/uwp/Visualizer/MainPage.xaml
@@ -81,6 +81,7 @@
 
             <!--Tab page-->
             <local:DocumentView
+                x:Name="AdaptiveCardDocumentView"
                 Grid.Column="1"
                 DataContext="{Binding CurrentDocument}"
                 Visibility="{Binding CurrentDocument, Converter={StaticResource NotNullToVisibilityConverter}}"/>

--- a/source/uwp/Visualizer/MainPage.xaml
+++ b/source/uwp/Visualizer/MainPage.xaml
@@ -42,7 +42,7 @@
                         Label="Save file"
                         Click="AppBarSave_Click"
                         IsCompact="True"/>
-                    <AppBarToggleButton
+                    <AppBarButton
                         x:Name="AppBarHostConfigEditor"
                         Icon="Setting"
                         Label="Host config"

--- a/source/uwp/Visualizer/MainPage.xaml.cs
+++ b/source/uwp/Visualizer/MainPage.xaml.cs
@@ -109,6 +109,8 @@ namespace AdaptiveCardVisualizer
         {
             IsInHostConfigEditor = isInHostConfigEditor;
 
+            AdaptiveCardDocumentView.IsEnabled = !isInHostConfigEditor;
+
             foreach (var button in StackPanelMainAppBarButtons.Children.OfType<ButtonBase>())
             {
                 if (button != AppBarHostConfigEditor)

--- a/source/uwp/Visualizer/MainPage.xaml.cs
+++ b/source/uwp/Visualizer/MainPage.xaml.cs
@@ -122,7 +122,6 @@ namespace AdaptiveCardVisualizer
 
         private void HostConfigTransparentBackdrop_Tapped(object sender, TappedRoutedEventArgs e)
         {
-            AppBarHostConfigEditor.IsChecked = false;
             SetIsInHostConfigEditor(false);
         }
     }


### PR DESCRIPTION
## Related Issue
Fixes #3827 
Fixes #3831 

## Description
Change the Hostconfig button from a toggleButton to a regular button as it doesn't behave as a toggle button.

## How Verified
The fix was applied to the Visualizer application and testing if the application presented the same behaviour but the narrator didn't.

The gif below shows the behaviour

![bugFix2](https://user-images.githubusercontent.com/35784165/76262566-eaba3e00-6219-11ea-81d2-1140d8a0f135.gif)

As work was already being done with the HostConfig button, the middle panel accessibility was also fixed. Now it can be accessed through keyboard input as can be seen below:

![bugFix3](https://user-images.githubusercontent.com/35784165/76347358-b7cc8480-62c3-11ea-8754-9f5923c986c9.gif)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3828)