### PR TITLE
Cherry-Pick fix for issue #3819 for 1.2.8 patch release

### DIFF
--- a/custom.props
+++ b/custom.props
@@ -4,7 +4,7 @@
     <VersionMajor>1</VersionMajor>
     <VersionMinor>2</VersionMinor>
     <!-- The nuget package version should be incremented when we produce QFEs -->
-    <NuGetPackVersion>1.2.7</NuGetPackVersion>
+    <NuGetPackVersion>1.2.8</NuGetPackVersion>
     <VersionInfoProductName>AdaptiveCards</VersionInfoProductName>
   </PropertyGroup>
 </Project>

--- a/source/uwp/Renderer/lib/ElementTagContent.cpp
+++ b/source/uwp/Renderer/lib/ElementTagContent.cpp
@@ -11,17 +11,24 @@ using namespace ABI::Windows::UI::Xaml::Controls;
 
 namespace AdaptiveNamespace
 {
+    HRESULT ElementTagContent::RuntimeClassInitialize() { return S_OK; }
+
     HRESULT ElementTagContent::RuntimeClassInitialize(_In_ IAdaptiveCardElement* cardElement,
                                                       _In_ IPanel* parentPanel,
                                                       _In_ IUIElement* separator,
-                                                      _In_ IColumnDefinition* columnDefinition)
+                                                      _In_ IColumnDefinition* columnDefinition,
+                                                      boolean isStretchable)
     {
-        ComPtr<IPanel> localParentPanel(parentPanel);
-        RETURN_IF_FAILED(localParentPanel.AsWeak(&m_parentPanel));
+        if (parentPanel != nullptr)
+        {
+            ComPtr<IPanel> localParentPanel(parentPanel);
+            RETURN_IF_FAILED(localParentPanel.AsWeak(&m_parentPanel));
+        }
 
         m_columnDefinition = columnDefinition;
         m_separator = separator;
         m_cardElement = cardElement;
+        m_isStretchable = isStretchable;
         return S_OK;
     }
 
@@ -43,5 +50,15 @@ namespace AdaptiveNamespace
     HRESULT ElementTagContent::get_ParentPanel(_COM_Outptr_ ABI::Windows::UI::Xaml::Controls::IPanel** parentPanel)
     {
         return m_parentPanel.CopyTo(parentPanel);
+    }
+    HRESULT ElementTagContent::get_IsStretchable(boolean* isStretchable)
+    {
+        *isStretchable = m_isStretchable;
+        return S_OK;
+    }
+    HRESULT ElementTagContent::put_IsStretchable(boolean isStretchable)
+    {
+        m_isStretchable = isStretchable;
+        return S_OK;
     }
 }

--- a/source/uwp/Renderer/lib/ElementTagContent.h
+++ b/source/uwp/Renderer/lib/ElementTagContent.h
@@ -12,26 +12,36 @@ namespace AdaptiveNamespace
         virtual HRESULT get_AdaptiveCardElement(_COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardElement * *cardElement) = 0;
         virtual HRESULT get_Separator(_COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement * *separator) = 0;
         virtual HRESULT get_ParentPanel(_COM_Outptr_ ABI::Windows::UI::Xaml::Controls::IPanel * *parentPanel) = 0;
+        virtual HRESULT get_IsStretchable(_Outptr_ boolean * isStretchable) = 0;
+        virtual HRESULT put_IsStretchable(boolean isStretchable) = 0;
     };
 
     class ElementTagContent
         : public Microsoft::WRL::RuntimeClass<Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::RuntimeClassType::WinRtClassicComMix>, IElementTagContent>
     {
     public:
+        ElementTagContent() : m_isStretchable(false) {}
+
+        HRESULT RuntimeClassInitialize();
+
         HRESULT RuntimeClassInitialize(_In_ ABI::AdaptiveNamespace::IAdaptiveCardElement* cardElement,
                                        _In_ ABI::Windows::UI::Xaml::Controls::IPanel* parentPanel,
                                        _In_ ABI::Windows::UI::Xaml::IUIElement* separator,
-                                       _In_ ABI::Windows::UI::Xaml::Controls::IColumnDefinition* columnDefinition);
+                                       _In_ ABI::Windows::UI::Xaml::Controls::IColumnDefinition* columnDefinition,
+                                        boolean isStretchable);
 
         virtual HRESULT get_ColumnDefinition(_COM_Outptr_ ABI::Windows::UI::Xaml::Controls::IColumnDefinition** columnDefinition) override;
         virtual HRESULT get_AdaptiveCardElement(_COM_Outptr_ ABI::AdaptiveNamespace::IAdaptiveCardElement** cardElement) override;
         virtual HRESULT get_Separator(_COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** separator) override;
         virtual HRESULT get_ParentPanel(_COM_Outptr_ ABI::Windows::UI::Xaml::Controls::IPanel** parentPanel) override;
+        virtual HRESULT get_IsStretchable(_Outptr_ boolean* isStretchable) override;
+        virtual HRESULT put_IsStretchable(boolean isStretchable) override;
 
     private:
         Microsoft::WRL::ComPtr<ABI::AdaptiveNamespace::IAdaptiveCardElement> m_cardElement;
         Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::Controls::IColumnDefinition> m_columnDefinition;
         Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IUIElement> m_separator;
         Microsoft::WRL::WeakRef m_parentPanel;
+        boolean m_isStretchable;
     };
 }

--- a/source/uwp/Renderer/lib/WholeItemsPanel.cpp
+++ b/source/uwp/Renderer/lib/WholeItemsPanel.cpp
@@ -6,6 +6,7 @@
 #include "pch.h"
 #include "WholeItemsPanel.h"
 #include "XamlHelpers.h"
+#include "ElementTagContent.h"
 
 using namespace std;
 using namespace Microsoft::WRL;
@@ -251,12 +252,11 @@ namespace AdaptiveNamespace
         RETURN_IF_FAILED(children->get_Size(&m_measuredCount));
 
         float extraPaddingPerItem{};
-        if (!m_stretchableItems.empty())
+        if (m_stretchableItemCount != 0)
         {
-            extraPaddingPerItem = floor((finalSize.Height - m_calculatedSize) / m_stretchableItems.size());
+            extraPaddingPerItem = floor((finalSize.Height - m_calculatedSize) / m_stretchableItemCount);
         }
-
-        if (m_stretchableItems.empty())
+        else
         {
             if (m_verticalContentAlignment == ABI::AdaptiveNamespace::VerticalContentAlignment::Center)
             {
@@ -399,36 +399,50 @@ namespace AdaptiveNamespace
     void WholeItemsPanel::AddElementToStretchablesList(_In_ IUIElement* element)
     {
         ComPtr<IUIElement> localElement(element);
-        ComPtr<IUIElement4> elementWithAccessKey;
-        if (SUCCEEDED(localElement.As(&elementWithAccessKey)))
-        {
-            std::string elementAccessKey = std::to_string(m_accessKeyCount);
-            ++m_accessKeyCount;
+        ComPtr<IFrameworkElement> elementAsFrameworkElement;
+        THROW_IF_FAILED(localElement.As(&elementAsFrameworkElement));
 
-            HSTRING accessKey;
-            if (SUCCEEDED(UTF8ToHString(elementAccessKey, &accessKey)))
-            {
-                elementWithAccessKey->put_AccessKey(accessKey);
-                m_stretchableItems.insert(elementAccessKey);
-            }
+        ComPtr<IInspectable> tagAsInspectable;
+        THROW_IF_FAILED(elementAsFrameworkElement->get_Tag(&tagAsInspectable));
+
+        ComPtr<IElementTagContent> elementTagContent;
+        if (tagAsInspectable != nullptr)
+        {
+            THROW_IF_FAILED(tagAsInspectable.As(&elementTagContent));
+            THROW_IF_FAILED(elementTagContent->put_IsStretchable(true));
         }
+        else
+        {
+            ComPtr<IElementTagContent> tagContent;
+            THROW_IF_FAILED(MakeAndInitialize<ElementTagContent>(&tagContent));
+
+            THROW_IF_FAILED(tagContent->put_IsStretchable(true));
+
+            THROW_IF_FAILED(tagContent.As(&tagAsInspectable));
+            THROW_IF_FAILED(elementAsFrameworkElement->put_Tag(tagAsInspectable.Get()));
+        }
+
+        ++m_stretchableItemCount;
     }
 
     bool WholeItemsPanel::IsUIElementInStretchableList(_In_ IUIElement* element)
     {
-        ComPtr<IUIElement> localElement(element);
-        ComPtr<IUIElement4> elementWithAccessKey;
-        if (SUCCEEDED(localElement.As(&elementWithAccessKey)))
+        ComPtr<IUIElement> localUIElement(element);
+        ComPtr<IFrameworkElement> uiElementAsFrameworkElement;
+        THROW_IF_FAILED(localUIElement.As(&uiElementAsFrameworkElement));
+
+        ComPtr<IInspectable> tagAsInspectable;
+        THROW_IF_FAILED(uiElementAsFrameworkElement->get_Tag(&tagAsInspectable));
+
+        boolean isStretchable = false;
+        if (tagAsInspectable != nullptr)
         {
-            HSTRING elementAccessKey;
-            if (SUCCEEDED(elementWithAccessKey->get_AccessKey(&elementAccessKey)))
-            {
-                std::string accessKey = HStringToUTF8(elementAccessKey);
-                return (m_stretchableItems.find(accessKey) != m_stretchableItems.end());
-            }
+            ComPtr<AdaptiveNamespace::IElementTagContent> tagContent;
+            THROW_IF_FAILED(tagAsInspectable.As(&tagContent));
+            THROW_IF_FAILED(tagContent->get_IsStretchable(&isStretchable));
         }
 
-        return false; // Couldn't get access key, weird, so it wasnt found
+        return isStretchable;
     }
 
     void WholeItemsPanel::SetVerticalContentAlignment(_In_ ABI::AdaptiveNamespace::VerticalContentAlignment verticalContentAlignment)

--- a/source/uwp/Renderer/lib/WholeItemsPanel.h
+++ b/source/uwp/Renderer/lib/WholeItemsPanel.h
@@ -55,10 +55,9 @@ namespace AdaptiveNamespace
         unsigned int m_visibleCount{};
         unsigned int m_measuredCount{};
 
-        unsigned int m_accessKeyCount{};
+        unsigned int m_stretchableItemCount{};
         float m_calculatedSize{};
         bool m_allElementsRendered{};
-        std::set<std::string> m_stretchableItems;
         ABI::AdaptiveNamespace::VerticalContentAlignment m_verticalContentAlignment{};
 
         // true if this represents the mainPanel.

--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -880,12 +880,13 @@ namespace AdaptiveNamespace
                 RETURN_IF_FAILED(newControlAsFrameworkElement->put_Name(id.Get()));
             }
 
-            ComPtr<ElementTagContent> tagContent;
-            RETURN_IF_FAILED(MakeAndInitialize<ElementTagContent>(&tagContent, element, parentPanel, separator, columnDefinition));
-            RETURN_IF_FAILED(newControlAsFrameworkElement->put_Tag(tagContent.Get()));
-
             ABI::AdaptiveNamespace::HeightType heightType{};
             RETURN_IF_FAILED(element->get_Height(&heightType));
+
+            ComPtr<ElementTagContent> tagContent;
+            RETURN_IF_FAILED(MakeAndInitialize<ElementTagContent>(&tagContent, element, parentPanel, separator, columnDefinition, heightType == HeightType_Stretch));
+            RETURN_IF_FAILED(newControlAsFrameworkElement->put_Tag(tagContent.Get()));
+
             XamlHelpers::AppendXamlElementToPanel(newControl, parentPanel, heightType);
 
             childCreatedCallback(newControl);


### PR DESCRIPTION
* [UWP][Accessibility] Use element tag instead of access key for internal tracking.

## Related Issue
Fixes #3819 

## Description
Cherry-Pick fix for issue #3819 for 1.2.8 patch release

## How Verified
1. Local build succeeded where I was able to launch the corresponding UWP visualizer, use the card from the original issue and verify that pressing "Alt" wouldn't result in a '0' key showing up.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3887)