### PR TITLE
[UWP] Add name for close button

### DIFF
--- a/source/uwp/Visualizer/TabView.xaml
+++ b/source/uwp/Visualizer/TabView.xaml
@@ -8,7 +8,8 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     d:DesignHeight="300"
-    d:DesignWidth="400">
+    d:DesignWidth="400"
+    AutomationProperties.Name="{Binding Name, FallbackValue=[name]}" >
 
     <Grid
         Background="Transparent"
@@ -23,6 +24,7 @@
             <ColumnDefinition Width="Auto"/>
         </Grid.ColumnDefinitions>
         <TextBlock
+            x:Name="AdaptiveCardName"
             Text="{Binding Name, FallbackValue=[name]}"
             Style="{ThemeResource CaptionTextBlockStyle}"
             VerticalAlignment="Center"

--- a/source/uwp/Visualizer/TabView.xaml
+++ b/source/uwp/Visualizer/TabView.xaml
@@ -35,7 +35,8 @@
             HorizontalAlignment="Right"
             Click="ButtonClose_Click"
             Visibility="Collapsed"
-            Margin="9,0,12,0">
+            Margin="9,0,12,0"
+            AutomationProperties.Name="Close">
             <Viewbox Width="10" Height="10">
             <SymbolIcon
                 Symbol="Cancel"/>


### PR DESCRIPTION
## Related Issue
Fixes #3832
Fixes #3834

## Description
Add name property for all close buttons in the visualizer app in the left panel. The ones next to the Card name

## How Verified
The visualizer app was executed and the elements were examined using the Accessibility insights application to see that the button now has the name property set.

![image](https://user-images.githubusercontent.com/35784165/76367624-d42fe780-62ea-11ea-8eed-a1b9e940ceb0.png)

This also fixes the issue where list items would not have a descriptive name. This is fixed as shown below

![image](https://user-images.githubusercontent.com/35784165/76369046-705bed80-62ef-11ea-9691-6ceea5201527.png)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3833)