### PR TITLE
[JS] Add doc generation support

### DIFF
--- a/source/nodejs/adaptivecards/docs/README.md
+++ b/source/nodejs/adaptivecards/docs/README.md
@@ -1,0 +1,556 @@
+[Adaptive Cards Javascript SDK](README.md)
+
+# Adaptive Cards Javascript SDK
+
+## Index
+
+### Enumerations
+
+* [ActionAlignment](enums/actionalignment.md)
+* [ActionIconPlacement](enums/actioniconplacement.md)
+* [ContainerFitStatus](enums/containerfitstatus.md)
+* [FillMode](enums/fillmode.md)
+* [FontType](enums/fonttype.md)
+* [HorizontalAlignment](enums/horizontalalignment.md)
+* [ImageStyle](enums/imagestyle.md)
+* [InputTextStyle](enums/inputtextstyle.md)
+* [InputValidationNecessity](enums/inputvalidationnecessity.md)
+* [Orientation](enums/orientation.md)
+* [ShowCardActionMode](enums/showcardactionmode.md)
+* [Size](enums/size.md)
+* [SizeUnit](enums/sizeunit.md)
+* [Spacing](enums/spacing.md)
+* [TextColor](enums/textcolor.md)
+* [TextSize](enums/textsize.md)
+* [TextWeight](enums/textweight.md)
+* [ValidationError](enums/validationerror.md)
+* [VerticalAlignment](enums/verticalalignment.md)
+
+### Classes
+
+* [Action](classes/action.md)
+* [ActionSet](classes/actionset.md)
+* [ActionStyle](classes/actionstyle.md)
+* [ActionTypeRegistry](classes/actiontyperegistry.md)
+* [ActionsConfig](classes/actionsconfig.md)
+* [AdaptiveCard](classes/adaptivecard.md)
+* [AdaptiveCardConfig](classes/adaptivecardconfig.md)
+* [BackgroundImage](classes/backgroundimage.md)
+* [BaseTextBlock](classes/basetextblock.md)
+* [CardElement](classes/cardelement.md)
+* [CardElementContainer](classes/cardelementcontainer.md)
+* [CardObject](classes/cardobject.md)
+* [Choice](classes/choice.md)
+* [ChoiceSetInput](classes/choicesetinput.md)
+* [ColorDefinition](classes/colordefinition.md)
+* [ColorSetDefinition](classes/colorsetdefinition.md)
+* [Column](classes/column.md)
+* [ColumnSet](classes/columnset.md)
+* [Container](classes/container.md)
+* [ContainerStyle](classes/containerstyle.md)
+* [ContainerStyleDefinition](classes/containerstyledefinition.md)
+* [ContainerStyleSet](classes/containerstyleset.md)
+* [ContainerWithActions](classes/containerwithactions.md)
+* [DateInput](classes/dateinput.md)
+* [ElementTypeRegistry](classes/elementtyperegistry.md)
+* [Fact](classes/fact.md)
+* [FactSet](classes/factset.md)
+* [FactSetConfig](classes/factsetconfig.md)
+* [FactTextDefinition](classes/facttextdefinition.md)
+* [FactTitleDefinition](classes/facttitledefinition.md)
+* [FontTypeDefinition](classes/fonttypedefinition.md)
+* [FontTypeSet](classes/fonttypeset.md)
+* [HostCapabilities](classes/hostcapabilities.md)
+* [HostConfig](classes/hostconfig.md)
+* [HttpAction](classes/httpaction.md)
+* [HttpHeader](classes/httpheader.md)
+* [Image](classes/image.md)
+* [ImageSet](classes/imageset.md)
+* [ImageSetConfig](classes/imagesetconfig.md)
+* [Input](classes/input.md)
+* [InputValidationOptions](classes/inputvalidationoptions.md)
+* [Media](classes/media.md)
+* [MediaConfig](classes/mediaconfig.md)
+* [MediaSource](classes/mediasource.md)
+* [NumberInput](classes/numberinput.md)
+* [OpenUrlAction](classes/openurlaction.md)
+* [PaddingDefinition](classes/paddingdefinition.md)
+* [RichTextBlock](classes/richtextblock.md)
+* [SerializableObject](classes/serializableobject.md)
+* [ShowCardAction](classes/showcardaction.md)
+* [ShowCardActionConfig](classes/showcardactionconfig.md)
+* [SizeAndUnit](classes/sizeandunit.md)
+* [SpacingDefinition](classes/spacingdefinition.md)
+* [StringWithSubstitutions](classes/stringwithsubstitutions.md)
+* [StylableCardElementContainer](classes/stylablecardelementcontainer.md)
+* [SubmitAction](classes/submitaction.md)
+* [TextBlock](classes/textblock.md)
+* [TextColorDefinition](classes/textcolordefinition.md)
+* [TextInput](classes/textinput.md)
+* [TextRun](classes/textrun.md)
+* [TimeInput](classes/timeinput.md)
+* [ToggleInput](classes/toggleinput.md)
+* [ToggleVisibilityAction](classes/togglevisibilityaction.md)
+* [TypeRegistry](classes/typeregistry.md)
+* [UUID](classes/uuid.md)
+* [ValidationFailure](classes/validationfailure.md)
+* [ValidationResults](classes/validationresults.md)
+* [Version](classes/version.md)
+
+### Interfaces
+
+* [IAdaptiveCard](interfaces/iadaptivecard.md)
+* [ICardElement](interfaces/icardelement.md)
+* [IFontSizeDefinitions](interfaces/ifontsizedefinitions.md)
+* [IFontWeightDefinitions](interfaces/ifontweightdefinitions.md)
+* [IInput](interfaces/iinput.md)
+* [ILineHeightDefinitions](interfaces/ilineheightdefinitions.md)
+* [IMarkdownProcessingResult](interfaces/imarkdownprocessingresult.md)
+* [IResourceInformation](interfaces/iresourceinformation.md)
+* [ISeparationDefinition](interfaces/iseparationdefinition.md)
+* [ITypeRegistration](interfaces/ityperegistration.md)
+* [IValidationError](interfaces/ivalidationerror.md)
+
+### Type aliases
+
+* [CardElementHeight](README.md#cardelementheight)
+* [ColumnWidth](README.md#columnwidth)
+* [Dictionary](README.md#dictionary)
+* [HostCapabilityMap](README.md#hostcapabilitymap)
+* [HostCapabilityVersion](README.md#hostcapabilityversion)
+
+### Functions
+
+* [appendChild](README.md#appendchild)
+* [createActionInstance](README.md#createactioninstance)
+* [createElementInstance](README.md#createelementinstance)
+* [generateUniqueId](README.md#generateuniqueid)
+* [getBoolValue](README.md#getboolvalue)
+* [getEnumValue](README.md#getenumvalue)
+* [getFitStatus](README.md#getfitstatus)
+* [getNumberValue](README.md#getnumbervalue)
+* [getStringValue](README.md#getstringvalue)
+* [isNullOrEmpty](README.md#isnullorempty)
+* [parseHostConfigEnum](README.md#parsehostconfigenum)
+* [renderSeparation](README.md#renderseparation)
+* [setArrayProperty](README.md#setarrayproperty)
+* [setEnumProperty](README.md#setenumproperty)
+* [setNumberProperty](README.md#setnumberproperty)
+* [setProperty](README.md#setproperty)
+* [stringToCssColor](README.md#stringtocsscolor)
+* [truncate](README.md#truncate)
+
+### Object literals
+
+* [ContentTypes](README.md#const-contenttypes)
+
+## Type aliases
+
+###  CardElementHeight
+
+Ƭ **CardElementHeight**: *"auto" | "stretch"*
+
+*Defined in [card-elements.ts:293](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L293)*
+
+___
+
+###  ColumnWidth
+
+Ƭ **ColumnWidth**: *[SizeAndUnit](classes/sizeandunit.md) | "auto" | "stretch"*
+
+*Defined in [card-elements.ts:5819](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5819)*
+
+___
+
+###  Dictionary
+
+Ƭ **Dictionary**: *object*
+
+*Defined in [shared.ts:22](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/shared.ts#L22)*
+
+#### Type declaration:
+
+* \[ **key**: *string*\]: T
+
+___
+
+###  HostCapabilityMap
+
+Ƭ **HostCapabilityMap**: *object*
+
+*Defined in [host-config.ts:479](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L479)*
+
+#### Type declaration:
+
+* \[ **key**: *string*\]: [HostCapabilityVersion](README.md#hostcapabilityversion)
+
+___
+
+###  HostCapabilityVersion
+
+Ƭ **HostCapabilityVersion**: *[Version](classes/version.md) | "*"*
+
+*Defined in [host-config.ts:478](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L478)*
+
+## Functions
+
+###  appendChild
+
+▸ **appendChild**(`node`: Node, `child`: Node): *void*
+
+*Defined in [utils.ts:25](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/utils.ts#L25)*
+
+Appends `child` to `node` if `child` is valid
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`node` | Node |
+`child` | Node |
+
+**Returns:** *void*
+
+___
+
+###  createActionInstance
+
+▸ **createActionInstance**(`parent`: [CardElement](classes/cardelement.md), `json`: any, `forbiddenActionTypes`: string[], `allowFallback`: boolean, `errors`: Array‹[IValidationError](interfaces/ivalidationerror.md)›): *[Action](classes/action.md)*
+
+*Defined in [card-elements.ts:99](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L99)*
+
+Instantiates an [`Action`](classes/action.md) for a [`CardElement`](classes/cardelement.md)
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`parent` | [CardElement](classes/cardelement.md) | The [`CardElement`](classes/cardelement.md) for which to create an [`Action`](classes/action.md) |
+`json` | any | A json object containing [`Action`](classes/action.md) properties |
+`forbiddenActionTypes` | string[] | A list of action types that are not allowed to be created |
+`allowFallback` | boolean | Whether to allow element fallback to occur |
+`errors` | Array‹[IValidationError](interfaces/ivalidationerror.md)› | A list of validation errors encountered while parsing the action  |
+
+**Returns:** *[Action](classes/action.md)*
+
+___
+
+###  createElementInstance
+
+▸ **createElementInstance**(`parent`: [CardElement](classes/cardelement.md), `json`: any, `allowFallback`: boolean, `errors`: Array‹[IValidationError](interfaces/ivalidationerror.md)›): *[CardElement](classes/cardelement.md)*
+
+*Defined in [card-elements.ts:135](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L135)*
+
+Instantiates a [`CardElement`](classes/cardelement.md)
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`parent` | [CardElement](classes/cardelement.md) | The parent of this [`CardElement`](classes/cardelement.md) |
+`json` | any | A json object containing [`CardElement`](classes/cardelement.md) properties |
+`allowFallback` | boolean | Whether to allow element fallback to occur |
+`errors` | Array‹[IValidationError](interfaces/ivalidationerror.md)› | A list of validation errors encountered while parsing the action  |
+
+**Returns:** *[CardElement](classes/cardelement.md)*
+
+___
+
+###  generateUniqueId
+
+▸ **generateUniqueId**(): *string*
+
+*Defined in [utils.ts:10](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/utils.ts#L10)*
+
+Generate a UUID prepended with "__ac-"
+
+**Returns:** *string*
+
+___
+
+###  getBoolValue
+
+▸ **getBoolValue**(`value`: any, `defaultValue`: boolean): *boolean*
+
+*Defined in [utils.ts:48](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/utils.ts#L48)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | any |
+`defaultValue` | boolean |
+
+**Returns:** *boolean*
+
+`value` if it's a `boolean` or if it's `"true"` or `"false"`. Otherwise returns `defaultValue || undefined`
+
+___
+
+###  getEnumValue
+
+▸ **getEnumValue**(`targetEnum`: object, `name`: string, `defaultValue`: number): *number*
+
+*Defined in [utils.ts:82](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/utils.ts#L82)*
+
+Convert from a `string` to an `enum` value
+``` typescript
+enum Test {
+     Pass,
+     Fail,
+     Unknown
+}
+getEnumValue(Test, "Fail", Test.Unknown); // returns 1 (Test.Fail)
+getEnumValue(Test, "Not an enum value", Test.Unknown); // returns 2 (Test.Unknown)
+```
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`targetEnum` | object | `enum` to resolve against |
+`name` | string | `string` to look up |
+`defaultValue` | number | value to use if lookup fails |
+
+**Returns:** *number*
+
+Numeric `enum` value if lookup succeeded. Otherwise `defaultValue`
+
+___
+
+###  getFitStatus
+
+▸ **getFitStatus**(`element`: HTMLElement, `containerEnd`: number): *[ContainerFitStatus](enums/containerfitstatus.md)*
+
+*Defined in [utils.ts:325](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/utils.ts#L325)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | HTMLElement |
+`containerEnd` | number |
+
+**Returns:** *[ContainerFitStatus](enums/containerfitstatus.md)*
+
+___
+
+###  getNumberValue
+
+▸ **getNumberValue**(`obj`: any, `defaultValue`: number): *number*
+
+*Defined in [utils.ts:41](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/utils.ts#L41)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`obj` | any | - |
+`defaultValue` | number | undefined |
+
+**Returns:** *number*
+
+`obj` if `obj` is of type `number`. Otherwise, returns `defaultValue || undefined`
+
+___
+
+###  getStringValue
+
+▸ **getStringValue**(`obj`: any, `defaultValue`: string): *string*
+
+*Defined in [utils.ts:34](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/utils.ts#L34)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`obj` | any | - |
+`defaultValue` | string | undefined |
+
+**Returns:** *string*
+
+`obj.toString()` if `obj` is of type `string`. Otherwise, returns `defaultValue || undefined`
+
+___
+
+###  isNullOrEmpty
+
+▸ **isNullOrEmpty**(`value`: string): *boolean*
+
+*Defined in [utils.ts:18](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/utils.ts#L18)*
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`value` | string | string to test |
+
+**Returns:** *boolean*
+
+`true` if `string` is `undefined`, `null`, or `""`
+
+___
+
+###  parseHostConfigEnum
+
+▸ **parseHostConfigEnum**(`targetEnum`: object, `value`: string | number, `defaultValue`: any): *any*
+
+*Defined in [utils.ts:175](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/utils.ts#L175)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`targetEnum` | object |
+`value` | string &#124; number |
+`defaultValue` | any |
+
+**Returns:** *any*
+
+___
+
+###  renderSeparation
+
+▸ **renderSeparation**(`hostConfig`: [HostConfig](classes/hostconfig.md), `separationDefinition`: [ISeparationDefinition](interfaces/iseparationdefinition.md), `orientation`: [Orientation](enums/orientation.md)): *HTMLElement*
+
+*Defined in [utils.ts:187](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/utils.ts#L187)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`hostConfig` | [HostConfig](classes/hostconfig.md) |
+`separationDefinition` | [ISeparationDefinition](interfaces/iseparationdefinition.md) |
+`orientation` | [Orientation](enums/orientation.md) |
+
+**Returns:** *HTMLElement*
+
+___
+
+###  setArrayProperty
+
+▸ **setArrayProperty**(`target`: object, `propertyName`: string, `propertyValue`: any[]): *void*
+
+*Defined in [utils.ts:156](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/utils.ts#L156)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`target` | object |
+`propertyName` | string |
+`propertyValue` | any[] |
+
+**Returns:** *void*
+
+___
+
+###  setEnumProperty
+
+▸ **setEnumProperty**(`enumType`: object, `target`: object, `propertyName`: string, `propertyValue`: number, `defaultValue`: number): *void*
+
+*Defined in [utils.ts:134](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/utils.ts#L134)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`enumType` | object | - |
+`target` | object | - |
+`propertyName` | string | - |
+`propertyValue` | number | - |
+`defaultValue` | number | undefined |
+
+**Returns:** *void*
+
+___
+
+###  setNumberProperty
+
+▸ **setNumberProperty**(`target`: object, `propertyName`: string, `propertyValue`: number, `defaultValue`: number): *void*
+
+*Defined in [utils.ts:125](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/utils.ts#L125)*
+
+**Parameters:**
+
+Name | Type | Default | Description |
+------ | ------ | ------ | ------ |
+`target` | object | - | `object` to set property on |
+`propertyName` | string | - | Name of property to set |
+`propertyValue` | number | - | Value to set property to |
+`defaultValue` | number | undefined | Value to use if `propertyValue` isn't valid  |
+
+**Returns:** *void*
+
+___
+
+###  setProperty
+
+▸ **setProperty**(`target`: object, `propertyName`: string, `propertyValue`: any, `defaultValue`: any): *void*
+
+*Defined in [utils.ts:110](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/utils.ts#L110)*
+
+**Parameters:**
+
+Name | Type | Default | Description |
+------ | ------ | ------ | ------ |
+`target` | object | - | `object` to set property on |
+`propertyName` | string | - | Name of property to set |
+`propertyValue` | any | - | Value to set property to |
+`defaultValue` | any | undefined | Value to use if `propertyValue` isn't valid  |
+
+**Returns:** *void*
+
+___
+
+###  stringToCssColor
+
+▸ **stringToCssColor**(`color`: string): *string*
+
+*Defined in [utils.ts:222](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/utils.ts#L222)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`color` | string |
+
+**Returns:** *string*
+
+___
+
+###  truncate
+
+▸ **truncate**(`element`: HTMLElement, `maxHeight`: number, `lineHeight?`: number): *void*
+
+*Defined in [utils.ts:240](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/utils.ts#L240)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | HTMLElement |
+`maxHeight` | number |
+`lineHeight?` | number |
+
+**Returns:** *void*
+
+## Object literals
+
+### `Const` ContentTypes
+
+### ▪ **ContentTypes**: *object*
+
+*Defined in [shared.ts:5](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/shared.ts#L5)*
+
+###  applicationJson
+
+• **applicationJson**: *string* = "application/json"
+
+*Defined in [shared.ts:6](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/shared.ts#L6)*
+
+###  applicationXWwwFormUrlencoded
+
+• **applicationXWwwFormUrlencoded**: *string* = "application/x-www-form-urlencoded"
+
+*Defined in [shared.ts:7](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/shared.ts#L7)*

--- a/source/nodejs/adaptivecards/docs/classes/action.md
+++ b/source/nodejs/adaptivecards/docs/classes/action.md
@@ -1,0 +1,491 @@
+[Adaptive Cards Javascript SDK](../README.md) › [Action](action.md)
+
+# Class: Action
+
+## Hierarchy
+
+  ↳ [CardObject](cardobject.md)
+
+  ↳ **Action**
+
+  ↳ [SubmitAction](submitaction.md)
+
+  ↳ [OpenUrlAction](openurlaction.md)
+
+  ↳ [ToggleVisibilityAction](togglevisibilityaction.md)
+
+  ↳ [HttpAction](httpaction.md)
+
+  ↳ [ShowCardAction](showcardaction.md)
+
+## Index
+
+### Properties
+
+* [iconUrl](action.md#iconurl)
+* [id](action.md#id)
+* [onExecute](action.md#onexecute)
+* [requires](action.md#requires)
+* [style](action.md#style)
+* [title](action.md#title)
+
+### Accessors
+
+* [ignoreInputValidation](action.md#ignoreinputvalidation)
+* [isPrimary](action.md#isprimary)
+* [parent](action.md#parent)
+* [renderedElement](action.md#renderedelement)
+
+### Methods
+
+* [addCssClasses](action.md#protected-addcssclasses)
+* [execute](action.md#execute)
+* [getActionById](action.md#getactionbyid)
+* [getAllInputs](action.md#getallinputs)
+* [getCustomProperty](action.md#getcustomproperty)
+* [getHref](action.md#gethref)
+* [getJsonTypeName](action.md#abstract-getjsontypename)
+* [getReferencedInputs](action.md#getreferencedinputs)
+* [getResourceInformation](action.md#getresourceinformation)
+* [internalGetReferencedInputs](action.md#protected-internalgetreferencedinputs)
+* [internalPrepareForExecution](action.md#protected-internalprepareforexecution)
+* [internalValidateInputs](action.md#protected-internalvalidateinputs)
+* [internalValidateProperties](action.md#internalvalidateproperties)
+* [parse](action.md#parse)
+* [prepareForExecution](action.md#prepareforexecution)
+* [remove](action.md#remove)
+* [render](action.md#render)
+* [setCustomProperty](action.md#setcustomproperty)
+* [setParent](action.md#setparent)
+* [shouldFallback](action.md#shouldfallback)
+* [toJSON](action.md#tojson)
+* [validateInputs](action.md#validateinputs)
+* [validateProperties](action.md#validateproperties)
+
+## Properties
+
+###  iconUrl
+
+• **iconUrl**: *string*
+
+*Defined in [card-elements.ts:3905](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3905)*
+
+___
+
+###  id
+
+• **id**: *string*
+
+*Inherited from [CardObject](cardobject.md).[id](cardobject.md#id)*
+
+*Defined in [card-elements.ts:247](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L247)*
+
+___
+
+###  onExecute
+
+• **onExecute**: *function*
+
+*Defined in [card-elements.ts:3908](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3908)*
+
+#### Type declaration:
+
+▸ (`sender`: [Action](action.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`sender` | [Action](action.md) |
+
+___
+
+###  requires
+
+• **requires**: *[HostCapabilities](hostcapabilities.md)‹›* = new HostConfig.HostCapabilities()
+
+*Defined in [card-elements.ts:3902](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3902)*
+
+___
+
+###  style
+
+• **style**: *string* = Enums.ActionStyle.Default
+
+*Defined in [card-elements.ts:3906](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3906)*
+
+___
+
+###  title
+
+• **title**: *string*
+
+*Defined in [card-elements.ts:3904](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3904)*
+
+## Accessors
+
+###  ignoreInputValidation
+
+• **get ignoreInputValidation**(): *boolean*
+
+*Defined in [card-elements.ts:4088](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4088)*
+
+**Returns:** *boolean*
+
+___
+
+###  isPrimary
+
+• **get isPrimary**(): *boolean*
+
+*Defined in [card-elements.ts:4073](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4073)*
+
+**Returns:** *boolean*
+
+• **set isPrimary**(`value`: boolean): *void*
+
+*Defined in [card-elements.ts:4077](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4077)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  parent
+
+• **get parent**(): *[CardElement](cardelement.md)*
+
+*Defined in [card-elements.ts:4092](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4092)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  renderedElement
+
+• **get renderedElement**(): *HTMLElement*
+
+*Defined in [card-elements.ts:4096](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4096)*
+
+**Returns:** *HTMLElement*
+
+## Methods
+
+### `Protected` addCssClasses
+
+▸ **addCssClasses**(`element`: HTMLElement): *void*
+
+*Defined in [card-elements.ts:3872](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3872)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+###  execute
+
+▸ **execute**(): *void*
+
+*Defined in [card-elements.ts:3992](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3992)*
+
+**Returns:** *void*
+
+___
+
+###  getActionById
+
+▸ **getActionById**(`id`: string): *[Action](action.md)*
+
+*Defined in [card-elements.ts:4055](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4055)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getAllInputs
+
+▸ **getAllInputs**(): *Array‹[Input](input.md)›*
+
+*Defined in [card-elements.ts:4042](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4042)*
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+###  getHref
+
+▸ **getHref**(): *string*
+
+*Defined in [card-elements.ts:3910](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3910)*
+
+**Returns:** *string*
+
+___
+
+### `Abstract` getJsonTypeName
+
+▸ **getJsonTypeName**(): *string*
+
+*Overrides [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
+
+*Defined in [card-elements.ts:3900](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3900)*
+
+**Returns:** *string*
+
+___
+
+###  getReferencedInputs
+
+▸ **getReferencedInputs**(): *Shared.Dictionary‹[Input](input.md)›*
+
+*Defined in [card-elements.ts:4061](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4061)*
+
+**Returns:** *Shared.Dictionary‹[Input](input.md)›*
+
+___
+
+###  getResourceInformation
+
+▸ **getResourceInformation**(): *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+*Defined in [card-elements.ts:4046](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4046)*
+
+**Returns:** *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+___
+
+### `Protected` internalGetReferencedInputs
+
+▸ **internalGetReferencedInputs**(`allInputs`: Array‹[Input](input.md)›): *Shared.Dictionary‹[Input](input.md)›*
+
+*Defined in [card-elements.ts:3876](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3876)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`allInputs` | Array‹[Input](input.md)› |
+
+**Returns:** *Shared.Dictionary‹[Input](input.md)›*
+
+___
+
+### `Protected` internalPrepareForExecution
+
+▸ **internalPrepareForExecution**(`inputs`: Shared.Dictionary‹[Input](input.md)›): *void*
+
+*Defined in [card-elements.ts:3880](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3880)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`inputs` | Shared.Dictionary‹[Input](input.md)› |
+
+**Returns:** *void*
+
+___
+
+### `Protected` internalValidateInputs
+
+▸ **internalValidateInputs**(`referencedInputs`: Shared.Dictionary‹[Input](input.md)›): *Array‹[Input](input.md)›*
+
+*Defined in [card-elements.ts:3884](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3884)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`referencedInputs` | Shared.Dictionary‹[Input](input.md)› |
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+###  internalValidateProperties
+
+▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
+
+*Inherited from [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
+
+*Defined in [card-elements.ts:249](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L249)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [ValidationResults](validationresults.md) |
+
+**Returns:** *void*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Overrides [CardObject](cardobject.md).[parse](cardobject.md#parse)*
+
+*Defined in [card-elements.ts:4012](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4012)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*
+
+___
+
+###  prepareForExecution
+
+▸ **prepareForExecution**(): *boolean*
+
+*Defined in [card-elements.ts:4000](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4000)*
+
+**Returns:** *boolean*
+
+___
+
+###  remove
+
+▸ **remove**(): *boolean*
+
+*Defined in [card-elements.ts:4034](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4034)*
+
+**Returns:** *boolean*
+
+___
+
+###  render
+
+▸ **render**(`baseCssClass`: string): *void*
+
+*Defined in [card-elements.ts:3925](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3925)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`baseCssClass` | string | "ac-pushButton" |
+
+**Returns:** *void*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+###  setParent
+
+▸ **setParent**(`value`: [CardElement](cardelement.md)): *void*
+
+*Overrides [CardObject](cardobject.md).[setParent](cardobject.md#abstract-setparent)*
+
+*Defined in [card-elements.ts:3988](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3988)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+###  shouldFallback
+
+▸ **shouldFallback**(): *boolean*
+
+*Overrides [CardObject](cardobject.md).[shouldFallback](cardobject.md#abstract-shouldfallback)*
+
+*Defined in [card-elements.ts:4069](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4069)*
+
+**Returns:** *boolean*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [CardObject](cardobject.md).[toJSON](cardobject.md#tojson)*
+
+*Defined in [card-elements.ts:3914](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3914)*
+
+**Returns:** *any*
+
+___
+
+###  validateInputs
+
+▸ **validateInputs**(): *[Input](input.md)‹›[]*
+
+*Defined in [card-elements.ts:4065](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4065)*
+
+**Returns:** *[Input](input.md)‹›[]*
+
+___
+
+###  validateProperties
+
+▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
+
+*Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
+
+*Defined in [card-elements.ts:284](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L284)*
+
+**Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/actionsconfig.md
+++ b/source/nodejs/adaptivecards/docs/classes/actionsconfig.md
@@ -1,0 +1,150 @@
+[Adaptive Cards Javascript SDK](../README.md) › [ActionsConfig](actionsconfig.md)
+
+# Class: ActionsConfig
+
+## Hierarchy
+
+* **ActionsConfig**
+
+## Index
+
+### Constructors
+
+* [constructor](actionsconfig.md#constructor)
+
+### Properties
+
+* [actionAlignment](actionsconfig.md#actionalignment)
+* [actionsOrientation](actionsconfig.md#actionsorientation)
+* [allowTitleToWrap](actionsconfig.md#allowtitletowrap)
+* [buttonSpacing](actionsconfig.md#buttonspacing)
+* [iconPlacement](actionsconfig.md#iconplacement)
+* [iconSize](actionsconfig.md#iconsize)
+* [maxActions](actionsconfig.md#maxactions)
+* [preExpandSingleShowCardAction](actionsconfig.md#optional-preexpandsingleshowcardaction)
+* [showCard](actionsconfig.md#showcard)
+* [spacing](actionsconfig.md#spacing)
+
+### Methods
+
+* [toJSON](actionsconfig.md#tojson)
+
+## Constructors
+
+###  constructor
+
+\+ **new ActionsConfig**(`obj?`: any): *[ActionsConfig](actionsconfig.md)*
+
+*Defined in [host-config.ts:190](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L190)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`obj?` | any |
+
+**Returns:** *[ActionsConfig](actionsconfig.md)*
+
+## Properties
+
+###  actionAlignment
+
+• **actionAlignment**: *[ActionAlignment](../enums/actionalignment.md)* = Enums.ActionAlignment.Left
+
+*Defined in [host-config.ts:187](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L187)*
+
+___
+
+###  actionsOrientation
+
+• **actionsOrientation**: *[Orientation](../enums/orientation.md)* = Enums.Orientation.Horizontal
+
+*Defined in [host-config.ts:186](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L186)*
+
+___
+
+###  allowTitleToWrap
+
+• **allowTitleToWrap**: *boolean* = false
+
+*Defined in [host-config.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L189)*
+
+___
+
+###  buttonSpacing
+
+• **buttonSpacing**: *number* = 20
+
+*Defined in [host-config.ts:183](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L183)*
+
+___
+
+###  iconPlacement
+
+• **iconPlacement**: *[ActionIconPlacement](../enums/actioniconplacement.md)* = Enums.ActionIconPlacement.LeftOfTitle
+
+*Defined in [host-config.ts:188](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L188)*
+
+___
+
+###  iconSize
+
+• **iconSize**: *number* = 24
+
+*Defined in [host-config.ts:190](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L190)*
+
+___
+
+###  maxActions
+
+• **maxActions**: *number* = 5
+
+*Defined in [host-config.ts:181](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L181)*
+
+___
+
+### `Optional` preExpandSingleShowCardAction
+
+• **preExpandSingleShowCardAction**? : *boolean* = false
+
+*Defined in [host-config.ts:185](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L185)*
+
+___
+
+###  showCard
+
+• **showCard**: *[ShowCardActionConfig](showcardactionconfig.md)* = new ShowCardActionConfig()
+
+*Defined in [host-config.ts:184](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L184)*
+
+___
+
+###  spacing
+
+• **spacing**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.Default
+
+*Defined in [host-config.ts:182](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L182)*
+
+## Methods
+
+###  toJSON
+
+▸ **toJSON**(): *object*
+
+*Defined in [host-config.ts:217](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L217)*
+
+**Returns:** *object*
+
+* **actionAlignment**: *string* = Enums.ActionAlignment[this.actionAlignment]
+
+* **actionsOrientation**: *string* = Enums.Orientation[this.actionsOrientation]
+
+* **buttonSpacing**: *number* = this.buttonSpacing
+
+* **maxActions**: *number* = this.maxActions
+
+* **preExpandSingleShowCardAction**: *boolean* = this.preExpandSingleShowCardAction
+
+* **showCard**: *[ShowCardActionConfig](showcardactionconfig.md)‹›* = this.showCard
+
+* **spacing**: *string* = Enums.Spacing[this.spacing]

--- a/source/nodejs/adaptivecards/docs/classes/actionset.md
+++ b/source/nodejs/adaptivecards/docs/classes/actionset.md
@@ -1,0 +1,1249 @@
+[Adaptive Cards Javascript SDK](../README.md) › [ActionSet](actionset.md)
+
+# Class: ActionSet
+
+## Hierarchy
+
+  ↳ [CardElement](cardelement.md)
+
+  ↳ **ActionSet**
+
+## Index
+
+### Constructors
+
+* [constructor](actionset.md#constructor)
+
+### Properties
+
+* [customCssSelector](actionset.md#customcssselector)
+* [height](actionset.md#height)
+* [horizontalAlignment](actionset.md#optional-horizontalalignment)
+* [id](actionset.md#id)
+* [minPixelHeight](actionset.md#optional-minpixelheight)
+* [orientation](actionset.md#optional-orientation)
+* [requires](actionset.md#requires)
+* [separator](actionset.md#separator)
+* [spacing](actionset.md#spacing)
+
+### Accessors
+
+* [allowCustomPadding](actionset.md#protected-allowcustompadding)
+* [defaultStyle](actionset.md#protected-defaultstyle)
+* [hasVisibleSeparator](actionset.md#hasvisibleseparator)
+* [hostConfig](actionset.md#hostconfig)
+* [index](actionset.md#index)
+* [isInline](actionset.md#isinline)
+* [isInteractive](actionset.md#isinteractive)
+* [isStandalone](actionset.md#isstandalone)
+* [isVisible](actionset.md#isvisible)
+* [lang](actionset.md#lang)
+* [parent](actionset.md#parent)
+* [renderedElement](actionset.md#renderedelement)
+* [separatorElement](actionset.md#separatorelement)
+* [separatorOrientation](actionset.md#protected-separatororientation)
+* [supportsMinHeight](actionset.md#protected-supportsminheight)
+* [useDefaultSizing](actionset.md#protected-usedefaultsizing)
+
+### Methods
+
+* [addAction](actionset.md#addaction)
+* [adjustRenderedElementSize](actionset.md#protected-adjustrenderedelementsize)
+* [applyPadding](actionset.md#protected-applypadding)
+* [asString](actionset.md#asstring)
+* [createPlaceholderElement](actionset.md#protected-createplaceholderelement)
+* [getActionAt](actionset.md#getactionat)
+* [getActionById](actionset.md#getactionbyid)
+* [getActionCount](actionset.md#getactioncount)
+* [getAllInputs](actionset.md#getallinputs)
+* [getCustomProperty](actionset.md#getcustomproperty)
+* [getDefaultPadding](actionset.md#protected-getdefaultpadding)
+* [getEffectivePadding](actionset.md#geteffectivepadding)
+* [getEffectiveStyle](actionset.md#geteffectivestyle)
+* [getElementById](actionset.md#getelementbyid)
+* [getForbiddenActionTypes](actionset.md#getforbiddenactiontypes)
+* [getForbiddenElementTypes](actionset.md#getforbiddenelementtypes)
+* [getHasBackground](actionset.md#protected-gethasbackground)
+* [getImmediateSurroundingPadding](actionset.md#getimmediatesurroundingpadding)
+* [getJsonTypeName](actionset.md#getjsontypename)
+* [getPadding](actionset.md#protected-getpadding)
+* [getParentContainer](actionset.md#getparentcontainer)
+* [getResourceInformation](actionset.md#getresourceinformation)
+* [getRootElement](actionset.md#getrootelement)
+* [indexOf](actionset.md#indexof)
+* [internalRender](actionset.md#protected-internalrender)
+* [internalValidateProperties](actionset.md#internalvalidateproperties)
+* [isAtTheVeryBottom](actionset.md#isattheverybottom)
+* [isAtTheVeryLeft](actionset.md#isattheveryleft)
+* [isAtTheVeryRight](actionset.md#isattheveryright)
+* [isAtTheVeryTop](actionset.md#isattheverytop)
+* [isBleeding](actionset.md#isbleeding)
+* [isBleedingAtBottom](actionset.md#isbleedingatbottom)
+* [isBleedingAtTop](actionset.md#isbleedingattop)
+* [isBottomElement](actionset.md#isbottomelement)
+* [isDesignMode](actionset.md#isdesignmode)
+* [isFirstElement](actionset.md#isfirstelement)
+* [isHiddenDueToOverflow](actionset.md#ishiddenduetooverflow)
+* [isLastElement](actionset.md#islastelement)
+* [isLeftMostElement](actionset.md#isleftmostelement)
+* [isRendered](actionset.md#isrendered)
+* [isRightMostElement](actionset.md#isrightmostelement)
+* [isTopElement](actionset.md#istopelement)
+* [overrideInternalRender](actionset.md#protected-overrideinternalrender)
+* [parse](actionset.md#parse)
+* [remove](actionset.md#remove)
+* [render](actionset.md#render)
+* [setCustomProperty](actionset.md#setcustomproperty)
+* [setPadding](actionset.md#protected-setpadding)
+* [setParent](actionset.md#setparent)
+* [setShouldFallback](actionset.md#setshouldfallback)
+* [shouldFallback](actionset.md#shouldfallback)
+* [toJSON](actionset.md#tojson)
+* [truncateOverflow](actionset.md#protected-truncateoverflow)
+* [undoOverflowTruncation](actionset.md#protected-undooverflowtruncation)
+* [updateLayout](actionset.md#updatelayout)
+* [validateProperties](actionset.md#validateproperties)
+
+## Constructors
+
+###  constructor
+
+\+ **new ActionSet**(): *[ActionSet](actionset.md)*
+
+*Defined in [card-elements.ts:5042](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5042)*
+
+**Returns:** *[ActionSet](actionset.md)*
+
+## Properties
+
+###  customCssSelector
+
+• **customCssSelector**: *string* = null
+
+*Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#customcssselector)*
+
+*Defined in [card-elements.ts:507](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L507)*
+
+___
+
+###  height
+
+• **height**: *[CardElementHeight](../README.md#cardelementheight)* = "auto"
+
+*Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
+
+*Defined in [card-elements.ts:508](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L508)*
+
+___
+
+### `Optional` horizontalAlignment
+
+• **horizontalAlignment**? : *[HorizontalAlignment](../enums/horizontalalignment.md)* = null
+
+*Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#optional-horizontalalignment)*
+
+*Defined in [card-elements.ts:504](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L504)*
+
+___
+
+###  id
+
+• **id**: *string*
+
+*Inherited from [CardObject](cardobject.md).[id](cardobject.md#id)*
+
+*Defined in [card-elements.ts:247](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L247)*
+
+___
+
+### `Optional` minPixelHeight
+
+• **minPixelHeight**? : *number* = null
+
+*Inherited from [CardElement](cardelement.md).[minPixelHeight](cardelement.md#optional-minpixelheight)*
+
+*Defined in [card-elements.ts:509](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L509)*
+
+___
+
+### `Optional` orientation
+
+• **orientation**? : *[Orientation](../enums/orientation.md)* = null
+
+*Defined in [card-elements.ts:5042](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5042)*
+
+___
+
+###  requires
+
+• **requires**: *[HostCapabilities](hostcapabilities.md)‹›* = new HostConfig.HostCapabilities()
+
+*Inherited from [CardElement](cardelement.md).[requires](cardelement.md#requires)*
+
+*Defined in [card-elements.ts:502](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L502)*
+
+___
+
+###  separator
+
+• **separator**: *boolean* = false
+
+*Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
+
+*Defined in [card-elements.ts:506](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L506)*
+
+___
+
+###  spacing
+
+• **spacing**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.Default
+
+*Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
+
+*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
+
+## Accessors
+
+### `Protected` allowCustomPadding
+
+• **get allowCustomPadding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
+
+*Defined in [card-elements.ts:490](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L490)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` defaultStyle
+
+• **get defaultStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
+
+*Defined in [card-elements.ts:498](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L498)*
+
+**Returns:** *string*
+
+___
+
+###  hasVisibleSeparator
+
+• **get hasVisibleSeparator**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
+
+*Defined in [card-elements.ts:928](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L928)*
+
+**Returns:** *boolean*
+
+___
+
+###  hostConfig
+
+• **get hostConfig**(): *[HostConfig](hostconfig.md)*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:881](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L881)*
+
+**Returns:** *[HostConfig](hostconfig.md)*
+
+• **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:895](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L895)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [HostConfig](hostconfig.md) |
+
+**Returns:** *void*
+
+___
+
+###  index
+
+• **get index**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
+
+*Defined in [card-elements.ts:899](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L899)*
+
+**Returns:** *number*
+
+___
+
+###  isInline
+
+• **get isInline**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
+
+*Defined in [card-elements.ts:916](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L916)*
+
+**Returns:** *boolean*
+
+___
+
+###  isInteractive
+
+• **get isInteractive**(): *boolean*
+
+*Overrides [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
+
+*Defined in [card-elements.ts:5120](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5120)*
+
+**Returns:** *boolean*
+
+___
+
+###  isStandalone
+
+• **get isStandalone**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
+
+*Defined in [card-elements.ts:912](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L912)*
+
+**Returns:** *boolean*
+
+___
+
+###  isVisible
+
+• **get isVisible**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:924](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L924)*
+
+**Returns:** *boolean*
+
+• **set isVisible**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:937](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L937)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  lang
+
+• **get lang**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:853](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L853)*
+
+**Returns:** *string*
+
+• **set lang**(`value`: string): *void*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:867](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L867)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  parent
+
+• **get parent**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[parent](cardelement.md#parent)*
+
+*Defined in [card-elements.ts:920](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L920)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  renderedElement
+
+• **get renderedElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[renderedElement](cardelement.md#renderedelement)*
+
+*Defined in [card-elements.ts:956](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L956)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  separatorElement
+
+• **get separatorElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
+
+*Defined in [card-elements.ts:960](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L960)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` separatorOrientation
+
+• **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
+
+*Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
+
+*Defined in [card-elements.ts:494](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L494)*
+
+**Returns:** *[Orientation](../enums/orientation.md)*
+
+___
+
+### `Protected` supportsMinHeight
+
+• **get supportsMinHeight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[supportsMinHeight](cardelement.md#protected-supportsminheight)*
+
+*Defined in [card-elements.ts:482](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L482)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` useDefaultSizing
+
+• **get useDefaultSizing**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
+
+*Defined in [card-elements.ts:486](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L486)*
+
+**Returns:** *boolean*
+
+## Methods
+
+###  addAction
+
+▸ **addAction**(`action`: [Action](action.md)): *void*
+
+*Defined in [card-elements.ts:5108](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5108)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`action` | [Action](action.md) |
+
+**Returns:** *void*
+
+___
+
+### `Protected` adjustRenderedElementSize
+
+▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
+
+*Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
+
+*Defined in [card-elements.ts:411](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L411)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`renderedElement` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+### `Protected` applyPadding
+
+▸ **applyPadding**(): *void*
+
+*Inherited from [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
+
+*Defined in [card-elements.ts:430](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L430)*
+
+**Returns:** *void*
+
+___
+
+###  asString
+
+▸ **asString**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
+
+*Defined in [card-elements.ts:513](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L513)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` createPlaceholderElement
+
+▸ **createPlaceholderElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
+
+*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  getActionAt
+
+▸ **getActionAt**(`index`: number): *[Action](action.md)*
+
+*Overrides [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
+
+*Defined in [card-elements.ts:5081](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5081)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionById
+
+▸ **getActionById**(`id`: string): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
+
+*Defined in [card-elements.ts:835](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L835)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionCount
+
+▸ **getActionCount**(): *number*
+
+*Overrides [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
+
+*Defined in [card-elements.ts:5077](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5077)*
+
+**Returns:** *number*
+
+___
+
+###  getAllInputs
+
+▸ **getAllInputs**(): *Array‹[Input](input.md)›*
+
+*Overrides [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
+
+*Defined in [card-elements.ts:5112](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5112)*
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+### `Protected` getDefaultPadding
+
+▸ **getDefaultPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
+
+*Defined in [card-elements.ts:466](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L466)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectivePadding
+
+▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
+
+*Defined in [card-elements.ts:847](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L847)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectiveStyle
+
+▸ **getEffectiveStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
+
+*Defined in [card-elements.ts:545](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L545)*
+
+**Returns:** *string*
+
+___
+
+###  getElementById
+
+▸ **getElementById**(`id`: string): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
+
+*Defined in [card-elements.ts:831](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L831)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getForbiddenActionTypes
+
+▸ **getForbiddenActionTypes**(): *Array‹any›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
+
+*Defined in [card-elements.ts:557](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L557)*
+
+**Returns:** *Array‹any›*
+
+___
+
+###  getForbiddenElementTypes
+
+▸ **getForbiddenElementTypes**(): *Array‹string›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenElementTypes](cardelement.md#getforbiddenelementtypes)*
+
+*Defined in [card-elements.ts:553](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L553)*
+
+**Returns:** *Array‹string›*
+
+___
+
+### `Protected` getHasBackground
+
+▸ **getHasBackground**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
+
+*Defined in [card-elements.ts:470](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L470)*
+
+**Returns:** *boolean*
+
+___
+
+###  getImmediateSurroundingPadding
+
+▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
+
+*Defined in [card-elements.ts:561](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L561)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`result` | [PaddingDefinition](paddingdefinition.md) | - |
+`processTop` | boolean | true |
+`processRight` | boolean | true |
+`processBottom` | boolean | true |
+`processLeft` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  getJsonTypeName
+
+▸ **getJsonTypeName**(): *string*
+
+*Overrides [CardElement](cardelement.md).[getJsonTypeName](cardelement.md#abstract-getjsontypename)*
+
+*Defined in [card-elements.ts:5073](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5073)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` getPadding
+
+▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
+
+*Defined in [card-elements.ts:474](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L474)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getParentContainer
+
+▸ **getParentContainer**(): *[Container](container.md)*
+
+*Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
+
+*Defined in [card-elements.ts:809](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L809)*
+
+**Returns:** *[Container](container.md)*
+
+___
+
+###  getResourceInformation
+
+▸ **getResourceInformation**(): *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+*Overrides [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
+
+*Defined in [card-elements.ts:5116](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5116)*
+
+**Returns:** *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+___
+
+###  getRootElement
+
+▸ **getRootElement**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
+
+*Defined in [card-elements.ts:799](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L799)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  indexOf
+
+▸ **indexOf**(`cardElement`: [CardElement](cardelement.md)): *number*
+
+*Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
+
+*Defined in [card-elements.ts:733](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L733)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`cardElement` | [CardElement](cardelement.md) |
+
+**Returns:** *number*
+
+___
+
+### `Protected` internalRender
+
+▸ **internalRender**(): *HTMLElement*
+
+*Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
+
+*Defined in [card-elements.ts:5038](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5038)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  internalValidateProperties
+
+▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
+
+*Overrides [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
+
+*Defined in [card-elements.ts:5090](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5090)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [ValidationResults](validationresults.md) |
+
+**Returns:** *void*
+
+___
+
+###  isAtTheVeryBottom
+
+▸ **isAtTheVeryBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
+
+*Defined in [card-elements.ts:767](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L767)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryLeft
+
+▸ **isAtTheVeryLeft**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
+
+*Defined in [card-elements.ts:755](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L755)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryRight
+
+▸ **isAtTheVeryRight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
+
+*Defined in [card-elements.ts:759](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L759)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryTop
+
+▸ **isAtTheVeryTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
+
+*Defined in [card-elements.ts:763](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L763)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleeding
+
+▸ **isBleeding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
+
+*Defined in [card-elements.ts:517](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L517)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtBottom
+
+▸ **isBleedingAtBottom**(): *boolean*
+
+*Overrides [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
+
+*Defined in [card-elements.ts:5059](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5059)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtTop
+
+▸ **isBleedingAtTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
+
+*Defined in [card-elements.ts:771](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L771)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBottomElement
+
+▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
+
+*Defined in [card-elements.ts:791](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L791)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isDesignMode
+
+▸ **isDesignMode**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
+
+*Defined in [card-elements.ts:737](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L737)*
+
+**Returns:** *boolean*
+
+___
+
+###  isFirstElement
+
+▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
+
+*Defined in [card-elements.ts:747](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L747)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isHiddenDueToOverflow
+
+▸ **isHiddenDueToOverflow**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
+
+*Defined in [card-elements.ts:795](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L795)*
+
+**Returns:** *boolean*
+
+___
+
+###  isLastElement
+
+▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
+
+*Defined in [card-elements.ts:751](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L751)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isLeftMostElement
+
+▸ **isLeftMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
+
+*Defined in [card-elements.ts:779](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L779)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isRendered
+
+▸ **isRendered**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRendered](cardelement.md#isrendered)*
+
+*Defined in [card-elements.ts:743](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L743)*
+
+**Returns:** *boolean*
+
+___
+
+###  isRightMostElement
+
+▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
+
+*Defined in [card-elements.ts:783](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L783)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isTopElement
+
+▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
+
+*Defined in [card-elements.ts:787](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L787)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` overrideInternalRender
+
+▸ **overrideInternalRender**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
+
+*Defined in [card-elements.ts:426](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L426)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Overrides [CardElement](cardelement.md).[parse](cardelement.md#parse)*
+
+*Defined in [card-elements.ts:5096](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5096)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*
+
+___
+
+###  remove
+
+▸ **remove**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
+
+*Defined in [card-elements.ts:698](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L698)*
+
+**Returns:** *boolean*
+
+___
+
+###  render
+
+▸ **render**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[render](cardelement.md#render)*
+
+*Defined in [card-elements.ts:706](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L706)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setPadding
+
+▸ **setPadding**(`value`: [PaddingDefinition](paddingdefinition.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
+
+*Defined in [card-elements.ts:478](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L478)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [PaddingDefinition](paddingdefinition.md) |
+
+**Returns:** *void*
+
+___
+
+###  setParent
+
+▸ **setParent**(`value`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setParent](cardelement.md#setparent)*
+
+*Overrides [CardObject](cardobject.md).[setParent](cardobject.md#abstract-setparent)*
+
+*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+###  setShouldFallback
+
+▸ **setShouldFallback**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[setShouldFallback](cardelement.md#setshouldfallback)*
+
+*Defined in [card-elements.ts:843](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L843)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  shouldFallback
+
+▸ **shouldFallback**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[shouldFallback](cardelement.md#shouldfallback)*
+
+*Overrides [CardObject](cardobject.md).[shouldFallback](cardobject.md#abstract-shouldfallback)*
+
+*Defined in [card-elements.ts:839](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L839)*
+
+**Returns:** *boolean*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [CardElement](cardelement.md).[toJSON](cardelement.md#tojson)*
+
+*Defined in [card-elements.ts:5050](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5050)*
+
+**Returns:** *any*
+
+___
+
+### `Protected` truncateOverflow
+
+▸ **truncateOverflow**(`maxHeight`: number): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
+
+*Defined in [card-elements.ts:454](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L454)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`maxHeight` | number |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` undoOverflowTruncation
+
+▸ **undoOverflowTruncation**(): *void*
+
+*Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
+
+*Defined in [card-elements.ts:464](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L464)*
+
+**Returns:** *void*
+
+___
+
+###  updateLayout
+
+▸ **updateLayout**(`processChildren`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
+
+*Defined in [card-elements.ts:728](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L728)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`processChildren` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  validateProperties
+
+▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
+
+*Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
+
+*Defined in [card-elements.ts:284](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L284)*
+
+**Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/actionstyle.md
+++ b/source/nodejs/adaptivecards/docs/classes/actionstyle.md
@@ -1,0 +1,39 @@
+[Adaptive Cards Javascript SDK](../README.md) › [ActionStyle](actionstyle.md)
+
+# Class: ActionStyle
+
+## Hierarchy
+
+* **ActionStyle**
+
+## Index
+
+### Properties
+
+* [Default](actionstyle.md#static-default)
+* [Destructive](actionstyle.md#static-destructive)
+* [Positive](actionstyle.md#static-positive)
+
+## Properties
+
+### `Static` Default
+
+▪ **Default**: *"default"* = "default"
+
+*Defined in [enums.ts:8](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L8)*
+
+___
+
+### `Static` Destructive
+
+▪ **Destructive**: *"destructive"* = "destructive"
+
+*Defined in [enums.ts:10](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L10)*
+
+___
+
+### `Static` Positive
+
+▪ **Positive**: *"positive"* = "positive"
+
+*Defined in [enums.ts:9](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L9)*

--- a/source/nodejs/adaptivecards/docs/classes/actiontyperegistry.md
+++ b/source/nodejs/adaptivecards/docs/classes/actiontyperegistry.md
@@ -1,0 +1,147 @@
+[Adaptive Cards Javascript SDK](../README.md) › [ActionTypeRegistry](actiontyperegistry.md)
+
+# Class: ActionTypeRegistry
+
+## Hierarchy
+
+* [TypeRegistry](typeregistry.md)‹[Action](action.md)›
+
+  ↳ **ActionTypeRegistry**
+
+## Index
+
+### Constructors
+
+* [constructor](actiontyperegistry.md#constructor)
+
+### Methods
+
+* [clear](actiontyperegistry.md#clear)
+* [createInstance](actiontyperegistry.md#createinstance)
+* [getItemAt](actiontyperegistry.md#getitemat)
+* [getItemCount](actiontyperegistry.md#getitemcount)
+* [registerType](actiontyperegistry.md#registertype)
+* [reset](actiontyperegistry.md#reset)
+* [unregisterType](actiontyperegistry.md#unregistertype)
+
+## Constructors
+
+###  constructor
+
+\+ **new ActionTypeRegistry**(): *[ActionTypeRegistry](actiontyperegistry.md)*
+
+*Inherited from [TypeRegistry](typeregistry.md).[constructor](typeregistry.md#constructor)*
+
+*Defined in [card-elements.ts:6539](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6539)*
+
+**Returns:** *[ActionTypeRegistry](actiontyperegistry.md)*
+
+## Methods
+
+###  clear
+
+▸ **clear**(): *void*
+
+*Inherited from [TypeRegistry](typeregistry.md).[clear](typeregistry.md#clear)*
+
+*Defined in [card-elements.ts:6545](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6545)*
+
+**Returns:** *void*
+
+___
+
+###  createInstance
+
+▸ **createInstance**(`typeName`: string): *[Action](action.md)*
+
+*Inherited from [TypeRegistry](typeregistry.md).[createInstance](typeregistry.md#createinstance)*
+
+*Defined in [card-elements.ts:6577](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6577)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`typeName` | string |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getItemAt
+
+▸ **getItemAt**(`index`: number): *[ITypeRegistration](../interfaces/ityperegistration.md)‹[Action](action.md)›*
+
+*Inherited from [TypeRegistry](typeregistry.md).[getItemAt](typeregistry.md#getitemat)*
+
+*Defined in [card-elements.ts:6587](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6587)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[ITypeRegistration](../interfaces/ityperegistration.md)‹[Action](action.md)›*
+
+___
+
+###  getItemCount
+
+▸ **getItemCount**(): *number*
+
+*Inherited from [TypeRegistry](typeregistry.md).[getItemCount](typeregistry.md#getitemcount)*
+
+*Defined in [card-elements.ts:6583](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6583)*
+
+**Returns:** *number*
+
+___
+
+###  registerType
+
+▸ **registerType**(`typeName`: string, `createInstance`: function): *void*
+
+*Inherited from [TypeRegistry](typeregistry.md).[registerType](typeregistry.md#registertype)*
+
+*Defined in [card-elements.ts:6551](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6551)*
+
+**Parameters:**
+
+▪ **typeName**: *string*
+
+▪ **createInstance**: *function*
+
+▸ (): *[Action](action.md)*
+
+**Returns:** *void*
+
+___
+
+###  reset
+
+▸ **reset**(): *void*
+
+*Overrides [TypeRegistry](typeregistry.md).[reset](typeregistry.md#abstract-reset)*
+
+*Defined in [card-elements.ts:6616](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6616)*
+
+**Returns:** *void*
+
+___
+
+###  unregisterType
+
+▸ **unregisterType**(`typeName`: string): *void*
+
+*Inherited from [TypeRegistry](typeregistry.md).[unregisterType](typeregistry.md#unregistertype)*
+
+*Defined in [card-elements.ts:6567](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6567)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`typeName` | string |
+
+**Returns:** *void*

--- a/source/nodejs/adaptivecards/docs/classes/adaptivecard.md
+++ b/source/nodejs/adaptivecards/docs/classes/adaptivecard.md
@@ -1,0 +1,2376 @@
+[Adaptive Cards Javascript SDK](../README.md) › [AdaptiveCard](adaptivecard.md)
+
+# Class: AdaptiveCard
+
+## Hierarchy
+
+  ↳ [ContainerWithActions](containerwithactions.md)
+
+  ↳ **AdaptiveCard**
+
+## Index
+
+### Constructors
+
+* [constructor](adaptivecard.md#constructor)
+
+### Properties
+
+* [allowVerticalOverflow](adaptivecard.md#allowverticaloverflow)
+* [backgroundImage](adaptivecard.md#backgroundimage)
+* [customCssSelector](adaptivecard.md#customcssselector)
+* [designMode](adaptivecard.md#designmode)
+* [fallbackText](adaptivecard.md#fallbacktext)
+* [height](adaptivecard.md#height)
+* [horizontalAlignment](adaptivecard.md#optional-horizontalalignment)
+* [id](adaptivecard.md#id)
+* [minPixelHeight](adaptivecard.md#optional-minpixelheight)
+* [onAnchorClicked](adaptivecard.md#onanchorclicked)
+* [onElementVisibilityChanged](adaptivecard.md#onelementvisibilitychanged)
+* [onExecuteAction](adaptivecard.md#onexecuteaction)
+* [onImageLoaded](adaptivecard.md#onimageloaded)
+* [onInlineCardExpanded](adaptivecard.md#oninlinecardexpanded)
+* [onInputValueChanged](adaptivecard.md#oninputvaluechanged)
+* [onParseAction](adaptivecard.md#onparseaction)
+* [onParseElement](adaptivecard.md#onparseelement)
+* [requires](adaptivecard.md#requires)
+* [rtl](adaptivecard.md#optional-rtl)
+* [separator](adaptivecard.md#separator)
+* [spacing](adaptivecard.md#spacing)
+* [speak](adaptivecard.md#speak)
+* [version](adaptivecard.md#optional-version)
+* [verticalContentAlignment](adaptivecard.md#verticalcontentalignment)
+* [actionTypeRegistry](adaptivecard.md#static-actiontyperegistry)
+* [allowMarkForTextHighlighting](adaptivecard.md#static-allowmarkfortexthighlighting)
+* [alwaysBleedSeparators](adaptivecard.md#static-alwaysbleedseparators)
+* [displayInputValidationErrors](adaptivecard.md#static-displayinputvalidationerrors)
+* [elementTypeRegistry](adaptivecard.md#static-elementtyperegistry)
+* [enableFullJsonRoundTrip](adaptivecard.md#static-enablefulljsonroundtrip)
+* [onAnchorClicked](adaptivecard.md#static-onanchorclicked)
+* [onElementVisibilityChanged](adaptivecard.md#static-onelementvisibilitychanged)
+* [onExecuteAction](adaptivecard.md#static-onexecuteaction)
+* [onImageLoaded](adaptivecard.md#static-onimageloaded)
+* [onInlineCardExpanded](adaptivecard.md#static-oninlinecardexpanded)
+* [onInputValueChanged](adaptivecard.md#static-oninputvaluechanged)
+* [onParseAction](adaptivecard.md#static-onparseaction)
+* [onParseElement](adaptivecard.md#static-onparseelement)
+* [onParseError](adaptivecard.md#static-onparseerror)
+* [onProcessMarkdown](adaptivecard.md#static-onprocessmarkdown)
+* [useAdvancedCardBottomTruncation](adaptivecard.md#static-useadvancedcardbottomtruncation)
+* [useAdvancedTextBlockTruncation](adaptivecard.md#static-useadvancedtextblocktruncation)
+* [useBuiltInInputValidation](adaptivecard.md#static-usebuiltininputvalidation)
+* [useMarkdownInRadioButtonAndCheckbox](adaptivecard.md#static-usemarkdowninradiobuttonandcheckbox)
+
+### Accessors
+
+* [allowCustomPadding](adaptivecard.md#protected-allowcustompadding)
+* [allowCustomStyle](adaptivecard.md#protected-allowcustomstyle)
+* [bleed](adaptivecard.md#bleed)
+* [bypassVersionCheck](adaptivecard.md#protected-bypassversioncheck)
+* [defaultStyle](adaptivecard.md#protected-defaultstyle)
+* [hasBackground](adaptivecard.md#protected-hasbackground)
+* [hasExplicitStyle](adaptivecard.md#protected-hasexplicitstyle)
+* [hasVisibleSeparator](adaptivecard.md#hasvisibleseparator)
+* [hostConfig](adaptivecard.md#hostconfig)
+* [index](adaptivecard.md#index)
+* [isInline](adaptivecard.md#isinline)
+* [isInteractive](adaptivecard.md#isinteractive)
+* [isSelectable](adaptivecard.md#protected-isselectable)
+* [isStandalone](adaptivecard.md#isstandalone)
+* [isVisible](adaptivecard.md#isvisible)
+* [lang](adaptivecard.md#lang)
+* [padding](adaptivecard.md#padding)
+* [parent](adaptivecard.md#parent)
+* [renderIfEmpty](adaptivecard.md#protected-renderifempty)
+* [renderedActionCount](adaptivecard.md#protected-renderedactioncount)
+* [renderedElement](adaptivecard.md#renderedelement)
+* [selectAction](adaptivecard.md#selectaction)
+* [separatorElement](adaptivecard.md#separatorelement)
+* [separatorOrientation](adaptivecard.md#protected-separatororientation)
+* [style](adaptivecard.md#style)
+* [supportsMinHeight](adaptivecard.md#protected-supportsminheight)
+* [useDefaultSizing](adaptivecard.md#protected-usedefaultsizing)
+* [processMarkdown](adaptivecard.md#static-processmarkdown)
+
+### Methods
+
+* [addAction](adaptivecard.md#addaction)
+* [addItem](adaptivecard.md#additem)
+* [adjustRenderedElementSize](adaptivecard.md#protected-adjustrenderedelementsize)
+* [applyBackground](adaptivecard.md#protected-applybackground)
+* [applyPadding](adaptivecard.md#protected-applypadding)
+* [asString](adaptivecard.md#asstring)
+* [clear](adaptivecard.md#clear)
+* [createPlaceholderElement](adaptivecard.md#protected-createplaceholderelement)
+* [getActionAt](adaptivecard.md#getactionat)
+* [getActionById](adaptivecard.md#getactionbyid)
+* [getActionCount](adaptivecard.md#getactioncount)
+* [getAllInputs](adaptivecard.md#getallinputs)
+* [getBleed](adaptivecard.md#protected-getbleed)
+* [getCustomProperty](adaptivecard.md#getcustomproperty)
+* [getDefaultPadding](adaptivecard.md#protected-getdefaultpadding)
+* [getEffectivePadding](adaptivecard.md#geteffectivepadding)
+* [getEffectiveStyle](adaptivecard.md#geteffectivestyle)
+* [getElementById](adaptivecard.md#getelementbyid)
+* [getFirstVisibleRenderedItem](adaptivecard.md#getfirstvisiblerendereditem)
+* [getForbiddenActionTypes](adaptivecard.md#getforbiddenactiontypes)
+* [getForbiddenElementTypes](adaptivecard.md#getforbiddenelementtypes)
+* [getHasBackground](adaptivecard.md#protected-gethasbackground)
+* [getHasExpandedAction](adaptivecard.md#protected-gethasexpandedaction)
+* [getImmediateSurroundingPadding](adaptivecard.md#getimmediatesurroundingpadding)
+* [getItemAt](adaptivecard.md#getitemat)
+* [getItemCount](adaptivecard.md#getitemcount)
+* [getItemsCollectionPropertyName](adaptivecard.md#protected-getitemscollectionpropertyname)
+* [getJsonTypeName](adaptivecard.md#getjsontypename)
+* [getLastVisibleRenderedItem](adaptivecard.md#getlastvisiblerendereditem)
+* [getPadding](adaptivecard.md#protected-getpadding)
+* [getParentContainer](adaptivecard.md#getparentcontainer)
+* [getResourceInformation](adaptivecard.md#getresourceinformation)
+* [getRootElement](adaptivecard.md#getrootelement)
+* [getSelectAction](adaptivecard.md#protected-getselectaction)
+* [indexOf](adaptivecard.md#indexof)
+* [insertItemAfter](adaptivecard.md#insertitemafter)
+* [insertItemBefore](adaptivecard.md#insertitembefore)
+* [internalRender](adaptivecard.md#protected-internalrender)
+* [internalValidateProperties](adaptivecard.md#internalvalidateproperties)
+* [isAtTheVeryBottom](adaptivecard.md#isattheverybottom)
+* [isAtTheVeryLeft](adaptivecard.md#isattheveryleft)
+* [isAtTheVeryRight](adaptivecard.md#isattheveryright)
+* [isAtTheVeryTop](adaptivecard.md#isattheverytop)
+* [isBleeding](adaptivecard.md#isbleeding)
+* [isBleedingAtBottom](adaptivecard.md#isbleedingatbottom)
+* [isBleedingAtTop](adaptivecard.md#isbleedingattop)
+* [isBottomElement](adaptivecard.md#isbottomelement)
+* [isDesignMode](adaptivecard.md#isdesignmode)
+* [isElementAllowed](adaptivecard.md#protected-iselementallowed)
+* [isFirstElement](adaptivecard.md#isfirstelement)
+* [isHiddenDueToOverflow](adaptivecard.md#ishiddenduetooverflow)
+* [isLastElement](adaptivecard.md#islastelement)
+* [isLeftMostElement](adaptivecard.md#isleftmostelement)
+* [isRendered](adaptivecard.md#isrendered)
+* [isRightMostElement](adaptivecard.md#isrightmostelement)
+* [isRtl](adaptivecard.md#isrtl)
+* [isTopElement](adaptivecard.md#istopelement)
+* [overrideInternalRender](adaptivecard.md#protected-overrideinternalrender)
+* [parse](adaptivecard.md#parse)
+* [remove](adaptivecard.md#remove)
+* [removeItem](adaptivecard.md#removeitem)
+* [render](adaptivecard.md#render)
+* [setBleed](adaptivecard.md#protected-setbleed)
+* [setCustomProperty](adaptivecard.md#setcustomproperty)
+* [setPadding](adaptivecard.md#protected-setpadding)
+* [setParent](adaptivecard.md#setparent)
+* [setSelectAction](adaptivecard.md#protected-setselectaction)
+* [setShouldFallback](adaptivecard.md#setshouldfallback)
+* [shouldFallback](adaptivecard.md#shouldfallback)
+* [supportsExcplitiHeight](adaptivecard.md#protected-supportsexcplitiheight)
+* [toJSON](adaptivecard.md#tojson)
+* [truncateOverflow](adaptivecard.md#protected-truncateoverflow)
+* [undoOverflowTruncation](adaptivecard.md#protected-undooverflowtruncation)
+* [updateLayout](adaptivecard.md#updatelayout)
+* [validateProperties](adaptivecard.md#validateproperties)
+* [applyMarkdown](adaptivecard.md#static-applymarkdown)
+
+## Constructors
+
+###  constructor
+
+\+ **new AdaptiveCard**(): *[AdaptiveCard](adaptivecard.md)*
+
+*Inherited from [ContainerWithActions](containerwithactions.md).[constructor](containerwithactions.md#constructor)*
+
+*Defined in [card-elements.ts:6438](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6438)*
+
+**Returns:** *[AdaptiveCard](adaptivecard.md)*
+
+## Properties
+
+###  allowVerticalOverflow
+
+• **allowVerticalOverflow**: *boolean* = false
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[allowVerticalOverflow](cardelementcontainer.md#allowverticaloverflow)*
+
+*Defined in [card-elements.ts:2229](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2229)*
+
+___
+
+###  backgroundImage
+
+• **backgroundImage**: *[BackgroundImage](backgroundimage.md)* = new BackgroundImage()
+
+*Inherited from [Container](container.md).[backgroundImage](container.md#backgroundimage)*
+
+*Defined in [card-elements.ts:5571](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5571)*
+
+___
+
+###  customCssSelector
+
+• **customCssSelector**: *string* = null
+
+*Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#customcssselector)*
+
+*Defined in [card-elements.ts:507](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L507)*
+
+___
+
+###  designMode
+
+• **designMode**: *boolean* = false
+
+*Defined in [card-elements.ts:6761](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6761)*
+
+___
+
+###  fallbackText
+
+• **fallbackText**: *string*
+
+*Defined in [card-elements.ts:6759](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6759)*
+
+___
+
+###  height
+
+• **height**: *[CardElementHeight](../README.md#cardelementheight)* = "auto"
+
+*Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
+
+*Defined in [card-elements.ts:508](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L508)*
+
+___
+
+### `Optional` horizontalAlignment
+
+• **horizontalAlignment**? : *[HorizontalAlignment](../enums/horizontalalignment.md)* = null
+
+*Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#optional-horizontalalignment)*
+
+*Defined in [card-elements.ts:504](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L504)*
+
+___
+
+###  id
+
+• **id**: *string*
+
+*Inherited from [CardObject](cardobject.md).[id](cardobject.md#id)*
+
+*Defined in [card-elements.ts:247](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L247)*
+
+___
+
+### `Optional` minPixelHeight
+
+• **minPixelHeight**? : *number* = null
+
+*Inherited from [CardElement](cardelement.md).[minPixelHeight](cardelement.md#optional-minpixelheight)*
+
+*Defined in [card-elements.ts:509](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L509)*
+
+___
+
+###  onAnchorClicked
+
+• **onAnchorClicked**: *function* = null
+
+*Defined in [card-elements.ts:6749](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6749)*
+
+#### Type declaration:
+
+▸ (`element`: [CardElement](cardelement.md), `anchor`: HTMLAnchorElement): *boolean*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+`anchor` | HTMLAnchorElement |
+
+___
+
+###  onElementVisibilityChanged
+
+• **onElementVisibilityChanged**: *function* = null
+
+*Defined in [card-elements.ts:6751](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6751)*
+
+#### Type declaration:
+
+▸ (`element`: [CardElement](cardelement.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+___
+
+###  onExecuteAction
+
+• **onExecuteAction**: *function* = null
+
+*Defined in [card-elements.ts:6750](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6750)*
+
+#### Type declaration:
+
+▸ (`action`: [Action](action.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`action` | [Action](action.md) |
+
+___
+
+###  onImageLoaded
+
+• **onImageLoaded**: *function* = null
+
+*Defined in [card-elements.ts:6752](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6752)*
+
+#### Type declaration:
+
+▸ (`image`: [Image](image.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`image` | [Image](image.md) |
+
+___
+
+###  onInlineCardExpanded
+
+• **onInlineCardExpanded**: *function* = null
+
+*Defined in [card-elements.ts:6753](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6753)*
+
+#### Type declaration:
+
+▸ (`action`: [ShowCardAction](showcardaction.md), `isExpanded`: boolean): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`action` | [ShowCardAction](showcardaction.md) |
+`isExpanded` | boolean |
+
+___
+
+###  onInputValueChanged
+
+• **onInputValueChanged**: *function* = null
+
+*Defined in [card-elements.ts:6754](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6754)*
+
+#### Type declaration:
+
+▸ (`input`: [Input](input.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`input` | [Input](input.md) |
+
+___
+
+###  onParseAction
+
+• **onParseAction**: *function* = null
+
+*Defined in [card-elements.ts:6756](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6756)*
+
+#### Type declaration:
+
+▸ (`element`: [Action](action.md), `json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [Action](action.md) |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+___
+
+###  onParseElement
+
+• **onParseElement**: *function* = null
+
+*Defined in [card-elements.ts:6755](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6755)*
+
+#### Type declaration:
+
+▸ (`element`: [CardElement](cardelement.md), `json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+___
+
+###  requires
+
+• **requires**: *[HostCapabilities](hostcapabilities.md)‹›* = new HostConfig.HostCapabilities()
+
+*Inherited from [CardElement](cardelement.md).[requires](cardelement.md#requires)*
+
+*Defined in [card-elements.ts:502](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L502)*
+
+___
+
+### `Optional` rtl
+
+• **rtl**? : *boolean* = null
+
+*Inherited from [Container](container.md).[rtl](container.md#optional-rtl)*
+
+*Defined in [card-elements.ts:5574](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5574)*
+
+___
+
+###  separator
+
+• **separator**: *boolean* = false
+
+*Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
+
+*Defined in [card-elements.ts:506](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L506)*
+
+___
+
+###  spacing
+
+• **spacing**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.Default
+
+*Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
+
+*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
+
+___
+
+###  speak
+
+• **speak**: *string*
+
+*Defined in [card-elements.ts:6760](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6760)*
+
+___
+
+### `Optional` version
+
+• **version**? : *[Version](version.md)* = new HostConfig.Version(1, 0)
+
+*Defined in [card-elements.ts:6758](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6758)*
+
+___
+
+###  verticalContentAlignment
+
+• **verticalContentAlignment**: *[VerticalAlignment](../enums/verticalalignment.md)* = Enums.VerticalAlignment.Top
+
+*Inherited from [Container](container.md).[verticalContentAlignment](container.md#verticalcontentalignment)*
+
+*Defined in [card-elements.ts:5573](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5573)*
+
+___
+
+### `Static` actionTypeRegistry
+
+▪ **actionTypeRegistry**: *[ActionTypeRegistry](actiontyperegistry.md)‹›* = new ActionTypeRegistry()
+
+*Defined in [card-elements.ts:6645](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6645)*
+
+___
+
+### `Static` allowMarkForTextHighlighting
+
+▪ **allowMarkForTextHighlighting**: *boolean* = false
+
+*Defined in [card-elements.ts:6638](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6638)*
+
+___
+
+### `Static` alwaysBleedSeparators
+
+▪ **alwaysBleedSeparators**: *boolean* = false
+
+*Defined in [card-elements.ts:6639](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6639)*
+
+___
+
+### `Static` displayInputValidationErrors
+
+▪ **displayInputValidationErrors**: *boolean* = true
+
+*Defined in [card-elements.ts:6642](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6642)*
+
+___
+
+### `Static` elementTypeRegistry
+
+▪ **elementTypeRegistry**: *[ElementTypeRegistry](elementtyperegistry.md)‹›* = new ElementTypeRegistry()
+
+*Defined in [card-elements.ts:6644](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6644)*
+
+___
+
+### `Static` enableFullJsonRoundTrip
+
+▪ **enableFullJsonRoundTrip**: *boolean* = false
+
+*Defined in [card-elements.ts:6640](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6640)*
+
+___
+
+### `Static` onAnchorClicked
+
+▪ **onAnchorClicked**: *function* = null
+
+*Defined in [card-elements.ts:6647](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6647)*
+
+#### Type declaration:
+
+▸ (`element`: [CardElement](cardelement.md), `anchor`: HTMLAnchorElement): *boolean*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+`anchor` | HTMLAnchorElement |
+
+___
+
+### `Static` onElementVisibilityChanged
+
+▪ **onElementVisibilityChanged**: *function* = null
+
+*Defined in [card-elements.ts:6649](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6649)*
+
+#### Type declaration:
+
+▸ (`element`: [CardElement](cardelement.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+___
+
+### `Static` onExecuteAction
+
+▪ **onExecuteAction**: *function* = null
+
+*Defined in [card-elements.ts:6648](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6648)*
+
+#### Type declaration:
+
+▸ (`action`: [Action](action.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`action` | [Action](action.md) |
+
+___
+
+### `Static` onImageLoaded
+
+▪ **onImageLoaded**: *function* = null
+
+*Defined in [card-elements.ts:6650](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6650)*
+
+#### Type declaration:
+
+▸ (`image`: [Image](image.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`image` | [Image](image.md) |
+
+___
+
+### `Static` onInlineCardExpanded
+
+▪ **onInlineCardExpanded**: *function* = null
+
+*Defined in [card-elements.ts:6651](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6651)*
+
+#### Type declaration:
+
+▸ (`action`: [ShowCardAction](showcardaction.md), `isExpanded`: boolean): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`action` | [ShowCardAction](showcardaction.md) |
+`isExpanded` | boolean |
+
+___
+
+### `Static` onInputValueChanged
+
+▪ **onInputValueChanged**: *function* = null
+
+*Defined in [card-elements.ts:6652](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6652)*
+
+#### Type declaration:
+
+▸ (`input`: [Input](input.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`input` | [Input](input.md) |
+
+___
+
+### `Static` onParseAction
+
+▪ **onParseAction**: *function* = null
+
+*Defined in [card-elements.ts:6654](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6654)*
+
+#### Type declaration:
+
+▸ (`element`: [Action](action.md), `json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [Action](action.md) |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+___
+
+### `Static` onParseElement
+
+▪ **onParseElement**: *function* = null
+
+*Defined in [card-elements.ts:6653](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6653)*
+
+#### Type declaration:
+
+▸ (`element`: [CardElement](cardelement.md), `json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+___
+
+### `Static` onParseError
+
+▪ **onParseError**: *function* = null
+
+*Defined in [card-elements.ts:6655](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6655)*
+
+#### Type declaration:
+
+▸ (`error`: [IValidationError](../interfaces/ivalidationerror.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`error` | [IValidationError](../interfaces/ivalidationerror.md) |
+
+___
+
+### `Static` onProcessMarkdown
+
+▪ **onProcessMarkdown**: *function* = null
+
+*Defined in [card-elements.ts:6656](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6656)*
+
+#### Type declaration:
+
+▸ (`text`: string, `result`: [IMarkdownProcessingResult](../interfaces/imarkdownprocessingresult.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`text` | string |
+`result` | [IMarkdownProcessingResult](../interfaces/imarkdownprocessingresult.md) |
+
+___
+
+### `Static` useAdvancedCardBottomTruncation
+
+▪ **useAdvancedCardBottomTruncation**: *boolean* = false
+
+*Defined in [card-elements.ts:6636](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6636)*
+
+___
+
+### `Static` useAdvancedTextBlockTruncation
+
+▪ **useAdvancedTextBlockTruncation**: *boolean* = true
+
+*Defined in [card-elements.ts:6635](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6635)*
+
+___
+
+### `Static` useBuiltInInputValidation
+
+▪ **useBuiltInInputValidation**: *boolean* = true
+
+*Defined in [card-elements.ts:6641](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6641)*
+
+___
+
+### `Static` useMarkdownInRadioButtonAndCheckbox
+
+▪ **useMarkdownInRadioButtonAndCheckbox**: *boolean* = true
+
+*Defined in [card-elements.ts:6637](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6637)*
+
+## Accessors
+
+### `Protected` allowCustomPadding
+
+• **get allowCustomPadding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
+
+*Defined in [card-elements.ts:490](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L490)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` allowCustomStyle
+
+• **get allowCustomStyle**(): *boolean*
+
+*Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[allowCustomStyle](stylablecardelementcontainer.md#protected-allowcustomstyle)*
+
+*Defined in [card-elements.ts:6741](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6741)*
+
+**Returns:** *boolean*
+
+___
+
+###  bleed
+
+• **get bleed**(): *boolean*
+
+*Inherited from [Container](container.md).[bleed](container.md#bleed)*
+
+*Defined in [card-elements.ts:5810](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5810)*
+
+**Returns:** *boolean*
+
+• **set bleed**(`value`: boolean): *void*
+
+*Inherited from [Container](container.md).[bleed](container.md#bleed)*
+
+*Defined in [card-elements.ts:5814](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5814)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+### `Protected` bypassVersionCheck
+
+• **get bypassVersionCheck**(): *boolean*
+
+*Defined in [card-elements.ts:6737](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6737)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` defaultStyle
+
+• **get defaultStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
+
+*Defined in [card-elements.ts:498](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L498)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` hasBackground
+
+• **get hasBackground**(): *boolean*
+
+*Defined in [card-elements.ts:6745](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6745)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` hasExplicitStyle
+
+• **get hasExplicitStyle**(): *boolean*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[hasExplicitStyle](stylablecardelementcontainer.md#protected-hasexplicitstyle)*
+
+*Defined in [card-elements.ts:5232](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5232)*
+
+**Returns:** *boolean*
+
+___
+
+###  hasVisibleSeparator
+
+• **get hasVisibleSeparator**(): *boolean*
+
+*Overrides [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
+
+*Defined in [card-elements.ts:6899](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6899)*
+
+**Returns:** *boolean*
+
+___
+
+###  hostConfig
+
+• **get hostConfig**(): *[HostConfig](hostconfig.md)*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:881](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L881)*
+
+**Returns:** *[HostConfig](hostconfig.md)*
+
+• **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:895](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L895)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [HostConfig](hostconfig.md) |
+
+**Returns:** *void*
+
+___
+
+###  index
+
+• **get index**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
+
+*Defined in [card-elements.ts:899](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L899)*
+
+**Returns:** *number*
+
+___
+
+###  isInline
+
+• **get isInline**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
+
+*Defined in [card-elements.ts:916](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L916)*
+
+**Returns:** *boolean*
+
+___
+
+###  isInteractive
+
+• **get isInteractive**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
+
+*Defined in [card-elements.ts:908](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L908)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` isSelectable
+
+• **get isSelectable**(): *boolean*
+
+*Inherited from [Container](container.md).[isSelectable](container.md#protected-isselectable)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[isSelectable](cardelementcontainer.md#protected-isselectable)*
+
+*Defined in [card-elements.ts:5567](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5567)*
+
+**Returns:** *boolean*
+
+___
+
+###  isStandalone
+
+• **get isStandalone**(): *boolean*
+
+*Inherited from [ContainerWithActions](containerwithactions.md).[isStandalone](containerwithactions.md#isstandalone)*
+
+*Overrides [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
+
+*Defined in [card-elements.ts:6523](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6523)*
+
+**Returns:** *boolean*
+
+___
+
+###  isVisible
+
+• **get isVisible**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:924](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L924)*
+
+**Returns:** *boolean*
+
+• **set isVisible**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:937](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L937)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  lang
+
+• **get lang**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:853](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L853)*
+
+**Returns:** *string*
+
+• **set lang**(`value`: string): *void*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:867](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L867)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  padding
+
+• **get padding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [Container](container.md).[padding](container.md#padding)*
+
+*Defined in [card-elements.ts:5794](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5794)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+• **set padding**(`value`: [PaddingDefinition](paddingdefinition.md)): *void*
+
+*Inherited from [Container](container.md).[padding](container.md#padding)*
+
+*Defined in [card-elements.ts:5798](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5798)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [PaddingDefinition](paddingdefinition.md) |
+
+**Returns:** *void*
+
+___
+
+###  parent
+
+• **get parent**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[parent](cardelement.md#parent)*
+
+*Defined in [card-elements.ts:920](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L920)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+### `Protected` renderIfEmpty
+
+• **get renderIfEmpty**(): *boolean*
+
+*Overrides [ContainerWithActions](containerwithactions.md).[renderIfEmpty](containerwithactions.md#protected-renderifempty)*
+
+*Defined in [card-elements.ts:6733](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6733)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` renderedActionCount
+
+• **get renderedActionCount**(): *number*
+
+*Inherited from [ContainerWithActions](containerwithactions.md).[renderedActionCount](containerwithactions.md#protected-renderedactioncount)*
+
+*Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[renderedActionCount](stylablecardelementcontainer.md#protected-renderedactioncount)*
+
+*Defined in [card-elements.ts:6432](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6432)*
+
+**Returns:** *number*
+
+___
+
+###  renderedElement
+
+• **get renderedElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[renderedElement](cardelement.md#renderedelement)*
+
+*Defined in [card-elements.ts:956](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L956)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  selectAction
+
+• **get selectAction**(): *[Action](action.md)*
+
+*Inherited from [Container](container.md).[selectAction](container.md#selectaction)*
+
+*Defined in [card-elements.ts:5802](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5802)*
+
+**Returns:** *[Action](action.md)*
+
+• **set selectAction**(`value`: [Action](action.md)): *void*
+
+*Inherited from [Container](container.md).[selectAction](container.md#selectaction)*
+
+*Defined in [card-elements.ts:5806](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5806)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [Action](action.md) |
+
+**Returns:** *void*
+
+___
+
+###  separatorElement
+
+• **get separatorElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
+
+*Defined in [card-elements.ts:960](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L960)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` separatorOrientation
+
+• **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
+
+*Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
+
+*Defined in [card-elements.ts:494](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L494)*
+
+**Returns:** *[Orientation](../enums/orientation.md)*
+
+___
+
+###  style
+
+• **get style**(): *string*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[style](stylablecardelementcontainer.md#style)*
+
+*Defined in [card-elements.ts:5295](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5295)*
+
+**Returns:** *string*
+
+• **set style**(`value`: string): *void*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[style](stylablecardelementcontainer.md#style)*
+
+*Defined in [card-elements.ts:5305](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5305)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+### `Protected` supportsMinHeight
+
+• **get supportsMinHeight**(): *boolean*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[supportsMinHeight](stylablecardelementcontainer.md#protected-supportsminheight)*
+
+*Overrides [CardElement](cardelement.md).[supportsMinHeight](cardelement.md#protected-supportsminheight)*
+
+*Defined in [card-elements.ts:5240](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5240)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` useDefaultSizing
+
+• **get useDefaultSizing**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
+
+*Defined in [card-elements.ts:486](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L486)*
+
+**Returns:** *boolean*
+
+___
+
+### `Static` processMarkdown
+
+• **get processMarkdown**(): *function*
+
+*Defined in [card-elements.ts:6658](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6658)*
+
+**Returns:** *function*
+
+▸ (`text`: string): *string*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`text` | string |
+
+• **set processMarkdown**(`value`: function): *void*
+
+*Defined in [card-elements.ts:6662](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6662)*
+
+**Parameters:**
+
+▪ **value**: *function*
+
+▸ (`text`: string): *string*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`text` | string |
+
+**Returns:** *void*
+
+## Methods
+
+###  addAction
+
+▸ **addAction**(`action`: [Action](action.md)): *void*
+
+*Inherited from [ContainerWithActions](containerwithactions.md).[addAction](containerwithactions.md#addaction)*
+
+*Defined in [card-elements.ts:6491](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6491)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`action` | [Action](action.md) |
+
+**Returns:** *void*
+
+___
+
+###  addItem
+
+▸ **addItem**(`item`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [Container](container.md).[addItem](container.md#additem)*
+
+*Defined in [card-elements.ts:5730](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5730)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`item` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+### `Protected` adjustRenderedElementSize
+
+▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
+
+*Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
+
+*Defined in [card-elements.ts:411](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L411)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`renderedElement` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+### `Protected` applyBackground
+
+▸ **applyBackground**(): *void*
+
+*Inherited from [Container](container.md).[applyBackground](container.md#protected-applybackground)*
+
+*Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[applyBackground](stylablecardelementcontainer.md#protected-applybackground)*
+
+*Defined in [card-elements.ts:5441](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5441)*
+
+**Returns:** *void*
+
+___
+
+### `Protected` applyPadding
+
+▸ **applyPadding**(): *void*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[applyPadding](stylablecardelementcontainer.md#protected-applypadding)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[applyPadding](cardelementcontainer.md#protected-applypadding)*
+
+*Defined in [card-elements.ts:5137](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5137)*
+
+**Returns:** *void*
+
+___
+
+###  asString
+
+▸ **asString**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
+
+*Defined in [card-elements.ts:513](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L513)*
+
+**Returns:** *string*
+
+___
+
+###  clear
+
+▸ **clear**(): *void*
+
+*Inherited from [ContainerWithActions](containerwithactions.md).[clear](containerwithactions.md#clear)*
+
+*Overrides [Container](container.md).[clear](container.md#clear)*
+
+*Defined in [card-elements.ts:6495](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6495)*
+
+**Returns:** *void*
+
+___
+
+### `Protected` createPlaceholderElement
+
+▸ **createPlaceholderElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
+
+*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  getActionAt
+
+▸ **getActionAt**(`index`: number): *[Action](action.md)*
+
+*Inherited from [ContainerWithActions](containerwithactions.md).[getActionAt](containerwithactions.md#getactionat)*
+
+*Overrides [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
+
+*Defined in [card-elements.ts:6458](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6458)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionById
+
+▸ **getActionById**(`id`: string): *[Action](action.md)*
+
+*Inherited from [ContainerWithActions](containerwithactions.md).[getActionById](containerwithactions.md#getactionbyid)*
+
+*Overrides [Container](container.md).[getActionById](container.md#getactionbyid)*
+
+*Defined in [card-elements.ts:6467](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6467)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionCount
+
+▸ **getActionCount**(): *number*
+
+*Inherited from [ContainerWithActions](containerwithactions.md).[getActionCount](containerwithactions.md#getactioncount)*
+
+*Overrides [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
+
+*Defined in [card-elements.ts:6454](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6454)*
+
+**Returns:** *number*
+
+___
+
+###  getAllInputs
+
+▸ **getAllInputs**(): *Array‹[Input](input.md)›*
+
+*Inherited from [ContainerWithActions](containerwithactions.md).[getAllInputs](containerwithactions.md#getallinputs)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[getAllInputs](cardelementcontainer.md#getallinputs)*
+
+*Defined in [card-elements.ts:6501](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6501)*
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+### `Protected` getBleed
+
+▸ **getBleed**(): *boolean*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[getBleed](stylablecardelementcontainer.md#protected-getbleed)*
+
+*Defined in [card-elements.ts:5220](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5220)*
+
+**Returns:** *boolean*
+
+___
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+### `Protected` getDefaultPadding
+
+▸ **getDefaultPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[getDefaultPadding](stylablecardelementcontainer.md#protected-getdefaultpadding)*
+
+*Defined in [card-elements.ts:6725](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6725)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectivePadding
+
+▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
+
+*Defined in [card-elements.ts:847](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L847)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectiveStyle
+
+▸ **getEffectiveStyle**(): *string*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[getEffectiveStyle](stylablecardelementcontainer.md#geteffectivestyle)*
+
+*Overrides [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
+
+*Defined in [card-elements.ts:5289](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5289)*
+
+**Returns:** *string*
+
+___
+
+###  getElementById
+
+▸ **getElementById**(`id`: string): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[getElementById](cardelementcontainer.md#getelementbyid)*
+
+*Overrides [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
+
+*Defined in [card-elements.ts:2354](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2354)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getFirstVisibleRenderedItem
+
+▸ **getFirstVisibleRenderedItem**(): *[CardElement](cardelement.md)*
+
+*Inherited from [Container](container.md).[getFirstVisibleRenderedItem](container.md#getfirstvisiblerendereditem)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[getFirstVisibleRenderedItem](cardelementcontainer.md#abstract-getfirstvisiblerendereditem)*
+
+*Defined in [card-elements.ts:5606](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5606)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getForbiddenActionTypes
+
+▸ **getForbiddenActionTypes**(): *Array‹any›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
+
+*Defined in [card-elements.ts:557](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L557)*
+
+**Returns:** *Array‹any›*
+
+___
+
+###  getForbiddenElementTypes
+
+▸ **getForbiddenElementTypes**(): *Array‹string›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenElementTypes](cardelement.md#getforbiddenelementtypes)*
+
+*Defined in [card-elements.ts:553](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L553)*
+
+**Returns:** *Array‹string›*
+
+___
+
+### `Protected` getHasBackground
+
+▸ **getHasBackground**(): *boolean*
+
+*Overrides [Container](container.md).[getHasBackground](container.md#protected-gethasbackground)*
+
+*Defined in [card-elements.ts:6721](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6721)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` getHasExpandedAction
+
+▸ **getHasExpandedAction**(): *boolean*
+
+*Inherited from [ContainerWithActions](containerwithactions.md).[getHasExpandedAction](containerwithactions.md#protected-gethasexpandedaction)*
+
+*Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[getHasExpandedAction](stylablecardelementcontainer.md#protected-gethasexpandedaction)*
+
+*Defined in [card-elements.ts:6420](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6420)*
+
+**Returns:** *boolean*
+
+___
+
+###  getImmediateSurroundingPadding
+
+▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
+
+*Defined in [card-elements.ts:561](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L561)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`result` | [PaddingDefinition](paddingdefinition.md) | - |
+`processTop` | boolean | true |
+`processRight` | boolean | true |
+`processBottom` | boolean | true |
+`processLeft` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  getItemAt
+
+▸ **getItemAt**(`index`: number): *[CardElement](cardelement.md)*
+
+*Inherited from [Container](container.md).[getItemAt](container.md#getitemat)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[getItemAt](cardelementcontainer.md#abstract-getitemat)*
+
+*Defined in [card-elements.ts:5602](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5602)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getItemCount
+
+▸ **getItemCount**(): *number*
+
+*Inherited from [Container](container.md).[getItemCount](container.md#getitemcount)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[getItemCount](cardelementcontainer.md#abstract-getitemcount)*
+
+*Defined in [card-elements.ts:5598](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5598)*
+
+**Returns:** *number*
+
+___
+
+### `Protected` getItemsCollectionPropertyName
+
+▸ **getItemsCollectionPropertyName**(): *string*
+
+*Overrides [Container](container.md).[getItemsCollectionPropertyName](container.md#protected-getitemscollectionpropertyname)*
+
+*Defined in [card-elements.ts:6704](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6704)*
+
+**Returns:** *string*
+
+___
+
+###  getJsonTypeName
+
+▸ **getJsonTypeName**(): *string*
+
+*Overrides [Container](container.md).[getJsonTypeName](container.md#getjsontypename)*
+
+*Defined in [card-elements.ts:6763](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6763)*
+
+**Returns:** *string*
+
+___
+
+###  getLastVisibleRenderedItem
+
+▸ **getLastVisibleRenderedItem**(): *[CardElement](cardelement.md)*
+
+*Inherited from [Container](container.md).[getLastVisibleRenderedItem](container.md#getlastvisiblerendereditem)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[getLastVisibleRenderedItem](cardelementcontainer.md#abstract-getlastvisiblerendereditem)*
+
+*Defined in [card-elements.ts:5618](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5618)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+### `Protected` getPadding
+
+▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
+
+*Defined in [card-elements.ts:474](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L474)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getParentContainer
+
+▸ **getParentContainer**(): *[Container](container.md)*
+
+*Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
+
+*Defined in [card-elements.ts:809](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L809)*
+
+**Returns:** *[Container](container.md)*
+
+___
+
+###  getResourceInformation
+
+▸ **getResourceInformation**(): *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+*Inherited from [ContainerWithActions](containerwithactions.md).[getResourceInformation](containerwithactions.md#getresourceinformation)*
+
+*Overrides [Container](container.md).[getResourceInformation](container.md#getresourceinformation)*
+
+*Defined in [card-elements.ts:6505](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6505)*
+
+**Returns:** *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+___
+
+###  getRootElement
+
+▸ **getRootElement**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
+
+*Defined in [card-elements.ts:799](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L799)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+### `Protected` getSelectAction
+
+▸ **getSelectAction**(): *[Action](action.md)*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[getSelectAction](cardelementcontainer.md#protected-getselectaction)*
+
+*Defined in [card-elements.ts:2207](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2207)*
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  indexOf
+
+▸ **indexOf**(`cardElement`: [CardElement](cardelement.md)): *number*
+
+*Inherited from [Container](container.md).[indexOf](container.md#indexof)*
+
+*Overrides [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
+
+*Defined in [card-elements.ts:5726](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5726)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`cardElement` | [CardElement](cardelement.md) |
+
+**Returns:** *number*
+
+___
+
+###  insertItemAfter
+
+▸ **insertItemAfter**(`item`: [CardElement](cardelement.md), `insertAfter`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [Container](container.md).[insertItemAfter](container.md#insertitemafter)*
+
+*Defined in [card-elements.ts:5738](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5738)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`item` | [CardElement](cardelement.md) |
+`insertAfter` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+###  insertItemBefore
+
+▸ **insertItemBefore**(`item`: [CardElement](cardelement.md), `insertBefore`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [Container](container.md).[insertItemBefore](container.md#insertitembefore)*
+
+*Defined in [card-elements.ts:5734](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5734)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`item` | [CardElement](cardelement.md) |
+`insertBefore` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+### `Protected` internalRender
+
+▸ **internalRender**(): *HTMLElement*
+
+*Overrides [ContainerWithActions](containerwithactions.md).[internalRender](containerwithactions.md#protected-internalrender)*
+
+*Defined in [card-elements.ts:6708](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6708)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  internalValidateProperties
+
+▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
+
+*Overrides [ContainerWithActions](containerwithactions.md).[internalValidateProperties](containerwithactions.md#internalvalidateproperties)*
+
+*Defined in [card-elements.ts:6783](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6783)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [ValidationResults](validationresults.md) |
+
+**Returns:** *void*
+
+___
+
+###  isAtTheVeryBottom
+
+▸ **isAtTheVeryBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
+
+*Defined in [card-elements.ts:767](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L767)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryLeft
+
+▸ **isAtTheVeryLeft**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
+
+*Defined in [card-elements.ts:755](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L755)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryRight
+
+▸ **isAtTheVeryRight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
+
+*Defined in [card-elements.ts:759](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L759)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryTop
+
+▸ **isAtTheVeryTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
+
+*Defined in [card-elements.ts:763](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L763)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleeding
+
+▸ **isBleeding**(): *boolean*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[isBleeding](stylablecardelementcontainer.md#isbleeding)*
+
+*Overrides [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
+
+*Defined in [card-elements.ts:5244](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5244)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtBottom
+
+▸ **isBleedingAtBottom**(): *boolean*
+
+*Inherited from [ContainerWithActions](containerwithactions.md).[isBleedingAtBottom](containerwithactions.md#isbleedingatbottom)*
+
+*Overrides [Container](container.md).[isBleedingAtBottom](container.md#isbleedingatbottom)*
+
+*Defined in [card-elements.ts:6509](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6509)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtTop
+
+▸ **isBleedingAtTop**(): *boolean*
+
+*Inherited from [Container](container.md).[isBleedingAtTop](container.md#isbleedingattop)*
+
+*Overrides [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
+
+*Defined in [card-elements.ts:5669](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5669)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBottomElement
+
+▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
+
+*Defined in [card-elements.ts:791](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L791)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isDesignMode
+
+▸ **isDesignMode**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
+
+*Defined in [card-elements.ts:737](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L737)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` isElementAllowed
+
+▸ **isElementAllowed**(`element`: [CardElement](cardelement.md), `forbiddenElementTypes`: Array‹string›): *boolean*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[isElementAllowed](cardelementcontainer.md#protected-iselementallowed)*
+
+*Defined in [card-elements.ts:2169](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2169)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+`forbiddenElementTypes` | Array‹string› |
+
+**Returns:** *boolean*
+
+___
+
+###  isFirstElement
+
+▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [Container](container.md).[isFirstElement](container.md#isfirstelement)*
+
+*Overrides [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
+
+*Defined in [card-elements.ts:5634](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5634)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isHiddenDueToOverflow
+
+▸ **isHiddenDueToOverflow**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
+
+*Defined in [card-elements.ts:795](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L795)*
+
+**Returns:** *boolean*
+
+___
+
+###  isLastElement
+
+▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [ContainerWithActions](containerwithactions.md).[isLastElement](containerwithactions.md#islastelement)*
+
+*Overrides [Container](container.md).[isLastElement](container.md#islastelement)*
+
+*Defined in [card-elements.ts:6487](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6487)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isLeftMostElement
+
+▸ **isLeftMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
+
+*Defined in [card-elements.ts:779](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L779)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isRendered
+
+▸ **isRendered**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRendered](cardelement.md#isrendered)*
+
+*Defined in [card-elements.ts:743](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L743)*
+
+**Returns:** *boolean*
+
+___
+
+###  isRightMostElement
+
+▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
+
+*Defined in [card-elements.ts:783](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L783)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isRtl
+
+▸ **isRtl**(): *boolean*
+
+*Inherited from [Container](container.md).[isRtl](container.md#isrtl)*
+
+*Defined in [card-elements.ts:5658](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5658)*
+
+**Returns:** *boolean*
+
+___
+
+###  isTopElement
+
+▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
+
+*Defined in [card-elements.ts:787](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L787)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` overrideInternalRender
+
+▸ **overrideInternalRender**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
+
+*Defined in [card-elements.ts:426](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L426)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Overrides [ContainerWithActions](containerwithactions.md).[parse](containerwithactions.md#parse)*
+
+*Defined in [card-elements.ts:6813](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6813)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*
+
+___
+
+###  remove
+
+▸ **remove**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
+
+*Defined in [card-elements.ts:698](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L698)*
+
+**Returns:** *boolean*
+
+___
+
+###  removeItem
+
+▸ **removeItem**(`item`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [Container](container.md).[removeItem](container.md#removeitem)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[removeItem](cardelementcontainer.md#abstract-removeitem)*
+
+*Defined in [card-elements.ts:5742](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5742)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`item` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  render
+
+▸ **render**(`target?`: HTMLElement): *HTMLElement*
+
+*Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[render](stylablecardelementcontainer.md#render)*
+
+*Defined in [card-elements.ts:6854](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6854)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`target?` | HTMLElement |
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` setBleed
+
+▸ **setBleed**(`value`: boolean): *void*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[setBleed](stylablecardelementcontainer.md#protected-setbleed)*
+
+*Defined in [card-elements.ts:5224](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5224)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setPadding
+
+▸ **setPadding**(`value`: [PaddingDefinition](paddingdefinition.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
+
+*Defined in [card-elements.ts:478](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L478)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [PaddingDefinition](paddingdefinition.md) |
+
+**Returns:** *void*
+
+___
+
+###  setParent
+
+▸ **setParent**(`value`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setParent](cardelement.md#setparent)*
+
+*Overrides [CardObject](cardobject.md).[setParent](cardobject.md#abstract-setparent)*
+
+*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setSelectAction
+
+▸ **setSelectAction**(`value`: [Action](action.md)): *void*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[setSelectAction](cardelementcontainer.md#protected-setselectaction)*
+
+*Defined in [card-elements.ts:2211](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2211)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [Action](action.md) |
+
+**Returns:** *void*
+
+___
+
+###  setShouldFallback
+
+▸ **setShouldFallback**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[setShouldFallback](cardelement.md#setshouldfallback)*
+
+*Defined in [card-elements.ts:843](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L843)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  shouldFallback
+
+▸ **shouldFallback**(): *boolean*
+
+*Overrides [CardElement](cardelement.md).[shouldFallback](cardelement.md#shouldfallback)*
+
+*Defined in [card-elements.ts:6895](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6895)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` supportsExcplitiHeight
+
+▸ **supportsExcplitiHeight**(): *boolean*
+
+*Inherited from [Container](container.md).[supportsExcplitiHeight](container.md#protected-supportsexcplitiheight)*
+
+*Defined in [card-elements.ts:5433](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5433)*
+
+**Returns:** *boolean*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [ContainerWithActions](containerwithactions.md).[toJSON](containerwithactions.md#tojson)*
+
+*Defined in [card-elements.ts:6767](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6767)*
+
+**Returns:** *any*
+
+___
+
+### `Protected` truncateOverflow
+
+▸ **truncateOverflow**(`maxHeight`: number): *boolean*
+
+*Inherited from [Container](container.md).[truncateOverflow](container.md#protected-truncateoverflow)*
+
+*Overrides [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
+
+*Defined in [card-elements.ts:5522](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5522)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`maxHeight` | number |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` undoOverflowTruncation
+
+▸ **undoOverflowTruncation**(): *void*
+
+*Inherited from [Container](container.md).[undoOverflowTruncation](container.md#protected-undooverflowtruncation)*
+
+*Overrides [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
+
+*Defined in [card-elements.ts:5557](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5557)*
+
+**Returns:** *void*
+
+___
+
+###  updateLayout
+
+▸ **updateLayout**(`processChildren`: boolean): *void*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[updateLayout](cardelementcontainer.md#updatelayout)*
+
+*Defined in [card-elements.ts:6884](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6884)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`processChildren` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  validateProperties
+
+▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
+
+*Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
+
+*Defined in [card-elements.ts:284](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L284)*
+
+**Returns:** *[ValidationResults](validationresults.md)*
+
+___
+
+### `Static` applyMarkdown
+
+▸ **applyMarkdown**(`text`: string): *[IMarkdownProcessingResult](../interfaces/imarkdownprocessingresult.md)*
+
+*Defined in [card-elements.ts:6666](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6666)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`text` | string |
+
+**Returns:** *[IMarkdownProcessingResult](../interfaces/imarkdownprocessingresult.md)*

--- a/source/nodejs/adaptivecards/docs/classes/adaptivecardconfig.md
+++ b/source/nodejs/adaptivecards/docs/classes/adaptivecardconfig.md
@@ -1,0 +1,41 @@
+[Adaptive Cards Javascript SDK](../README.md) › [AdaptiveCardConfig](adaptivecardconfig.md)
+
+# Class: AdaptiveCardConfig
+
+## Hierarchy
+
+* **AdaptiveCardConfig**
+
+## Index
+
+### Constructors
+
+* [constructor](adaptivecardconfig.md#constructor)
+
+### Properties
+
+* [allowCustomStyle](adaptivecardconfig.md#allowcustomstyle)
+
+## Constructors
+
+###  constructor
+
+\+ **new AdaptiveCardConfig**(`obj?`: any): *[AdaptiveCardConfig](adaptivecardconfig.md)*
+
+*Defined in [host-config.ts:47](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L47)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`obj?` | any |
+
+**Returns:** *[AdaptiveCardConfig](adaptivecardconfig.md)*
+
+## Properties
+
+###  allowCustomStyle
+
+• **allowCustomStyle**: *boolean* = false
+
+*Defined in [host-config.ts:47](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L47)*

--- a/source/nodejs/adaptivecards/docs/classes/backgroundimage.md
+++ b/source/nodejs/adaptivecards/docs/classes/backgroundimage.md
@@ -1,0 +1,164 @@
+[Adaptive Cards Javascript SDK](../README.md) › [BackgroundImage](backgroundimage.md)
+
+# Class: BackgroundImage
+
+## Hierarchy
+
+* [SerializableObject](serializableobject.md)
+
+  ↳ **BackgroundImage**
+
+## Index
+
+### Properties
+
+* [fillMode](backgroundimage.md#fillmode)
+* [horizontalAlignment](backgroundimage.md#horizontalalignment)
+* [url](backgroundimage.md#url)
+* [verticalAlignment](backgroundimage.md#verticalalignment)
+
+### Methods
+
+* [apply](backgroundimage.md#apply)
+* [getCustomProperty](backgroundimage.md#getcustomproperty)
+* [isValid](backgroundimage.md#isvalid)
+* [parse](backgroundimage.md#parse)
+* [reset](backgroundimage.md#reset)
+* [setCustomProperty](backgroundimage.md#setcustomproperty)
+* [toJSON](backgroundimage.md#tojson)
+
+## Properties
+
+###  fillMode
+
+• **fillMode**: *[FillMode](../enums/fillmode.md)* = BackgroundImage.defaultFillMode
+
+*Defined in [card-elements.ts:5316](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5316)*
+
+___
+
+###  horizontalAlignment
+
+• **horizontalAlignment**: *[HorizontalAlignment](../enums/horizontalalignment.md)* = BackgroundImage.defaultHorizontalAlignment
+
+*Defined in [card-elements.ts:5317](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5317)*
+
+___
+
+###  url
+
+• **url**: *string*
+
+*Defined in [card-elements.ts:5315](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5315)*
+
+___
+
+###  verticalAlignment
+
+• **verticalAlignment**: *[VerticalAlignment](../enums/verticalalignment.md)* = BackgroundImage.defaultVerticalAlignment
+
+*Defined in [card-elements.ts:5318](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5318)*
+
+## Methods
+
+###  apply
+
+▸ **apply**(`element`: HTMLElement): *void*
+
+*Defined in [card-elements.ts:5359](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5359)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+###  isValid
+
+▸ **isValid**(): *boolean*
+
+*Defined in [card-elements.ts:5400](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5400)*
+
+**Returns:** *boolean*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
+
+*Defined in [card-elements.ts:5327](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5327)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*
+
+___
+
+###  reset
+
+▸ **reset**(): *void*
+
+*Defined in [card-elements.ts:5320](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5320)*
+
+**Returns:** *void*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
+
+*Defined in [card-elements.ts:5336](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5336)*
+
+**Returns:** *any*

--- a/source/nodejs/adaptivecards/docs/classes/basetextblock.md
+++ b/source/nodejs/adaptivecards/docs/classes/basetextblock.md
@@ -1,0 +1,1397 @@
+[Adaptive Cards Javascript SDK](../README.md) › [BaseTextBlock](basetextblock.md)
+
+# Class: BaseTextBlock
+
+## Hierarchy
+
+  ↳ [CardElement](cardelement.md)
+
+  ↳ **BaseTextBlock**
+
+  ↳ [TextBlock](textblock.md)
+
+  ↳ [TextRun](textrun.md)
+
+## Index
+
+### Properties
+
+* [color](basetextblock.md#color)
+* [customCssSelector](basetextblock.md#customcssselector)
+* [fontType](basetextblock.md#optional-fonttype)
+* [height](basetextblock.md#height)
+* [horizontalAlignment](basetextblock.md#optional-horizontalalignment)
+* [id](basetextblock.md#id)
+* [isSubtle](basetextblock.md#issubtle)
+* [minPixelHeight](basetextblock.md#optional-minpixelheight)
+* [requires](basetextblock.md#requires)
+* [separator](basetextblock.md#separator)
+* [size](basetextblock.md#size)
+* [spacing](basetextblock.md#spacing)
+* [weight](basetextblock.md#weight)
+
+### Accessors
+
+* [allowCustomPadding](basetextblock.md#protected-allowcustompadding)
+* [defaultStyle](basetextblock.md#protected-defaultstyle)
+* [effectiveColor](basetextblock.md#effectivecolor)
+* [hasVisibleSeparator](basetextblock.md#hasvisibleseparator)
+* [hostConfig](basetextblock.md#hostconfig)
+* [index](basetextblock.md#index)
+* [isInline](basetextblock.md#isinline)
+* [isInteractive](basetextblock.md#isinteractive)
+* [isStandalone](basetextblock.md#isstandalone)
+* [isVisible](basetextblock.md#isvisible)
+* [lang](basetextblock.md#lang)
+* [parent](basetextblock.md#parent)
+* [renderedElement](basetextblock.md#renderedelement)
+* [selectAction](basetextblock.md#selectaction)
+* [separatorElement](basetextblock.md#separatorelement)
+* [separatorOrientation](basetextblock.md#protected-separatororientation)
+* [supportsMinHeight](basetextblock.md#protected-supportsminheight)
+* [text](basetextblock.md#text)
+* [useDefaultSizing](basetextblock.md#protected-usedefaultsizing)
+
+### Methods
+
+* [adjustRenderedElementSize](basetextblock.md#protected-adjustrenderedelementsize)
+* [applyPadding](basetextblock.md#protected-applypadding)
+* [applyStylesTo](basetextblock.md#applystylesto)
+* [asString](basetextblock.md#asstring)
+* [createPlaceholderElement](basetextblock.md#protected-createplaceholderelement)
+* [getActionAt](basetextblock.md#getactionat)
+* [getActionById](basetextblock.md#getactionbyid)
+* [getActionCount](basetextblock.md#getactioncount)
+* [getAllInputs](basetextblock.md#getallinputs)
+* [getColorDefinition](basetextblock.md#protected-getcolordefinition)
+* [getCustomProperty](basetextblock.md#getcustomproperty)
+* [getDefaultPadding](basetextblock.md#protected-getdefaultpadding)
+* [getEffectivePadding](basetextblock.md#geteffectivepadding)
+* [getEffectiveStyle](basetextblock.md#geteffectivestyle)
+* [getEffectiveStyleDefinition](basetextblock.md#protected-geteffectivestyledefinition)
+* [getElementById](basetextblock.md#getelementbyid)
+* [getFontSize](basetextblock.md#protected-getfontsize)
+* [getForbiddenActionTypes](basetextblock.md#getforbiddenactiontypes)
+* [getForbiddenElementTypes](basetextblock.md#getforbiddenelementtypes)
+* [getHasBackground](basetextblock.md#protected-gethasbackground)
+* [getImmediateSurroundingPadding](basetextblock.md#getimmediatesurroundingpadding)
+* [getJsonTypeName](basetextblock.md#abstract-getjsontypename)
+* [getPadding](basetextblock.md#protected-getpadding)
+* [getParentContainer](basetextblock.md#getparentcontainer)
+* [getResourceInformation](basetextblock.md#getresourceinformation)
+* [getRootElement](basetextblock.md#getrootelement)
+* [indexOf](basetextblock.md#indexof)
+* [internalRender](basetextblock.md#protected-abstract-internalrender)
+* [internalValidateProperties](basetextblock.md#internalvalidateproperties)
+* [isAtTheVeryBottom](basetextblock.md#isattheverybottom)
+* [isAtTheVeryLeft](basetextblock.md#isattheveryleft)
+* [isAtTheVeryRight](basetextblock.md#isattheveryright)
+* [isAtTheVeryTop](basetextblock.md#isattheverytop)
+* [isBleeding](basetextblock.md#isbleeding)
+* [isBleedingAtBottom](basetextblock.md#isbleedingatbottom)
+* [isBleedingAtTop](basetextblock.md#isbleedingattop)
+* [isBottomElement](basetextblock.md#isbottomelement)
+* [isDesignMode](basetextblock.md#isdesignmode)
+* [isFirstElement](basetextblock.md#isfirstelement)
+* [isHiddenDueToOverflow](basetextblock.md#ishiddenduetooverflow)
+* [isLastElement](basetextblock.md#islastelement)
+* [isLeftMostElement](basetextblock.md#isleftmostelement)
+* [isRendered](basetextblock.md#isrendered)
+* [isRightMostElement](basetextblock.md#isrightmostelement)
+* [isTopElement](basetextblock.md#istopelement)
+* [overrideInternalRender](basetextblock.md#protected-overrideinternalrender)
+* [parse](basetextblock.md#parse)
+* [remove](basetextblock.md#remove)
+* [render](basetextblock.md#render)
+* [setCustomProperty](basetextblock.md#setcustomproperty)
+* [setPadding](basetextblock.md#protected-setpadding)
+* [setParent](basetextblock.md#setparent)
+* [setShouldFallback](basetextblock.md#setshouldfallback)
+* [setText](basetextblock.md#protected-settext)
+* [shouldFallback](basetextblock.md#shouldfallback)
+* [toJSON](basetextblock.md#tojson)
+* [truncateOverflow](basetextblock.md#protected-truncateoverflow)
+* [undoOverflowTruncation](basetextblock.md#protected-undooverflowtruncation)
+* [updateLayout](basetextblock.md#updatelayout)
+* [validateProperties](basetextblock.md#validateproperties)
+
+## Properties
+
+###  color
+
+• **color**: *[TextColor](../enums/textcolor.md)* = Enums.TextColor.Default
+
+*Defined in [card-elements.ts:1013](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1013)*
+
+___
+
+###  customCssSelector
+
+• **customCssSelector**: *string* = null
+
+*Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#customcssselector)*
+
+*Defined in [card-elements.ts:507](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L507)*
+
+___
+
+### `Optional` fontType
+
+• **fontType**? : *[FontType](../enums/fonttype.md)* = null
+
+*Defined in [card-elements.ts:1015](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1015)*
+
+___
+
+###  height
+
+• **height**: *[CardElementHeight](../README.md#cardelementheight)* = "auto"
+
+*Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
+
+*Defined in [card-elements.ts:508](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L508)*
+
+___
+
+### `Optional` horizontalAlignment
+
+• **horizontalAlignment**? : *[HorizontalAlignment](../enums/horizontalalignment.md)* = null
+
+*Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#optional-horizontalalignment)*
+
+*Defined in [card-elements.ts:504](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L504)*
+
+___
+
+###  id
+
+• **id**: *string*
+
+*Inherited from [CardObject](cardobject.md).[id](cardobject.md#id)*
+
+*Defined in [card-elements.ts:247](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L247)*
+
+___
+
+###  isSubtle
+
+• **isSubtle**: *boolean* = false
+
+*Defined in [card-elements.ts:1014](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1014)*
+
+___
+
+### `Optional` minPixelHeight
+
+• **minPixelHeight**? : *number* = null
+
+*Inherited from [CardElement](cardelement.md).[minPixelHeight](cardelement.md#optional-minpixelheight)*
+
+*Defined in [card-elements.ts:509](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L509)*
+
+___
+
+###  requires
+
+• **requires**: *[HostCapabilities](hostcapabilities.md)‹›* = new HostConfig.HostCapabilities()
+
+*Inherited from [CardElement](cardelement.md).[requires](cardelement.md#requires)*
+
+*Defined in [card-elements.ts:502](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L502)*
+
+___
+
+###  separator
+
+• **separator**: *boolean* = false
+
+*Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
+
+*Defined in [card-elements.ts:506](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L506)*
+
+___
+
+###  size
+
+• **size**: *[TextSize](../enums/textsize.md)* = Enums.TextSize.Default
+
+*Defined in [card-elements.ts:1011](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1011)*
+
+___
+
+###  spacing
+
+• **spacing**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.Default
+
+*Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
+
+*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
+
+___
+
+###  weight
+
+• **weight**: *[TextWeight](../enums/textweight.md)* = Enums.TextWeight.Default
+
+*Defined in [card-elements.ts:1012](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1012)*
+
+## Accessors
+
+### `Protected` allowCustomPadding
+
+• **get allowCustomPadding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
+
+*Defined in [card-elements.ts:490](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L490)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` defaultStyle
+
+• **get defaultStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
+
+*Defined in [card-elements.ts:498](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L498)*
+
+**Returns:** *string*
+
+___
+
+###  effectiveColor
+
+• **get effectiveColor**(): *[TextColor](../enums/textcolor.md)*
+
+*Defined in [card-elements.ts:1128](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1128)*
+
+**Returns:** *[TextColor](../enums/textcolor.md)*
+
+___
+
+###  hasVisibleSeparator
+
+• **get hasVisibleSeparator**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
+
+*Defined in [card-elements.ts:928](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L928)*
+
+**Returns:** *boolean*
+
+___
+
+###  hostConfig
+
+• **get hostConfig**(): *[HostConfig](hostconfig.md)*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:881](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L881)*
+
+**Returns:** *[HostConfig](hostconfig.md)*
+
+• **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:895](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L895)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [HostConfig](hostconfig.md) |
+
+**Returns:** *void*
+
+___
+
+###  index
+
+• **get index**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
+
+*Defined in [card-elements.ts:899](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L899)*
+
+**Returns:** *number*
+
+___
+
+###  isInline
+
+• **get isInline**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
+
+*Defined in [card-elements.ts:916](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L916)*
+
+**Returns:** *boolean*
+
+___
+
+###  isInteractive
+
+• **get isInteractive**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
+
+*Defined in [card-elements.ts:908](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L908)*
+
+**Returns:** *boolean*
+
+___
+
+###  isStandalone
+
+• **get isStandalone**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
+
+*Defined in [card-elements.ts:912](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L912)*
+
+**Returns:** *boolean*
+
+___
+
+###  isVisible
+
+• **get isVisible**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:924](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L924)*
+
+**Returns:** *boolean*
+
+• **set isVisible**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:937](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L937)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  lang
+
+• **get lang**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:853](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L853)*
+
+**Returns:** *string*
+
+• **set lang**(`value`: string): *void*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:867](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L867)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  parent
+
+• **get parent**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[parent](cardelement.md#parent)*
+
+*Defined in [card-elements.ts:920](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L920)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  renderedElement
+
+• **get renderedElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[renderedElement](cardelement.md#renderedelement)*
+
+*Defined in [card-elements.ts:956](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L956)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  selectAction
+
+• **get selectAction**(): *[Action](action.md)*
+
+*Defined in [card-elements.ts:1140](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1140)*
+
+**Returns:** *[Action](action.md)*
+
+• **set selectAction**(`value`: [Action](action.md)): *void*
+
+*Defined in [card-elements.ts:1144](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1144)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [Action](action.md) |
+
+**Returns:** *void*
+
+___
+
+###  separatorElement
+
+• **get separatorElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
+
+*Defined in [card-elements.ts:960](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L960)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` separatorOrientation
+
+• **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
+
+*Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
+
+*Defined in [card-elements.ts:494](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L494)*
+
+**Returns:** *[Orientation](../enums/orientation.md)*
+
+___
+
+### `Protected` supportsMinHeight
+
+• **get supportsMinHeight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[supportsMinHeight](cardelement.md#protected-supportsminheight)*
+
+*Defined in [card-elements.ts:482](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L482)*
+
+**Returns:** *boolean*
+
+___
+
+###  text
+
+• **get text**(): *string*
+
+*Defined in [card-elements.ts:1132](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1132)*
+
+**Returns:** *string*
+
+• **set text**(`value`: string): *void*
+
+*Defined in [card-elements.ts:1136](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1136)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+### `Protected` useDefaultSizing
+
+• **get useDefaultSizing**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
+
+*Defined in [card-elements.ts:486](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L486)*
+
+**Returns:** *boolean*
+
+## Methods
+
+### `Protected` adjustRenderedElementSize
+
+▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
+
+*Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
+
+*Defined in [card-elements.ts:411](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L411)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`renderedElement` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+### `Protected` applyPadding
+
+▸ **applyPadding**(): *void*
+
+*Inherited from [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
+
+*Defined in [card-elements.ts:430](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L430)*
+
+**Returns:** *void*
+
+___
+
+###  applyStylesTo
+
+▸ **applyStylesTo**(`targetElement`: HTMLElement): *void*
+
+*Defined in [card-elements.ts:1034](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1034)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`targetElement` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+###  asString
+
+▸ **asString**(): *string*
+
+*Overrides [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
+
+*Defined in [card-elements.ts:1017](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1017)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` createPlaceholderElement
+
+▸ **createPlaceholderElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
+
+*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  getActionAt
+
+▸ **getActionAt**(`index`: number): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
+
+*Defined in [card-elements.ts:694](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L694)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionById
+
+▸ **getActionById**(`id`: string): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
+
+*Defined in [card-elements.ts:835](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L835)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionCount
+
+▸ **getActionCount**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
+
+*Defined in [card-elements.ts:690](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L690)*
+
+**Returns:** *number*
+
+___
+
+###  getAllInputs
+
+▸ **getAllInputs**(): *Array‹[Input](input.md)›*
+
+*Inherited from [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
+
+*Defined in [card-elements.ts:823](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L823)*
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+### `Protected` getColorDefinition
+
+▸ **getColorDefinition**(`colorSet`: [ColorSetDefinition](colorsetdefinition.md), `color`: [TextColor](../enums/textcolor.md)): *[TextColorDefinition](textcolordefinition.md)*
+
+*Defined in [card-elements.ts:988](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L988)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`colorSet` | [ColorSetDefinition](colorsetdefinition.md) |
+`color` | [TextColor](../enums/textcolor.md) |
+
+**Returns:** *[TextColorDefinition](textcolordefinition.md)*
+
+___
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+### `Protected` getDefaultPadding
+
+▸ **getDefaultPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
+
+*Defined in [card-elements.ts:466](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L466)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectivePadding
+
+▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
+
+*Defined in [card-elements.ts:847](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L847)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectiveStyle
+
+▸ **getEffectiveStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
+
+*Defined in [card-elements.ts:545](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L545)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` getEffectiveStyleDefinition
+
+▸ **getEffectiveStyleDefinition**(): *[ContainerStyleDefinition](containerstyledefinition.md)‹›*
+
+*Defined in [card-elements.ts:969](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L969)*
+
+**Returns:** *[ContainerStyleDefinition](containerstyledefinition.md)‹›*
+
+___
+
+###  getElementById
+
+▸ **getElementById**(`id`: string): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
+
+*Defined in [card-elements.ts:831](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L831)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+### `Protected` getFontSize
+
+▸ **getFontSize**(`fontType`: [FontTypeDefinition](fonttypedefinition.md)): *number*
+
+*Defined in [card-elements.ts:973](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L973)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`fontType` | [FontTypeDefinition](fonttypedefinition.md) |
+
+**Returns:** *number*
+
+___
+
+###  getForbiddenActionTypes
+
+▸ **getForbiddenActionTypes**(): *Array‹any›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
+
+*Defined in [card-elements.ts:557](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L557)*
+
+**Returns:** *Array‹any›*
+
+___
+
+###  getForbiddenElementTypes
+
+▸ **getForbiddenElementTypes**(): *Array‹string›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenElementTypes](cardelement.md#getforbiddenelementtypes)*
+
+*Defined in [card-elements.ts:553](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L553)*
+
+**Returns:** *Array‹string›*
+
+___
+
+### `Protected` getHasBackground
+
+▸ **getHasBackground**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
+
+*Defined in [card-elements.ts:470](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L470)*
+
+**Returns:** *boolean*
+
+___
+
+###  getImmediateSurroundingPadding
+
+▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
+
+*Defined in [card-elements.ts:561](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L561)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`result` | [PaddingDefinition](paddingdefinition.md) | - |
+`processTop` | boolean | true |
+`processRight` | boolean | true |
+`processBottom` | boolean | true |
+`processLeft` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+### `Abstract` getJsonTypeName
+
+▸ **getJsonTypeName**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[getJsonTypeName](cardelement.md#abstract-getjsontypename)*
+
+*Overrides [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
+
+*Defined in [card-elements.ts:511](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L511)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` getPadding
+
+▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
+
+*Defined in [card-elements.ts:474](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L474)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getParentContainer
+
+▸ **getParentContainer**(): *[Container](container.md)*
+
+*Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
+
+*Defined in [card-elements.ts:809](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L809)*
+
+**Returns:** *[Container](container.md)*
+
+___
+
+###  getResourceInformation
+
+▸ **getResourceInformation**(): *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+*Inherited from [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
+
+*Defined in [card-elements.ts:827](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L827)*
+
+**Returns:** *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+___
+
+###  getRootElement
+
+▸ **getRootElement**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
+
+*Defined in [card-elements.ts:799](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L799)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  indexOf
+
+▸ **indexOf**(`cardElement`: [CardElement](cardelement.md)): *number*
+
+*Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
+
+*Defined in [card-elements.ts:733](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L733)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`cardElement` | [CardElement](cardelement.md) |
+
+**Returns:** *number*
+
+___
+
+### `Protected` `Abstract` internalRender
+
+▸ **internalRender**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
+
+*Defined in [card-elements.ts:424](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L424)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  internalValidateProperties
+
+▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
+
+*Inherited from [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
+
+*Defined in [card-elements.ts:249](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L249)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [ValidationResults](validationresults.md) |
+
+**Returns:** *void*
+
+___
+
+###  isAtTheVeryBottom
+
+▸ **isAtTheVeryBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
+
+*Defined in [card-elements.ts:767](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L767)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryLeft
+
+▸ **isAtTheVeryLeft**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
+
+*Defined in [card-elements.ts:755](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L755)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryRight
+
+▸ **isAtTheVeryRight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
+
+*Defined in [card-elements.ts:759](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L759)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryTop
+
+▸ **isAtTheVeryTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
+
+*Defined in [card-elements.ts:763](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L763)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleeding
+
+▸ **isBleeding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
+
+*Defined in [card-elements.ts:517](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L517)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtBottom
+
+▸ **isBleedingAtBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
+
+*Defined in [card-elements.ts:775](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L775)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtTop
+
+▸ **isBleedingAtTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
+
+*Defined in [card-elements.ts:771](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L771)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBottomElement
+
+▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
+
+*Defined in [card-elements.ts:791](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L791)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isDesignMode
+
+▸ **isDesignMode**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
+
+*Defined in [card-elements.ts:737](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L737)*
+
+**Returns:** *boolean*
+
+___
+
+###  isFirstElement
+
+▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
+
+*Defined in [card-elements.ts:747](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L747)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isHiddenDueToOverflow
+
+▸ **isHiddenDueToOverflow**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
+
+*Defined in [card-elements.ts:795](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L795)*
+
+**Returns:** *boolean*
+
+___
+
+###  isLastElement
+
+▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
+
+*Defined in [card-elements.ts:751](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L751)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isLeftMostElement
+
+▸ **isLeftMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
+
+*Defined in [card-elements.ts:779](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L779)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isRendered
+
+▸ **isRendered**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRendered](cardelement.md#isrendered)*
+
+*Defined in [card-elements.ts:743](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L743)*
+
+**Returns:** *boolean*
+
+___
+
+###  isRightMostElement
+
+▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
+
+*Defined in [card-elements.ts:783](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L783)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isTopElement
+
+▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
+
+*Defined in [card-elements.ts:787](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L787)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` overrideInternalRender
+
+▸ **overrideInternalRender**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
+
+*Defined in [card-elements.ts:426](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L426)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Overrides [CardElement](cardelement.md).[parse](cardelement.md#parse)*
+
+*Defined in [card-elements.ts:1084](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1084)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*
+
+___
+
+###  remove
+
+▸ **remove**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
+
+*Defined in [card-elements.ts:698](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L698)*
+
+**Returns:** *boolean*
+
+___
+
+###  render
+
+▸ **render**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[render](cardelement.md#render)*
+
+*Defined in [card-elements.ts:706](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L706)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setPadding
+
+▸ **setPadding**(`value`: [PaddingDefinition](paddingdefinition.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
+
+*Defined in [card-elements.ts:478](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L478)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [PaddingDefinition](paddingdefinition.md) |
+
+**Returns:** *void*
+
+___
+
+###  setParent
+
+▸ **setParent**(`value`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setParent](cardelement.md#setparent)*
+
+*Overrides [CardObject](cardobject.md).[setParent](cardobject.md#abstract-setparent)*
+
+*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+###  setShouldFallback
+
+▸ **setShouldFallback**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[setShouldFallback](cardelement.md#setshouldfallback)*
+
+*Defined in [card-elements.ts:843](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L843)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setText
+
+▸ **setText**(`value`: string): *void*
+
+*Defined in [card-elements.ts:1007](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1007)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  shouldFallback
+
+▸ **shouldFallback**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[shouldFallback](cardelement.md#shouldfallback)*
+
+*Overrides [CardObject](cardobject.md).[shouldFallback](cardobject.md#abstract-shouldfallback)*
+
+*Defined in [card-elements.ts:839](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L839)*
+
+**Returns:** *boolean*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [CardElement](cardelement.md).[toJSON](cardelement.md#tojson)*
+
+*Defined in [card-elements.ts:1021](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1021)*
+
+**Returns:** *any*
+
+___
+
+### `Protected` truncateOverflow
+
+▸ **truncateOverflow**(`maxHeight`: number): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
+
+*Defined in [card-elements.ts:454](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L454)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`maxHeight` | number |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` undoOverflowTruncation
+
+▸ **undoOverflowTruncation**(): *void*
+
+*Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
+
+*Defined in [card-elements.ts:464](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L464)*
+
+**Returns:** *void*
+
+___
+
+###  updateLayout
+
+▸ **updateLayout**(`processChildren`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
+
+*Defined in [card-elements.ts:728](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L728)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`processChildren` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  validateProperties
+
+▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
+
+*Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
+
+*Defined in [card-elements.ts:284](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L284)*
+
+**Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/cardelement.md
+++ b/source/nodejs/adaptivecards/docs/classes/cardelement.md
@@ -1,0 +1,1077 @@
+[Adaptive Cards Javascript SDK](../README.md) › [CardElement](cardelement.md)
+
+# Class: CardElement
+
+## Hierarchy
+
+  ↳ [CardObject](cardobject.md)
+
+  ↳ **CardElement**
+
+  ↳ [BaseTextBlock](basetextblock.md)
+
+  ↳ [RichTextBlock](richtextblock.md)
+
+  ↳ [FactSet](factset.md)
+
+  ↳ [Image](image.md)
+
+  ↳ [CardElementContainer](cardelementcontainer.md)
+
+  ↳ [Media](media.md)
+
+  ↳ [Input](input.md)
+
+  ↳ [ActionSet](actionset.md)
+
+## Index
+
+### Properties
+
+* [customCssSelector](cardelement.md#customcssselector)
+* [height](cardelement.md#height)
+* [horizontalAlignment](cardelement.md#optional-horizontalalignment)
+* [id](cardelement.md#id)
+* [minPixelHeight](cardelement.md#optional-minpixelheight)
+* [requires](cardelement.md#requires)
+* [separator](cardelement.md#separator)
+* [spacing](cardelement.md#spacing)
+
+### Accessors
+
+* [allowCustomPadding](cardelement.md#protected-allowcustompadding)
+* [defaultStyle](cardelement.md#protected-defaultstyle)
+* [hasVisibleSeparator](cardelement.md#hasvisibleseparator)
+* [hostConfig](cardelement.md#hostconfig)
+* [index](cardelement.md#index)
+* [isInline](cardelement.md#isinline)
+* [isInteractive](cardelement.md#isinteractive)
+* [isStandalone](cardelement.md#isstandalone)
+* [isVisible](cardelement.md#isvisible)
+* [lang](cardelement.md#lang)
+* [parent](cardelement.md#parent)
+* [renderedElement](cardelement.md#renderedelement)
+* [separatorElement](cardelement.md#separatorelement)
+* [separatorOrientation](cardelement.md#protected-separatororientation)
+* [supportsMinHeight](cardelement.md#protected-supportsminheight)
+* [useDefaultSizing](cardelement.md#protected-usedefaultsizing)
+
+### Methods
+
+* [adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)
+* [applyPadding](cardelement.md#protected-applypadding)
+* [asString](cardelement.md#asstring)
+* [createPlaceholderElement](cardelement.md#protected-createplaceholderelement)
+* [getActionAt](cardelement.md#getactionat)
+* [getActionById](cardelement.md#getactionbyid)
+* [getActionCount](cardelement.md#getactioncount)
+* [getAllInputs](cardelement.md#getallinputs)
+* [getCustomProperty](cardelement.md#getcustomproperty)
+* [getDefaultPadding](cardelement.md#protected-getdefaultpadding)
+* [getEffectivePadding](cardelement.md#geteffectivepadding)
+* [getEffectiveStyle](cardelement.md#geteffectivestyle)
+* [getElementById](cardelement.md#getelementbyid)
+* [getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)
+* [getForbiddenElementTypes](cardelement.md#getforbiddenelementtypes)
+* [getHasBackground](cardelement.md#protected-gethasbackground)
+* [getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)
+* [getJsonTypeName](cardelement.md#abstract-getjsontypename)
+* [getPadding](cardelement.md#protected-getpadding)
+* [getParentContainer](cardelement.md#getparentcontainer)
+* [getResourceInformation](cardelement.md#getresourceinformation)
+* [getRootElement](cardelement.md#getrootelement)
+* [indexOf](cardelement.md#indexof)
+* [internalRender](cardelement.md#protected-abstract-internalrender)
+* [internalValidateProperties](cardelement.md#internalvalidateproperties)
+* [isAtTheVeryBottom](cardelement.md#isattheverybottom)
+* [isAtTheVeryLeft](cardelement.md#isattheveryleft)
+* [isAtTheVeryRight](cardelement.md#isattheveryright)
+* [isAtTheVeryTop](cardelement.md#isattheverytop)
+* [isBleeding](cardelement.md#isbleeding)
+* [isBleedingAtBottom](cardelement.md#isbleedingatbottom)
+* [isBleedingAtTop](cardelement.md#isbleedingattop)
+* [isBottomElement](cardelement.md#isbottomelement)
+* [isDesignMode](cardelement.md#isdesignmode)
+* [isFirstElement](cardelement.md#isfirstelement)
+* [isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)
+* [isLastElement](cardelement.md#islastelement)
+* [isLeftMostElement](cardelement.md#isleftmostelement)
+* [isRendered](cardelement.md#isrendered)
+* [isRightMostElement](cardelement.md#isrightmostelement)
+* [isTopElement](cardelement.md#istopelement)
+* [overrideInternalRender](cardelement.md#protected-overrideinternalrender)
+* [parse](cardelement.md#parse)
+* [remove](cardelement.md#remove)
+* [render](cardelement.md#render)
+* [setCustomProperty](cardelement.md#setcustomproperty)
+* [setPadding](cardelement.md#protected-setpadding)
+* [setParent](cardelement.md#setparent)
+* [setShouldFallback](cardelement.md#setshouldfallback)
+* [shouldFallback](cardelement.md#shouldfallback)
+* [toJSON](cardelement.md#tojson)
+* [truncateOverflow](cardelement.md#protected-truncateoverflow)
+* [undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)
+* [updateLayout](cardelement.md#updatelayout)
+* [validateProperties](cardelement.md#validateproperties)
+
+## Properties
+
+###  customCssSelector
+
+• **customCssSelector**: *string* = null
+
+*Defined in [card-elements.ts:507](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L507)*
+
+___
+
+###  height
+
+• **height**: *[CardElementHeight](../README.md#cardelementheight)* = "auto"
+
+*Defined in [card-elements.ts:508](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L508)*
+
+___
+
+### `Optional` horizontalAlignment
+
+• **horizontalAlignment**? : *[HorizontalAlignment](../enums/horizontalalignment.md)* = null
+
+*Defined in [card-elements.ts:504](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L504)*
+
+___
+
+###  id
+
+• **id**: *string*
+
+*Inherited from [CardObject](cardobject.md).[id](cardobject.md#id)*
+
+*Defined in [card-elements.ts:247](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L247)*
+
+___
+
+### `Optional` minPixelHeight
+
+• **minPixelHeight**? : *number* = null
+
+*Defined in [card-elements.ts:509](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L509)*
+
+___
+
+###  requires
+
+• **requires**: *[HostCapabilities](hostcapabilities.md)‹›* = new HostConfig.HostCapabilities()
+
+*Defined in [card-elements.ts:502](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L502)*
+
+___
+
+###  separator
+
+• **separator**: *boolean* = false
+
+*Defined in [card-elements.ts:506](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L506)*
+
+___
+
+###  spacing
+
+• **spacing**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.Default
+
+*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
+
+## Accessors
+
+### `Protected` allowCustomPadding
+
+• **get allowCustomPadding**(): *boolean*
+
+*Defined in [card-elements.ts:490](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L490)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` defaultStyle
+
+• **get defaultStyle**(): *string*
+
+*Defined in [card-elements.ts:498](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L498)*
+
+**Returns:** *string*
+
+___
+
+###  hasVisibleSeparator
+
+• **get hasVisibleSeparator**(): *boolean*
+
+*Defined in [card-elements.ts:928](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L928)*
+
+**Returns:** *boolean*
+
+___
+
+###  hostConfig
+
+• **get hostConfig**(): *[HostConfig](hostconfig.md)*
+
+*Defined in [card-elements.ts:881](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L881)*
+
+**Returns:** *[HostConfig](hostconfig.md)*
+
+• **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
+
+*Defined in [card-elements.ts:895](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L895)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [HostConfig](hostconfig.md) |
+
+**Returns:** *void*
+
+___
+
+###  index
+
+• **get index**(): *number*
+
+*Defined in [card-elements.ts:899](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L899)*
+
+**Returns:** *number*
+
+___
+
+###  isInline
+
+• **get isInline**(): *boolean*
+
+*Defined in [card-elements.ts:916](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L916)*
+
+**Returns:** *boolean*
+
+___
+
+###  isInteractive
+
+• **get isInteractive**(): *boolean*
+
+*Defined in [card-elements.ts:908](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L908)*
+
+**Returns:** *boolean*
+
+___
+
+###  isStandalone
+
+• **get isStandalone**(): *boolean*
+
+*Defined in [card-elements.ts:912](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L912)*
+
+**Returns:** *boolean*
+
+___
+
+###  isVisible
+
+• **get isVisible**(): *boolean*
+
+*Defined in [card-elements.ts:924](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L924)*
+
+**Returns:** *boolean*
+
+• **set isVisible**(`value`: boolean): *void*
+
+*Defined in [card-elements.ts:937](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L937)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  lang
+
+• **get lang**(): *string*
+
+*Defined in [card-elements.ts:853](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L853)*
+
+**Returns:** *string*
+
+• **set lang**(`value`: string): *void*
+
+*Defined in [card-elements.ts:867](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L867)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  parent
+
+• **get parent**(): *[CardElement](cardelement.md)*
+
+*Defined in [card-elements.ts:920](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L920)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  renderedElement
+
+• **get renderedElement**(): *HTMLElement*
+
+*Defined in [card-elements.ts:956](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L956)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  separatorElement
+
+• **get separatorElement**(): *HTMLElement*
+
+*Defined in [card-elements.ts:960](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L960)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` separatorOrientation
+
+• **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
+
+*Defined in [card-elements.ts:494](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L494)*
+
+**Returns:** *[Orientation](../enums/orientation.md)*
+
+___
+
+### `Protected` supportsMinHeight
+
+• **get supportsMinHeight**(): *boolean*
+
+*Defined in [card-elements.ts:482](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L482)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` useDefaultSizing
+
+• **get useDefaultSizing**(): *boolean*
+
+*Defined in [card-elements.ts:486](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L486)*
+
+**Returns:** *boolean*
+
+## Methods
+
+### `Protected` adjustRenderedElementSize
+
+▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
+
+*Defined in [card-elements.ts:411](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L411)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`renderedElement` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+### `Protected` applyPadding
+
+▸ **applyPadding**(): *void*
+
+*Defined in [card-elements.ts:430](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L430)*
+
+**Returns:** *void*
+
+___
+
+###  asString
+
+▸ **asString**(): *string*
+
+*Defined in [card-elements.ts:513](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L513)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` createPlaceholderElement
+
+▸ **createPlaceholderElement**(): *HTMLElement*
+
+*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  getActionAt
+
+▸ **getActionAt**(`index`: number): *[Action](action.md)*
+
+*Defined in [card-elements.ts:694](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L694)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionById
+
+▸ **getActionById**(`id`: string): *[Action](action.md)*
+
+*Defined in [card-elements.ts:835](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L835)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionCount
+
+▸ **getActionCount**(): *number*
+
+*Defined in [card-elements.ts:690](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L690)*
+
+**Returns:** *number*
+
+___
+
+###  getAllInputs
+
+▸ **getAllInputs**(): *Array‹[Input](input.md)›*
+
+*Defined in [card-elements.ts:823](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L823)*
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+### `Protected` getDefaultPadding
+
+▸ **getDefaultPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Defined in [card-elements.ts:466](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L466)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectivePadding
+
+▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Defined in [card-elements.ts:847](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L847)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectiveStyle
+
+▸ **getEffectiveStyle**(): *string*
+
+*Defined in [card-elements.ts:545](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L545)*
+
+**Returns:** *string*
+
+___
+
+###  getElementById
+
+▸ **getElementById**(`id`: string): *[CardElement](cardelement.md)*
+
+*Defined in [card-elements.ts:831](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L831)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getForbiddenActionTypes
+
+▸ **getForbiddenActionTypes**(): *Array‹any›*
+
+*Defined in [card-elements.ts:557](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L557)*
+
+**Returns:** *Array‹any›*
+
+___
+
+###  getForbiddenElementTypes
+
+▸ **getForbiddenElementTypes**(): *Array‹string›*
+
+*Defined in [card-elements.ts:553](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L553)*
+
+**Returns:** *Array‹string›*
+
+___
+
+### `Protected` getHasBackground
+
+▸ **getHasBackground**(): *boolean*
+
+*Defined in [card-elements.ts:470](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L470)*
+
+**Returns:** *boolean*
+
+___
+
+###  getImmediateSurroundingPadding
+
+▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
+
+*Defined in [card-elements.ts:561](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L561)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`result` | [PaddingDefinition](paddingdefinition.md) | - |
+`processTop` | boolean | true |
+`processRight` | boolean | true |
+`processBottom` | boolean | true |
+`processLeft` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+### `Abstract` getJsonTypeName
+
+▸ **getJsonTypeName**(): *string*
+
+*Overrides [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
+
+*Defined in [card-elements.ts:511](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L511)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` getPadding
+
+▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Defined in [card-elements.ts:474](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L474)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getParentContainer
+
+▸ **getParentContainer**(): *[Container](container.md)*
+
+*Defined in [card-elements.ts:809](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L809)*
+
+**Returns:** *[Container](container.md)*
+
+___
+
+###  getResourceInformation
+
+▸ **getResourceInformation**(): *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+*Defined in [card-elements.ts:827](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L827)*
+
+**Returns:** *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+___
+
+###  getRootElement
+
+▸ **getRootElement**(): *[CardElement](cardelement.md)*
+
+*Defined in [card-elements.ts:799](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L799)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  indexOf
+
+▸ **indexOf**(`cardElement`: [CardElement](cardelement.md)): *number*
+
+*Defined in [card-elements.ts:733](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L733)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`cardElement` | [CardElement](cardelement.md) |
+
+**Returns:** *number*
+
+___
+
+### `Protected` `Abstract` internalRender
+
+▸ **internalRender**(): *HTMLElement*
+
+*Defined in [card-elements.ts:424](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L424)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  internalValidateProperties
+
+▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
+
+*Inherited from [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
+
+*Defined in [card-elements.ts:249](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L249)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [ValidationResults](validationresults.md) |
+
+**Returns:** *void*
+
+___
+
+###  isAtTheVeryBottom
+
+▸ **isAtTheVeryBottom**(): *boolean*
+
+*Defined in [card-elements.ts:767](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L767)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryLeft
+
+▸ **isAtTheVeryLeft**(): *boolean*
+
+*Defined in [card-elements.ts:755](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L755)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryRight
+
+▸ **isAtTheVeryRight**(): *boolean*
+
+*Defined in [card-elements.ts:759](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L759)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryTop
+
+▸ **isAtTheVeryTop**(): *boolean*
+
+*Defined in [card-elements.ts:763](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L763)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleeding
+
+▸ **isBleeding**(): *boolean*
+
+*Defined in [card-elements.ts:517](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L517)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtBottom
+
+▸ **isBleedingAtBottom**(): *boolean*
+
+*Defined in [card-elements.ts:775](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L775)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtTop
+
+▸ **isBleedingAtTop**(): *boolean*
+
+*Defined in [card-elements.ts:771](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L771)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBottomElement
+
+▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Defined in [card-elements.ts:791](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L791)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isDesignMode
+
+▸ **isDesignMode**(): *boolean*
+
+*Defined in [card-elements.ts:737](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L737)*
+
+**Returns:** *boolean*
+
+___
+
+###  isFirstElement
+
+▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Defined in [card-elements.ts:747](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L747)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isHiddenDueToOverflow
+
+▸ **isHiddenDueToOverflow**(): *boolean*
+
+*Defined in [card-elements.ts:795](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L795)*
+
+**Returns:** *boolean*
+
+___
+
+###  isLastElement
+
+▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Defined in [card-elements.ts:751](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L751)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isLeftMostElement
+
+▸ **isLeftMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Defined in [card-elements.ts:779](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L779)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isRendered
+
+▸ **isRendered**(): *boolean*
+
+*Defined in [card-elements.ts:743](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L743)*
+
+**Returns:** *boolean*
+
+___
+
+###  isRightMostElement
+
+▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Defined in [card-elements.ts:783](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L783)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isTopElement
+
+▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Defined in [card-elements.ts:787](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L787)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` overrideInternalRender
+
+▸ **overrideInternalRender**(): *HTMLElement*
+
+*Defined in [card-elements.ts:426](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L426)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Overrides [CardObject](cardobject.md).[parse](cardobject.md#parse)*
+
+*Defined in [card-elements.ts:612](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L612)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*
+
+___
+
+###  remove
+
+▸ **remove**(): *boolean*
+
+*Defined in [card-elements.ts:698](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L698)*
+
+**Returns:** *boolean*
+
+___
+
+###  render
+
+▸ **render**(): *HTMLElement*
+
+*Defined in [card-elements.ts:706](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L706)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setPadding
+
+▸ **setPadding**(`value`: [PaddingDefinition](paddingdefinition.md)): *void*
+
+*Defined in [card-elements.ts:478](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L478)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [PaddingDefinition](paddingdefinition.md) |
+
+**Returns:** *void*
+
+___
+
+###  setParent
+
+▸ **setParent**(`value`: [CardElement](cardelement.md)): *void*
+
+*Overrides [CardObject](cardobject.md).[setParent](cardobject.md#abstract-setparent)*
+
+*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+###  setShouldFallback
+
+▸ **setShouldFallback**(`value`: boolean): *void*
+
+*Defined in [card-elements.ts:843](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L843)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  shouldFallback
+
+▸ **shouldFallback**(): *boolean*
+
+*Overrides [CardObject](cardobject.md).[shouldFallback](cardobject.md#abstract-shouldfallback)*
+
+*Defined in [card-elements.ts:839](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L839)*
+
+**Returns:** *boolean*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [CardObject](cardobject.md).[toJSON](cardobject.md#tojson)*
+
+*Defined in [card-elements.ts:521](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L521)*
+
+**Returns:** *any*
+
+___
+
+### `Protected` truncateOverflow
+
+▸ **truncateOverflow**(`maxHeight`: number): *boolean*
+
+*Defined in [card-elements.ts:454](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L454)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`maxHeight` | number |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` undoOverflowTruncation
+
+▸ **undoOverflowTruncation**(): *void*
+
+*Defined in [card-elements.ts:464](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L464)*
+
+**Returns:** *void*
+
+___
+
+###  updateLayout
+
+▸ **updateLayout**(`processChildren`: boolean): *void*
+
+*Defined in [card-elements.ts:728](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L728)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`processChildren` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  validateProperties
+
+▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
+
+*Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
+
+*Defined in [card-elements.ts:284](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L284)*
+
+**Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/cardelementcontainer.md
+++ b/source/nodejs/adaptivecards/docs/classes/cardelementcontainer.md
@@ -1,0 +1,1348 @@
+[Adaptive Cards Javascript SDK](../README.md) › [CardElementContainer](cardelementcontainer.md)
+
+# Class: CardElementContainer
+
+## Hierarchy
+
+  ↳ [CardElement](cardelement.md)
+
+  ↳ **CardElementContainer**
+
+  ↳ [ImageSet](imageset.md)
+
+  ↳ [StylableCardElementContainer](stylablecardelementcontainer.md)
+
+## Index
+
+### Properties
+
+* [allowVerticalOverflow](cardelementcontainer.md#allowverticaloverflow)
+* [customCssSelector](cardelementcontainer.md#customcssselector)
+* [height](cardelementcontainer.md#height)
+* [horizontalAlignment](cardelementcontainer.md#optional-horizontalalignment)
+* [id](cardelementcontainer.md#id)
+* [minPixelHeight](cardelementcontainer.md#optional-minpixelheight)
+* [requires](cardelementcontainer.md#requires)
+* [separator](cardelementcontainer.md#separator)
+* [spacing](cardelementcontainer.md#spacing)
+
+### Accessors
+
+* [allowCustomPadding](cardelementcontainer.md#protected-allowcustompadding)
+* [defaultStyle](cardelementcontainer.md#protected-defaultstyle)
+* [hasVisibleSeparator](cardelementcontainer.md#hasvisibleseparator)
+* [hostConfig](cardelementcontainer.md#hostconfig)
+* [index](cardelementcontainer.md#index)
+* [isInline](cardelementcontainer.md#isinline)
+* [isInteractive](cardelementcontainer.md#isinteractive)
+* [isSelectable](cardelementcontainer.md#protected-isselectable)
+* [isStandalone](cardelementcontainer.md#isstandalone)
+* [isVisible](cardelementcontainer.md#isvisible)
+* [lang](cardelementcontainer.md#lang)
+* [parent](cardelementcontainer.md#parent)
+* [renderedElement](cardelementcontainer.md#renderedelement)
+* [separatorElement](cardelementcontainer.md#separatorelement)
+* [separatorOrientation](cardelementcontainer.md#protected-separatororientation)
+* [supportsMinHeight](cardelementcontainer.md#protected-supportsminheight)
+* [useDefaultSizing](cardelementcontainer.md#protected-usedefaultsizing)
+
+### Methods
+
+* [adjustRenderedElementSize](cardelementcontainer.md#protected-adjustrenderedelementsize)
+* [applyPadding](cardelementcontainer.md#protected-applypadding)
+* [asString](cardelementcontainer.md#asstring)
+* [createPlaceholderElement](cardelementcontainer.md#protected-createplaceholderelement)
+* [getActionAt](cardelementcontainer.md#getactionat)
+* [getActionById](cardelementcontainer.md#getactionbyid)
+* [getActionCount](cardelementcontainer.md#getactioncount)
+* [getAllInputs](cardelementcontainer.md#getallinputs)
+* [getCustomProperty](cardelementcontainer.md#getcustomproperty)
+* [getDefaultPadding](cardelementcontainer.md#protected-getdefaultpadding)
+* [getEffectivePadding](cardelementcontainer.md#geteffectivepadding)
+* [getEffectiveStyle](cardelementcontainer.md#geteffectivestyle)
+* [getElementById](cardelementcontainer.md#getelementbyid)
+* [getFirstVisibleRenderedItem](cardelementcontainer.md#abstract-getfirstvisiblerendereditem)
+* [getForbiddenActionTypes](cardelementcontainer.md#getforbiddenactiontypes)
+* [getForbiddenElementTypes](cardelementcontainer.md#getforbiddenelementtypes)
+* [getHasBackground](cardelementcontainer.md#protected-gethasbackground)
+* [getImmediateSurroundingPadding](cardelementcontainer.md#getimmediatesurroundingpadding)
+* [getItemAt](cardelementcontainer.md#abstract-getitemat)
+* [getItemCount](cardelementcontainer.md#abstract-getitemcount)
+* [getJsonTypeName](cardelementcontainer.md#abstract-getjsontypename)
+* [getLastVisibleRenderedItem](cardelementcontainer.md#abstract-getlastvisiblerendereditem)
+* [getPadding](cardelementcontainer.md#protected-getpadding)
+* [getParentContainer](cardelementcontainer.md#getparentcontainer)
+* [getResourceInformation](cardelementcontainer.md#getresourceinformation)
+* [getRootElement](cardelementcontainer.md#getrootelement)
+* [getSelectAction](cardelementcontainer.md#protected-getselectaction)
+* [indexOf](cardelementcontainer.md#indexof)
+* [internalRender](cardelementcontainer.md#protected-abstract-internalrender)
+* [internalValidateProperties](cardelementcontainer.md#internalvalidateproperties)
+* [isAtTheVeryBottom](cardelementcontainer.md#isattheverybottom)
+* [isAtTheVeryLeft](cardelementcontainer.md#isattheveryleft)
+* [isAtTheVeryRight](cardelementcontainer.md#isattheveryright)
+* [isAtTheVeryTop](cardelementcontainer.md#isattheverytop)
+* [isBleeding](cardelementcontainer.md#isbleeding)
+* [isBleedingAtBottom](cardelementcontainer.md#isbleedingatbottom)
+* [isBleedingAtTop](cardelementcontainer.md#isbleedingattop)
+* [isBottomElement](cardelementcontainer.md#isbottomelement)
+* [isDesignMode](cardelementcontainer.md#isdesignmode)
+* [isElementAllowed](cardelementcontainer.md#protected-iselementallowed)
+* [isFirstElement](cardelementcontainer.md#isfirstelement)
+* [isHiddenDueToOverflow](cardelementcontainer.md#ishiddenduetooverflow)
+* [isLastElement](cardelementcontainer.md#islastelement)
+* [isLeftMostElement](cardelementcontainer.md#isleftmostelement)
+* [isRendered](cardelementcontainer.md#isrendered)
+* [isRightMostElement](cardelementcontainer.md#isrightmostelement)
+* [isTopElement](cardelementcontainer.md#istopelement)
+* [overrideInternalRender](cardelementcontainer.md#protected-overrideinternalrender)
+* [parse](cardelementcontainer.md#parse)
+* [remove](cardelementcontainer.md#remove)
+* [removeItem](cardelementcontainer.md#abstract-removeitem)
+* [render](cardelementcontainer.md#render)
+* [setCustomProperty](cardelementcontainer.md#setcustomproperty)
+* [setPadding](cardelementcontainer.md#protected-setpadding)
+* [setParent](cardelementcontainer.md#setparent)
+* [setSelectAction](cardelementcontainer.md#protected-setselectaction)
+* [setShouldFallback](cardelementcontainer.md#setshouldfallback)
+* [shouldFallback](cardelementcontainer.md#shouldfallback)
+* [toJSON](cardelementcontainer.md#tojson)
+* [truncateOverflow](cardelementcontainer.md#protected-truncateoverflow)
+* [undoOverflowTruncation](cardelementcontainer.md#protected-undooverflowtruncation)
+* [updateLayout](cardelementcontainer.md#updatelayout)
+* [validateProperties](cardelementcontainer.md#validateproperties)
+
+## Properties
+
+###  allowVerticalOverflow
+
+• **allowVerticalOverflow**: *boolean* = false
+
+*Defined in [card-elements.ts:2229](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2229)*
+
+___
+
+###  customCssSelector
+
+• **customCssSelector**: *string* = null
+
+*Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#customcssselector)*
+
+*Defined in [card-elements.ts:507](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L507)*
+
+___
+
+###  height
+
+• **height**: *[CardElementHeight](../README.md#cardelementheight)* = "auto"
+
+*Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
+
+*Defined in [card-elements.ts:508](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L508)*
+
+___
+
+### `Optional` horizontalAlignment
+
+• **horizontalAlignment**? : *[HorizontalAlignment](../enums/horizontalalignment.md)* = null
+
+*Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#optional-horizontalalignment)*
+
+*Defined in [card-elements.ts:504](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L504)*
+
+___
+
+###  id
+
+• **id**: *string*
+
+*Inherited from [CardObject](cardobject.md).[id](cardobject.md#id)*
+
+*Defined in [card-elements.ts:247](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L247)*
+
+___
+
+### `Optional` minPixelHeight
+
+• **minPixelHeight**? : *number* = null
+
+*Inherited from [CardElement](cardelement.md).[minPixelHeight](cardelement.md#optional-minpixelheight)*
+
+*Defined in [card-elements.ts:509](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L509)*
+
+___
+
+###  requires
+
+• **requires**: *[HostCapabilities](hostcapabilities.md)‹›* = new HostConfig.HostCapabilities()
+
+*Inherited from [CardElement](cardelement.md).[requires](cardelement.md#requires)*
+
+*Defined in [card-elements.ts:502](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L502)*
+
+___
+
+###  separator
+
+• **separator**: *boolean* = false
+
+*Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
+
+*Defined in [card-elements.ts:506](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L506)*
+
+___
+
+###  spacing
+
+• **spacing**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.Default
+
+*Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
+
+*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
+
+## Accessors
+
+### `Protected` allowCustomPadding
+
+• **get allowCustomPadding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
+
+*Defined in [card-elements.ts:490](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L490)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` defaultStyle
+
+• **get defaultStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
+
+*Defined in [card-elements.ts:498](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L498)*
+
+**Returns:** *string*
+
+___
+
+###  hasVisibleSeparator
+
+• **get hasVisibleSeparator**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
+
+*Defined in [card-elements.ts:928](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L928)*
+
+**Returns:** *boolean*
+
+___
+
+###  hostConfig
+
+• **get hostConfig**(): *[HostConfig](hostconfig.md)*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:881](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L881)*
+
+**Returns:** *[HostConfig](hostconfig.md)*
+
+• **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:895](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L895)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [HostConfig](hostconfig.md) |
+
+**Returns:** *void*
+
+___
+
+###  index
+
+• **get index**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
+
+*Defined in [card-elements.ts:899](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L899)*
+
+**Returns:** *number*
+
+___
+
+###  isInline
+
+• **get isInline**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
+
+*Defined in [card-elements.ts:916](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L916)*
+
+**Returns:** *boolean*
+
+___
+
+###  isInteractive
+
+• **get isInteractive**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
+
+*Defined in [card-elements.ts:908](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L908)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` isSelectable
+
+• **get isSelectable**(): *boolean*
+
+*Defined in [card-elements.ts:2219](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2219)*
+
+**Returns:** *boolean*
+
+___
+
+###  isStandalone
+
+• **get isStandalone**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
+
+*Defined in [card-elements.ts:912](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L912)*
+
+**Returns:** *boolean*
+
+___
+
+###  isVisible
+
+• **get isVisible**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:924](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L924)*
+
+**Returns:** *boolean*
+
+• **set isVisible**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:937](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L937)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  lang
+
+• **get lang**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:853](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L853)*
+
+**Returns:** *string*
+
+• **set lang**(`value`: string): *void*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:867](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L867)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  parent
+
+• **get parent**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[parent](cardelement.md#parent)*
+
+*Defined in [card-elements.ts:920](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L920)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  renderedElement
+
+• **get renderedElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[renderedElement](cardelement.md#renderedelement)*
+
+*Defined in [card-elements.ts:956](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L956)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  separatorElement
+
+• **get separatorElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
+
+*Defined in [card-elements.ts:960](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L960)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` separatorOrientation
+
+• **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
+
+*Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
+
+*Defined in [card-elements.ts:494](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L494)*
+
+**Returns:** *[Orientation](../enums/orientation.md)*
+
+___
+
+### `Protected` supportsMinHeight
+
+• **get supportsMinHeight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[supportsMinHeight](cardelement.md#protected-supportsminheight)*
+
+*Defined in [card-elements.ts:482](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L482)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` useDefaultSizing
+
+• **get useDefaultSizing**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
+
+*Defined in [card-elements.ts:486](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L486)*
+
+**Returns:** *boolean*
+
+## Methods
+
+### `Protected` adjustRenderedElementSize
+
+▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
+
+*Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
+
+*Defined in [card-elements.ts:411](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L411)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`renderedElement` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+### `Protected` applyPadding
+
+▸ **applyPadding**(): *void*
+
+*Overrides [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
+
+*Defined in [card-elements.ts:2185](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2185)*
+
+**Returns:** *void*
+
+___
+
+###  asString
+
+▸ **asString**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
+
+*Defined in [card-elements.ts:513](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L513)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` createPlaceholderElement
+
+▸ **createPlaceholderElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
+
+*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  getActionAt
+
+▸ **getActionAt**(`index`: number): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
+
+*Defined in [card-elements.ts:694](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L694)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionById
+
+▸ **getActionById**(`id`: string): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
+
+*Defined in [card-elements.ts:835](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L835)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionCount
+
+▸ **getActionCount**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
+
+*Defined in [card-elements.ts:690](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L690)*
+
+**Returns:** *number*
+
+___
+
+###  getAllInputs
+
+▸ **getAllInputs**(): *Array‹[Input](input.md)›*
+
+*Overrides [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
+
+*Defined in [card-elements.ts:2334](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2334)*
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+### `Protected` getDefaultPadding
+
+▸ **getDefaultPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
+
+*Defined in [card-elements.ts:466](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L466)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectivePadding
+
+▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
+
+*Defined in [card-elements.ts:847](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L847)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectiveStyle
+
+▸ **getEffectiveStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
+
+*Defined in [card-elements.ts:545](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L545)*
+
+**Returns:** *string*
+
+___
+
+###  getElementById
+
+▸ **getElementById**(`id`: string): *[CardElement](cardelement.md)*
+
+*Overrides [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
+
+*Defined in [card-elements.ts:2354](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2354)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+### `Abstract` getFirstVisibleRenderedItem
+
+▸ **getFirstVisibleRenderedItem**(): *[CardElement](cardelement.md)*
+
+*Defined in [card-elements.ts:2225](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2225)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getForbiddenActionTypes
+
+▸ **getForbiddenActionTypes**(): *Array‹any›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
+
+*Defined in [card-elements.ts:557](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L557)*
+
+**Returns:** *Array‹any›*
+
+___
+
+###  getForbiddenElementTypes
+
+▸ **getForbiddenElementTypes**(): *Array‹string›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenElementTypes](cardelement.md#getforbiddenelementtypes)*
+
+*Defined in [card-elements.ts:553](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L553)*
+
+**Returns:** *Array‹string›*
+
+___
+
+### `Protected` getHasBackground
+
+▸ **getHasBackground**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
+
+*Defined in [card-elements.ts:470](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L470)*
+
+**Returns:** *boolean*
+
+___
+
+###  getImmediateSurroundingPadding
+
+▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
+
+*Defined in [card-elements.ts:561](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L561)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`result` | [PaddingDefinition](paddingdefinition.md) | - |
+`processTop` | boolean | true |
+`processRight` | boolean | true |
+`processBottom` | boolean | true |
+`processLeft` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+### `Abstract` getItemAt
+
+▸ **getItemAt**(`index`: number): *[CardElement](cardelement.md)*
+
+*Defined in [card-elements.ts:2224](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2224)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+### `Abstract` getItemCount
+
+▸ **getItemCount**(): *number*
+
+*Defined in [card-elements.ts:2223](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2223)*
+
+**Returns:** *number*
+
+___
+
+### `Abstract` getJsonTypeName
+
+▸ **getJsonTypeName**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[getJsonTypeName](cardelement.md#abstract-getjsontypename)*
+
+*Overrides [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
+
+*Defined in [card-elements.ts:511](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L511)*
+
+**Returns:** *string*
+
+___
+
+### `Abstract` getLastVisibleRenderedItem
+
+▸ **getLastVisibleRenderedItem**(): *[CardElement](cardelement.md)*
+
+*Defined in [card-elements.ts:2226](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2226)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+### `Protected` getPadding
+
+▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
+
+*Defined in [card-elements.ts:474](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L474)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getParentContainer
+
+▸ **getParentContainer**(): *[Container](container.md)*
+
+*Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
+
+*Defined in [card-elements.ts:809](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L809)*
+
+**Returns:** *[Container](container.md)*
+
+___
+
+###  getResourceInformation
+
+▸ **getResourceInformation**(): *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+*Overrides [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
+
+*Defined in [card-elements.ts:2344](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2344)*
+
+**Returns:** *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+___
+
+###  getRootElement
+
+▸ **getRootElement**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
+
+*Defined in [card-elements.ts:799](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L799)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+### `Protected` getSelectAction
+
+▸ **getSelectAction**(): *[Action](action.md)*
+
+*Defined in [card-elements.ts:2207](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2207)*
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  indexOf
+
+▸ **indexOf**(`cardElement`: [CardElement](cardelement.md)): *number*
+
+*Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
+
+*Defined in [card-elements.ts:733](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L733)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`cardElement` | [CardElement](cardelement.md) |
+
+**Returns:** *number*
+
+___
+
+### `Protected` `Abstract` internalRender
+
+▸ **internalRender**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
+
+*Defined in [card-elements.ts:424](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L424)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  internalValidateProperties
+
+▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
+
+*Overrides [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
+
+*Defined in [card-elements.ts:2254](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2254)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [ValidationResults](validationresults.md) |
+
+**Returns:** *void*
+
+___
+
+###  isAtTheVeryBottom
+
+▸ **isAtTheVeryBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
+
+*Defined in [card-elements.ts:767](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L767)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryLeft
+
+▸ **isAtTheVeryLeft**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
+
+*Defined in [card-elements.ts:755](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L755)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryRight
+
+▸ **isAtTheVeryRight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
+
+*Defined in [card-elements.ts:759](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L759)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryTop
+
+▸ **isAtTheVeryTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
+
+*Defined in [card-elements.ts:763](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L763)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleeding
+
+▸ **isBleeding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
+
+*Defined in [card-elements.ts:517](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L517)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtBottom
+
+▸ **isBleedingAtBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
+
+*Defined in [card-elements.ts:775](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L775)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtTop
+
+▸ **isBleedingAtTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
+
+*Defined in [card-elements.ts:771](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L771)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBottomElement
+
+▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
+
+*Defined in [card-elements.ts:791](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L791)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isDesignMode
+
+▸ **isDesignMode**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
+
+*Defined in [card-elements.ts:737](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L737)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` isElementAllowed
+
+▸ **isElementAllowed**(`element`: [CardElement](cardelement.md), `forbiddenElementTypes`: Array‹string›): *boolean*
+
+*Defined in [card-elements.ts:2169](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2169)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+`forbiddenElementTypes` | Array‹string› |
+
+**Returns:** *boolean*
+
+___
+
+###  isFirstElement
+
+▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
+
+*Defined in [card-elements.ts:747](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L747)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isHiddenDueToOverflow
+
+▸ **isHiddenDueToOverflow**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
+
+*Defined in [card-elements.ts:795](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L795)*
+
+**Returns:** *boolean*
+
+___
+
+###  isLastElement
+
+▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
+
+*Defined in [card-elements.ts:751](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L751)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isLeftMostElement
+
+▸ **isLeftMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
+
+*Defined in [card-elements.ts:779](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L779)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isRendered
+
+▸ **isRendered**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRendered](cardelement.md#isrendered)*
+
+*Defined in [card-elements.ts:743](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L743)*
+
+**Returns:** *boolean*
+
+___
+
+###  isRightMostElement
+
+▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
+
+*Defined in [card-elements.ts:783](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L783)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isTopElement
+
+▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
+
+*Defined in [card-elements.ts:787](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L787)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` overrideInternalRender
+
+▸ **overrideInternalRender**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
+
+*Defined in [card-elements.ts:426](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L426)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Overrides [CardElement](cardelement.md).[parse](cardelement.md#parse)*
+
+*Defined in [card-elements.ts:2231](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2231)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*
+
+___
+
+###  remove
+
+▸ **remove**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
+
+*Defined in [card-elements.ts:698](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L698)*
+
+**Returns:** *boolean*
+
+___
+
+### `Abstract` removeItem
+
+▸ **removeItem**(`item`: [CardElement](cardelement.md)): *boolean*
+
+*Defined in [card-elements.ts:2227](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2227)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`item` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  render
+
+▸ **render**(): *HTMLElement*
+
+*Overrides [CardElement](cardelement.md).[render](cardelement.md#render)*
+
+*Defined in [card-elements.ts:2286](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2286)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setPadding
+
+▸ **setPadding**(`value`: [PaddingDefinition](paddingdefinition.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
+
+*Defined in [card-elements.ts:478](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L478)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [PaddingDefinition](paddingdefinition.md) |
+
+**Returns:** *void*
+
+___
+
+###  setParent
+
+▸ **setParent**(`value`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setParent](cardelement.md#setparent)*
+
+*Overrides [CardObject](cardobject.md).[setParent](cardobject.md#abstract-setparent)*
+
+*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setSelectAction
+
+▸ **setSelectAction**(`value`: [Action](action.md)): *void*
+
+*Defined in [card-elements.ts:2211](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2211)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [Action](action.md) |
+
+**Returns:** *void*
+
+___
+
+###  setShouldFallback
+
+▸ **setShouldFallback**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[setShouldFallback](cardelement.md#setshouldfallback)*
+
+*Defined in [card-elements.ts:843](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L843)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  shouldFallback
+
+▸ **shouldFallback**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[shouldFallback](cardelement.md#shouldfallback)*
+
+*Overrides [CardObject](cardobject.md).[shouldFallback](cardobject.md#abstract-shouldfallback)*
+
+*Defined in [card-elements.ts:839](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L839)*
+
+**Returns:** *boolean*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [CardElement](cardelement.md).[toJSON](cardelement.md#tojson)*
+
+*Defined in [card-elements.ts:2244](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2244)*
+
+**Returns:** *any*
+
+___
+
+### `Protected` truncateOverflow
+
+▸ **truncateOverflow**(`maxHeight`: number): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
+
+*Defined in [card-elements.ts:454](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L454)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`maxHeight` | number |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` undoOverflowTruncation
+
+▸ **undoOverflowTruncation**(): *void*
+
+*Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
+
+*Defined in [card-elements.ts:464](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L464)*
+
+**Returns:** *void*
+
+___
+
+###  updateLayout
+
+▸ **updateLayout**(`processChildren`: boolean): *void*
+
+*Overrides [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
+
+*Defined in [card-elements.ts:2324](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2324)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`processChildren` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  validateProperties
+
+▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
+
+*Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
+
+*Defined in [card-elements.ts:284](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L284)*
+
+**Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/cardobject.md
+++ b/source/nodejs/adaptivecards/docs/classes/cardobject.md
@@ -1,0 +1,169 @@
+[Adaptive Cards Javascript SDK](../README.md) › [CardObject](cardobject.md)
+
+# Class: CardObject
+
+## Hierarchy
+
+* [SerializableObject](serializableobject.md)
+
+  ↳ **CardObject**
+
+  ↳ [CardElement](cardelement.md)
+
+  ↳ [Action](action.md)
+
+## Index
+
+### Properties
+
+* [id](cardobject.md#id)
+
+### Methods
+
+* [getCustomProperty](cardobject.md#getcustomproperty)
+* [getJsonTypeName](cardobject.md#abstract-getjsontypename)
+* [internalValidateProperties](cardobject.md#internalvalidateproperties)
+* [parse](cardobject.md#parse)
+* [setCustomProperty](cardobject.md#setcustomproperty)
+* [setParent](cardobject.md#abstract-setparent)
+* [shouldFallback](cardobject.md#abstract-shouldfallback)
+* [toJSON](cardobject.md#tojson)
+* [validateProperties](cardobject.md#validateproperties)
+
+## Properties
+
+###  id
+
+• **id**: *string*
+
+*Defined in [card-elements.ts:247](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L247)*
+
+## Methods
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+### `Abstract` getJsonTypeName
+
+▸ **getJsonTypeName**(): *string*
+
+*Defined in [card-elements.ts:243](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L243)*
+
+**Returns:** *string*
+
+___
+
+###  internalValidateProperties
+
+▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
+
+*Defined in [card-elements.ts:249](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L249)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [ValidationResults](validationresults.md) |
+
+**Returns:** *void*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
+
+*Defined in [card-elements.ts:269](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L269)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+### `Abstract` setParent
+
+▸ **setParent**(`parent`: [CardElement](cardelement.md)): *any*
+
+*Defined in [card-elements.ts:245](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L245)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`parent` | [CardElement](cardelement.md) |
+
+**Returns:** *any*
+
+___
+
+### `Abstract` shouldFallback
+
+▸ **shouldFallback**(): *boolean*
+
+*Defined in [card-elements.ts:244](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L244)*
+
+**Returns:** *boolean*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
+
+*Defined in [card-elements.ts:275](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L275)*
+
+**Returns:** *any*
+
+___
+
+###  validateProperties
+
+▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
+
+*Defined in [card-elements.ts:284](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L284)*
+
+**Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/choice.md
+++ b/source/nodejs/adaptivecards/docs/classes/choice.md
@@ -1,0 +1,127 @@
+[Adaptive Cards Javascript SDK](../README.md) › [Choice](choice.md)
+
+# Class: Choice
+
+## Hierarchy
+
+* [SerializableObject](serializableobject.md)
+
+  ↳ **Choice**
+
+## Index
+
+### Constructors
+
+* [constructor](choice.md#constructor)
+
+### Properties
+
+* [title](choice.md#title)
+* [value](choice.md#value)
+
+### Methods
+
+* [getCustomProperty](choice.md#getcustomproperty)
+* [parse](choice.md#parse)
+* [setCustomProperty](choice.md#setcustomproperty)
+* [toJSON](choice.md#tojson)
+
+## Constructors
+
+###  constructor
+
+\+ **new Choice**(`title`: string, `value`: string): *[Choice](choice.md)*
+
+*Defined in [card-elements.ts:3248](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3248)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`title` | string | undefined |
+`value` | string | undefined |
+
+**Returns:** *[Choice](choice.md)*
+
+## Properties
+
+###  title
+
+• **title**: *string*
+
+*Defined in [card-elements.ts:3247](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3247)*
+
+___
+
+###  value
+
+• **value**: *string*
+
+*Defined in [card-elements.ts:3248](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3248)*
+
+## Methods
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any): *void*
+
+*Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
+
+*Defined in [card-elements.ts:3257](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3257)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+
+**Returns:** *void*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
+
+*Defined in [card-elements.ts:3264](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3264)*
+
+**Returns:** *any*

--- a/source/nodejs/adaptivecards/docs/classes/choicesetinput.md
+++ b/source/nodejs/adaptivecards/docs/classes/choicesetinput.md
@@ -1,0 +1,1461 @@
+[Adaptive Cards Javascript SDK](../README.md) › [ChoiceSetInput](choicesetinput.md)
+
+# Class: ChoiceSetInput
+
+## Hierarchy
+
+  ↳ [Input](input.md)
+
+  ↳ **ChoiceSetInput**
+
+## Implements
+
+* [IInput](../interfaces/iinput.md)
+
+## Index
+
+### Properties
+
+* [choices](choicesetinput.md#choices)
+* [customCssSelector](choicesetinput.md#customcssselector)
+* [height](choicesetinput.md#height)
+* [horizontalAlignment](choicesetinput.md#optional-horizontalalignment)
+* [id](choicesetinput.md#id)
+* [isCompact](choicesetinput.md#iscompact)
+* [isMultiSelect](choicesetinput.md#ismultiselect)
+* [minPixelHeight](choicesetinput.md#optional-minpixelheight)
+* [onValueChanged](choicesetinput.md#onvaluechanged)
+* [placeholder](choicesetinput.md#placeholder)
+* [requires](choicesetinput.md#requires)
+* [separator](choicesetinput.md#separator)
+* [spacing](choicesetinput.md#spacing)
+* [title](choicesetinput.md#title)
+* [validation](choicesetinput.md#validation)
+* [wrap](choicesetinput.md#wrap)
+
+### Accessors
+
+* [allowCustomPadding](choicesetinput.md#protected-allowcustompadding)
+* [defaultStyle](choicesetinput.md#protected-defaultstyle)
+* [defaultValue](choicesetinput.md#defaultvalue)
+* [hasVisibleSeparator](choicesetinput.md#hasvisibleseparator)
+* [hostConfig](choicesetinput.md#hostconfig)
+* [index](choicesetinput.md#index)
+* [inputControlContainerElement](choicesetinput.md#protected-inputcontrolcontainerelement)
+* [isInline](choicesetinput.md#isinline)
+* [isInteractive](choicesetinput.md#isinteractive)
+* [isNullable](choicesetinput.md#protected-isnullable)
+* [isStandalone](choicesetinput.md#isstandalone)
+* [isVisible](choicesetinput.md#isvisible)
+* [lang](choicesetinput.md#lang)
+* [parent](choicesetinput.md#parent)
+* [renderedElement](choicesetinput.md#renderedelement)
+* [renderedInputControlElement](choicesetinput.md#protected-renderedinputcontrolelement)
+* [separatorElement](choicesetinput.md#separatorelement)
+* [separatorOrientation](choicesetinput.md#protected-separatororientation)
+* [supportsMinHeight](choicesetinput.md#protected-supportsminheight)
+* [useDefaultSizing](choicesetinput.md#protected-usedefaultsizing)
+* [value](choicesetinput.md#value)
+
+### Methods
+
+* [adjustRenderedElementSize](choicesetinput.md#protected-adjustrenderedelementsize)
+* [applyPadding](choicesetinput.md#protected-applypadding)
+* [asString](choicesetinput.md#asstring)
+* [createPlaceholderElement](choicesetinput.md#protected-createplaceholderelement)
+* [getActionAt](choicesetinput.md#getactionat)
+* [getActionById](choicesetinput.md#getactionbyid)
+* [getActionCount](choicesetinput.md#getactioncount)
+* [getAllInputs](choicesetinput.md#getallinputs)
+* [getCustomProperty](choicesetinput.md#getcustomproperty)
+* [getDefaultPadding](choicesetinput.md#protected-getdefaultpadding)
+* [getEffectivePadding](choicesetinput.md#geteffectivepadding)
+* [getEffectiveStyle](choicesetinput.md#geteffectivestyle)
+* [getElementById](choicesetinput.md#getelementbyid)
+* [getForbiddenActionTypes](choicesetinput.md#getforbiddenactiontypes)
+* [getForbiddenElementTypes](choicesetinput.md#getforbiddenelementtypes)
+* [getHasBackground](choicesetinput.md#protected-gethasbackground)
+* [getImmediateSurroundingPadding](choicesetinput.md#getimmediatesurroundingpadding)
+* [getJsonTypeName](choicesetinput.md#getjsontypename)
+* [getPadding](choicesetinput.md#protected-getpadding)
+* [getParentContainer](choicesetinput.md#getparentcontainer)
+* [getResourceInformation](choicesetinput.md#getresourceinformation)
+* [getRootElement](choicesetinput.md#getrootelement)
+* [indexOf](choicesetinput.md#indexof)
+* [internalRender](choicesetinput.md#protected-internalrender)
+* [internalValidateProperties](choicesetinput.md#internalvalidateproperties)
+* [isAtTheVeryBottom](choicesetinput.md#isattheverybottom)
+* [isAtTheVeryLeft](choicesetinput.md#isattheveryleft)
+* [isAtTheVeryRight](choicesetinput.md#isattheveryright)
+* [isAtTheVeryTop](choicesetinput.md#isattheverytop)
+* [isBleeding](choicesetinput.md#isbleeding)
+* [isBleedingAtBottom](choicesetinput.md#isbleedingatbottom)
+* [isBleedingAtTop](choicesetinput.md#isbleedingattop)
+* [isBottomElement](choicesetinput.md#isbottomelement)
+* [isDesignMode](choicesetinput.md#isdesignmode)
+* [isFirstElement](choicesetinput.md#isfirstelement)
+* [isHiddenDueToOverflow](choicesetinput.md#ishiddenduetooverflow)
+* [isLastElement](choicesetinput.md#islastelement)
+* [isLeftMostElement](choicesetinput.md#isleftmostelement)
+* [isRendered](choicesetinput.md#isrendered)
+* [isRightMostElement](choicesetinput.md#isrightmostelement)
+* [isTopElement](choicesetinput.md#istopelement)
+* [overrideInternalRender](choicesetinput.md#protected-overrideinternalrender)
+* [parse](choicesetinput.md#parse)
+* [parseInputValue](choicesetinput.md#protected-parseinputvalue)
+* [remove](choicesetinput.md#remove)
+* [render](choicesetinput.md#render)
+* [resetValidationFailureCue](choicesetinput.md#protected-resetvalidationfailurecue)
+* [setCustomProperty](choicesetinput.md#setcustomproperty)
+* [setPadding](choicesetinput.md#protected-setpadding)
+* [setParent](choicesetinput.md#setparent)
+* [setShouldFallback](choicesetinput.md#setshouldfallback)
+* [shouldFallback](choicesetinput.md#shouldfallback)
+* [showValidationErrorMessage](choicesetinput.md#protected-showvalidationerrormessage)
+* [toJSON](choicesetinput.md#tojson)
+* [truncateOverflow](choicesetinput.md#protected-truncateoverflow)
+* [undoOverflowTruncation](choicesetinput.md#protected-undooverflowtruncation)
+* [updateLayout](choicesetinput.md#updatelayout)
+* [validateProperties](choicesetinput.md#validateproperties)
+* [validateValue](choicesetinput.md#validatevalue)
+* [valueChanged](choicesetinput.md#protected-valuechanged)
+
+## Properties
+
+###  choices
+
+• **choices**: *Array‹[Choice](choice.md)›* = []
+
+*Defined in [card-elements.ts:3449](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3449)*
+
+___
+
+###  customCssSelector
+
+• **customCssSelector**: *string* = null
+
+*Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#customcssselector)*
+
+*Defined in [card-elements.ts:507](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L507)*
+
+___
+
+###  height
+
+• **height**: *[CardElementHeight](../README.md#cardelementheight)* = "auto"
+
+*Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
+
+*Defined in [card-elements.ts:508](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L508)*
+
+___
+
+### `Optional` horizontalAlignment
+
+• **horizontalAlignment**? : *[HorizontalAlignment](../enums/horizontalalignment.md)* = null
+
+*Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#optional-horizontalalignment)*
+
+*Defined in [card-elements.ts:504](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L504)*
+
+___
+
+###  id
+
+• **id**: *string*
+
+*Implementation of [IInput](../interfaces/iinput.md).[id](../interfaces/iinput.md#id)*
+
+*Inherited from [CardObject](cardobject.md).[id](cardobject.md#id)*
+
+*Defined in [card-elements.ts:247](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L247)*
+
+___
+
+###  isCompact
+
+• **isCompact**: *boolean* = false
+
+*Defined in [card-elements.ts:3450](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3450)*
+
+___
+
+###  isMultiSelect
+
+• **isMultiSelect**: *boolean* = false
+
+*Defined in [card-elements.ts:3451](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3451)*
+
+___
+
+### `Optional` minPixelHeight
+
+• **minPixelHeight**? : *number* = null
+
+*Inherited from [CardElement](cardelement.md).[minPixelHeight](cardelement.md#optional-minpixelheight)*
+
+*Defined in [card-elements.ts:509](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L509)*
+
+___
+
+###  onValueChanged
+
+• **onValueChanged**: *function*
+
+*Inherited from [Input](input.md).[onValueChanged](input.md#onvaluechanged)*
+
+*Defined in [card-elements.ts:2874](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2874)*
+
+#### Type declaration:
+
+▸ (`sender`: [Input](input.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`sender` | [Input](input.md) |
+
+___
+
+###  placeholder
+
+• **placeholder**: *string*
+
+*Defined in [card-elements.ts:3452](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3452)*
+
+___
+
+###  requires
+
+• **requires**: *[HostCapabilities](hostcapabilities.md)‹›* = new HostConfig.HostCapabilities()
+
+*Inherited from [CardElement](cardelement.md).[requires](cardelement.md#requires)*
+
+*Defined in [card-elements.ts:502](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L502)*
+
+___
+
+###  separator
+
+• **separator**: *boolean* = false
+
+*Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
+
+*Defined in [card-elements.ts:506](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L506)*
+
+___
+
+###  spacing
+
+• **spacing**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.Default
+
+*Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
+
+*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
+
+___
+
+###  title
+
+• **title**: *string*
+
+*Inherited from [Input](input.md).[title](input.md#title)*
+
+*Defined in [card-elements.ts:2878](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2878)*
+
+___
+
+###  validation
+
+• **validation**: *[InputValidationOptions](inputvalidationoptions.md)‹›* = new InputValidationOptions()
+
+*Inherited from [Input](input.md).[validation](input.md#validation)*
+
+*Defined in [card-elements.ts:2876](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2876)*
+
+___
+
+###  wrap
+
+• **wrap**: *boolean* = false
+
+*Defined in [card-elements.ts:3453](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3453)*
+
+## Accessors
+
+### `Protected` allowCustomPadding
+
+• **get allowCustomPadding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
+
+*Defined in [card-elements.ts:490](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L490)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` defaultStyle
+
+• **get defaultStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
+
+*Defined in [card-elements.ts:498](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L498)*
+
+**Returns:** *string*
+
+___
+
+###  defaultValue
+
+• **get defaultValue**(): *string*
+
+*Inherited from [Input](input.md).[defaultValue](input.md#defaultvalue)*
+
+*Defined in [card-elements.ts:2944](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2944)*
+
+**Returns:** *string*
+
+• **set defaultValue**(`value`: string): *void*
+
+*Inherited from [Input](input.md).[defaultValue](input.md#defaultvalue)*
+
+*Defined in [card-elements.ts:2948](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2948)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  hasVisibleSeparator
+
+• **get hasVisibleSeparator**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
+
+*Defined in [card-elements.ts:928](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L928)*
+
+**Returns:** *boolean*
+
+___
+
+###  hostConfig
+
+• **get hostConfig**(): *[HostConfig](hostconfig.md)*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:881](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L881)*
+
+**Returns:** *[HostConfig](hostconfig.md)*
+
+• **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:895](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L895)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [HostConfig](hostconfig.md) |
+
+**Returns:** *void*
+
+___
+
+###  index
+
+• **get index**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
+
+*Defined in [card-elements.ts:899](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L899)*
+
+**Returns:** *number*
+
+___
+
+### `Protected` inputControlContainerElement
+
+• **get inputControlContainerElement**(): *HTMLElement*
+
+*Inherited from [Input](input.md).[inputControlContainerElement](input.md#protected-inputcontrolcontainerelement)*
+
+*Defined in [card-elements.ts:2807](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2807)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  isInline
+
+• **get isInline**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
+
+*Defined in [card-elements.ts:916](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L916)*
+
+**Returns:** *boolean*
+
+___
+
+###  isInteractive
+
+• **get isInteractive**(): *boolean*
+
+*Inherited from [Input](input.md).[isInteractive](input.md#isinteractive)*
+
+*Overrides [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
+
+*Defined in [card-elements.ts:2952](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2952)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` isNullable
+
+• **get isNullable**(): *boolean*
+
+*Inherited from [Input](input.md).[isNullable](input.md#protected-isnullable)*
+
+*Defined in [card-elements.ts:2799](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2799)*
+
+**Returns:** *boolean*
+
+___
+
+###  isStandalone
+
+• **get isStandalone**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
+
+*Defined in [card-elements.ts:912](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L912)*
+
+**Returns:** *boolean*
+
+___
+
+###  isVisible
+
+• **get isVisible**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:924](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L924)*
+
+**Returns:** *boolean*
+
+• **set isVisible**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:937](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L937)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  lang
+
+• **get lang**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:853](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L853)*
+
+**Returns:** *string*
+
+• **set lang**(`value`: string): *void*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:867](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L867)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  parent
+
+• **get parent**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[parent](cardelement.md#parent)*
+
+*Defined in [card-elements.ts:920](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L920)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  renderedElement
+
+• **get renderedElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[renderedElement](cardelement.md#renderedelement)*
+
+*Defined in [card-elements.ts:956](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L956)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` renderedInputControlElement
+
+• **get renderedInputControlElement**(): *HTMLElement*
+
+*Inherited from [Input](input.md).[renderedInputControlElement](input.md#protected-renderedinputcontrolelement)*
+
+*Defined in [card-elements.ts:2803](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2803)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  separatorElement
+
+• **get separatorElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
+
+*Defined in [card-elements.ts:960](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L960)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` separatorOrientation
+
+• **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
+
+*Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
+
+*Defined in [card-elements.ts:494](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L494)*
+
+**Returns:** *[Orientation](../enums/orientation.md)*
+
+___
+
+### `Protected` supportsMinHeight
+
+• **get supportsMinHeight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[supportsMinHeight](cardelement.md#protected-supportsminheight)*
+
+*Defined in [card-elements.ts:482](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L482)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` useDefaultSizing
+
+• **get useDefaultSizing**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
+
+*Defined in [card-elements.ts:486](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L486)*
+
+**Returns:** *boolean*
+
+___
+
+###  value
+
+• **get value**(): *string*
+
+*Overrides [Input](input.md).[value](input.md#value)*
+
+*Defined in [card-elements.ts:3516](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3516)*
+
+**Returns:** *string*
+
+## Methods
+
+### `Protected` adjustRenderedElementSize
+
+▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
+
+*Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
+
+*Defined in [card-elements.ts:411](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L411)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`renderedElement` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+### `Protected` applyPadding
+
+▸ **applyPadding**(): *void*
+
+*Inherited from [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
+
+*Defined in [card-elements.ts:430](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L430)*
+
+**Returns:** *void*
+
+___
+
+###  asString
+
+▸ **asString**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
+
+*Defined in [card-elements.ts:513](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L513)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` createPlaceholderElement
+
+▸ **createPlaceholderElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
+
+*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  getActionAt
+
+▸ **getActionAt**(`index`: number): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
+
+*Defined in [card-elements.ts:694](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L694)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionById
+
+▸ **getActionById**(`id`: string): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
+
+*Defined in [card-elements.ts:835](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L835)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionCount
+
+▸ **getActionCount**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
+
+*Defined in [card-elements.ts:690](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L690)*
+
+**Returns:** *number*
+
+___
+
+###  getAllInputs
+
+▸ **getAllInputs**(): *Array‹[Input](input.md)›*
+
+*Inherited from [Input](input.md).[getAllInputs](input.md#getallinputs)*
+
+*Overrides [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
+
+*Defined in [card-elements.ts:2940](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2940)*
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+### `Protected` getDefaultPadding
+
+▸ **getDefaultPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
+
+*Defined in [card-elements.ts:466](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L466)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectivePadding
+
+▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
+
+*Defined in [card-elements.ts:847](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L847)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectiveStyle
+
+▸ **getEffectiveStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
+
+*Defined in [card-elements.ts:545](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L545)*
+
+**Returns:** *string*
+
+___
+
+###  getElementById
+
+▸ **getElementById**(`id`: string): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
+
+*Defined in [card-elements.ts:831](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L831)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getForbiddenActionTypes
+
+▸ **getForbiddenActionTypes**(): *Array‹any›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
+
+*Defined in [card-elements.ts:557](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L557)*
+
+**Returns:** *Array‹any›*
+
+___
+
+###  getForbiddenElementTypes
+
+▸ **getForbiddenElementTypes**(): *Array‹string›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenElementTypes](cardelement.md#getforbiddenelementtypes)*
+
+*Defined in [card-elements.ts:553](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L553)*
+
+**Returns:** *Array‹string›*
+
+___
+
+### `Protected` getHasBackground
+
+▸ **getHasBackground**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
+
+*Defined in [card-elements.ts:470](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L470)*
+
+**Returns:** *boolean*
+
+___
+
+###  getImmediateSurroundingPadding
+
+▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
+
+*Defined in [card-elements.ts:561](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L561)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`result` | [PaddingDefinition](paddingdefinition.md) | - |
+`processTop` | boolean | true |
+`processRight` | boolean | true |
+`processBottom` | boolean | true |
+`processLeft` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  getJsonTypeName
+
+▸ **getJsonTypeName**(): *string*
+
+*Overrides [CardElement](cardelement.md).[getJsonTypeName](cardelement.md#abstract-getjsontypename)*
+
+*Defined in [card-elements.ts:3455](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3455)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` getPadding
+
+▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
+
+*Defined in [card-elements.ts:474](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L474)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getParentContainer
+
+▸ **getParentContainer**(): *[Container](container.md)*
+
+*Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
+
+*Defined in [card-elements.ts:809](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L809)*
+
+**Returns:** *[Container](container.md)*
+
+___
+
+###  getResourceInformation
+
+▸ **getResourceInformation**(): *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+*Inherited from [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
+
+*Defined in [card-elements.ts:827](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L827)*
+
+**Returns:** *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+___
+
+###  getRootElement
+
+▸ **getRootElement**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
+
+*Defined in [card-elements.ts:799](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L799)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  indexOf
+
+▸ **indexOf**(`cardElement`: [CardElement](cardelement.md)): *number*
+
+*Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
+
+*Defined in [card-elements.ts:733](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L733)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`cardElement` | [CardElement](cardelement.md) |
+
+**Returns:** *number*
+
+___
+
+### `Protected` internalRender
+
+▸ **internalRender**(): *HTMLElement*
+
+*Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
+
+*Defined in [card-elements.ts:3288](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3288)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  internalValidateProperties
+
+▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
+
+*Overrides [Input](input.md).[internalValidateProperties](input.md#internalvalidateproperties)*
+
+*Defined in [card-elements.ts:3471](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3471)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [ValidationResults](validationresults.md) |
+
+**Returns:** *void*
+
+___
+
+###  isAtTheVeryBottom
+
+▸ **isAtTheVeryBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
+
+*Defined in [card-elements.ts:767](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L767)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryLeft
+
+▸ **isAtTheVeryLeft**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
+
+*Defined in [card-elements.ts:755](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L755)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryRight
+
+▸ **isAtTheVeryRight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
+
+*Defined in [card-elements.ts:759](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L759)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryTop
+
+▸ **isAtTheVeryTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
+
+*Defined in [card-elements.ts:763](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L763)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleeding
+
+▸ **isBleeding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
+
+*Defined in [card-elements.ts:517](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L517)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtBottom
+
+▸ **isBleedingAtBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
+
+*Defined in [card-elements.ts:775](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L775)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtTop
+
+▸ **isBleedingAtTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
+
+*Defined in [card-elements.ts:771](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L771)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBottomElement
+
+▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
+
+*Defined in [card-elements.ts:791](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L791)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isDesignMode
+
+▸ **isDesignMode**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
+
+*Defined in [card-elements.ts:737](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L737)*
+
+**Returns:** *boolean*
+
+___
+
+###  isFirstElement
+
+▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
+
+*Defined in [card-elements.ts:747](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L747)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isHiddenDueToOverflow
+
+▸ **isHiddenDueToOverflow**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
+
+*Defined in [card-elements.ts:795](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L795)*
+
+**Returns:** *boolean*
+
+___
+
+###  isLastElement
+
+▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
+
+*Defined in [card-elements.ts:751](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L751)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isLeftMostElement
+
+▸ **isLeftMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
+
+*Defined in [card-elements.ts:779](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L779)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isRendered
+
+▸ **isRendered**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRendered](cardelement.md#isrendered)*
+
+*Defined in [card-elements.ts:743](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L743)*
+
+**Returns:** *boolean*
+
+___
+
+###  isRightMostElement
+
+▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
+
+*Defined in [card-elements.ts:783](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L783)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isTopElement
+
+▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
+
+*Defined in [card-elements.ts:787](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L787)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` overrideInternalRender
+
+▸ **overrideInternalRender**(): *HTMLElement*
+
+*Inherited from [Input](input.md).[overrideInternalRender](input.md#protected-overrideinternalrender)*
+
+*Overrides [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
+
+*Defined in [card-elements.ts:2811](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2811)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Overrides [Input](input.md).[parse](input.md#parse)*
+
+*Defined in [card-elements.ts:3495](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3495)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*
+
+___
+
+### `Protected` parseInputValue
+
+▸ **parseInputValue**(`value`: string): *string*
+
+*Inherited from [Input](input.md).[parseInputValue](input.md#protected-parseinputvalue)*
+
+*Defined in [card-elements.ts:2868](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2868)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *string*
+
+___
+
+###  remove
+
+▸ **remove**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
+
+*Defined in [card-elements.ts:698](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L698)*
+
+**Returns:** *boolean*
+
+___
+
+###  render
+
+▸ **render**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[render](cardelement.md#render)*
+
+*Defined in [card-elements.ts:706](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L706)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` resetValidationFailureCue
+
+▸ **resetValidationFailureCue**(): *void*
+
+*Inherited from [Input](input.md).[resetValidationFailureCue](input.md#protected-resetvalidationfailurecue)*
+
+*Defined in [card-elements.ts:2846](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2846)*
+
+**Returns:** *void*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setPadding
+
+▸ **setPadding**(`value`: [PaddingDefinition](paddingdefinition.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
+
+*Defined in [card-elements.ts:478](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L478)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [PaddingDefinition](paddingdefinition.md) |
+
+**Returns:** *void*
+
+___
+
+###  setParent
+
+▸ **setParent**(`value`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setParent](cardelement.md#setparent)*
+
+*Overrides [CardObject](cardobject.md).[setParent](cardobject.md#abstract-setparent)*
+
+*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+###  setShouldFallback
+
+▸ **setShouldFallback**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[setShouldFallback](cardelement.md#setshouldfallback)*
+
+*Defined in [card-elements.ts:843](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L843)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  shouldFallback
+
+▸ **shouldFallback**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[shouldFallback](cardelement.md#shouldfallback)*
+
+*Overrides [CardObject](cardobject.md).[shouldFallback](cardobject.md#abstract-shouldfallback)*
+
+*Defined in [card-elements.ts:839](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L839)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` showValidationErrorMessage
+
+▸ **showValidationErrorMessage**(): *void*
+
+*Inherited from [Input](input.md).[showValidationErrorMessage](input.md#protected-showvalidationerrormessage)*
+
+*Defined in [card-elements.ts:2858](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2858)*
+
+**Returns:** *void*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [Input](input.md).[toJSON](input.md#tojson)*
+
+*Defined in [card-elements.ts:3459](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3459)*
+
+**Returns:** *any*
+
+___
+
+### `Protected` truncateOverflow
+
+▸ **truncateOverflow**(`maxHeight`: number): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
+
+*Defined in [card-elements.ts:454](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L454)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`maxHeight` | number |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` undoOverflowTruncation
+
+▸ **undoOverflowTruncation**(): *void*
+
+*Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
+
+*Defined in [card-elements.ts:464](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L464)*
+
+**Returns:** *void*
+
+___
+
+###  updateLayout
+
+▸ **updateLayout**(`processChildren`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
+
+*Defined in [card-elements.ts:728](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L728)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`processChildren` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  validateProperties
+
+▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
+
+*Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
+
+*Defined in [card-elements.ts:284](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L284)*
+
+**Returns:** *[ValidationResults](validationresults.md)*
+
+___
+
+###  validateValue
+
+▸ **validateValue**(): *boolean*
+
+*Implementation of [IInput](../interfaces/iinput.md)*
+
+*Inherited from [Input](input.md).[validateValue](input.md#validatevalue)*
+
+*Defined in [card-elements.ts:2906](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2906)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` valueChanged
+
+▸ **valueChanged**(): *void*
+
+*Inherited from [Input](input.md).[valueChanged](input.md#protected-valuechanged)*
+
+*Defined in [card-elements.ts:2836](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2836)*
+
+**Returns:** *void*

--- a/source/nodejs/adaptivecards/docs/classes/colordefinition.md
+++ b/source/nodejs/adaptivecards/docs/classes/colordefinition.md
@@ -1,0 +1,73 @@
+[Adaptive Cards Javascript SDK](../README.md) › [ColorDefinition](colordefinition.md)
+
+# Class: ColorDefinition
+
+## Hierarchy
+
+* **ColorDefinition**
+
+  ↳ [TextColorDefinition](textcolordefinition.md)
+
+## Index
+
+### Constructors
+
+* [constructor](colordefinition.md#constructor)
+
+### Properties
+
+* [default](colordefinition.md#default)
+* [subtle](colordefinition.md#subtle)
+
+### Methods
+
+* [parse](colordefinition.md#parse)
+
+## Constructors
+
+###  constructor
+
+\+ **new ColorDefinition**(`defaultColor?`: string, `subtleColor?`: string): *[ColorDefinition](colordefinition.md)*
+
+*Defined in [host-config.ts:14](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L14)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`defaultColor?` | string |
+`subtleColor?` | string |
+
+**Returns:** *[ColorDefinition](colordefinition.md)*
+
+## Properties
+
+###  default
+
+• **default**: *string* = "#000000"
+
+*Defined in [host-config.ts:13](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L13)*
+
+___
+
+###  subtle
+
+• **subtle**: *string* = "#666666"
+
+*Defined in [host-config.ts:14](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L14)*
+
+## Methods
+
+###  parse
+
+▸ **parse**(`obj?`: any): *void*
+
+*Defined in [host-config.ts:26](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L26)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`obj?` | any |
+
+**Returns:** *void*

--- a/source/nodejs/adaptivecards/docs/classes/colorsetdefinition.md
+++ b/source/nodejs/adaptivecards/docs/classes/colorsetdefinition.md
@@ -1,0 +1,115 @@
+[Adaptive Cards Javascript SDK](../README.md) › [ColorSetDefinition](colorsetdefinition.md)
+
+# Class: ColorSetDefinition
+
+## Hierarchy
+
+* **ColorSetDefinition**
+
+## Index
+
+### Constructors
+
+* [constructor](colorsetdefinition.md#constructor)
+
+### Properties
+
+* [accent](colorsetdefinition.md#accent)
+* [attention](colorsetdefinition.md#attention)
+* [dark](colorsetdefinition.md#dark)
+* [default](colorsetdefinition.md#default)
+* [good](colorsetdefinition.md#good)
+* [light](colorsetdefinition.md#light)
+* [warning](colorsetdefinition.md#warning)
+
+### Methods
+
+* [parse](colorsetdefinition.md#parse)
+
+## Constructors
+
+###  constructor
+
+\+ **new ColorSetDefinition**(`obj?`: any): *[ColorSetDefinition](colorsetdefinition.md)*
+
+*Defined in [host-config.ts:243](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L243)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`obj?` | any |
+
+**Returns:** *[ColorSetDefinition](colorsetdefinition.md)*
+
+## Properties
+
+###  accent
+
+• **accent**: *[TextColorDefinition](textcolordefinition.md)* = new TextColorDefinition()
+
+*Defined in [host-config.ts:240](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L240)*
+
+___
+
+###  attention
+
+• **attention**: *[TextColorDefinition](textcolordefinition.md)* = new TextColorDefinition()
+
+*Defined in [host-config.ts:243](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L243)*
+
+___
+
+###  dark
+
+• **dark**: *[TextColorDefinition](textcolordefinition.md)* = new TextColorDefinition()
+
+*Defined in [host-config.ts:238](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L238)*
+
+___
+
+###  default
+
+• **default**: *[TextColorDefinition](textcolordefinition.md)* = new TextColorDefinition()
+
+*Defined in [host-config.ts:237](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L237)*
+
+___
+
+###  good
+
+• **good**: *[TextColorDefinition](textcolordefinition.md)* = new TextColorDefinition()
+
+*Defined in [host-config.ts:241](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L241)*
+
+___
+
+###  light
+
+• **light**: *[TextColorDefinition](textcolordefinition.md)* = new TextColorDefinition()
+
+*Defined in [host-config.ts:239](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L239)*
+
+___
+
+###  warning
+
+• **warning**: *[TextColorDefinition](textcolordefinition.md)* = new TextColorDefinition()
+
+*Defined in [host-config.ts:242](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L242)*
+
+## Methods
+
+###  parse
+
+▸ **parse**(`obj`: any): *void*
+
+*Defined in [host-config.ts:249](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L249)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`obj` | any |
+
+**Returns:** *void*

--- a/source/nodejs/adaptivecards/docs/classes/column.md
+++ b/source/nodejs/adaptivecards/docs/classes/column.md
@@ -1,0 +1,1796 @@
+[Adaptive Cards Javascript SDK](../README.md) › [Column](column.md)
+
+# Class: Column
+
+## Hierarchy
+
+  ↳ [Container](container.md)
+
+  ↳ **Column**
+
+## Index
+
+### Constructors
+
+* [constructor](column.md#constructor)
+
+### Properties
+
+* [allowVerticalOverflow](column.md#allowverticaloverflow)
+* [backgroundImage](column.md#backgroundimage)
+* [customCssSelector](column.md#customcssselector)
+* [height](column.md#height)
+* [horizontalAlignment](column.md#optional-horizontalalignment)
+* [id](column.md#id)
+* [minPixelHeight](column.md#optional-minpixelheight)
+* [requires](column.md#requires)
+* [rtl](column.md#optional-rtl)
+* [separator](column.md#separator)
+* [spacing](column.md#spacing)
+* [verticalContentAlignment](column.md#verticalcontentalignment)
+* [width](column.md#width)
+
+### Accessors
+
+* [allowCustomPadding](column.md#protected-allowcustompadding)
+* [allowCustomStyle](column.md#protected-allowcustomstyle)
+* [bleed](column.md#bleed)
+* [defaultStyle](column.md#protected-defaultstyle)
+* [hasExplicitStyle](column.md#protected-hasexplicitstyle)
+* [hasVisibleSeparator](column.md#hasvisibleseparator)
+* [hostConfig](column.md#hostconfig)
+* [index](column.md#index)
+* [isInline](column.md#isinline)
+* [isInteractive](column.md#isinteractive)
+* [isSelectable](column.md#protected-isselectable)
+* [isStandalone](column.md#isstandalone)
+* [isVisible](column.md#isvisible)
+* [lang](column.md#lang)
+* [padding](column.md#padding)
+* [parent](column.md#parent)
+* [renderedActionCount](column.md#protected-renderedactioncount)
+* [renderedElement](column.md#renderedelement)
+* [selectAction](column.md#selectaction)
+* [separatorElement](column.md#separatorelement)
+* [separatorOrientation](column.md#protected-separatororientation)
+* [style](column.md#style)
+* [supportsMinHeight](column.md#protected-supportsminheight)
+* [useDefaultSizing](column.md#protected-usedefaultsizing)
+
+### Methods
+
+* [addItem](column.md#additem)
+* [adjustRenderedElementSize](column.md#protected-adjustrenderedelementsize)
+* [applyBackground](column.md#protected-applybackground)
+* [applyPadding](column.md#protected-applypadding)
+* [asString](column.md#asstring)
+* [clear](column.md#clear)
+* [createPlaceholderElement](column.md#protected-createplaceholderelement)
+* [getActionAt](column.md#getactionat)
+* [getActionById](column.md#getactionbyid)
+* [getActionCount](column.md#getactioncount)
+* [getAllInputs](column.md#getallinputs)
+* [getBleed](column.md#protected-getbleed)
+* [getCustomProperty](column.md#getcustomproperty)
+* [getDefaultPadding](column.md#protected-getdefaultpadding)
+* [getEffectivePadding](column.md#geteffectivepadding)
+* [getEffectiveStyle](column.md#geteffectivestyle)
+* [getElementById](column.md#getelementbyid)
+* [getFirstVisibleRenderedItem](column.md#getfirstvisiblerendereditem)
+* [getForbiddenActionTypes](column.md#getforbiddenactiontypes)
+* [getForbiddenElementTypes](column.md#getforbiddenelementtypes)
+* [getHasBackground](column.md#protected-gethasbackground)
+* [getHasExpandedAction](column.md#protected-gethasexpandedaction)
+* [getImmediateSurroundingPadding](column.md#getimmediatesurroundingpadding)
+* [getItemAt](column.md#getitemat)
+* [getItemCount](column.md#getitemcount)
+* [getItemsCollectionPropertyName](column.md#protected-getitemscollectionpropertyname)
+* [getJsonTypeName](column.md#getjsontypename)
+* [getLastVisibleRenderedItem](column.md#getlastvisiblerendereditem)
+* [getPadding](column.md#protected-getpadding)
+* [getParentContainer](column.md#getparentcontainer)
+* [getResourceInformation](column.md#getresourceinformation)
+* [getRootElement](column.md#getrootelement)
+* [getSelectAction](column.md#protected-getselectaction)
+* [indexOf](column.md#indexof)
+* [insertItemAfter](column.md#insertitemafter)
+* [insertItemBefore](column.md#insertitembefore)
+* [internalRender](column.md#protected-internalrender)
+* [internalValidateProperties](column.md#internalvalidateproperties)
+* [isAtTheVeryBottom](column.md#isattheverybottom)
+* [isAtTheVeryLeft](column.md#isattheveryleft)
+* [isAtTheVeryRight](column.md#isattheveryright)
+* [isAtTheVeryTop](column.md#isattheverytop)
+* [isBleeding](column.md#isbleeding)
+* [isBleedingAtBottom](column.md#isbleedingatbottom)
+* [isBleedingAtTop](column.md#isbleedingattop)
+* [isBottomElement](column.md#isbottomelement)
+* [isDesignMode](column.md#isdesignmode)
+* [isElementAllowed](column.md#protected-iselementallowed)
+* [isFirstElement](column.md#isfirstelement)
+* [isHiddenDueToOverflow](column.md#ishiddenduetooverflow)
+* [isLastElement](column.md#islastelement)
+* [isLeftMostElement](column.md#isleftmostelement)
+* [isRendered](column.md#isrendered)
+* [isRightMostElement](column.md#isrightmostelement)
+* [isRtl](column.md#isrtl)
+* [isTopElement](column.md#istopelement)
+* [overrideInternalRender](column.md#protected-overrideinternalrender)
+* [parse](column.md#parse)
+* [remove](column.md#remove)
+* [removeItem](column.md#removeitem)
+* [render](column.md#render)
+* [setBleed](column.md#protected-setbleed)
+* [setCustomProperty](column.md#setcustomproperty)
+* [setPadding](column.md#protected-setpadding)
+* [setParent](column.md#setparent)
+* [setSelectAction](column.md#protected-setselectaction)
+* [setShouldFallback](column.md#setshouldfallback)
+* [shouldFallback](column.md#shouldfallback)
+* [supportsExcplitiHeight](column.md#protected-supportsexcplitiheight)
+* [toJSON](column.md#tojson)
+* [truncateOverflow](column.md#protected-truncateoverflow)
+* [undoOverflowTruncation](column.md#protected-undooverflowtruncation)
+* [updateLayout](column.md#updatelayout)
+* [validateProperties](column.md#validateproperties)
+
+## Constructors
+
+###  constructor
+
+\+ **new Column**(`width`: [ColumnWidth](../README.md#columnwidth)): *[Column](column.md)*
+
+*Defined in [card-elements.ts:5862](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5862)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`width` | [ColumnWidth](../README.md#columnwidth) | "stretch" |
+
+**Returns:** *[Column](column.md)*
+
+## Properties
+
+###  allowVerticalOverflow
+
+• **allowVerticalOverflow**: *boolean* = false
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[allowVerticalOverflow](cardelementcontainer.md#allowverticaloverflow)*
+
+*Defined in [card-elements.ts:2229](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2229)*
+
+___
+
+###  backgroundImage
+
+• **backgroundImage**: *[BackgroundImage](backgroundimage.md)* = new BackgroundImage()
+
+*Inherited from [Container](container.md).[backgroundImage](container.md#backgroundimage)*
+
+*Defined in [card-elements.ts:5571](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5571)*
+
+___
+
+###  customCssSelector
+
+• **customCssSelector**: *string* = null
+
+*Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#customcssselector)*
+
+*Defined in [card-elements.ts:507](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L507)*
+
+___
+
+###  height
+
+• **height**: *[CardElementHeight](../README.md#cardelementheight)* = "auto"
+
+*Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
+
+*Defined in [card-elements.ts:508](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L508)*
+
+___
+
+### `Optional` horizontalAlignment
+
+• **horizontalAlignment**? : *[HorizontalAlignment](../enums/horizontalalignment.md)* = null
+
+*Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#optional-horizontalalignment)*
+
+*Defined in [card-elements.ts:504](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L504)*
+
+___
+
+###  id
+
+• **id**: *string*
+
+*Inherited from [CardObject](cardobject.md).[id](cardobject.md#id)*
+
+*Defined in [card-elements.ts:247](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L247)*
+
+___
+
+### `Optional` minPixelHeight
+
+• **minPixelHeight**? : *number* = null
+
+*Inherited from [CardElement](cardelement.md).[minPixelHeight](cardelement.md#optional-minpixelheight)*
+
+*Defined in [card-elements.ts:509](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L509)*
+
+___
+
+###  requires
+
+• **requires**: *[HostCapabilities](hostcapabilities.md)‹›* = new HostConfig.HostCapabilities()
+
+*Inherited from [CardElement](cardelement.md).[requires](cardelement.md#requires)*
+
+*Defined in [card-elements.ts:502](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L502)*
+
+___
+
+### `Optional` rtl
+
+• **rtl**? : *boolean* = null
+
+*Inherited from [Container](container.md).[rtl](container.md#optional-rtl)*
+
+*Defined in [card-elements.ts:5574](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5574)*
+
+___
+
+###  separator
+
+• **separator**: *boolean* = false
+
+*Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
+
+*Defined in [card-elements.ts:506](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L506)*
+
+___
+
+###  spacing
+
+• **spacing**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.Default
+
+*Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
+
+*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
+
+___
+
+###  verticalContentAlignment
+
+• **verticalContentAlignment**: *[VerticalAlignment](../enums/verticalalignment.md)* = Enums.VerticalAlignment.Top
+
+*Inherited from [Container](container.md).[verticalContentAlignment](container.md#verticalcontentalignment)*
+
+*Defined in [card-elements.ts:5573](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5573)*
+
+___
+
+###  width
+
+• **width**: *[ColumnWidth](../README.md#columnwidth)* = "stretch"
+
+*Defined in [card-elements.ts:5862](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5862)*
+
+## Accessors
+
+### `Protected` allowCustomPadding
+
+• **get allowCustomPadding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
+
+*Defined in [card-elements.ts:490](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L490)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` allowCustomStyle
+
+• **get allowCustomStyle**(): *boolean*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[allowCustomStyle](stylablecardelementcontainer.md#protected-allowcustomstyle)*
+
+*Defined in [card-elements.ts:5236](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5236)*
+
+**Returns:** *boolean*
+
+___
+
+###  bleed
+
+• **get bleed**(): *boolean*
+
+*Inherited from [Container](container.md).[bleed](container.md#bleed)*
+
+*Defined in [card-elements.ts:5810](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5810)*
+
+**Returns:** *boolean*
+
+• **set bleed**(`value`: boolean): *void*
+
+*Inherited from [Container](container.md).[bleed](container.md#bleed)*
+
+*Defined in [card-elements.ts:5814](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5814)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+### `Protected` defaultStyle
+
+• **get defaultStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
+
+*Defined in [card-elements.ts:498](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L498)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` hasExplicitStyle
+
+• **get hasExplicitStyle**(): *boolean*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[hasExplicitStyle](stylablecardelementcontainer.md#protected-hasexplicitstyle)*
+
+*Defined in [card-elements.ts:5232](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5232)*
+
+**Returns:** *boolean*
+
+___
+
+###  hasVisibleSeparator
+
+• **get hasVisibleSeparator**(): *boolean*
+
+*Overrides [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
+
+*Defined in [card-elements.ts:5938](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5938)*
+
+**Returns:** *boolean*
+
+___
+
+###  hostConfig
+
+• **get hostConfig**(): *[HostConfig](hostconfig.md)*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:881](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L881)*
+
+**Returns:** *[HostConfig](hostconfig.md)*
+
+• **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:895](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L895)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [HostConfig](hostconfig.md) |
+
+**Returns:** *void*
+
+___
+
+###  index
+
+• **get index**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
+
+*Defined in [card-elements.ts:899](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L899)*
+
+**Returns:** *number*
+
+___
+
+###  isInline
+
+• **get isInline**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
+
+*Defined in [card-elements.ts:916](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L916)*
+
+**Returns:** *boolean*
+
+___
+
+###  isInteractive
+
+• **get isInteractive**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
+
+*Defined in [card-elements.ts:908](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L908)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` isSelectable
+
+• **get isSelectable**(): *boolean*
+
+*Inherited from [Container](container.md).[isSelectable](container.md#protected-isselectable)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[isSelectable](cardelementcontainer.md#protected-isselectable)*
+
+*Defined in [card-elements.ts:5567](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5567)*
+
+**Returns:** *boolean*
+
+___
+
+###  isStandalone
+
+• **get isStandalone**(): *boolean*
+
+*Overrides [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
+
+*Defined in [card-elements.ts:5947](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5947)*
+
+**Returns:** *boolean*
+
+___
+
+###  isVisible
+
+• **get isVisible**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:924](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L924)*
+
+**Returns:** *boolean*
+
+• **set isVisible**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:937](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L937)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  lang
+
+• **get lang**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:853](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L853)*
+
+**Returns:** *string*
+
+• **set lang**(`value`: string): *void*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:867](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L867)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  padding
+
+• **get padding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [Container](container.md).[padding](container.md#padding)*
+
+*Defined in [card-elements.ts:5794](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5794)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+• **set padding**(`value`: [PaddingDefinition](paddingdefinition.md)): *void*
+
+*Inherited from [Container](container.md).[padding](container.md#padding)*
+
+*Defined in [card-elements.ts:5798](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5798)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [PaddingDefinition](paddingdefinition.md) |
+
+**Returns:** *void*
+
+___
+
+###  parent
+
+• **get parent**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[parent](cardelement.md#parent)*
+
+*Defined in [card-elements.ts:920](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L920)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+### `Protected` renderedActionCount
+
+• **get renderedActionCount**(): *number*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[renderedActionCount](stylablecardelementcontainer.md#protected-renderedactioncount)*
+
+*Defined in [card-elements.ts:5228](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5228)*
+
+**Returns:** *number*
+
+___
+
+###  renderedElement
+
+• **get renderedElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[renderedElement](cardelement.md#renderedelement)*
+
+*Defined in [card-elements.ts:956](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L956)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  selectAction
+
+• **get selectAction**(): *[Action](action.md)*
+
+*Inherited from [Container](container.md).[selectAction](container.md#selectaction)*
+
+*Defined in [card-elements.ts:5802](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5802)*
+
+**Returns:** *[Action](action.md)*
+
+• **set selectAction**(`value`: [Action](action.md)): *void*
+
+*Inherited from [Container](container.md).[selectAction](container.md#selectaction)*
+
+*Defined in [card-elements.ts:5806](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5806)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [Action](action.md) |
+
+**Returns:** *void*
+
+___
+
+###  separatorElement
+
+• **get separatorElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
+
+*Defined in [card-elements.ts:960](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L960)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` separatorOrientation
+
+• **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
+
+*Overrides [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
+
+*Defined in [card-elements.ts:5858](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5858)*
+
+**Returns:** *[Orientation](../enums/orientation.md)*
+
+___
+
+###  style
+
+• **get style**(): *string*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[style](stylablecardelementcontainer.md#style)*
+
+*Defined in [card-elements.ts:5295](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5295)*
+
+**Returns:** *string*
+
+• **set style**(`value`: string): *void*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[style](stylablecardelementcontainer.md#style)*
+
+*Defined in [card-elements.ts:5305](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5305)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+### `Protected` supportsMinHeight
+
+• **get supportsMinHeight**(): *boolean*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[supportsMinHeight](stylablecardelementcontainer.md#protected-supportsminheight)*
+
+*Overrides [CardElement](cardelement.md).[supportsMinHeight](cardelement.md#protected-supportsminheight)*
+
+*Defined in [card-elements.ts:5240](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5240)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` useDefaultSizing
+
+• **get useDefaultSizing**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
+
+*Defined in [card-elements.ts:486](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L486)*
+
+**Returns:** *boolean*
+
+## Methods
+
+###  addItem
+
+▸ **addItem**(`item`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [Container](container.md).[addItem](container.md#additem)*
+
+*Defined in [card-elements.ts:5730](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5730)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`item` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+### `Protected` adjustRenderedElementSize
+
+▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
+
+*Overrides [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
+
+*Defined in [card-elements.ts:5824](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5824)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`renderedElement` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+### `Protected` applyBackground
+
+▸ **applyBackground**(): *void*
+
+*Inherited from [Container](container.md).[applyBackground](container.md#protected-applybackground)*
+
+*Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[applyBackground](stylablecardelementcontainer.md#protected-applybackground)*
+
+*Defined in [card-elements.ts:5441](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5441)*
+
+**Returns:** *void*
+
+___
+
+### `Protected` applyPadding
+
+▸ **applyPadding**(): *void*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[applyPadding](stylablecardelementcontainer.md#protected-applypadding)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[applyPadding](cardelementcontainer.md#protected-applypadding)*
+
+*Defined in [card-elements.ts:5137](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5137)*
+
+**Returns:** *void*
+
+___
+
+###  asString
+
+▸ **asString**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
+
+*Defined in [card-elements.ts:513](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L513)*
+
+**Returns:** *string*
+
+___
+
+###  clear
+
+▸ **clear**(): *void*
+
+*Inherited from [Container](container.md).[clear](container.md#clear)*
+
+*Defined in [card-elements.ts:5758](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5758)*
+
+**Returns:** *void*
+
+___
+
+### `Protected` createPlaceholderElement
+
+▸ **createPlaceholderElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
+
+*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  getActionAt
+
+▸ **getActionAt**(`index`: number): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
+
+*Defined in [card-elements.ts:694](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L694)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionById
+
+▸ **getActionById**(`id`: string): *[Action](action.md)*
+
+*Inherited from [Container](container.md).[getActionById](container.md#getactionbyid)*
+
+*Overrides [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
+
+*Defined in [card-elements.ts:5772](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5772)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionCount
+
+▸ **getActionCount**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
+
+*Defined in [card-elements.ts:690](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L690)*
+
+**Returns:** *number*
+
+___
+
+###  getAllInputs
+
+▸ **getAllInputs**(): *Array‹[Input](input.md)›*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[getAllInputs](cardelementcontainer.md#getallinputs)*
+
+*Overrides [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
+
+*Defined in [card-elements.ts:2334](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2334)*
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+### `Protected` getBleed
+
+▸ **getBleed**(): *boolean*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[getBleed](stylablecardelementcontainer.md#protected-getbleed)*
+
+*Defined in [card-elements.ts:5220](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5220)*
+
+**Returns:** *boolean*
+
+___
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+### `Protected` getDefaultPadding
+
+▸ **getDefaultPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[getDefaultPadding](stylablecardelementcontainer.md#protected-getdefaultpadding)*
+
+*Overrides [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
+
+*Defined in [card-elements.ts:5207](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5207)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectivePadding
+
+▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
+
+*Defined in [card-elements.ts:847](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L847)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectiveStyle
+
+▸ **getEffectiveStyle**(): *string*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[getEffectiveStyle](stylablecardelementcontainer.md#geteffectivestyle)*
+
+*Overrides [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
+
+*Defined in [card-elements.ts:5289](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5289)*
+
+**Returns:** *string*
+
+___
+
+###  getElementById
+
+▸ **getElementById**(`id`: string): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[getElementById](cardelementcontainer.md#getelementbyid)*
+
+*Overrides [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
+
+*Defined in [card-elements.ts:2354](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2354)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getFirstVisibleRenderedItem
+
+▸ **getFirstVisibleRenderedItem**(): *[CardElement](cardelement.md)*
+
+*Inherited from [Container](container.md).[getFirstVisibleRenderedItem](container.md#getfirstvisiblerendereditem)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[getFirstVisibleRenderedItem](cardelementcontainer.md#abstract-getfirstvisiblerendereditem)*
+
+*Defined in [card-elements.ts:5606](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5606)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getForbiddenActionTypes
+
+▸ **getForbiddenActionTypes**(): *Array‹any›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
+
+*Defined in [card-elements.ts:557](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L557)*
+
+**Returns:** *Array‹any›*
+
+___
+
+###  getForbiddenElementTypes
+
+▸ **getForbiddenElementTypes**(): *Array‹string›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenElementTypes](cardelement.md#getforbiddenelementtypes)*
+
+*Defined in [card-elements.ts:553](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L553)*
+
+**Returns:** *Array‹string›*
+
+___
+
+### `Protected` getHasBackground
+
+▸ **getHasBackground**(): *boolean*
+
+*Inherited from [Container](container.md).[getHasBackground](container.md#protected-gethasbackground)*
+
+*Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[getHasBackground](stylablecardelementcontainer.md#protected-gethasbackground)*
+
+*Defined in [card-elements.ts:5563](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5563)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` getHasExpandedAction
+
+▸ **getHasExpandedAction**(): *boolean*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[getHasExpandedAction](stylablecardelementcontainer.md#protected-gethasexpandedaction)*
+
+*Defined in [card-elements.ts:5216](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5216)*
+
+**Returns:** *boolean*
+
+___
+
+###  getImmediateSurroundingPadding
+
+▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
+
+*Defined in [card-elements.ts:561](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L561)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`result` | [PaddingDefinition](paddingdefinition.md) | - |
+`processTop` | boolean | true |
+`processRight` | boolean | true |
+`processBottom` | boolean | true |
+`processLeft` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  getItemAt
+
+▸ **getItemAt**(`index`: number): *[CardElement](cardelement.md)*
+
+*Inherited from [Container](container.md).[getItemAt](container.md#getitemat)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[getItemAt](cardelementcontainer.md#abstract-getitemat)*
+
+*Defined in [card-elements.ts:5602](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5602)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getItemCount
+
+▸ **getItemCount**(): *number*
+
+*Inherited from [Container](container.md).[getItemCount](container.md#getitemcount)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[getItemCount](cardelementcontainer.md#abstract-getitemcount)*
+
+*Defined in [card-elements.ts:5598](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5598)*
+
+**Returns:** *number*
+
+___
+
+### `Protected` getItemsCollectionPropertyName
+
+▸ **getItemsCollectionPropertyName**(): *string*
+
+*Inherited from [Container](container.md).[getItemsCollectionPropertyName](container.md#protected-getitemscollectionpropertyname)*
+
+*Defined in [card-elements.ts:5437](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5437)*
+
+**Returns:** *string*
+
+___
+
+###  getJsonTypeName
+
+▸ **getJsonTypeName**(): *string*
+
+*Overrides [Container](container.md).[getJsonTypeName](container.md#getjsontypename)*
+
+*Defined in [card-elements.ts:5870](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5870)*
+
+**Returns:** *string*
+
+___
+
+###  getLastVisibleRenderedItem
+
+▸ **getLastVisibleRenderedItem**(): *[CardElement](cardelement.md)*
+
+*Inherited from [Container](container.md).[getLastVisibleRenderedItem](container.md#getlastvisiblerendereditem)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[getLastVisibleRenderedItem](cardelementcontainer.md#abstract-getlastvisiblerendereditem)*
+
+*Defined in [card-elements.ts:5618](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5618)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+### `Protected` getPadding
+
+▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
+
+*Defined in [card-elements.ts:474](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L474)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getParentContainer
+
+▸ **getParentContainer**(): *[Container](container.md)*
+
+*Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
+
+*Defined in [card-elements.ts:809](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L809)*
+
+**Returns:** *[Container](container.md)*
+
+___
+
+###  getResourceInformation
+
+▸ **getResourceInformation**(): *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+*Inherited from [Container](container.md).[getResourceInformation](container.md#getresourceinformation)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[getResourceInformation](cardelementcontainer.md#getresourceinformation)*
+
+*Defined in [card-elements.ts:5762](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5762)*
+
+**Returns:** *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+___
+
+###  getRootElement
+
+▸ **getRootElement**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
+
+*Defined in [card-elements.ts:799](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L799)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+### `Protected` getSelectAction
+
+▸ **getSelectAction**(): *[Action](action.md)*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[getSelectAction](cardelementcontainer.md#protected-getselectaction)*
+
+*Defined in [card-elements.ts:2207](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2207)*
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  indexOf
+
+▸ **indexOf**(`cardElement`: [CardElement](cardelement.md)): *number*
+
+*Inherited from [Container](container.md).[indexOf](container.md#indexof)*
+
+*Overrides [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
+
+*Defined in [card-elements.ts:5726](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5726)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`cardElement` | [CardElement](cardelement.md) |
+
+**Returns:** *number*
+
+___
+
+###  insertItemAfter
+
+▸ **insertItemAfter**(`item`: [CardElement](cardelement.md), `insertAfter`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [Container](container.md).[insertItemAfter](container.md#insertitemafter)*
+
+*Defined in [card-elements.ts:5738](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5738)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`item` | [CardElement](cardelement.md) |
+`insertAfter` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+###  insertItemBefore
+
+▸ **insertItemBefore**(`item`: [CardElement](cardelement.md), `insertBefore`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [Container](container.md).[insertItemBefore](container.md#insertitembefore)*
+
+*Defined in [card-elements.ts:5734](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5734)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`item` | [CardElement](cardelement.md) |
+`insertBefore` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+### `Protected` internalRender
+
+▸ **internalRender**(): *HTMLElement*
+
+*Inherited from [Container](container.md).[internalRender](container.md#protected-internalrender)*
+
+*Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
+
+*Defined in [card-elements.ts:5449](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5449)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  internalValidateProperties
+
+▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[internalValidateProperties](stylablecardelementcontainer.md#internalvalidateproperties)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[internalValidateProperties](cardelementcontainer.md#internalvalidateproperties)*
+
+*Defined in [card-elements.ts:5256](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5256)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [ValidationResults](validationresults.md) |
+
+**Returns:** *void*
+
+___
+
+###  isAtTheVeryBottom
+
+▸ **isAtTheVeryBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
+
+*Defined in [card-elements.ts:767](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L767)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryLeft
+
+▸ **isAtTheVeryLeft**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
+
+*Defined in [card-elements.ts:755](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L755)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryRight
+
+▸ **isAtTheVeryRight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
+
+*Defined in [card-elements.ts:759](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L759)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryTop
+
+▸ **isAtTheVeryTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
+
+*Defined in [card-elements.ts:763](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L763)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleeding
+
+▸ **isBleeding**(): *boolean*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[isBleeding](stylablecardelementcontainer.md#isbleeding)*
+
+*Overrides [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
+
+*Defined in [card-elements.ts:5244](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5244)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtBottom
+
+▸ **isBleedingAtBottom**(): *boolean*
+
+*Inherited from [Container](container.md).[isBleedingAtBottom](container.md#isbleedingatbottom)*
+
+*Overrides [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
+
+*Defined in [card-elements.ts:5675](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5675)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtTop
+
+▸ **isBleedingAtTop**(): *boolean*
+
+*Inherited from [Container](container.md).[isBleedingAtTop](container.md#isbleedingattop)*
+
+*Overrides [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
+
+*Defined in [card-elements.ts:5669](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5669)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBottomElement
+
+▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
+
+*Defined in [card-elements.ts:791](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L791)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isDesignMode
+
+▸ **isDesignMode**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
+
+*Defined in [card-elements.ts:737](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L737)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` isElementAllowed
+
+▸ **isElementAllowed**(`element`: [CardElement](cardelement.md), `forbiddenElementTypes`: Array‹string›): *boolean*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[isElementAllowed](cardelementcontainer.md#protected-iselementallowed)*
+
+*Defined in [card-elements.ts:2169](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2169)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+`forbiddenElementTypes` | Array‹string› |
+
+**Returns:** *boolean*
+
+___
+
+###  isFirstElement
+
+▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [Container](container.md).[isFirstElement](container.md#isfirstelement)*
+
+*Overrides [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
+
+*Defined in [card-elements.ts:5634](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5634)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isHiddenDueToOverflow
+
+▸ **isHiddenDueToOverflow**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
+
+*Defined in [card-elements.ts:795](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L795)*
+
+**Returns:** *boolean*
+
+___
+
+###  isLastElement
+
+▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [Container](container.md).[isLastElement](container.md#islastelement)*
+
+*Overrides [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
+
+*Defined in [card-elements.ts:5646](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5646)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isLeftMostElement
+
+▸ **isLeftMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
+
+*Defined in [card-elements.ts:779](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L779)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isRendered
+
+▸ **isRendered**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRendered](cardelement.md#isrendered)*
+
+*Defined in [card-elements.ts:743](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L743)*
+
+**Returns:** *boolean*
+
+___
+
+###  isRightMostElement
+
+▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
+
+*Defined in [card-elements.ts:783](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L783)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isRtl
+
+▸ **isRtl**(): *boolean*
+
+*Inherited from [Container](container.md).[isRtl](container.md#isrtl)*
+
+*Defined in [card-elements.ts:5658](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5658)*
+
+**Returns:** *boolean*
+
+___
+
+###  isTopElement
+
+▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
+
+*Defined in [card-elements.ts:787](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L787)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` overrideInternalRender
+
+▸ **overrideInternalRender**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
+
+*Defined in [card-elements.ts:426](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L426)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Overrides [Container](container.md).[parse](container.md#parse)*
+
+*Defined in [card-elements.ts:5892](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5892)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*
+
+___
+
+###  remove
+
+▸ **remove**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
+
+*Defined in [card-elements.ts:698](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L698)*
+
+**Returns:** *boolean*
+
+___
+
+###  removeItem
+
+▸ **removeItem**(`item`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [Container](container.md).[removeItem](container.md#removeitem)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[removeItem](cardelementcontainer.md#abstract-removeitem)*
+
+*Defined in [card-elements.ts:5742](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5742)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`item` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  render
+
+▸ **render**(): *HTMLElement*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[render](stylablecardelementcontainer.md#render)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[render](cardelementcontainer.md#render)*
+
+*Defined in [card-elements.ts:5279](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5279)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` setBleed
+
+▸ **setBleed**(`value`: boolean): *void*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[setBleed](stylablecardelementcontainer.md#protected-setbleed)*
+
+*Defined in [card-elements.ts:5224](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5224)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setPadding
+
+▸ **setPadding**(`value`: [PaddingDefinition](paddingdefinition.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
+
+*Defined in [card-elements.ts:478](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L478)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [PaddingDefinition](paddingdefinition.md) |
+
+**Returns:** *void*
+
+___
+
+###  setParent
+
+▸ **setParent**(`value`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setParent](cardelement.md#setparent)*
+
+*Overrides [CardObject](cardobject.md).[setParent](cardobject.md#abstract-setparent)*
+
+*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setSelectAction
+
+▸ **setSelectAction**(`value`: [Action](action.md)): *void*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[setSelectAction](cardelementcontainer.md#protected-setselectaction)*
+
+*Defined in [card-elements.ts:2211](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2211)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [Action](action.md) |
+
+**Returns:** *void*
+
+___
+
+###  setShouldFallback
+
+▸ **setShouldFallback**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[setShouldFallback](cardelement.md#setshouldfallback)*
+
+*Defined in [card-elements.ts:843](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L843)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  shouldFallback
+
+▸ **shouldFallback**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[shouldFallback](cardelement.md#shouldfallback)*
+
+*Overrides [CardObject](cardobject.md).[shouldFallback](cardobject.md#abstract-shouldfallback)*
+
+*Defined in [card-elements.ts:839](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L839)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` supportsExcplitiHeight
+
+▸ **supportsExcplitiHeight**(): *boolean*
+
+*Inherited from [Container](container.md).[supportsExcplitiHeight](container.md#protected-supportsexcplitiheight)*
+
+*Defined in [card-elements.ts:5433](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5433)*
+
+**Returns:** *boolean*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [Container](container.md).[toJSON](container.md#tojson)*
+
+*Defined in [card-elements.ts:5874](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5874)*
+
+**Returns:** *any*
+
+___
+
+### `Protected` truncateOverflow
+
+▸ **truncateOverflow**(`maxHeight`: number): *boolean*
+
+*Inherited from [Container](container.md).[truncateOverflow](container.md#protected-truncateoverflow)*
+
+*Overrides [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
+
+*Defined in [card-elements.ts:5522](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5522)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`maxHeight` | number |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` undoOverflowTruncation
+
+▸ **undoOverflowTruncation**(): *void*
+
+*Inherited from [Container](container.md).[undoOverflowTruncation](container.md#protected-undooverflowtruncation)*
+
+*Overrides [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
+
+*Defined in [card-elements.ts:5557](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5557)*
+
+**Returns:** *void*
+
+___
+
+###  updateLayout
+
+▸ **updateLayout**(`processChildren`: boolean): *void*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[updateLayout](cardelementcontainer.md#updatelayout)*
+
+*Overrides [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
+
+*Defined in [card-elements.ts:2324](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2324)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`processChildren` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  validateProperties
+
+▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
+
+*Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
+
+*Defined in [card-elements.ts:284](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L284)*
+
+**Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/columnset.md
+++ b/source/nodejs/adaptivecards/docs/classes/columnset.md
@@ -1,0 +1,1622 @@
+[Adaptive Cards Javascript SDK](../README.md) › [ColumnSet](columnset.md)
+
+# Class: ColumnSet
+
+## Hierarchy
+
+  ↳ [StylableCardElementContainer](stylablecardelementcontainer.md)
+
+  ↳ **ColumnSet**
+
+## Index
+
+### Properties
+
+* [allowVerticalOverflow](columnset.md#allowverticaloverflow)
+* [customCssSelector](columnset.md#customcssselector)
+* [height](columnset.md#height)
+* [horizontalAlignment](columnset.md#optional-horizontalalignment)
+* [id](columnset.md#id)
+* [minPixelHeight](columnset.md#optional-minpixelheight)
+* [requires](columnset.md#requires)
+* [separator](columnset.md#separator)
+* [spacing](columnset.md#spacing)
+
+### Accessors
+
+* [allowCustomPadding](columnset.md#protected-allowcustompadding)
+* [allowCustomStyle](columnset.md#protected-allowcustomstyle)
+* [bleed](columnset.md#bleed)
+* [defaultStyle](columnset.md#protected-defaultstyle)
+* [hasExplicitStyle](columnset.md#protected-hasexplicitstyle)
+* [hasVisibleSeparator](columnset.md#hasvisibleseparator)
+* [hostConfig](columnset.md#hostconfig)
+* [index](columnset.md#index)
+* [isInline](columnset.md#isinline)
+* [isInteractive](columnset.md#isinteractive)
+* [isSelectable](columnset.md#protected-isselectable)
+* [isStandalone](columnset.md#isstandalone)
+* [isVisible](columnset.md#isvisible)
+* [lang](columnset.md#lang)
+* [padding](columnset.md#padding)
+* [parent](columnset.md#parent)
+* [renderedActionCount](columnset.md#protected-renderedactioncount)
+* [renderedElement](columnset.md#renderedelement)
+* [selectAction](columnset.md#selectaction)
+* [separatorElement](columnset.md#separatorelement)
+* [separatorOrientation](columnset.md#protected-separatororientation)
+* [style](columnset.md#style)
+* [supportsMinHeight](columnset.md#protected-supportsminheight)
+* [useDefaultSizing](columnset.md#protected-usedefaultsizing)
+
+### Methods
+
+* [addColumn](columnset.md#addcolumn)
+* [adjustRenderedElementSize](columnset.md#protected-adjustrenderedelementsize)
+* [applyBackground](columnset.md#protected-applybackground)
+* [applyPadding](columnset.md#protected-applypadding)
+* [asString](columnset.md#asstring)
+* [createPlaceholderElement](columnset.md#protected-createplaceholderelement)
+* [getActionAt](columnset.md#getactionat)
+* [getActionById](columnset.md#getactionbyid)
+* [getActionCount](columnset.md#getactioncount)
+* [getAllInputs](columnset.md#getallinputs)
+* [getBleed](columnset.md#protected-getbleed)
+* [getColumnAt](columnset.md#getcolumnat)
+* [getCount](columnset.md#getcount)
+* [getCustomProperty](columnset.md#getcustomproperty)
+* [getDefaultPadding](columnset.md#protected-getdefaultpadding)
+* [getEffectivePadding](columnset.md#geteffectivepadding)
+* [getEffectiveStyle](columnset.md#geteffectivestyle)
+* [getElementById](columnset.md#getelementbyid)
+* [getFirstVisibleRenderedItem](columnset.md#getfirstvisiblerendereditem)
+* [getForbiddenActionTypes](columnset.md#getforbiddenactiontypes)
+* [getForbiddenElementTypes](columnset.md#getforbiddenelementtypes)
+* [getHasBackground](columnset.md#protected-gethasbackground)
+* [getHasExpandedAction](columnset.md#protected-gethasexpandedaction)
+* [getImmediateSurroundingPadding](columnset.md#getimmediatesurroundingpadding)
+* [getItemAt](columnset.md#getitemat)
+* [getItemCount](columnset.md#getitemcount)
+* [getJsonTypeName](columnset.md#getjsontypename)
+* [getLastVisibleRenderedItem](columnset.md#getlastvisiblerendereditem)
+* [getPadding](columnset.md#protected-getpadding)
+* [getParentContainer](columnset.md#getparentcontainer)
+* [getResourceInformation](columnset.md#getresourceinformation)
+* [getRootElement](columnset.md#getrootelement)
+* [getSelectAction](columnset.md#protected-getselectaction)
+* [indexOf](columnset.md#indexof)
+* [internalRender](columnset.md#protected-internalrender)
+* [internalValidateProperties](columnset.md#internalvalidateproperties)
+* [isAtTheVeryBottom](columnset.md#isattheverybottom)
+* [isAtTheVeryLeft](columnset.md#isattheveryleft)
+* [isAtTheVeryRight](columnset.md#isattheveryright)
+* [isAtTheVeryTop](columnset.md#isattheverytop)
+* [isBleeding](columnset.md#isbleeding)
+* [isBleedingAtBottom](columnset.md#isbleedingatbottom)
+* [isBleedingAtTop](columnset.md#isbleedingattop)
+* [isBottomElement](columnset.md#isbottomelement)
+* [isDesignMode](columnset.md#isdesignmode)
+* [isElementAllowed](columnset.md#protected-iselementallowed)
+* [isFirstElement](columnset.md#isfirstelement)
+* [isHiddenDueToOverflow](columnset.md#ishiddenduetooverflow)
+* [isLastElement](columnset.md#islastelement)
+* [isLeftMostElement](columnset.md#isleftmostelement)
+* [isRendered](columnset.md#isrendered)
+* [isRightMostElement](columnset.md#isrightmostelement)
+* [isTopElement](columnset.md#istopelement)
+* [overrideInternalRender](columnset.md#protected-overrideinternalrender)
+* [parse](columnset.md#parse)
+* [remove](columnset.md#remove)
+* [removeItem](columnset.md#removeitem)
+* [render](columnset.md#render)
+* [setBleed](columnset.md#protected-setbleed)
+* [setCustomProperty](columnset.md#setcustomproperty)
+* [setPadding](columnset.md#protected-setpadding)
+* [setParent](columnset.md#setparent)
+* [setSelectAction](columnset.md#protected-setselectaction)
+* [setShouldFallback](columnset.md#setshouldfallback)
+* [shouldFallback](columnset.md#shouldfallback)
+* [toJSON](columnset.md#tojson)
+* [truncateOverflow](columnset.md#protected-truncateoverflow)
+* [undoOverflowTruncation](columnset.md#protected-undooverflowtruncation)
+* [updateLayout](columnset.md#updatelayout)
+* [validateProperties](columnset.md#validateproperties)
+
+## Properties
+
+###  allowVerticalOverflow
+
+• **allowVerticalOverflow**: *boolean* = false
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[allowVerticalOverflow](cardelementcontainer.md#allowverticaloverflow)*
+
+*Defined in [card-elements.ts:2229](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2229)*
+
+___
+
+###  customCssSelector
+
+• **customCssSelector**: *string* = null
+
+*Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#customcssselector)*
+
+*Defined in [card-elements.ts:507](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L507)*
+
+___
+
+###  height
+
+• **height**: *[CardElementHeight](../README.md#cardelementheight)* = "auto"
+
+*Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
+
+*Defined in [card-elements.ts:508](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L508)*
+
+___
+
+### `Optional` horizontalAlignment
+
+• **horizontalAlignment**? : *[HorizontalAlignment](../enums/horizontalalignment.md)* = null
+
+*Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#optional-horizontalalignment)*
+
+*Defined in [card-elements.ts:504](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L504)*
+
+___
+
+###  id
+
+• **id**: *string*
+
+*Inherited from [CardObject](cardobject.md).[id](cardobject.md#id)*
+
+*Defined in [card-elements.ts:247](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L247)*
+
+___
+
+### `Optional` minPixelHeight
+
+• **minPixelHeight**? : *number* = null
+
+*Inherited from [CardElement](cardelement.md).[minPixelHeight](cardelement.md#optional-minpixelheight)*
+
+*Defined in [card-elements.ts:509](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L509)*
+
+___
+
+###  requires
+
+• **requires**: *[HostCapabilities](hostcapabilities.md)‹›* = new HostConfig.HostCapabilities()
+
+*Inherited from [CardElement](cardelement.md).[requires](cardelement.md#requires)*
+
+*Defined in [card-elements.ts:502](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L502)*
+
+___
+
+###  separator
+
+• **separator**: *boolean* = false
+
+*Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
+
+*Defined in [card-elements.ts:506](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L506)*
+
+___
+
+###  spacing
+
+• **spacing**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.Default
+
+*Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
+
+*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
+
+## Accessors
+
+### `Protected` allowCustomPadding
+
+• **get allowCustomPadding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
+
+*Defined in [card-elements.ts:490](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L490)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` allowCustomStyle
+
+• **get allowCustomStyle**(): *boolean*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[allowCustomStyle](stylablecardelementcontainer.md#protected-allowcustomstyle)*
+
+*Defined in [card-elements.ts:5236](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5236)*
+
+**Returns:** *boolean*
+
+___
+
+###  bleed
+
+• **get bleed**(): *boolean*
+
+*Defined in [card-elements.ts:6272](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6272)*
+
+**Returns:** *boolean*
+
+• **set bleed**(`value`: boolean): *void*
+
+*Defined in [card-elements.ts:6276](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6276)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+### `Protected` defaultStyle
+
+• **get defaultStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
+
+*Defined in [card-elements.ts:498](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L498)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` hasExplicitStyle
+
+• **get hasExplicitStyle**(): *boolean*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[hasExplicitStyle](stylablecardelementcontainer.md#protected-hasexplicitstyle)*
+
+*Defined in [card-elements.ts:5232](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5232)*
+
+**Returns:** *boolean*
+
+___
+
+###  hasVisibleSeparator
+
+• **get hasVisibleSeparator**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
+
+*Defined in [card-elements.ts:928](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L928)*
+
+**Returns:** *boolean*
+
+___
+
+###  hostConfig
+
+• **get hostConfig**(): *[HostConfig](hostconfig.md)*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:881](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L881)*
+
+**Returns:** *[HostConfig](hostconfig.md)*
+
+• **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:895](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L895)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [HostConfig](hostconfig.md) |
+
+**Returns:** *void*
+
+___
+
+###  index
+
+• **get index**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
+
+*Defined in [card-elements.ts:899](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L899)*
+
+**Returns:** *number*
+
+___
+
+###  isInline
+
+• **get isInline**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
+
+*Defined in [card-elements.ts:916](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L916)*
+
+**Returns:** *boolean*
+
+___
+
+###  isInteractive
+
+• **get isInteractive**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
+
+*Defined in [card-elements.ts:908](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L908)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` isSelectable
+
+• **get isSelectable**(): *boolean*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[isSelectable](cardelementcontainer.md#protected-isselectable)*
+
+*Defined in [card-elements.ts:6062](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6062)*
+
+**Returns:** *boolean*
+
+___
+
+###  isStandalone
+
+• **get isStandalone**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
+
+*Defined in [card-elements.ts:912](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L912)*
+
+**Returns:** *boolean*
+
+___
+
+###  isVisible
+
+• **get isVisible**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:924](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L924)*
+
+**Returns:** *boolean*
+
+• **set isVisible**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:937](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L937)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  lang
+
+• **get lang**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:853](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L853)*
+
+**Returns:** *string*
+
+• **set lang**(`value`: string): *void*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:867](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L867)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  padding
+
+• **get padding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Defined in [card-elements.ts:6280](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6280)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+• **set padding**(`value`: [PaddingDefinition](paddingdefinition.md)): *void*
+
+*Defined in [card-elements.ts:6284](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6284)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [PaddingDefinition](paddingdefinition.md) |
+
+**Returns:** *void*
+
+___
+
+###  parent
+
+• **get parent**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[parent](cardelement.md#parent)*
+
+*Defined in [card-elements.ts:920](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L920)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+### `Protected` renderedActionCount
+
+• **get renderedActionCount**(): *number*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[renderedActionCount](stylablecardelementcontainer.md#protected-renderedactioncount)*
+
+*Defined in [card-elements.ts:5228](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5228)*
+
+**Returns:** *number*
+
+___
+
+###  renderedElement
+
+• **get renderedElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[renderedElement](cardelement.md#renderedelement)*
+
+*Defined in [card-elements.ts:956](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L956)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  selectAction
+
+• **get selectAction**(): *[Action](action.md)*
+
+*Defined in [card-elements.ts:6288](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6288)*
+
+**Returns:** *[Action](action.md)*
+
+• **set selectAction**(`value`: [Action](action.md)): *void*
+
+*Defined in [card-elements.ts:6292](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6292)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [Action](action.md) |
+
+**Returns:** *void*
+
+___
+
+###  separatorElement
+
+• **get separatorElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
+
+*Defined in [card-elements.ts:960](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L960)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` separatorOrientation
+
+• **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
+
+*Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
+
+*Defined in [card-elements.ts:494](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L494)*
+
+**Returns:** *[Orientation](../enums/orientation.md)*
+
+___
+
+###  style
+
+• **get style**(): *string*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[style](stylablecardelementcontainer.md#style)*
+
+*Defined in [card-elements.ts:5295](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5295)*
+
+**Returns:** *string*
+
+• **set style**(`value`: string): *void*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[style](stylablecardelementcontainer.md#style)*
+
+*Defined in [card-elements.ts:5305](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5305)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+### `Protected` supportsMinHeight
+
+• **get supportsMinHeight**(): *boolean*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[supportsMinHeight](stylablecardelementcontainer.md#protected-supportsminheight)*
+
+*Overrides [CardElement](cardelement.md).[supportsMinHeight](cardelement.md#protected-supportsminheight)*
+
+*Defined in [card-elements.ts:5240](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5240)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` useDefaultSizing
+
+• **get useDefaultSizing**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
+
+*Defined in [card-elements.ts:486](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L486)*
+
+**Returns:** *boolean*
+
+## Methods
+
+###  addColumn
+
+▸ **addColumn**(`column`: [Column](column.md)): *void*
+
+*Defined in [card-elements.ts:6209](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6209)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`column` | [Column](column.md) |
+
+**Returns:** *void*
+
+___
+
+### `Protected` adjustRenderedElementSize
+
+▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
+
+*Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
+
+*Defined in [card-elements.ts:411](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L411)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`renderedElement` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+### `Protected` applyBackground
+
+▸ **applyBackground**(): *void*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[applyBackground](stylablecardelementcontainer.md#protected-applybackground)*
+
+*Defined in [card-elements.ts:5129](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5129)*
+
+**Returns:** *void*
+
+___
+
+### `Protected` applyPadding
+
+▸ **applyPadding**(): *void*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[applyPadding](stylablecardelementcontainer.md#protected-applypadding)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[applyPadding](cardelementcontainer.md#protected-applypadding)*
+
+*Defined in [card-elements.ts:5137](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5137)*
+
+**Returns:** *void*
+
+___
+
+###  asString
+
+▸ **asString**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
+
+*Defined in [card-elements.ts:513](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L513)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` createPlaceholderElement
+
+▸ **createPlaceholderElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
+
+*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  getActionAt
+
+▸ **getActionAt**(`index`: number): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
+
+*Defined in [card-elements.ts:694](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L694)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionById
+
+▸ **getActionById**(`id`: string): *[Action](action.md)*
+
+*Overrides [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
+
+*Defined in [card-elements.ts:6258](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6258)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionCount
+
+▸ **getActionCount**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
+
+*Defined in [card-elements.ts:690](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L690)*
+
+**Returns:** *number*
+
+___
+
+###  getAllInputs
+
+▸ **getAllInputs**(): *Array‹[Input](input.md)›*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[getAllInputs](cardelementcontainer.md#getallinputs)*
+
+*Overrides [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
+
+*Defined in [card-elements.ts:2334](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2334)*
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+### `Protected` getBleed
+
+▸ **getBleed**(): *boolean*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[getBleed](stylablecardelementcontainer.md#protected-getbleed)*
+
+*Defined in [card-elements.ts:5220](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5220)*
+
+**Returns:** *boolean*
+
+___
+
+###  getColumnAt
+
+▸ **getColumnAt**(`index`: number): *[Column](column.md)*
+
+*Defined in [card-elements.ts:6152](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6152)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[Column](column.md)*
+
+___
+
+###  getCount
+
+▸ **getCount**(): *number*
+
+*Defined in [card-elements.ts:6126](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6126)*
+
+**Returns:** *number*
+
+___
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+### `Protected` getDefaultPadding
+
+▸ **getDefaultPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[getDefaultPadding](stylablecardelementcontainer.md#protected-getdefaultpadding)*
+
+*Overrides [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
+
+*Defined in [card-elements.ts:5207](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5207)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectivePadding
+
+▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
+
+*Defined in [card-elements.ts:847](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L847)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectiveStyle
+
+▸ **getEffectiveStyle**(): *string*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[getEffectiveStyle](stylablecardelementcontainer.md#geteffectivestyle)*
+
+*Overrides [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
+
+*Defined in [card-elements.ts:5289](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5289)*
+
+**Returns:** *string*
+
+___
+
+###  getElementById
+
+▸ **getElementById**(`id`: string): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[getElementById](cardelementcontainer.md#getelementbyid)*
+
+*Overrides [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
+
+*Defined in [card-elements.ts:2354](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2354)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getFirstVisibleRenderedItem
+
+▸ **getFirstVisibleRenderedItem**(): *[CardElement](cardelement.md)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[getFirstVisibleRenderedItem](cardelementcontainer.md#abstract-getfirstvisiblerendereditem)*
+
+*Defined in [card-elements.ts:6134](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6134)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getForbiddenActionTypes
+
+▸ **getForbiddenActionTypes**(): *Array‹any›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
+
+*Defined in [card-elements.ts:557](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L557)*
+
+**Returns:** *Array‹any›*
+
+___
+
+###  getForbiddenElementTypes
+
+▸ **getForbiddenElementTypes**(): *Array‹string›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenElementTypes](cardelement.md#getforbiddenelementtypes)*
+
+*Defined in [card-elements.ts:553](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L553)*
+
+**Returns:** *Array‹string›*
+
+___
+
+### `Protected` getHasBackground
+
+▸ **getHasBackground**(): *boolean*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[getHasBackground](stylablecardelementcontainer.md#protected-gethasbackground)*
+
+*Overrides [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
+
+*Defined in [card-elements.ts:5189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5189)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` getHasExpandedAction
+
+▸ **getHasExpandedAction**(): *boolean*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[getHasExpandedAction](stylablecardelementcontainer.md#protected-gethasexpandedaction)*
+
+*Defined in [card-elements.ts:5216](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5216)*
+
+**Returns:** *boolean*
+
+___
+
+###  getImmediateSurroundingPadding
+
+▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
+
+*Defined in [card-elements.ts:561](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L561)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`result` | [PaddingDefinition](paddingdefinition.md) | - |
+`processTop` | boolean | true |
+`processRight` | boolean | true |
+`processBottom` | boolean | true |
+`processLeft` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  getItemAt
+
+▸ **getItemAt**(`index`: number): *[CardElement](cardelement.md)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[getItemAt](cardelementcontainer.md#abstract-getitemat)*
+
+*Defined in [card-elements.ts:6156](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6156)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getItemCount
+
+▸ **getItemCount**(): *number*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[getItemCount](cardelementcontainer.md#abstract-getitemcount)*
+
+*Defined in [card-elements.ts:6130](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6130)*
+
+**Returns:** *number*
+
+___
+
+###  getJsonTypeName
+
+▸ **getJsonTypeName**(): *string*
+
+*Overrides [CardElement](cardelement.md).[getJsonTypeName](cardelement.md#abstract-getjsontypename)*
+
+*Defined in [card-elements.ts:6160](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6160)*
+
+**Returns:** *string*
+
+___
+
+###  getLastVisibleRenderedItem
+
+▸ **getLastVisibleRenderedItem**(): *[CardElement](cardelement.md)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[getLastVisibleRenderedItem](cardelementcontainer.md#abstract-getlastvisiblerendereditem)*
+
+*Defined in [card-elements.ts:6143](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6143)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+### `Protected` getPadding
+
+▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
+
+*Defined in [card-elements.ts:474](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L474)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getParentContainer
+
+▸ **getParentContainer**(): *[Container](container.md)*
+
+*Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
+
+*Defined in [card-elements.ts:809](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L809)*
+
+**Returns:** *[Container](container.md)*
+
+___
+
+###  getResourceInformation
+
+▸ **getResourceInformation**(): *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[getResourceInformation](cardelementcontainer.md#getresourceinformation)*
+
+*Overrides [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
+
+*Defined in [card-elements.ts:2344](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2344)*
+
+**Returns:** *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+___
+
+###  getRootElement
+
+▸ **getRootElement**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
+
+*Defined in [card-elements.ts:799](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L799)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+### `Protected` getSelectAction
+
+▸ **getSelectAction**(): *[Action](action.md)*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[getSelectAction](cardelementcontainer.md#protected-getselectaction)*
+
+*Defined in [card-elements.ts:2207](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2207)*
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  indexOf
+
+▸ **indexOf**(`cardElement`: [CardElement](cardelement.md)): *number*
+
+*Overrides [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
+
+*Defined in [card-elements.ts:6238](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6238)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`cardElement` | [CardElement](cardelement.md) |
+
+**Returns:** *number*
+
+___
+
+### `Protected` internalRender
+
+▸ **internalRender**(): *HTMLElement*
+
+*Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
+
+*Defined in [card-elements.ts:5982](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5982)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  internalValidateProperties
+
+▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
+
+*Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[internalValidateProperties](stylablecardelementcontainer.md#internalvalidateproperties)*
+
+*Defined in [card-elements.ts:6184](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6184)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [ValidationResults](validationresults.md) |
+
+**Returns:** *void*
+
+___
+
+###  isAtTheVeryBottom
+
+▸ **isAtTheVeryBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
+
+*Defined in [card-elements.ts:767](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L767)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryLeft
+
+▸ **isAtTheVeryLeft**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
+
+*Defined in [card-elements.ts:755](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L755)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryRight
+
+▸ **isAtTheVeryRight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
+
+*Defined in [card-elements.ts:759](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L759)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryTop
+
+▸ **isAtTheVeryTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
+
+*Defined in [card-elements.ts:763](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L763)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleeding
+
+▸ **isBleeding**(): *boolean*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[isBleeding](stylablecardelementcontainer.md#isbleeding)*
+
+*Overrides [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
+
+*Defined in [card-elements.ts:5244](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5244)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtBottom
+
+▸ **isBleedingAtBottom**(): *boolean*
+
+*Overrides [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
+
+*Defined in [card-elements.ts:6110](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6110)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtTop
+
+▸ **isBleedingAtTop**(): *boolean*
+
+*Overrides [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
+
+*Defined in [card-elements.ts:6094](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6094)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBottomElement
+
+▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Overrides [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
+
+*Defined in [card-elements.ts:6254](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6254)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isDesignMode
+
+▸ **isDesignMode**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
+
+*Defined in [card-elements.ts:737](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L737)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` isElementAllowed
+
+▸ **isElementAllowed**(`element`: [CardElement](cardelement.md), `forbiddenElementTypes`: Array‹string›): *boolean*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[isElementAllowed](cardelementcontainer.md#protected-iselementallowed)*
+
+*Defined in [card-elements.ts:2169](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2169)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+`forbiddenElementTypes` | Array‹string› |
+
+**Returns:** *boolean*
+
+___
+
+###  isFirstElement
+
+▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Overrides [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
+
+*Defined in [card-elements.ts:6084](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6084)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isHiddenDueToOverflow
+
+▸ **isHiddenDueToOverflow**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
+
+*Defined in [card-elements.ts:795](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L795)*
+
+**Returns:** *boolean*
+
+___
+
+###  isLastElement
+
+▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
+
+*Defined in [card-elements.ts:751](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L751)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isLeftMostElement
+
+▸ **isLeftMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Overrides [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
+
+*Defined in [card-elements.ts:6242](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6242)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isRendered
+
+▸ **isRendered**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRendered](cardelement.md#isrendered)*
+
+*Defined in [card-elements.ts:743](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L743)*
+
+**Returns:** *boolean*
+
+___
+
+###  isRightMostElement
+
+▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Overrides [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
+
+*Defined in [card-elements.ts:6246](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6246)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isTopElement
+
+▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Overrides [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
+
+*Defined in [card-elements.ts:6250](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6250)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` overrideInternalRender
+
+▸ **overrideInternalRender**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
+
+*Defined in [card-elements.ts:426](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L426)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[parse](stylablecardelementcontainer.md#parse)*
+
+*Defined in [card-elements.ts:6164](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6164)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*
+
+___
+
+###  remove
+
+▸ **remove**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
+
+*Defined in [card-elements.ts:698](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L698)*
+
+**Returns:** *boolean*
+
+___
+
+###  removeItem
+
+▸ **removeItem**(`item`: [CardElement](cardelement.md)): *boolean*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[removeItem](cardelementcontainer.md#abstract-removeitem)*
+
+*Defined in [card-elements.ts:6220](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6220)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`item` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  render
+
+▸ **render**(): *HTMLElement*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[render](stylablecardelementcontainer.md#render)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[render](cardelementcontainer.md#render)*
+
+*Defined in [card-elements.ts:5279](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5279)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` setBleed
+
+▸ **setBleed**(`value`: boolean): *void*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[setBleed](stylablecardelementcontainer.md#protected-setbleed)*
+
+*Defined in [card-elements.ts:5224](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5224)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setPadding
+
+▸ **setPadding**(`value`: [PaddingDefinition](paddingdefinition.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
+
+*Defined in [card-elements.ts:478](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L478)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [PaddingDefinition](paddingdefinition.md) |
+
+**Returns:** *void*
+
+___
+
+###  setParent
+
+▸ **setParent**(`value`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setParent](cardelement.md#setparent)*
+
+*Overrides [CardObject](cardobject.md).[setParent](cardobject.md#abstract-setparent)*
+
+*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setSelectAction
+
+▸ **setSelectAction**(`value`: [Action](action.md)): *void*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[setSelectAction](cardelementcontainer.md#protected-setselectaction)*
+
+*Defined in [card-elements.ts:2211](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2211)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [Action](action.md) |
+
+**Returns:** *void*
+
+___
+
+###  setShouldFallback
+
+▸ **setShouldFallback**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[setShouldFallback](cardelement.md#setshouldfallback)*
+
+*Defined in [card-elements.ts:843](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L843)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  shouldFallback
+
+▸ **shouldFallback**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[shouldFallback](cardelement.md#shouldfallback)*
+
+*Overrides [CardObject](cardobject.md).[shouldFallback](cardobject.md#abstract-shouldfallback)*
+
+*Defined in [card-elements.ts:839](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L839)*
+
+**Returns:** *boolean*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[toJSON](stylablecardelementcontainer.md#tojson)*
+
+*Defined in [card-elements.ts:6066](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6066)*
+
+**Returns:** *any*
+
+___
+
+### `Protected` truncateOverflow
+
+▸ **truncateOverflow**(`maxHeight`: number): *boolean*
+
+*Overrides [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
+
+*Defined in [card-elements.ts:6048](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6048)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`maxHeight` | number |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` undoOverflowTruncation
+
+▸ **undoOverflowTruncation**(): *void*
+
+*Overrides [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
+
+*Defined in [card-elements.ts:6056](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6056)*
+
+**Returns:** *void*
+
+___
+
+###  updateLayout
+
+▸ **updateLayout**(`processChildren`: boolean): *void*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[updateLayout](cardelementcontainer.md#updatelayout)*
+
+*Overrides [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
+
+*Defined in [card-elements.ts:2324](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2324)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`processChildren` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  validateProperties
+
+▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
+
+*Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
+
+*Defined in [card-elements.ts:284](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L284)*
+
+**Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/container.md
+++ b/source/nodejs/adaptivecards/docs/classes/container.md
@@ -1,0 +1,1703 @@
+[Adaptive Cards Javascript SDK](../README.md) › [Container](container.md)
+
+# Class: Container
+
+## Hierarchy
+
+  ↳ [StylableCardElementContainer](stylablecardelementcontainer.md)
+
+  ↳ **Container**
+
+  ↳ [Column](column.md)
+
+  ↳ [ContainerWithActions](containerwithactions.md)
+
+## Index
+
+### Properties
+
+* [allowVerticalOverflow](container.md#allowverticaloverflow)
+* [backgroundImage](container.md#backgroundimage)
+* [customCssSelector](container.md#customcssselector)
+* [height](container.md#height)
+* [horizontalAlignment](container.md#optional-horizontalalignment)
+* [id](container.md#id)
+* [minPixelHeight](container.md#optional-minpixelheight)
+* [requires](container.md#requires)
+* [rtl](container.md#optional-rtl)
+* [separator](container.md#separator)
+* [spacing](container.md#spacing)
+* [verticalContentAlignment](container.md#verticalcontentalignment)
+
+### Accessors
+
+* [allowCustomPadding](container.md#protected-allowcustompadding)
+* [allowCustomStyle](container.md#protected-allowcustomstyle)
+* [bleed](container.md#bleed)
+* [defaultStyle](container.md#protected-defaultstyle)
+* [hasExplicitStyle](container.md#protected-hasexplicitstyle)
+* [hasVisibleSeparator](container.md#hasvisibleseparator)
+* [hostConfig](container.md#hostconfig)
+* [index](container.md#index)
+* [isInline](container.md#isinline)
+* [isInteractive](container.md#isinteractive)
+* [isSelectable](container.md#protected-isselectable)
+* [isStandalone](container.md#isstandalone)
+* [isVisible](container.md#isvisible)
+* [lang](container.md#lang)
+* [padding](container.md#padding)
+* [parent](container.md#parent)
+* [renderedActionCount](container.md#protected-renderedactioncount)
+* [renderedElement](container.md#renderedelement)
+* [selectAction](container.md#selectaction)
+* [separatorElement](container.md#separatorelement)
+* [separatorOrientation](container.md#protected-separatororientation)
+* [style](container.md#style)
+* [supportsMinHeight](container.md#protected-supportsminheight)
+* [useDefaultSizing](container.md#protected-usedefaultsizing)
+
+### Methods
+
+* [addItem](container.md#additem)
+* [adjustRenderedElementSize](container.md#protected-adjustrenderedelementsize)
+* [applyBackground](container.md#protected-applybackground)
+* [applyPadding](container.md#protected-applypadding)
+* [asString](container.md#asstring)
+* [clear](container.md#clear)
+* [createPlaceholderElement](container.md#protected-createplaceholderelement)
+* [getActionAt](container.md#getactionat)
+* [getActionById](container.md#getactionbyid)
+* [getActionCount](container.md#getactioncount)
+* [getAllInputs](container.md#getallinputs)
+* [getBleed](container.md#protected-getbleed)
+* [getCustomProperty](container.md#getcustomproperty)
+* [getDefaultPadding](container.md#protected-getdefaultpadding)
+* [getEffectivePadding](container.md#geteffectivepadding)
+* [getEffectiveStyle](container.md#geteffectivestyle)
+* [getElementById](container.md#getelementbyid)
+* [getFirstVisibleRenderedItem](container.md#getfirstvisiblerendereditem)
+* [getForbiddenActionTypes](container.md#getforbiddenactiontypes)
+* [getForbiddenElementTypes](container.md#getforbiddenelementtypes)
+* [getHasBackground](container.md#protected-gethasbackground)
+* [getHasExpandedAction](container.md#protected-gethasexpandedaction)
+* [getImmediateSurroundingPadding](container.md#getimmediatesurroundingpadding)
+* [getItemAt](container.md#getitemat)
+* [getItemCount](container.md#getitemcount)
+* [getItemsCollectionPropertyName](container.md#protected-getitemscollectionpropertyname)
+* [getJsonTypeName](container.md#getjsontypename)
+* [getLastVisibleRenderedItem](container.md#getlastvisiblerendereditem)
+* [getPadding](container.md#protected-getpadding)
+* [getParentContainer](container.md#getparentcontainer)
+* [getResourceInformation](container.md#getresourceinformation)
+* [getRootElement](container.md#getrootelement)
+* [getSelectAction](container.md#protected-getselectaction)
+* [indexOf](container.md#indexof)
+* [insertItemAfter](container.md#insertitemafter)
+* [insertItemBefore](container.md#insertitembefore)
+* [internalRender](container.md#protected-internalrender)
+* [internalValidateProperties](container.md#internalvalidateproperties)
+* [isAtTheVeryBottom](container.md#isattheverybottom)
+* [isAtTheVeryLeft](container.md#isattheveryleft)
+* [isAtTheVeryRight](container.md#isattheveryright)
+* [isAtTheVeryTop](container.md#isattheverytop)
+* [isBleeding](container.md#isbleeding)
+* [isBleedingAtBottom](container.md#isbleedingatbottom)
+* [isBleedingAtTop](container.md#isbleedingattop)
+* [isBottomElement](container.md#isbottomelement)
+* [isDesignMode](container.md#isdesignmode)
+* [isElementAllowed](container.md#protected-iselementallowed)
+* [isFirstElement](container.md#isfirstelement)
+* [isHiddenDueToOverflow](container.md#ishiddenduetooverflow)
+* [isLastElement](container.md#islastelement)
+* [isLeftMostElement](container.md#isleftmostelement)
+* [isRendered](container.md#isrendered)
+* [isRightMostElement](container.md#isrightmostelement)
+* [isRtl](container.md#isrtl)
+* [isTopElement](container.md#istopelement)
+* [overrideInternalRender](container.md#protected-overrideinternalrender)
+* [parse](container.md#parse)
+* [remove](container.md#remove)
+* [removeItem](container.md#removeitem)
+* [render](container.md#render)
+* [setBleed](container.md#protected-setbleed)
+* [setCustomProperty](container.md#setcustomproperty)
+* [setPadding](container.md#protected-setpadding)
+* [setParent](container.md#setparent)
+* [setSelectAction](container.md#protected-setselectaction)
+* [setShouldFallback](container.md#setshouldfallback)
+* [shouldFallback](container.md#shouldfallback)
+* [supportsExcplitiHeight](container.md#protected-supportsexcplitiheight)
+* [toJSON](container.md#tojson)
+* [truncateOverflow](container.md#protected-truncateoverflow)
+* [undoOverflowTruncation](container.md#protected-undooverflowtruncation)
+* [updateLayout](container.md#updatelayout)
+* [validateProperties](container.md#validateproperties)
+
+## Properties
+
+###  allowVerticalOverflow
+
+• **allowVerticalOverflow**: *boolean* = false
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[allowVerticalOverflow](cardelementcontainer.md#allowverticaloverflow)*
+
+*Defined in [card-elements.ts:2229](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2229)*
+
+___
+
+###  backgroundImage
+
+• **backgroundImage**: *[BackgroundImage](backgroundimage.md)* = new BackgroundImage()
+
+*Defined in [card-elements.ts:5571](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5571)*
+
+___
+
+###  customCssSelector
+
+• **customCssSelector**: *string* = null
+
+*Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#customcssselector)*
+
+*Defined in [card-elements.ts:507](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L507)*
+
+___
+
+###  height
+
+• **height**: *[CardElementHeight](../README.md#cardelementheight)* = "auto"
+
+*Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
+
+*Defined in [card-elements.ts:508](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L508)*
+
+___
+
+### `Optional` horizontalAlignment
+
+• **horizontalAlignment**? : *[HorizontalAlignment](../enums/horizontalalignment.md)* = null
+
+*Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#optional-horizontalalignment)*
+
+*Defined in [card-elements.ts:504](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L504)*
+
+___
+
+###  id
+
+• **id**: *string*
+
+*Inherited from [CardObject](cardobject.md).[id](cardobject.md#id)*
+
+*Defined in [card-elements.ts:247](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L247)*
+
+___
+
+### `Optional` minPixelHeight
+
+• **minPixelHeight**? : *number* = null
+
+*Inherited from [CardElement](cardelement.md).[minPixelHeight](cardelement.md#optional-minpixelheight)*
+
+*Defined in [card-elements.ts:509](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L509)*
+
+___
+
+###  requires
+
+• **requires**: *[HostCapabilities](hostcapabilities.md)‹›* = new HostConfig.HostCapabilities()
+
+*Inherited from [CardElement](cardelement.md).[requires](cardelement.md#requires)*
+
+*Defined in [card-elements.ts:502](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L502)*
+
+___
+
+### `Optional` rtl
+
+• **rtl**? : *boolean* = null
+
+*Defined in [card-elements.ts:5574](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5574)*
+
+___
+
+###  separator
+
+• **separator**: *boolean* = false
+
+*Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
+
+*Defined in [card-elements.ts:506](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L506)*
+
+___
+
+###  spacing
+
+• **spacing**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.Default
+
+*Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
+
+*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
+
+___
+
+###  verticalContentAlignment
+
+• **verticalContentAlignment**: *[VerticalAlignment](../enums/verticalalignment.md)* = Enums.VerticalAlignment.Top
+
+*Defined in [card-elements.ts:5573](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5573)*
+
+## Accessors
+
+### `Protected` allowCustomPadding
+
+• **get allowCustomPadding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
+
+*Defined in [card-elements.ts:490](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L490)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` allowCustomStyle
+
+• **get allowCustomStyle**(): *boolean*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[allowCustomStyle](stylablecardelementcontainer.md#protected-allowcustomstyle)*
+
+*Defined in [card-elements.ts:5236](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5236)*
+
+**Returns:** *boolean*
+
+___
+
+###  bleed
+
+• **get bleed**(): *boolean*
+
+*Defined in [card-elements.ts:5810](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5810)*
+
+**Returns:** *boolean*
+
+• **set bleed**(`value`: boolean): *void*
+
+*Defined in [card-elements.ts:5814](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5814)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+### `Protected` defaultStyle
+
+• **get defaultStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
+
+*Defined in [card-elements.ts:498](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L498)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` hasExplicitStyle
+
+• **get hasExplicitStyle**(): *boolean*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[hasExplicitStyle](stylablecardelementcontainer.md#protected-hasexplicitstyle)*
+
+*Defined in [card-elements.ts:5232](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5232)*
+
+**Returns:** *boolean*
+
+___
+
+###  hasVisibleSeparator
+
+• **get hasVisibleSeparator**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
+
+*Defined in [card-elements.ts:928](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L928)*
+
+**Returns:** *boolean*
+
+___
+
+###  hostConfig
+
+• **get hostConfig**(): *[HostConfig](hostconfig.md)*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:881](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L881)*
+
+**Returns:** *[HostConfig](hostconfig.md)*
+
+• **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:895](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L895)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [HostConfig](hostconfig.md) |
+
+**Returns:** *void*
+
+___
+
+###  index
+
+• **get index**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
+
+*Defined in [card-elements.ts:899](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L899)*
+
+**Returns:** *number*
+
+___
+
+###  isInline
+
+• **get isInline**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
+
+*Defined in [card-elements.ts:916](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L916)*
+
+**Returns:** *boolean*
+
+___
+
+###  isInteractive
+
+• **get isInteractive**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
+
+*Defined in [card-elements.ts:908](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L908)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` isSelectable
+
+• **get isSelectable**(): *boolean*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[isSelectable](cardelementcontainer.md#protected-isselectable)*
+
+*Defined in [card-elements.ts:5567](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5567)*
+
+**Returns:** *boolean*
+
+___
+
+###  isStandalone
+
+• **get isStandalone**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
+
+*Defined in [card-elements.ts:912](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L912)*
+
+**Returns:** *boolean*
+
+___
+
+###  isVisible
+
+• **get isVisible**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:924](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L924)*
+
+**Returns:** *boolean*
+
+• **set isVisible**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:937](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L937)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  lang
+
+• **get lang**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:853](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L853)*
+
+**Returns:** *string*
+
+• **set lang**(`value`: string): *void*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:867](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L867)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  padding
+
+• **get padding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Defined in [card-elements.ts:5794](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5794)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+• **set padding**(`value`: [PaddingDefinition](paddingdefinition.md)): *void*
+
+*Defined in [card-elements.ts:5798](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5798)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [PaddingDefinition](paddingdefinition.md) |
+
+**Returns:** *void*
+
+___
+
+###  parent
+
+• **get parent**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[parent](cardelement.md#parent)*
+
+*Defined in [card-elements.ts:920](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L920)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+### `Protected` renderedActionCount
+
+• **get renderedActionCount**(): *number*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[renderedActionCount](stylablecardelementcontainer.md#protected-renderedactioncount)*
+
+*Defined in [card-elements.ts:5228](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5228)*
+
+**Returns:** *number*
+
+___
+
+###  renderedElement
+
+• **get renderedElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[renderedElement](cardelement.md#renderedelement)*
+
+*Defined in [card-elements.ts:956](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L956)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  selectAction
+
+• **get selectAction**(): *[Action](action.md)*
+
+*Defined in [card-elements.ts:5802](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5802)*
+
+**Returns:** *[Action](action.md)*
+
+• **set selectAction**(`value`: [Action](action.md)): *void*
+
+*Defined in [card-elements.ts:5806](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5806)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [Action](action.md) |
+
+**Returns:** *void*
+
+___
+
+###  separatorElement
+
+• **get separatorElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
+
+*Defined in [card-elements.ts:960](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L960)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` separatorOrientation
+
+• **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
+
+*Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
+
+*Defined in [card-elements.ts:494](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L494)*
+
+**Returns:** *[Orientation](../enums/orientation.md)*
+
+___
+
+###  style
+
+• **get style**(): *string*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[style](stylablecardelementcontainer.md#style)*
+
+*Defined in [card-elements.ts:5295](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5295)*
+
+**Returns:** *string*
+
+• **set style**(`value`: string): *void*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[style](stylablecardelementcontainer.md#style)*
+
+*Defined in [card-elements.ts:5305](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5305)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+### `Protected` supportsMinHeight
+
+• **get supportsMinHeight**(): *boolean*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[supportsMinHeight](stylablecardelementcontainer.md#protected-supportsminheight)*
+
+*Overrides [CardElement](cardelement.md).[supportsMinHeight](cardelement.md#protected-supportsminheight)*
+
+*Defined in [card-elements.ts:5240](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5240)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` useDefaultSizing
+
+• **get useDefaultSizing**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
+
+*Defined in [card-elements.ts:486](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L486)*
+
+**Returns:** *boolean*
+
+## Methods
+
+###  addItem
+
+▸ **addItem**(`item`: [CardElement](cardelement.md)): *void*
+
+*Defined in [card-elements.ts:5730](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5730)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`item` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+### `Protected` adjustRenderedElementSize
+
+▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
+
+*Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
+
+*Defined in [card-elements.ts:411](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L411)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`renderedElement` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+### `Protected` applyBackground
+
+▸ **applyBackground**(): *void*
+
+*Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[applyBackground](stylablecardelementcontainer.md#protected-applybackground)*
+
+*Defined in [card-elements.ts:5441](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5441)*
+
+**Returns:** *void*
+
+___
+
+### `Protected` applyPadding
+
+▸ **applyPadding**(): *void*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[applyPadding](stylablecardelementcontainer.md#protected-applypadding)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[applyPadding](cardelementcontainer.md#protected-applypadding)*
+
+*Defined in [card-elements.ts:5137](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5137)*
+
+**Returns:** *void*
+
+___
+
+###  asString
+
+▸ **asString**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
+
+*Defined in [card-elements.ts:513](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L513)*
+
+**Returns:** *string*
+
+___
+
+###  clear
+
+▸ **clear**(): *void*
+
+*Defined in [card-elements.ts:5758](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5758)*
+
+**Returns:** *void*
+
+___
+
+### `Protected` createPlaceholderElement
+
+▸ **createPlaceholderElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
+
+*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  getActionAt
+
+▸ **getActionAt**(`index`: number): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
+
+*Defined in [card-elements.ts:694](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L694)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionById
+
+▸ **getActionById**(`id`: string): *[Action](action.md)*
+
+*Overrides [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
+
+*Defined in [card-elements.ts:5772](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5772)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionCount
+
+▸ **getActionCount**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
+
+*Defined in [card-elements.ts:690](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L690)*
+
+**Returns:** *number*
+
+___
+
+###  getAllInputs
+
+▸ **getAllInputs**(): *Array‹[Input](input.md)›*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[getAllInputs](cardelementcontainer.md#getallinputs)*
+
+*Overrides [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
+
+*Defined in [card-elements.ts:2334](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2334)*
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+### `Protected` getBleed
+
+▸ **getBleed**(): *boolean*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[getBleed](stylablecardelementcontainer.md#protected-getbleed)*
+
+*Defined in [card-elements.ts:5220](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5220)*
+
+**Returns:** *boolean*
+
+___
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+### `Protected` getDefaultPadding
+
+▸ **getDefaultPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[getDefaultPadding](stylablecardelementcontainer.md#protected-getdefaultpadding)*
+
+*Overrides [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
+
+*Defined in [card-elements.ts:5207](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5207)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectivePadding
+
+▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
+
+*Defined in [card-elements.ts:847](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L847)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectiveStyle
+
+▸ **getEffectiveStyle**(): *string*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[getEffectiveStyle](stylablecardelementcontainer.md#geteffectivestyle)*
+
+*Overrides [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
+
+*Defined in [card-elements.ts:5289](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5289)*
+
+**Returns:** *string*
+
+___
+
+###  getElementById
+
+▸ **getElementById**(`id`: string): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[getElementById](cardelementcontainer.md#getelementbyid)*
+
+*Overrides [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
+
+*Defined in [card-elements.ts:2354](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2354)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getFirstVisibleRenderedItem
+
+▸ **getFirstVisibleRenderedItem**(): *[CardElement](cardelement.md)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[getFirstVisibleRenderedItem](cardelementcontainer.md#abstract-getfirstvisiblerendereditem)*
+
+*Defined in [card-elements.ts:5606](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5606)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getForbiddenActionTypes
+
+▸ **getForbiddenActionTypes**(): *Array‹any›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
+
+*Defined in [card-elements.ts:557](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L557)*
+
+**Returns:** *Array‹any›*
+
+___
+
+###  getForbiddenElementTypes
+
+▸ **getForbiddenElementTypes**(): *Array‹string›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenElementTypes](cardelement.md#getforbiddenelementtypes)*
+
+*Defined in [card-elements.ts:553](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L553)*
+
+**Returns:** *Array‹string›*
+
+___
+
+### `Protected` getHasBackground
+
+▸ **getHasBackground**(): *boolean*
+
+*Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[getHasBackground](stylablecardelementcontainer.md#protected-gethasbackground)*
+
+*Defined in [card-elements.ts:5563](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5563)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` getHasExpandedAction
+
+▸ **getHasExpandedAction**(): *boolean*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[getHasExpandedAction](stylablecardelementcontainer.md#protected-gethasexpandedaction)*
+
+*Defined in [card-elements.ts:5216](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5216)*
+
+**Returns:** *boolean*
+
+___
+
+###  getImmediateSurroundingPadding
+
+▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
+
+*Defined in [card-elements.ts:561](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L561)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`result` | [PaddingDefinition](paddingdefinition.md) | - |
+`processTop` | boolean | true |
+`processRight` | boolean | true |
+`processBottom` | boolean | true |
+`processLeft` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  getItemAt
+
+▸ **getItemAt**(`index`: number): *[CardElement](cardelement.md)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[getItemAt](cardelementcontainer.md#abstract-getitemat)*
+
+*Defined in [card-elements.ts:5602](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5602)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getItemCount
+
+▸ **getItemCount**(): *number*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[getItemCount](cardelementcontainer.md#abstract-getitemcount)*
+
+*Defined in [card-elements.ts:5598](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5598)*
+
+**Returns:** *number*
+
+___
+
+### `Protected` getItemsCollectionPropertyName
+
+▸ **getItemsCollectionPropertyName**(): *string*
+
+*Defined in [card-elements.ts:5437](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5437)*
+
+**Returns:** *string*
+
+___
+
+###  getJsonTypeName
+
+▸ **getJsonTypeName**(): *string*
+
+*Overrides [CardElement](cardelement.md).[getJsonTypeName](cardelement.md#abstract-getjsontypename)*
+
+*Defined in [card-elements.ts:5630](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5630)*
+
+**Returns:** *string*
+
+___
+
+###  getLastVisibleRenderedItem
+
+▸ **getLastVisibleRenderedItem**(): *[CardElement](cardelement.md)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[getLastVisibleRenderedItem](cardelementcontainer.md#abstract-getlastvisiblerendereditem)*
+
+*Defined in [card-elements.ts:5618](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5618)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+### `Protected` getPadding
+
+▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
+
+*Defined in [card-elements.ts:474](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L474)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getParentContainer
+
+▸ **getParentContainer**(): *[Container](container.md)*
+
+*Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
+
+*Defined in [card-elements.ts:809](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L809)*
+
+**Returns:** *[Container](container.md)*
+
+___
+
+###  getResourceInformation
+
+▸ **getResourceInformation**(): *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[getResourceInformation](cardelementcontainer.md#getresourceinformation)*
+
+*Defined in [card-elements.ts:5762](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5762)*
+
+**Returns:** *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+___
+
+###  getRootElement
+
+▸ **getRootElement**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
+
+*Defined in [card-elements.ts:799](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L799)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+### `Protected` getSelectAction
+
+▸ **getSelectAction**(): *[Action](action.md)*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[getSelectAction](cardelementcontainer.md#protected-getselectaction)*
+
+*Defined in [card-elements.ts:2207](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2207)*
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  indexOf
+
+▸ **indexOf**(`cardElement`: [CardElement](cardelement.md)): *number*
+
+*Overrides [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
+
+*Defined in [card-elements.ts:5726](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5726)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`cardElement` | [CardElement](cardelement.md) |
+
+**Returns:** *number*
+
+___
+
+###  insertItemAfter
+
+▸ **insertItemAfter**(`item`: [CardElement](cardelement.md), `insertAfter`: [CardElement](cardelement.md)): *void*
+
+*Defined in [card-elements.ts:5738](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5738)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`item` | [CardElement](cardelement.md) |
+`insertAfter` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+###  insertItemBefore
+
+▸ **insertItemBefore**(`item`: [CardElement](cardelement.md), `insertBefore`: [CardElement](cardelement.md)): *void*
+
+*Defined in [card-elements.ts:5734](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5734)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`item` | [CardElement](cardelement.md) |
+`insertBefore` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+### `Protected` internalRender
+
+▸ **internalRender**(): *HTMLElement*
+
+*Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
+
+*Defined in [card-elements.ts:5449](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5449)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  internalValidateProperties
+
+▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[internalValidateProperties](stylablecardelementcontainer.md#internalvalidateproperties)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[internalValidateProperties](cardelementcontainer.md#internalvalidateproperties)*
+
+*Defined in [card-elements.ts:5256](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5256)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [ValidationResults](validationresults.md) |
+
+**Returns:** *void*
+
+___
+
+###  isAtTheVeryBottom
+
+▸ **isAtTheVeryBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
+
+*Defined in [card-elements.ts:767](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L767)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryLeft
+
+▸ **isAtTheVeryLeft**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
+
+*Defined in [card-elements.ts:755](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L755)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryRight
+
+▸ **isAtTheVeryRight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
+
+*Defined in [card-elements.ts:759](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L759)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryTop
+
+▸ **isAtTheVeryTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
+
+*Defined in [card-elements.ts:763](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L763)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleeding
+
+▸ **isBleeding**(): *boolean*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[isBleeding](stylablecardelementcontainer.md#isbleeding)*
+
+*Overrides [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
+
+*Defined in [card-elements.ts:5244](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5244)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtBottom
+
+▸ **isBleedingAtBottom**(): *boolean*
+
+*Overrides [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
+
+*Defined in [card-elements.ts:5675](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5675)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtTop
+
+▸ **isBleedingAtTop**(): *boolean*
+
+*Overrides [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
+
+*Defined in [card-elements.ts:5669](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5669)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBottomElement
+
+▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
+
+*Defined in [card-elements.ts:791](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L791)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isDesignMode
+
+▸ **isDesignMode**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
+
+*Defined in [card-elements.ts:737](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L737)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` isElementAllowed
+
+▸ **isElementAllowed**(`element`: [CardElement](cardelement.md), `forbiddenElementTypes`: Array‹string›): *boolean*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[isElementAllowed](cardelementcontainer.md#protected-iselementallowed)*
+
+*Defined in [card-elements.ts:2169](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2169)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+`forbiddenElementTypes` | Array‹string› |
+
+**Returns:** *boolean*
+
+___
+
+###  isFirstElement
+
+▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Overrides [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
+
+*Defined in [card-elements.ts:5634](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5634)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isHiddenDueToOverflow
+
+▸ **isHiddenDueToOverflow**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
+
+*Defined in [card-elements.ts:795](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L795)*
+
+**Returns:** *boolean*
+
+___
+
+###  isLastElement
+
+▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Overrides [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
+
+*Defined in [card-elements.ts:5646](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5646)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isLeftMostElement
+
+▸ **isLeftMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
+
+*Defined in [card-elements.ts:779](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L779)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isRendered
+
+▸ **isRendered**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRendered](cardelement.md#isrendered)*
+
+*Defined in [card-elements.ts:743](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L743)*
+
+**Returns:** *boolean*
+
+___
+
+###  isRightMostElement
+
+▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
+
+*Defined in [card-elements.ts:783](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L783)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isRtl
+
+▸ **isRtl**(): *boolean*
+
+*Defined in [card-elements.ts:5658](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5658)*
+
+**Returns:** *boolean*
+
+___
+
+###  isTopElement
+
+▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
+
+*Defined in [card-elements.ts:787](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L787)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` overrideInternalRender
+
+▸ **overrideInternalRender**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
+
+*Defined in [card-elements.ts:426](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L426)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[parse](stylablecardelementcontainer.md#parse)*
+
+*Defined in [card-elements.ts:5681](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5681)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*
+
+___
+
+###  remove
+
+▸ **remove**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
+
+*Defined in [card-elements.ts:698](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L698)*
+
+**Returns:** *boolean*
+
+___
+
+###  removeItem
+
+▸ **removeItem**(`item`: [CardElement](cardelement.md)): *boolean*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[removeItem](cardelementcontainer.md#abstract-removeitem)*
+
+*Defined in [card-elements.ts:5742](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5742)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`item` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  render
+
+▸ **render**(): *HTMLElement*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[render](stylablecardelementcontainer.md#render)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[render](cardelementcontainer.md#render)*
+
+*Defined in [card-elements.ts:5279](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5279)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` setBleed
+
+▸ **setBleed**(`value`: boolean): *void*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[setBleed](stylablecardelementcontainer.md#protected-setbleed)*
+
+*Defined in [card-elements.ts:5224](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5224)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setPadding
+
+▸ **setPadding**(`value`: [PaddingDefinition](paddingdefinition.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
+
+*Defined in [card-elements.ts:478](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L478)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [PaddingDefinition](paddingdefinition.md) |
+
+**Returns:** *void*
+
+___
+
+###  setParent
+
+▸ **setParent**(`value`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setParent](cardelement.md#setparent)*
+
+*Overrides [CardObject](cardobject.md).[setParent](cardobject.md#abstract-setparent)*
+
+*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setSelectAction
+
+▸ **setSelectAction**(`value`: [Action](action.md)): *void*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[setSelectAction](cardelementcontainer.md#protected-setselectaction)*
+
+*Defined in [card-elements.ts:2211](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2211)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [Action](action.md) |
+
+**Returns:** *void*
+
+___
+
+###  setShouldFallback
+
+▸ **setShouldFallback**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[setShouldFallback](cardelement.md#setshouldfallback)*
+
+*Defined in [card-elements.ts:843](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L843)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  shouldFallback
+
+▸ **shouldFallback**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[shouldFallback](cardelement.md#shouldfallback)*
+
+*Overrides [CardObject](cardobject.md).[shouldFallback](cardobject.md#abstract-shouldfallback)*
+
+*Defined in [card-elements.ts:839](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L839)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` supportsExcplitiHeight
+
+▸ **supportsExcplitiHeight**(): *boolean*
+
+*Defined in [card-elements.ts:5433](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5433)*
+
+**Returns:** *boolean*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[toJSON](stylablecardelementcontainer.md#tojson)*
+
+*Defined in [card-elements.ts:5576](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5576)*
+
+**Returns:** *any*
+
+___
+
+### `Protected` truncateOverflow
+
+▸ **truncateOverflow**(`maxHeight`: number): *boolean*
+
+*Overrides [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
+
+*Defined in [card-elements.ts:5522](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5522)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`maxHeight` | number |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` undoOverflowTruncation
+
+▸ **undoOverflowTruncation**(): *void*
+
+*Overrides [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
+
+*Defined in [card-elements.ts:5557](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5557)*
+
+**Returns:** *void*
+
+___
+
+###  updateLayout
+
+▸ **updateLayout**(`processChildren`: boolean): *void*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[updateLayout](cardelementcontainer.md#updatelayout)*
+
+*Overrides [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
+
+*Defined in [card-elements.ts:2324](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2324)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`processChildren` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  validateProperties
+
+▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
+
+*Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
+
+*Defined in [card-elements.ts:284](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L284)*
+
+**Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/containerstyle.md
+++ b/source/nodejs/adaptivecards/docs/classes/containerstyle.md
@@ -1,0 +1,66 @@
+[Adaptive Cards Javascript SDK](../README.md) › [ContainerStyle](containerstyle.md)
+
+# Class: ContainerStyle
+
+## Hierarchy
+
+* **ContainerStyle**
+
+## Index
+
+### Properties
+
+* [Accent](containerstyle.md#static-accent)
+* [Attention](containerstyle.md#static-attention)
+* [Default](containerstyle.md#static-default)
+* [Emphasis](containerstyle.md#static-emphasis)
+* [Good](containerstyle.md#static-good)
+* [Warning](containerstyle.md#static-warning)
+
+## Properties
+
+### `Static` Accent
+
+▪ **Accent**: *"accent"* = "accent"
+
+*Defined in [enums.ts:144](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L144)*
+
+___
+
+### `Static` Attention
+
+▪ **Attention**: *"attention"* = "attention"
+
+*Defined in [enums.ts:146](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L146)*
+
+___
+
+### `Static` Default
+
+▪ **Default**: *"default"* = "default"
+
+*Defined in [enums.ts:142](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L142)*
+
+___
+
+### `Static` Emphasis
+
+▪ **Emphasis**: *"emphasis"* = "emphasis"
+
+*Defined in [enums.ts:143](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L143)*
+
+___
+
+### `Static` Good
+
+▪ **Good**: *"good"* = "good"
+
+*Defined in [enums.ts:145](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L145)*
+
+___
+
+### `Static` Warning
+
+▪ **Warning**: *"warning"* = "warning"
+
+*Defined in [enums.ts:147](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L147)*

--- a/source/nodejs/adaptivecards/docs/classes/containerstyledefinition.md
+++ b/source/nodejs/adaptivecards/docs/classes/containerstyledefinition.md
@@ -1,0 +1,112 @@
+[Adaptive Cards Javascript SDK](../README.md) › [ContainerStyleDefinition](containerstyledefinition.md)
+
+# Class: ContainerStyleDefinition
+
+## Hierarchy
+
+* **ContainerStyleDefinition**
+
+## Index
+
+### Constructors
+
+* [constructor](containerstyledefinition.md#constructor)
+
+### Properties
+
+* [backgroundColor](containerstyledefinition.md#optional-backgroundcolor)
+* [foregroundColors](containerstyledefinition.md#foregroundcolors)
+* [highlightBackgroundColor](containerstyledefinition.md#optional-highlightbackgroundcolor)
+* [highlightForegroundColor](containerstyledefinition.md#optional-highlightforegroundcolor)
+
+### Accessors
+
+* [isBuiltIn](containerstyledefinition.md#isbuiltin)
+
+### Methods
+
+* [parse](containerstyledefinition.md#parse)
+
+## Constructors
+
+###  constructor
+
+\+ **new ContainerStyleDefinition**(`obj?`: any): *[ContainerStyleDefinition](containerstyledefinition.md)*
+
+*Defined in [host-config.ts:289](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L289)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`obj?` | any |
+
+**Returns:** *[ContainerStyleDefinition](containerstyledefinition.md)*
+
+## Properties
+
+### `Optional` backgroundColor
+
+• **backgroundColor**? : *string*
+
+*Defined in [host-config.ts:263](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L263)*
+
+___
+
+###  foregroundColors
+
+• **foregroundColors**: *[ColorSetDefinition](colorsetdefinition.md)* = new ColorSetDefinition(
+        {
+            "default": { default: "#333333", subtle: "#EE333333" },
+            "dark": { default: "#000000", subtle: "#66000000" },
+            "light": { default: "#FFFFFF", subtle: "#33000000" },
+            "accent": { default: "#2E89FC", subtle: "#882E89FC" },
+            "good": { default: "#54A254", subtle: "#DD54A254" },
+            "warning": { default: "#E69500", subtle: "#DDE69500" },
+            "attention": { default: "#CC3300", subtle: "#DDCC3300" }
+        }
+    )
+
+*Defined in [host-config.ts:265](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L265)*
+
+___
+
+### `Optional` highlightBackgroundColor
+
+• **highlightBackgroundColor**? : *string*
+
+*Defined in [host-config.ts:277](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L277)*
+
+___
+
+### `Optional` highlightForegroundColor
+
+• **highlightForegroundColor**? : *string*
+
+*Defined in [host-config.ts:278](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L278)*
+
+## Accessors
+
+###  isBuiltIn
+
+• **get isBuiltIn**(): *boolean*
+
+*Defined in [host-config.ts:295](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L295)*
+
+**Returns:** *boolean*
+
+## Methods
+
+###  parse
+
+▸ **parse**(`obj`: any): *void*
+
+*Defined in [host-config.ts:280](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L280)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`obj` | any |
+
+**Returns:** *void*

--- a/source/nodejs/adaptivecards/docs/classes/containerstyleset.md
+++ b/source/nodejs/adaptivecards/docs/classes/containerstyleset.md
@@ -1,0 +1,86 @@
+[Adaptive Cards Javascript SDK](../README.md) › [ContainerStyleSet](containerstyleset.md)
+
+# Class: ContainerStyleSet
+
+## Hierarchy
+
+* **ContainerStyleSet**
+
+## Index
+
+### Constructors
+
+* [constructor](containerstyleset.md#constructor)
+
+### Accessors
+
+* [default](containerstyleset.md#default)
+* [emphasis](containerstyleset.md#emphasis)
+
+### Methods
+
+* [getStyleByName](containerstyleset.md#getstylebyname)
+* [toJSON](containerstyleset.md#tojson)
+
+## Constructors
+
+###  constructor
+
+\+ **new ContainerStyleSet**(`obj?`: any): *[ContainerStyleSet](containerstyleset.md)*
+
+*Defined in [host-config.ts:315](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L315)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`obj?` | any |
+
+**Returns:** *[ContainerStyleSet](containerstyleset.md)*
+
+## Accessors
+
+###  default
+
+• **get default**(): *[ContainerStyleDefinition](containerstyledefinition.md)*
+
+*Defined in [host-config.ts:383](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L383)*
+
+**Returns:** *[ContainerStyleDefinition](containerstyledefinition.md)*
+
+___
+
+###  emphasis
+
+• **get emphasis**(): *[ContainerStyleDefinition](containerstyledefinition.md)*
+
+*Defined in [host-config.ts:387](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L387)*
+
+**Returns:** *[ContainerStyleDefinition](containerstyledefinition.md)*
+
+## Methods
+
+###  getStyleByName
+
+▸ **getStyleByName**(`name`: string, `defaultValue`: [ContainerStyleDefinition](containerstyledefinition.md)): *[ContainerStyleDefinition](containerstyledefinition.md)*
+
+*Defined in [host-config.ts:379](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L379)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`name` | string | - |
+`defaultValue` | [ContainerStyleDefinition](containerstyledefinition.md) | null |
+
+**Returns:** *[ContainerStyleDefinition](containerstyledefinition.md)*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Defined in [host-config.ts:354](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L354)*
+
+**Returns:** *any*

--- a/source/nodejs/adaptivecards/docs/classes/containerwithactions.md
+++ b/source/nodejs/adaptivecards/docs/classes/containerwithactions.md
@@ -1,0 +1,1799 @@
+[Adaptive Cards Javascript SDK](../README.md) › [ContainerWithActions](containerwithactions.md)
+
+# Class: ContainerWithActions
+
+## Hierarchy
+
+  ↳ [Container](container.md)
+
+  ↳ **ContainerWithActions**
+
+  ↳ [AdaptiveCard](adaptivecard.md)
+
+## Index
+
+### Constructors
+
+* [constructor](containerwithactions.md#constructor)
+
+### Properties
+
+* [allowVerticalOverflow](containerwithactions.md#allowverticaloverflow)
+* [backgroundImage](containerwithactions.md#backgroundimage)
+* [customCssSelector](containerwithactions.md#customcssselector)
+* [height](containerwithactions.md#height)
+* [horizontalAlignment](containerwithactions.md#optional-horizontalalignment)
+* [id](containerwithactions.md#id)
+* [minPixelHeight](containerwithactions.md#optional-minpixelheight)
+* [requires](containerwithactions.md#requires)
+* [rtl](containerwithactions.md#optional-rtl)
+* [separator](containerwithactions.md#separator)
+* [spacing](containerwithactions.md#spacing)
+* [verticalContentAlignment](containerwithactions.md#verticalcontentalignment)
+
+### Accessors
+
+* [allowCustomPadding](containerwithactions.md#protected-allowcustompadding)
+* [allowCustomStyle](containerwithactions.md#protected-allowcustomstyle)
+* [bleed](containerwithactions.md#bleed)
+* [defaultStyle](containerwithactions.md#protected-defaultstyle)
+* [hasExplicitStyle](containerwithactions.md#protected-hasexplicitstyle)
+* [hasVisibleSeparator](containerwithactions.md#hasvisibleseparator)
+* [hostConfig](containerwithactions.md#hostconfig)
+* [index](containerwithactions.md#index)
+* [isInline](containerwithactions.md#isinline)
+* [isInteractive](containerwithactions.md#isinteractive)
+* [isSelectable](containerwithactions.md#protected-isselectable)
+* [isStandalone](containerwithactions.md#isstandalone)
+* [isVisible](containerwithactions.md#isvisible)
+* [lang](containerwithactions.md#lang)
+* [padding](containerwithactions.md#padding)
+* [parent](containerwithactions.md#parent)
+* [renderIfEmpty](containerwithactions.md#protected-renderifempty)
+* [renderedActionCount](containerwithactions.md#protected-renderedactioncount)
+* [renderedElement](containerwithactions.md#renderedelement)
+* [selectAction](containerwithactions.md#selectaction)
+* [separatorElement](containerwithactions.md#separatorelement)
+* [separatorOrientation](containerwithactions.md#protected-separatororientation)
+* [style](containerwithactions.md#style)
+* [supportsMinHeight](containerwithactions.md#protected-supportsminheight)
+* [useDefaultSizing](containerwithactions.md#protected-usedefaultsizing)
+
+### Methods
+
+* [addAction](containerwithactions.md#addaction)
+* [addItem](containerwithactions.md#additem)
+* [adjustRenderedElementSize](containerwithactions.md#protected-adjustrenderedelementsize)
+* [applyBackground](containerwithactions.md#protected-applybackground)
+* [applyPadding](containerwithactions.md#protected-applypadding)
+* [asString](containerwithactions.md#asstring)
+* [clear](containerwithactions.md#clear)
+* [createPlaceholderElement](containerwithactions.md#protected-createplaceholderelement)
+* [getActionAt](containerwithactions.md#getactionat)
+* [getActionById](containerwithactions.md#getactionbyid)
+* [getActionCount](containerwithactions.md#getactioncount)
+* [getAllInputs](containerwithactions.md#getallinputs)
+* [getBleed](containerwithactions.md#protected-getbleed)
+* [getCustomProperty](containerwithactions.md#getcustomproperty)
+* [getDefaultPadding](containerwithactions.md#protected-getdefaultpadding)
+* [getEffectivePadding](containerwithactions.md#geteffectivepadding)
+* [getEffectiveStyle](containerwithactions.md#geteffectivestyle)
+* [getElementById](containerwithactions.md#getelementbyid)
+* [getFirstVisibleRenderedItem](containerwithactions.md#getfirstvisiblerendereditem)
+* [getForbiddenActionTypes](containerwithactions.md#getforbiddenactiontypes)
+* [getForbiddenElementTypes](containerwithactions.md#getforbiddenelementtypes)
+* [getHasBackground](containerwithactions.md#protected-gethasbackground)
+* [getHasExpandedAction](containerwithactions.md#protected-gethasexpandedaction)
+* [getImmediateSurroundingPadding](containerwithactions.md#getimmediatesurroundingpadding)
+* [getItemAt](containerwithactions.md#getitemat)
+* [getItemCount](containerwithactions.md#getitemcount)
+* [getItemsCollectionPropertyName](containerwithactions.md#protected-getitemscollectionpropertyname)
+* [getJsonTypeName](containerwithactions.md#getjsontypename)
+* [getLastVisibleRenderedItem](containerwithactions.md#getlastvisiblerendereditem)
+* [getPadding](containerwithactions.md#protected-getpadding)
+* [getParentContainer](containerwithactions.md#getparentcontainer)
+* [getResourceInformation](containerwithactions.md#getresourceinformation)
+* [getRootElement](containerwithactions.md#getrootelement)
+* [getSelectAction](containerwithactions.md#protected-getselectaction)
+* [indexOf](containerwithactions.md#indexof)
+* [insertItemAfter](containerwithactions.md#insertitemafter)
+* [insertItemBefore](containerwithactions.md#insertitembefore)
+* [internalRender](containerwithactions.md#protected-internalrender)
+* [internalValidateProperties](containerwithactions.md#internalvalidateproperties)
+* [isAtTheVeryBottom](containerwithactions.md#isattheverybottom)
+* [isAtTheVeryLeft](containerwithactions.md#isattheveryleft)
+* [isAtTheVeryRight](containerwithactions.md#isattheveryright)
+* [isAtTheVeryTop](containerwithactions.md#isattheverytop)
+* [isBleeding](containerwithactions.md#isbleeding)
+* [isBleedingAtBottom](containerwithactions.md#isbleedingatbottom)
+* [isBleedingAtTop](containerwithactions.md#isbleedingattop)
+* [isBottomElement](containerwithactions.md#isbottomelement)
+* [isDesignMode](containerwithactions.md#isdesignmode)
+* [isElementAllowed](containerwithactions.md#protected-iselementallowed)
+* [isFirstElement](containerwithactions.md#isfirstelement)
+* [isHiddenDueToOverflow](containerwithactions.md#ishiddenduetooverflow)
+* [isLastElement](containerwithactions.md#islastelement)
+* [isLeftMostElement](containerwithactions.md#isleftmostelement)
+* [isRendered](containerwithactions.md#isrendered)
+* [isRightMostElement](containerwithactions.md#isrightmostelement)
+* [isRtl](containerwithactions.md#isrtl)
+* [isTopElement](containerwithactions.md#istopelement)
+* [overrideInternalRender](containerwithactions.md#protected-overrideinternalrender)
+* [parse](containerwithactions.md#parse)
+* [remove](containerwithactions.md#remove)
+* [removeItem](containerwithactions.md#removeitem)
+* [render](containerwithactions.md#render)
+* [setBleed](containerwithactions.md#protected-setbleed)
+* [setCustomProperty](containerwithactions.md#setcustomproperty)
+* [setPadding](containerwithactions.md#protected-setpadding)
+* [setParent](containerwithactions.md#setparent)
+* [setSelectAction](containerwithactions.md#protected-setselectaction)
+* [setShouldFallback](containerwithactions.md#setshouldfallback)
+* [shouldFallback](containerwithactions.md#shouldfallback)
+* [supportsExcplitiHeight](containerwithactions.md#protected-supportsexcplitiheight)
+* [toJSON](containerwithactions.md#tojson)
+* [truncateOverflow](containerwithactions.md#protected-truncateoverflow)
+* [undoOverflowTruncation](containerwithactions.md#protected-undooverflowtruncation)
+* [updateLayout](containerwithactions.md#updatelayout)
+* [validateProperties](containerwithactions.md#validateproperties)
+
+## Constructors
+
+###  constructor
+
+\+ **new ContainerWithActions**(): *[ContainerWithActions](containerwithactions.md)*
+
+*Defined in [card-elements.ts:6438](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6438)*
+
+**Returns:** *[ContainerWithActions](containerwithactions.md)*
+
+## Properties
+
+###  allowVerticalOverflow
+
+• **allowVerticalOverflow**: *boolean* = false
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[allowVerticalOverflow](cardelementcontainer.md#allowverticaloverflow)*
+
+*Defined in [card-elements.ts:2229](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2229)*
+
+___
+
+###  backgroundImage
+
+• **backgroundImage**: *[BackgroundImage](backgroundimage.md)* = new BackgroundImage()
+
+*Inherited from [Container](container.md).[backgroundImage](container.md#backgroundimage)*
+
+*Defined in [card-elements.ts:5571](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5571)*
+
+___
+
+###  customCssSelector
+
+• **customCssSelector**: *string* = null
+
+*Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#customcssselector)*
+
+*Defined in [card-elements.ts:507](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L507)*
+
+___
+
+###  height
+
+• **height**: *[CardElementHeight](../README.md#cardelementheight)* = "auto"
+
+*Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
+
+*Defined in [card-elements.ts:508](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L508)*
+
+___
+
+### `Optional` horizontalAlignment
+
+• **horizontalAlignment**? : *[HorizontalAlignment](../enums/horizontalalignment.md)* = null
+
+*Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#optional-horizontalalignment)*
+
+*Defined in [card-elements.ts:504](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L504)*
+
+___
+
+###  id
+
+• **id**: *string*
+
+*Inherited from [CardObject](cardobject.md).[id](cardobject.md#id)*
+
+*Defined in [card-elements.ts:247](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L247)*
+
+___
+
+### `Optional` minPixelHeight
+
+• **minPixelHeight**? : *number* = null
+
+*Inherited from [CardElement](cardelement.md).[minPixelHeight](cardelement.md#optional-minpixelheight)*
+
+*Defined in [card-elements.ts:509](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L509)*
+
+___
+
+###  requires
+
+• **requires**: *[HostCapabilities](hostcapabilities.md)‹›* = new HostConfig.HostCapabilities()
+
+*Inherited from [CardElement](cardelement.md).[requires](cardelement.md#requires)*
+
+*Defined in [card-elements.ts:502](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L502)*
+
+___
+
+### `Optional` rtl
+
+• **rtl**? : *boolean* = null
+
+*Inherited from [Container](container.md).[rtl](container.md#optional-rtl)*
+
+*Defined in [card-elements.ts:5574](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5574)*
+
+___
+
+###  separator
+
+• **separator**: *boolean* = false
+
+*Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
+
+*Defined in [card-elements.ts:506](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L506)*
+
+___
+
+###  spacing
+
+• **spacing**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.Default
+
+*Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
+
+*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
+
+___
+
+###  verticalContentAlignment
+
+• **verticalContentAlignment**: *[VerticalAlignment](../enums/verticalalignment.md)* = Enums.VerticalAlignment.Top
+
+*Inherited from [Container](container.md).[verticalContentAlignment](container.md#verticalcontentalignment)*
+
+*Defined in [card-elements.ts:5573](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5573)*
+
+## Accessors
+
+### `Protected` allowCustomPadding
+
+• **get allowCustomPadding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
+
+*Defined in [card-elements.ts:490](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L490)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` allowCustomStyle
+
+• **get allowCustomStyle**(): *boolean*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[allowCustomStyle](stylablecardelementcontainer.md#protected-allowcustomstyle)*
+
+*Defined in [card-elements.ts:5236](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5236)*
+
+**Returns:** *boolean*
+
+___
+
+###  bleed
+
+• **get bleed**(): *boolean*
+
+*Inherited from [Container](container.md).[bleed](container.md#bleed)*
+
+*Defined in [card-elements.ts:5810](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5810)*
+
+**Returns:** *boolean*
+
+• **set bleed**(`value`: boolean): *void*
+
+*Inherited from [Container](container.md).[bleed](container.md#bleed)*
+
+*Defined in [card-elements.ts:5814](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5814)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+### `Protected` defaultStyle
+
+• **get defaultStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
+
+*Defined in [card-elements.ts:498](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L498)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` hasExplicitStyle
+
+• **get hasExplicitStyle**(): *boolean*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[hasExplicitStyle](stylablecardelementcontainer.md#protected-hasexplicitstyle)*
+
+*Defined in [card-elements.ts:5232](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5232)*
+
+**Returns:** *boolean*
+
+___
+
+###  hasVisibleSeparator
+
+• **get hasVisibleSeparator**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
+
+*Defined in [card-elements.ts:928](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L928)*
+
+**Returns:** *boolean*
+
+___
+
+###  hostConfig
+
+• **get hostConfig**(): *[HostConfig](hostconfig.md)*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:881](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L881)*
+
+**Returns:** *[HostConfig](hostconfig.md)*
+
+• **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:895](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L895)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [HostConfig](hostconfig.md) |
+
+**Returns:** *void*
+
+___
+
+###  index
+
+• **get index**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
+
+*Defined in [card-elements.ts:899](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L899)*
+
+**Returns:** *number*
+
+___
+
+###  isInline
+
+• **get isInline**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
+
+*Defined in [card-elements.ts:916](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L916)*
+
+**Returns:** *boolean*
+
+___
+
+###  isInteractive
+
+• **get isInteractive**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
+
+*Defined in [card-elements.ts:908](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L908)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` isSelectable
+
+• **get isSelectable**(): *boolean*
+
+*Inherited from [Container](container.md).[isSelectable](container.md#protected-isselectable)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[isSelectable](cardelementcontainer.md#protected-isselectable)*
+
+*Defined in [card-elements.ts:5567](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5567)*
+
+**Returns:** *boolean*
+
+___
+
+###  isStandalone
+
+• **get isStandalone**(): *boolean*
+
+*Overrides [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
+
+*Defined in [card-elements.ts:6523](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6523)*
+
+**Returns:** *boolean*
+
+___
+
+###  isVisible
+
+• **get isVisible**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:924](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L924)*
+
+**Returns:** *boolean*
+
+• **set isVisible**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:937](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L937)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  lang
+
+• **get lang**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:853](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L853)*
+
+**Returns:** *string*
+
+• **set lang**(`value`: string): *void*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:867](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L867)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  padding
+
+• **get padding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [Container](container.md).[padding](container.md#padding)*
+
+*Defined in [card-elements.ts:5794](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5794)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+• **set padding**(`value`: [PaddingDefinition](paddingdefinition.md)): *void*
+
+*Inherited from [Container](container.md).[padding](container.md#padding)*
+
+*Defined in [card-elements.ts:5798](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5798)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [PaddingDefinition](paddingdefinition.md) |
+
+**Returns:** *void*
+
+___
+
+###  parent
+
+• **get parent**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[parent](cardelement.md#parent)*
+
+*Defined in [card-elements.ts:920](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L920)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+### `Protected` renderIfEmpty
+
+• **get renderIfEmpty**(): *boolean*
+
+*Defined in [card-elements.ts:6436](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6436)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` renderedActionCount
+
+• **get renderedActionCount**(): *number*
+
+*Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[renderedActionCount](stylablecardelementcontainer.md#protected-renderedactioncount)*
+
+*Defined in [card-elements.ts:6432](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6432)*
+
+**Returns:** *number*
+
+___
+
+###  renderedElement
+
+• **get renderedElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[renderedElement](cardelement.md#renderedelement)*
+
+*Defined in [card-elements.ts:956](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L956)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  selectAction
+
+• **get selectAction**(): *[Action](action.md)*
+
+*Inherited from [Container](container.md).[selectAction](container.md#selectaction)*
+
+*Defined in [card-elements.ts:5802](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5802)*
+
+**Returns:** *[Action](action.md)*
+
+• **set selectAction**(`value`: [Action](action.md)): *void*
+
+*Inherited from [Container](container.md).[selectAction](container.md#selectaction)*
+
+*Defined in [card-elements.ts:5806](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5806)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [Action](action.md) |
+
+**Returns:** *void*
+
+___
+
+###  separatorElement
+
+• **get separatorElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
+
+*Defined in [card-elements.ts:960](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L960)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` separatorOrientation
+
+• **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
+
+*Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
+
+*Defined in [card-elements.ts:494](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L494)*
+
+**Returns:** *[Orientation](../enums/orientation.md)*
+
+___
+
+###  style
+
+• **get style**(): *string*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[style](stylablecardelementcontainer.md#style)*
+
+*Defined in [card-elements.ts:5295](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5295)*
+
+**Returns:** *string*
+
+• **set style**(`value`: string): *void*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[style](stylablecardelementcontainer.md#style)*
+
+*Defined in [card-elements.ts:5305](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5305)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+### `Protected` supportsMinHeight
+
+• **get supportsMinHeight**(): *boolean*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[supportsMinHeight](stylablecardelementcontainer.md#protected-supportsminheight)*
+
+*Overrides [CardElement](cardelement.md).[supportsMinHeight](cardelement.md#protected-supportsminheight)*
+
+*Defined in [card-elements.ts:5240](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5240)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` useDefaultSizing
+
+• **get useDefaultSizing**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
+
+*Defined in [card-elements.ts:486](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L486)*
+
+**Returns:** *boolean*
+
+## Methods
+
+###  addAction
+
+▸ **addAction**(`action`: [Action](action.md)): *void*
+
+*Defined in [card-elements.ts:6491](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6491)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`action` | [Action](action.md) |
+
+**Returns:** *void*
+
+___
+
+###  addItem
+
+▸ **addItem**(`item`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [Container](container.md).[addItem](container.md#additem)*
+
+*Defined in [card-elements.ts:5730](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5730)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`item` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+### `Protected` adjustRenderedElementSize
+
+▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
+
+*Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
+
+*Defined in [card-elements.ts:411](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L411)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`renderedElement` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+### `Protected` applyBackground
+
+▸ **applyBackground**(): *void*
+
+*Inherited from [Container](container.md).[applyBackground](container.md#protected-applybackground)*
+
+*Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[applyBackground](stylablecardelementcontainer.md#protected-applybackground)*
+
+*Defined in [card-elements.ts:5441](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5441)*
+
+**Returns:** *void*
+
+___
+
+### `Protected` applyPadding
+
+▸ **applyPadding**(): *void*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[applyPadding](stylablecardelementcontainer.md#protected-applypadding)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[applyPadding](cardelementcontainer.md#protected-applypadding)*
+
+*Defined in [card-elements.ts:5137](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5137)*
+
+**Returns:** *void*
+
+___
+
+###  asString
+
+▸ **asString**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
+
+*Defined in [card-elements.ts:513](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L513)*
+
+**Returns:** *string*
+
+___
+
+###  clear
+
+▸ **clear**(): *void*
+
+*Overrides [Container](container.md).[clear](container.md#clear)*
+
+*Defined in [card-elements.ts:6495](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6495)*
+
+**Returns:** *void*
+
+___
+
+### `Protected` createPlaceholderElement
+
+▸ **createPlaceholderElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
+
+*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  getActionAt
+
+▸ **getActionAt**(`index`: number): *[Action](action.md)*
+
+*Overrides [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
+
+*Defined in [card-elements.ts:6458](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6458)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionById
+
+▸ **getActionById**(`id`: string): *[Action](action.md)*
+
+*Overrides [Container](container.md).[getActionById](container.md#getactionbyid)*
+
+*Defined in [card-elements.ts:6467](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6467)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionCount
+
+▸ **getActionCount**(): *number*
+
+*Overrides [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
+
+*Defined in [card-elements.ts:6454](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6454)*
+
+**Returns:** *number*
+
+___
+
+###  getAllInputs
+
+▸ **getAllInputs**(): *Array‹[Input](input.md)›*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[getAllInputs](cardelementcontainer.md#getallinputs)*
+
+*Defined in [card-elements.ts:6501](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6501)*
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+### `Protected` getBleed
+
+▸ **getBleed**(): *boolean*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[getBleed](stylablecardelementcontainer.md#protected-getbleed)*
+
+*Defined in [card-elements.ts:5220](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5220)*
+
+**Returns:** *boolean*
+
+___
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+### `Protected` getDefaultPadding
+
+▸ **getDefaultPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[getDefaultPadding](stylablecardelementcontainer.md#protected-getdefaultpadding)*
+
+*Overrides [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
+
+*Defined in [card-elements.ts:5207](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5207)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectivePadding
+
+▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
+
+*Defined in [card-elements.ts:847](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L847)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectiveStyle
+
+▸ **getEffectiveStyle**(): *string*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[getEffectiveStyle](stylablecardelementcontainer.md#geteffectivestyle)*
+
+*Overrides [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
+
+*Defined in [card-elements.ts:5289](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5289)*
+
+**Returns:** *string*
+
+___
+
+###  getElementById
+
+▸ **getElementById**(`id`: string): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[getElementById](cardelementcontainer.md#getelementbyid)*
+
+*Overrides [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
+
+*Defined in [card-elements.ts:2354](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2354)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getFirstVisibleRenderedItem
+
+▸ **getFirstVisibleRenderedItem**(): *[CardElement](cardelement.md)*
+
+*Inherited from [Container](container.md).[getFirstVisibleRenderedItem](container.md#getfirstvisiblerendereditem)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[getFirstVisibleRenderedItem](cardelementcontainer.md#abstract-getfirstvisiblerendereditem)*
+
+*Defined in [card-elements.ts:5606](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5606)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getForbiddenActionTypes
+
+▸ **getForbiddenActionTypes**(): *Array‹any›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
+
+*Defined in [card-elements.ts:557](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L557)*
+
+**Returns:** *Array‹any›*
+
+___
+
+###  getForbiddenElementTypes
+
+▸ **getForbiddenElementTypes**(): *Array‹string›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenElementTypes](cardelement.md#getforbiddenelementtypes)*
+
+*Defined in [card-elements.ts:553](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L553)*
+
+**Returns:** *Array‹string›*
+
+___
+
+### `Protected` getHasBackground
+
+▸ **getHasBackground**(): *boolean*
+
+*Inherited from [Container](container.md).[getHasBackground](container.md#protected-gethasbackground)*
+
+*Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[getHasBackground](stylablecardelementcontainer.md#protected-gethasbackground)*
+
+*Defined in [card-elements.ts:5563](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5563)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` getHasExpandedAction
+
+▸ **getHasExpandedAction**(): *boolean*
+
+*Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[getHasExpandedAction](stylablecardelementcontainer.md#protected-gethasexpandedaction)*
+
+*Defined in [card-elements.ts:6420](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6420)*
+
+**Returns:** *boolean*
+
+___
+
+###  getImmediateSurroundingPadding
+
+▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
+
+*Defined in [card-elements.ts:561](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L561)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`result` | [PaddingDefinition](paddingdefinition.md) | - |
+`processTop` | boolean | true |
+`processRight` | boolean | true |
+`processBottom` | boolean | true |
+`processLeft` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  getItemAt
+
+▸ **getItemAt**(`index`: number): *[CardElement](cardelement.md)*
+
+*Inherited from [Container](container.md).[getItemAt](container.md#getitemat)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[getItemAt](cardelementcontainer.md#abstract-getitemat)*
+
+*Defined in [card-elements.ts:5602](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5602)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getItemCount
+
+▸ **getItemCount**(): *number*
+
+*Inherited from [Container](container.md).[getItemCount](container.md#getitemcount)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[getItemCount](cardelementcontainer.md#abstract-getitemcount)*
+
+*Defined in [card-elements.ts:5598](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5598)*
+
+**Returns:** *number*
+
+___
+
+### `Protected` getItemsCollectionPropertyName
+
+▸ **getItemsCollectionPropertyName**(): *string*
+
+*Inherited from [Container](container.md).[getItemsCollectionPropertyName](container.md#protected-getitemscollectionpropertyname)*
+
+*Defined in [card-elements.ts:5437](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5437)*
+
+**Returns:** *string*
+
+___
+
+###  getJsonTypeName
+
+▸ **getJsonTypeName**(): *string*
+
+*Inherited from [Container](container.md).[getJsonTypeName](container.md#getjsontypename)*
+
+*Overrides [CardElement](cardelement.md).[getJsonTypeName](cardelement.md#abstract-getjsontypename)*
+
+*Defined in [card-elements.ts:5630](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5630)*
+
+**Returns:** *string*
+
+___
+
+###  getLastVisibleRenderedItem
+
+▸ **getLastVisibleRenderedItem**(): *[CardElement](cardelement.md)*
+
+*Inherited from [Container](container.md).[getLastVisibleRenderedItem](container.md#getlastvisiblerendereditem)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[getLastVisibleRenderedItem](cardelementcontainer.md#abstract-getlastvisiblerendereditem)*
+
+*Defined in [card-elements.ts:5618](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5618)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+### `Protected` getPadding
+
+▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
+
+*Defined in [card-elements.ts:474](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L474)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getParentContainer
+
+▸ **getParentContainer**(): *[Container](container.md)*
+
+*Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
+
+*Defined in [card-elements.ts:809](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L809)*
+
+**Returns:** *[Container](container.md)*
+
+___
+
+###  getResourceInformation
+
+▸ **getResourceInformation**(): *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+*Overrides [Container](container.md).[getResourceInformation](container.md#getresourceinformation)*
+
+*Defined in [card-elements.ts:6505](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6505)*
+
+**Returns:** *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+___
+
+###  getRootElement
+
+▸ **getRootElement**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
+
+*Defined in [card-elements.ts:799](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L799)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+### `Protected` getSelectAction
+
+▸ **getSelectAction**(): *[Action](action.md)*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[getSelectAction](cardelementcontainer.md#protected-getselectaction)*
+
+*Defined in [card-elements.ts:2207](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2207)*
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  indexOf
+
+▸ **indexOf**(`cardElement`: [CardElement](cardelement.md)): *number*
+
+*Inherited from [Container](container.md).[indexOf](container.md#indexof)*
+
+*Overrides [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
+
+*Defined in [card-elements.ts:5726](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5726)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`cardElement` | [CardElement](cardelement.md) |
+
+**Returns:** *number*
+
+___
+
+###  insertItemAfter
+
+▸ **insertItemAfter**(`item`: [CardElement](cardelement.md), `insertAfter`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [Container](container.md).[insertItemAfter](container.md#insertitemafter)*
+
+*Defined in [card-elements.ts:5738](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5738)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`item` | [CardElement](cardelement.md) |
+`insertAfter` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+###  insertItemBefore
+
+▸ **insertItemBefore**(`item`: [CardElement](cardelement.md), `insertBefore`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [Container](container.md).[insertItemBefore](container.md#insertitembefore)*
+
+*Defined in [card-elements.ts:5734](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5734)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`item` | [CardElement](cardelement.md) |
+`insertBefore` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+### `Protected` internalRender
+
+▸ **internalRender**(): *HTMLElement*
+
+*Overrides [Container](container.md).[internalRender](container.md#protected-internalrender)*
+
+*Defined in [card-elements.ts:6393](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6393)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  internalValidateProperties
+
+▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
+
+*Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[internalValidateProperties](stylablecardelementcontainer.md#internalvalidateproperties)*
+
+*Defined in [card-elements.ts:6479](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6479)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [ValidationResults](validationresults.md) |
+
+**Returns:** *void*
+
+___
+
+###  isAtTheVeryBottom
+
+▸ **isAtTheVeryBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
+
+*Defined in [card-elements.ts:767](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L767)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryLeft
+
+▸ **isAtTheVeryLeft**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
+
+*Defined in [card-elements.ts:755](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L755)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryRight
+
+▸ **isAtTheVeryRight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
+
+*Defined in [card-elements.ts:759](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L759)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryTop
+
+▸ **isAtTheVeryTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
+
+*Defined in [card-elements.ts:763](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L763)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleeding
+
+▸ **isBleeding**(): *boolean*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[isBleeding](stylablecardelementcontainer.md#isbleeding)*
+
+*Overrides [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
+
+*Defined in [card-elements.ts:5244](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5244)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtBottom
+
+▸ **isBleedingAtBottom**(): *boolean*
+
+*Overrides [Container](container.md).[isBleedingAtBottom](container.md#isbleedingatbottom)*
+
+*Defined in [card-elements.ts:6509](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6509)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtTop
+
+▸ **isBleedingAtTop**(): *boolean*
+
+*Inherited from [Container](container.md).[isBleedingAtTop](container.md#isbleedingattop)*
+
+*Overrides [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
+
+*Defined in [card-elements.ts:5669](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5669)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBottomElement
+
+▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
+
+*Defined in [card-elements.ts:791](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L791)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isDesignMode
+
+▸ **isDesignMode**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
+
+*Defined in [card-elements.ts:737](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L737)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` isElementAllowed
+
+▸ **isElementAllowed**(`element`: [CardElement](cardelement.md), `forbiddenElementTypes`: Array‹string›): *boolean*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[isElementAllowed](cardelementcontainer.md#protected-iselementallowed)*
+
+*Defined in [card-elements.ts:2169](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2169)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+`forbiddenElementTypes` | Array‹string› |
+
+**Returns:** *boolean*
+
+___
+
+###  isFirstElement
+
+▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [Container](container.md).[isFirstElement](container.md#isfirstelement)*
+
+*Overrides [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
+
+*Defined in [card-elements.ts:5634](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5634)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isHiddenDueToOverflow
+
+▸ **isHiddenDueToOverflow**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
+
+*Defined in [card-elements.ts:795](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L795)*
+
+**Returns:** *boolean*
+
+___
+
+###  isLastElement
+
+▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Overrides [Container](container.md).[isLastElement](container.md#islastelement)*
+
+*Defined in [card-elements.ts:6487](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6487)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isLeftMostElement
+
+▸ **isLeftMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
+
+*Defined in [card-elements.ts:779](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L779)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isRendered
+
+▸ **isRendered**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRendered](cardelement.md#isrendered)*
+
+*Defined in [card-elements.ts:743](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L743)*
+
+**Returns:** *boolean*
+
+___
+
+###  isRightMostElement
+
+▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
+
+*Defined in [card-elements.ts:783](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L783)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isRtl
+
+▸ **isRtl**(): *boolean*
+
+*Inherited from [Container](container.md).[isRtl](container.md#isrtl)*
+
+*Defined in [card-elements.ts:5658](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5658)*
+
+**Returns:** *boolean*
+
+___
+
+###  isTopElement
+
+▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
+
+*Defined in [card-elements.ts:787](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L787)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` overrideInternalRender
+
+▸ **overrideInternalRender**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
+
+*Defined in [card-elements.ts:426](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L426)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Overrides [Container](container.md).[parse](container.md#parse)*
+
+*Defined in [card-elements.ts:6473](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6473)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*
+
+___
+
+###  remove
+
+▸ **remove**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
+
+*Defined in [card-elements.ts:698](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L698)*
+
+**Returns:** *boolean*
+
+___
+
+###  removeItem
+
+▸ **removeItem**(`item`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [Container](container.md).[removeItem](container.md#removeitem)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[removeItem](cardelementcontainer.md#abstract-removeitem)*
+
+*Defined in [card-elements.ts:5742](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5742)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`item` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  render
+
+▸ **render**(): *HTMLElement*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[render](stylablecardelementcontainer.md#render)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[render](cardelementcontainer.md#render)*
+
+*Defined in [card-elements.ts:5279](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5279)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` setBleed
+
+▸ **setBleed**(`value`: boolean): *void*
+
+*Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[setBleed](stylablecardelementcontainer.md#protected-setbleed)*
+
+*Defined in [card-elements.ts:5224](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5224)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setPadding
+
+▸ **setPadding**(`value`: [PaddingDefinition](paddingdefinition.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
+
+*Defined in [card-elements.ts:478](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L478)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [PaddingDefinition](paddingdefinition.md) |
+
+**Returns:** *void*
+
+___
+
+###  setParent
+
+▸ **setParent**(`value`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setParent](cardelement.md#setparent)*
+
+*Overrides [CardObject](cardobject.md).[setParent](cardobject.md#abstract-setparent)*
+
+*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setSelectAction
+
+▸ **setSelectAction**(`value`: [Action](action.md)): *void*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[setSelectAction](cardelementcontainer.md#protected-setselectaction)*
+
+*Defined in [card-elements.ts:2211](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2211)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [Action](action.md) |
+
+**Returns:** *void*
+
+___
+
+###  setShouldFallback
+
+▸ **setShouldFallback**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[setShouldFallback](cardelement.md#setshouldfallback)*
+
+*Defined in [card-elements.ts:843](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L843)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  shouldFallback
+
+▸ **shouldFallback**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[shouldFallback](cardelement.md#shouldfallback)*
+
+*Overrides [CardObject](cardobject.md).[shouldFallback](cardobject.md#abstract-shouldfallback)*
+
+*Defined in [card-elements.ts:839](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L839)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` supportsExcplitiHeight
+
+▸ **supportsExcplitiHeight**(): *boolean*
+
+*Inherited from [Container](container.md).[supportsExcplitiHeight](container.md#protected-supportsexcplitiheight)*
+
+*Defined in [card-elements.ts:5433](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5433)*
+
+**Returns:** *boolean*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [Container](container.md).[toJSON](container.md#tojson)*
+
+*Defined in [card-elements.ts:6446](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6446)*
+
+**Returns:** *any*
+
+___
+
+### `Protected` truncateOverflow
+
+▸ **truncateOverflow**(`maxHeight`: number): *boolean*
+
+*Inherited from [Container](container.md).[truncateOverflow](container.md#protected-truncateoverflow)*
+
+*Overrides [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
+
+*Defined in [card-elements.ts:5522](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5522)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`maxHeight` | number |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` undoOverflowTruncation
+
+▸ **undoOverflowTruncation**(): *void*
+
+*Inherited from [Container](container.md).[undoOverflowTruncation](container.md#protected-undooverflowtruncation)*
+
+*Overrides [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
+
+*Defined in [card-elements.ts:5557](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5557)*
+
+**Returns:** *void*
+
+___
+
+###  updateLayout
+
+▸ **updateLayout**(`processChildren`: boolean): *void*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[updateLayout](cardelementcontainer.md#updatelayout)*
+
+*Overrides [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
+
+*Defined in [card-elements.ts:2324](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2324)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`processChildren` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  validateProperties
+
+▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
+
+*Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
+
+*Defined in [card-elements.ts:284](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L284)*
+
+**Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/dateinput.md
+++ b/source/nodejs/adaptivecards/docs/classes/dateinput.md
@@ -1,0 +1,1464 @@
+[Adaptive Cards Javascript SDK](../README.md) › [DateInput](dateinput.md)
+
+# Class: DateInput
+
+## Hierarchy
+
+  ↳ [Input](input.md)
+
+  ↳ **DateInput**
+
+## Implements
+
+* [IInput](../interfaces/iinput.md)
+
+## Index
+
+### Properties
+
+* [customCssSelector](dateinput.md#customcssselector)
+* [height](dateinput.md#height)
+* [horizontalAlignment](dateinput.md#optional-horizontalalignment)
+* [id](dateinput.md#id)
+* [minPixelHeight](dateinput.md#optional-minpixelheight)
+* [onValueChanged](dateinput.md#onvaluechanged)
+* [requires](dateinput.md#requires)
+* [separator](dateinput.md#separator)
+* [spacing](dateinput.md#spacing)
+* [title](dateinput.md#title)
+* [validation](dateinput.md#validation)
+
+### Accessors
+
+* [allowCustomPadding](dateinput.md#protected-allowcustompadding)
+* [defaultStyle](dateinput.md#protected-defaultstyle)
+* [defaultValue](dateinput.md#defaultvalue)
+* [hasVisibleSeparator](dateinput.md#hasvisibleseparator)
+* [hostConfig](dateinput.md#hostconfig)
+* [index](dateinput.md#index)
+* [inputControlContainerElement](dateinput.md#protected-inputcontrolcontainerelement)
+* [isInline](dateinput.md#isinline)
+* [isInteractive](dateinput.md#isinteractive)
+* [isNullable](dateinput.md#protected-isnullable)
+* [isStandalone](dateinput.md#isstandalone)
+* [isVisible](dateinput.md#isvisible)
+* [lang](dateinput.md#lang)
+* [max](dateinput.md#max)
+* [min](dateinput.md#min)
+* [parent](dateinput.md#parent)
+* [renderedElement](dateinput.md#renderedelement)
+* [renderedInputControlElement](dateinput.md#protected-renderedinputcontrolelement)
+* [separatorElement](dateinput.md#separatorelement)
+* [separatorOrientation](dateinput.md#protected-separatororientation)
+* [supportsMinHeight](dateinput.md#protected-supportsminheight)
+* [useDefaultSizing](dateinput.md#protected-usedefaultsizing)
+* [value](dateinput.md#value)
+
+### Methods
+
+* [adjustRenderedElementSize](dateinput.md#protected-adjustrenderedelementsize)
+* [applyPadding](dateinput.md#protected-applypadding)
+* [asString](dateinput.md#asstring)
+* [createPlaceholderElement](dateinput.md#protected-createplaceholderelement)
+* [getActionAt](dateinput.md#getactionat)
+* [getActionById](dateinput.md#getactionbyid)
+* [getActionCount](dateinput.md#getactioncount)
+* [getAllInputs](dateinput.md#getallinputs)
+* [getCustomProperty](dateinput.md#getcustomproperty)
+* [getDefaultPadding](dateinput.md#protected-getdefaultpadding)
+* [getEffectivePadding](dateinput.md#geteffectivepadding)
+* [getEffectiveStyle](dateinput.md#geteffectivestyle)
+* [getElementById](dateinput.md#getelementbyid)
+* [getForbiddenActionTypes](dateinput.md#getforbiddenactiontypes)
+* [getForbiddenElementTypes](dateinput.md#getforbiddenelementtypes)
+* [getHasBackground](dateinput.md#protected-gethasbackground)
+* [getImmediateSurroundingPadding](dateinput.md#getimmediatesurroundingpadding)
+* [getJsonTypeName](dateinput.md#getjsontypename)
+* [getPadding](dateinput.md#protected-getpadding)
+* [getParentContainer](dateinput.md#getparentcontainer)
+* [getResourceInformation](dateinput.md#getresourceinformation)
+* [getRootElement](dateinput.md#getrootelement)
+* [indexOf](dateinput.md#indexof)
+* [internalRender](dateinput.md#protected-internalrender)
+* [internalValidateProperties](dateinput.md#internalvalidateproperties)
+* [isAtTheVeryBottom](dateinput.md#isattheverybottom)
+* [isAtTheVeryLeft](dateinput.md#isattheveryleft)
+* [isAtTheVeryRight](dateinput.md#isattheveryright)
+* [isAtTheVeryTop](dateinput.md#isattheverytop)
+* [isBleeding](dateinput.md#isbleeding)
+* [isBleedingAtBottom](dateinput.md#isbleedingatbottom)
+* [isBleedingAtTop](dateinput.md#isbleedingattop)
+* [isBottomElement](dateinput.md#isbottomelement)
+* [isDesignMode](dateinput.md#isdesignmode)
+* [isFirstElement](dateinput.md#isfirstelement)
+* [isHiddenDueToOverflow](dateinput.md#ishiddenduetooverflow)
+* [isLastElement](dateinput.md#islastelement)
+* [isLeftMostElement](dateinput.md#isleftmostelement)
+* [isRendered](dateinput.md#isrendered)
+* [isRightMostElement](dateinput.md#isrightmostelement)
+* [isTopElement](dateinput.md#istopelement)
+* [overrideInternalRender](dateinput.md#protected-overrideinternalrender)
+* [parse](dateinput.md#parse)
+* [parseInputValue](dateinput.md#protected-parseinputvalue)
+* [remove](dateinput.md#remove)
+* [render](dateinput.md#render)
+* [resetValidationFailureCue](dateinput.md#protected-resetvalidationfailurecue)
+* [setCustomProperty](dateinput.md#setcustomproperty)
+* [setPadding](dateinput.md#protected-setpadding)
+* [setParent](dateinput.md#setparent)
+* [setShouldFallback](dateinput.md#setshouldfallback)
+* [shouldFallback](dateinput.md#shouldfallback)
+* [showValidationErrorMessage](dateinput.md#protected-showvalidationerrormessage)
+* [toJSON](dateinput.md#tojson)
+* [truncateOverflow](dateinput.md#protected-truncateoverflow)
+* [undoOverflowTruncation](dateinput.md#protected-undooverflowtruncation)
+* [updateLayout](dateinput.md#updatelayout)
+* [validateProperties](dateinput.md#validateproperties)
+* [validateValue](dateinput.md#validatevalue)
+* [valueChanged](dateinput.md#protected-valuechanged)
+
+## Properties
+
+###  customCssSelector
+
+• **customCssSelector**: *string* = null
+
+*Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#customcssselector)*
+
+*Defined in [card-elements.ts:507](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L507)*
+
+___
+
+###  height
+
+• **height**: *[CardElementHeight](../README.md#cardelementheight)* = "auto"
+
+*Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
+
+*Defined in [card-elements.ts:508](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L508)*
+
+___
+
+### `Optional` horizontalAlignment
+
+• **horizontalAlignment**? : *[HorizontalAlignment](../enums/horizontalalignment.md)* = null
+
+*Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#optional-horizontalalignment)*
+
+*Defined in [card-elements.ts:504](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L504)*
+
+___
+
+###  id
+
+• **id**: *string*
+
+*Implementation of [IInput](../interfaces/iinput.md).[id](../interfaces/iinput.md#id)*
+
+*Inherited from [CardObject](cardobject.md).[id](cardobject.md#id)*
+
+*Defined in [card-elements.ts:247](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L247)*
+
+___
+
+### `Optional` minPixelHeight
+
+• **minPixelHeight**? : *number* = null
+
+*Inherited from [CardElement](cardelement.md).[minPixelHeight](cardelement.md#optional-minpixelheight)*
+
+*Defined in [card-elements.ts:509](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L509)*
+
+___
+
+###  onValueChanged
+
+• **onValueChanged**: *function*
+
+*Inherited from [Input](input.md).[onValueChanged](input.md#onvaluechanged)*
+
+*Defined in [card-elements.ts:2874](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2874)*
+
+#### Type declaration:
+
+▸ (`sender`: [Input](input.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`sender` | [Input](input.md) |
+
+___
+
+###  requires
+
+• **requires**: *[HostCapabilities](hostcapabilities.md)‹›* = new HostConfig.HostCapabilities()
+
+*Inherited from [CardElement](cardelement.md).[requires](cardelement.md#requires)*
+
+*Defined in [card-elements.ts:502](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L502)*
+
+___
+
+###  separator
+
+• **separator**: *boolean* = false
+
+*Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
+
+*Defined in [card-elements.ts:506](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L506)*
+
+___
+
+###  spacing
+
+• **spacing**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.Default
+
+*Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
+
+*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
+
+___
+
+###  title
+
+• **title**: *string*
+
+*Inherited from [Input](input.md).[title](input.md#title)*
+
+*Defined in [card-elements.ts:2878](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2878)*
+
+___
+
+###  validation
+
+• **validation**: *[InputValidationOptions](inputvalidationoptions.md)‹›* = new InputValidationOptions()
+
+*Inherited from [Input](input.md).[validation](input.md#validation)*
+
+*Defined in [card-elements.ts:2876](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2876)*
+
+## Accessors
+
+### `Protected` allowCustomPadding
+
+• **get allowCustomPadding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
+
+*Defined in [card-elements.ts:490](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L490)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` defaultStyle
+
+• **get defaultStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
+
+*Defined in [card-elements.ts:498](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L498)*
+
+**Returns:** *string*
+
+___
+
+###  defaultValue
+
+• **get defaultValue**(): *string*
+
+*Inherited from [Input](input.md).[defaultValue](input.md#defaultvalue)*
+
+*Defined in [card-elements.ts:2944](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2944)*
+
+**Returns:** *string*
+
+• **set defaultValue**(`value`: string): *void*
+
+*Inherited from [Input](input.md).[defaultValue](input.md#defaultvalue)*
+
+*Defined in [card-elements.ts:2948](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2948)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  hasVisibleSeparator
+
+• **get hasVisibleSeparator**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
+
+*Defined in [card-elements.ts:928](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L928)*
+
+**Returns:** *boolean*
+
+___
+
+###  hostConfig
+
+• **get hostConfig**(): *[HostConfig](hostconfig.md)*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:881](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L881)*
+
+**Returns:** *[HostConfig](hostconfig.md)*
+
+• **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:895](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L895)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [HostConfig](hostconfig.md) |
+
+**Returns:** *void*
+
+___
+
+###  index
+
+• **get index**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
+
+*Defined in [card-elements.ts:899](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L899)*
+
+**Returns:** *number*
+
+___
+
+### `Protected` inputControlContainerElement
+
+• **get inputControlContainerElement**(): *HTMLElement*
+
+*Inherited from [Input](input.md).[inputControlContainerElement](input.md#protected-inputcontrolcontainerelement)*
+
+*Defined in [card-elements.ts:2807](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2807)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  isInline
+
+• **get isInline**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
+
+*Defined in [card-elements.ts:916](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L916)*
+
+**Returns:** *boolean*
+
+___
+
+###  isInteractive
+
+• **get isInteractive**(): *boolean*
+
+*Inherited from [Input](input.md).[isInteractive](input.md#isinteractive)*
+
+*Overrides [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
+
+*Defined in [card-elements.ts:2952](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2952)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` isNullable
+
+• **get isNullable**(): *boolean*
+
+*Inherited from [Input](input.md).[isNullable](input.md#protected-isnullable)*
+
+*Defined in [card-elements.ts:2799](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2799)*
+
+**Returns:** *boolean*
+
+___
+
+###  isStandalone
+
+• **get isStandalone**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
+
+*Defined in [card-elements.ts:912](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L912)*
+
+**Returns:** *boolean*
+
+___
+
+###  isVisible
+
+• **get isVisible**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:924](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L924)*
+
+**Returns:** *boolean*
+
+• **set isVisible**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:937](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L937)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  lang
+
+• **get lang**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:853](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L853)*
+
+**Returns:** *string*
+
+• **set lang**(`value`: string): *void*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:867](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L867)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  max
+
+• **get max**(): *string*
+
+*Defined in [card-elements.ts:3695](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3695)*
+
+**Returns:** *string*
+
+• **set max**(`value`: string): *void*
+
+*Defined in [card-elements.ts:3699](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3699)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  min
+
+• **get min**(): *string*
+
+*Defined in [card-elements.ts:3687](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3687)*
+
+**Returns:** *string*
+
+• **set min**(`value`: string): *void*
+
+*Defined in [card-elements.ts:3691](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3691)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  parent
+
+• **get parent**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[parent](cardelement.md#parent)*
+
+*Defined in [card-elements.ts:920](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L920)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  renderedElement
+
+• **get renderedElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[renderedElement](cardelement.md#renderedelement)*
+
+*Defined in [card-elements.ts:956](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L956)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` renderedInputControlElement
+
+• **get renderedInputControlElement**(): *HTMLElement*
+
+*Inherited from [Input](input.md).[renderedInputControlElement](input.md#protected-renderedinputcontrolelement)*
+
+*Defined in [card-elements.ts:2803](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2803)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  separatorElement
+
+• **get separatorElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
+
+*Defined in [card-elements.ts:960](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L960)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` separatorOrientation
+
+• **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
+
+*Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
+
+*Defined in [card-elements.ts:494](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L494)*
+
+**Returns:** *[Orientation](../enums/orientation.md)*
+
+___
+
+### `Protected` supportsMinHeight
+
+• **get supportsMinHeight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[supportsMinHeight](cardelement.md#protected-supportsminheight)*
+
+*Defined in [card-elements.ts:482](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L482)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` useDefaultSizing
+
+• **get useDefaultSizing**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
+
+*Defined in [card-elements.ts:486](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L486)*
+
+**Returns:** *boolean*
+
+___
+
+###  value
+
+• **get value**(): *string*
+
+*Overrides [Input](input.md).[value](input.md#value)*
+
+*Defined in [card-elements.ts:3703](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3703)*
+
+**Returns:** *string*
+
+## Methods
+
+### `Protected` adjustRenderedElementSize
+
+▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
+
+*Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
+
+*Defined in [card-elements.ts:411](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L411)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`renderedElement` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+### `Protected` applyPadding
+
+▸ **applyPadding**(): *void*
+
+*Inherited from [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
+
+*Defined in [card-elements.ts:430](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L430)*
+
+**Returns:** *void*
+
+___
+
+###  asString
+
+▸ **asString**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
+
+*Defined in [card-elements.ts:513](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L513)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` createPlaceholderElement
+
+▸ **createPlaceholderElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
+
+*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  getActionAt
+
+▸ **getActionAt**(`index`: number): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
+
+*Defined in [card-elements.ts:694](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L694)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionById
+
+▸ **getActionById**(`id`: string): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
+
+*Defined in [card-elements.ts:835](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L835)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionCount
+
+▸ **getActionCount**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
+
+*Defined in [card-elements.ts:690](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L690)*
+
+**Returns:** *number*
+
+___
+
+###  getAllInputs
+
+▸ **getAllInputs**(): *Array‹[Input](input.md)›*
+
+*Inherited from [Input](input.md).[getAllInputs](input.md#getallinputs)*
+
+*Overrides [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
+
+*Defined in [card-elements.ts:2940](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2940)*
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+### `Protected` getDefaultPadding
+
+▸ **getDefaultPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
+
+*Defined in [card-elements.ts:466](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L466)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectivePadding
+
+▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
+
+*Defined in [card-elements.ts:847](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L847)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectiveStyle
+
+▸ **getEffectiveStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
+
+*Defined in [card-elements.ts:545](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L545)*
+
+**Returns:** *string*
+
+___
+
+###  getElementById
+
+▸ **getElementById**(`id`: string): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
+
+*Defined in [card-elements.ts:831](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L831)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getForbiddenActionTypes
+
+▸ **getForbiddenActionTypes**(): *Array‹any›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
+
+*Defined in [card-elements.ts:557](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L557)*
+
+**Returns:** *Array‹any›*
+
+___
+
+###  getForbiddenElementTypes
+
+▸ **getForbiddenElementTypes**(): *Array‹string›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenElementTypes](cardelement.md#getforbiddenelementtypes)*
+
+*Defined in [card-elements.ts:553](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L553)*
+
+**Returns:** *Array‹string›*
+
+___
+
+### `Protected` getHasBackground
+
+▸ **getHasBackground**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
+
+*Defined in [card-elements.ts:470](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L470)*
+
+**Returns:** *boolean*
+
+___
+
+###  getImmediateSurroundingPadding
+
+▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
+
+*Defined in [card-elements.ts:561](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L561)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`result` | [PaddingDefinition](paddingdefinition.md) | - |
+`processTop` | boolean | true |
+`processRight` | boolean | true |
+`processBottom` | boolean | true |
+`processLeft` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  getJsonTypeName
+
+▸ **getJsonTypeName**(): *string*
+
+*Overrides [CardElement](cardelement.md).[getJsonTypeName](cardelement.md#abstract-getjsontypename)*
+
+*Defined in [card-elements.ts:3667](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3667)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` getPadding
+
+▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
+
+*Defined in [card-elements.ts:474](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L474)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getParentContainer
+
+▸ **getParentContainer**(): *[Container](container.md)*
+
+*Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
+
+*Defined in [card-elements.ts:809](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L809)*
+
+**Returns:** *[Container](container.md)*
+
+___
+
+###  getResourceInformation
+
+▸ **getResourceInformation**(): *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+*Inherited from [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
+
+*Defined in [card-elements.ts:827](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L827)*
+
+**Returns:** *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+___
+
+###  getRootElement
+
+▸ **getRootElement**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
+
+*Defined in [card-elements.ts:799](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L799)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  indexOf
+
+▸ **indexOf**(`cardElement`: [CardElement](cardelement.md)): *number*
+
+*Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
+
+*Defined in [card-elements.ts:733](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L733)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`cardElement` | [CardElement](cardelement.md) |
+
+**Returns:** *number*
+
+___
+
+### `Protected` internalRender
+
+▸ **internalRender**(): *HTMLElement*
+
+*Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
+
+*Defined in [card-elements.ts:3650](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3650)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  internalValidateProperties
+
+▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
+
+*Inherited from [Input](input.md).[internalValidateProperties](input.md#internalvalidateproperties)*
+
+*Overrides [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
+
+*Defined in [card-elements.ts:2893](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2893)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [ValidationResults](validationresults.md) |
+
+**Returns:** *void*
+
+___
+
+###  isAtTheVeryBottom
+
+▸ **isAtTheVeryBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
+
+*Defined in [card-elements.ts:767](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L767)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryLeft
+
+▸ **isAtTheVeryLeft**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
+
+*Defined in [card-elements.ts:755](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L755)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryRight
+
+▸ **isAtTheVeryRight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
+
+*Defined in [card-elements.ts:759](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L759)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryTop
+
+▸ **isAtTheVeryTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
+
+*Defined in [card-elements.ts:763](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L763)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleeding
+
+▸ **isBleeding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
+
+*Defined in [card-elements.ts:517](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L517)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtBottom
+
+▸ **isBleedingAtBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
+
+*Defined in [card-elements.ts:775](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L775)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtTop
+
+▸ **isBleedingAtTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
+
+*Defined in [card-elements.ts:771](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L771)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBottomElement
+
+▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
+
+*Defined in [card-elements.ts:791](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L791)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isDesignMode
+
+▸ **isDesignMode**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
+
+*Defined in [card-elements.ts:737](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L737)*
+
+**Returns:** *boolean*
+
+___
+
+###  isFirstElement
+
+▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
+
+*Defined in [card-elements.ts:747](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L747)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isHiddenDueToOverflow
+
+▸ **isHiddenDueToOverflow**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
+
+*Defined in [card-elements.ts:795](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L795)*
+
+**Returns:** *boolean*
+
+___
+
+###  isLastElement
+
+▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
+
+*Defined in [card-elements.ts:751](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L751)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isLeftMostElement
+
+▸ **isLeftMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
+
+*Defined in [card-elements.ts:779](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L779)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isRendered
+
+▸ **isRendered**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRendered](cardelement.md#isrendered)*
+
+*Defined in [card-elements.ts:743](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L743)*
+
+**Returns:** *boolean*
+
+___
+
+###  isRightMostElement
+
+▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
+
+*Defined in [card-elements.ts:783](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L783)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isTopElement
+
+▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
+
+*Defined in [card-elements.ts:787](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L787)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` overrideInternalRender
+
+▸ **overrideInternalRender**(): *HTMLElement*
+
+*Inherited from [Input](input.md).[overrideInternalRender](input.md#protected-overrideinternalrender)*
+
+*Overrides [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
+
+*Defined in [card-elements.ts:2811](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2811)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Overrides [Input](input.md).[parse](input.md#parse)*
+
+*Defined in [card-elements.ts:3680](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3680)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*
+
+___
+
+### `Protected` parseInputValue
+
+▸ **parseInputValue**(`value`: string): *string*
+
+*Inherited from [Input](input.md).[parseInputValue](input.md#protected-parseinputvalue)*
+
+*Defined in [card-elements.ts:2868](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2868)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *string*
+
+___
+
+###  remove
+
+▸ **remove**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
+
+*Defined in [card-elements.ts:698](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L698)*
+
+**Returns:** *boolean*
+
+___
+
+###  render
+
+▸ **render**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[render](cardelement.md#render)*
+
+*Defined in [card-elements.ts:706](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L706)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` resetValidationFailureCue
+
+▸ **resetValidationFailureCue**(): *void*
+
+*Inherited from [Input](input.md).[resetValidationFailureCue](input.md#protected-resetvalidationfailurecue)*
+
+*Defined in [card-elements.ts:2846](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2846)*
+
+**Returns:** *void*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setPadding
+
+▸ **setPadding**(`value`: [PaddingDefinition](paddingdefinition.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
+
+*Defined in [card-elements.ts:478](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L478)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [PaddingDefinition](paddingdefinition.md) |
+
+**Returns:** *void*
+
+___
+
+###  setParent
+
+▸ **setParent**(`value`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setParent](cardelement.md#setparent)*
+
+*Overrides [CardObject](cardobject.md).[setParent](cardobject.md#abstract-setparent)*
+
+*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+###  setShouldFallback
+
+▸ **setShouldFallback**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[setShouldFallback](cardelement.md#setshouldfallback)*
+
+*Defined in [card-elements.ts:843](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L843)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  shouldFallback
+
+▸ **shouldFallback**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[shouldFallback](cardelement.md#shouldfallback)*
+
+*Overrides [CardObject](cardobject.md).[shouldFallback](cardobject.md#abstract-shouldfallback)*
+
+*Defined in [card-elements.ts:839](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L839)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` showValidationErrorMessage
+
+▸ **showValidationErrorMessage**(): *void*
+
+*Inherited from [Input](input.md).[showValidationErrorMessage](input.md#protected-showvalidationerrormessage)*
+
+*Defined in [card-elements.ts:2858](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2858)*
+
+**Returns:** *void*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [Input](input.md).[toJSON](input.md#tojson)*
+
+*Defined in [card-elements.ts:3671](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3671)*
+
+**Returns:** *any*
+
+___
+
+### `Protected` truncateOverflow
+
+▸ **truncateOverflow**(`maxHeight`: number): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
+
+*Defined in [card-elements.ts:454](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L454)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`maxHeight` | number |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` undoOverflowTruncation
+
+▸ **undoOverflowTruncation**(): *void*
+
+*Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
+
+*Defined in [card-elements.ts:464](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L464)*
+
+**Returns:** *void*
+
+___
+
+###  updateLayout
+
+▸ **updateLayout**(`processChildren`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
+
+*Defined in [card-elements.ts:728](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L728)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`processChildren` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  validateProperties
+
+▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
+
+*Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
+
+*Defined in [card-elements.ts:284](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L284)*
+
+**Returns:** *[ValidationResults](validationresults.md)*
+
+___
+
+###  validateValue
+
+▸ **validateValue**(): *boolean*
+
+*Implementation of [IInput](../interfaces/iinput.md)*
+
+*Inherited from [Input](input.md).[validateValue](input.md#validatevalue)*
+
+*Defined in [card-elements.ts:2906](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2906)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` valueChanged
+
+▸ **valueChanged**(): *void*
+
+*Inherited from [Input](input.md).[valueChanged](input.md#protected-valuechanged)*
+
+*Defined in [card-elements.ts:2836](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2836)*
+
+**Returns:** *void*

--- a/source/nodejs/adaptivecards/docs/classes/elementtyperegistry.md
+++ b/source/nodejs/adaptivecards/docs/classes/elementtyperegistry.md
@@ -1,0 +1,147 @@
+[Adaptive Cards Javascript SDK](../README.md) › [ElementTypeRegistry](elementtyperegistry.md)
+
+# Class: ElementTypeRegistry
+
+## Hierarchy
+
+* [TypeRegistry](typeregistry.md)‹[CardElement](cardelement.md)›
+
+  ↳ **ElementTypeRegistry**
+
+## Index
+
+### Constructors
+
+* [constructor](elementtyperegistry.md#constructor)
+
+### Methods
+
+* [clear](elementtyperegistry.md#clear)
+* [createInstance](elementtyperegistry.md#createinstance)
+* [getItemAt](elementtyperegistry.md#getitemat)
+* [getItemCount](elementtyperegistry.md#getitemcount)
+* [registerType](elementtyperegistry.md#registertype)
+* [reset](elementtyperegistry.md#reset)
+* [unregisterType](elementtyperegistry.md#unregistertype)
+
+## Constructors
+
+###  constructor
+
+\+ **new ElementTypeRegistry**(): *[ElementTypeRegistry](elementtyperegistry.md)*
+
+*Inherited from [TypeRegistry](typeregistry.md).[constructor](typeregistry.md#constructor)*
+
+*Defined in [card-elements.ts:6539](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6539)*
+
+**Returns:** *[ElementTypeRegistry](elementtyperegistry.md)*
+
+## Methods
+
+###  clear
+
+▸ **clear**(): *void*
+
+*Inherited from [TypeRegistry](typeregistry.md).[clear](typeregistry.md#clear)*
+
+*Defined in [card-elements.ts:6545](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6545)*
+
+**Returns:** *void*
+
+___
+
+###  createInstance
+
+▸ **createInstance**(`typeName`: string): *[CardElement](cardelement.md)*
+
+*Inherited from [TypeRegistry](typeregistry.md).[createInstance](typeregistry.md#createinstance)*
+
+*Defined in [card-elements.ts:6577](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6577)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`typeName` | string |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getItemAt
+
+▸ **getItemAt**(`index`: number): *[ITypeRegistration](../interfaces/ityperegistration.md)‹[CardElement](cardelement.md)›*
+
+*Inherited from [TypeRegistry](typeregistry.md).[getItemAt](typeregistry.md#getitemat)*
+
+*Defined in [card-elements.ts:6587](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6587)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[ITypeRegistration](../interfaces/ityperegistration.md)‹[CardElement](cardelement.md)›*
+
+___
+
+###  getItemCount
+
+▸ **getItemCount**(): *number*
+
+*Inherited from [TypeRegistry](typeregistry.md).[getItemCount](typeregistry.md#getitemcount)*
+
+*Defined in [card-elements.ts:6583](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6583)*
+
+**Returns:** *number*
+
+___
+
+###  registerType
+
+▸ **registerType**(`typeName`: string, `createInstance`: function): *void*
+
+*Inherited from [TypeRegistry](typeregistry.md).[registerType](typeregistry.md#registertype)*
+
+*Defined in [card-elements.ts:6551](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6551)*
+
+**Parameters:**
+
+▪ **typeName**: *string*
+
+▪ **createInstance**: *function*
+
+▸ (): *[CardElement](cardelement.md)*
+
+**Returns:** *void*
+
+___
+
+###  reset
+
+▸ **reset**(): *void*
+
+*Overrides [TypeRegistry](typeregistry.md).[reset](typeregistry.md#abstract-reset)*
+
+*Defined in [card-elements.ts:6593](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6593)*
+
+**Returns:** *void*
+
+___
+
+###  unregisterType
+
+▸ **unregisterType**(`typeName`: string): *void*
+
+*Inherited from [TypeRegistry](typeregistry.md).[unregisterType](typeregistry.md#unregistertype)*
+
+*Defined in [card-elements.ts:6567](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6567)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`typeName` | string |
+
+**Returns:** *void*

--- a/source/nodejs/adaptivecards/docs/classes/fact.md
+++ b/source/nodejs/adaptivecards/docs/classes/fact.md
@@ -1,0 +1,127 @@
+[Adaptive Cards Javascript SDK](../README.md) › [Fact](fact.md)
+
+# Class: Fact
+
+## Hierarchy
+
+* [SerializableObject](serializableobject.md)
+
+  ↳ **Fact**
+
+## Index
+
+### Constructors
+
+* [constructor](fact.md#constructor)
+
+### Properties
+
+* [name](fact.md#name)
+* [value](fact.md#value)
+
+### Methods
+
+* [getCustomProperty](fact.md#getcustomproperty)
+* [parse](fact.md#parse)
+* [setCustomProperty](fact.md#setcustomproperty)
+* [toJSON](fact.md#tojson)
+
+## Constructors
+
+###  constructor
+
+\+ **new Fact**(`name`: string, `value`: string): *[Fact](fact.md)*
+
+*Defined in [card-elements.ts:1709](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1709)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`name` | string | undefined |
+`value` | string | undefined |
+
+**Returns:** *[Fact](fact.md)*
+
+## Properties
+
+###  name
+
+• **name**: *string*
+
+*Defined in [card-elements.ts:1708](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1708)*
+
+___
+
+###  value
+
+• **value**: *string*
+
+*Defined in [card-elements.ts:1709](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1709)*
+
+## Methods
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any): *void*
+
+*Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
+
+*Defined in [card-elements.ts:1718](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1718)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+
+**Returns:** *void*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
+
+*Defined in [card-elements.ts:1725](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1725)*
+
+**Returns:** *any*

--- a/source/nodejs/adaptivecards/docs/classes/factset.md
+++ b/source/nodejs/adaptivecards/docs/classes/factset.md
@@ -1,0 +1,1218 @@
+[Adaptive Cards Javascript SDK](../README.md) › [FactSet](factset.md)
+
+# Class: FactSet
+
+## Hierarchy
+
+  ↳ [CardElement](cardelement.md)
+
+  ↳ **FactSet**
+
+## Index
+
+### Properties
+
+* [customCssSelector](factset.md#customcssselector)
+* [facts](factset.md#facts)
+* [height](factset.md#height)
+* [horizontalAlignment](factset.md#optional-horizontalalignment)
+* [id](factset.md#id)
+* [minPixelHeight](factset.md#optional-minpixelheight)
+* [requires](factset.md#requires)
+* [separator](factset.md#separator)
+* [spacing](factset.md#spacing)
+
+### Accessors
+
+* [allowCustomPadding](factset.md#protected-allowcustompadding)
+* [defaultStyle](factset.md#protected-defaultstyle)
+* [hasVisibleSeparator](factset.md#hasvisibleseparator)
+* [hostConfig](factset.md#hostconfig)
+* [index](factset.md#index)
+* [isInline](factset.md#isinline)
+* [isInteractive](factset.md#isinteractive)
+* [isStandalone](factset.md#isstandalone)
+* [isVisible](factset.md#isvisible)
+* [lang](factset.md#lang)
+* [parent](factset.md#parent)
+* [renderedElement](factset.md#renderedelement)
+* [separatorElement](factset.md#separatorelement)
+* [separatorOrientation](factset.md#protected-separatororientation)
+* [supportsMinHeight](factset.md#protected-supportsminheight)
+* [useDefaultSizing](factset.md#protected-usedefaultsizing)
+
+### Methods
+
+* [adjustRenderedElementSize](factset.md#protected-adjustrenderedelementsize)
+* [applyPadding](factset.md#protected-applypadding)
+* [asString](factset.md#asstring)
+* [createPlaceholderElement](factset.md#protected-createplaceholderelement)
+* [getActionAt](factset.md#getactionat)
+* [getActionById](factset.md#getactionbyid)
+* [getActionCount](factset.md#getactioncount)
+* [getAllInputs](factset.md#getallinputs)
+* [getCustomProperty](factset.md#getcustomproperty)
+* [getDefaultPadding](factset.md#protected-getdefaultpadding)
+* [getEffectivePadding](factset.md#geteffectivepadding)
+* [getEffectiveStyle](factset.md#geteffectivestyle)
+* [getElementById](factset.md#getelementbyid)
+* [getForbiddenActionTypes](factset.md#getforbiddenactiontypes)
+* [getForbiddenElementTypes](factset.md#getforbiddenelementtypes)
+* [getHasBackground](factset.md#protected-gethasbackground)
+* [getImmediateSurroundingPadding](factset.md#getimmediatesurroundingpadding)
+* [getJsonTypeName](factset.md#getjsontypename)
+* [getPadding](factset.md#protected-getpadding)
+* [getParentContainer](factset.md#getparentcontainer)
+* [getResourceInformation](factset.md#getresourceinformation)
+* [getRootElement](factset.md#getrootelement)
+* [indexOf](factset.md#indexof)
+* [internalRender](factset.md#protected-internalrender)
+* [internalValidateProperties](factset.md#internalvalidateproperties)
+* [isAtTheVeryBottom](factset.md#isattheverybottom)
+* [isAtTheVeryLeft](factset.md#isattheveryleft)
+* [isAtTheVeryRight](factset.md#isattheveryright)
+* [isAtTheVeryTop](factset.md#isattheverytop)
+* [isBleeding](factset.md#isbleeding)
+* [isBleedingAtBottom](factset.md#isbleedingatbottom)
+* [isBleedingAtTop](factset.md#isbleedingattop)
+* [isBottomElement](factset.md#isbottomelement)
+* [isDesignMode](factset.md#isdesignmode)
+* [isFirstElement](factset.md#isfirstelement)
+* [isHiddenDueToOverflow](factset.md#ishiddenduetooverflow)
+* [isLastElement](factset.md#islastelement)
+* [isLeftMostElement](factset.md#isleftmostelement)
+* [isRendered](factset.md#isrendered)
+* [isRightMostElement](factset.md#isrightmostelement)
+* [isTopElement](factset.md#istopelement)
+* [overrideInternalRender](factset.md#protected-overrideinternalrender)
+* [parse](factset.md#parse)
+* [remove](factset.md#remove)
+* [render](factset.md#render)
+* [setCustomProperty](factset.md#setcustomproperty)
+* [setPadding](factset.md#protected-setpadding)
+* [setParent](factset.md#setparent)
+* [setShouldFallback](factset.md#setshouldfallback)
+* [shouldFallback](factset.md#shouldfallback)
+* [toJSON](factset.md#tojson)
+* [truncateOverflow](factset.md#protected-truncateoverflow)
+* [undoOverflowTruncation](factset.md#protected-undooverflowtruncation)
+* [updateLayout](factset.md#updatelayout)
+* [validateProperties](factset.md#validateproperties)
+
+## Properties
+
+###  customCssSelector
+
+• **customCssSelector**: *string* = null
+
+*Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#customcssselector)*
+
+*Defined in [card-elements.ts:507](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L507)*
+
+___
+
+###  facts
+
+• **facts**: *Array‹[Fact](fact.md)›* = []
+
+*Defined in [card-elements.ts:1816](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1816)*
+
+___
+
+###  height
+
+• **height**: *[CardElementHeight](../README.md#cardelementheight)* = "auto"
+
+*Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
+
+*Defined in [card-elements.ts:508](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L508)*
+
+___
+
+### `Optional` horizontalAlignment
+
+• **horizontalAlignment**? : *[HorizontalAlignment](../enums/horizontalalignment.md)* = null
+
+*Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#optional-horizontalalignment)*
+
+*Defined in [card-elements.ts:504](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L504)*
+
+___
+
+###  id
+
+• **id**: *string*
+
+*Inherited from [CardObject](cardobject.md).[id](cardobject.md#id)*
+
+*Defined in [card-elements.ts:247](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L247)*
+
+___
+
+### `Optional` minPixelHeight
+
+• **minPixelHeight**? : *number* = null
+
+*Inherited from [CardElement](cardelement.md).[minPixelHeight](cardelement.md#optional-minpixelheight)*
+
+*Defined in [card-elements.ts:509](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L509)*
+
+___
+
+###  requires
+
+• **requires**: *[HostCapabilities](hostcapabilities.md)‹›* = new HostConfig.HostCapabilities()
+
+*Inherited from [CardElement](cardelement.md).[requires](cardelement.md#requires)*
+
+*Defined in [card-elements.ts:502](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L502)*
+
+___
+
+###  separator
+
+• **separator**: *boolean* = false
+
+*Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
+
+*Defined in [card-elements.ts:506](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L506)*
+
+___
+
+###  spacing
+
+• **spacing**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.Default
+
+*Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
+
+*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
+
+## Accessors
+
+### `Protected` allowCustomPadding
+
+• **get allowCustomPadding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
+
+*Defined in [card-elements.ts:490](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L490)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` defaultStyle
+
+• **get defaultStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
+
+*Defined in [card-elements.ts:498](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L498)*
+
+**Returns:** *string*
+
+___
+
+###  hasVisibleSeparator
+
+• **get hasVisibleSeparator**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
+
+*Defined in [card-elements.ts:928](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L928)*
+
+**Returns:** *boolean*
+
+___
+
+###  hostConfig
+
+• **get hostConfig**(): *[HostConfig](hostconfig.md)*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:881](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L881)*
+
+**Returns:** *[HostConfig](hostconfig.md)*
+
+• **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:895](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L895)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [HostConfig](hostconfig.md) |
+
+**Returns:** *void*
+
+___
+
+###  index
+
+• **get index**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
+
+*Defined in [card-elements.ts:899](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L899)*
+
+**Returns:** *number*
+
+___
+
+###  isInline
+
+• **get isInline**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
+
+*Defined in [card-elements.ts:916](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L916)*
+
+**Returns:** *boolean*
+
+___
+
+###  isInteractive
+
+• **get isInteractive**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
+
+*Defined in [card-elements.ts:908](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L908)*
+
+**Returns:** *boolean*
+
+___
+
+###  isStandalone
+
+• **get isStandalone**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
+
+*Defined in [card-elements.ts:912](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L912)*
+
+**Returns:** *boolean*
+
+___
+
+###  isVisible
+
+• **get isVisible**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:924](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L924)*
+
+**Returns:** *boolean*
+
+• **set isVisible**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:937](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L937)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  lang
+
+• **get lang**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:853](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L853)*
+
+**Returns:** *string*
+
+• **set lang**(`value`: string): *void*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:867](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L867)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  parent
+
+• **get parent**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[parent](cardelement.md#parent)*
+
+*Defined in [card-elements.ts:920](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L920)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  renderedElement
+
+• **get renderedElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[renderedElement](cardelement.md#renderedelement)*
+
+*Defined in [card-elements.ts:956](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L956)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  separatorElement
+
+• **get separatorElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
+
+*Defined in [card-elements.ts:960](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L960)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` separatorOrientation
+
+• **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
+
+*Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
+
+*Defined in [card-elements.ts:494](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L494)*
+
+**Returns:** *[Orientation](../enums/orientation.md)*
+
+___
+
+### `Protected` supportsMinHeight
+
+• **get supportsMinHeight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[supportsMinHeight](cardelement.md#protected-supportsminheight)*
+
+*Defined in [card-elements.ts:482](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L482)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` useDefaultSizing
+
+• **get useDefaultSizing**(): *boolean*
+
+*Overrides [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
+
+*Defined in [card-elements.ts:1736](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1736)*
+
+**Returns:** *boolean*
+
+## Methods
+
+### `Protected` adjustRenderedElementSize
+
+▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
+
+*Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
+
+*Defined in [card-elements.ts:411](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L411)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`renderedElement` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+### `Protected` applyPadding
+
+▸ **applyPadding**(): *void*
+
+*Inherited from [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
+
+*Defined in [card-elements.ts:430](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L430)*
+
+**Returns:** *void*
+
+___
+
+###  asString
+
+▸ **asString**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
+
+*Defined in [card-elements.ts:513](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L513)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` createPlaceholderElement
+
+▸ **createPlaceholderElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
+
+*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  getActionAt
+
+▸ **getActionAt**(`index`: number): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
+
+*Defined in [card-elements.ts:694](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L694)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionById
+
+▸ **getActionById**(`id`: string): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
+
+*Defined in [card-elements.ts:835](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L835)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionCount
+
+▸ **getActionCount**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
+
+*Defined in [card-elements.ts:690](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L690)*
+
+**Returns:** *number*
+
+___
+
+###  getAllInputs
+
+▸ **getAllInputs**(): *Array‹[Input](input.md)›*
+
+*Inherited from [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
+
+*Defined in [card-elements.ts:823](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L823)*
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+### `Protected` getDefaultPadding
+
+▸ **getDefaultPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
+
+*Defined in [card-elements.ts:466](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L466)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectivePadding
+
+▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
+
+*Defined in [card-elements.ts:847](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L847)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectiveStyle
+
+▸ **getEffectiveStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
+
+*Defined in [card-elements.ts:545](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L545)*
+
+**Returns:** *string*
+
+___
+
+###  getElementById
+
+▸ **getElementById**(`id`: string): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
+
+*Defined in [card-elements.ts:831](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L831)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getForbiddenActionTypes
+
+▸ **getForbiddenActionTypes**(): *Array‹any›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
+
+*Defined in [card-elements.ts:557](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L557)*
+
+**Returns:** *Array‹any›*
+
+___
+
+###  getForbiddenElementTypes
+
+▸ **getForbiddenElementTypes**(): *Array‹string›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenElementTypes](cardelement.md#getforbiddenelementtypes)*
+
+*Defined in [card-elements.ts:553](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L553)*
+
+**Returns:** *Array‹string›*
+
+___
+
+### `Protected` getHasBackground
+
+▸ **getHasBackground**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
+
+*Defined in [card-elements.ts:470](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L470)*
+
+**Returns:** *boolean*
+
+___
+
+###  getImmediateSurroundingPadding
+
+▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
+
+*Defined in [card-elements.ts:561](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L561)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`result` | [PaddingDefinition](paddingdefinition.md) | - |
+`processTop` | boolean | true |
+`processRight` | boolean | true |
+`processBottom` | boolean | true |
+`processLeft` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  getJsonTypeName
+
+▸ **getJsonTypeName**(): *string*
+
+*Overrides [CardElement](cardelement.md).[getJsonTypeName](cardelement.md#abstract-getjsontypename)*
+
+*Defined in [card-elements.ts:1818](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1818)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` getPadding
+
+▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
+
+*Defined in [card-elements.ts:474](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L474)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getParentContainer
+
+▸ **getParentContainer**(): *[Container](container.md)*
+
+*Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
+
+*Defined in [card-elements.ts:809](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L809)*
+
+**Returns:** *[Container](container.md)*
+
+___
+
+###  getResourceInformation
+
+▸ **getResourceInformation**(): *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+*Inherited from [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
+
+*Defined in [card-elements.ts:827](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L827)*
+
+**Returns:** *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+___
+
+###  getRootElement
+
+▸ **getRootElement**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
+
+*Defined in [card-elements.ts:799](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L799)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  indexOf
+
+▸ **indexOf**(`cardElement`: [CardElement](cardelement.md)): *number*
+
+*Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
+
+*Defined in [card-elements.ts:733](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L733)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`cardElement` | [CardElement](cardelement.md) |
+
+**Returns:** *number*
+
+___
+
+### `Protected` internalRender
+
+▸ **internalRender**(): *HTMLElement*
+
+*Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
+
+*Defined in [card-elements.ts:1740](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1740)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  internalValidateProperties
+
+▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
+
+*Inherited from [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
+
+*Defined in [card-elements.ts:249](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L249)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [ValidationResults](validationresults.md) |
+
+**Returns:** *void*
+
+___
+
+###  isAtTheVeryBottom
+
+▸ **isAtTheVeryBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
+
+*Defined in [card-elements.ts:767](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L767)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryLeft
+
+▸ **isAtTheVeryLeft**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
+
+*Defined in [card-elements.ts:755](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L755)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryRight
+
+▸ **isAtTheVeryRight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
+
+*Defined in [card-elements.ts:759](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L759)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryTop
+
+▸ **isAtTheVeryTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
+
+*Defined in [card-elements.ts:763](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L763)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleeding
+
+▸ **isBleeding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
+
+*Defined in [card-elements.ts:517](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L517)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtBottom
+
+▸ **isBleedingAtBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
+
+*Defined in [card-elements.ts:775](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L775)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtTop
+
+▸ **isBleedingAtTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
+
+*Defined in [card-elements.ts:771](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L771)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBottomElement
+
+▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
+
+*Defined in [card-elements.ts:791](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L791)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isDesignMode
+
+▸ **isDesignMode**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
+
+*Defined in [card-elements.ts:737](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L737)*
+
+**Returns:** *boolean*
+
+___
+
+###  isFirstElement
+
+▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
+
+*Defined in [card-elements.ts:747](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L747)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isHiddenDueToOverflow
+
+▸ **isHiddenDueToOverflow**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
+
+*Defined in [card-elements.ts:795](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L795)*
+
+**Returns:** *boolean*
+
+___
+
+###  isLastElement
+
+▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
+
+*Defined in [card-elements.ts:751](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L751)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isLeftMostElement
+
+▸ **isLeftMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
+
+*Defined in [card-elements.ts:779](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L779)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isRendered
+
+▸ **isRendered**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRendered](cardelement.md#isrendered)*
+
+*Defined in [card-elements.ts:743](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L743)*
+
+**Returns:** *boolean*
+
+___
+
+###  isRightMostElement
+
+▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
+
+*Defined in [card-elements.ts:783](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L783)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isTopElement
+
+▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
+
+*Defined in [card-elements.ts:787](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L787)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` overrideInternalRender
+
+▸ **overrideInternalRender**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
+
+*Defined in [card-elements.ts:426](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L426)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Overrides [CardElement](cardelement.md).[parse](cardelement.md#parse)*
+
+*Defined in [card-elements.ts:1842](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1842)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*
+
+___
+
+###  remove
+
+▸ **remove**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
+
+*Defined in [card-elements.ts:698](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L698)*
+
+**Returns:** *boolean*
+
+___
+
+###  render
+
+▸ **render**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[render](cardelement.md#render)*
+
+*Defined in [card-elements.ts:706](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L706)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setPadding
+
+▸ **setPadding**(`value`: [PaddingDefinition](paddingdefinition.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
+
+*Defined in [card-elements.ts:478](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L478)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [PaddingDefinition](paddingdefinition.md) |
+
+**Returns:** *void*
+
+___
+
+###  setParent
+
+▸ **setParent**(`value`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setParent](cardelement.md#setparent)*
+
+*Overrides [CardObject](cardobject.md).[setParent](cardobject.md#abstract-setparent)*
+
+*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+###  setShouldFallback
+
+▸ **setShouldFallback**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[setShouldFallback](cardelement.md#setshouldfallback)*
+
+*Defined in [card-elements.ts:843](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L843)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  shouldFallback
+
+▸ **shouldFallback**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[shouldFallback](cardelement.md#shouldfallback)*
+
+*Overrides [CardObject](cardobject.md).[shouldFallback](cardobject.md#abstract-shouldfallback)*
+
+*Defined in [card-elements.ts:839](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L839)*
+
+**Returns:** *boolean*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [CardElement](cardelement.md).[toJSON](cardelement.md#tojson)*
+
+*Defined in [card-elements.ts:1822](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1822)*
+
+**Returns:** *any*
+
+___
+
+### `Protected` truncateOverflow
+
+▸ **truncateOverflow**(`maxHeight`: number): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
+
+*Defined in [card-elements.ts:454](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L454)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`maxHeight` | number |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` undoOverflowTruncation
+
+▸ **undoOverflowTruncation**(): *void*
+
+*Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
+
+*Defined in [card-elements.ts:464](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L464)*
+
+**Returns:** *void*
+
+___
+
+###  updateLayout
+
+▸ **updateLayout**(`processChildren`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
+
+*Defined in [card-elements.ts:728](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L728)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`processChildren` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  validateProperties
+
+▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
+
+*Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
+
+*Defined in [card-elements.ts:284](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L284)*
+
+**Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/factsetconfig.md
+++ b/source/nodejs/adaptivecards/docs/classes/factsetconfig.md
@@ -1,0 +1,59 @@
+[Adaptive Cards Javascript SDK](../README.md) › [FactSetConfig](factsetconfig.md)
+
+# Class: FactSetConfig
+
+## Hierarchy
+
+* **FactSetConfig**
+
+## Index
+
+### Constructors
+
+* [constructor](factsetconfig.md#constructor)
+
+### Properties
+
+* [spacing](factsetconfig.md#spacing)
+* [title](factsetconfig.md#title)
+* [value](factsetconfig.md#value)
+
+## Constructors
+
+###  constructor
+
+\+ **new FactSetConfig**(`obj?`: any): *[FactSetConfig](factsetconfig.md)*
+
+*Defined in [host-config.ts:147](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L147)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`obj?` | any |
+
+**Returns:** *[FactSetConfig](factsetconfig.md)*
+
+## Properties
+
+###  spacing
+
+• **spacing**: *number* = 10
+
+*Defined in [host-config.ts:147](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L147)*
+
+___
+
+###  title
+
+• **title**: *[FactTitleDefinition](facttitledefinition.md)* = new FactTitleDefinition()
+
+*Defined in [host-config.ts:145](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L145)*
+
+___
+
+###  value
+
+• **value**: *[FactTextDefinition](facttextdefinition.md)* = new FactTextDefinition()
+
+*Defined in [host-config.ts:146](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L146)*

--- a/source/nodejs/adaptivecards/docs/classes/facttextdefinition.md
+++ b/source/nodejs/adaptivecards/docs/classes/facttextdefinition.md
@@ -1,0 +1,104 @@
+[Adaptive Cards Javascript SDK](../README.md) › [FactTextDefinition](facttextdefinition.md)
+
+# Class: FactTextDefinition
+
+## Hierarchy
+
+* **FactTextDefinition**
+
+  ↳ [FactTitleDefinition](facttitledefinition.md)
+
+## Index
+
+### Constructors
+
+* [constructor](facttextdefinition.md#constructor)
+
+### Properties
+
+* [color](facttextdefinition.md#color)
+* [isSubtle](facttextdefinition.md#issubtle)
+* [size](facttextdefinition.md#size)
+* [weight](facttextdefinition.md#weight)
+* [wrap](facttextdefinition.md#wrap)
+
+### Methods
+
+* [getDefaultWeight](facttextdefinition.md#getdefaultweight)
+* [toJSON](facttextdefinition.md#tojson)
+
+## Constructors
+
+###  constructor
+
+\+ **new FactTextDefinition**(`obj?`: any): *[FactTextDefinition](facttextdefinition.md)*
+
+*Defined in [host-config.ts:99](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L99)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`obj?` | any |
+
+**Returns:** *[FactTextDefinition](facttextdefinition.md)*
+
+## Properties
+
+###  color
+
+• **color**: *[TextColor](../enums/textcolor.md)* = Enums.TextColor.Default
+
+*Defined in [host-config.ts:96](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L96)*
+
+___
+
+###  isSubtle
+
+• **isSubtle**: *boolean* = false
+
+*Defined in [host-config.ts:97](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L97)*
+
+___
+
+###  size
+
+• **size**: *[TextSize](../enums/textsize.md)* = Enums.TextSize.Default
+
+*Defined in [host-config.ts:95](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L95)*
+
+___
+
+###  weight
+
+• **weight**: *[TextWeight](../enums/textweight.md)* = Enums.TextWeight.Default
+
+*Defined in [host-config.ts:98](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L98)*
+
+___
+
+###  wrap
+
+• **wrap**: *boolean* = true
+
+*Defined in [host-config.ts:99](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L99)*
+
+## Methods
+
+###  getDefaultWeight
+
+▸ **getDefaultWeight**(): *[TextWeight](../enums/textweight.md)*
+
+*Defined in [host-config.ts:111](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L111)*
+
+**Returns:** *[TextWeight](../enums/textweight.md)*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Defined in [host-config.ts:115](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L115)*
+
+**Returns:** *any*

--- a/source/nodejs/adaptivecards/docs/classes/facttitledefinition.md
+++ b/source/nodejs/adaptivecards/docs/classes/facttitledefinition.md
@@ -1,0 +1,129 @@
+[Adaptive Cards Javascript SDK](../README.md) › [FactTitleDefinition](facttitledefinition.md)
+
+# Class: FactTitleDefinition
+
+## Hierarchy
+
+* [FactTextDefinition](facttextdefinition.md)
+
+  ↳ **FactTitleDefinition**
+
+## Index
+
+### Constructors
+
+* [constructor](facttitledefinition.md#constructor)
+
+### Properties
+
+* [color](facttitledefinition.md#color)
+* [isSubtle](facttitledefinition.md#issubtle)
+* [maxWidth](facttitledefinition.md#optional-maxwidth)
+* [size](facttitledefinition.md#size)
+* [weight](facttitledefinition.md#weight)
+* [wrap](facttitledefinition.md#wrap)
+
+### Methods
+
+* [getDefaultWeight](facttitledefinition.md#getdefaultweight)
+* [toJSON](facttitledefinition.md#tojson)
+
+## Constructors
+
+###  constructor
+
+\+ **new FactTitleDefinition**(`obj?`: any): *[FactTitleDefinition](facttitledefinition.md)*
+
+*Overrides [FactTextDefinition](facttextdefinition.md).[constructor](facttextdefinition.md#constructor)*
+
+*Defined in [host-config.ts:128](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L128)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`obj?` | any |
+
+**Returns:** *[FactTitleDefinition](facttitledefinition.md)*
+
+## Properties
+
+###  color
+
+• **color**: *[TextColor](../enums/textcolor.md)* = Enums.TextColor.Default
+
+*Inherited from [FactTextDefinition](facttextdefinition.md).[color](facttextdefinition.md#color)*
+
+*Defined in [host-config.ts:96](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L96)*
+
+___
+
+###  isSubtle
+
+• **isSubtle**: *boolean* = false
+
+*Inherited from [FactTextDefinition](facttextdefinition.md).[isSubtle](facttextdefinition.md#issubtle)*
+
+*Defined in [host-config.ts:97](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L97)*
+
+___
+
+### `Optional` maxWidth
+
+• **maxWidth**? : *number* = 150
+
+*Defined in [host-config.ts:127](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L127)*
+
+___
+
+###  size
+
+• **size**: *[TextSize](../enums/textsize.md)* = Enums.TextSize.Default
+
+*Inherited from [FactTextDefinition](facttextdefinition.md).[size](facttextdefinition.md#size)*
+
+*Defined in [host-config.ts:95](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L95)*
+
+___
+
+###  weight
+
+• **weight**: *[TextWeight](../enums/textweight.md)* = Enums.TextWeight.Bolder
+
+*Overrides [FactTextDefinition](facttextdefinition.md).[weight](facttextdefinition.md#weight)*
+
+*Defined in [host-config.ts:128](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L128)*
+
+___
+
+###  wrap
+
+• **wrap**: *boolean* = true
+
+*Inherited from [FactTextDefinition](facttextdefinition.md).[wrap](facttextdefinition.md#wrap)*
+
+*Defined in [host-config.ts:99](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L99)*
+
+## Methods
+
+###  getDefaultWeight
+
+▸ **getDefaultWeight**(): *[TextWeight](../enums/textweight.md)*
+
+*Overrides [FactTextDefinition](facttextdefinition.md).[getDefaultWeight](facttextdefinition.md#getdefaultweight)*
+
+*Defined in [host-config.ts:139](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L139)*
+
+**Returns:** *[TextWeight](../enums/textweight.md)*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Inherited from [FactTextDefinition](facttextdefinition.md).[toJSON](facttextdefinition.md#tojson)*
+
+*Defined in [host-config.ts:115](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L115)*
+
+**Returns:** *any*

--- a/source/nodejs/adaptivecards/docs/classes/fonttypedefinition.md
+++ b/source/nodejs/adaptivecards/docs/classes/fonttypedefinition.md
@@ -1,0 +1,139 @@
+[Adaptive Cards Javascript SDK](../README.md) › [FontTypeDefinition](fonttypedefinition.md)
+
+# Class: FontTypeDefinition
+
+## Hierarchy
+
+* **FontTypeDefinition**
+
+## Index
+
+### Constructors
+
+* [constructor](fonttypedefinition.md#constructor)
+
+### Properties
+
+* [fontFamily](fonttypedefinition.md#optional-fontfamily)
+* [monospace](fonttypedefinition.md#static-monospace)
+
+### Methods
+
+* [parse](fonttypedefinition.md#parse)
+
+### Object literals
+
+* [fontSizes](fonttypedefinition.md#fontsizes)
+* [fontWeights](fonttypedefinition.md#fontweights)
+
+## Constructors
+
+###  constructor
+
+\+ **new FontTypeDefinition**(`fontFamily?`: string): *[FontTypeDefinition](fonttypedefinition.md)*
+
+*Defined in [host-config.ts:569](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L569)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`fontFamily?` | string |
+
+**Returns:** *[FontTypeDefinition](fonttypedefinition.md)*
+
+## Properties
+
+### `Optional` fontFamily
+
+• **fontFamily**? : *string* = "Segoe UI,Segoe,Segoe WP,Helvetica Neue,Helvetica,sans-serif"
+
+*Defined in [host-config.ts:555](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L555)*
+
+___
+
+### `Static` monospace
+
+▪ **monospace**: *[FontTypeDefinition](fonttypedefinition.md)‹›* = new FontTypeDefinition("'Courier New', Courier, monospace")
+
+*Defined in [host-config.ts:553](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L553)*
+
+## Methods
+
+###  parse
+
+▸ **parse**(`obj?`: any): *void*
+
+*Defined in [host-config.ts:577](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L577)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`obj?` | any |
+
+**Returns:** *void*
+
+## Object literals
+
+###  fontSizes
+
+### ▪ **fontSizes**: *object*
+
+*Defined in [host-config.ts:557](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L557)*
+
+###  default
+
+• **default**: *number* = 14
+
+*Defined in [host-config.ts:559](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L559)*
+
+###  extraLarge
+
+• **extraLarge**: *number* = 26
+
+*Defined in [host-config.ts:562](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L562)*
+
+###  large
+
+• **large**: *number* = 21
+
+*Defined in [host-config.ts:561](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L561)*
+
+###  medium
+
+• **medium**: *number* = 17
+
+*Defined in [host-config.ts:560](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L560)*
+
+###  small
+
+• **small**: *number* = 12
+
+*Defined in [host-config.ts:558](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L558)*
+
+___
+
+###  fontWeights
+
+### ▪ **fontWeights**: *object*
+
+*Defined in [host-config.ts:565](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L565)*
+
+###  bolder
+
+• **bolder**: *number* = 600
+
+*Defined in [host-config.ts:568](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L568)*
+
+###  default
+
+• **default**: *number* = 400
+
+*Defined in [host-config.ts:567](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L567)*
+
+###  lighter
+
+• **lighter**: *number* = 200
+
+*Defined in [host-config.ts:566](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L566)*

--- a/source/nodejs/adaptivecards/docs/classes/fonttypeset.md
+++ b/source/nodejs/adaptivecards/docs/classes/fonttypeset.md
@@ -1,0 +1,70 @@
+[Adaptive Cards Javascript SDK](../README.md) › [FontTypeSet](fonttypeset.md)
+
+# Class: FontTypeSet
+
+## Hierarchy
+
+* **FontTypeSet**
+
+## Index
+
+### Constructors
+
+* [constructor](fonttypeset.md#constructor)
+
+### Properties
+
+* [default](fonttypeset.md#default)
+* [monospace](fonttypeset.md#monospace)
+
+### Methods
+
+* [getStyleDefinition](fonttypeset.md#getstyledefinition)
+
+## Constructors
+
+###  constructor
+
+\+ **new FontTypeSet**(`obj?`: any): *[FontTypeSet](fonttypeset.md)*
+
+*Defined in [host-config.ts:596](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L596)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`obj?` | any |
+
+**Returns:** *[FontTypeSet](fonttypeset.md)*
+
+## Properties
+
+###  default
+
+• **default**: *[FontTypeDefinition](fonttypedefinition.md)*
+
+*Defined in [host-config.ts:595](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L595)*
+
+___
+
+###  monospace
+
+• **monospace**: *[FontTypeDefinition](fonttypedefinition.md)*
+
+*Defined in [host-config.ts:596](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L596)*
+
+## Methods
+
+###  getStyleDefinition
+
+▸ **getStyleDefinition**(`style`: [FontType](../enums/fonttype.md)): *[FontTypeDefinition](fonttypedefinition.md)*
+
+*Defined in [host-config.ts:608](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L608)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`style` | [FontType](../enums/fonttype.md) |
+
+**Returns:** *[FontTypeDefinition](fonttypedefinition.md)*

--- a/source/nodejs/adaptivecards/docs/classes/hostcapabilities.md
+++ b/source/nodejs/adaptivecards/docs/classes/hostcapabilities.md
@@ -1,0 +1,77 @@
+[Adaptive Cards Javascript SDK](../README.md) › [HostCapabilities](hostcapabilities.md)
+
+# Class: HostCapabilities
+
+## Hierarchy
+
+* **HostCapabilities**
+
+## Index
+
+### Properties
+
+* [capabilities](hostcapabilities.md#capabilities)
+
+### Methods
+
+* [areAllMet](hostcapabilities.md#areallmet)
+* [hasCapability](hostcapabilities.md#hascapability)
+* [parse](hostcapabilities.md#parse)
+
+## Properties
+
+###  capabilities
+
+• **capabilities**: *[HostCapabilityMap](../README.md#hostcapabilitymap)* = null
+
+*Defined in [host-config.ts:490](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L490)*
+
+## Methods
+
+###  areAllMet
+
+▸ **areAllMet**(`hostCapabilities`: [HostCapabilities](hostcapabilities.md)): *boolean*
+
+*Defined in [host-config.ts:525](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L525)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`hostCapabilities` | [HostCapabilities](hostcapabilities.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  hasCapability
+
+▸ **hasCapability**(`name`: string, `version`: [HostCapabilityVersion](../README.md#hostcapabilityversion)): *boolean*
+
+*Defined in [host-config.ts:513](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L513)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`version` | [HostCapabilityVersion](../README.md#hostcapabilityversion) |
+
+**Returns:** *boolean*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Defined in [host-config.ts:492](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L492)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*

--- a/source/nodejs/adaptivecards/docs/classes/hostconfig.md
+++ b/source/nodejs/adaptivecards/docs/classes/hostconfig.md
@@ -1,0 +1,381 @@
+[Adaptive Cards Javascript SDK](../README.md) › [HostConfig](hostconfig.md)
+
+# Class: HostConfig
+
+## Hierarchy
+
+* **HostConfig**
+
+## Index
+
+### Constructors
+
+* [constructor](hostconfig.md#constructor)
+
+### Properties
+
+* [actions](hostconfig.md#actions)
+* [adaptiveCard](hostconfig.md#adaptivecard)
+* [alwaysAllowBleed](hostconfig.md#alwaysallowbleed)
+* [choiceSetInputValueSeparator](hostconfig.md#choicesetinputvalueseparator)
+* [containerStyles](hostconfig.md#containerstyles)
+* [cssClassNamePrefix](hostconfig.md#cssclassnameprefix)
+* [factSet](hostconfig.md#factset)
+* [fontTypes](hostconfig.md#fonttypes)
+* [hostCapabilities](hostconfig.md#hostcapabilities)
+* [imageSet](hostconfig.md#imageset)
+* [lineHeights](hostconfig.md#optional-lineheights)
+* [media](hostconfig.md#media)
+* [supportsInteractivity](hostconfig.md#supportsinteractivity)
+
+### Accessors
+
+* [fontFamily](hostconfig.md#fontfamily)
+* [fontSizes](hostconfig.md#fontsizes)
+* [fontWeights](hostconfig.md#fontweights)
+
+### Methods
+
+* [getEffectiveSpacing](hostconfig.md#geteffectivespacing)
+* [getFontTypeDefinition](hostconfig.md#getfonttypedefinition)
+* [makeCssClassName](hostconfig.md#makecssclassname)
+* [makeCssClassNames](hostconfig.md#makecssclassnames)
+* [paddingDefinitionToSpacingDefinition](hostconfig.md#paddingdefinitiontospacingdefinition)
+
+### Object literals
+
+* [imageSizes](hostconfig.md#imagesizes)
+* [separator](hostconfig.md#separator)
+* [spacing](hostconfig.md#spacing)
+
+## Constructors
+
+###  constructor
+
+\+ **new HostConfig**(`obj?`: any): *[HostConfig](hostconfig.md)*
+
+*Defined in [host-config.ts:657](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L657)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`obj?` | any |
+
+**Returns:** *[HostConfig](hostconfig.md)*
+
+## Properties
+
+###  actions
+
+• **actions**: *[ActionsConfig](actionsconfig.md)* = new ActionsConfig()
+
+*Defined in [host-config.ts:650](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L650)*
+
+___
+
+###  adaptiveCard
+
+• **adaptiveCard**: *[AdaptiveCardConfig](adaptivecardconfig.md)* = new AdaptiveCardConfig()
+
+*Defined in [host-config.ts:651](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L651)*
+
+___
+
+###  alwaysAllowBleed
+
+• **alwaysAllowBleed**: *boolean* = false
+
+*Defined in [host-config.ts:657](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L657)*
+
+___
+
+###  choiceSetInputValueSeparator
+
+• **choiceSetInputValueSeparator**: *string* = ","
+
+*Defined in [host-config.ts:624](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L624)*
+
+___
+
+###  containerStyles
+
+• **containerStyles**: *[ContainerStyleSet](containerstyleset.md)* = new ContainerStyleSet()
+
+*Defined in [host-config.ts:649](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L649)*
+
+___
+
+###  cssClassNamePrefix
+
+• **cssClassNamePrefix**: *string* = null
+
+*Defined in [host-config.ts:656](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L656)*
+
+___
+
+###  factSet
+
+• **factSet**: *[FactSetConfig](factsetconfig.md)* = new FactSetConfig()
+
+*Defined in [host-config.ts:654](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L654)*
+
+___
+
+###  fontTypes
+
+• **fontTypes**: *[FontTypeSet](fonttypeset.md)* = null
+
+*Defined in [host-config.ts:627](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L627)*
+
+___
+
+###  hostCapabilities
+
+• **hostCapabilities**: *[HostCapabilities](hostcapabilities.md)‹›* = new HostCapabilities()
+
+*Defined in [host-config.ts:620](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L620)*
+
+___
+
+###  imageSet
+
+• **imageSet**: *[ImageSetConfig](imagesetconfig.md)* = new ImageSetConfig()
+
+*Defined in [host-config.ts:652](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L652)*
+
+___
+
+### `Optional` lineHeights
+
+• **lineHeights**? : *[ILineHeightDefinitions](../interfaces/ilineheightdefinitions.md)*
+
+*Defined in [host-config.ts:626](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L626)*
+
+___
+
+###  media
+
+• **media**: *[MediaConfig](mediaconfig.md)* = new MediaConfig()
+
+*Defined in [host-config.ts:653](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L653)*
+
+___
+
+###  supportsInteractivity
+
+• **supportsInteractivity**: *boolean* = true
+
+*Defined in [host-config.ts:625](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L625)*
+
+## Accessors
+
+###  fontFamily
+
+• **get fontFamily**(): *string*
+
+*Defined in [host-config.ts:765](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L765)*
+
+**Returns:** *string*
+
+• **set fontFamily**(`value`: string): *void*
+
+*Defined in [host-config.ts:769](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L769)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  fontSizes
+
+• **get fontSizes**(): *[IFontSizeDefinitions](../interfaces/ifontsizedefinitions.md)*
+
+*Defined in [host-config.ts:773](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L773)*
+
+**Returns:** *[IFontSizeDefinitions](../interfaces/ifontsizedefinitions.md)*
+
+___
+
+###  fontWeights
+
+• **get fontWeights**(): *[IFontWeightDefinitions](../interfaces/ifontweightdefinitions.md)*
+
+*Defined in [host-config.ts:777](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L777)*
+
+**Returns:** *[IFontWeightDefinitions](../interfaces/ifontweightdefinitions.md)*
+
+## Methods
+
+###  getEffectiveSpacing
+
+▸ **getEffectiveSpacing**(`spacing`: [Spacing](../enums/spacing.md)): *number*
+
+*Defined in [host-config.ts:722](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L722)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`spacing` | [Spacing](../enums/spacing.md) |
+
+**Returns:** *number*
+
+___
+
+###  getFontTypeDefinition
+
+▸ **getFontTypeDefinition**(`style?`: [FontType](../enums/fonttype.md)): *[FontTypeDefinition](fonttypedefinition.md)*
+
+*Defined in [host-config.ts:713](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L713)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`style?` | [FontType](../enums/fonttype.md) |
+
+**Returns:** *[FontTypeDefinition](fonttypedefinition.md)*
+
+___
+
+###  makeCssClassName
+
+▸ **makeCssClassName**(...`classNames`: string[]): *string*
+
+*Defined in [host-config.ts:759](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L759)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`...classNames` | string[] |
+
+**Returns:** *string*
+
+___
+
+###  makeCssClassNames
+
+▸ **makeCssClassNames**(...`classNames`: string[]): *string[]*
+
+*Defined in [host-config.ts:749](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L749)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`...classNames` | string[] |
+
+**Returns:** *string[]*
+
+___
+
+###  paddingDefinitionToSpacingDefinition
+
+▸ **paddingDefinitionToSpacingDefinition**(`paddingDefinition`: [PaddingDefinition](paddingdefinition.md)): *[SpacingDefinition](spacingdefinition.md)*
+
+*Defined in [host-config.ts:741](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L741)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`paddingDefinition` | [PaddingDefinition](paddingdefinition.md) |
+
+**Returns:** *[SpacingDefinition](spacingdefinition.md)*
+
+## Object literals
+
+###  imageSizes
+
+### ▪ **imageSizes**: *object*
+
+*Defined in [host-config.ts:643](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L643)*
+
+###  large
+
+• **large**: *number* = 160
+
+*Defined in [host-config.ts:646](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L646)*
+
+###  medium
+
+• **medium**: *number* = 80
+
+*Defined in [host-config.ts:645](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L645)*
+
+###  small
+
+• **small**: *number* = 40
+
+*Defined in [host-config.ts:644](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L644)*
+
+___
+
+###  separator
+
+### ▪ **separator**: *object*
+
+*Defined in [host-config.ts:638](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L638)*
+
+###  lineColor
+
+• **lineColor**: *string* = "#EEEEEE"
+
+*Defined in [host-config.ts:640](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L640)*
+
+###  lineThickness
+
+• **lineThickness**: *number* = 1
+
+*Defined in [host-config.ts:639](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L639)*
+
+___
+
+###  spacing
+
+### ▪ **spacing**: *object*
+
+*Defined in [host-config.ts:629](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L629)*
+
+###  default
+
+• **default**: *number* = 8
+
+*Defined in [host-config.ts:631](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L631)*
+
+###  extraLarge
+
+• **extraLarge**: *number* = 40
+
+*Defined in [host-config.ts:634](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L634)*
+
+###  large
+
+• **large**: *number* = 30
+
+*Defined in [host-config.ts:633](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L633)*
+
+###  medium
+
+• **medium**: *number* = 20
+
+*Defined in [host-config.ts:632](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L632)*
+
+###  padding
+
+• **padding**: *number* = 15
+
+*Defined in [host-config.ts:635](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L635)*
+
+###  small
+
+• **small**: *number* = 3
+
+*Defined in [host-config.ts:630](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L630)*

--- a/source/nodejs/adaptivecards/docs/classes/httpaction.md
+++ b/source/nodejs/adaptivecards/docs/classes/httpaction.md
@@ -1,0 +1,634 @@
+[Adaptive Cards Javascript SDK](../README.md) › [HttpAction](httpaction.md)
+
+# Class: HttpAction
+
+## Hierarchy
+
+  ↳ [Action](action.md)
+
+  ↳ **HttpAction**
+
+## Index
+
+### Properties
+
+* [iconUrl](httpaction.md#iconurl)
+* [id](httpaction.md#id)
+* [method](httpaction.md#method)
+* [onExecute](httpaction.md#onexecute)
+* [requires](httpaction.md#requires)
+* [style](httpaction.md#style)
+* [title](httpaction.md#title)
+* [JsonTypeName](httpaction.md#static-jsontypename)
+
+### Accessors
+
+* [body](httpaction.md#body)
+* [headers](httpaction.md#headers)
+* [ignoreInputValidation](httpaction.md#ignoreinputvalidation)
+* [isPrimary](httpaction.md#isprimary)
+* [parent](httpaction.md#parent)
+* [renderedElement](httpaction.md#renderedelement)
+* [url](httpaction.md#url)
+
+### Methods
+
+* [addCssClasses](httpaction.md#protected-addcssclasses)
+* [execute](httpaction.md#execute)
+* [getActionById](httpaction.md#getactionbyid)
+* [getAllInputs](httpaction.md#getallinputs)
+* [getCustomProperty](httpaction.md#getcustomproperty)
+* [getHref](httpaction.md#gethref)
+* [getJsonTypeName](httpaction.md#getjsontypename)
+* [getReferencedInputs](httpaction.md#getreferencedinputs)
+* [getResourceInformation](httpaction.md#getresourceinformation)
+* [internalGetReferencedInputs](httpaction.md#protected-internalgetreferencedinputs)
+* [internalPrepareForExecution](httpaction.md#protected-internalprepareforexecution)
+* [internalValidateInputs](httpaction.md#protected-internalvalidateinputs)
+* [internalValidateProperties](httpaction.md#internalvalidateproperties)
+* [parse](httpaction.md#parse)
+* [prepareForExecution](httpaction.md#prepareforexecution)
+* [remove](httpaction.md#remove)
+* [render](httpaction.md#render)
+* [setCustomProperty](httpaction.md#setcustomproperty)
+* [setParent](httpaction.md#setparent)
+* [shouldFallback](httpaction.md#shouldfallback)
+* [toJSON](httpaction.md#tojson)
+* [validateInputs](httpaction.md#validateinputs)
+* [validateProperties](httpaction.md#validateproperties)
+
+## Properties
+
+###  iconUrl
+
+• **iconUrl**: *string*
+
+*Inherited from [Action](action.md).[iconUrl](action.md#iconurl)*
+
+*Defined in [card-elements.ts:3905](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3905)*
+
+___
+
+###  id
+
+• **id**: *string*
+
+*Inherited from [CardObject](cardobject.md).[id](cardobject.md#id)*
+
+*Defined in [card-elements.ts:247](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L247)*
+
+___
+
+###  method
+
+• **method**: *string*
+
+*Defined in [card-elements.ts:4388](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4388)*
+
+___
+
+###  onExecute
+
+• **onExecute**: *function*
+
+*Inherited from [Action](action.md).[onExecute](action.md#onexecute)*
+
+*Defined in [card-elements.ts:3908](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3908)*
+
+#### Type declaration:
+
+▸ (`sender`: [Action](action.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`sender` | [Action](action.md) |
+
+___
+
+###  requires
+
+• **requires**: *[HostCapabilities](hostcapabilities.md)‹›* = new HostConfig.HostCapabilities()
+
+*Inherited from [Action](action.md).[requires](action.md#requires)*
+
+*Defined in [card-elements.ts:3902](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3902)*
+
+___
+
+###  style
+
+• **style**: *string* = Enums.ActionStyle.Default
+
+*Inherited from [Action](action.md).[style](action.md#style)*
+
+*Defined in [card-elements.ts:3906](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3906)*
+
+___
+
+###  title
+
+• **title**: *string*
+
+*Inherited from [Action](action.md).[title](action.md#title)*
+
+*Defined in [card-elements.ts:3904](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3904)*
+
+___
+
+### `Static` JsonTypeName
+
+▪ **JsonTypeName**: *"Action.Http"* = "Action.Http"
+
+*Defined in [card-elements.ts:4351](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4351)*
+
+## Accessors
+
+###  body
+
+• **get body**(): *string*
+
+*Defined in [card-elements.ts:4468](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4468)*
+
+**Returns:** *string*
+
+• **set body**(`value`: string): *void*
+
+*Defined in [card-elements.ts:4472](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4472)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  headers
+
+• **get headers**(): *Array‹[HttpHeader](httpheader.md)›*
+
+*Defined in [card-elements.ts:4476](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4476)*
+
+**Returns:** *Array‹[HttpHeader](httpheader.md)›*
+
+• **set headers**(`value`: Array‹[HttpHeader](httpheader.md)›): *void*
+
+*Defined in [card-elements.ts:4480](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4480)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | Array‹[HttpHeader](httpheader.md)› |
+
+**Returns:** *void*
+
+___
+
+###  ignoreInputValidation
+
+• **get ignoreInputValidation**(): *boolean*
+
+*Overrides [Action](action.md).[ignoreInputValidation](action.md#ignoreinputvalidation)*
+
+*Defined in [card-elements.ts:4452](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4452)*
+
+**Returns:** *boolean*
+
+• **set ignoreInputValidation**(`value`: boolean): *void*
+
+*Overrides [Action](action.md).[ignoreInputValidation](action.md#ignoreinputvalidation)*
+
+*Defined in [card-elements.ts:4456](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4456)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  isPrimary
+
+• **get isPrimary**(): *boolean*
+
+*Inherited from [Action](action.md).[isPrimary](action.md#isprimary)*
+
+*Defined in [card-elements.ts:4073](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4073)*
+
+**Returns:** *boolean*
+
+• **set isPrimary**(`value`: boolean): *void*
+
+*Inherited from [Action](action.md).[isPrimary](action.md#isprimary)*
+
+*Defined in [card-elements.ts:4077](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4077)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  parent
+
+• **get parent**(): *[CardElement](cardelement.md)*
+
+*Inherited from [Action](action.md).[parent](action.md#parent)*
+
+*Defined in [card-elements.ts:4092](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4092)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  renderedElement
+
+• **get renderedElement**(): *HTMLElement*
+
+*Inherited from [Action](action.md).[renderedElement](action.md#renderedelement)*
+
+*Defined in [card-elements.ts:4096](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4096)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  url
+
+• **get url**(): *string*
+
+*Defined in [card-elements.ts:4460](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4460)*
+
+**Returns:** *string*
+
+• **set url**(`value`: string): *void*
+
+*Defined in [card-elements.ts:4464](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4464)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+## Methods
+
+### `Protected` addCssClasses
+
+▸ **addCssClasses**(`element`: HTMLElement): *void*
+
+*Inherited from [Action](action.md).[addCssClasses](action.md#protected-addcssclasses)*
+
+*Defined in [card-elements.ts:3872](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3872)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+###  execute
+
+▸ **execute**(): *void*
+
+*Inherited from [Action](action.md).[execute](action.md#execute)*
+
+*Defined in [card-elements.ts:3992](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3992)*
+
+**Returns:** *void*
+
+___
+
+###  getActionById
+
+▸ **getActionById**(`id`: string): *[Action](action.md)*
+
+*Inherited from [Action](action.md).[getActionById](action.md#getactionbyid)*
+
+*Defined in [card-elements.ts:4055](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4055)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getAllInputs
+
+▸ **getAllInputs**(): *Array‹[Input](input.md)›*
+
+*Inherited from [Action](action.md).[getAllInputs](action.md#getallinputs)*
+
+*Defined in [card-elements.ts:4042](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4042)*
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+###  getHref
+
+▸ **getHref**(): *string*
+
+*Inherited from [Action](action.md).[getHref](action.md#gethref)*
+
+*Defined in [card-elements.ts:3910](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3910)*
+
+**Returns:** *string*
+
+___
+
+###  getJsonTypeName
+
+▸ **getJsonTypeName**(): *string*
+
+*Overrides [Action](action.md).[getJsonTypeName](action.md#abstract-getjsontypename)*
+
+*Defined in [card-elements.ts:4390](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4390)*
+
+**Returns:** *string*
+
+___
+
+###  getReferencedInputs
+
+▸ **getReferencedInputs**(): *Shared.Dictionary‹[Input](input.md)›*
+
+*Inherited from [Action](action.md).[getReferencedInputs](action.md#getreferencedinputs)*
+
+*Defined in [card-elements.ts:4061](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4061)*
+
+**Returns:** *Shared.Dictionary‹[Input](input.md)›*
+
+___
+
+###  getResourceInformation
+
+▸ **getResourceInformation**(): *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+*Inherited from [Action](action.md).[getResourceInformation](action.md#getresourceinformation)*
+
+*Defined in [card-elements.ts:4046](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4046)*
+
+**Returns:** *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+___
+
+### `Protected` internalGetReferencedInputs
+
+▸ **internalGetReferencedInputs**(`allInputs`: Array‹[Input](input.md)›): *Shared.Dictionary‹[Input](input.md)›*
+
+*Overrides [Action](action.md).[internalGetReferencedInputs](action.md#protected-internalgetreferencedinputs)*
+
+*Defined in [card-elements.ts:4358](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4358)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`allInputs` | Array‹[Input](input.md)› |
+
+**Returns:** *Shared.Dictionary‹[Input](input.md)›*
+
+___
+
+### `Protected` internalPrepareForExecution
+
+▸ **internalPrepareForExecution**(`inputs`: Shared.Dictionary‹[Input](input.md)›): *void*
+
+*Overrides [Action](action.md).[internalPrepareForExecution](action.md#protected-internalprepareforexecution)*
+
+*Defined in [card-elements.ts:4372](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4372)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`inputs` | Shared.Dictionary‹[Input](input.md)› |
+
+**Returns:** *void*
+
+___
+
+### `Protected` internalValidateInputs
+
+▸ **internalValidateInputs**(`referencedInputs`: Shared.Dictionary‹[Input](input.md)›): *Array‹[Input](input.md)›*
+
+*Inherited from [Action](action.md).[internalValidateInputs](action.md#protected-internalvalidateinputs)*
+
+*Defined in [card-elements.ts:3884](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3884)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`referencedInputs` | Shared.Dictionary‹[Input](input.md)› |
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+###  internalValidateProperties
+
+▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
+
+*Overrides [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
+
+*Defined in [card-elements.ts:4406](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4406)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [ValidationResults](validationresults.md) |
+
+**Returns:** *void*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Overrides [Action](action.md).[parse](action.md#parse)*
+
+*Defined in [card-elements.ts:4432](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4432)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*
+
+___
+
+###  prepareForExecution
+
+▸ **prepareForExecution**(): *boolean*
+
+*Inherited from [Action](action.md).[prepareForExecution](action.md#prepareforexecution)*
+
+*Defined in [card-elements.ts:4000](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4000)*
+
+**Returns:** *boolean*
+
+___
+
+###  remove
+
+▸ **remove**(): *boolean*
+
+*Inherited from [Action](action.md).[remove](action.md#remove)*
+
+*Defined in [card-elements.ts:4034](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4034)*
+
+**Returns:** *boolean*
+
+___
+
+###  render
+
+▸ **render**(`baseCssClass`: string): *void*
+
+*Inherited from [Action](action.md).[render](action.md#render)*
+
+*Defined in [card-elements.ts:3925](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3925)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`baseCssClass` | string | "ac-pushButton" |
+
+**Returns:** *void*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+###  setParent
+
+▸ **setParent**(`value`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [Action](action.md).[setParent](action.md#setparent)*
+
+*Overrides [CardObject](cardobject.md).[setParent](cardobject.md#abstract-setparent)*
+
+*Defined in [card-elements.ts:3988](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3988)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+###  shouldFallback
+
+▸ **shouldFallback**(): *boolean*
+
+*Inherited from [Action](action.md).[shouldFallback](action.md#shouldfallback)*
+
+*Overrides [CardObject](cardobject.md).[shouldFallback](cardobject.md#abstract-shouldfallback)*
+
+*Defined in [card-elements.ts:4069](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4069)*
+
+**Returns:** *boolean*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [Action](action.md).[toJSON](action.md#tojson)*
+
+*Defined in [card-elements.ts:4394](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4394)*
+
+**Returns:** *any*
+
+___
+
+###  validateInputs
+
+▸ **validateInputs**(): *[Input](input.md)‹›[]*
+
+*Inherited from [Action](action.md).[validateInputs](action.md#validateinputs)*
+
+*Defined in [card-elements.ts:4065](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4065)*
+
+**Returns:** *[Input](input.md)‹›[]*
+
+___
+
+###  validateProperties
+
+▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
+
+*Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
+
+*Defined in [card-elements.ts:284](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L284)*
+
+**Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/httpheader.md
+++ b/source/nodejs/adaptivecards/docs/classes/httpheader.md
@@ -1,0 +1,179 @@
+[Adaptive Cards Javascript SDK](../README.md) › [HttpHeader](httpheader.md)
+
+# Class: HttpHeader
+
+## Hierarchy
+
+* [SerializableObject](serializableobject.md)
+
+  ↳ **HttpHeader**
+
+## Index
+
+### Constructors
+
+* [constructor](httpheader.md#constructor)
+
+### Properties
+
+* [name](httpheader.md#name)
+
+### Accessors
+
+* [value](httpheader.md#value)
+
+### Methods
+
+* [getCustomProperty](httpheader.md#getcustomproperty)
+* [getReferencedInputs](httpheader.md#getreferencedinputs)
+* [parse](httpheader.md#parse)
+* [prepareForExecution](httpheader.md#prepareforexecution)
+* [setCustomProperty](httpheader.md#setcustomproperty)
+* [toJSON](httpheader.md#tojson)
+
+## Constructors
+
+###  constructor
+
+\+ **new HttpHeader**(`name`: string, `value`: string): *[HttpHeader](httpheader.md)*
+
+*Defined in [card-elements.ts:4306](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4306)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`name` | string | "" |
+`value` | string | "" |
+
+**Returns:** *[HttpHeader](httpheader.md)*
+
+## Properties
+
+###  name
+
+• **name**: *string*
+
+*Defined in [card-elements.ts:4306](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4306)*
+
+## Accessors
+
+###  value
+
+• **get value**(): *string*
+
+*Defined in [card-elements.ts:4339](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4339)*
+
+**Returns:** *string*
+
+• **set value**(`newValue`: string): *void*
+
+*Defined in [card-elements.ts:4343](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4343)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`newValue` | string |
+
+**Returns:** *void*
+
+## Methods
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+###  getReferencedInputs
+
+▸ **getReferencedInputs**(`inputs`: Array‹[Input](input.md)›, `referencedInputs`: Shared.Dictionary‹[Input](input.md)›): *void*
+
+*Defined in [card-elements.ts:4331](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4331)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`inputs` | Array‹[Input](input.md)› |
+`referencedInputs` | Shared.Dictionary‹[Input](input.md)› |
+
+**Returns:** *void*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any): *void*
+
+*Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
+
+*Defined in [card-elements.ts:4315](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4315)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+
+**Returns:** *void*
+
+___
+
+###  prepareForExecution
+
+▸ **prepareForExecution**(`inputs`: Shared.Dictionary‹[Input](input.md)›): *void*
+
+*Defined in [card-elements.ts:4335](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4335)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`inputs` | Shared.Dictionary‹[Input](input.md)› |
+
+**Returns:** *void*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
+
+*Defined in [card-elements.ts:4322](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4322)*
+
+**Returns:** *any*

--- a/source/nodejs/adaptivecards/docs/classes/image.md
+++ b/source/nodejs/adaptivecards/docs/classes/image.md
@@ -1,0 +1,1304 @@
+[Adaptive Cards Javascript SDK](../README.md) › [Image](image.md)
+
+# Class: Image
+
+## Hierarchy
+
+  ↳ [CardElement](cardelement.md)
+
+  ↳ **Image**
+
+## Index
+
+### Properties
+
+* [altText](image.md#alttext)
+* [backgroundColor](image.md#backgroundcolor)
+* [customCssSelector](image.md#customcssselector)
+* [height](image.md#height)
+* [horizontalAlignment](image.md#optional-horizontalalignment)
+* [id](image.md#id)
+* [minPixelHeight](image.md#optional-minpixelheight)
+* [pixelHeight](image.md#optional-pixelheight)
+* [pixelWidth](image.md#optional-pixelwidth)
+* [requires](image.md#requires)
+* [separator](image.md#separator)
+* [size](image.md#size)
+* [spacing](image.md#spacing)
+* [style](image.md#style)
+* [url](image.md#url)
+* [width](image.md#width)
+
+### Accessors
+
+* [allowCustomPadding](image.md#protected-allowcustompadding)
+* [defaultStyle](image.md#protected-defaultstyle)
+* [hasVisibleSeparator](image.md#hasvisibleseparator)
+* [hostConfig](image.md#hostconfig)
+* [index](image.md#index)
+* [isInline](image.md#isinline)
+* [isInteractive](image.md#isinteractive)
+* [isStandalone](image.md#isstandalone)
+* [isVisible](image.md#isvisible)
+* [lang](image.md#lang)
+* [parent](image.md#parent)
+* [renderedElement](image.md#renderedelement)
+* [selectAction](image.md#selectaction)
+* [separatorElement](image.md#separatorelement)
+* [separatorOrientation](image.md#protected-separatororientation)
+* [supportsMinHeight](image.md#protected-supportsminheight)
+* [useDefaultSizing](image.md#protected-usedefaultsizing)
+
+### Methods
+
+* [adjustRenderedElementSize](image.md#protected-adjustrenderedelementsize)
+* [applyPadding](image.md#protected-applypadding)
+* [asString](image.md#asstring)
+* [createPlaceholderElement](image.md#protected-createplaceholderelement)
+* [getActionAt](image.md#getactionat)
+* [getActionById](image.md#getactionbyid)
+* [getActionCount](image.md#getactioncount)
+* [getAllInputs](image.md#getallinputs)
+* [getCustomProperty](image.md#getcustomproperty)
+* [getDefaultPadding](image.md#protected-getdefaultpadding)
+* [getEffectivePadding](image.md#geteffectivepadding)
+* [getEffectiveStyle](image.md#geteffectivestyle)
+* [getElementById](image.md#getelementbyid)
+* [getForbiddenActionTypes](image.md#getforbiddenactiontypes)
+* [getForbiddenElementTypes](image.md#getforbiddenelementtypes)
+* [getHasBackground](image.md#protected-gethasbackground)
+* [getImmediateSurroundingPadding](image.md#getimmediatesurroundingpadding)
+* [getJsonTypeName](image.md#getjsontypename)
+* [getPadding](image.md#protected-getpadding)
+* [getParentContainer](image.md#getparentcontainer)
+* [getResourceInformation](image.md#getresourceinformation)
+* [getRootElement](image.md#getrootelement)
+* [indexOf](image.md#indexof)
+* [internalRender](image.md#protected-internalrender)
+* [internalValidateProperties](image.md#internalvalidateproperties)
+* [isAtTheVeryBottom](image.md#isattheverybottom)
+* [isAtTheVeryLeft](image.md#isattheveryleft)
+* [isAtTheVeryRight](image.md#isattheveryright)
+* [isAtTheVeryTop](image.md#isattheverytop)
+* [isBleeding](image.md#isbleeding)
+* [isBleedingAtBottom](image.md#isbleedingatbottom)
+* [isBleedingAtTop](image.md#isbleedingattop)
+* [isBottomElement](image.md#isbottomelement)
+* [isDesignMode](image.md#isdesignmode)
+* [isFirstElement](image.md#isfirstelement)
+* [isHiddenDueToOverflow](image.md#ishiddenduetooverflow)
+* [isLastElement](image.md#islastelement)
+* [isLeftMostElement](image.md#isleftmostelement)
+* [isRendered](image.md#isrendered)
+* [isRightMostElement](image.md#isrightmostelement)
+* [isTopElement](image.md#istopelement)
+* [overrideInternalRender](image.md#protected-overrideinternalrender)
+* [parse](image.md#parse)
+* [remove](image.md#remove)
+* [render](image.md#render)
+* [setCustomProperty](image.md#setcustomproperty)
+* [setPadding](image.md#protected-setpadding)
+* [setParent](image.md#setparent)
+* [setShouldFallback](image.md#setshouldfallback)
+* [shouldFallback](image.md#shouldfallback)
+* [toJSON](image.md#tojson)
+* [truncateOverflow](image.md#protected-truncateoverflow)
+* [undoOverflowTruncation](image.md#protected-undooverflowtruncation)
+* [updateLayout](image.md#updatelayout)
+* [validateProperties](image.md#validateproperties)
+
+## Properties
+
+###  altText
+
+• **altText**: *string* = ""
+
+*Defined in [card-elements.ts:2031](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2031)*
+
+___
+
+###  backgroundColor
+
+• **backgroundColor**: *string*
+
+*Defined in [card-elements.ts:2025](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2025)*
+
+___
+
+###  customCssSelector
+
+• **customCssSelector**: *string* = null
+
+*Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#customcssselector)*
+
+*Defined in [card-elements.ts:507](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L507)*
+
+___
+
+###  height
+
+• **height**: *[CardElementHeight](../README.md#cardelementheight)* = "auto"
+
+*Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
+
+*Defined in [card-elements.ts:508](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L508)*
+
+___
+
+### `Optional` horizontalAlignment
+
+• **horizontalAlignment**? : *[HorizontalAlignment](../enums/horizontalalignment.md)* = null
+
+*Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#optional-horizontalalignment)*
+
+*Defined in [card-elements.ts:504](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L504)*
+
+___
+
+###  id
+
+• **id**: *string*
+
+*Inherited from [CardObject](cardobject.md).[id](cardobject.md#id)*
+
+*Defined in [card-elements.ts:247](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L247)*
+
+___
+
+### `Optional` minPixelHeight
+
+• **minPixelHeight**? : *number* = null
+
+*Inherited from [CardElement](cardelement.md).[minPixelHeight](cardelement.md#optional-minpixelheight)*
+
+*Defined in [card-elements.ts:509](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L509)*
+
+___
+
+### `Optional` pixelHeight
+
+• **pixelHeight**? : *number* = null
+
+*Defined in [card-elements.ts:2030](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2030)*
+
+___
+
+### `Optional` pixelWidth
+
+• **pixelWidth**? : *number* = null
+
+*Defined in [card-elements.ts:2029](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2029)*
+
+___
+
+###  requires
+
+• **requires**: *[HostCapabilities](hostcapabilities.md)‹›* = new HostConfig.HostCapabilities()
+
+*Inherited from [CardElement](cardelement.md).[requires](cardelement.md#requires)*
+
+*Defined in [card-elements.ts:502](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L502)*
+
+___
+
+###  separator
+
+• **separator**: *boolean* = false
+
+*Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
+
+*Defined in [card-elements.ts:506](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L506)*
+
+___
+
+###  size
+
+• **size**: *[Size](../enums/size.md)* = Enums.Size.Auto
+
+*Defined in [card-elements.ts:2027](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2027)*
+
+___
+
+###  spacing
+
+• **spacing**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.Default
+
+*Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
+
+*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
+
+___
+
+###  style
+
+• **style**: *[ImageStyle](../enums/imagestyle.md)* = Enums.ImageStyle.Default
+
+*Defined in [card-elements.ts:2024](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2024)*
+
+___
+
+###  url
+
+• **url**: *string*
+
+*Defined in [card-elements.ts:2026](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2026)*
+
+___
+
+###  width
+
+• **width**: *[SizeAndUnit](sizeandunit.md)*
+
+*Defined in [card-elements.ts:2028](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2028)*
+
+## Accessors
+
+### `Protected` allowCustomPadding
+
+• **get allowCustomPadding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
+
+*Defined in [card-elements.ts:490](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L490)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` defaultStyle
+
+• **get defaultStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
+
+*Defined in [card-elements.ts:498](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L498)*
+
+**Returns:** *string*
+
+___
+
+###  hasVisibleSeparator
+
+• **get hasVisibleSeparator**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
+
+*Defined in [card-elements.ts:928](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L928)*
+
+**Returns:** *boolean*
+
+___
+
+###  hostConfig
+
+• **get hostConfig**(): *[HostConfig](hostconfig.md)*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:881](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L881)*
+
+**Returns:** *[HostConfig](hostconfig.md)*
+
+• **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:895](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L895)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [HostConfig](hostconfig.md) |
+
+**Returns:** *void*
+
+___
+
+###  index
+
+• **get index**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
+
+*Defined in [card-elements.ts:899](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L899)*
+
+**Returns:** *number*
+
+___
+
+###  isInline
+
+• **get isInline**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
+
+*Defined in [card-elements.ts:916](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L916)*
+
+**Returns:** *boolean*
+
+___
+
+###  isInteractive
+
+• **get isInteractive**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
+
+*Defined in [card-elements.ts:908](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L908)*
+
+**Returns:** *boolean*
+
+___
+
+###  isStandalone
+
+• **get isStandalone**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
+
+*Defined in [card-elements.ts:912](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L912)*
+
+**Returns:** *boolean*
+
+___
+
+###  isVisible
+
+• **get isVisible**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:924](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L924)*
+
+**Returns:** *boolean*
+
+• **set isVisible**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:937](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L937)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  lang
+
+• **get lang**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:853](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L853)*
+
+**Returns:** *string*
+
+• **set lang**(`value`: string): *void*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:867](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L867)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  parent
+
+• **get parent**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[parent](cardelement.md#parent)*
+
+*Defined in [card-elements.ts:920](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L920)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  renderedElement
+
+• **get renderedElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[renderedElement](cardelement.md#renderedelement)*
+
+*Defined in [card-elements.ts:956](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L956)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  selectAction
+
+• **get selectAction**(): *[Action](action.md)*
+
+*Defined in [card-elements.ts:2153](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2153)*
+
+**Returns:** *[Action](action.md)*
+
+• **set selectAction**(`value`: [Action](action.md)): *void*
+
+*Defined in [card-elements.ts:2157](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2157)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [Action](action.md) |
+
+**Returns:** *void*
+
+___
+
+###  separatorElement
+
+• **get separatorElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
+
+*Defined in [card-elements.ts:960](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L960)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` separatorOrientation
+
+• **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
+
+*Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
+
+*Defined in [card-elements.ts:494](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L494)*
+
+**Returns:** *[Orientation](../enums/orientation.md)*
+
+___
+
+### `Protected` supportsMinHeight
+
+• **get supportsMinHeight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[supportsMinHeight](cardelement.md#protected-supportsminheight)*
+
+*Defined in [card-elements.ts:482](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L482)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` useDefaultSizing
+
+• **get useDefaultSizing**(): *boolean*
+
+*Overrides [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
+
+*Defined in [card-elements.ts:1921](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1921)*
+
+**Returns:** *boolean*
+
+## Methods
+
+### `Protected` adjustRenderedElementSize
+
+▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
+
+*Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
+
+*Defined in [card-elements.ts:411](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L411)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`renderedElement` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+### `Protected` applyPadding
+
+▸ **applyPadding**(): *void*
+
+*Inherited from [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
+
+*Defined in [card-elements.ts:430](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L430)*
+
+**Returns:** *void*
+
+___
+
+###  asString
+
+▸ **asString**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
+
+*Defined in [card-elements.ts:513](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L513)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` createPlaceholderElement
+
+▸ **createPlaceholderElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
+
+*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  getActionAt
+
+▸ **getActionAt**(`index`: number): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
+
+*Defined in [card-elements.ts:694](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L694)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionById
+
+▸ **getActionById**(`id`: string): *[Action](action.md)‹›*
+
+*Overrides [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
+
+*Defined in [card-elements.ts:2062](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2062)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[Action](action.md)‹›*
+
+___
+
+###  getActionCount
+
+▸ **getActionCount**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
+
+*Defined in [card-elements.ts:690](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L690)*
+
+**Returns:** *number*
+
+___
+
+###  getAllInputs
+
+▸ **getAllInputs**(): *Array‹[Input](input.md)›*
+
+*Inherited from [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
+
+*Defined in [card-elements.ts:823](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L823)*
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+### `Protected` getDefaultPadding
+
+▸ **getDefaultPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
+
+*Defined in [card-elements.ts:466](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L466)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectivePadding
+
+▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
+
+*Defined in [card-elements.ts:847](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L847)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectiveStyle
+
+▸ **getEffectiveStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
+
+*Defined in [card-elements.ts:545](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L545)*
+
+**Returns:** *string*
+
+___
+
+###  getElementById
+
+▸ **getElementById**(`id`: string): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
+
+*Defined in [card-elements.ts:831](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L831)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getForbiddenActionTypes
+
+▸ **getForbiddenActionTypes**(): *Array‹any›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
+
+*Defined in [card-elements.ts:557](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L557)*
+
+**Returns:** *Array‹any›*
+
+___
+
+###  getForbiddenElementTypes
+
+▸ **getForbiddenElementTypes**(): *Array‹string›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenElementTypes](cardelement.md#getforbiddenelementtypes)*
+
+*Defined in [card-elements.ts:553](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L553)*
+
+**Returns:** *Array‹string›*
+
+___
+
+### `Protected` getHasBackground
+
+▸ **getHasBackground**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
+
+*Defined in [card-elements.ts:470](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L470)*
+
+**Returns:** *boolean*
+
+___
+
+###  getImmediateSurroundingPadding
+
+▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
+
+*Defined in [card-elements.ts:561](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L561)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`result` | [PaddingDefinition](paddingdefinition.md) | - |
+`processTop` | boolean | true |
+`processRight` | boolean | true |
+`processBottom` | boolean | true |
+`processLeft` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  getJsonTypeName
+
+▸ **getJsonTypeName**(): *string*
+
+*Overrides [CardElement](cardelement.md).[getJsonTypeName](cardelement.md#abstract-getjsontypename)*
+
+*Defined in [card-elements.ts:2058](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2058)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` getPadding
+
+▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
+
+*Defined in [card-elements.ts:474](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L474)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getParentContainer
+
+▸ **getParentContainer**(): *[Container](container.md)*
+
+*Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
+
+*Defined in [card-elements.ts:809](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L809)*
+
+**Returns:** *[Container](container.md)*
+
+___
+
+###  getResourceInformation
+
+▸ **getResourceInformation**(): *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+*Overrides [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
+
+*Defined in [card-elements.ts:2144](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2144)*
+
+**Returns:** *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+___
+
+###  getRootElement
+
+▸ **getRootElement**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
+
+*Defined in [card-elements.ts:799](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L799)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  indexOf
+
+▸ **indexOf**(`cardElement`: [CardElement](cardelement.md)): *number*
+
+*Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
+
+*Defined in [card-elements.ts:733](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L733)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`cardElement` | [CardElement](cardelement.md) |
+
+**Returns:** *number*
+
+___
+
+### `Protected` internalRender
+
+▸ **internalRender**(): *HTMLElement*
+
+*Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
+
+*Defined in [card-elements.ts:1925](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1925)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  internalValidateProperties
+
+▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
+
+*Inherited from [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
+
+*Defined in [card-elements.ts:249](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L249)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [ValidationResults](validationresults.md) |
+
+**Returns:** *void*
+
+___
+
+###  isAtTheVeryBottom
+
+▸ **isAtTheVeryBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
+
+*Defined in [card-elements.ts:767](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L767)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryLeft
+
+▸ **isAtTheVeryLeft**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
+
+*Defined in [card-elements.ts:755](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L755)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryRight
+
+▸ **isAtTheVeryRight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
+
+*Defined in [card-elements.ts:759](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L759)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryTop
+
+▸ **isAtTheVeryTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
+
+*Defined in [card-elements.ts:763](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L763)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleeding
+
+▸ **isBleeding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
+
+*Defined in [card-elements.ts:517](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L517)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtBottom
+
+▸ **isBleedingAtBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
+
+*Defined in [card-elements.ts:775](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L775)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtTop
+
+▸ **isBleedingAtTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
+
+*Defined in [card-elements.ts:771](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L771)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBottomElement
+
+▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
+
+*Defined in [card-elements.ts:791](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L791)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isDesignMode
+
+▸ **isDesignMode**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
+
+*Defined in [card-elements.ts:737](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L737)*
+
+**Returns:** *boolean*
+
+___
+
+###  isFirstElement
+
+▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
+
+*Defined in [card-elements.ts:747](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L747)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isHiddenDueToOverflow
+
+▸ **isHiddenDueToOverflow**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
+
+*Defined in [card-elements.ts:795](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L795)*
+
+**Returns:** *boolean*
+
+___
+
+###  isLastElement
+
+▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
+
+*Defined in [card-elements.ts:751](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L751)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isLeftMostElement
+
+▸ **isLeftMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
+
+*Defined in [card-elements.ts:779](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L779)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isRendered
+
+▸ **isRendered**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRendered](cardelement.md#isrendered)*
+
+*Defined in [card-elements.ts:743](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L743)*
+
+**Returns:** *boolean*
+
+___
+
+###  isRightMostElement
+
+▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
+
+*Defined in [card-elements.ts:783](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L783)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isTopElement
+
+▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
+
+*Defined in [card-elements.ts:787](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L787)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` overrideInternalRender
+
+▸ **overrideInternalRender**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
+
+*Defined in [card-elements.ts:426](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L426)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Overrides [CardElement](cardelement.md).[parse](cardelement.md#parse)*
+
+*Defined in [card-elements.ts:2072](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2072)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*
+
+___
+
+###  remove
+
+▸ **remove**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
+
+*Defined in [card-elements.ts:698](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L698)*
+
+**Returns:** *boolean*
+
+___
+
+###  render
+
+▸ **render**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[render](cardelement.md#render)*
+
+*Defined in [card-elements.ts:706](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L706)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setPadding
+
+▸ **setPadding**(`value`: [PaddingDefinition](paddingdefinition.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
+
+*Defined in [card-elements.ts:478](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L478)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [PaddingDefinition](paddingdefinition.md) |
+
+**Returns:** *void*
+
+___
+
+###  setParent
+
+▸ **setParent**(`value`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setParent](cardelement.md#setparent)*
+
+*Overrides [CardObject](cardobject.md).[setParent](cardobject.md#abstract-setparent)*
+
+*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+###  setShouldFallback
+
+▸ **setShouldFallback**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[setShouldFallback](cardelement.md#setshouldfallback)*
+
+*Defined in [card-elements.ts:843](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L843)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  shouldFallback
+
+▸ **shouldFallback**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[shouldFallback](cardelement.md#shouldfallback)*
+
+*Overrides [CardObject](cardobject.md).[shouldFallback](cardobject.md#abstract-shouldfallback)*
+
+*Defined in [card-elements.ts:839](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L839)*
+
+**Returns:** *boolean*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [CardElement](cardelement.md).[toJSON](cardelement.md#tojson)*
+
+*Defined in [card-elements.ts:2033](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2033)*
+
+**Returns:** *any*
+
+___
+
+### `Protected` truncateOverflow
+
+▸ **truncateOverflow**(`maxHeight`: number): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
+
+*Defined in [card-elements.ts:454](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L454)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`maxHeight` | number |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` undoOverflowTruncation
+
+▸ **undoOverflowTruncation**(): *void*
+
+*Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
+
+*Defined in [card-elements.ts:464](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L464)*
+
+**Returns:** *void*
+
+___
+
+###  updateLayout
+
+▸ **updateLayout**(`processChildren`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
+
+*Defined in [card-elements.ts:728](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L728)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`processChildren` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  validateProperties
+
+▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
+
+*Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
+
+*Defined in [card-elements.ts:284](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L284)*
+
+**Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/imageset.md
+++ b/source/nodejs/adaptivecards/docs/classes/imageset.md
@@ -1,0 +1,1402 @@
+[Adaptive Cards Javascript SDK](../README.md) › [ImageSet](imageset.md)
+
+# Class: ImageSet
+
+## Hierarchy
+
+  ↳ [CardElementContainer](cardelementcontainer.md)
+
+  ↳ **ImageSet**
+
+## Index
+
+### Properties
+
+* [allowVerticalOverflow](imageset.md#allowverticaloverflow)
+* [customCssSelector](imageset.md#customcssselector)
+* [height](imageset.md#height)
+* [horizontalAlignment](imageset.md#optional-horizontalalignment)
+* [id](imageset.md#id)
+* [imageSize](imageset.md#imagesize)
+* [minPixelHeight](imageset.md#optional-minpixelheight)
+* [requires](imageset.md#requires)
+* [separator](imageset.md#separator)
+* [spacing](imageset.md#spacing)
+
+### Accessors
+
+* [allowCustomPadding](imageset.md#protected-allowcustompadding)
+* [defaultStyle](imageset.md#protected-defaultstyle)
+* [hasVisibleSeparator](imageset.md#hasvisibleseparator)
+* [hostConfig](imageset.md#hostconfig)
+* [index](imageset.md#index)
+* [isInline](imageset.md#isinline)
+* [isInteractive](imageset.md#isinteractive)
+* [isSelectable](imageset.md#protected-isselectable)
+* [isStandalone](imageset.md#isstandalone)
+* [isVisible](imageset.md#isvisible)
+* [lang](imageset.md#lang)
+* [parent](imageset.md#parent)
+* [renderedElement](imageset.md#renderedelement)
+* [separatorElement](imageset.md#separatorelement)
+* [separatorOrientation](imageset.md#protected-separatororientation)
+* [supportsMinHeight](imageset.md#protected-supportsminheight)
+* [useDefaultSizing](imageset.md#protected-usedefaultsizing)
+
+### Methods
+
+* [addImage](imageset.md#addimage)
+* [adjustRenderedElementSize](imageset.md#protected-adjustrenderedelementsize)
+* [applyPadding](imageset.md#protected-applypadding)
+* [asString](imageset.md#asstring)
+* [createPlaceholderElement](imageset.md#protected-createplaceholderelement)
+* [getActionAt](imageset.md#getactionat)
+* [getActionById](imageset.md#getactionbyid)
+* [getActionCount](imageset.md#getactioncount)
+* [getAllInputs](imageset.md#getallinputs)
+* [getCustomProperty](imageset.md#getcustomproperty)
+* [getDefaultPadding](imageset.md#protected-getdefaultpadding)
+* [getEffectivePadding](imageset.md#geteffectivepadding)
+* [getEffectiveStyle](imageset.md#geteffectivestyle)
+* [getElementById](imageset.md#getelementbyid)
+* [getFirstVisibleRenderedItem](imageset.md#getfirstvisiblerendereditem)
+* [getForbiddenActionTypes](imageset.md#getforbiddenactiontypes)
+* [getForbiddenElementTypes](imageset.md#getforbiddenelementtypes)
+* [getHasBackground](imageset.md#protected-gethasbackground)
+* [getImmediateSurroundingPadding](imageset.md#getimmediatesurroundingpadding)
+* [getItemAt](imageset.md#getitemat)
+* [getItemCount](imageset.md#getitemcount)
+* [getJsonTypeName](imageset.md#getjsontypename)
+* [getLastVisibleRenderedItem](imageset.md#getlastvisiblerendereditem)
+* [getPadding](imageset.md#protected-getpadding)
+* [getParentContainer](imageset.md#getparentcontainer)
+* [getResourceInformation](imageset.md#getresourceinformation)
+* [getRootElement](imageset.md#getrootelement)
+* [getSelectAction](imageset.md#protected-getselectaction)
+* [indexOf](imageset.md#indexof)
+* [internalRender](imageset.md#protected-internalrender)
+* [internalValidateProperties](imageset.md#internalvalidateproperties)
+* [isAtTheVeryBottom](imageset.md#isattheverybottom)
+* [isAtTheVeryLeft](imageset.md#isattheveryleft)
+* [isAtTheVeryRight](imageset.md#isattheveryright)
+* [isAtTheVeryTop](imageset.md#isattheverytop)
+* [isBleeding](imageset.md#isbleeding)
+* [isBleedingAtBottom](imageset.md#isbleedingatbottom)
+* [isBleedingAtTop](imageset.md#isbleedingattop)
+* [isBottomElement](imageset.md#isbottomelement)
+* [isDesignMode](imageset.md#isdesignmode)
+* [isElementAllowed](imageset.md#protected-iselementallowed)
+* [isFirstElement](imageset.md#isfirstelement)
+* [isHiddenDueToOverflow](imageset.md#ishiddenduetooverflow)
+* [isLastElement](imageset.md#islastelement)
+* [isLeftMostElement](imageset.md#isleftmostelement)
+* [isRendered](imageset.md#isrendered)
+* [isRightMostElement](imageset.md#isrightmostelement)
+* [isTopElement](imageset.md#istopelement)
+* [overrideInternalRender](imageset.md#protected-overrideinternalrender)
+* [parse](imageset.md#parse)
+* [remove](imageset.md#remove)
+* [removeItem](imageset.md#removeitem)
+* [render](imageset.md#render)
+* [setCustomProperty](imageset.md#setcustomproperty)
+* [setPadding](imageset.md#protected-setpadding)
+* [setParent](imageset.md#setparent)
+* [setSelectAction](imageset.md#protected-setselectaction)
+* [setShouldFallback](imageset.md#setshouldfallback)
+* [shouldFallback](imageset.md#shouldfallback)
+* [toJSON](imageset.md#tojson)
+* [truncateOverflow](imageset.md#protected-truncateoverflow)
+* [undoOverflowTruncation](imageset.md#protected-undooverflowtruncation)
+* [updateLayout](imageset.md#updatelayout)
+* [validateProperties](imageset.md#validateproperties)
+
+## Properties
+
+###  allowVerticalOverflow
+
+• **allowVerticalOverflow**: *boolean* = false
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[allowVerticalOverflow](cardelementcontainer.md#allowverticaloverflow)*
+
+*Defined in [card-elements.ts:2229](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2229)*
+
+___
+
+###  customCssSelector
+
+• **customCssSelector**: *string* = null
+
+*Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#customcssselector)*
+
+*Defined in [card-elements.ts:507](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L507)*
+
+___
+
+###  height
+
+• **height**: *[CardElementHeight](../README.md#cardelementheight)* = "auto"
+
+*Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
+
+*Defined in [card-elements.ts:508](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L508)*
+
+___
+
+### `Optional` horizontalAlignment
+
+• **horizontalAlignment**? : *[HorizontalAlignment](../enums/horizontalalignment.md)* = null
+
+*Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#optional-horizontalalignment)*
+
+*Defined in [card-elements.ts:504](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L504)*
+
+___
+
+###  id
+
+• **id**: *string*
+
+*Inherited from [CardObject](cardobject.md).[id](cardobject.md#id)*
+
+*Defined in [card-elements.ts:247](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L247)*
+
+___
+
+###  imageSize
+
+• **imageSize**: *[Size](../enums/size.md)* = Enums.Size.Medium
+
+*Defined in [card-elements.ts:2399](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2399)*
+
+___
+
+### `Optional` minPixelHeight
+
+• **minPixelHeight**? : *number* = null
+
+*Inherited from [CardElement](cardelement.md).[minPixelHeight](cardelement.md#optional-minpixelheight)*
+
+*Defined in [card-elements.ts:509](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L509)*
+
+___
+
+###  requires
+
+• **requires**: *[HostCapabilities](hostcapabilities.md)‹›* = new HostConfig.HostCapabilities()
+
+*Inherited from [CardElement](cardelement.md).[requires](cardelement.md#requires)*
+
+*Defined in [card-elements.ts:502](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L502)*
+
+___
+
+###  separator
+
+• **separator**: *boolean* = false
+
+*Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
+
+*Defined in [card-elements.ts:506](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L506)*
+
+___
+
+###  spacing
+
+• **spacing**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.Default
+
+*Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
+
+*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
+
+## Accessors
+
+### `Protected` allowCustomPadding
+
+• **get allowCustomPadding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
+
+*Defined in [card-elements.ts:490](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L490)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` defaultStyle
+
+• **get defaultStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
+
+*Defined in [card-elements.ts:498](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L498)*
+
+**Returns:** *string*
+
+___
+
+###  hasVisibleSeparator
+
+• **get hasVisibleSeparator**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
+
+*Defined in [card-elements.ts:928](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L928)*
+
+**Returns:** *boolean*
+
+___
+
+###  hostConfig
+
+• **get hostConfig**(): *[HostConfig](hostconfig.md)*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:881](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L881)*
+
+**Returns:** *[HostConfig](hostconfig.md)*
+
+• **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:895](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L895)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [HostConfig](hostconfig.md) |
+
+**Returns:** *void*
+
+___
+
+###  index
+
+• **get index**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
+
+*Defined in [card-elements.ts:899](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L899)*
+
+**Returns:** *number*
+
+___
+
+###  isInline
+
+• **get isInline**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
+
+*Defined in [card-elements.ts:916](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L916)*
+
+**Returns:** *boolean*
+
+___
+
+###  isInteractive
+
+• **get isInteractive**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
+
+*Defined in [card-elements.ts:908](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L908)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` isSelectable
+
+• **get isSelectable**(): *boolean*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[isSelectable](cardelementcontainer.md#protected-isselectable)*
+
+*Defined in [card-elements.ts:2219](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2219)*
+
+**Returns:** *boolean*
+
+___
+
+###  isStandalone
+
+• **get isStandalone**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
+
+*Defined in [card-elements.ts:912](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L912)*
+
+**Returns:** *boolean*
+
+___
+
+###  isVisible
+
+• **get isVisible**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:924](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L924)*
+
+**Returns:** *boolean*
+
+• **set isVisible**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:937](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L937)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  lang
+
+• **get lang**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:853](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L853)*
+
+**Returns:** *string*
+
+• **set lang**(`value`: string): *void*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:867](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L867)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  parent
+
+• **get parent**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[parent](cardelement.md#parent)*
+
+*Defined in [card-elements.ts:920](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L920)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  renderedElement
+
+• **get renderedElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[renderedElement](cardelement.md#renderedelement)*
+
+*Defined in [card-elements.ts:956](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L956)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  separatorElement
+
+• **get separatorElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
+
+*Defined in [card-elements.ts:960](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L960)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` separatorOrientation
+
+• **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
+
+*Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
+
+*Defined in [card-elements.ts:494](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L494)*
+
+**Returns:** *[Orientation](../enums/orientation.md)*
+
+___
+
+### `Protected` supportsMinHeight
+
+• **get supportsMinHeight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[supportsMinHeight](cardelement.md#protected-supportsminheight)*
+
+*Defined in [card-elements.ts:482](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L482)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` useDefaultSizing
+
+• **get useDefaultSizing**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
+
+*Defined in [card-elements.ts:486](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L486)*
+
+**Returns:** *boolean*
+
+## Methods
+
+###  addImage
+
+▸ **addImage**(`image`: [Image](image.md)): *void*
+
+*Defined in [card-elements.ts:2476](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2476)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`image` | [Image](image.md) |
+
+**Returns:** *void*
+
+___
+
+### `Protected` adjustRenderedElementSize
+
+▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
+
+*Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
+
+*Defined in [card-elements.ts:411](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L411)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`renderedElement` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+### `Protected` applyPadding
+
+▸ **applyPadding**(): *void*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[applyPadding](cardelementcontainer.md#protected-applypadding)*
+
+*Overrides [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
+
+*Defined in [card-elements.ts:2185](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2185)*
+
+**Returns:** *void*
+
+___
+
+###  asString
+
+▸ **asString**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
+
+*Defined in [card-elements.ts:513](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L513)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` createPlaceholderElement
+
+▸ **createPlaceholderElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
+
+*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  getActionAt
+
+▸ **getActionAt**(`index`: number): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
+
+*Defined in [card-elements.ts:694](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L694)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionById
+
+▸ **getActionById**(`id`: string): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
+
+*Defined in [card-elements.ts:835](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L835)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionCount
+
+▸ **getActionCount**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
+
+*Defined in [card-elements.ts:690](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L690)*
+
+**Returns:** *number*
+
+___
+
+###  getAllInputs
+
+▸ **getAllInputs**(): *Array‹[Input](input.md)›*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[getAllInputs](cardelementcontainer.md#getallinputs)*
+
+*Overrides [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
+
+*Defined in [card-elements.ts:2334](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2334)*
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+### `Protected` getDefaultPadding
+
+▸ **getDefaultPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
+
+*Defined in [card-elements.ts:466](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L466)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectivePadding
+
+▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
+
+*Defined in [card-elements.ts:847](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L847)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectiveStyle
+
+▸ **getEffectiveStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
+
+*Defined in [card-elements.ts:545](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L545)*
+
+**Returns:** *string*
+
+___
+
+###  getElementById
+
+▸ **getElementById**(`id`: string): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[getElementById](cardelementcontainer.md#getelementbyid)*
+
+*Overrides [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
+
+*Defined in [card-elements.ts:2354](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2354)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getFirstVisibleRenderedItem
+
+▸ **getFirstVisibleRenderedItem**(): *[CardElement](cardelement.md)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[getFirstVisibleRenderedItem](cardelementcontainer.md#abstract-getfirstvisiblerendereditem)*
+
+*Defined in [card-elements.ts:2409](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2409)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getForbiddenActionTypes
+
+▸ **getForbiddenActionTypes**(): *Array‹any›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
+
+*Defined in [card-elements.ts:557](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L557)*
+
+**Returns:** *Array‹any›*
+
+___
+
+###  getForbiddenElementTypes
+
+▸ **getForbiddenElementTypes**(): *Array‹string›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenElementTypes](cardelement.md#getforbiddenelementtypes)*
+
+*Defined in [card-elements.ts:553](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L553)*
+
+**Returns:** *Array‹string›*
+
+___
+
+### `Protected` getHasBackground
+
+▸ **getHasBackground**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
+
+*Defined in [card-elements.ts:470](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L470)*
+
+**Returns:** *boolean*
+
+___
+
+###  getImmediateSurroundingPadding
+
+▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
+
+*Defined in [card-elements.ts:561](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L561)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`result` | [PaddingDefinition](paddingdefinition.md) | - |
+`processTop` | boolean | true |
+`processRight` | boolean | true |
+`processBottom` | boolean | true |
+`processLeft` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  getItemAt
+
+▸ **getItemAt**(`index`: number): *[CardElement](cardelement.md)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[getItemAt](cardelementcontainer.md#abstract-getitemat)*
+
+*Defined in [card-elements.ts:2405](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2405)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getItemCount
+
+▸ **getItemCount**(): *number*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[getItemCount](cardelementcontainer.md#abstract-getitemcount)*
+
+*Defined in [card-elements.ts:2401](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2401)*
+
+**Returns:** *number*
+
+___
+
+###  getJsonTypeName
+
+▸ **getJsonTypeName**(): *string*
+
+*Overrides [CardElement](cardelement.md).[getJsonTypeName](cardelement.md#abstract-getjsontypename)*
+
+*Defined in [card-elements.ts:2435](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2435)*
+
+**Returns:** *string*
+
+___
+
+###  getLastVisibleRenderedItem
+
+▸ **getLastVisibleRenderedItem**(): *[CardElement](cardelement.md)*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[getLastVisibleRenderedItem](cardelementcontainer.md#abstract-getlastvisiblerendereditem)*
+
+*Defined in [card-elements.ts:2413](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2413)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+### `Protected` getPadding
+
+▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
+
+*Defined in [card-elements.ts:474](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L474)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getParentContainer
+
+▸ **getParentContainer**(): *[Container](container.md)*
+
+*Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
+
+*Defined in [card-elements.ts:809](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L809)*
+
+**Returns:** *[Container](container.md)*
+
+___
+
+###  getResourceInformation
+
+▸ **getResourceInformation**(): *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[getResourceInformation](cardelementcontainer.md#getresourceinformation)*
+
+*Overrides [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
+
+*Defined in [card-elements.ts:2344](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2344)*
+
+**Returns:** *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+___
+
+###  getRootElement
+
+▸ **getRootElement**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
+
+*Defined in [card-elements.ts:799](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L799)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+### `Protected` getSelectAction
+
+▸ **getSelectAction**(): *[Action](action.md)*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[getSelectAction](cardelementcontainer.md#protected-getselectaction)*
+
+*Defined in [card-elements.ts:2207](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2207)*
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  indexOf
+
+▸ **indexOf**(`cardElement`: [CardElement](cardelement.md)): *number*
+
+*Overrides [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
+
+*Defined in [card-elements.ts:2487](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2487)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`cardElement` | [CardElement](cardelement.md) |
+
+**Returns:** *number*
+
+___
+
+### `Protected` internalRender
+
+▸ **internalRender**(): *HTMLElement*
+
+*Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
+
+*Defined in [card-elements.ts:2374](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2374)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  internalValidateProperties
+
+▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[internalValidateProperties](cardelementcontainer.md#internalvalidateproperties)*
+
+*Overrides [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
+
+*Defined in [card-elements.ts:2254](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2254)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [ValidationResults](validationresults.md) |
+
+**Returns:** *void*
+
+___
+
+###  isAtTheVeryBottom
+
+▸ **isAtTheVeryBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
+
+*Defined in [card-elements.ts:767](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L767)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryLeft
+
+▸ **isAtTheVeryLeft**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
+
+*Defined in [card-elements.ts:755](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L755)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryRight
+
+▸ **isAtTheVeryRight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
+
+*Defined in [card-elements.ts:759](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L759)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryTop
+
+▸ **isAtTheVeryTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
+
+*Defined in [card-elements.ts:763](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L763)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleeding
+
+▸ **isBleeding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
+
+*Defined in [card-elements.ts:517](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L517)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtBottom
+
+▸ **isBleedingAtBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
+
+*Defined in [card-elements.ts:775](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L775)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtTop
+
+▸ **isBleedingAtTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
+
+*Defined in [card-elements.ts:771](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L771)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBottomElement
+
+▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
+
+*Defined in [card-elements.ts:791](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L791)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isDesignMode
+
+▸ **isDesignMode**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
+
+*Defined in [card-elements.ts:737](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L737)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` isElementAllowed
+
+▸ **isElementAllowed**(`element`: [CardElement](cardelement.md), `forbiddenElementTypes`: Array‹string›): *boolean*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[isElementAllowed](cardelementcontainer.md#protected-iselementallowed)*
+
+*Defined in [card-elements.ts:2169](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2169)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+`forbiddenElementTypes` | Array‹string› |
+
+**Returns:** *boolean*
+
+___
+
+###  isFirstElement
+
+▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
+
+*Defined in [card-elements.ts:747](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L747)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isHiddenDueToOverflow
+
+▸ **isHiddenDueToOverflow**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
+
+*Defined in [card-elements.ts:795](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L795)*
+
+**Returns:** *boolean*
+
+___
+
+###  isLastElement
+
+▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
+
+*Defined in [card-elements.ts:751](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L751)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isLeftMostElement
+
+▸ **isLeftMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
+
+*Defined in [card-elements.ts:779](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L779)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isRendered
+
+▸ **isRendered**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRendered](cardelement.md#isrendered)*
+
+*Defined in [card-elements.ts:743](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L743)*
+
+**Returns:** *boolean*
+
+___
+
+###  isRightMostElement
+
+▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
+
+*Defined in [card-elements.ts:783](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L783)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isTopElement
+
+▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
+
+*Defined in [card-elements.ts:787](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L787)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` overrideInternalRender
+
+▸ **overrideInternalRender**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
+
+*Defined in [card-elements.ts:426](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L426)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[parse](cardelementcontainer.md#parse)*
+
+*Defined in [card-elements.ts:2457](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2457)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*
+
+___
+
+###  remove
+
+▸ **remove**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
+
+*Defined in [card-elements.ts:698](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L698)*
+
+**Returns:** *boolean*
+
+___
+
+###  removeItem
+
+▸ **removeItem**(`item`: [CardElement](cardelement.md)): *boolean*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[removeItem](cardelementcontainer.md#abstract-removeitem)*
+
+*Defined in [card-elements.ts:2417](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2417)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`item` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  render
+
+▸ **render**(): *HTMLElement*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[render](cardelementcontainer.md#render)*
+
+*Overrides [CardElement](cardelement.md).[render](cardelement.md#render)*
+
+*Defined in [card-elements.ts:2286](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2286)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setPadding
+
+▸ **setPadding**(`value`: [PaddingDefinition](paddingdefinition.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
+
+*Defined in [card-elements.ts:478](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L478)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [PaddingDefinition](paddingdefinition.md) |
+
+**Returns:** *void*
+
+___
+
+###  setParent
+
+▸ **setParent**(`value`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setParent](cardelement.md#setparent)*
+
+*Overrides [CardObject](cardobject.md).[setParent](cardobject.md#abstract-setparent)*
+
+*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setSelectAction
+
+▸ **setSelectAction**(`value`: [Action](action.md)): *void*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[setSelectAction](cardelementcontainer.md#protected-setselectaction)*
+
+*Defined in [card-elements.ts:2211](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2211)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [Action](action.md) |
+
+**Returns:** *void*
+
+___
+
+###  setShouldFallback
+
+▸ **setShouldFallback**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[setShouldFallback](cardelement.md#setshouldfallback)*
+
+*Defined in [card-elements.ts:843](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L843)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  shouldFallback
+
+▸ **shouldFallback**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[shouldFallback](cardelement.md#shouldfallback)*
+
+*Overrides [CardObject](cardobject.md).[shouldFallback](cardobject.md#abstract-shouldfallback)*
+
+*Defined in [card-elements.ts:839](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L839)*
+
+**Returns:** *boolean*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[toJSON](cardelementcontainer.md#tojson)*
+
+*Defined in [card-elements.ts:2439](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2439)*
+
+**Returns:** *any*
+
+___
+
+### `Protected` truncateOverflow
+
+▸ **truncateOverflow**(`maxHeight`: number): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
+
+*Defined in [card-elements.ts:454](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L454)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`maxHeight` | number |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` undoOverflowTruncation
+
+▸ **undoOverflowTruncation**(): *void*
+
+*Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
+
+*Defined in [card-elements.ts:464](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L464)*
+
+**Returns:** *void*
+
+___
+
+###  updateLayout
+
+▸ **updateLayout**(`processChildren`: boolean): *void*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[updateLayout](cardelementcontainer.md#updatelayout)*
+
+*Overrides [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
+
+*Defined in [card-elements.ts:2324](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2324)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`processChildren` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  validateProperties
+
+▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
+
+*Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
+
+*Defined in [card-elements.ts:284](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L284)*
+
+**Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/imagesetconfig.md
+++ b/source/nodejs/adaptivecards/docs/classes/imagesetconfig.md
@@ -1,0 +1,68 @@
+[Adaptive Cards Javascript SDK](../README.md) › [ImageSetConfig](imagesetconfig.md)
+
+# Class: ImageSetConfig
+
+## Hierarchy
+
+* **ImageSetConfig**
+
+## Index
+
+### Constructors
+
+* [constructor](imagesetconfig.md#constructor)
+
+### Properties
+
+* [imageSize](imagesetconfig.md#imagesize)
+* [maxImageHeight](imagesetconfig.md#maximageheight)
+
+### Methods
+
+* [toJSON](imagesetconfig.md#tojson)
+
+## Constructors
+
+###  constructor
+
+\+ **new ImageSetConfig**(`obj?`: any): *[ImageSetConfig](imagesetconfig.md)*
+
+*Defined in [host-config.ts:58](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L58)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`obj?` | any |
+
+**Returns:** *[ImageSetConfig](imagesetconfig.md)*
+
+## Properties
+
+###  imageSize
+
+• **imageSize**: *[Size](../enums/size.md)* = Enums.Size.Medium
+
+*Defined in [host-config.ts:57](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L57)*
+
+___
+
+###  maxImageHeight
+
+• **maxImageHeight**: *number* = 100
+
+*Defined in [host-config.ts:58](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L58)*
+
+## Methods
+
+###  toJSON
+
+▸ **toJSON**(): *object*
+
+*Defined in [host-config.ts:67](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L67)*
+
+**Returns:** *object*
+
+* **imageSize**: *string* = Enums.Size[this.imageSize]
+
+* **maxImageHeight**: *number* = this.maxImageHeight

--- a/source/nodejs/adaptivecards/docs/classes/input.md
+++ b/source/nodejs/adaptivecards/docs/classes/input.md
@@ -1,0 +1,1396 @@
+[Adaptive Cards Javascript SDK](../README.md) › [Input](input.md)
+
+# Class: Input
+
+## Hierarchy
+
+  ↳ [CardElement](cardelement.md)
+
+  ↳ **Input**
+
+  ↳ [TextInput](textinput.md)
+
+  ↳ [ToggleInput](toggleinput.md)
+
+  ↳ [ChoiceSetInput](choicesetinput.md)
+
+  ↳ [NumberInput](numberinput.md)
+
+  ↳ [DateInput](dateinput.md)
+
+  ↳ [TimeInput](timeinput.md)
+
+## Implements
+
+* [IInput](../interfaces/iinput.md)
+
+## Index
+
+### Properties
+
+* [customCssSelector](input.md#customcssselector)
+* [height](input.md#height)
+* [horizontalAlignment](input.md#optional-horizontalalignment)
+* [id](input.md#id)
+* [minPixelHeight](input.md#optional-minpixelheight)
+* [onValueChanged](input.md#onvaluechanged)
+* [requires](input.md#requires)
+* [separator](input.md#separator)
+* [spacing](input.md#spacing)
+* [title](input.md#title)
+* [validation](input.md#validation)
+
+### Accessors
+
+* [allowCustomPadding](input.md#protected-allowcustompadding)
+* [defaultStyle](input.md#protected-defaultstyle)
+* [defaultValue](input.md#defaultvalue)
+* [hasVisibleSeparator](input.md#hasvisibleseparator)
+* [hostConfig](input.md#hostconfig)
+* [index](input.md#index)
+* [inputControlContainerElement](input.md#protected-inputcontrolcontainerelement)
+* [isInline](input.md#isinline)
+* [isInteractive](input.md#isinteractive)
+* [isNullable](input.md#protected-isnullable)
+* [isStandalone](input.md#isstandalone)
+* [isVisible](input.md#isvisible)
+* [lang](input.md#lang)
+* [parent](input.md#parent)
+* [renderedElement](input.md#renderedelement)
+* [renderedInputControlElement](input.md#protected-renderedinputcontrolelement)
+* [separatorElement](input.md#separatorelement)
+* [separatorOrientation](input.md#protected-separatororientation)
+* [supportsMinHeight](input.md#protected-supportsminheight)
+* [useDefaultSizing](input.md#protected-usedefaultsizing)
+* [value](input.md#value)
+
+### Methods
+
+* [adjustRenderedElementSize](input.md#protected-adjustrenderedelementsize)
+* [applyPadding](input.md#protected-applypadding)
+* [asString](input.md#asstring)
+* [createPlaceholderElement](input.md#protected-createplaceholderelement)
+* [getActionAt](input.md#getactionat)
+* [getActionById](input.md#getactionbyid)
+* [getActionCount](input.md#getactioncount)
+* [getAllInputs](input.md#getallinputs)
+* [getCustomProperty](input.md#getcustomproperty)
+* [getDefaultPadding](input.md#protected-getdefaultpadding)
+* [getEffectivePadding](input.md#geteffectivepadding)
+* [getEffectiveStyle](input.md#geteffectivestyle)
+* [getElementById](input.md#getelementbyid)
+* [getForbiddenActionTypes](input.md#getforbiddenactiontypes)
+* [getForbiddenElementTypes](input.md#getforbiddenelementtypes)
+* [getHasBackground](input.md#protected-gethasbackground)
+* [getImmediateSurroundingPadding](input.md#getimmediatesurroundingpadding)
+* [getJsonTypeName](input.md#abstract-getjsontypename)
+* [getPadding](input.md#protected-getpadding)
+* [getParentContainer](input.md#getparentcontainer)
+* [getResourceInformation](input.md#getresourceinformation)
+* [getRootElement](input.md#getrootelement)
+* [indexOf](input.md#indexof)
+* [internalRender](input.md#protected-abstract-internalrender)
+* [internalValidateProperties](input.md#internalvalidateproperties)
+* [isAtTheVeryBottom](input.md#isattheverybottom)
+* [isAtTheVeryLeft](input.md#isattheveryleft)
+* [isAtTheVeryRight](input.md#isattheveryright)
+* [isAtTheVeryTop](input.md#isattheverytop)
+* [isBleeding](input.md#isbleeding)
+* [isBleedingAtBottom](input.md#isbleedingatbottom)
+* [isBleedingAtTop](input.md#isbleedingattop)
+* [isBottomElement](input.md#isbottomelement)
+* [isDesignMode](input.md#isdesignmode)
+* [isFirstElement](input.md#isfirstelement)
+* [isHiddenDueToOverflow](input.md#ishiddenduetooverflow)
+* [isLastElement](input.md#islastelement)
+* [isLeftMostElement](input.md#isleftmostelement)
+* [isRendered](input.md#isrendered)
+* [isRightMostElement](input.md#isrightmostelement)
+* [isTopElement](input.md#istopelement)
+* [overrideInternalRender](input.md#protected-overrideinternalrender)
+* [parse](input.md#parse)
+* [parseInputValue](input.md#protected-parseinputvalue)
+* [remove](input.md#remove)
+* [render](input.md#render)
+* [resetValidationFailureCue](input.md#protected-resetvalidationfailurecue)
+* [setCustomProperty](input.md#setcustomproperty)
+* [setPadding](input.md#protected-setpadding)
+* [setParent](input.md#setparent)
+* [setShouldFallback](input.md#setshouldfallback)
+* [shouldFallback](input.md#shouldfallback)
+* [showValidationErrorMessage](input.md#protected-showvalidationerrormessage)
+* [toJSON](input.md#tojson)
+* [truncateOverflow](input.md#protected-truncateoverflow)
+* [undoOverflowTruncation](input.md#protected-undooverflowtruncation)
+* [updateLayout](input.md#updatelayout)
+* [validateProperties](input.md#validateproperties)
+* [validateValue](input.md#validatevalue)
+* [valueChanged](input.md#protected-valuechanged)
+
+## Properties
+
+###  customCssSelector
+
+• **customCssSelector**: *string* = null
+
+*Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#customcssselector)*
+
+*Defined in [card-elements.ts:507](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L507)*
+
+___
+
+###  height
+
+• **height**: *[CardElementHeight](../README.md#cardelementheight)* = "auto"
+
+*Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
+
+*Defined in [card-elements.ts:508](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L508)*
+
+___
+
+### `Optional` horizontalAlignment
+
+• **horizontalAlignment**? : *[HorizontalAlignment](../enums/horizontalalignment.md)* = null
+
+*Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#optional-horizontalalignment)*
+
+*Defined in [card-elements.ts:504](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L504)*
+
+___
+
+###  id
+
+• **id**: *string*
+
+*Implementation of [IInput](../interfaces/iinput.md).[id](../interfaces/iinput.md#id)*
+
+*Inherited from [CardObject](cardobject.md).[id](cardobject.md#id)*
+
+*Defined in [card-elements.ts:247](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L247)*
+
+___
+
+### `Optional` minPixelHeight
+
+• **minPixelHeight**? : *number* = null
+
+*Inherited from [CardElement](cardelement.md).[minPixelHeight](cardelement.md#optional-minpixelheight)*
+
+*Defined in [card-elements.ts:509](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L509)*
+
+___
+
+###  onValueChanged
+
+• **onValueChanged**: *function*
+
+*Defined in [card-elements.ts:2874](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2874)*
+
+#### Type declaration:
+
+▸ (`sender`: [Input](input.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`sender` | [Input](input.md) |
+
+___
+
+###  requires
+
+• **requires**: *[HostCapabilities](hostcapabilities.md)‹›* = new HostConfig.HostCapabilities()
+
+*Inherited from [CardElement](cardelement.md).[requires](cardelement.md#requires)*
+
+*Defined in [card-elements.ts:502](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L502)*
+
+___
+
+###  separator
+
+• **separator**: *boolean* = false
+
+*Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
+
+*Defined in [card-elements.ts:506](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L506)*
+
+___
+
+###  spacing
+
+• **spacing**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.Default
+
+*Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
+
+*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
+
+___
+
+###  title
+
+• **title**: *string*
+
+*Defined in [card-elements.ts:2878](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2878)*
+
+___
+
+###  validation
+
+• **validation**: *[InputValidationOptions](inputvalidationoptions.md)‹›* = new InputValidationOptions()
+
+*Defined in [card-elements.ts:2876](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2876)*
+
+## Accessors
+
+### `Protected` allowCustomPadding
+
+• **get allowCustomPadding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
+
+*Defined in [card-elements.ts:490](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L490)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` defaultStyle
+
+• **get defaultStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
+
+*Defined in [card-elements.ts:498](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L498)*
+
+**Returns:** *string*
+
+___
+
+###  defaultValue
+
+• **get defaultValue**(): *string*
+
+*Defined in [card-elements.ts:2944](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2944)*
+
+**Returns:** *string*
+
+• **set defaultValue**(`value`: string): *void*
+
+*Defined in [card-elements.ts:2948](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2948)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  hasVisibleSeparator
+
+• **get hasVisibleSeparator**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
+
+*Defined in [card-elements.ts:928](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L928)*
+
+**Returns:** *boolean*
+
+___
+
+###  hostConfig
+
+• **get hostConfig**(): *[HostConfig](hostconfig.md)*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:881](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L881)*
+
+**Returns:** *[HostConfig](hostconfig.md)*
+
+• **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:895](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L895)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [HostConfig](hostconfig.md) |
+
+**Returns:** *void*
+
+___
+
+###  index
+
+• **get index**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
+
+*Defined in [card-elements.ts:899](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L899)*
+
+**Returns:** *number*
+
+___
+
+### `Protected` inputControlContainerElement
+
+• **get inputControlContainerElement**(): *HTMLElement*
+
+*Defined in [card-elements.ts:2807](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2807)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  isInline
+
+• **get isInline**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
+
+*Defined in [card-elements.ts:916](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L916)*
+
+**Returns:** *boolean*
+
+___
+
+###  isInteractive
+
+• **get isInteractive**(): *boolean*
+
+*Overrides [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
+
+*Defined in [card-elements.ts:2952](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2952)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` isNullable
+
+• **get isNullable**(): *boolean*
+
+*Defined in [card-elements.ts:2799](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2799)*
+
+**Returns:** *boolean*
+
+___
+
+###  isStandalone
+
+• **get isStandalone**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
+
+*Defined in [card-elements.ts:912](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L912)*
+
+**Returns:** *boolean*
+
+___
+
+###  isVisible
+
+• **get isVisible**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:924](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L924)*
+
+**Returns:** *boolean*
+
+• **set isVisible**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:937](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L937)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  lang
+
+• **get lang**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:853](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L853)*
+
+**Returns:** *string*
+
+• **set lang**(`value`: string): *void*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:867](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L867)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  parent
+
+• **get parent**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[parent](cardelement.md#parent)*
+
+*Defined in [card-elements.ts:920](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L920)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  renderedElement
+
+• **get renderedElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[renderedElement](cardelement.md#renderedelement)*
+
+*Defined in [card-elements.ts:956](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L956)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` renderedInputControlElement
+
+• **get renderedInputControlElement**(): *HTMLElement*
+
+*Defined in [card-elements.ts:2803](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2803)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  separatorElement
+
+• **get separatorElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
+
+*Defined in [card-elements.ts:960](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L960)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` separatorOrientation
+
+• **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
+
+*Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
+
+*Defined in [card-elements.ts:494](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L494)*
+
+**Returns:** *[Orientation](../enums/orientation.md)*
+
+___
+
+### `Protected` supportsMinHeight
+
+• **get supportsMinHeight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[supportsMinHeight](cardelement.md#protected-supportsminheight)*
+
+*Defined in [card-elements.ts:482](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L482)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` useDefaultSizing
+
+• **get useDefaultSizing**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
+
+*Defined in [card-elements.ts:486](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L486)*
+
+**Returns:** *boolean*
+
+___
+
+###  value
+
+• **get value**(): *string*
+
+*Defined in [card-elements.ts:2872](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2872)*
+
+**Returns:** *string*
+
+## Methods
+
+### `Protected` adjustRenderedElementSize
+
+▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
+
+*Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
+
+*Defined in [card-elements.ts:411](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L411)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`renderedElement` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+### `Protected` applyPadding
+
+▸ **applyPadding**(): *void*
+
+*Inherited from [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
+
+*Defined in [card-elements.ts:430](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L430)*
+
+**Returns:** *void*
+
+___
+
+###  asString
+
+▸ **asString**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
+
+*Defined in [card-elements.ts:513](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L513)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` createPlaceholderElement
+
+▸ **createPlaceholderElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
+
+*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  getActionAt
+
+▸ **getActionAt**(`index`: number): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
+
+*Defined in [card-elements.ts:694](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L694)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionById
+
+▸ **getActionById**(`id`: string): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
+
+*Defined in [card-elements.ts:835](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L835)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionCount
+
+▸ **getActionCount**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
+
+*Defined in [card-elements.ts:690](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L690)*
+
+**Returns:** *number*
+
+___
+
+###  getAllInputs
+
+▸ **getAllInputs**(): *Array‹[Input](input.md)›*
+
+*Overrides [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
+
+*Defined in [card-elements.ts:2940](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2940)*
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+### `Protected` getDefaultPadding
+
+▸ **getDefaultPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
+
+*Defined in [card-elements.ts:466](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L466)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectivePadding
+
+▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
+
+*Defined in [card-elements.ts:847](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L847)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectiveStyle
+
+▸ **getEffectiveStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
+
+*Defined in [card-elements.ts:545](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L545)*
+
+**Returns:** *string*
+
+___
+
+###  getElementById
+
+▸ **getElementById**(`id`: string): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
+
+*Defined in [card-elements.ts:831](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L831)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getForbiddenActionTypes
+
+▸ **getForbiddenActionTypes**(): *Array‹any›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
+
+*Defined in [card-elements.ts:557](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L557)*
+
+**Returns:** *Array‹any›*
+
+___
+
+###  getForbiddenElementTypes
+
+▸ **getForbiddenElementTypes**(): *Array‹string›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenElementTypes](cardelement.md#getforbiddenelementtypes)*
+
+*Defined in [card-elements.ts:553](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L553)*
+
+**Returns:** *Array‹string›*
+
+___
+
+### `Protected` getHasBackground
+
+▸ **getHasBackground**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
+
+*Defined in [card-elements.ts:470](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L470)*
+
+**Returns:** *boolean*
+
+___
+
+###  getImmediateSurroundingPadding
+
+▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
+
+*Defined in [card-elements.ts:561](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L561)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`result` | [PaddingDefinition](paddingdefinition.md) | - |
+`processTop` | boolean | true |
+`processRight` | boolean | true |
+`processBottom` | boolean | true |
+`processLeft` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+### `Abstract` getJsonTypeName
+
+▸ **getJsonTypeName**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[getJsonTypeName](cardelement.md#abstract-getjsontypename)*
+
+*Overrides [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
+
+*Defined in [card-elements.ts:511](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L511)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` getPadding
+
+▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
+
+*Defined in [card-elements.ts:474](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L474)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getParentContainer
+
+▸ **getParentContainer**(): *[Container](container.md)*
+
+*Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
+
+*Defined in [card-elements.ts:809](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L809)*
+
+**Returns:** *[Container](container.md)*
+
+___
+
+###  getResourceInformation
+
+▸ **getResourceInformation**(): *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+*Inherited from [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
+
+*Defined in [card-elements.ts:827](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L827)*
+
+**Returns:** *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+___
+
+###  getRootElement
+
+▸ **getRootElement**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
+
+*Defined in [card-elements.ts:799](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L799)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  indexOf
+
+▸ **indexOf**(`cardElement`: [CardElement](cardelement.md)): *number*
+
+*Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
+
+*Defined in [card-elements.ts:733](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L733)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`cardElement` | [CardElement](cardelement.md) |
+
+**Returns:** *number*
+
+___
+
+### `Protected` `Abstract` internalRender
+
+▸ **internalRender**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
+
+*Defined in [card-elements.ts:424](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L424)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  internalValidateProperties
+
+▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
+
+*Overrides [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
+
+*Defined in [card-elements.ts:2893](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2893)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [ValidationResults](validationresults.md) |
+
+**Returns:** *void*
+
+___
+
+###  isAtTheVeryBottom
+
+▸ **isAtTheVeryBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
+
+*Defined in [card-elements.ts:767](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L767)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryLeft
+
+▸ **isAtTheVeryLeft**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
+
+*Defined in [card-elements.ts:755](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L755)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryRight
+
+▸ **isAtTheVeryRight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
+
+*Defined in [card-elements.ts:759](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L759)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryTop
+
+▸ **isAtTheVeryTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
+
+*Defined in [card-elements.ts:763](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L763)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleeding
+
+▸ **isBleeding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
+
+*Defined in [card-elements.ts:517](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L517)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtBottom
+
+▸ **isBleedingAtBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
+
+*Defined in [card-elements.ts:775](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L775)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtTop
+
+▸ **isBleedingAtTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
+
+*Defined in [card-elements.ts:771](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L771)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBottomElement
+
+▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
+
+*Defined in [card-elements.ts:791](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L791)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isDesignMode
+
+▸ **isDesignMode**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
+
+*Defined in [card-elements.ts:737](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L737)*
+
+**Returns:** *boolean*
+
+___
+
+###  isFirstElement
+
+▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
+
+*Defined in [card-elements.ts:747](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L747)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isHiddenDueToOverflow
+
+▸ **isHiddenDueToOverflow**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
+
+*Defined in [card-elements.ts:795](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L795)*
+
+**Returns:** *boolean*
+
+___
+
+###  isLastElement
+
+▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
+
+*Defined in [card-elements.ts:751](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L751)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isLeftMostElement
+
+▸ **isLeftMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
+
+*Defined in [card-elements.ts:779](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L779)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isRendered
+
+▸ **isRendered**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRendered](cardelement.md#isrendered)*
+
+*Defined in [card-elements.ts:743](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L743)*
+
+**Returns:** *boolean*
+
+___
+
+###  isRightMostElement
+
+▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
+
+*Defined in [card-elements.ts:783](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L783)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isTopElement
+
+▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
+
+*Defined in [card-elements.ts:787](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L787)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` overrideInternalRender
+
+▸ **overrideInternalRender**(): *HTMLElement*
+
+*Overrides [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
+
+*Defined in [card-elements.ts:2811](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2811)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Overrides [CardElement](cardelement.md).[parse](cardelement.md#parse)*
+
+*Defined in [card-elements.ts:2925](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2925)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*
+
+___
+
+### `Protected` parseInputValue
+
+▸ **parseInputValue**(`value`: string): *string*
+
+*Defined in [card-elements.ts:2868](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2868)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *string*
+
+___
+
+###  remove
+
+▸ **remove**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
+
+*Defined in [card-elements.ts:698](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L698)*
+
+**Returns:** *boolean*
+
+___
+
+###  render
+
+▸ **render**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[render](cardelement.md#render)*
+
+*Defined in [card-elements.ts:706](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L706)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` resetValidationFailureCue
+
+▸ **resetValidationFailureCue**(): *void*
+
+*Defined in [card-elements.ts:2846](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2846)*
+
+**Returns:** *void*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setPadding
+
+▸ **setPadding**(`value`: [PaddingDefinition](paddingdefinition.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
+
+*Defined in [card-elements.ts:478](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L478)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [PaddingDefinition](paddingdefinition.md) |
+
+**Returns:** *void*
+
+___
+
+###  setParent
+
+▸ **setParent**(`value`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setParent](cardelement.md#setparent)*
+
+*Overrides [CardObject](cardobject.md).[setParent](cardobject.md#abstract-setparent)*
+
+*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+###  setShouldFallback
+
+▸ **setShouldFallback**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[setShouldFallback](cardelement.md#setshouldfallback)*
+
+*Defined in [card-elements.ts:843](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L843)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  shouldFallback
+
+▸ **shouldFallback**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[shouldFallback](cardelement.md#shouldfallback)*
+
+*Overrides [CardObject](cardobject.md).[shouldFallback](cardobject.md#abstract-shouldfallback)*
+
+*Defined in [card-elements.ts:839](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L839)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` showValidationErrorMessage
+
+▸ **showValidationErrorMessage**(): *void*
+
+*Defined in [card-elements.ts:2858](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2858)*
+
+**Returns:** *void*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [CardElement](cardelement.md).[toJSON](cardelement.md#tojson)*
+
+*Defined in [card-elements.ts:2880](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2880)*
+
+**Returns:** *any*
+
+___
+
+### `Protected` truncateOverflow
+
+▸ **truncateOverflow**(`maxHeight`: number): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
+
+*Defined in [card-elements.ts:454](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L454)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`maxHeight` | number |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` undoOverflowTruncation
+
+▸ **undoOverflowTruncation**(): *void*
+
+*Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
+
+*Defined in [card-elements.ts:464](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L464)*
+
+**Returns:** *void*
+
+___
+
+###  updateLayout
+
+▸ **updateLayout**(`processChildren`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
+
+*Defined in [card-elements.ts:728](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L728)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`processChildren` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  validateProperties
+
+▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
+
+*Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
+
+*Defined in [card-elements.ts:284](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L284)*
+
+**Returns:** *[ValidationResults](validationresults.md)*
+
+___
+
+###  validateValue
+
+▸ **validateValue**(): *boolean*
+
+*Implementation of [IInput](../interfaces/iinput.md)*
+
+*Defined in [card-elements.ts:2906](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2906)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` valueChanged
+
+▸ **valueChanged**(): *void*
+
+*Defined in [card-elements.ts:2836](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2836)*
+
+**Returns:** *void*

--- a/source/nodejs/adaptivecards/docs/classes/inputvalidationoptions.md
+++ b/source/nodejs/adaptivecards/docs/classes/inputvalidationoptions.md
@@ -1,0 +1,106 @@
+[Adaptive Cards Javascript SDK](../README.md) › [InputValidationOptions](inputvalidationoptions.md)
+
+# Class: InputValidationOptions
+
+## Hierarchy
+
+* [SerializableObject](serializableobject.md)
+
+  ↳ **InputValidationOptions**
+
+## Index
+
+### Properties
+
+* [errorMessage](inputvalidationoptions.md#errormessage)
+* [necessity](inputvalidationoptions.md#necessity)
+
+### Methods
+
+* [getCustomProperty](inputvalidationoptions.md#getcustomproperty)
+* [parse](inputvalidationoptions.md#parse)
+* [setCustomProperty](inputvalidationoptions.md#setcustomproperty)
+* [toJSON](inputvalidationoptions.md#tojson)
+
+## Properties
+
+###  errorMessage
+
+• **errorMessage**: *string* = undefined
+
+*Defined in [card-elements.ts:2768](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2768)*
+
+___
+
+###  necessity
+
+• **necessity**: *[InputValidationNecessity](../enums/inputvalidationnecessity.md)* = Enums.InputValidationNecessity.Optional
+
+*Defined in [card-elements.ts:2767](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2767)*
+
+## Methods
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any): *void*
+
+*Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
+
+*Defined in [card-elements.ts:2770](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2770)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+
+**Returns:** *void*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
+
+*Defined in [card-elements.ts:2777](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2777)*
+
+**Returns:** *any*

--- a/source/nodejs/adaptivecards/docs/classes/media.md
+++ b/source/nodejs/adaptivecards/docs/classes/media.md
@@ -1,0 +1,1275 @@
+[Adaptive Cards Javascript SDK](../README.md) › [Media](media.md)
+
+# Class: Media
+
+## Hierarchy
+
+  ↳ [CardElement](cardelement.md)
+
+  ↳ **Media**
+
+## Index
+
+### Properties
+
+* [altText](media.md#alttext)
+* [customCssSelector](media.md#customcssselector)
+* [height](media.md#height)
+* [horizontalAlignment](media.md#optional-horizontalalignment)
+* [id](media.md#id)
+* [minPixelHeight](media.md#optional-minpixelheight)
+* [poster](media.md#poster)
+* [requires](media.md#requires)
+* [separator](media.md#separator)
+* [sources](media.md#sources)
+* [spacing](media.md#spacing)
+* [onPlay](media.md#static-onplay)
+* [supportedMediaTypes](media.md#static-supportedmediatypes)
+
+### Accessors
+
+* [allowCustomPadding](media.md#protected-allowcustompadding)
+* [defaultStyle](media.md#protected-defaultstyle)
+* [hasVisibleSeparator](media.md#hasvisibleseparator)
+* [hostConfig](media.md#hostconfig)
+* [index](media.md#index)
+* [isInline](media.md#isinline)
+* [isInteractive](media.md#isinteractive)
+* [isStandalone](media.md#isstandalone)
+* [isVisible](media.md#isvisible)
+* [lang](media.md#lang)
+* [parent](media.md#parent)
+* [renderedElement](media.md#renderedelement)
+* [selectedMediaType](media.md#selectedmediatype)
+* [separatorElement](media.md#separatorelement)
+* [separatorOrientation](media.md#protected-separatororientation)
+* [supportsMinHeight](media.md#protected-supportsminheight)
+* [useDefaultSizing](media.md#protected-usedefaultsizing)
+
+### Methods
+
+* [adjustRenderedElementSize](media.md#protected-adjustrenderedelementsize)
+* [applyPadding](media.md#protected-applypadding)
+* [asString](media.md#asstring)
+* [createPlaceholderElement](media.md#protected-createplaceholderelement)
+* [getActionAt](media.md#getactionat)
+* [getActionById](media.md#getactionbyid)
+* [getActionCount](media.md#getactioncount)
+* [getAllInputs](media.md#getallinputs)
+* [getCustomProperty](media.md#getcustomproperty)
+* [getDefaultPadding](media.md#protected-getdefaultpadding)
+* [getEffectivePadding](media.md#geteffectivepadding)
+* [getEffectiveStyle](media.md#geteffectivestyle)
+* [getElementById](media.md#getelementbyid)
+* [getForbiddenActionTypes](media.md#getforbiddenactiontypes)
+* [getForbiddenElementTypes](media.md#getforbiddenelementtypes)
+* [getHasBackground](media.md#protected-gethasbackground)
+* [getImmediateSurroundingPadding](media.md#getimmediatesurroundingpadding)
+* [getJsonTypeName](media.md#getjsontypename)
+* [getPadding](media.md#protected-getpadding)
+* [getParentContainer](media.md#getparentcontainer)
+* [getResourceInformation](media.md#getresourceinformation)
+* [getRootElement](media.md#getrootelement)
+* [indexOf](media.md#indexof)
+* [internalRender](media.md#protected-internalrender)
+* [internalValidateProperties](media.md#internalvalidateproperties)
+* [isAtTheVeryBottom](media.md#isattheverybottom)
+* [isAtTheVeryLeft](media.md#isattheveryleft)
+* [isAtTheVeryRight](media.md#isattheveryright)
+* [isAtTheVeryTop](media.md#isattheverytop)
+* [isBleeding](media.md#isbleeding)
+* [isBleedingAtBottom](media.md#isbleedingatbottom)
+* [isBleedingAtTop](media.md#isbleedingattop)
+* [isBottomElement](media.md#isbottomelement)
+* [isDesignMode](media.md#isdesignmode)
+* [isFirstElement](media.md#isfirstelement)
+* [isHiddenDueToOverflow](media.md#ishiddenduetooverflow)
+* [isLastElement](media.md#islastelement)
+* [isLeftMostElement](media.md#isleftmostelement)
+* [isRendered](media.md#isrendered)
+* [isRightMostElement](media.md#isrightmostelement)
+* [isTopElement](media.md#istopelement)
+* [overrideInternalRender](media.md#protected-overrideinternalrender)
+* [parse](media.md#parse)
+* [remove](media.md#remove)
+* [render](media.md#render)
+* [setCustomProperty](media.md#setcustomproperty)
+* [setPadding](media.md#protected-setpadding)
+* [setParent](media.md#setparent)
+* [setShouldFallback](media.md#setshouldfallback)
+* [shouldFallback](media.md#shouldfallback)
+* [toJSON](media.md#tojson)
+* [truncateOverflow](media.md#protected-truncateoverflow)
+* [undoOverflowTruncation](media.md#protected-undooverflowtruncation)
+* [updateLayout](media.md#updatelayout)
+* [validateProperties](media.md#validateproperties)
+
+## Properties
+
+###  altText
+
+• **altText**: *string*
+
+*Defined in [card-elements.ts:2696](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2696)*
+
+___
+
+###  customCssSelector
+
+• **customCssSelector**: *string* = null
+
+*Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#customcssselector)*
+
+*Defined in [card-elements.ts:507](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L507)*
+
+___
+
+###  height
+
+• **height**: *[CardElementHeight](../README.md#cardelementheight)* = "auto"
+
+*Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
+
+*Defined in [card-elements.ts:508](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L508)*
+
+___
+
+### `Optional` horizontalAlignment
+
+• **horizontalAlignment**? : *[HorizontalAlignment](../enums/horizontalalignment.md)* = null
+
+*Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#optional-horizontalalignment)*
+
+*Defined in [card-elements.ts:504](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L504)*
+
+___
+
+###  id
+
+• **id**: *string*
+
+*Inherited from [CardObject](cardobject.md).[id](cardobject.md#id)*
+
+*Defined in [card-elements.ts:247](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L247)*
+
+___
+
+### `Optional` minPixelHeight
+
+• **minPixelHeight**? : *number* = null
+
+*Inherited from [CardElement](cardelement.md).[minPixelHeight](cardelement.md#optional-minpixelheight)*
+
+*Defined in [card-elements.ts:509](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L509)*
+
+___
+
+###  poster
+
+• **poster**: *string*
+
+*Defined in [card-elements.ts:2695](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2695)*
+
+___
+
+###  requires
+
+• **requires**: *[HostCapabilities](hostcapabilities.md)‹›* = new HostConfig.HostCapabilities()
+
+*Inherited from [CardElement](cardelement.md).[requires](cardelement.md#requires)*
+
+*Defined in [card-elements.ts:502](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L502)*
+
+___
+
+###  separator
+
+• **separator**: *boolean* = false
+
+*Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
+
+*Defined in [card-elements.ts:506](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L506)*
+
+___
+
+###  sources
+
+• **sources**: *Array‹[MediaSource](mediasource.md)›* = []
+
+*Defined in [card-elements.ts:2694](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2694)*
+
+___
+
+###  spacing
+
+• **spacing**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.Default
+
+*Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
+
+*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
+
+___
+
+### `Static` onPlay
+
+▪ **onPlay**: *function* = null
+
+*Defined in [card-elements.ts:2692](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2692)*
+
+#### Type declaration:
+
+▸ (`sender`: [Media](media.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`sender` | [Media](media.md) |
+
+___
+
+### `Static` supportedMediaTypes
+
+▪ **supportedMediaTypes**: *string[]* = ["audio", "video"]
+
+*Defined in [card-elements.ts:2521](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2521)*
+
+## Accessors
+
+### `Protected` allowCustomPadding
+
+• **get allowCustomPadding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
+
+*Defined in [card-elements.ts:490](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L490)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` defaultStyle
+
+• **get defaultStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
+
+*Defined in [card-elements.ts:498](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L498)*
+
+**Returns:** *string*
+
+___
+
+###  hasVisibleSeparator
+
+• **get hasVisibleSeparator**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
+
+*Defined in [card-elements.ts:928](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L928)*
+
+**Returns:** *boolean*
+
+___
+
+###  hostConfig
+
+• **get hostConfig**(): *[HostConfig](hostconfig.md)*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:881](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L881)*
+
+**Returns:** *[HostConfig](hostconfig.md)*
+
+• **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:895](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L895)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [HostConfig](hostconfig.md) |
+
+**Returns:** *void*
+
+___
+
+###  index
+
+• **get index**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
+
+*Defined in [card-elements.ts:899](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L899)*
+
+**Returns:** *number*
+
+___
+
+###  isInline
+
+• **get isInline**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
+
+*Defined in [card-elements.ts:916](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L916)*
+
+**Returns:** *boolean*
+
+___
+
+###  isInteractive
+
+• **get isInteractive**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
+
+*Defined in [card-elements.ts:908](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L908)*
+
+**Returns:** *boolean*
+
+___
+
+###  isStandalone
+
+• **get isStandalone**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
+
+*Defined in [card-elements.ts:912](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L912)*
+
+**Returns:** *boolean*
+
+___
+
+###  isVisible
+
+• **get isVisible**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:924](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L924)*
+
+**Returns:** *boolean*
+
+• **set isVisible**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:937](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L937)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  lang
+
+• **get lang**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:853](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L853)*
+
+**Returns:** *string*
+
+• **set lang**(`value`: string): *void*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:867](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L867)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  parent
+
+• **get parent**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[parent](cardelement.md#parent)*
+
+*Defined in [card-elements.ts:920](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L920)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  renderedElement
+
+• **get renderedElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[renderedElement](cardelement.md#renderedelement)*
+
+*Defined in [card-elements.ts:956](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L956)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  selectedMediaType
+
+• **get selectedMediaType**(): *string*
+
+*Defined in [card-elements.ts:2761](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2761)*
+
+**Returns:** *string*
+
+___
+
+###  separatorElement
+
+• **get separatorElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
+
+*Defined in [card-elements.ts:960](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L960)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` separatorOrientation
+
+• **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
+
+*Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
+
+*Defined in [card-elements.ts:494](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L494)*
+
+**Returns:** *[Orientation](../enums/orientation.md)*
+
+___
+
+### `Protected` supportsMinHeight
+
+• **get supportsMinHeight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[supportsMinHeight](cardelement.md#protected-supportsminheight)*
+
+*Defined in [card-elements.ts:482](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L482)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` useDefaultSizing
+
+• **get useDefaultSizing**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
+
+*Defined in [card-elements.ts:486](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L486)*
+
+**Returns:** *boolean*
+
+## Methods
+
+### `Protected` adjustRenderedElementSize
+
+▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
+
+*Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
+
+*Defined in [card-elements.ts:411](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L411)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`renderedElement` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+### `Protected` applyPadding
+
+▸ **applyPadding**(): *void*
+
+*Inherited from [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
+
+*Defined in [card-elements.ts:430](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L430)*
+
+**Returns:** *void*
+
+___
+
+###  asString
+
+▸ **asString**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
+
+*Defined in [card-elements.ts:513](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L513)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` createPlaceholderElement
+
+▸ **createPlaceholderElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
+
+*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  getActionAt
+
+▸ **getActionAt**(`index`: number): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
+
+*Defined in [card-elements.ts:694](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L694)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionById
+
+▸ **getActionById**(`id`: string): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
+
+*Defined in [card-elements.ts:835](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L835)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionCount
+
+▸ **getActionCount**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
+
+*Defined in [card-elements.ts:690](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L690)*
+
+**Returns:** *number*
+
+___
+
+###  getAllInputs
+
+▸ **getAllInputs**(): *Array‹[Input](input.md)›*
+
+*Inherited from [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
+
+*Defined in [card-elements.ts:823](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L823)*
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+### `Protected` getDefaultPadding
+
+▸ **getDefaultPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
+
+*Defined in [card-elements.ts:466](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L466)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectivePadding
+
+▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
+
+*Defined in [card-elements.ts:847](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L847)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectiveStyle
+
+▸ **getEffectiveStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
+
+*Defined in [card-elements.ts:545](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L545)*
+
+**Returns:** *string*
+
+___
+
+###  getElementById
+
+▸ **getElementById**(`id`: string): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
+
+*Defined in [card-elements.ts:831](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L831)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getForbiddenActionTypes
+
+▸ **getForbiddenActionTypes**(): *Array‹any›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
+
+*Defined in [card-elements.ts:557](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L557)*
+
+**Returns:** *Array‹any›*
+
+___
+
+###  getForbiddenElementTypes
+
+▸ **getForbiddenElementTypes**(): *Array‹string›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenElementTypes](cardelement.md#getforbiddenelementtypes)*
+
+*Defined in [card-elements.ts:553](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L553)*
+
+**Returns:** *Array‹string›*
+
+___
+
+### `Protected` getHasBackground
+
+▸ **getHasBackground**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
+
+*Defined in [card-elements.ts:470](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L470)*
+
+**Returns:** *boolean*
+
+___
+
+###  getImmediateSurroundingPadding
+
+▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
+
+*Defined in [card-elements.ts:561](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L561)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`result` | [PaddingDefinition](paddingdefinition.md) | - |
+`processTop` | boolean | true |
+`processRight` | boolean | true |
+`processBottom` | boolean | true |
+`processLeft` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  getJsonTypeName
+
+▸ **getJsonTypeName**(): *string*
+
+*Overrides [CardElement](cardelement.md).[getJsonTypeName](cardelement.md#abstract-getjsontypename)*
+
+*Defined in [card-elements.ts:2739](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2739)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` getPadding
+
+▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
+
+*Defined in [card-elements.ts:474](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L474)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getParentContainer
+
+▸ **getParentContainer**(): *[Container](container.md)*
+
+*Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
+
+*Defined in [card-elements.ts:809](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L809)*
+
+**Returns:** *[Container](container.md)*
+
+___
+
+###  getResourceInformation
+
+▸ **getResourceInformation**(): *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+*Overrides [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
+
+*Defined in [card-elements.ts:2743](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2743)*
+
+**Returns:** *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+___
+
+###  getRootElement
+
+▸ **getRootElement**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
+
+*Defined in [card-elements.ts:799](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L799)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  indexOf
+
+▸ **indexOf**(`cardElement`: [CardElement](cardelement.md)): *number*
+
+*Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
+
+*Defined in [card-elements.ts:733](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L733)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`cardElement` | [CardElement](cardelement.md) |
+
+**Returns:** *number*
+
+___
+
+### `Protected` internalRender
+
+▸ **internalRender**(): *HTMLElement*
+
+*Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
+
+*Defined in [card-elements.ts:2681](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2681)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  internalValidateProperties
+
+▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
+
+*Inherited from [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
+
+*Defined in [card-elements.ts:249](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L249)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [ValidationResults](validationresults.md) |
+
+**Returns:** *void*
+
+___
+
+###  isAtTheVeryBottom
+
+▸ **isAtTheVeryBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
+
+*Defined in [card-elements.ts:767](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L767)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryLeft
+
+▸ **isAtTheVeryLeft**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
+
+*Defined in [card-elements.ts:755](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L755)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryRight
+
+▸ **isAtTheVeryRight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
+
+*Defined in [card-elements.ts:759](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L759)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryTop
+
+▸ **isAtTheVeryTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
+
+*Defined in [card-elements.ts:763](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L763)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleeding
+
+▸ **isBleeding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
+
+*Defined in [card-elements.ts:517](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L517)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtBottom
+
+▸ **isBleedingAtBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
+
+*Defined in [card-elements.ts:775](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L775)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtTop
+
+▸ **isBleedingAtTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
+
+*Defined in [card-elements.ts:771](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L771)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBottomElement
+
+▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
+
+*Defined in [card-elements.ts:791](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L791)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isDesignMode
+
+▸ **isDesignMode**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
+
+*Defined in [card-elements.ts:737](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L737)*
+
+**Returns:** *boolean*
+
+___
+
+###  isFirstElement
+
+▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
+
+*Defined in [card-elements.ts:747](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L747)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isHiddenDueToOverflow
+
+▸ **isHiddenDueToOverflow**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
+
+*Defined in [card-elements.ts:795](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L795)*
+
+**Returns:** *boolean*
+
+___
+
+###  isLastElement
+
+▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
+
+*Defined in [card-elements.ts:751](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L751)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isLeftMostElement
+
+▸ **isLeftMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
+
+*Defined in [card-elements.ts:779](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L779)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isRendered
+
+▸ **isRendered**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRendered](cardelement.md#isrendered)*
+
+*Defined in [card-elements.ts:743](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L743)*
+
+**Returns:** *boolean*
+
+___
+
+###  isRightMostElement
+
+▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
+
+*Defined in [card-elements.ts:783](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L783)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isTopElement
+
+▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
+
+*Defined in [card-elements.ts:787](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L787)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` overrideInternalRender
+
+▸ **overrideInternalRender**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
+
+*Defined in [card-elements.ts:426](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L426)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Overrides [CardElement](cardelement.md).[parse](cardelement.md#parse)*
+
+*Defined in [card-elements.ts:2698](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2698)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*
+
+___
+
+###  remove
+
+▸ **remove**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
+
+*Defined in [card-elements.ts:698](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L698)*
+
+**Returns:** *boolean*
+
+___
+
+###  render
+
+▸ **render**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[render](cardelement.md#render)*
+
+*Defined in [card-elements.ts:706](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L706)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setPadding
+
+▸ **setPadding**(`value`: [PaddingDefinition](paddingdefinition.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
+
+*Defined in [card-elements.ts:478](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L478)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [PaddingDefinition](paddingdefinition.md) |
+
+**Returns:** *void*
+
+___
+
+###  setParent
+
+▸ **setParent**(`value`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setParent](cardelement.md#setparent)*
+
+*Overrides [CardObject](cardobject.md).[setParent](cardobject.md#abstract-setparent)*
+
+*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+###  setShouldFallback
+
+▸ **setShouldFallback**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[setShouldFallback](cardelement.md#setshouldfallback)*
+
+*Defined in [card-elements.ts:843](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L843)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  shouldFallback
+
+▸ **shouldFallback**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[shouldFallback](cardelement.md#shouldfallback)*
+
+*Overrides [CardObject](cardobject.md).[shouldFallback](cardobject.md#abstract-shouldfallback)*
+
+*Defined in [card-elements.ts:839](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L839)*
+
+**Returns:** *boolean*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [CardElement](cardelement.md).[toJSON](cardelement.md#tojson)*
+
+*Defined in [card-elements.ts:2716](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2716)*
+
+**Returns:** *any*
+
+___
+
+### `Protected` truncateOverflow
+
+▸ **truncateOverflow**(`maxHeight`: number): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
+
+*Defined in [card-elements.ts:454](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L454)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`maxHeight` | number |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` undoOverflowTruncation
+
+▸ **undoOverflowTruncation**(): *void*
+
+*Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
+
+*Defined in [card-elements.ts:464](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L464)*
+
+**Returns:** *void*
+
+___
+
+###  updateLayout
+
+▸ **updateLayout**(`processChildren`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
+
+*Defined in [card-elements.ts:728](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L728)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`processChildren` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  validateProperties
+
+▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
+
+*Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
+
+*Defined in [card-elements.ts:284](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L284)*
+
+**Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/mediaconfig.md
+++ b/source/nodejs/adaptivecards/docs/classes/mediaconfig.md
@@ -1,0 +1,68 @@
+[Adaptive Cards Javascript SDK](../README.md) › [MediaConfig](mediaconfig.md)
+
+# Class: MediaConfig
+
+## Hierarchy
+
+* **MediaConfig**
+
+## Index
+
+### Constructors
+
+* [constructor](mediaconfig.md#constructor)
+
+### Properties
+
+* [allowInlinePlayback](mediaconfig.md#allowinlineplayback)
+* [defaultPoster](mediaconfig.md#defaultposter)
+
+### Methods
+
+* [toJSON](mediaconfig.md#tojson)
+
+## Constructors
+
+###  constructor
+
+\+ **new MediaConfig**(`obj?`: any): *[MediaConfig](mediaconfig.md)*
+
+*Defined in [host-config.ts:77](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L77)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`obj?` | any |
+
+**Returns:** *[MediaConfig](mediaconfig.md)*
+
+## Properties
+
+###  allowInlinePlayback
+
+• **allowInlinePlayback**: *boolean* = true
+
+*Defined in [host-config.ts:77](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L77)*
+
+___
+
+###  defaultPoster
+
+• **defaultPoster**: *string*
+
+*Defined in [host-config.ts:76](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L76)*
+
+## Methods
+
+###  toJSON
+
+▸ **toJSON**(): *object*
+
+*Defined in [host-config.ts:86](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L86)*
+
+**Returns:** *object*
+
+* **allowInlinePlayback**: *boolean* = this.allowInlinePlayback
+
+* **defaultPoster**: *string* = this.defaultPoster

--- a/source/nodejs/adaptivecards/docs/classes/mediasource.md
+++ b/source/nodejs/adaptivecards/docs/classes/mediasource.md
@@ -1,0 +1,128 @@
+[Adaptive Cards Javascript SDK](../README.md) › [MediaSource](mediasource.md)
+
+# Class: MediaSource
+
+## Hierarchy
+
+* [SerializableObject](serializableobject.md)
+
+  ↳ **MediaSource**
+
+## Index
+
+### Constructors
+
+* [constructor](mediasource.md#constructor)
+
+### Properties
+
+* [mimeType](mediasource.md#mimetype)
+* [url](mediasource.md#url)
+
+### Methods
+
+* [getCustomProperty](mediasource.md#getcustomproperty)
+* [parse](mediasource.md#parse)
+* [setCustomProperty](mediasource.md#setcustomproperty)
+* [toJSON](mediasource.md#tojson)
+
+## Constructors
+
+###  constructor
+
+\+ **new MediaSource**(`url`: string, `mimeType`: string): *[MediaSource](mediasource.md)*
+
+*Defined in [card-elements.ts:2494](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2494)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`url` | string | undefined |
+`mimeType` | string | undefined |
+
+**Returns:** *[MediaSource](mediasource.md)*
+
+## Properties
+
+###  mimeType
+
+• **mimeType**: *string*
+
+*Defined in [card-elements.ts:2493](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2493)*
+
+___
+
+###  url
+
+• **url**: *string*
+
+*Defined in [card-elements.ts:2494](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2494)*
+
+## Methods
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
+
+*Defined in [card-elements.ts:2503](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2503)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
+
+*Defined in [card-elements.ts:2510](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2510)*
+
+**Returns:** *any*

--- a/source/nodejs/adaptivecards/docs/classes/numberinput.md
+++ b/source/nodejs/adaptivecards/docs/classes/numberinput.md
@@ -1,0 +1,1484 @@
+[Adaptive Cards Javascript SDK](../README.md) › [NumberInput](numberinput.md)
+
+# Class: NumberInput
+
+## Hierarchy
+
+  ↳ [Input](input.md)
+
+  ↳ **NumberInput**
+
+## Implements
+
+* [IInput](../interfaces/iinput.md)
+
+## Index
+
+### Properties
+
+* [customCssSelector](numberinput.md#customcssselector)
+* [height](numberinput.md#height)
+* [horizontalAlignment](numberinput.md#optional-horizontalalignment)
+* [id](numberinput.md#id)
+* [minPixelHeight](numberinput.md#optional-minpixelheight)
+* [onValueChanged](numberinput.md#onvaluechanged)
+* [placeholder](numberinput.md#placeholder)
+* [requires](numberinput.md#requires)
+* [separator](numberinput.md#separator)
+* [spacing](numberinput.md#spacing)
+* [title](numberinput.md#title)
+* [validation](numberinput.md#validation)
+
+### Accessors
+
+* [allowCustomPadding](numberinput.md#protected-allowcustompadding)
+* [defaultStyle](numberinput.md#protected-defaultstyle)
+* [defaultValue](numberinput.md#defaultvalue)
+* [hasVisibleSeparator](numberinput.md#hasvisibleseparator)
+* [hostConfig](numberinput.md#hostconfig)
+* [index](numberinput.md#index)
+* [inputControlContainerElement](numberinput.md#protected-inputcontrolcontainerelement)
+* [isInline](numberinput.md#isinline)
+* [isInteractive](numberinput.md#isinteractive)
+* [isNullable](numberinput.md#protected-isnullable)
+* [isStandalone](numberinput.md#isstandalone)
+* [isVisible](numberinput.md#isvisible)
+* [lang](numberinput.md#lang)
+* [max](numberinput.md#max)
+* [min](numberinput.md#min)
+* [parent](numberinput.md#parent)
+* [renderedElement](numberinput.md#renderedelement)
+* [renderedInputControlElement](numberinput.md#protected-renderedinputcontrolelement)
+* [separatorElement](numberinput.md#separatorelement)
+* [separatorOrientation](numberinput.md#protected-separatororientation)
+* [supportsMinHeight](numberinput.md#protected-supportsminheight)
+* [useDefaultSizing](numberinput.md#protected-usedefaultsizing)
+* [value](numberinput.md#value)
+* [valueAsNumber](numberinput.md#valueasnumber)
+
+### Methods
+
+* [adjustRenderedElementSize](numberinput.md#protected-adjustrenderedelementsize)
+* [applyPadding](numberinput.md#protected-applypadding)
+* [asString](numberinput.md#asstring)
+* [createPlaceholderElement](numberinput.md#protected-createplaceholderelement)
+* [getActionAt](numberinput.md#getactionat)
+* [getActionById](numberinput.md#getactionbyid)
+* [getActionCount](numberinput.md#getactioncount)
+* [getAllInputs](numberinput.md#getallinputs)
+* [getCustomProperty](numberinput.md#getcustomproperty)
+* [getDefaultPadding](numberinput.md#protected-getdefaultpadding)
+* [getEffectivePadding](numberinput.md#geteffectivepadding)
+* [getEffectiveStyle](numberinput.md#geteffectivestyle)
+* [getElementById](numberinput.md#getelementbyid)
+* [getForbiddenActionTypes](numberinput.md#getforbiddenactiontypes)
+* [getForbiddenElementTypes](numberinput.md#getforbiddenelementtypes)
+* [getHasBackground](numberinput.md#protected-gethasbackground)
+* [getImmediateSurroundingPadding](numberinput.md#getimmediatesurroundingpadding)
+* [getJsonTypeName](numberinput.md#getjsontypename)
+* [getPadding](numberinput.md#protected-getpadding)
+* [getParentContainer](numberinput.md#getparentcontainer)
+* [getResourceInformation](numberinput.md#getresourceinformation)
+* [getRootElement](numberinput.md#getrootelement)
+* [indexOf](numberinput.md#indexof)
+* [internalRender](numberinput.md#protected-internalrender)
+* [internalValidateProperties](numberinput.md#internalvalidateproperties)
+* [isAtTheVeryBottom](numberinput.md#isattheverybottom)
+* [isAtTheVeryLeft](numberinput.md#isattheveryleft)
+* [isAtTheVeryRight](numberinput.md#isattheveryright)
+* [isAtTheVeryTop](numberinput.md#isattheverytop)
+* [isBleeding](numberinput.md#isbleeding)
+* [isBleedingAtBottom](numberinput.md#isbleedingatbottom)
+* [isBleedingAtTop](numberinput.md#isbleedingattop)
+* [isBottomElement](numberinput.md#isbottomelement)
+* [isDesignMode](numberinput.md#isdesignmode)
+* [isFirstElement](numberinput.md#isfirstelement)
+* [isHiddenDueToOverflow](numberinput.md#ishiddenduetooverflow)
+* [isLastElement](numberinput.md#islastelement)
+* [isLeftMostElement](numberinput.md#isleftmostelement)
+* [isRendered](numberinput.md#isrendered)
+* [isRightMostElement](numberinput.md#isrightmostelement)
+* [isTopElement](numberinput.md#istopelement)
+* [overrideInternalRender](numberinput.md#protected-overrideinternalrender)
+* [parse](numberinput.md#parse)
+* [parseInputValue](numberinput.md#protected-parseinputvalue)
+* [remove](numberinput.md#remove)
+* [render](numberinput.md#render)
+* [resetValidationFailureCue](numberinput.md#protected-resetvalidationfailurecue)
+* [setCustomProperty](numberinput.md#setcustomproperty)
+* [setPadding](numberinput.md#protected-setpadding)
+* [setParent](numberinput.md#setparent)
+* [setShouldFallback](numberinput.md#setshouldfallback)
+* [shouldFallback](numberinput.md#shouldfallback)
+* [showValidationErrorMessage](numberinput.md#protected-showvalidationerrormessage)
+* [toJSON](numberinput.md#tojson)
+* [truncateOverflow](numberinput.md#protected-truncateoverflow)
+* [undoOverflowTruncation](numberinput.md#protected-undooverflowtruncation)
+* [updateLayout](numberinput.md#updatelayout)
+* [validateProperties](numberinput.md#validateproperties)
+* [validateValue](numberinput.md#validatevalue)
+* [valueChanged](numberinput.md#protected-valuechanged)
+
+## Properties
+
+###  customCssSelector
+
+• **customCssSelector**: *string* = null
+
+*Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#customcssselector)*
+
+*Defined in [card-elements.ts:507](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L507)*
+
+___
+
+###  height
+
+• **height**: *[CardElementHeight](../README.md#cardelementheight)* = "auto"
+
+*Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
+
+*Defined in [card-elements.ts:508](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L508)*
+
+___
+
+### `Optional` horizontalAlignment
+
+• **horizontalAlignment**? : *[HorizontalAlignment](../enums/horizontalalignment.md)* = null
+
+*Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#optional-horizontalalignment)*
+
+*Defined in [card-elements.ts:504](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L504)*
+
+___
+
+###  id
+
+• **id**: *string*
+
+*Implementation of [IInput](../interfaces/iinput.md).[id](../interfaces/iinput.md#id)*
+
+*Inherited from [CardObject](cardobject.md).[id](cardobject.md#id)*
+
+*Defined in [card-elements.ts:247](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L247)*
+
+___
+
+### `Optional` minPixelHeight
+
+• **minPixelHeight**? : *number* = null
+
+*Inherited from [CardElement](cardelement.md).[minPixelHeight](cardelement.md#optional-minpixelheight)*
+
+*Defined in [card-elements.ts:509](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L509)*
+
+___
+
+###  onValueChanged
+
+• **onValueChanged**: *function*
+
+*Inherited from [Input](input.md).[onValueChanged](input.md#onvaluechanged)*
+
+*Defined in [card-elements.ts:2874](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2874)*
+
+#### Type declaration:
+
+▸ (`sender`: [Input](input.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`sender` | [Input](input.md) |
+
+___
+
+###  placeholder
+
+• **placeholder**: *string*
+
+*Defined in [card-elements.ts:3596](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3596)*
+
+___
+
+###  requires
+
+• **requires**: *[HostCapabilities](hostcapabilities.md)‹›* = new HostConfig.HostCapabilities()
+
+*Inherited from [CardElement](cardelement.md).[requires](cardelement.md#requires)*
+
+*Defined in [card-elements.ts:502](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L502)*
+
+___
+
+###  separator
+
+• **separator**: *boolean* = false
+
+*Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
+
+*Defined in [card-elements.ts:506](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L506)*
+
+___
+
+###  spacing
+
+• **spacing**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.Default
+
+*Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
+
+*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
+
+___
+
+###  title
+
+• **title**: *string*
+
+*Inherited from [Input](input.md).[title](input.md#title)*
+
+*Defined in [card-elements.ts:2878](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2878)*
+
+___
+
+###  validation
+
+• **validation**: *[InputValidationOptions](inputvalidationoptions.md)‹›* = new InputValidationOptions()
+
+*Inherited from [Input](input.md).[validation](input.md#validation)*
+
+*Defined in [card-elements.ts:2876](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2876)*
+
+## Accessors
+
+### `Protected` allowCustomPadding
+
+• **get allowCustomPadding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
+
+*Defined in [card-elements.ts:490](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L490)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` defaultStyle
+
+• **get defaultStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
+
+*Defined in [card-elements.ts:498](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L498)*
+
+**Returns:** *string*
+
+___
+
+###  defaultValue
+
+• **get defaultValue**(): *string*
+
+*Inherited from [Input](input.md).[defaultValue](input.md#defaultvalue)*
+
+*Defined in [card-elements.ts:2944](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2944)*
+
+**Returns:** *string*
+
+• **set defaultValue**(`value`: string): *void*
+
+*Inherited from [Input](input.md).[defaultValue](input.md#defaultvalue)*
+
+*Defined in [card-elements.ts:2948](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2948)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  hasVisibleSeparator
+
+• **get hasVisibleSeparator**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
+
+*Defined in [card-elements.ts:928](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L928)*
+
+**Returns:** *boolean*
+
+___
+
+###  hostConfig
+
+• **get hostConfig**(): *[HostConfig](hostconfig.md)*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:881](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L881)*
+
+**Returns:** *[HostConfig](hostconfig.md)*
+
+• **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:895](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L895)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [HostConfig](hostconfig.md) |
+
+**Returns:** *void*
+
+___
+
+###  index
+
+• **get index**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
+
+*Defined in [card-elements.ts:899](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L899)*
+
+**Returns:** *number*
+
+___
+
+### `Protected` inputControlContainerElement
+
+• **get inputControlContainerElement**(): *HTMLElement*
+
+*Inherited from [Input](input.md).[inputControlContainerElement](input.md#protected-inputcontrolcontainerelement)*
+
+*Defined in [card-elements.ts:2807](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2807)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  isInline
+
+• **get isInline**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
+
+*Defined in [card-elements.ts:916](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L916)*
+
+**Returns:** *boolean*
+
+___
+
+###  isInteractive
+
+• **get isInteractive**(): *boolean*
+
+*Inherited from [Input](input.md).[isInteractive](input.md#isinteractive)*
+
+*Overrides [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
+
+*Defined in [card-elements.ts:2952](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2952)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` isNullable
+
+• **get isNullable**(): *boolean*
+
+*Inherited from [Input](input.md).[isNullable](input.md#protected-isnullable)*
+
+*Defined in [card-elements.ts:2799](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2799)*
+
+**Returns:** *boolean*
+
+___
+
+###  isStandalone
+
+• **get isStandalone**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
+
+*Defined in [card-elements.ts:912](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L912)*
+
+**Returns:** *boolean*
+
+___
+
+###  isVisible
+
+• **get isVisible**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:924](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L924)*
+
+**Returns:** *boolean*
+
+• **set isVisible**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:937](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L937)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  lang
+
+• **get lang**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:853](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L853)*
+
+**Returns:** *string*
+
+• **set lang**(`value`: string): *void*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:867](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L867)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  max
+
+• **get max**(): *number*
+
+*Defined in [card-elements.ts:3628](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3628)*
+
+**Returns:** *number*
+
+• **set max**(`value`: number): *void*
+
+*Defined in [card-elements.ts:3632](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3632)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | number |
+
+**Returns:** *void*
+
+___
+
+###  min
+
+• **get min**(): *number*
+
+*Defined in [card-elements.ts:3620](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3620)*
+
+**Returns:** *number*
+
+• **set min**(`value`: number): *void*
+
+*Defined in [card-elements.ts:3624](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3624)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | number |
+
+**Returns:** *void*
+
+___
+
+###  parent
+
+• **get parent**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[parent](cardelement.md#parent)*
+
+*Defined in [card-elements.ts:920](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L920)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  renderedElement
+
+• **get renderedElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[renderedElement](cardelement.md#renderedelement)*
+
+*Defined in [card-elements.ts:956](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L956)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` renderedInputControlElement
+
+• **get renderedInputControlElement**(): *HTMLElement*
+
+*Inherited from [Input](input.md).[renderedInputControlElement](input.md#protected-renderedinputcontrolelement)*
+
+*Defined in [card-elements.ts:2803](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2803)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  separatorElement
+
+• **get separatorElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
+
+*Defined in [card-elements.ts:960](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L960)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` separatorOrientation
+
+• **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
+
+*Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
+
+*Defined in [card-elements.ts:494](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L494)*
+
+**Returns:** *[Orientation](../enums/orientation.md)*
+
+___
+
+### `Protected` supportsMinHeight
+
+• **get supportsMinHeight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[supportsMinHeight](cardelement.md#protected-supportsminheight)*
+
+*Defined in [card-elements.ts:482](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L482)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` useDefaultSizing
+
+• **get useDefaultSizing**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
+
+*Defined in [card-elements.ts:486](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L486)*
+
+**Returns:** *boolean*
+
+___
+
+###  value
+
+• **get value**(): *string*
+
+*Overrides [Input](input.md).[value](input.md#value)*
+
+*Defined in [card-elements.ts:3636](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3636)*
+
+**Returns:** *string*
+
+___
+
+###  valueAsNumber
+
+• **get valueAsNumber**(): *number*
+
+*Defined in [card-elements.ts:3640](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3640)*
+
+**Returns:** *number*
+
+## Methods
+
+### `Protected` adjustRenderedElementSize
+
+▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
+
+*Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
+
+*Defined in [card-elements.ts:411](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L411)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`renderedElement` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+### `Protected` applyPadding
+
+▸ **applyPadding**(): *void*
+
+*Inherited from [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
+
+*Defined in [card-elements.ts:430](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L430)*
+
+**Returns:** *void*
+
+___
+
+###  asString
+
+▸ **asString**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
+
+*Defined in [card-elements.ts:513](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L513)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` createPlaceholderElement
+
+▸ **createPlaceholderElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
+
+*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  getActionAt
+
+▸ **getActionAt**(`index`: number): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
+
+*Defined in [card-elements.ts:694](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L694)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionById
+
+▸ **getActionById**(`id`: string): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
+
+*Defined in [card-elements.ts:835](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L835)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionCount
+
+▸ **getActionCount**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
+
+*Defined in [card-elements.ts:690](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L690)*
+
+**Returns:** *number*
+
+___
+
+###  getAllInputs
+
+▸ **getAllInputs**(): *Array‹[Input](input.md)›*
+
+*Inherited from [Input](input.md).[getAllInputs](input.md#getallinputs)*
+
+*Overrides [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
+
+*Defined in [card-elements.ts:2940](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2940)*
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+### `Protected` getDefaultPadding
+
+▸ **getDefaultPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
+
+*Defined in [card-elements.ts:466](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L466)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectivePadding
+
+▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
+
+*Defined in [card-elements.ts:847](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L847)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectiveStyle
+
+▸ **getEffectiveStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
+
+*Defined in [card-elements.ts:545](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L545)*
+
+**Returns:** *string*
+
+___
+
+###  getElementById
+
+▸ **getElementById**(`id`: string): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
+
+*Defined in [card-elements.ts:831](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L831)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getForbiddenActionTypes
+
+▸ **getForbiddenActionTypes**(): *Array‹any›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
+
+*Defined in [card-elements.ts:557](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L557)*
+
+**Returns:** *Array‹any›*
+
+___
+
+###  getForbiddenElementTypes
+
+▸ **getForbiddenElementTypes**(): *Array‹string›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenElementTypes](cardelement.md#getforbiddenelementtypes)*
+
+*Defined in [card-elements.ts:553](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L553)*
+
+**Returns:** *Array‹string›*
+
+___
+
+### `Protected` getHasBackground
+
+▸ **getHasBackground**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
+
+*Defined in [card-elements.ts:470](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L470)*
+
+**Returns:** *boolean*
+
+___
+
+###  getImmediateSurroundingPadding
+
+▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
+
+*Defined in [card-elements.ts:561](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L561)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`result` | [PaddingDefinition](paddingdefinition.md) | - |
+`processTop` | boolean | true |
+`processRight` | boolean | true |
+`processBottom` | boolean | true |
+`processLeft` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  getJsonTypeName
+
+▸ **getJsonTypeName**(): *string*
+
+*Overrides [CardElement](cardelement.md).[getJsonTypeName](cardelement.md#abstract-getjsontypename)*
+
+*Defined in [card-elements.ts:3598](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3598)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` getPadding
+
+▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
+
+*Defined in [card-elements.ts:474](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L474)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getParentContainer
+
+▸ **getParentContainer**(): *[Container](container.md)*
+
+*Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
+
+*Defined in [card-elements.ts:809](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L809)*
+
+**Returns:** *[Container](container.md)*
+
+___
+
+###  getResourceInformation
+
+▸ **getResourceInformation**(): *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+*Inherited from [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
+
+*Defined in [card-elements.ts:827](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L827)*
+
+**Returns:** *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+___
+
+###  getRootElement
+
+▸ **getRootElement**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
+
+*Defined in [card-elements.ts:799](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L799)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  indexOf
+
+▸ **indexOf**(`cardElement`: [CardElement](cardelement.md)): *number*
+
+*Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
+
+*Defined in [card-elements.ts:733](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L733)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`cardElement` | [CardElement](cardelement.md) |
+
+**Returns:** *number*
+
+___
+
+### `Protected` internalRender
+
+▸ **internalRender**(): *HTMLElement*
+
+*Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
+
+*Defined in [card-elements.ts:3566](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3566)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  internalValidateProperties
+
+▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
+
+*Inherited from [Input](input.md).[internalValidateProperties](input.md#internalvalidateproperties)*
+
+*Overrides [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
+
+*Defined in [card-elements.ts:2893](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2893)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [ValidationResults](validationresults.md) |
+
+**Returns:** *void*
+
+___
+
+###  isAtTheVeryBottom
+
+▸ **isAtTheVeryBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
+
+*Defined in [card-elements.ts:767](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L767)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryLeft
+
+▸ **isAtTheVeryLeft**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
+
+*Defined in [card-elements.ts:755](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L755)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryRight
+
+▸ **isAtTheVeryRight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
+
+*Defined in [card-elements.ts:759](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L759)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryTop
+
+▸ **isAtTheVeryTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
+
+*Defined in [card-elements.ts:763](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L763)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleeding
+
+▸ **isBleeding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
+
+*Defined in [card-elements.ts:517](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L517)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtBottom
+
+▸ **isBleedingAtBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
+
+*Defined in [card-elements.ts:775](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L775)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtTop
+
+▸ **isBleedingAtTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
+
+*Defined in [card-elements.ts:771](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L771)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBottomElement
+
+▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
+
+*Defined in [card-elements.ts:791](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L791)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isDesignMode
+
+▸ **isDesignMode**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
+
+*Defined in [card-elements.ts:737](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L737)*
+
+**Returns:** *boolean*
+
+___
+
+###  isFirstElement
+
+▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
+
+*Defined in [card-elements.ts:747](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L747)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isHiddenDueToOverflow
+
+▸ **isHiddenDueToOverflow**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
+
+*Defined in [card-elements.ts:795](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L795)*
+
+**Returns:** *boolean*
+
+___
+
+###  isLastElement
+
+▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
+
+*Defined in [card-elements.ts:751](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L751)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isLeftMostElement
+
+▸ **isLeftMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
+
+*Defined in [card-elements.ts:779](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L779)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isRendered
+
+▸ **isRendered**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRendered](cardelement.md#isrendered)*
+
+*Defined in [card-elements.ts:743](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L743)*
+
+**Returns:** *boolean*
+
+___
+
+###  isRightMostElement
+
+▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
+
+*Defined in [card-elements.ts:783](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L783)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isTopElement
+
+▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
+
+*Defined in [card-elements.ts:787](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L787)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` overrideInternalRender
+
+▸ **overrideInternalRender**(): *HTMLElement*
+
+*Inherited from [Input](input.md).[overrideInternalRender](input.md#protected-overrideinternalrender)*
+
+*Overrides [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
+
+*Defined in [card-elements.ts:2811](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2811)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Overrides [Input](input.md).[parse](input.md#parse)*
+
+*Defined in [card-elements.ts:3612](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3612)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*
+
+___
+
+### `Protected` parseInputValue
+
+▸ **parseInputValue**(`value`: string): *string*
+
+*Inherited from [Input](input.md).[parseInputValue](input.md#protected-parseinputvalue)*
+
+*Defined in [card-elements.ts:2868](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2868)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *string*
+
+___
+
+###  remove
+
+▸ **remove**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
+
+*Defined in [card-elements.ts:698](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L698)*
+
+**Returns:** *boolean*
+
+___
+
+###  render
+
+▸ **render**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[render](cardelement.md#render)*
+
+*Defined in [card-elements.ts:706](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L706)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` resetValidationFailureCue
+
+▸ **resetValidationFailureCue**(): *void*
+
+*Inherited from [Input](input.md).[resetValidationFailureCue](input.md#protected-resetvalidationfailurecue)*
+
+*Defined in [card-elements.ts:2846](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2846)*
+
+**Returns:** *void*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setPadding
+
+▸ **setPadding**(`value`: [PaddingDefinition](paddingdefinition.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
+
+*Defined in [card-elements.ts:478](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L478)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [PaddingDefinition](paddingdefinition.md) |
+
+**Returns:** *void*
+
+___
+
+###  setParent
+
+▸ **setParent**(`value`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setParent](cardelement.md#setparent)*
+
+*Overrides [CardObject](cardobject.md).[setParent](cardobject.md#abstract-setparent)*
+
+*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+###  setShouldFallback
+
+▸ **setShouldFallback**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[setShouldFallback](cardelement.md#setshouldfallback)*
+
+*Defined in [card-elements.ts:843](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L843)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  shouldFallback
+
+▸ **shouldFallback**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[shouldFallback](cardelement.md#shouldfallback)*
+
+*Overrides [CardObject](cardobject.md).[shouldFallback](cardobject.md#abstract-shouldfallback)*
+
+*Defined in [card-elements.ts:839](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L839)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` showValidationErrorMessage
+
+▸ **showValidationErrorMessage**(): *void*
+
+*Inherited from [Input](input.md).[showValidationErrorMessage](input.md#protected-showvalidationerrormessage)*
+
+*Defined in [card-elements.ts:2858](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2858)*
+
+**Returns:** *void*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [Input](input.md).[toJSON](input.md#tojson)*
+
+*Defined in [card-elements.ts:3602](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3602)*
+
+**Returns:** *any*
+
+___
+
+### `Protected` truncateOverflow
+
+▸ **truncateOverflow**(`maxHeight`: number): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
+
+*Defined in [card-elements.ts:454](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L454)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`maxHeight` | number |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` undoOverflowTruncation
+
+▸ **undoOverflowTruncation**(): *void*
+
+*Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
+
+*Defined in [card-elements.ts:464](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L464)*
+
+**Returns:** *void*
+
+___
+
+###  updateLayout
+
+▸ **updateLayout**(`processChildren`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
+
+*Defined in [card-elements.ts:728](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L728)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`processChildren` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  validateProperties
+
+▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
+
+*Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
+
+*Defined in [card-elements.ts:284](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L284)*
+
+**Returns:** *[ValidationResults](validationresults.md)*
+
+___
+
+###  validateValue
+
+▸ **validateValue**(): *boolean*
+
+*Implementation of [IInput](../interfaces/iinput.md)*
+
+*Inherited from [Input](input.md).[validateValue](input.md#validatevalue)*
+
+*Defined in [card-elements.ts:2906](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2906)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` valueChanged
+
+▸ **valueChanged**(): *void*
+
+*Inherited from [Input](input.md).[valueChanged](input.md#protected-valuechanged)*
+
+*Defined in [card-elements.ts:2836](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2836)*
+
+**Returns:** *void*

--- a/source/nodejs/adaptivecards/docs/classes/openurlaction.md
+++ b/source/nodejs/adaptivecards/docs/classes/openurlaction.md
@@ -1,0 +1,551 @@
+[Adaptive Cards Javascript SDK](../README.md) › [OpenUrlAction](openurlaction.md)
+
+# Class: OpenUrlAction
+
+## Hierarchy
+
+  ↳ [Action](action.md)
+
+  ↳ **OpenUrlAction**
+
+## Index
+
+### Properties
+
+* [iconUrl](openurlaction.md#iconurl)
+* [id](openurlaction.md#id)
+* [onExecute](openurlaction.md#onexecute)
+* [requires](openurlaction.md#requires)
+* [style](openurlaction.md#style)
+* [title](openurlaction.md#title)
+* [url](openurlaction.md#url)
+* [JsonTypeName](openurlaction.md#static-jsontypename)
+
+### Accessors
+
+* [ignoreInputValidation](openurlaction.md#ignoreinputvalidation)
+* [isPrimary](openurlaction.md#isprimary)
+* [parent](openurlaction.md#parent)
+* [renderedElement](openurlaction.md#renderedelement)
+
+### Methods
+
+* [addCssClasses](openurlaction.md#protected-addcssclasses)
+* [execute](openurlaction.md#execute)
+* [getActionById](openurlaction.md#getactionbyid)
+* [getAllInputs](openurlaction.md#getallinputs)
+* [getCustomProperty](openurlaction.md#getcustomproperty)
+* [getHref](openurlaction.md#gethref)
+* [getJsonTypeName](openurlaction.md#getjsontypename)
+* [getReferencedInputs](openurlaction.md#getreferencedinputs)
+* [getResourceInformation](openurlaction.md#getresourceinformation)
+* [internalGetReferencedInputs](openurlaction.md#protected-internalgetreferencedinputs)
+* [internalPrepareForExecution](openurlaction.md#protected-internalprepareforexecution)
+* [internalValidateInputs](openurlaction.md#protected-internalvalidateinputs)
+* [internalValidateProperties](openurlaction.md#internalvalidateproperties)
+* [parse](openurlaction.md#parse)
+* [prepareForExecution](openurlaction.md#prepareforexecution)
+* [remove](openurlaction.md#remove)
+* [render](openurlaction.md#render)
+* [setCustomProperty](openurlaction.md#setcustomproperty)
+* [setParent](openurlaction.md#setparent)
+* [shouldFallback](openurlaction.md#shouldfallback)
+* [toJSON](openurlaction.md#tojson)
+* [validateInputs](openurlaction.md#validateinputs)
+* [validateProperties](openurlaction.md#validateproperties)
+
+## Properties
+
+###  iconUrl
+
+• **iconUrl**: *string*
+
+*Inherited from [Action](action.md).[iconUrl](action.md#iconurl)*
+
+*Defined in [card-elements.ts:3905](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3905)*
+
+___
+
+###  id
+
+• **id**: *string*
+
+*Inherited from [CardObject](cardobject.md).[id](cardobject.md#id)*
+
+*Defined in [card-elements.ts:247](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L247)*
+
+___
+
+###  onExecute
+
+• **onExecute**: *function*
+
+*Inherited from [Action](action.md).[onExecute](action.md#onexecute)*
+
+*Defined in [card-elements.ts:3908](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3908)*
+
+#### Type declaration:
+
+▸ (`sender`: [Action](action.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`sender` | [Action](action.md) |
+
+___
+
+###  requires
+
+• **requires**: *[HostCapabilities](hostcapabilities.md)‹›* = new HostConfig.HostCapabilities()
+
+*Inherited from [Action](action.md).[requires](action.md#requires)*
+
+*Defined in [card-elements.ts:3902](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3902)*
+
+___
+
+###  style
+
+• **style**: *string* = Enums.ActionStyle.Default
+
+*Inherited from [Action](action.md).[style](action.md#style)*
+
+*Defined in [card-elements.ts:3906](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3906)*
+
+___
+
+###  title
+
+• **title**: *string*
+
+*Inherited from [Action](action.md).[title](action.md#title)*
+
+*Defined in [card-elements.ts:3904](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3904)*
+
+___
+
+###  url
+
+• **url**: *string*
+
+*Defined in [card-elements.ts:4183](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4183)*
+
+___
+
+### `Static` JsonTypeName
+
+▪ **JsonTypeName**: *"Action.OpenUrl"* = "Action.OpenUrl"
+
+*Defined in [card-elements.ts:4181](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4181)*
+
+## Accessors
+
+###  ignoreInputValidation
+
+• **get ignoreInputValidation**(): *boolean*
+
+*Inherited from [Action](action.md).[ignoreInputValidation](action.md#ignoreinputvalidation)*
+
+*Defined in [card-elements.ts:4088](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4088)*
+
+**Returns:** *boolean*
+
+___
+
+###  isPrimary
+
+• **get isPrimary**(): *boolean*
+
+*Inherited from [Action](action.md).[isPrimary](action.md#isprimary)*
+
+*Defined in [card-elements.ts:4073](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4073)*
+
+**Returns:** *boolean*
+
+• **set isPrimary**(`value`: boolean): *void*
+
+*Inherited from [Action](action.md).[isPrimary](action.md#isprimary)*
+
+*Defined in [card-elements.ts:4077](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4077)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  parent
+
+• **get parent**(): *[CardElement](cardelement.md)*
+
+*Inherited from [Action](action.md).[parent](action.md#parent)*
+
+*Defined in [card-elements.ts:4092](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4092)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  renderedElement
+
+• **get renderedElement**(): *HTMLElement*
+
+*Inherited from [Action](action.md).[renderedElement](action.md#renderedelement)*
+
+*Defined in [card-elements.ts:4096](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4096)*
+
+**Returns:** *HTMLElement*
+
+## Methods
+
+### `Protected` addCssClasses
+
+▸ **addCssClasses**(`element`: HTMLElement): *void*
+
+*Inherited from [Action](action.md).[addCssClasses](action.md#protected-addcssclasses)*
+
+*Defined in [card-elements.ts:3872](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3872)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+###  execute
+
+▸ **execute**(): *void*
+
+*Inherited from [Action](action.md).[execute](action.md#execute)*
+
+*Defined in [card-elements.ts:3992](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3992)*
+
+**Returns:** *void*
+
+___
+
+###  getActionById
+
+▸ **getActionById**(`id`: string): *[Action](action.md)*
+
+*Inherited from [Action](action.md).[getActionById](action.md#getactionbyid)*
+
+*Defined in [card-elements.ts:4055](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4055)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getAllInputs
+
+▸ **getAllInputs**(): *Array‹[Input](input.md)›*
+
+*Inherited from [Action](action.md).[getAllInputs](action.md#getallinputs)*
+
+*Defined in [card-elements.ts:4042](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4042)*
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+###  getHref
+
+▸ **getHref**(): *string*
+
+*Overrides [Action](action.md).[getHref](action.md#gethref)*
+
+*Defined in [card-elements.ts:4216](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4216)*
+
+**Returns:** *string*
+
+___
+
+###  getJsonTypeName
+
+▸ **getJsonTypeName**(): *string*
+
+*Overrides [Action](action.md).[getJsonTypeName](action.md#abstract-getjsontypename)*
+
+*Defined in [card-elements.ts:4185](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4185)*
+
+**Returns:** *string*
+
+___
+
+###  getReferencedInputs
+
+▸ **getReferencedInputs**(): *Shared.Dictionary‹[Input](input.md)›*
+
+*Inherited from [Action](action.md).[getReferencedInputs](action.md#getreferencedinputs)*
+
+*Defined in [card-elements.ts:4061](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4061)*
+
+**Returns:** *Shared.Dictionary‹[Input](input.md)›*
+
+___
+
+###  getResourceInformation
+
+▸ **getResourceInformation**(): *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+*Inherited from [Action](action.md).[getResourceInformation](action.md#getresourceinformation)*
+
+*Defined in [card-elements.ts:4046](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4046)*
+
+**Returns:** *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+___
+
+### `Protected` internalGetReferencedInputs
+
+▸ **internalGetReferencedInputs**(`allInputs`: Array‹[Input](input.md)›): *Shared.Dictionary‹[Input](input.md)›*
+
+*Inherited from [Action](action.md).[internalGetReferencedInputs](action.md#protected-internalgetreferencedinputs)*
+
+*Defined in [card-elements.ts:3876](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3876)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`allInputs` | Array‹[Input](input.md)› |
+
+**Returns:** *Shared.Dictionary‹[Input](input.md)›*
+
+___
+
+### `Protected` internalPrepareForExecution
+
+▸ **internalPrepareForExecution**(`inputs`: Shared.Dictionary‹[Input](input.md)›): *void*
+
+*Inherited from [Action](action.md).[internalPrepareForExecution](action.md#protected-internalprepareforexecution)*
+
+*Defined in [card-elements.ts:3880](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3880)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`inputs` | Shared.Dictionary‹[Input](input.md)› |
+
+**Returns:** *void*
+
+___
+
+### `Protected` internalValidateInputs
+
+▸ **internalValidateInputs**(`referencedInputs`: Shared.Dictionary‹[Input](input.md)›): *Array‹[Input](input.md)›*
+
+*Inherited from [Action](action.md).[internalValidateInputs](action.md#protected-internalvalidateinputs)*
+
+*Defined in [card-elements.ts:3884](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3884)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`referencedInputs` | Shared.Dictionary‹[Input](input.md)› |
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+###  internalValidateProperties
+
+▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
+
+*Overrides [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
+
+*Defined in [card-elements.ts:4197](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4197)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [ValidationResults](validationresults.md) |
+
+**Returns:** *void*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Overrides [Action](action.md).[parse](action.md#parse)*
+
+*Defined in [card-elements.ts:4210](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4210)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*
+
+___
+
+###  prepareForExecution
+
+▸ **prepareForExecution**(): *boolean*
+
+*Inherited from [Action](action.md).[prepareForExecution](action.md#prepareforexecution)*
+
+*Defined in [card-elements.ts:4000](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4000)*
+
+**Returns:** *boolean*
+
+___
+
+###  remove
+
+▸ **remove**(): *boolean*
+
+*Inherited from [Action](action.md).[remove](action.md#remove)*
+
+*Defined in [card-elements.ts:4034](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4034)*
+
+**Returns:** *boolean*
+
+___
+
+###  render
+
+▸ **render**(`baseCssClass`: string): *void*
+
+*Inherited from [Action](action.md).[render](action.md#render)*
+
+*Defined in [card-elements.ts:3925](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3925)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`baseCssClass` | string | "ac-pushButton" |
+
+**Returns:** *void*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+###  setParent
+
+▸ **setParent**(`value`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [Action](action.md).[setParent](action.md#setparent)*
+
+*Overrides [CardObject](cardobject.md).[setParent](cardobject.md#abstract-setparent)*
+
+*Defined in [card-elements.ts:3988](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3988)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+###  shouldFallback
+
+▸ **shouldFallback**(): *boolean*
+
+*Inherited from [Action](action.md).[shouldFallback](action.md#shouldfallback)*
+
+*Overrides [CardObject](cardobject.md).[shouldFallback](cardobject.md#abstract-shouldfallback)*
+
+*Defined in [card-elements.ts:4069](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4069)*
+
+**Returns:** *boolean*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [Action](action.md).[toJSON](action.md#tojson)*
+
+*Defined in [card-elements.ts:4189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4189)*
+
+**Returns:** *any*
+
+___
+
+###  validateInputs
+
+▸ **validateInputs**(): *[Input](input.md)‹›[]*
+
+*Inherited from [Action](action.md).[validateInputs](action.md#validateinputs)*
+
+*Defined in [card-elements.ts:4065](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4065)*
+
+**Returns:** *[Input](input.md)‹›[]*
+
+___
+
+###  validateProperties
+
+▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
+
+*Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
+
+*Defined in [card-elements.ts:284](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L284)*
+
+**Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/paddingdefinition.md
+++ b/source/nodejs/adaptivecards/docs/classes/paddingdefinition.md
@@ -1,0 +1,71 @@
+[Adaptive Cards Javascript SDK](../README.md) › [PaddingDefinition](paddingdefinition.md)
+
+# Class: PaddingDefinition
+
+## Hierarchy
+
+* **PaddingDefinition**
+
+## Index
+
+### Constructors
+
+* [constructor](paddingdefinition.md#constructor)
+
+### Properties
+
+* [bottom](paddingdefinition.md#bottom)
+* [left](paddingdefinition.md#left)
+* [right](paddingdefinition.md#right)
+* [top](paddingdefinition.md#top)
+
+## Constructors
+
+###  constructor
+
+\+ **new PaddingDefinition**(`top`: [Spacing](../enums/spacing.md), `right`: [Spacing](../enums/spacing.md), `bottom`: [Spacing](../enums/spacing.md), `left`: [Spacing](../enums/spacing.md)): *[PaddingDefinition](paddingdefinition.md)*
+
+*Defined in [shared.ts:121](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/shared.ts#L121)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`top` | [Spacing](../enums/spacing.md) | Enums.Spacing.None |
+`right` | [Spacing](../enums/spacing.md) | Enums.Spacing.None |
+`bottom` | [Spacing](../enums/spacing.md) | Enums.Spacing.None |
+`left` | [Spacing](../enums/spacing.md) | Enums.Spacing.None |
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+## Properties
+
+###  bottom
+
+• **bottom**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.None
+
+*Defined in [shared.ts:120](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/shared.ts#L120)*
+
+___
+
+###  left
+
+• **left**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.None
+
+*Defined in [shared.ts:121](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/shared.ts#L121)*
+
+___
+
+###  right
+
+• **right**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.None
+
+*Defined in [shared.ts:119](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/shared.ts#L119)*
+
+___
+
+###  top
+
+• **top**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.None
+
+*Defined in [shared.ts:118](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/shared.ts#L118)*

--- a/source/nodejs/adaptivecards/docs/classes/richtextblock.md
+++ b/source/nodejs/adaptivecards/docs/classes/richtextblock.md
@@ -1,0 +1,1271 @@
+[Adaptive Cards Javascript SDK](../README.md) › [RichTextBlock](richtextblock.md)
+
+# Class: RichTextBlock
+
+## Hierarchy
+
+  ↳ [CardElement](cardelement.md)
+
+  ↳ **RichTextBlock**
+
+## Index
+
+### Properties
+
+* [customCssSelector](richtextblock.md#customcssselector)
+* [height](richtextblock.md#height)
+* [horizontalAlignment](richtextblock.md#optional-horizontalalignment)
+* [id](richtextblock.md#id)
+* [minPixelHeight](richtextblock.md#optional-minpixelheight)
+* [requires](richtextblock.md#requires)
+* [separator](richtextblock.md#separator)
+* [spacing](richtextblock.md#spacing)
+
+### Accessors
+
+* [allowCustomPadding](richtextblock.md#protected-allowcustompadding)
+* [defaultStyle](richtextblock.md#protected-defaultstyle)
+* [hasVisibleSeparator](richtextblock.md#hasvisibleseparator)
+* [hostConfig](richtextblock.md#hostconfig)
+* [index](richtextblock.md#index)
+* [isInline](richtextblock.md#isinline)
+* [isInteractive](richtextblock.md#isinteractive)
+* [isStandalone](richtextblock.md#isstandalone)
+* [isVisible](richtextblock.md#isvisible)
+* [lang](richtextblock.md#lang)
+* [parent](richtextblock.md#parent)
+* [renderedElement](richtextblock.md#renderedelement)
+* [separatorElement](richtextblock.md#separatorelement)
+* [separatorOrientation](richtextblock.md#protected-separatororientation)
+* [supportsMinHeight](richtextblock.md#protected-supportsminheight)
+* [useDefaultSizing](richtextblock.md#protected-usedefaultsizing)
+
+### Methods
+
+* [addInline](richtextblock.md#addinline)
+* [adjustRenderedElementSize](richtextblock.md#protected-adjustrenderedelementsize)
+* [applyPadding](richtextblock.md#protected-applypadding)
+* [asString](richtextblock.md#asstring)
+* [createPlaceholderElement](richtextblock.md#protected-createplaceholderelement)
+* [getActionAt](richtextblock.md#getactionat)
+* [getActionById](richtextblock.md#getactionbyid)
+* [getActionCount](richtextblock.md#getactioncount)
+* [getAllInputs](richtextblock.md#getallinputs)
+* [getCustomProperty](richtextblock.md#getcustomproperty)
+* [getDefaultPadding](richtextblock.md#protected-getdefaultpadding)
+* [getEffectivePadding](richtextblock.md#geteffectivepadding)
+* [getEffectiveStyle](richtextblock.md#geteffectivestyle)
+* [getElementById](richtextblock.md#getelementbyid)
+* [getForbiddenActionTypes](richtextblock.md#getforbiddenactiontypes)
+* [getForbiddenElementTypes](richtextblock.md#getforbiddenelementtypes)
+* [getHasBackground](richtextblock.md#protected-gethasbackground)
+* [getImmediateSurroundingPadding](richtextblock.md#getimmediatesurroundingpadding)
+* [getInlineAt](richtextblock.md#getinlineat)
+* [getInlineCount](richtextblock.md#getinlinecount)
+* [getJsonTypeName](richtextblock.md#getjsontypename)
+* [getPadding](richtextblock.md#protected-getpadding)
+* [getParentContainer](richtextblock.md#getparentcontainer)
+* [getResourceInformation](richtextblock.md#getresourceinformation)
+* [getRootElement](richtextblock.md#getrootelement)
+* [indexOf](richtextblock.md#indexof)
+* [internalRender](richtextblock.md#protected-internalrender)
+* [internalValidateProperties](richtextblock.md#internalvalidateproperties)
+* [isAtTheVeryBottom](richtextblock.md#isattheverybottom)
+* [isAtTheVeryLeft](richtextblock.md#isattheveryleft)
+* [isAtTheVeryRight](richtextblock.md#isattheveryright)
+* [isAtTheVeryTop](richtextblock.md#isattheverytop)
+* [isBleeding](richtextblock.md#isbleeding)
+* [isBleedingAtBottom](richtextblock.md#isbleedingatbottom)
+* [isBleedingAtTop](richtextblock.md#isbleedingattop)
+* [isBottomElement](richtextblock.md#isbottomelement)
+* [isDesignMode](richtextblock.md#isdesignmode)
+* [isFirstElement](richtextblock.md#isfirstelement)
+* [isHiddenDueToOverflow](richtextblock.md#ishiddenduetooverflow)
+* [isLastElement](richtextblock.md#islastelement)
+* [isLeftMostElement](richtextblock.md#isleftmostelement)
+* [isRendered](richtextblock.md#isrendered)
+* [isRightMostElement](richtextblock.md#isrightmostelement)
+* [isTopElement](richtextblock.md#istopelement)
+* [overrideInternalRender](richtextblock.md#protected-overrideinternalrender)
+* [parse](richtextblock.md#parse)
+* [remove](richtextblock.md#remove)
+* [removeInline](richtextblock.md#removeinline)
+* [render](richtextblock.md#render)
+* [setCustomProperty](richtextblock.md#setcustomproperty)
+* [setPadding](richtextblock.md#protected-setpadding)
+* [setParent](richtextblock.md#setparent)
+* [setShouldFallback](richtextblock.md#setshouldfallback)
+* [shouldFallback](richtextblock.md#shouldfallback)
+* [toJSON](richtextblock.md#tojson)
+* [truncateOverflow](richtextblock.md#protected-truncateoverflow)
+* [undoOverflowTruncation](richtextblock.md#protected-undooverflowtruncation)
+* [updateLayout](richtextblock.md#updatelayout)
+* [validateProperties](richtextblock.md#validateproperties)
+
+## Properties
+
+###  customCssSelector
+
+• **customCssSelector**: *string* = null
+
+*Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#customcssselector)*
+
+*Defined in [card-elements.ts:507](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L507)*
+
+___
+
+###  height
+
+• **height**: *[CardElementHeight](../README.md#cardelementheight)* = "auto"
+
+*Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
+
+*Defined in [card-elements.ts:508](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L508)*
+
+___
+
+### `Optional` horizontalAlignment
+
+• **horizontalAlignment**? : *[HorizontalAlignment](../enums/horizontalalignment.md)* = null
+
+*Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#optional-horizontalalignment)*
+
+*Defined in [card-elements.ts:504](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L504)*
+
+___
+
+###  id
+
+• **id**: *string*
+
+*Inherited from [CardObject](cardobject.md).[id](cardobject.md#id)*
+
+*Defined in [card-elements.ts:247](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L247)*
+
+___
+
+### `Optional` minPixelHeight
+
+• **minPixelHeight**? : *number* = null
+
+*Inherited from [CardElement](cardelement.md).[minPixelHeight](cardelement.md#optional-minpixelheight)*
+
+*Defined in [card-elements.ts:509](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L509)*
+
+___
+
+###  requires
+
+• **requires**: *[HostCapabilities](hostcapabilities.md)‹›* = new HostConfig.HostCapabilities()
+
+*Inherited from [CardElement](cardelement.md).[requires](cardelement.md#requires)*
+
+*Defined in [card-elements.ts:502](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L502)*
+
+___
+
+###  separator
+
+• **separator**: *boolean* = false
+
+*Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
+
+*Defined in [card-elements.ts:506](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L506)*
+
+___
+
+###  spacing
+
+• **spacing**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.Default
+
+*Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
+
+*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
+
+## Accessors
+
+### `Protected` allowCustomPadding
+
+• **get allowCustomPadding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
+
+*Defined in [card-elements.ts:490](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L490)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` defaultStyle
+
+• **get defaultStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
+
+*Defined in [card-elements.ts:498](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L498)*
+
+**Returns:** *string*
+
+___
+
+###  hasVisibleSeparator
+
+• **get hasVisibleSeparator**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
+
+*Defined in [card-elements.ts:928](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L928)*
+
+**Returns:** *boolean*
+
+___
+
+###  hostConfig
+
+• **get hostConfig**(): *[HostConfig](hostconfig.md)*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:881](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L881)*
+
+**Returns:** *[HostConfig](hostconfig.md)*
+
+• **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:895](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L895)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [HostConfig](hostconfig.md) |
+
+**Returns:** *void*
+
+___
+
+###  index
+
+• **get index**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
+
+*Defined in [card-elements.ts:899](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L899)*
+
+**Returns:** *number*
+
+___
+
+###  isInline
+
+• **get isInline**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
+
+*Defined in [card-elements.ts:916](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L916)*
+
+**Returns:** *boolean*
+
+___
+
+###  isInteractive
+
+• **get isInteractive**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
+
+*Defined in [card-elements.ts:908](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L908)*
+
+**Returns:** *boolean*
+
+___
+
+###  isStandalone
+
+• **get isStandalone**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
+
+*Defined in [card-elements.ts:912](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L912)*
+
+**Returns:** *boolean*
+
+___
+
+###  isVisible
+
+• **get isVisible**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:924](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L924)*
+
+**Returns:** *boolean*
+
+• **set isVisible**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:937](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L937)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  lang
+
+• **get lang**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:853](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L853)*
+
+**Returns:** *string*
+
+• **set lang**(`value`: string): *void*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:867](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L867)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  parent
+
+• **get parent**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[parent](cardelement.md#parent)*
+
+*Defined in [card-elements.ts:920](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L920)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  renderedElement
+
+• **get renderedElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[renderedElement](cardelement.md#renderedelement)*
+
+*Defined in [card-elements.ts:956](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L956)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  separatorElement
+
+• **get separatorElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
+
+*Defined in [card-elements.ts:960](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L960)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` separatorOrientation
+
+• **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
+
+*Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
+
+*Defined in [card-elements.ts:494](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L494)*
+
+**Returns:** *[Orientation](../enums/orientation.md)*
+
+___
+
+### `Protected` supportsMinHeight
+
+• **get supportsMinHeight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[supportsMinHeight](cardelement.md#protected-supportsminheight)*
+
+*Defined in [card-elements.ts:482](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L482)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` useDefaultSizing
+
+• **get useDefaultSizing**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
+
+*Defined in [card-elements.ts:486](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L486)*
+
+**Returns:** *boolean*
+
+## Methods
+
+###  addInline
+
+▸ **addInline**(`inline`: [CardElement](cardelement.md)): *void*
+
+*Defined in [card-elements.ts:1689](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1689)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`inline` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+### `Protected` adjustRenderedElementSize
+
+▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
+
+*Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
+
+*Defined in [card-elements.ts:411](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L411)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`renderedElement` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+### `Protected` applyPadding
+
+▸ **applyPadding**(): *void*
+
+*Inherited from [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
+
+*Defined in [card-elements.ts:430](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L430)*
+
+**Returns:** *void*
+
+___
+
+###  asString
+
+▸ **asString**(): *string*
+
+*Overrides [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
+
+*Defined in [card-elements.ts:1616](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1616)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` createPlaceholderElement
+
+▸ **createPlaceholderElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
+
+*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  getActionAt
+
+▸ **getActionAt**(`index`: number): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
+
+*Defined in [card-elements.ts:694](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L694)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionById
+
+▸ **getActionById**(`id`: string): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
+
+*Defined in [card-elements.ts:835](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L835)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionCount
+
+▸ **getActionCount**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
+
+*Defined in [card-elements.ts:690](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L690)*
+
+**Returns:** *number*
+
+___
+
+###  getAllInputs
+
+▸ **getAllInputs**(): *Array‹[Input](input.md)›*
+
+*Inherited from [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
+
+*Defined in [card-elements.ts:823](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L823)*
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+### `Protected` getDefaultPadding
+
+▸ **getDefaultPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
+
+*Defined in [card-elements.ts:466](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L466)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectivePadding
+
+▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
+
+*Defined in [card-elements.ts:847](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L847)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectiveStyle
+
+▸ **getEffectiveStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
+
+*Defined in [card-elements.ts:545](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L545)*
+
+**Returns:** *string*
+
+___
+
+###  getElementById
+
+▸ **getElementById**(`id`: string): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
+
+*Defined in [card-elements.ts:831](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L831)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getForbiddenActionTypes
+
+▸ **getForbiddenActionTypes**(): *Array‹any›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
+
+*Defined in [card-elements.ts:557](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L557)*
+
+**Returns:** *Array‹any›*
+
+___
+
+###  getForbiddenElementTypes
+
+▸ **getForbiddenElementTypes**(): *Array‹string›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenElementTypes](cardelement.md#getforbiddenelementtypes)*
+
+*Defined in [card-elements.ts:553](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L553)*
+
+**Returns:** *Array‹string›*
+
+___
+
+### `Protected` getHasBackground
+
+▸ **getHasBackground**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
+
+*Defined in [card-elements.ts:470](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L470)*
+
+**Returns:** *boolean*
+
+___
+
+###  getImmediateSurroundingPadding
+
+▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
+
+*Defined in [card-elements.ts:561](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L561)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`result` | [PaddingDefinition](paddingdefinition.md) | - |
+`processTop` | boolean | true |
+`processRight` | boolean | true |
+`processBottom` | boolean | true |
+`processLeft` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  getInlineAt
+
+▸ **getInlineAt**(`index`: number): *[CardElement](cardelement.md)*
+
+*Defined in [card-elements.ts:1680](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1680)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getInlineCount
+
+▸ **getInlineCount**(): *number*
+
+*Defined in [card-elements.ts:1676](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1676)*
+
+**Returns:** *number*
+
+___
+
+###  getJsonTypeName
+
+▸ **getJsonTypeName**(): *string*
+
+*Overrides [CardElement](cardelement.md).[getJsonTypeName](cardelement.md#abstract-getjsontypename)*
+
+*Defined in [card-elements.ts:1672](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1672)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` getPadding
+
+▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
+
+*Defined in [card-elements.ts:474](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L474)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getParentContainer
+
+▸ **getParentContainer**(): *[Container](container.md)*
+
+*Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
+
+*Defined in [card-elements.ts:809](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L809)*
+
+**Returns:** *[Container](container.md)*
+
+___
+
+###  getResourceInformation
+
+▸ **getResourceInformation**(): *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+*Inherited from [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
+
+*Defined in [card-elements.ts:827](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L827)*
+
+**Returns:** *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+___
+
+###  getRootElement
+
+▸ **getRootElement**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
+
+*Defined in [card-elements.ts:799](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L799)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  indexOf
+
+▸ **indexOf**(`cardElement`: [CardElement](cardelement.md)): *number*
+
+*Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
+
+*Defined in [card-elements.ts:733](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L733)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`cardElement` | [CardElement](cardelement.md) |
+
+**Returns:** *number*
+
+___
+
+### `Protected` internalRender
+
+▸ **internalRender**(): *HTMLElement*
+
+*Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
+
+*Defined in [card-elements.ts:1576](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1576)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  internalValidateProperties
+
+▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
+
+*Inherited from [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
+
+*Defined in [card-elements.ts:249](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L249)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [ValidationResults](validationresults.md) |
+
+**Returns:** *void*
+
+___
+
+###  isAtTheVeryBottom
+
+▸ **isAtTheVeryBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
+
+*Defined in [card-elements.ts:767](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L767)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryLeft
+
+▸ **isAtTheVeryLeft**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
+
+*Defined in [card-elements.ts:755](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L755)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryRight
+
+▸ **isAtTheVeryRight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
+
+*Defined in [card-elements.ts:759](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L759)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryTop
+
+▸ **isAtTheVeryTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
+
+*Defined in [card-elements.ts:763](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L763)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleeding
+
+▸ **isBleeding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
+
+*Defined in [card-elements.ts:517](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L517)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtBottom
+
+▸ **isBleedingAtBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
+
+*Defined in [card-elements.ts:775](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L775)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtTop
+
+▸ **isBleedingAtTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
+
+*Defined in [card-elements.ts:771](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L771)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBottomElement
+
+▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
+
+*Defined in [card-elements.ts:791](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L791)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isDesignMode
+
+▸ **isDesignMode**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
+
+*Defined in [card-elements.ts:737](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L737)*
+
+**Returns:** *boolean*
+
+___
+
+###  isFirstElement
+
+▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
+
+*Defined in [card-elements.ts:747](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L747)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isHiddenDueToOverflow
+
+▸ **isHiddenDueToOverflow**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
+
+*Defined in [card-elements.ts:795](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L795)*
+
+**Returns:** *boolean*
+
+___
+
+###  isLastElement
+
+▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
+
+*Defined in [card-elements.ts:751](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L751)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isLeftMostElement
+
+▸ **isLeftMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
+
+*Defined in [card-elements.ts:779](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L779)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isRendered
+
+▸ **isRendered**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRendered](cardelement.md#isrendered)*
+
+*Defined in [card-elements.ts:743](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L743)*
+
+**Returns:** *boolean*
+
+___
+
+###  isRightMostElement
+
+▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
+
+*Defined in [card-elements.ts:783](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L783)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isTopElement
+
+▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
+
+*Defined in [card-elements.ts:787](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L787)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` overrideInternalRender
+
+▸ **overrideInternalRender**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
+
+*Defined in [card-elements.ts:426](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L426)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Overrides [CardElement](cardelement.md).[parse](cardelement.md#parse)*
+
+*Defined in [card-elements.ts:1626](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1626)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*
+
+___
+
+###  remove
+
+▸ **remove**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
+
+*Defined in [card-elements.ts:698](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L698)*
+
+**Returns:** *boolean*
+
+___
+
+###  removeInline
+
+▸ **removeInline**(`inline`: [CardElement](cardelement.md)): *boolean*
+
+*Defined in [card-elements.ts:1693](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1693)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`inline` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  render
+
+▸ **render**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[render](cardelement.md#render)*
+
+*Defined in [card-elements.ts:706](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L706)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setPadding
+
+▸ **setPadding**(`value`: [PaddingDefinition](paddingdefinition.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
+
+*Defined in [card-elements.ts:478](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L478)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [PaddingDefinition](paddingdefinition.md) |
+
+**Returns:** *void*
+
+___
+
+###  setParent
+
+▸ **setParent**(`value`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setParent](cardelement.md#setparent)*
+
+*Overrides [CardObject](cardobject.md).[setParent](cardobject.md#abstract-setparent)*
+
+*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+###  setShouldFallback
+
+▸ **setShouldFallback**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[setShouldFallback](cardelement.md#setshouldfallback)*
+
+*Defined in [card-elements.ts:843](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L843)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  shouldFallback
+
+▸ **shouldFallback**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[shouldFallback](cardelement.md#shouldfallback)*
+
+*Overrides [CardObject](cardobject.md).[shouldFallback](cardobject.md#abstract-shouldfallback)*
+
+*Defined in [card-elements.ts:839](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L839)*
+
+**Returns:** *boolean*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [CardElement](cardelement.md).[toJSON](cardelement.md#tojson)*
+
+*Defined in [card-elements.ts:1656](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1656)*
+
+**Returns:** *any*
+
+___
+
+### `Protected` truncateOverflow
+
+▸ **truncateOverflow**(`maxHeight`: number): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
+
+*Defined in [card-elements.ts:454](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L454)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`maxHeight` | number |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` undoOverflowTruncation
+
+▸ **undoOverflowTruncation**(): *void*
+
+*Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
+
+*Defined in [card-elements.ts:464](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L464)*
+
+**Returns:** *void*
+
+___
+
+###  updateLayout
+
+▸ **updateLayout**(`processChildren`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
+
+*Defined in [card-elements.ts:728](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L728)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`processChildren` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  validateProperties
+
+▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
+
+*Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
+
+*Defined in [card-elements.ts:284](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L284)*
+
+**Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/serializableobject.md
+++ b/source/nodejs/adaptivecards/docs/classes/serializableobject.md
@@ -1,0 +1,92 @@
+[Adaptive Cards Javascript SDK](../README.md) › [SerializableObject](serializableobject.md)
+
+# Class: SerializableObject
+
+Represents an object that can be serialized to/from JSON
+
+## Hierarchy
+
+* **SerializableObject**
+
+  ↳ [CardObject](cardobject.md)
+
+  ↳ [Fact](fact.md)
+
+  ↳ [MediaSource](mediasource.md)
+
+  ↳ [InputValidationOptions](inputvalidationoptions.md)
+
+  ↳ [Choice](choice.md)
+
+  ↳ [HttpHeader](httpheader.md)
+
+  ↳ [BackgroundImage](backgroundimage.md)
+
+## Index
+
+### Methods
+
+* [getCustomProperty](serializableobject.md#getcustomproperty)
+* [parse](serializableobject.md#parse)
+* [setCustomProperty](serializableobject.md#setcustomproperty)
+* [toJSON](serializableobject.md#tojson)
+
+## Methods
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Defined in [card-elements.ts:172](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L172)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Defined in [card-elements.ts:176](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L176)*
+
+**Returns:** *any*

--- a/source/nodejs/adaptivecards/docs/classes/showcardaction.md
+++ b/source/nodejs/adaptivecards/docs/classes/showcardaction.md
@@ -1,0 +1,549 @@
+[Adaptive Cards Javascript SDK](../README.md) › [ShowCardAction](showcardaction.md)
+
+# Class: ShowCardAction
+
+## Hierarchy
+
+  ↳ [Action](action.md)
+
+  ↳ **ShowCardAction**
+
+## Index
+
+### Properties
+
+* [card](showcardaction.md#card)
+* [iconUrl](showcardaction.md#iconurl)
+* [id](showcardaction.md#id)
+* [onExecute](showcardaction.md#onexecute)
+* [requires](showcardaction.md#requires)
+* [style](showcardaction.md#style)
+* [title](showcardaction.md#title)
+* [JsonTypeName](showcardaction.md#static-jsontypename)
+
+### Accessors
+
+* [ignoreInputValidation](showcardaction.md#ignoreinputvalidation)
+* [isPrimary](showcardaction.md#isprimary)
+* [parent](showcardaction.md#parent)
+* [renderedElement](showcardaction.md#renderedelement)
+
+### Methods
+
+* [addCssClasses](showcardaction.md#protected-addcssclasses)
+* [execute](showcardaction.md#execute)
+* [getActionById](showcardaction.md#getactionbyid)
+* [getAllInputs](showcardaction.md#getallinputs)
+* [getCustomProperty](showcardaction.md#getcustomproperty)
+* [getHref](showcardaction.md#gethref)
+* [getJsonTypeName](showcardaction.md#getjsontypename)
+* [getReferencedInputs](showcardaction.md#getreferencedinputs)
+* [getResourceInformation](showcardaction.md#getresourceinformation)
+* [internalGetReferencedInputs](showcardaction.md#protected-internalgetreferencedinputs)
+* [internalPrepareForExecution](showcardaction.md#protected-internalprepareforexecution)
+* [internalValidateInputs](showcardaction.md#protected-internalvalidateinputs)
+* [internalValidateProperties](showcardaction.md#internalvalidateproperties)
+* [parse](showcardaction.md#parse)
+* [prepareForExecution](showcardaction.md#prepareforexecution)
+* [remove](showcardaction.md#remove)
+* [render](showcardaction.md#render)
+* [setCustomProperty](showcardaction.md#setcustomproperty)
+* [setParent](showcardaction.md#setparent)
+* [shouldFallback](showcardaction.md#shouldfallback)
+* [toJSON](showcardaction.md#tojson)
+* [validateInputs](showcardaction.md#validateinputs)
+* [validateProperties](showcardaction.md#validateproperties)
+
+## Properties
+
+###  card
+
+• **card**: *[AdaptiveCard](adaptivecard.md)* = new InlineAdaptiveCard()
+
+*Defined in [card-elements.ts:4496](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4496)*
+
+___
+
+###  iconUrl
+
+• **iconUrl**: *string*
+
+*Inherited from [Action](action.md).[iconUrl](action.md#iconurl)*
+
+*Defined in [card-elements.ts:3905](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3905)*
+
+___
+
+###  id
+
+• **id**: *string*
+
+*Inherited from [CardObject](cardobject.md).[id](cardobject.md#id)*
+
+*Defined in [card-elements.ts:247](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L247)*
+
+___
+
+###  onExecute
+
+• **onExecute**: *function*
+
+*Inherited from [Action](action.md).[onExecute](action.md#onexecute)*
+
+*Defined in [card-elements.ts:3908](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3908)*
+
+#### Type declaration:
+
+▸ (`sender`: [Action](action.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`sender` | [Action](action.md) |
+
+___
+
+###  requires
+
+• **requires**: *[HostCapabilities](hostcapabilities.md)‹›* = new HostConfig.HostCapabilities()
+
+*Inherited from [Action](action.md).[requires](action.md#requires)*
+
+*Defined in [card-elements.ts:3902](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3902)*
+
+___
+
+###  style
+
+• **style**: *string* = Enums.ActionStyle.Default
+
+*Inherited from [Action](action.md).[style](action.md#style)*
+
+*Defined in [card-elements.ts:3906](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3906)*
+
+___
+
+###  title
+
+• **title**: *string*
+
+*Inherited from [Action](action.md).[title](action.md#title)*
+
+*Defined in [card-elements.ts:3904](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3904)*
+
+___
+
+### `Static` JsonTypeName
+
+▪ **JsonTypeName**: *"Action.ShowCard"* = "Action.ShowCard"
+
+*Defined in [card-elements.ts:4488](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4488)*
+
+## Accessors
+
+###  ignoreInputValidation
+
+• **get ignoreInputValidation**(): *boolean*
+
+*Inherited from [Action](action.md).[ignoreInputValidation](action.md#ignoreinputvalidation)*
+
+*Defined in [card-elements.ts:4088](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4088)*
+
+**Returns:** *boolean*
+
+___
+
+###  isPrimary
+
+• **get isPrimary**(): *boolean*
+
+*Inherited from [Action](action.md).[isPrimary](action.md#isprimary)*
+
+*Defined in [card-elements.ts:4073](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4073)*
+
+**Returns:** *boolean*
+
+• **set isPrimary**(`value`: boolean): *void*
+
+*Inherited from [Action](action.md).[isPrimary](action.md#isprimary)*
+
+*Defined in [card-elements.ts:4077](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4077)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  parent
+
+• **get parent**(): *[CardElement](cardelement.md)*
+
+*Inherited from [Action](action.md).[parent](action.md#parent)*
+
+*Defined in [card-elements.ts:4092](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4092)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  renderedElement
+
+• **get renderedElement**(): *HTMLElement*
+
+*Inherited from [Action](action.md).[renderedElement](action.md#renderedelement)*
+
+*Defined in [card-elements.ts:4096](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4096)*
+
+**Returns:** *HTMLElement*
+
+## Methods
+
+### `Protected` addCssClasses
+
+▸ **addCssClasses**(`element`: HTMLElement): *void*
+
+*Overrides [Action](action.md).[addCssClasses](action.md#protected-addcssclasses)*
+
+*Defined in [card-elements.ts:4490](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4490)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+###  execute
+
+▸ **execute**(): *void*
+
+*Inherited from [Action](action.md).[execute](action.md#execute)*
+
+*Defined in [card-elements.ts:3992](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3992)*
+
+**Returns:** *void*
+
+___
+
+###  getActionById
+
+▸ **getActionById**(`id`: string): *[Action](action.md)*
+
+*Overrides [Action](action.md).[getActionById](action.md#getactionbyid)*
+
+*Defined in [card-elements.ts:4551](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4551)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getAllInputs
+
+▸ **getAllInputs**(): *Array‹[Input](input.md)›*
+
+*Overrides [Action](action.md).[getAllInputs](action.md#getallinputs)*
+
+*Defined in [card-elements.ts:4543](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4543)*
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+###  getHref
+
+▸ **getHref**(): *string*
+
+*Inherited from [Action](action.md).[getHref](action.md#gethref)*
+
+*Defined in [card-elements.ts:3910](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3910)*
+
+**Returns:** *string*
+
+___
+
+###  getJsonTypeName
+
+▸ **getJsonTypeName**(): *string*
+
+*Overrides [Action](action.md).[getJsonTypeName](action.md#abstract-getjsontypename)*
+
+*Defined in [card-elements.ts:4498](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4498)*
+
+**Returns:** *string*
+
+___
+
+###  getReferencedInputs
+
+▸ **getReferencedInputs**(): *Shared.Dictionary‹[Input](input.md)›*
+
+*Inherited from [Action](action.md).[getReferencedInputs](action.md#getreferencedinputs)*
+
+*Defined in [card-elements.ts:4061](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4061)*
+
+**Returns:** *Shared.Dictionary‹[Input](input.md)›*
+
+___
+
+###  getResourceInformation
+
+▸ **getResourceInformation**(): *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+*Overrides [Action](action.md).[getResourceInformation](action.md#getresourceinformation)*
+
+*Defined in [card-elements.ts:4547](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4547)*
+
+**Returns:** *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+___
+
+### `Protected` internalGetReferencedInputs
+
+▸ **internalGetReferencedInputs**(`allInputs`: Array‹[Input](input.md)›): *Shared.Dictionary‹[Input](input.md)›*
+
+*Inherited from [Action](action.md).[internalGetReferencedInputs](action.md#protected-internalgetreferencedinputs)*
+
+*Defined in [card-elements.ts:3876](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3876)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`allInputs` | Array‹[Input](input.md)› |
+
+**Returns:** *Shared.Dictionary‹[Input](input.md)›*
+
+___
+
+### `Protected` internalPrepareForExecution
+
+▸ **internalPrepareForExecution**(`inputs`: Shared.Dictionary‹[Input](input.md)›): *void*
+
+*Inherited from [Action](action.md).[internalPrepareForExecution](action.md#protected-internalprepareforexecution)*
+
+*Defined in [card-elements.ts:3880](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3880)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`inputs` | Shared.Dictionary‹[Input](input.md)› |
+
+**Returns:** *void*
+
+___
+
+### `Protected` internalValidateInputs
+
+▸ **internalValidateInputs**(`referencedInputs`: Shared.Dictionary‹[Input](input.md)›): *Array‹[Input](input.md)›*
+
+*Inherited from [Action](action.md).[internalValidateInputs](action.md#protected-internalvalidateinputs)*
+
+*Defined in [card-elements.ts:3884](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3884)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`referencedInputs` | Shared.Dictionary‹[Input](input.md)› |
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+###  internalValidateProperties
+
+▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
+
+*Overrides [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
+
+*Defined in [card-elements.ts:4512](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4512)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [ValidationResults](validationresults.md) |
+
+**Returns:** *void*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Overrides [Action](action.md).[parse](action.md#parse)*
+
+*Defined in [card-elements.ts:4518](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4518)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*
+
+___
+
+###  prepareForExecution
+
+▸ **prepareForExecution**(): *boolean*
+
+*Inherited from [Action](action.md).[prepareForExecution](action.md#prepareforexecution)*
+
+*Defined in [card-elements.ts:4000](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4000)*
+
+**Returns:** *boolean*
+
+___
+
+###  remove
+
+▸ **remove**(): *boolean*
+
+*Inherited from [Action](action.md).[remove](action.md#remove)*
+
+*Defined in [card-elements.ts:4034](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4034)*
+
+**Returns:** *boolean*
+
+___
+
+###  render
+
+▸ **render**(`baseCssClass`: string): *void*
+
+*Inherited from [Action](action.md).[render](action.md#render)*
+
+*Defined in [card-elements.ts:3925](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3925)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`baseCssClass` | string | "ac-pushButton" |
+
+**Returns:** *void*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+###  setParent
+
+▸ **setParent**(`value`: [CardElement](cardelement.md)): *void*
+
+*Overrides [Action](action.md).[setParent](action.md#setparent)*
+
+*Defined in [card-elements.ts:4537](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4537)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+###  shouldFallback
+
+▸ **shouldFallback**(): *boolean*
+
+*Inherited from [Action](action.md).[shouldFallback](action.md#shouldfallback)*
+
+*Overrides [CardObject](cardobject.md).[shouldFallback](cardobject.md#abstract-shouldfallback)*
+
+*Defined in [card-elements.ts:4069](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4069)*
+
+**Returns:** *boolean*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [Action](action.md).[toJSON](action.md#tojson)*
+
+*Defined in [card-elements.ts:4502](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4502)*
+
+**Returns:** *any*
+
+___
+
+###  validateInputs
+
+▸ **validateInputs**(): *[Input](input.md)‹›[]*
+
+*Inherited from [Action](action.md).[validateInputs](action.md#validateinputs)*
+
+*Defined in [card-elements.ts:4065](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4065)*
+
+**Returns:** *[Input](input.md)‹›[]*
+
+___
+
+###  validateProperties
+
+▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
+
+*Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
+
+*Defined in [card-elements.ts:284](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L284)*
+
+**Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/showcardactionconfig.md
+++ b/source/nodejs/adaptivecards/docs/classes/showcardactionconfig.md
@@ -1,0 +1,79 @@
+[Adaptive Cards Javascript SDK](../README.md) › [ShowCardActionConfig](showcardactionconfig.md)
+
+# Class: ShowCardActionConfig
+
+## Hierarchy
+
+* **ShowCardActionConfig**
+
+## Index
+
+### Constructors
+
+* [constructor](showcardactionconfig.md#constructor)
+
+### Properties
+
+* [actionMode](showcardactionconfig.md#actionmode)
+* [inlineTopMargin](showcardactionconfig.md#inlinetopmargin)
+* [style](showcardactionconfig.md#optional-style)
+
+### Methods
+
+* [toJSON](showcardactionconfig.md#tojson)
+
+## Constructors
+
+###  constructor
+
+\+ **new ShowCardActionConfig**(`obj?`: any): *[ShowCardActionConfig](showcardactionconfig.md)*
+
+*Defined in [host-config.ts:161](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L161)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`obj?` | any |
+
+**Returns:** *[ShowCardActionConfig](showcardactionconfig.md)*
+
+## Properties
+
+###  actionMode
+
+• **actionMode**: *[ShowCardActionMode](../enums/showcardactionmode.md)* = Enums.ShowCardActionMode.Inline
+
+*Defined in [host-config.ts:159](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L159)*
+
+___
+
+###  inlineTopMargin
+
+• **inlineTopMargin**: *number* = 16
+
+*Defined in [host-config.ts:160](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L160)*
+
+___
+
+### `Optional` style
+
+• **style**? : *string* = Enums.ContainerStyle.Emphasis
+
+*Defined in [host-config.ts:161](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L161)*
+
+## Methods
+
+###  toJSON
+
+▸ **toJSON**(): *object*
+
+*Defined in [host-config.ts:171](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L171)*
+
+**Returns:** *object*
+
+* **actionMode**: *string* = Enums.ShowCardActionMode[this.actionMode]
+
+* **inlineTopMargin**: *number* = this.inlineTopMargin
+
+* **style**: *string* = this.style

--- a/source/nodejs/adaptivecards/docs/classes/sizeandunit.md
+++ b/source/nodejs/adaptivecards/docs/classes/sizeandunit.md
@@ -1,0 +1,72 @@
+[Adaptive Cards Javascript SDK](../README.md) › [SizeAndUnit](sizeandunit.md)
+
+# Class: SizeAndUnit
+
+## Hierarchy
+
+* **SizeAndUnit**
+
+## Index
+
+### Constructors
+
+* [constructor](sizeandunit.md#constructor)
+
+### Properties
+
+* [physicalSize](sizeandunit.md#physicalsize)
+* [unit](sizeandunit.md#unit)
+
+### Methods
+
+* [parse](sizeandunit.md#static-parse)
+
+## Constructors
+
+###  constructor
+
+\+ **new SizeAndUnit**(`physicalSize`: number, `unit`: [SizeUnit](../enums/sizeunit.md)): *[SizeAndUnit](sizeandunit.md)*
+
+*Defined in [shared.ts:165](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/shared.ts#L165)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`physicalSize` | number |
+`unit` | [SizeUnit](../enums/sizeunit.md) |
+
+**Returns:** *[SizeAndUnit](sizeandunit.md)*
+
+## Properties
+
+###  physicalSize
+
+• **physicalSize**: *number*
+
+*Defined in [shared.ts:135](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/shared.ts#L135)*
+
+___
+
+###  unit
+
+• **unit**: *[SizeUnit](../enums/sizeunit.md)*
+
+*Defined in [shared.ts:136](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/shared.ts#L136)*
+
+## Methods
+
+### `Static` parse
+
+▸ **parse**(`input`: any, `requireUnitSpecifier`: boolean): *[SizeAndUnit](sizeandunit.md)*
+
+*Defined in [shared.ts:138](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/shared.ts#L138)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`input` | any | - |
+`requireUnitSpecifier` | boolean | false |
+
+**Returns:** *[SizeAndUnit](sizeandunit.md)*

--- a/source/nodejs/adaptivecards/docs/classes/spacingdefinition.md
+++ b/source/nodejs/adaptivecards/docs/classes/spacingdefinition.md
@@ -1,0 +1,71 @@
+[Adaptive Cards Javascript SDK](../README.md) › [SpacingDefinition](spacingdefinition.md)
+
+# Class: SpacingDefinition
+
+## Hierarchy
+
+* **SpacingDefinition**
+
+## Index
+
+### Constructors
+
+* [constructor](spacingdefinition.md#constructor)
+
+### Properties
+
+* [bottom](spacingdefinition.md#bottom)
+* [left](spacingdefinition.md#left)
+* [right](spacingdefinition.md#right)
+* [top](spacingdefinition.md#top)
+
+## Constructors
+
+###  constructor
+
+\+ **new SpacingDefinition**(`top`: number, `right`: number, `bottom`: number, `left`: number): *[SpacingDefinition](spacingdefinition.md)*
+
+*Defined in [shared.ts:104](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/shared.ts#L104)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`top` | number | 0 |
+`right` | number | 0 |
+`bottom` | number | 0 |
+`left` | number | 0 |
+
+**Returns:** *[SpacingDefinition](spacingdefinition.md)*
+
+## Properties
+
+###  bottom
+
+• **bottom**: *number* = 0
+
+*Defined in [shared.ts:104](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/shared.ts#L104)*
+
+___
+
+###  left
+
+• **left**: *number* = 0
+
+*Defined in [shared.ts:101](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/shared.ts#L101)*
+
+___
+
+###  right
+
+• **right**: *number* = 0
+
+*Defined in [shared.ts:103](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/shared.ts#L103)*
+
+___
+
+###  top
+
+• **top**: *number* = 0
+
+*Defined in [shared.ts:102](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/shared.ts#L102)*

--- a/source/nodejs/adaptivecards/docs/classes/stringwithsubstitutions.md
+++ b/source/nodejs/adaptivecards/docs/classes/stringwithsubstitutions.md
@@ -1,0 +1,87 @@
+[Adaptive Cards Javascript SDK](../README.md) › [StringWithSubstitutions](stringwithsubstitutions.md)
+
+# Class: StringWithSubstitutions
+
+## Hierarchy
+
+* **StringWithSubstitutions**
+
+## Index
+
+### Methods
+
+* [get](stringwithsubstitutions.md#get)
+* [getOriginal](stringwithsubstitutions.md#getoriginal)
+* [getReferencedInputs](stringwithsubstitutions.md#getreferencedinputs)
+* [set](stringwithsubstitutions.md#set)
+* [substituteInputValues](stringwithsubstitutions.md#substituteinputvalues)
+
+## Methods
+
+###  get
+
+▸ **get**(): *string*
+
+*Defined in [shared.ts:85](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/shared.ts#L85)*
+
+**Returns:** *string*
+
+___
+
+###  getOriginal
+
+▸ **getOriginal**(): *string*
+
+*Defined in [shared.ts:81](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/shared.ts#L81)*
+
+**Returns:** *string*
+
+___
+
+###  getReferencedInputs
+
+▸ **getReferencedInputs**(`inputs`: [IInput](../interfaces/iinput.md)[], `referencedInputs`: [Dictionary](../README.md#dictionary)‹[IInput](../interfaces/iinput.md)›): *void*
+
+*Defined in [shared.ts:29](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/shared.ts#L29)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`inputs` | [IInput](../interfaces/iinput.md)[] |
+`referencedInputs` | [Dictionary](../README.md#dictionary)‹[IInput](../interfaces/iinput.md)› |
+
+**Returns:** *void*
+
+___
+
+###  set
+
+▸ **set**(`value`: string): *void*
+
+*Defined in [shared.ts:94](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/shared.ts#L94)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  substituteInputValues
+
+▸ **substituteInputValues**(`inputs`: [Dictionary](../README.md#dictionary)‹[IInput](../interfaces/iinput.md)›, `contentType`: string): *void*
+
+*Defined in [shared.ts:43](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/shared.ts#L43)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`inputs` | [Dictionary](../README.md#dictionary)‹[IInput](../interfaces/iinput.md)› |
+`contentType` | string |
+
+**Returns:** *void*

--- a/source/nodejs/adaptivecards/docs/classes/stylablecardelementcontainer.md
+++ b/source/nodejs/adaptivecards/docs/classes/stylablecardelementcontainer.md
@@ -1,0 +1,1482 @@
+[Adaptive Cards Javascript SDK](../README.md) › [StylableCardElementContainer](stylablecardelementcontainer.md)
+
+# Class: StylableCardElementContainer
+
+## Hierarchy
+
+  ↳ [CardElementContainer](cardelementcontainer.md)
+
+  ↳ **StylableCardElementContainer**
+
+  ↳ [Container](container.md)
+
+  ↳ [ColumnSet](columnset.md)
+
+## Index
+
+### Properties
+
+* [allowVerticalOverflow](stylablecardelementcontainer.md#allowverticaloverflow)
+* [customCssSelector](stylablecardelementcontainer.md#customcssselector)
+* [height](stylablecardelementcontainer.md#height)
+* [horizontalAlignment](stylablecardelementcontainer.md#optional-horizontalalignment)
+* [id](stylablecardelementcontainer.md#id)
+* [minPixelHeight](stylablecardelementcontainer.md#optional-minpixelheight)
+* [requires](stylablecardelementcontainer.md#requires)
+* [separator](stylablecardelementcontainer.md#separator)
+* [spacing](stylablecardelementcontainer.md#spacing)
+
+### Accessors
+
+* [allowCustomPadding](stylablecardelementcontainer.md#protected-allowcustompadding)
+* [allowCustomStyle](stylablecardelementcontainer.md#protected-allowcustomstyle)
+* [defaultStyle](stylablecardelementcontainer.md#protected-defaultstyle)
+* [hasExplicitStyle](stylablecardelementcontainer.md#protected-hasexplicitstyle)
+* [hasVisibleSeparator](stylablecardelementcontainer.md#hasvisibleseparator)
+* [hostConfig](stylablecardelementcontainer.md#hostconfig)
+* [index](stylablecardelementcontainer.md#index)
+* [isInline](stylablecardelementcontainer.md#isinline)
+* [isInteractive](stylablecardelementcontainer.md#isinteractive)
+* [isSelectable](stylablecardelementcontainer.md#protected-isselectable)
+* [isStandalone](stylablecardelementcontainer.md#isstandalone)
+* [isVisible](stylablecardelementcontainer.md#isvisible)
+* [lang](stylablecardelementcontainer.md#lang)
+* [parent](stylablecardelementcontainer.md#parent)
+* [renderedActionCount](stylablecardelementcontainer.md#protected-renderedactioncount)
+* [renderedElement](stylablecardelementcontainer.md#renderedelement)
+* [separatorElement](stylablecardelementcontainer.md#separatorelement)
+* [separatorOrientation](stylablecardelementcontainer.md#protected-separatororientation)
+* [style](stylablecardelementcontainer.md#style)
+* [supportsMinHeight](stylablecardelementcontainer.md#protected-supportsminheight)
+* [useDefaultSizing](stylablecardelementcontainer.md#protected-usedefaultsizing)
+
+### Methods
+
+* [adjustRenderedElementSize](stylablecardelementcontainer.md#protected-adjustrenderedelementsize)
+* [applyBackground](stylablecardelementcontainer.md#protected-applybackground)
+* [applyPadding](stylablecardelementcontainer.md#protected-applypadding)
+* [asString](stylablecardelementcontainer.md#asstring)
+* [createPlaceholderElement](stylablecardelementcontainer.md#protected-createplaceholderelement)
+* [getActionAt](stylablecardelementcontainer.md#getactionat)
+* [getActionById](stylablecardelementcontainer.md#getactionbyid)
+* [getActionCount](stylablecardelementcontainer.md#getactioncount)
+* [getAllInputs](stylablecardelementcontainer.md#getallinputs)
+* [getBleed](stylablecardelementcontainer.md#protected-getbleed)
+* [getCustomProperty](stylablecardelementcontainer.md#getcustomproperty)
+* [getDefaultPadding](stylablecardelementcontainer.md#protected-getdefaultpadding)
+* [getEffectivePadding](stylablecardelementcontainer.md#geteffectivepadding)
+* [getEffectiveStyle](stylablecardelementcontainer.md#geteffectivestyle)
+* [getElementById](stylablecardelementcontainer.md#getelementbyid)
+* [getFirstVisibleRenderedItem](stylablecardelementcontainer.md#abstract-getfirstvisiblerendereditem)
+* [getForbiddenActionTypes](stylablecardelementcontainer.md#getforbiddenactiontypes)
+* [getForbiddenElementTypes](stylablecardelementcontainer.md#getforbiddenelementtypes)
+* [getHasBackground](stylablecardelementcontainer.md#protected-gethasbackground)
+* [getHasExpandedAction](stylablecardelementcontainer.md#protected-gethasexpandedaction)
+* [getImmediateSurroundingPadding](stylablecardelementcontainer.md#getimmediatesurroundingpadding)
+* [getItemAt](stylablecardelementcontainer.md#abstract-getitemat)
+* [getItemCount](stylablecardelementcontainer.md#abstract-getitemcount)
+* [getJsonTypeName](stylablecardelementcontainer.md#abstract-getjsontypename)
+* [getLastVisibleRenderedItem](stylablecardelementcontainer.md#abstract-getlastvisiblerendereditem)
+* [getPadding](stylablecardelementcontainer.md#protected-getpadding)
+* [getParentContainer](stylablecardelementcontainer.md#getparentcontainer)
+* [getResourceInformation](stylablecardelementcontainer.md#getresourceinformation)
+* [getRootElement](stylablecardelementcontainer.md#getrootelement)
+* [getSelectAction](stylablecardelementcontainer.md#protected-getselectaction)
+* [indexOf](stylablecardelementcontainer.md#indexof)
+* [internalRender](stylablecardelementcontainer.md#protected-abstract-internalrender)
+* [internalValidateProperties](stylablecardelementcontainer.md#internalvalidateproperties)
+* [isAtTheVeryBottom](stylablecardelementcontainer.md#isattheverybottom)
+* [isAtTheVeryLeft](stylablecardelementcontainer.md#isattheveryleft)
+* [isAtTheVeryRight](stylablecardelementcontainer.md#isattheveryright)
+* [isAtTheVeryTop](stylablecardelementcontainer.md#isattheverytop)
+* [isBleeding](stylablecardelementcontainer.md#isbleeding)
+* [isBleedingAtBottom](stylablecardelementcontainer.md#isbleedingatbottom)
+* [isBleedingAtTop](stylablecardelementcontainer.md#isbleedingattop)
+* [isBottomElement](stylablecardelementcontainer.md#isbottomelement)
+* [isDesignMode](stylablecardelementcontainer.md#isdesignmode)
+* [isElementAllowed](stylablecardelementcontainer.md#protected-iselementallowed)
+* [isFirstElement](stylablecardelementcontainer.md#isfirstelement)
+* [isHiddenDueToOverflow](stylablecardelementcontainer.md#ishiddenduetooverflow)
+* [isLastElement](stylablecardelementcontainer.md#islastelement)
+* [isLeftMostElement](stylablecardelementcontainer.md#isleftmostelement)
+* [isRendered](stylablecardelementcontainer.md#isrendered)
+* [isRightMostElement](stylablecardelementcontainer.md#isrightmostelement)
+* [isTopElement](stylablecardelementcontainer.md#istopelement)
+* [overrideInternalRender](stylablecardelementcontainer.md#protected-overrideinternalrender)
+* [parse](stylablecardelementcontainer.md#parse)
+* [remove](stylablecardelementcontainer.md#remove)
+* [removeItem](stylablecardelementcontainer.md#abstract-removeitem)
+* [render](stylablecardelementcontainer.md#render)
+* [setBleed](stylablecardelementcontainer.md#protected-setbleed)
+* [setCustomProperty](stylablecardelementcontainer.md#setcustomproperty)
+* [setPadding](stylablecardelementcontainer.md#protected-setpadding)
+* [setParent](stylablecardelementcontainer.md#setparent)
+* [setSelectAction](stylablecardelementcontainer.md#protected-setselectaction)
+* [setShouldFallback](stylablecardelementcontainer.md#setshouldfallback)
+* [shouldFallback](stylablecardelementcontainer.md#shouldfallback)
+* [toJSON](stylablecardelementcontainer.md#tojson)
+* [truncateOverflow](stylablecardelementcontainer.md#protected-truncateoverflow)
+* [undoOverflowTruncation](stylablecardelementcontainer.md#protected-undooverflowtruncation)
+* [updateLayout](stylablecardelementcontainer.md#updatelayout)
+* [validateProperties](stylablecardelementcontainer.md#validateproperties)
+
+## Properties
+
+###  allowVerticalOverflow
+
+• **allowVerticalOverflow**: *boolean* = false
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[allowVerticalOverflow](cardelementcontainer.md#allowverticaloverflow)*
+
+*Defined in [card-elements.ts:2229](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2229)*
+
+___
+
+###  customCssSelector
+
+• **customCssSelector**: *string* = null
+
+*Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#customcssselector)*
+
+*Defined in [card-elements.ts:507](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L507)*
+
+___
+
+###  height
+
+• **height**: *[CardElementHeight](../README.md#cardelementheight)* = "auto"
+
+*Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
+
+*Defined in [card-elements.ts:508](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L508)*
+
+___
+
+### `Optional` horizontalAlignment
+
+• **horizontalAlignment**? : *[HorizontalAlignment](../enums/horizontalalignment.md)* = null
+
+*Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#optional-horizontalalignment)*
+
+*Defined in [card-elements.ts:504](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L504)*
+
+___
+
+###  id
+
+• **id**: *string*
+
+*Inherited from [CardObject](cardobject.md).[id](cardobject.md#id)*
+
+*Defined in [card-elements.ts:247](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L247)*
+
+___
+
+### `Optional` minPixelHeight
+
+• **minPixelHeight**? : *number* = null
+
+*Inherited from [CardElement](cardelement.md).[minPixelHeight](cardelement.md#optional-minpixelheight)*
+
+*Defined in [card-elements.ts:509](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L509)*
+
+___
+
+###  requires
+
+• **requires**: *[HostCapabilities](hostcapabilities.md)‹›* = new HostConfig.HostCapabilities()
+
+*Inherited from [CardElement](cardelement.md).[requires](cardelement.md#requires)*
+
+*Defined in [card-elements.ts:502](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L502)*
+
+___
+
+###  separator
+
+• **separator**: *boolean* = false
+
+*Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
+
+*Defined in [card-elements.ts:506](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L506)*
+
+___
+
+###  spacing
+
+• **spacing**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.Default
+
+*Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
+
+*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
+
+## Accessors
+
+### `Protected` allowCustomPadding
+
+• **get allowCustomPadding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
+
+*Defined in [card-elements.ts:490](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L490)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` allowCustomStyle
+
+• **get allowCustomStyle**(): *boolean*
+
+*Defined in [card-elements.ts:5236](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5236)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` defaultStyle
+
+• **get defaultStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
+
+*Defined in [card-elements.ts:498](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L498)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` hasExplicitStyle
+
+• **get hasExplicitStyle**(): *boolean*
+
+*Defined in [card-elements.ts:5232](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5232)*
+
+**Returns:** *boolean*
+
+___
+
+###  hasVisibleSeparator
+
+• **get hasVisibleSeparator**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
+
+*Defined in [card-elements.ts:928](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L928)*
+
+**Returns:** *boolean*
+
+___
+
+###  hostConfig
+
+• **get hostConfig**(): *[HostConfig](hostconfig.md)*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:881](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L881)*
+
+**Returns:** *[HostConfig](hostconfig.md)*
+
+• **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:895](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L895)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [HostConfig](hostconfig.md) |
+
+**Returns:** *void*
+
+___
+
+###  index
+
+• **get index**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
+
+*Defined in [card-elements.ts:899](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L899)*
+
+**Returns:** *number*
+
+___
+
+###  isInline
+
+• **get isInline**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
+
+*Defined in [card-elements.ts:916](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L916)*
+
+**Returns:** *boolean*
+
+___
+
+###  isInteractive
+
+• **get isInteractive**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
+
+*Defined in [card-elements.ts:908](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L908)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` isSelectable
+
+• **get isSelectable**(): *boolean*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[isSelectable](cardelementcontainer.md#protected-isselectable)*
+
+*Defined in [card-elements.ts:2219](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2219)*
+
+**Returns:** *boolean*
+
+___
+
+###  isStandalone
+
+• **get isStandalone**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
+
+*Defined in [card-elements.ts:912](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L912)*
+
+**Returns:** *boolean*
+
+___
+
+###  isVisible
+
+• **get isVisible**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:924](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L924)*
+
+**Returns:** *boolean*
+
+• **set isVisible**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:937](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L937)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  lang
+
+• **get lang**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:853](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L853)*
+
+**Returns:** *string*
+
+• **set lang**(`value`: string): *void*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:867](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L867)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  parent
+
+• **get parent**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[parent](cardelement.md#parent)*
+
+*Defined in [card-elements.ts:920](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L920)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+### `Protected` renderedActionCount
+
+• **get renderedActionCount**(): *number*
+
+*Defined in [card-elements.ts:5228](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5228)*
+
+**Returns:** *number*
+
+___
+
+###  renderedElement
+
+• **get renderedElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[renderedElement](cardelement.md#renderedelement)*
+
+*Defined in [card-elements.ts:956](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L956)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  separatorElement
+
+• **get separatorElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
+
+*Defined in [card-elements.ts:960](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L960)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` separatorOrientation
+
+• **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
+
+*Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
+
+*Defined in [card-elements.ts:494](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L494)*
+
+**Returns:** *[Orientation](../enums/orientation.md)*
+
+___
+
+###  style
+
+• **get style**(): *string*
+
+*Defined in [card-elements.ts:5295](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5295)*
+
+**Returns:** *string*
+
+• **set style**(`value`: string): *void*
+
+*Defined in [card-elements.ts:5305](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5305)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+### `Protected` supportsMinHeight
+
+• **get supportsMinHeight**(): *boolean*
+
+*Overrides [CardElement](cardelement.md).[supportsMinHeight](cardelement.md#protected-supportsminheight)*
+
+*Defined in [card-elements.ts:5240](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5240)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` useDefaultSizing
+
+• **get useDefaultSizing**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
+
+*Defined in [card-elements.ts:486](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L486)*
+
+**Returns:** *boolean*
+
+## Methods
+
+### `Protected` adjustRenderedElementSize
+
+▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
+
+*Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
+
+*Defined in [card-elements.ts:411](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L411)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`renderedElement` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+### `Protected` applyBackground
+
+▸ **applyBackground**(): *void*
+
+*Defined in [card-elements.ts:5129](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5129)*
+
+**Returns:** *void*
+
+___
+
+### `Protected` applyPadding
+
+▸ **applyPadding**(): *void*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[applyPadding](cardelementcontainer.md#protected-applypadding)*
+
+*Defined in [card-elements.ts:5137](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5137)*
+
+**Returns:** *void*
+
+___
+
+###  asString
+
+▸ **asString**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
+
+*Defined in [card-elements.ts:513](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L513)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` createPlaceholderElement
+
+▸ **createPlaceholderElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
+
+*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  getActionAt
+
+▸ **getActionAt**(`index`: number): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
+
+*Defined in [card-elements.ts:694](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L694)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionById
+
+▸ **getActionById**(`id`: string): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
+
+*Defined in [card-elements.ts:835](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L835)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionCount
+
+▸ **getActionCount**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
+
+*Defined in [card-elements.ts:690](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L690)*
+
+**Returns:** *number*
+
+___
+
+###  getAllInputs
+
+▸ **getAllInputs**(): *Array‹[Input](input.md)›*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[getAllInputs](cardelementcontainer.md#getallinputs)*
+
+*Overrides [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
+
+*Defined in [card-elements.ts:2334](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2334)*
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+### `Protected` getBleed
+
+▸ **getBleed**(): *boolean*
+
+*Defined in [card-elements.ts:5220](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5220)*
+
+**Returns:** *boolean*
+
+___
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+### `Protected` getDefaultPadding
+
+▸ **getDefaultPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Overrides [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
+
+*Defined in [card-elements.ts:5207](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5207)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectivePadding
+
+▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
+
+*Defined in [card-elements.ts:847](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L847)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectiveStyle
+
+▸ **getEffectiveStyle**(): *string*
+
+*Overrides [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
+
+*Defined in [card-elements.ts:5289](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5289)*
+
+**Returns:** *string*
+
+___
+
+###  getElementById
+
+▸ **getElementById**(`id`: string): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[getElementById](cardelementcontainer.md#getelementbyid)*
+
+*Overrides [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
+
+*Defined in [card-elements.ts:2354](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2354)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+### `Abstract` getFirstVisibleRenderedItem
+
+▸ **getFirstVisibleRenderedItem**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[getFirstVisibleRenderedItem](cardelementcontainer.md#abstract-getfirstvisiblerendereditem)*
+
+*Defined in [card-elements.ts:2225](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2225)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getForbiddenActionTypes
+
+▸ **getForbiddenActionTypes**(): *Array‹any›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
+
+*Defined in [card-elements.ts:557](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L557)*
+
+**Returns:** *Array‹any›*
+
+___
+
+###  getForbiddenElementTypes
+
+▸ **getForbiddenElementTypes**(): *Array‹string›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenElementTypes](cardelement.md#getforbiddenelementtypes)*
+
+*Defined in [card-elements.ts:553](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L553)*
+
+**Returns:** *Array‹string›*
+
+___
+
+### `Protected` getHasBackground
+
+▸ **getHasBackground**(): *boolean*
+
+*Overrides [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
+
+*Defined in [card-elements.ts:5189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5189)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` getHasExpandedAction
+
+▸ **getHasExpandedAction**(): *boolean*
+
+*Defined in [card-elements.ts:5216](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5216)*
+
+**Returns:** *boolean*
+
+___
+
+###  getImmediateSurroundingPadding
+
+▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
+
+*Defined in [card-elements.ts:561](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L561)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`result` | [PaddingDefinition](paddingdefinition.md) | - |
+`processTop` | boolean | true |
+`processRight` | boolean | true |
+`processBottom` | boolean | true |
+`processLeft` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+### `Abstract` getItemAt
+
+▸ **getItemAt**(`index`: number): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[getItemAt](cardelementcontainer.md#abstract-getitemat)*
+
+*Defined in [card-elements.ts:2224](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2224)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+### `Abstract` getItemCount
+
+▸ **getItemCount**(): *number*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[getItemCount](cardelementcontainer.md#abstract-getitemcount)*
+
+*Defined in [card-elements.ts:2223](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2223)*
+
+**Returns:** *number*
+
+___
+
+### `Abstract` getJsonTypeName
+
+▸ **getJsonTypeName**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[getJsonTypeName](cardelement.md#abstract-getjsontypename)*
+
+*Overrides [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
+
+*Defined in [card-elements.ts:511](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L511)*
+
+**Returns:** *string*
+
+___
+
+### `Abstract` getLastVisibleRenderedItem
+
+▸ **getLastVisibleRenderedItem**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[getLastVisibleRenderedItem](cardelementcontainer.md#abstract-getlastvisiblerendereditem)*
+
+*Defined in [card-elements.ts:2226](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2226)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+### `Protected` getPadding
+
+▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
+
+*Defined in [card-elements.ts:474](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L474)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getParentContainer
+
+▸ **getParentContainer**(): *[Container](container.md)*
+
+*Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
+
+*Defined in [card-elements.ts:809](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L809)*
+
+**Returns:** *[Container](container.md)*
+
+___
+
+###  getResourceInformation
+
+▸ **getResourceInformation**(): *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[getResourceInformation](cardelementcontainer.md#getresourceinformation)*
+
+*Overrides [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
+
+*Defined in [card-elements.ts:2344](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2344)*
+
+**Returns:** *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+___
+
+###  getRootElement
+
+▸ **getRootElement**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
+
+*Defined in [card-elements.ts:799](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L799)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+### `Protected` getSelectAction
+
+▸ **getSelectAction**(): *[Action](action.md)*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[getSelectAction](cardelementcontainer.md#protected-getselectaction)*
+
+*Defined in [card-elements.ts:2207](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2207)*
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  indexOf
+
+▸ **indexOf**(`cardElement`: [CardElement](cardelement.md)): *number*
+
+*Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
+
+*Defined in [card-elements.ts:733](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L733)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`cardElement` | [CardElement](cardelement.md) |
+
+**Returns:** *number*
+
+___
+
+### `Protected` `Abstract` internalRender
+
+▸ **internalRender**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
+
+*Defined in [card-elements.ts:424](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L424)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  internalValidateProperties
+
+▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[internalValidateProperties](cardelementcontainer.md#internalvalidateproperties)*
+
+*Defined in [card-elements.ts:5256](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5256)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [ValidationResults](validationresults.md) |
+
+**Returns:** *void*
+
+___
+
+###  isAtTheVeryBottom
+
+▸ **isAtTheVeryBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
+
+*Defined in [card-elements.ts:767](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L767)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryLeft
+
+▸ **isAtTheVeryLeft**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
+
+*Defined in [card-elements.ts:755](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L755)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryRight
+
+▸ **isAtTheVeryRight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
+
+*Defined in [card-elements.ts:759](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L759)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryTop
+
+▸ **isAtTheVeryTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
+
+*Defined in [card-elements.ts:763](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L763)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleeding
+
+▸ **isBleeding**(): *boolean*
+
+*Overrides [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
+
+*Defined in [card-elements.ts:5244](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5244)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtBottom
+
+▸ **isBleedingAtBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
+
+*Defined in [card-elements.ts:775](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L775)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtTop
+
+▸ **isBleedingAtTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
+
+*Defined in [card-elements.ts:771](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L771)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBottomElement
+
+▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
+
+*Defined in [card-elements.ts:791](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L791)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isDesignMode
+
+▸ **isDesignMode**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
+
+*Defined in [card-elements.ts:737](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L737)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` isElementAllowed
+
+▸ **isElementAllowed**(`element`: [CardElement](cardelement.md), `forbiddenElementTypes`: Array‹string›): *boolean*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[isElementAllowed](cardelementcontainer.md#protected-iselementallowed)*
+
+*Defined in [card-elements.ts:2169](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2169)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+`forbiddenElementTypes` | Array‹string› |
+
+**Returns:** *boolean*
+
+___
+
+###  isFirstElement
+
+▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
+
+*Defined in [card-elements.ts:747](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L747)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isHiddenDueToOverflow
+
+▸ **isHiddenDueToOverflow**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
+
+*Defined in [card-elements.ts:795](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L795)*
+
+**Returns:** *boolean*
+
+___
+
+###  isLastElement
+
+▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
+
+*Defined in [card-elements.ts:751](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L751)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isLeftMostElement
+
+▸ **isLeftMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
+
+*Defined in [card-elements.ts:779](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L779)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isRendered
+
+▸ **isRendered**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRendered](cardelement.md#isrendered)*
+
+*Defined in [card-elements.ts:743](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L743)*
+
+**Returns:** *boolean*
+
+___
+
+###  isRightMostElement
+
+▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
+
+*Defined in [card-elements.ts:783](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L783)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isTopElement
+
+▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
+
+*Defined in [card-elements.ts:787](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L787)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` overrideInternalRender
+
+▸ **overrideInternalRender**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
+
+*Defined in [card-elements.ts:426](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L426)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[parse](cardelementcontainer.md#parse)*
+
+*Defined in [card-elements.ts:5273](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5273)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*
+
+___
+
+###  remove
+
+▸ **remove**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
+
+*Defined in [card-elements.ts:698](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L698)*
+
+**Returns:** *boolean*
+
+___
+
+### `Abstract` removeItem
+
+▸ **removeItem**(`item`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[removeItem](cardelementcontainer.md#abstract-removeitem)*
+
+*Defined in [card-elements.ts:2227](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2227)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`item` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  render
+
+▸ **render**(): *HTMLElement*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[render](cardelementcontainer.md#render)*
+
+*Defined in [card-elements.ts:5279](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5279)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` setBleed
+
+▸ **setBleed**(`value`: boolean): *void*
+
+*Defined in [card-elements.ts:5224](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5224)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setPadding
+
+▸ **setPadding**(`value`: [PaddingDefinition](paddingdefinition.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
+
+*Defined in [card-elements.ts:478](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L478)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [PaddingDefinition](paddingdefinition.md) |
+
+**Returns:** *void*
+
+___
+
+###  setParent
+
+▸ **setParent**(`value`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setParent](cardelement.md#setparent)*
+
+*Overrides [CardObject](cardobject.md).[setParent](cardobject.md#abstract-setparent)*
+
+*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setSelectAction
+
+▸ **setSelectAction**(`value`: [Action](action.md)): *void*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[setSelectAction](cardelementcontainer.md#protected-setselectaction)*
+
+*Defined in [card-elements.ts:2211](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2211)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [Action](action.md) |
+
+**Returns:** *void*
+
+___
+
+###  setShouldFallback
+
+▸ **setShouldFallback**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[setShouldFallback](cardelement.md#setshouldfallback)*
+
+*Defined in [card-elements.ts:843](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L843)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  shouldFallback
+
+▸ **shouldFallback**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[shouldFallback](cardelement.md#shouldfallback)*
+
+*Overrides [CardObject](cardobject.md).[shouldFallback](cardobject.md#abstract-shouldfallback)*
+
+*Defined in [card-elements.ts:839](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L839)*
+
+**Returns:** *boolean*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [CardElementContainer](cardelementcontainer.md).[toJSON](cardelementcontainer.md#tojson)*
+
+*Defined in [card-elements.ts:5248](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L5248)*
+
+**Returns:** *any*
+
+___
+
+### `Protected` truncateOverflow
+
+▸ **truncateOverflow**(`maxHeight`: number): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
+
+*Defined in [card-elements.ts:454](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L454)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`maxHeight` | number |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` undoOverflowTruncation
+
+▸ **undoOverflowTruncation**(): *void*
+
+*Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
+
+*Defined in [card-elements.ts:464](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L464)*
+
+**Returns:** *void*
+
+___
+
+###  updateLayout
+
+▸ **updateLayout**(`processChildren`: boolean): *void*
+
+*Inherited from [CardElementContainer](cardelementcontainer.md).[updateLayout](cardelementcontainer.md#updatelayout)*
+
+*Overrides [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
+
+*Defined in [card-elements.ts:2324](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2324)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`processChildren` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  validateProperties
+
+▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
+
+*Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
+
+*Defined in [card-elements.ts:284](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L284)*
+
+**Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/submitaction.md
+++ b/source/nodejs/adaptivecards/docs/classes/submitaction.md
@@ -1,0 +1,579 @@
+[Adaptive Cards Javascript SDK](../README.md) › [SubmitAction](submitaction.md)
+
+# Class: SubmitAction
+
+## Hierarchy
+
+  ↳ [Action](action.md)
+
+  ↳ **SubmitAction**
+
+## Index
+
+### Properties
+
+* [iconUrl](submitaction.md#iconurl)
+* [id](submitaction.md#id)
+* [onExecute](submitaction.md#onexecute)
+* [requires](submitaction.md#requires)
+* [style](submitaction.md#style)
+* [title](submitaction.md#title)
+* [JsonTypeName](submitaction.md#static-jsontypename)
+
+### Accessors
+
+* [data](submitaction.md#data)
+* [ignoreInputValidation](submitaction.md#ignoreinputvalidation)
+* [isPrimary](submitaction.md#isprimary)
+* [parent](submitaction.md#parent)
+* [renderedElement](submitaction.md#renderedelement)
+
+### Methods
+
+* [addCssClasses](submitaction.md#protected-addcssclasses)
+* [execute](submitaction.md#execute)
+* [getActionById](submitaction.md#getactionbyid)
+* [getAllInputs](submitaction.md#getallinputs)
+* [getCustomProperty](submitaction.md#getcustomproperty)
+* [getHref](submitaction.md#gethref)
+* [getJsonTypeName](submitaction.md#getjsontypename)
+* [getReferencedInputs](submitaction.md#getreferencedinputs)
+* [getResourceInformation](submitaction.md#getresourceinformation)
+* [internalGetReferencedInputs](submitaction.md#protected-internalgetreferencedinputs)
+* [internalPrepareForExecution](submitaction.md#protected-internalprepareforexecution)
+* [internalValidateInputs](submitaction.md#protected-internalvalidateinputs)
+* [internalValidateProperties](submitaction.md#internalvalidateproperties)
+* [parse](submitaction.md#parse)
+* [prepareForExecution](submitaction.md#prepareforexecution)
+* [remove](submitaction.md#remove)
+* [render](submitaction.md#render)
+* [setCustomProperty](submitaction.md#setcustomproperty)
+* [setParent](submitaction.md#setparent)
+* [shouldFallback](submitaction.md#shouldfallback)
+* [toJSON](submitaction.md#tojson)
+* [validateInputs](submitaction.md#validateinputs)
+* [validateProperties](submitaction.md#validateproperties)
+
+## Properties
+
+###  iconUrl
+
+• **iconUrl**: *string*
+
+*Inherited from [Action](action.md).[iconUrl](action.md#iconurl)*
+
+*Defined in [card-elements.ts:3905](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3905)*
+
+___
+
+###  id
+
+• **id**: *string*
+
+*Inherited from [CardObject](cardobject.md).[id](cardobject.md#id)*
+
+*Defined in [card-elements.ts:247](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L247)*
+
+___
+
+###  onExecute
+
+• **onExecute**: *function*
+
+*Inherited from [Action](action.md).[onExecute](action.md#onexecute)*
+
+*Defined in [card-elements.ts:3908](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3908)*
+
+#### Type declaration:
+
+▸ (`sender`: [Action](action.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`sender` | [Action](action.md) |
+
+___
+
+###  requires
+
+• **requires**: *[HostCapabilities](hostcapabilities.md)‹›* = new HostConfig.HostCapabilities()
+
+*Inherited from [Action](action.md).[requires](action.md#requires)*
+
+*Defined in [card-elements.ts:3902](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3902)*
+
+___
+
+###  style
+
+• **style**: *string* = Enums.ActionStyle.Default
+
+*Inherited from [Action](action.md).[style](action.md#style)*
+
+*Defined in [card-elements.ts:3906](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3906)*
+
+___
+
+###  title
+
+• **title**: *string*
+
+*Inherited from [Action](action.md).[title](action.md#title)*
+
+*Defined in [card-elements.ts:3904](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3904)*
+
+___
+
+### `Static` JsonTypeName
+
+▪ **JsonTypeName**: *"Action.Submit"* = "Action.Submit"
+
+*Defined in [card-elements.ts:4104](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4104)*
+
+## Accessors
+
+###  data
+
+• **get data**(): *Object*
+
+*Defined in [card-elements.ts:4168](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4168)*
+
+**Returns:** *Object*
+
+• **set data**(`value`: Object): *void*
+
+*Defined in [card-elements.ts:4172](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4172)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | Object |
+
+**Returns:** *void*
+
+___
+
+###  ignoreInputValidation
+
+• **get ignoreInputValidation**(): *boolean*
+
+*Overrides [Action](action.md).[ignoreInputValidation](action.md#ignoreinputvalidation)*
+
+*Defined in [card-elements.ts:4160](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4160)*
+
+**Returns:** *boolean*
+
+• **set ignoreInputValidation**(`value`: boolean): *void*
+
+*Overrides [Action](action.md).[ignoreInputValidation](action.md#ignoreinputvalidation)*
+
+*Defined in [card-elements.ts:4164](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4164)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  isPrimary
+
+• **get isPrimary**(): *boolean*
+
+*Inherited from [Action](action.md).[isPrimary](action.md#isprimary)*
+
+*Defined in [card-elements.ts:4073](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4073)*
+
+**Returns:** *boolean*
+
+• **set isPrimary**(`value`: boolean): *void*
+
+*Inherited from [Action](action.md).[isPrimary](action.md#isprimary)*
+
+*Defined in [card-elements.ts:4077](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4077)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  parent
+
+• **get parent**(): *[CardElement](cardelement.md)*
+
+*Inherited from [Action](action.md).[parent](action.md#parent)*
+
+*Defined in [card-elements.ts:4092](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4092)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  renderedElement
+
+• **get renderedElement**(): *HTMLElement*
+
+*Inherited from [Action](action.md).[renderedElement](action.md#renderedelement)*
+
+*Defined in [card-elements.ts:4096](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4096)*
+
+**Returns:** *HTMLElement*
+
+## Methods
+
+### `Protected` addCssClasses
+
+▸ **addCssClasses**(`element`: HTMLElement): *void*
+
+*Inherited from [Action](action.md).[addCssClasses](action.md#protected-addcssclasses)*
+
+*Defined in [card-elements.ts:3872](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3872)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+###  execute
+
+▸ **execute**(): *void*
+
+*Inherited from [Action](action.md).[execute](action.md#execute)*
+
+*Defined in [card-elements.ts:3992](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3992)*
+
+**Returns:** *void*
+
+___
+
+###  getActionById
+
+▸ **getActionById**(`id`: string): *[Action](action.md)*
+
+*Inherited from [Action](action.md).[getActionById](action.md#getactionbyid)*
+
+*Defined in [card-elements.ts:4055](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4055)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getAllInputs
+
+▸ **getAllInputs**(): *Array‹[Input](input.md)›*
+
+*Inherited from [Action](action.md).[getAllInputs](action.md#getallinputs)*
+
+*Defined in [card-elements.ts:4042](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4042)*
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+###  getHref
+
+▸ **getHref**(): *string*
+
+*Inherited from [Action](action.md).[getHref](action.md#gethref)*
+
+*Defined in [card-elements.ts:3910](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3910)*
+
+**Returns:** *string*
+
+___
+
+###  getJsonTypeName
+
+▸ **getJsonTypeName**(): *string*
+
+*Overrides [Action](action.md).[getJsonTypeName](action.md#abstract-getjsontypename)*
+
+*Defined in [card-elements.ts:4140](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4140)*
+
+**Returns:** *string*
+
+___
+
+###  getReferencedInputs
+
+▸ **getReferencedInputs**(): *Shared.Dictionary‹[Input](input.md)›*
+
+*Inherited from [Action](action.md).[getReferencedInputs](action.md#getreferencedinputs)*
+
+*Defined in [card-elements.ts:4061](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4061)*
+
+**Returns:** *Shared.Dictionary‹[Input](input.md)›*
+
+___
+
+###  getResourceInformation
+
+▸ **getResourceInformation**(): *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+*Inherited from [Action](action.md).[getResourceInformation](action.md#getresourceinformation)*
+
+*Defined in [card-elements.ts:4046](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4046)*
+
+**Returns:** *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+___
+
+### `Protected` internalGetReferencedInputs
+
+▸ **internalGetReferencedInputs**(`allInputs`: Array‹[Input](input.md)›): *Shared.Dictionary‹[Input](input.md)›*
+
+*Overrides [Action](action.md).[internalGetReferencedInputs](action.md#protected-internalgetreferencedinputs)*
+
+*Defined in [card-elements.ts:4111](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4111)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`allInputs` | Array‹[Input](input.md)› |
+
+**Returns:** *Shared.Dictionary‹[Input](input.md)›*
+
+___
+
+### `Protected` internalPrepareForExecution
+
+▸ **internalPrepareForExecution**(`inputs`: Shared.Dictionary‹[Input](input.md)›): *void*
+
+*Overrides [Action](action.md).[internalPrepareForExecution](action.md#protected-internalprepareforexecution)*
+
+*Defined in [card-elements.ts:4121](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4121)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`inputs` | Shared.Dictionary‹[Input](input.md)› |
+
+**Returns:** *void*
+
+___
+
+### `Protected` internalValidateInputs
+
+▸ **internalValidateInputs**(`referencedInputs`: Shared.Dictionary‹[Input](input.md)›): *Array‹[Input](input.md)›*
+
+*Inherited from [Action](action.md).[internalValidateInputs](action.md#protected-internalvalidateinputs)*
+
+*Defined in [card-elements.ts:3884](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3884)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`referencedInputs` | Shared.Dictionary‹[Input](input.md)› |
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+###  internalValidateProperties
+
+▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
+
+*Inherited from [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
+
+*Defined in [card-elements.ts:249](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L249)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [ValidationResults](validationresults.md) |
+
+**Returns:** *void*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Overrides [Action](action.md).[parse](action.md#parse)*
+
+*Defined in [card-elements.ts:4153](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4153)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*
+
+___
+
+###  prepareForExecution
+
+▸ **prepareForExecution**(): *boolean*
+
+*Inherited from [Action](action.md).[prepareForExecution](action.md#prepareforexecution)*
+
+*Defined in [card-elements.ts:4000](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4000)*
+
+**Returns:** *boolean*
+
+___
+
+###  remove
+
+▸ **remove**(): *boolean*
+
+*Inherited from [Action](action.md).[remove](action.md#remove)*
+
+*Defined in [card-elements.ts:4034](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4034)*
+
+**Returns:** *boolean*
+
+___
+
+###  render
+
+▸ **render**(`baseCssClass`: string): *void*
+
+*Inherited from [Action](action.md).[render](action.md#render)*
+
+*Defined in [card-elements.ts:3925](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3925)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`baseCssClass` | string | "ac-pushButton" |
+
+**Returns:** *void*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+###  setParent
+
+▸ **setParent**(`value`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [Action](action.md).[setParent](action.md#setparent)*
+
+*Overrides [CardObject](cardobject.md).[setParent](cardobject.md#abstract-setparent)*
+
+*Defined in [card-elements.ts:3988](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3988)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+###  shouldFallback
+
+▸ **shouldFallback**(): *boolean*
+
+*Inherited from [Action](action.md).[shouldFallback](action.md#shouldfallback)*
+
+*Overrides [CardObject](cardobject.md).[shouldFallback](cardobject.md#abstract-shouldfallback)*
+
+*Defined in [card-elements.ts:4069](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4069)*
+
+**Returns:** *boolean*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [Action](action.md).[toJSON](action.md#tojson)*
+
+*Defined in [card-elements.ts:4144](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4144)*
+
+**Returns:** *any*
+
+___
+
+###  validateInputs
+
+▸ **validateInputs**(): *[Input](input.md)‹›[]*
+
+*Inherited from [Action](action.md).[validateInputs](action.md#validateinputs)*
+
+*Defined in [card-elements.ts:4065](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4065)*
+
+**Returns:** *[Input](input.md)‹›[]*
+
+___
+
+###  validateProperties
+
+▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
+
+*Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
+
+*Defined in [card-elements.ts:284](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L284)*
+
+**Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/textblock.md
+++ b/source/nodejs/adaptivecards/docs/classes/textblock.md
@@ -1,0 +1,1461 @@
+[Adaptive Cards Javascript SDK](../README.md) › [TextBlock](textblock.md)
+
+# Class: TextBlock
+
+## Hierarchy
+
+  ↳ [BaseTextBlock](basetextblock.md)
+
+  ↳ **TextBlock**
+
+## Index
+
+### Properties
+
+* [color](textblock.md#color)
+* [customCssSelector](textblock.md#customcssselector)
+* [fontType](textblock.md#optional-fonttype)
+* [height](textblock.md#height)
+* [horizontalAlignment](textblock.md#optional-horizontalalignment)
+* [id](textblock.md#id)
+* [isSubtle](textblock.md#issubtle)
+* [maxLines](textblock.md#maxlines)
+* [minPixelHeight](textblock.md#optional-minpixelheight)
+* [requires](textblock.md#requires)
+* [separator](textblock.md#separator)
+* [size](textblock.md#size)
+* [spacing](textblock.md#spacing)
+* [useMarkdown](textblock.md#usemarkdown)
+* [weight](textblock.md#weight)
+* [wrap](textblock.md#wrap)
+
+### Accessors
+
+* [allowCustomPadding](textblock.md#protected-allowcustompadding)
+* [defaultStyle](textblock.md#protected-defaultstyle)
+* [effectiveColor](textblock.md#effectivecolor)
+* [hasVisibleSeparator](textblock.md#hasvisibleseparator)
+* [hostConfig](textblock.md#hostconfig)
+* [index](textblock.md#index)
+* [isInline](textblock.md#isinline)
+* [isInteractive](textblock.md#isinteractive)
+* [isStandalone](textblock.md#isstandalone)
+* [isVisible](textblock.md#isvisible)
+* [lang](textblock.md#lang)
+* [parent](textblock.md#parent)
+* [renderedElement](textblock.md#renderedelement)
+* [selectAction](textblock.md#selectaction)
+* [separatorElement](textblock.md#separatorelement)
+* [separatorOrientation](textblock.md#protected-separatororientation)
+* [supportsMinHeight](textblock.md#protected-supportsminheight)
+* [text](textblock.md#text)
+* [useDefaultSizing](textblock.md#protected-usedefaultsizing)
+
+### Methods
+
+* [adjustRenderedElementSize](textblock.md#protected-adjustrenderedelementsize)
+* [applyPadding](textblock.md#protected-applypadding)
+* [applyStylesTo](textblock.md#applystylesto)
+* [asString](textblock.md#asstring)
+* [createPlaceholderElement](textblock.md#protected-createplaceholderelement)
+* [getActionAt](textblock.md#getactionat)
+* [getActionById](textblock.md#getactionbyid)
+* [getActionCount](textblock.md#getactioncount)
+* [getAllInputs](textblock.md#getallinputs)
+* [getColorDefinition](textblock.md#protected-getcolordefinition)
+* [getCustomProperty](textblock.md#getcustomproperty)
+* [getDefaultPadding](textblock.md#protected-getdefaultpadding)
+* [getEffectivePadding](textblock.md#geteffectivepadding)
+* [getEffectiveStyle](textblock.md#geteffectivestyle)
+* [getEffectiveStyleDefinition](textblock.md#protected-geteffectivestyledefinition)
+* [getElementById](textblock.md#getelementbyid)
+* [getFontSize](textblock.md#protected-getfontsize)
+* [getForbiddenActionTypes](textblock.md#getforbiddenactiontypes)
+* [getForbiddenElementTypes](textblock.md#getforbiddenelementtypes)
+* [getHasBackground](textblock.md#protected-gethasbackground)
+* [getImmediateSurroundingPadding](textblock.md#getimmediatesurroundingpadding)
+* [getJsonTypeName](textblock.md#getjsontypename)
+* [getPadding](textblock.md#protected-getpadding)
+* [getParentContainer](textblock.md#getparentcontainer)
+* [getRenderedDomElementType](textblock.md#protected-getrendereddomelementtype)
+* [getResourceInformation](textblock.md#getresourceinformation)
+* [getRootElement](textblock.md#getrootelement)
+* [indexOf](textblock.md#indexof)
+* [internalRender](textblock.md#protected-internalrender)
+* [internalValidateProperties](textblock.md#internalvalidateproperties)
+* [isAtTheVeryBottom](textblock.md#isattheverybottom)
+* [isAtTheVeryLeft](textblock.md#isattheveryleft)
+* [isAtTheVeryRight](textblock.md#isattheveryright)
+* [isAtTheVeryTop](textblock.md#isattheverytop)
+* [isBleeding](textblock.md#isbleeding)
+* [isBleedingAtBottom](textblock.md#isbleedingatbottom)
+* [isBleedingAtTop](textblock.md#isbleedingattop)
+* [isBottomElement](textblock.md#isbottomelement)
+* [isDesignMode](textblock.md#isdesignmode)
+* [isFirstElement](textblock.md#isfirstelement)
+* [isHiddenDueToOverflow](textblock.md#ishiddenduetooverflow)
+* [isLastElement](textblock.md#islastelement)
+* [isLeftMostElement](textblock.md#isleftmostelement)
+* [isRendered](textblock.md#isrendered)
+* [isRightMostElement](textblock.md#isrightmostelement)
+* [isTopElement](textblock.md#istopelement)
+* [overrideInternalRender](textblock.md#protected-overrideinternalrender)
+* [parse](textblock.md#parse)
+* [remove](textblock.md#remove)
+* [render](textblock.md#render)
+* [setCustomProperty](textblock.md#setcustomproperty)
+* [setPadding](textblock.md#protected-setpadding)
+* [setParent](textblock.md#setparent)
+* [setShouldFallback](textblock.md#setshouldfallback)
+* [setText](textblock.md#protected-settext)
+* [shouldFallback](textblock.md#shouldfallback)
+* [toJSON](textblock.md#tojson)
+* [truncateOverflow](textblock.md#protected-truncateoverflow)
+* [undoOverflowTruncation](textblock.md#protected-undooverflowtruncation)
+* [updateLayout](textblock.md#updatelayout)
+* [validateProperties](textblock.md#validateproperties)
+
+## Properties
+
+###  color
+
+• **color**: *[TextColor](../enums/textcolor.md)* = Enums.TextColor.Default
+
+*Inherited from [BaseTextBlock](basetextblock.md).[color](basetextblock.md#color)*
+
+*Defined in [card-elements.ts:1013](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1013)*
+
+___
+
+###  customCssSelector
+
+• **customCssSelector**: *string* = null
+
+*Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#customcssselector)*
+
+*Defined in [card-elements.ts:507](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L507)*
+
+___
+
+### `Optional` fontType
+
+• **fontType**? : *[FontType](../enums/fonttype.md)* = null
+
+*Inherited from [BaseTextBlock](basetextblock.md).[fontType](basetextblock.md#optional-fonttype)*
+
+*Defined in [card-elements.ts:1015](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1015)*
+
+___
+
+###  height
+
+• **height**: *[CardElementHeight](../README.md#cardelementheight)* = "auto"
+
+*Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
+
+*Defined in [card-elements.ts:508](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L508)*
+
+___
+
+### `Optional` horizontalAlignment
+
+• **horizontalAlignment**? : *[HorizontalAlignment](../enums/horizontalalignment.md)* = null
+
+*Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#optional-horizontalalignment)*
+
+*Defined in [card-elements.ts:504](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L504)*
+
+___
+
+###  id
+
+• **id**: *string*
+
+*Inherited from [CardObject](cardobject.md).[id](cardobject.md#id)*
+
+*Defined in [card-elements.ts:247](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L247)*
+
+___
+
+###  isSubtle
+
+• **isSubtle**: *boolean* = false
+
+*Inherited from [BaseTextBlock](basetextblock.md).[isSubtle](basetextblock.md#issubtle)*
+
+*Defined in [card-elements.ts:1014](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1014)*
+
+___
+
+###  maxLines
+
+• **maxLines**: *number*
+
+*Defined in [card-elements.ts:1353](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1353)*
+
+___
+
+### `Optional` minPixelHeight
+
+• **minPixelHeight**? : *number* = null
+
+*Inherited from [CardElement](cardelement.md).[minPixelHeight](cardelement.md#optional-minpixelheight)*
+
+*Defined in [card-elements.ts:509](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L509)*
+
+___
+
+###  requires
+
+• **requires**: *[HostCapabilities](hostcapabilities.md)‹›* = new HostConfig.HostCapabilities()
+
+*Inherited from [CardElement](cardelement.md).[requires](cardelement.md#requires)*
+
+*Defined in [card-elements.ts:502](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L502)*
+
+___
+
+###  separator
+
+• **separator**: *boolean* = false
+
+*Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
+
+*Defined in [card-elements.ts:506](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L506)*
+
+___
+
+###  size
+
+• **size**: *[TextSize](../enums/textsize.md)* = Enums.TextSize.Default
+
+*Inherited from [BaseTextBlock](basetextblock.md).[size](basetextblock.md#size)*
+
+*Defined in [card-elements.ts:1011](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1011)*
+
+___
+
+###  spacing
+
+• **spacing**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.Default
+
+*Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
+
+*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
+
+___
+
+###  useMarkdown
+
+• **useMarkdown**: *boolean* = true
+
+*Defined in [card-elements.ts:1354](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1354)*
+
+___
+
+###  weight
+
+• **weight**: *[TextWeight](../enums/textweight.md)* = Enums.TextWeight.Default
+
+*Inherited from [BaseTextBlock](basetextblock.md).[weight](basetextblock.md#weight)*
+
+*Defined in [card-elements.ts:1012](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1012)*
+
+___
+
+###  wrap
+
+• **wrap**: *boolean* = false
+
+*Defined in [card-elements.ts:1352](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1352)*
+
+## Accessors
+
+### `Protected` allowCustomPadding
+
+• **get allowCustomPadding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
+
+*Defined in [card-elements.ts:490](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L490)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` defaultStyle
+
+• **get defaultStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
+
+*Defined in [card-elements.ts:498](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L498)*
+
+**Returns:** *string*
+
+___
+
+###  effectiveColor
+
+• **get effectiveColor**(): *[TextColor](../enums/textcolor.md)*
+
+*Inherited from [BaseTextBlock](basetextblock.md).[effectiveColor](basetextblock.md#effectivecolor)*
+
+*Defined in [card-elements.ts:1128](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1128)*
+
+**Returns:** *[TextColor](../enums/textcolor.md)*
+
+___
+
+###  hasVisibleSeparator
+
+• **get hasVisibleSeparator**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
+
+*Defined in [card-elements.ts:928](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L928)*
+
+**Returns:** *boolean*
+
+___
+
+###  hostConfig
+
+• **get hostConfig**(): *[HostConfig](hostconfig.md)*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:881](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L881)*
+
+**Returns:** *[HostConfig](hostconfig.md)*
+
+• **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:895](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L895)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [HostConfig](hostconfig.md) |
+
+**Returns:** *void*
+
+___
+
+###  index
+
+• **get index**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
+
+*Defined in [card-elements.ts:899](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L899)*
+
+**Returns:** *number*
+
+___
+
+###  isInline
+
+• **get isInline**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
+
+*Defined in [card-elements.ts:916](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L916)*
+
+**Returns:** *boolean*
+
+___
+
+###  isInteractive
+
+• **get isInteractive**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
+
+*Defined in [card-elements.ts:908](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L908)*
+
+**Returns:** *boolean*
+
+___
+
+###  isStandalone
+
+• **get isStandalone**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
+
+*Defined in [card-elements.ts:912](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L912)*
+
+**Returns:** *boolean*
+
+___
+
+###  isVisible
+
+• **get isVisible**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:924](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L924)*
+
+**Returns:** *boolean*
+
+• **set isVisible**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:937](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L937)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  lang
+
+• **get lang**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:853](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L853)*
+
+**Returns:** *string*
+
+• **set lang**(`value`: string): *void*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:867](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L867)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  parent
+
+• **get parent**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[parent](cardelement.md#parent)*
+
+*Defined in [card-elements.ts:920](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L920)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  renderedElement
+
+• **get renderedElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[renderedElement](cardelement.md#renderedelement)*
+
+*Defined in [card-elements.ts:956](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L956)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  selectAction
+
+• **get selectAction**(): *[Action](action.md)*
+
+*Inherited from [BaseTextBlock](basetextblock.md).[selectAction](basetextblock.md#selectaction)*
+
+*Defined in [card-elements.ts:1140](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1140)*
+
+**Returns:** *[Action](action.md)*
+
+• **set selectAction**(`value`: [Action](action.md)): *void*
+
+*Inherited from [BaseTextBlock](basetextblock.md).[selectAction](basetextblock.md#selectaction)*
+
+*Defined in [card-elements.ts:1144](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1144)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [Action](action.md) |
+
+**Returns:** *void*
+
+___
+
+###  separatorElement
+
+• **get separatorElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
+
+*Defined in [card-elements.ts:960](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L960)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` separatorOrientation
+
+• **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
+
+*Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
+
+*Defined in [card-elements.ts:494](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L494)*
+
+**Returns:** *[Orientation](../enums/orientation.md)*
+
+___
+
+### `Protected` supportsMinHeight
+
+• **get supportsMinHeight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[supportsMinHeight](cardelement.md#protected-supportsminheight)*
+
+*Defined in [card-elements.ts:482](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L482)*
+
+**Returns:** *boolean*
+
+___
+
+###  text
+
+• **get text**(): *string*
+
+*Inherited from [BaseTextBlock](basetextblock.md).[text](basetextblock.md#text)*
+
+*Defined in [card-elements.ts:1132](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1132)*
+
+**Returns:** *string*
+
+• **set text**(`value`: string): *void*
+
+*Inherited from [BaseTextBlock](basetextblock.md).[text](basetextblock.md#text)*
+
+*Defined in [card-elements.ts:1136](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1136)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+### `Protected` useDefaultSizing
+
+• **get useDefaultSizing**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
+
+*Defined in [card-elements.ts:486](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L486)*
+
+**Returns:** *boolean*
+
+## Methods
+
+### `Protected` adjustRenderedElementSize
+
+▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
+
+*Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
+
+*Defined in [card-elements.ts:411](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L411)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`renderedElement` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+### `Protected` applyPadding
+
+▸ **applyPadding**(): *void*
+
+*Inherited from [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
+
+*Defined in [card-elements.ts:430](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L430)*
+
+**Returns:** *void*
+
+___
+
+###  applyStylesTo
+
+▸ **applyStylesTo**(`targetElement`: HTMLElement): *void*
+
+*Overrides [BaseTextBlock](basetextblock.md).[applyStylesTo](basetextblock.md#applystylesto)*
+
+*Defined in [card-elements.ts:1365](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1365)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`targetElement` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+###  asString
+
+▸ **asString**(): *string*
+
+*Inherited from [BaseTextBlock](basetextblock.md).[asString](basetextblock.md#asstring)*
+
+*Overrides [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
+
+*Defined in [card-elements.ts:1017](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1017)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` createPlaceholderElement
+
+▸ **createPlaceholderElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
+
+*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  getActionAt
+
+▸ **getActionAt**(`index`: number): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
+
+*Defined in [card-elements.ts:694](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L694)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionById
+
+▸ **getActionById**(`id`: string): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
+
+*Defined in [card-elements.ts:835](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L835)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionCount
+
+▸ **getActionCount**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
+
+*Defined in [card-elements.ts:690](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L690)*
+
+**Returns:** *number*
+
+___
+
+###  getAllInputs
+
+▸ **getAllInputs**(): *Array‹[Input](input.md)›*
+
+*Inherited from [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
+
+*Defined in [card-elements.ts:823](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L823)*
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+### `Protected` getColorDefinition
+
+▸ **getColorDefinition**(`colorSet`: [ColorSetDefinition](colorsetdefinition.md), `color`: [TextColor](../enums/textcolor.md)): *[TextColorDefinition](textcolordefinition.md)*
+
+*Inherited from [BaseTextBlock](basetextblock.md).[getColorDefinition](basetextblock.md#protected-getcolordefinition)*
+
+*Defined in [card-elements.ts:988](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L988)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`colorSet` | [ColorSetDefinition](colorsetdefinition.md) |
+`color` | [TextColor](../enums/textcolor.md) |
+
+**Returns:** *[TextColorDefinition](textcolordefinition.md)*
+
+___
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+### `Protected` getDefaultPadding
+
+▸ **getDefaultPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
+
+*Defined in [card-elements.ts:466](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L466)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectivePadding
+
+▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
+
+*Defined in [card-elements.ts:847](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L847)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectiveStyle
+
+▸ **getEffectiveStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
+
+*Defined in [card-elements.ts:545](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L545)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` getEffectiveStyleDefinition
+
+▸ **getEffectiveStyleDefinition**(): *[ContainerStyleDefinition](containerstyledefinition.md)‹›*
+
+*Inherited from [BaseTextBlock](basetextblock.md).[getEffectiveStyleDefinition](basetextblock.md#protected-geteffectivestyledefinition)*
+
+*Defined in [card-elements.ts:969](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L969)*
+
+**Returns:** *[ContainerStyleDefinition](containerstyledefinition.md)‹›*
+
+___
+
+###  getElementById
+
+▸ **getElementById**(`id`: string): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
+
+*Defined in [card-elements.ts:831](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L831)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+### `Protected` getFontSize
+
+▸ **getFontSize**(`fontType`: [FontTypeDefinition](fonttypedefinition.md)): *number*
+
+*Inherited from [BaseTextBlock](basetextblock.md).[getFontSize](basetextblock.md#protected-getfontsize)*
+
+*Defined in [card-elements.ts:973](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L973)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`fontType` | [FontTypeDefinition](fonttypedefinition.md) |
+
+**Returns:** *number*
+
+___
+
+###  getForbiddenActionTypes
+
+▸ **getForbiddenActionTypes**(): *Array‹any›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
+
+*Defined in [card-elements.ts:557](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L557)*
+
+**Returns:** *Array‹any›*
+
+___
+
+###  getForbiddenElementTypes
+
+▸ **getForbiddenElementTypes**(): *Array‹string›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenElementTypes](cardelement.md#getforbiddenelementtypes)*
+
+*Defined in [card-elements.ts:553](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L553)*
+
+**Returns:** *Array‹string›*
+
+___
+
+### `Protected` getHasBackground
+
+▸ **getHasBackground**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
+
+*Defined in [card-elements.ts:470](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L470)*
+
+**Returns:** *boolean*
+
+___
+
+###  getImmediateSurroundingPadding
+
+▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
+
+*Defined in [card-elements.ts:561](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L561)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`result` | [PaddingDefinition](paddingdefinition.md) | - |
+`processTop` | boolean | true |
+`processRight` | boolean | true |
+`processBottom` | boolean | true |
+`processLeft` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  getJsonTypeName
+
+▸ **getJsonTypeName**(): *string*
+
+*Overrides [CardElement](cardelement.md).[getJsonTypeName](cardelement.md#abstract-getjsontypename)*
+
+*Defined in [card-elements.ts:1420](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1420)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` getPadding
+
+▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
+
+*Defined in [card-elements.ts:474](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L474)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getParentContainer
+
+▸ **getParentContainer**(): *[Container](container.md)*
+
+*Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
+
+*Defined in [card-elements.ts:809](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L809)*
+
+**Returns:** *[Container](container.md)*
+
+___
+
+### `Protected` getRenderedDomElementType
+
+▸ **getRenderedDomElementType**(): *string*
+
+*Defined in [card-elements.ts:1196](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1196)*
+
+**Returns:** *string*
+
+___
+
+###  getResourceInformation
+
+▸ **getResourceInformation**(): *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+*Inherited from [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
+
+*Defined in [card-elements.ts:827](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L827)*
+
+**Returns:** *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+___
+
+###  getRootElement
+
+▸ **getRootElement**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
+
+*Defined in [card-elements.ts:799](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L799)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  indexOf
+
+▸ **indexOf**(`cardElement`: [CardElement](cardelement.md)): *number*
+
+*Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
+
+*Defined in [card-elements.ts:733](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L733)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`cardElement` | [CardElement](cardelement.md) |
+
+**Returns:** *number*
+
+___
+
+### `Protected` internalRender
+
+▸ **internalRender**(): *HTMLElement*
+
+*Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
+
+*Defined in [card-elements.ts:1200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1200)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  internalValidateProperties
+
+▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
+
+*Inherited from [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
+
+*Defined in [card-elements.ts:249](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L249)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [ValidationResults](validationresults.md) |
+
+**Returns:** *void*
+
+___
+
+###  isAtTheVeryBottom
+
+▸ **isAtTheVeryBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
+
+*Defined in [card-elements.ts:767](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L767)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryLeft
+
+▸ **isAtTheVeryLeft**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
+
+*Defined in [card-elements.ts:755](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L755)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryRight
+
+▸ **isAtTheVeryRight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
+
+*Defined in [card-elements.ts:759](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L759)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryTop
+
+▸ **isAtTheVeryTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
+
+*Defined in [card-elements.ts:763](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L763)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleeding
+
+▸ **isBleeding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
+
+*Defined in [card-elements.ts:517](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L517)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtBottom
+
+▸ **isBleedingAtBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
+
+*Defined in [card-elements.ts:775](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L775)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtTop
+
+▸ **isBleedingAtTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
+
+*Defined in [card-elements.ts:771](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L771)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBottomElement
+
+▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
+
+*Defined in [card-elements.ts:791](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L791)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isDesignMode
+
+▸ **isDesignMode**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
+
+*Defined in [card-elements.ts:737](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L737)*
+
+**Returns:** *boolean*
+
+___
+
+###  isFirstElement
+
+▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
+
+*Defined in [card-elements.ts:747](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L747)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isHiddenDueToOverflow
+
+▸ **isHiddenDueToOverflow**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
+
+*Defined in [card-elements.ts:795](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L795)*
+
+**Returns:** *boolean*
+
+___
+
+###  isLastElement
+
+▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
+
+*Defined in [card-elements.ts:751](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L751)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isLeftMostElement
+
+▸ **isLeftMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
+
+*Defined in [card-elements.ts:779](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L779)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isRendered
+
+▸ **isRendered**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRendered](cardelement.md#isrendered)*
+
+*Defined in [card-elements.ts:743](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L743)*
+
+**Returns:** *boolean*
+
+___
+
+###  isRightMostElement
+
+▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
+
+*Defined in [card-elements.ts:783](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L783)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isTopElement
+
+▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
+
+*Defined in [card-elements.ts:787](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L787)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` overrideInternalRender
+
+▸ **overrideInternalRender**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
+
+*Defined in [card-elements.ts:426](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L426)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Overrides [BaseTextBlock](basetextblock.md).[parse](basetextblock.md#parse)*
+
+*Defined in [card-elements.ts:1413](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1413)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*
+
+___
+
+###  remove
+
+▸ **remove**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
+
+*Defined in [card-elements.ts:698](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L698)*
+
+**Returns:** *boolean*
+
+___
+
+###  render
+
+▸ **render**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[render](cardelement.md#render)*
+
+*Defined in [card-elements.ts:706](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L706)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setPadding
+
+▸ **setPadding**(`value`: [PaddingDefinition](paddingdefinition.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
+
+*Defined in [card-elements.ts:478](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L478)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [PaddingDefinition](paddingdefinition.md) |
+
+**Returns:** *void*
+
+___
+
+###  setParent
+
+▸ **setParent**(`value`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setParent](cardelement.md#setparent)*
+
+*Overrides [CardObject](cardobject.md).[setParent](cardobject.md#abstract-setparent)*
+
+*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+###  setShouldFallback
+
+▸ **setShouldFallback**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[setShouldFallback](cardelement.md#setshouldfallback)*
+
+*Defined in [card-elements.ts:843](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L843)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setText
+
+▸ **setText**(`value`: string): *void*
+
+*Overrides [BaseTextBlock](basetextblock.md).[setText](basetextblock.md#protected-settext)*
+
+*Defined in [card-elements.ts:1190](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1190)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  shouldFallback
+
+▸ **shouldFallback**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[shouldFallback](cardelement.md#shouldfallback)*
+
+*Overrides [CardObject](cardobject.md).[shouldFallback](cardobject.md#abstract-shouldfallback)*
+
+*Defined in [card-elements.ts:839](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L839)*
+
+**Returns:** *boolean*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [BaseTextBlock](basetextblock.md).[toJSON](basetextblock.md#tojson)*
+
+*Defined in [card-elements.ts:1356](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1356)*
+
+**Returns:** *any*
+
+___
+
+### `Protected` truncateOverflow
+
+▸ **truncateOverflow**(`maxHeight`: number): *boolean*
+
+*Overrides [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
+
+*Defined in [card-elements.ts:1335](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1335)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`maxHeight` | number |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` undoOverflowTruncation
+
+▸ **undoOverflowTruncation**(): *void*
+
+*Overrides [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
+
+*Defined in [card-elements.ts:1343](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1343)*
+
+**Returns:** *void*
+
+___
+
+###  updateLayout
+
+▸ **updateLayout**(`processChildren`: boolean): *void*
+
+*Overrides [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
+
+*Defined in [card-elements.ts:1424](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1424)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`processChildren` | boolean | false |
+
+**Returns:** *void*
+
+___
+
+###  validateProperties
+
+▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
+
+*Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
+
+*Defined in [card-elements.ts:284](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L284)*
+
+**Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/textcolordefinition.md
+++ b/source/nodejs/adaptivecards/docs/classes/textcolordefinition.md
@@ -1,0 +1,90 @@
+[Adaptive Cards Javascript SDK](../README.md) › [TextColorDefinition](textcolordefinition.md)
+
+# Class: TextColorDefinition
+
+## Hierarchy
+
+* [ColorDefinition](colordefinition.md)
+
+  ↳ **TextColorDefinition**
+
+## Index
+
+### Constructors
+
+* [constructor](textcolordefinition.md#constructor)
+
+### Properties
+
+* [default](textcolordefinition.md#default)
+* [highlightColors](textcolordefinition.md#highlightcolors)
+* [subtle](textcolordefinition.md#subtle)
+
+### Methods
+
+* [parse](textcolordefinition.md#parse)
+
+## Constructors
+
+###  constructor
+
+\+ **new TextColorDefinition**(`defaultColor?`: string, `subtleColor?`: string): *[TextColorDefinition](textcolordefinition.md)*
+
+*Inherited from [ColorDefinition](colordefinition.md).[constructor](colordefinition.md#constructor)*
+
+*Defined in [host-config.ts:14](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L14)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`defaultColor?` | string |
+`subtleColor?` | string |
+
+**Returns:** *[TextColorDefinition](textcolordefinition.md)*
+
+## Properties
+
+###  default
+
+• **default**: *string* = "#000000"
+
+*Inherited from [ColorDefinition](colordefinition.md).[default](colordefinition.md#default)*
+
+*Defined in [host-config.ts:13](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L13)*
+
+___
+
+###  highlightColors
+
+• **highlightColors**: *[ColorDefinition](colordefinition.md)‹›* = new ColorDefinition("#22000000", "#11000000")
+
+*Defined in [host-config.ts:35](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L35)*
+
+___
+
+###  subtle
+
+• **subtle**: *string* = "#666666"
+
+*Inherited from [ColorDefinition](colordefinition.md).[subtle](colordefinition.md#subtle)*
+
+*Defined in [host-config.ts:14](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L14)*
+
+## Methods
+
+###  parse
+
+▸ **parse**(`obj?`: any): *void*
+
+*Overrides [ColorDefinition](colordefinition.md).[parse](colordefinition.md#parse)*
+
+*Defined in [host-config.ts:37](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L37)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`obj?` | any |
+
+**Returns:** *void*

--- a/source/nodejs/adaptivecards/docs/classes/textinput.md
+++ b/source/nodejs/adaptivecards/docs/classes/textinput.md
@@ -1,0 +1,1475 @@
+[Adaptive Cards Javascript SDK](../README.md) › [TextInput](textinput.md)
+
+# Class: TextInput
+
+## Hierarchy
+
+  ↳ [Input](input.md)
+
+  ↳ **TextInput**
+
+## Implements
+
+* [IInput](../interfaces/iinput.md)
+
+## Index
+
+### Properties
+
+* [customCssSelector](textinput.md#customcssselector)
+* [height](textinput.md#height)
+* [horizontalAlignment](textinput.md#optional-horizontalalignment)
+* [id](textinput.md#id)
+* [isMultiline](textinput.md#ismultiline)
+* [maxLength](textinput.md#maxlength)
+* [minPixelHeight](textinput.md#optional-minpixelheight)
+* [onValueChanged](textinput.md#onvaluechanged)
+* [placeholder](textinput.md#placeholder)
+* [requires](textinput.md#requires)
+* [separator](textinput.md#separator)
+* [spacing](textinput.md#spacing)
+* [style](textinput.md#style)
+* [title](textinput.md#title)
+* [validation](textinput.md#validation)
+
+### Accessors
+
+* [allowCustomPadding](textinput.md#protected-allowcustompadding)
+* [defaultStyle](textinput.md#protected-defaultstyle)
+* [defaultValue](textinput.md#defaultvalue)
+* [hasVisibleSeparator](textinput.md#hasvisibleseparator)
+* [hostConfig](textinput.md#hostconfig)
+* [index](textinput.md#index)
+* [inlineAction](textinput.md#inlineaction)
+* [inputControlContainerElement](textinput.md#protected-inputcontrolcontainerelement)
+* [isInline](textinput.md#isinline)
+* [isInteractive](textinput.md#isinteractive)
+* [isNullable](textinput.md#protected-isnullable)
+* [isStandalone](textinput.md#isstandalone)
+* [isVisible](textinput.md#isvisible)
+* [lang](textinput.md#lang)
+* [parent](textinput.md#parent)
+* [renderedElement](textinput.md#renderedelement)
+* [renderedInputControlElement](textinput.md#protected-renderedinputcontrolelement)
+* [separatorElement](textinput.md#separatorelement)
+* [separatorOrientation](textinput.md#protected-separatororientation)
+* [supportsMinHeight](textinput.md#protected-supportsminheight)
+* [useDefaultSizing](textinput.md#protected-usedefaultsizing)
+* [value](textinput.md#value)
+
+### Methods
+
+* [adjustRenderedElementSize](textinput.md#protected-adjustrenderedelementsize)
+* [applyPadding](textinput.md#protected-applypadding)
+* [asString](textinput.md#asstring)
+* [createPlaceholderElement](textinput.md#protected-createplaceholderelement)
+* [getActionAt](textinput.md#getactionat)
+* [getActionById](textinput.md#getactionbyid)
+* [getActionCount](textinput.md#getactioncount)
+* [getAllInputs](textinput.md#getallinputs)
+* [getCustomProperty](textinput.md#getcustomproperty)
+* [getDefaultPadding](textinput.md#protected-getdefaultpadding)
+* [getEffectivePadding](textinput.md#geteffectivepadding)
+* [getEffectiveStyle](textinput.md#geteffectivestyle)
+* [getElementById](textinput.md#getelementbyid)
+* [getForbiddenActionTypes](textinput.md#getforbiddenactiontypes)
+* [getForbiddenElementTypes](textinput.md#getforbiddenelementtypes)
+* [getHasBackground](textinput.md#protected-gethasbackground)
+* [getImmediateSurroundingPadding](textinput.md#getimmediatesurroundingpadding)
+* [getJsonTypeName](textinput.md#getjsontypename)
+* [getPadding](textinput.md#protected-getpadding)
+* [getParentContainer](textinput.md#getparentcontainer)
+* [getResourceInformation](textinput.md#getresourceinformation)
+* [getRootElement](textinput.md#getrootelement)
+* [indexOf](textinput.md#indexof)
+* [internalRender](textinput.md#protected-internalrender)
+* [internalValidateProperties](textinput.md#internalvalidateproperties)
+* [isAtTheVeryBottom](textinput.md#isattheverybottom)
+* [isAtTheVeryLeft](textinput.md#isattheveryleft)
+* [isAtTheVeryRight](textinput.md#isattheveryright)
+* [isAtTheVeryTop](textinput.md#isattheverytop)
+* [isBleeding](textinput.md#isbleeding)
+* [isBleedingAtBottom](textinput.md#isbleedingatbottom)
+* [isBleedingAtTop](textinput.md#isbleedingattop)
+* [isBottomElement](textinput.md#isbottomelement)
+* [isDesignMode](textinput.md#isdesignmode)
+* [isFirstElement](textinput.md#isfirstelement)
+* [isHiddenDueToOverflow](textinput.md#ishiddenduetooverflow)
+* [isLastElement](textinput.md#islastelement)
+* [isLeftMostElement](textinput.md#isleftmostelement)
+* [isRendered](textinput.md#isrendered)
+* [isRightMostElement](textinput.md#isrightmostelement)
+* [isTopElement](textinput.md#istopelement)
+* [overrideInternalRender](textinput.md#protected-overrideinternalrender)
+* [parse](textinput.md#parse)
+* [parseInputValue](textinput.md#protected-parseinputvalue)
+* [remove](textinput.md#remove)
+* [render](textinput.md#render)
+* [resetValidationFailureCue](textinput.md#protected-resetvalidationfailurecue)
+* [setCustomProperty](textinput.md#setcustomproperty)
+* [setPadding](textinput.md#protected-setpadding)
+* [setParent](textinput.md#setparent)
+* [setShouldFallback](textinput.md#setshouldfallback)
+* [shouldFallback](textinput.md#shouldfallback)
+* [showValidationErrorMessage](textinput.md#protected-showvalidationerrormessage)
+* [toJSON](textinput.md#tojson)
+* [truncateOverflow](textinput.md#protected-truncateoverflow)
+* [undoOverflowTruncation](textinput.md#protected-undooverflowtruncation)
+* [updateLayout](textinput.md#updatelayout)
+* [validateProperties](textinput.md#validateproperties)
+* [validateValue](textinput.md#validatevalue)
+* [valueChanged](textinput.md#protected-valuechanged)
+
+## Properties
+
+###  customCssSelector
+
+• **customCssSelector**: *string* = null
+
+*Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#customcssselector)*
+
+*Defined in [card-elements.ts:507](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L507)*
+
+___
+
+###  height
+
+• **height**: *[CardElementHeight](../README.md#cardelementheight)* = "auto"
+
+*Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
+
+*Defined in [card-elements.ts:508](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L508)*
+
+___
+
+### `Optional` horizontalAlignment
+
+• **horizontalAlignment**? : *[HorizontalAlignment](../enums/horizontalalignment.md)* = null
+
+*Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#optional-horizontalalignment)*
+
+*Defined in [card-elements.ts:504](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L504)*
+
+___
+
+###  id
+
+• **id**: *string*
+
+*Implementation of [IInput](../interfaces/iinput.md).[id](../interfaces/iinput.md#id)*
+
+*Inherited from [CardObject](cardobject.md).[id](cardobject.md#id)*
+
+*Defined in [card-elements.ts:247](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L247)*
+
+___
+
+###  isMultiline
+
+• **isMultiline**: *boolean* = false
+
+*Defined in [card-elements.ts:3077](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3077)*
+
+___
+
+###  maxLength
+
+• **maxLength**: *number*
+
+*Defined in [card-elements.ts:3076](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3076)*
+
+___
+
+### `Optional` minPixelHeight
+
+• **minPixelHeight**? : *number* = null
+
+*Inherited from [CardElement](cardelement.md).[minPixelHeight](cardelement.md#optional-minpixelheight)*
+
+*Defined in [card-elements.ts:509](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L509)*
+
+___
+
+###  onValueChanged
+
+• **onValueChanged**: *function*
+
+*Inherited from [Input](input.md).[onValueChanged](input.md#onvaluechanged)*
+
+*Defined in [card-elements.ts:2874](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2874)*
+
+#### Type declaration:
+
+▸ (`sender`: [Input](input.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`sender` | [Input](input.md) |
+
+___
+
+###  placeholder
+
+• **placeholder**: *string*
+
+*Defined in [card-elements.ts:3078](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3078)*
+
+___
+
+###  requires
+
+• **requires**: *[HostCapabilities](hostcapabilities.md)‹›* = new HostConfig.HostCapabilities()
+
+*Inherited from [CardElement](cardelement.md).[requires](cardelement.md#requires)*
+
+*Defined in [card-elements.ts:502](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L502)*
+
+___
+
+###  separator
+
+• **separator**: *boolean* = false
+
+*Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
+
+*Defined in [card-elements.ts:506](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L506)*
+
+___
+
+###  spacing
+
+• **spacing**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.Default
+
+*Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
+
+*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
+
+___
+
+###  style
+
+• **style**: *[InputTextStyle](../enums/inputtextstyle.md)* = Enums.InputTextStyle.Text
+
+*Defined in [card-elements.ts:3079](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3079)*
+
+___
+
+###  title
+
+• **title**: *string*
+
+*Inherited from [Input](input.md).[title](input.md#title)*
+
+*Defined in [card-elements.ts:2878](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2878)*
+
+___
+
+###  validation
+
+• **validation**: *[InputValidationOptions](inputvalidationoptions.md)‹›* = new InputValidationOptions()
+
+*Inherited from [Input](input.md).[validation](input.md#validation)*
+
+*Defined in [card-elements.ts:2876](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2876)*
+
+## Accessors
+
+### `Protected` allowCustomPadding
+
+• **get allowCustomPadding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
+
+*Defined in [card-elements.ts:490](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L490)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` defaultStyle
+
+• **get defaultStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
+
+*Defined in [card-elements.ts:498](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L498)*
+
+**Returns:** *string*
+
+___
+
+###  defaultValue
+
+• **get defaultValue**(): *string*
+
+*Inherited from [Input](input.md).[defaultValue](input.md#defaultvalue)*
+
+*Defined in [card-elements.ts:2944](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2944)*
+
+**Returns:** *string*
+
+• **set defaultValue**(`value`: string): *void*
+
+*Inherited from [Input](input.md).[defaultValue](input.md#defaultvalue)*
+
+*Defined in [card-elements.ts:2948](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2948)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  hasVisibleSeparator
+
+• **get hasVisibleSeparator**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
+
+*Defined in [card-elements.ts:928](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L928)*
+
+**Returns:** *boolean*
+
+___
+
+###  hostConfig
+
+• **get hostConfig**(): *[HostConfig](hostconfig.md)*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:881](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L881)*
+
+**Returns:** *[HostConfig](hostconfig.md)*
+
+• **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:895](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L895)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [HostConfig](hostconfig.md) |
+
+**Returns:** *void*
+
+___
+
+###  index
+
+• **get index**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
+
+*Defined in [card-elements.ts:899](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L899)*
+
+**Returns:** *number*
+
+___
+
+###  inlineAction
+
+• **get inlineAction**(): *[Action](action.md)*
+
+*Defined in [card-elements.ts:3125](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3125)*
+
+**Returns:** *[Action](action.md)*
+
+• **set inlineAction**(`value`: [Action](action.md)): *void*
+
+*Defined in [card-elements.ts:3129](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3129)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [Action](action.md) |
+
+**Returns:** *void*
+
+___
+
+### `Protected` inputControlContainerElement
+
+• **get inputControlContainerElement**(): *HTMLElement*
+
+*Inherited from [Input](input.md).[inputControlContainerElement](input.md#protected-inputcontrolcontainerelement)*
+
+*Defined in [card-elements.ts:2807](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2807)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  isInline
+
+• **get isInline**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
+
+*Defined in [card-elements.ts:916](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L916)*
+
+**Returns:** *boolean*
+
+___
+
+###  isInteractive
+
+• **get isInteractive**(): *boolean*
+
+*Inherited from [Input](input.md).[isInteractive](input.md#isinteractive)*
+
+*Overrides [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
+
+*Defined in [card-elements.ts:2952](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2952)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` isNullable
+
+• **get isNullable**(): *boolean*
+
+*Inherited from [Input](input.md).[isNullable](input.md#protected-isnullable)*
+
+*Defined in [card-elements.ts:2799](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2799)*
+
+**Returns:** *boolean*
+
+___
+
+###  isStandalone
+
+• **get isStandalone**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
+
+*Defined in [card-elements.ts:912](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L912)*
+
+**Returns:** *boolean*
+
+___
+
+###  isVisible
+
+• **get isVisible**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:924](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L924)*
+
+**Returns:** *boolean*
+
+• **set isVisible**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:937](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L937)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  lang
+
+• **get lang**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:853](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L853)*
+
+**Returns:** *string*
+
+• **set lang**(`value`: string): *void*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:867](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L867)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  parent
+
+• **get parent**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[parent](cardelement.md#parent)*
+
+*Defined in [card-elements.ts:920](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L920)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  renderedElement
+
+• **get renderedElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[renderedElement](cardelement.md#renderedelement)*
+
+*Defined in [card-elements.ts:956](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L956)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` renderedInputControlElement
+
+• **get renderedInputControlElement**(): *HTMLElement*
+
+*Inherited from [Input](input.md).[renderedInputControlElement](input.md#protected-renderedinputcontrolelement)*
+
+*Defined in [card-elements.ts:2803](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2803)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  separatorElement
+
+• **get separatorElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
+
+*Defined in [card-elements.ts:960](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L960)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` separatorOrientation
+
+• **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
+
+*Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
+
+*Defined in [card-elements.ts:494](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L494)*
+
+**Returns:** *[Orientation](../enums/orientation.md)*
+
+___
+
+### `Protected` supportsMinHeight
+
+• **get supportsMinHeight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[supportsMinHeight](cardelement.md#protected-supportsminheight)*
+
+*Defined in [card-elements.ts:482](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L482)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` useDefaultSizing
+
+• **get useDefaultSizing**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
+
+*Defined in [card-elements.ts:486](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L486)*
+
+**Returns:** *boolean*
+
+___
+
+###  value
+
+• **get value**(): *string*
+
+*Overrides [Input](input.md).[value](input.md#value)*
+
+*Defined in [card-elements.ts:3137](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3137)*
+
+**Returns:** *string*
+
+## Methods
+
+### `Protected` adjustRenderedElementSize
+
+▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
+
+*Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
+
+*Defined in [card-elements.ts:411](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L411)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`renderedElement` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+### `Protected` applyPadding
+
+▸ **applyPadding**(): *void*
+
+*Inherited from [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
+
+*Defined in [card-elements.ts:430](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L430)*
+
+**Returns:** *void*
+
+___
+
+###  asString
+
+▸ **asString**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
+
+*Defined in [card-elements.ts:513](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L513)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` createPlaceholderElement
+
+▸ **createPlaceholderElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
+
+*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  getActionAt
+
+▸ **getActionAt**(`index`: number): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
+
+*Defined in [card-elements.ts:694](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L694)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionById
+
+▸ **getActionById**(`id`: string): *[Action](action.md)‹›*
+
+*Overrides [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
+
+*Defined in [card-elements.ts:3085](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3085)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[Action](action.md)‹›*
+
+___
+
+###  getActionCount
+
+▸ **getActionCount**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
+
+*Defined in [card-elements.ts:690](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L690)*
+
+**Returns:** *number*
+
+___
+
+###  getAllInputs
+
+▸ **getAllInputs**(): *Array‹[Input](input.md)›*
+
+*Inherited from [Input](input.md).[getAllInputs](input.md#getallinputs)*
+
+*Overrides [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
+
+*Defined in [card-elements.ts:2940](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2940)*
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+### `Protected` getDefaultPadding
+
+▸ **getDefaultPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
+
+*Defined in [card-elements.ts:466](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L466)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectivePadding
+
+▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
+
+*Defined in [card-elements.ts:847](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L847)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectiveStyle
+
+▸ **getEffectiveStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
+
+*Defined in [card-elements.ts:545](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L545)*
+
+**Returns:** *string*
+
+___
+
+###  getElementById
+
+▸ **getElementById**(`id`: string): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
+
+*Defined in [card-elements.ts:831](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L831)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getForbiddenActionTypes
+
+▸ **getForbiddenActionTypes**(): *Array‹any›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
+
+*Defined in [card-elements.ts:557](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L557)*
+
+**Returns:** *Array‹any›*
+
+___
+
+###  getForbiddenElementTypes
+
+▸ **getForbiddenElementTypes**(): *Array‹string›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenElementTypes](cardelement.md#getforbiddenelementtypes)*
+
+*Defined in [card-elements.ts:553](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L553)*
+
+**Returns:** *Array‹string›*
+
+___
+
+### `Protected` getHasBackground
+
+▸ **getHasBackground**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
+
+*Defined in [card-elements.ts:470](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L470)*
+
+**Returns:** *boolean*
+
+___
+
+###  getImmediateSurroundingPadding
+
+▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
+
+*Defined in [card-elements.ts:561](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L561)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`result` | [PaddingDefinition](paddingdefinition.md) | - |
+`processTop` | boolean | true |
+`processRight` | boolean | true |
+`processBottom` | boolean | true |
+`processLeft` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  getJsonTypeName
+
+▸ **getJsonTypeName**(): *string*
+
+*Overrides [CardElement](cardelement.md).[getJsonTypeName](cardelement.md#abstract-getjsontypename)*
+
+*Defined in [card-elements.ts:3081](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3081)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` getPadding
+
+▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
+
+*Defined in [card-elements.ts:474](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L474)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getParentContainer
+
+▸ **getParentContainer**(): *[Container](container.md)*
+
+*Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
+
+*Defined in [card-elements.ts:809](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L809)*
+
+**Returns:** *[Container](container.md)*
+
+___
+
+###  getResourceInformation
+
+▸ **getResourceInformation**(): *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+*Inherited from [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
+
+*Defined in [card-elements.ts:827](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L827)*
+
+**Returns:** *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+___
+
+###  getRootElement
+
+▸ **getRootElement**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
+
+*Defined in [card-elements.ts:799](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L799)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  indexOf
+
+▸ **indexOf**(`cardElement`: [CardElement](cardelement.md)): *number*
+
+*Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
+
+*Defined in [card-elements.ts:733](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L733)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`cardElement` | [CardElement](cardelement.md) |
+
+**Returns:** *number*
+
+___
+
+### `Protected` internalRender
+
+▸ **internalRender**(): *HTMLElement*
+
+*Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
+
+*Defined in [card-elements.ts:2960](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2960)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  internalValidateProperties
+
+▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
+
+*Inherited from [Input](input.md).[internalValidateProperties](input.md#internalvalidateproperties)*
+
+*Overrides [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
+
+*Defined in [card-elements.ts:2893](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2893)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [ValidationResults](validationresults.md) |
+
+**Returns:** *void*
+
+___
+
+###  isAtTheVeryBottom
+
+▸ **isAtTheVeryBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
+
+*Defined in [card-elements.ts:767](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L767)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryLeft
+
+▸ **isAtTheVeryLeft**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
+
+*Defined in [card-elements.ts:755](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L755)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryRight
+
+▸ **isAtTheVeryRight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
+
+*Defined in [card-elements.ts:759](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L759)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryTop
+
+▸ **isAtTheVeryTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
+
+*Defined in [card-elements.ts:763](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L763)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleeding
+
+▸ **isBleeding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
+
+*Defined in [card-elements.ts:517](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L517)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtBottom
+
+▸ **isBleedingAtBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
+
+*Defined in [card-elements.ts:775](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L775)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtTop
+
+▸ **isBleedingAtTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
+
+*Defined in [card-elements.ts:771](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L771)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBottomElement
+
+▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
+
+*Defined in [card-elements.ts:791](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L791)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isDesignMode
+
+▸ **isDesignMode**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
+
+*Defined in [card-elements.ts:737](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L737)*
+
+**Returns:** *boolean*
+
+___
+
+###  isFirstElement
+
+▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
+
+*Defined in [card-elements.ts:747](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L747)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isHiddenDueToOverflow
+
+▸ **isHiddenDueToOverflow**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
+
+*Defined in [card-elements.ts:795](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L795)*
+
+**Returns:** *boolean*
+
+___
+
+###  isLastElement
+
+▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
+
+*Defined in [card-elements.ts:751](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L751)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isLeftMostElement
+
+▸ **isLeftMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
+
+*Defined in [card-elements.ts:779](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L779)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isRendered
+
+▸ **isRendered**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRendered](cardelement.md#isrendered)*
+
+*Defined in [card-elements.ts:743](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L743)*
+
+**Returns:** *boolean*
+
+___
+
+###  isRightMostElement
+
+▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
+
+*Defined in [card-elements.ts:783](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L783)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isTopElement
+
+▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
+
+*Defined in [card-elements.ts:787](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L787)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` overrideInternalRender
+
+▸ **overrideInternalRender**(): *HTMLElement*
+
+*Overrides [Input](input.md).[overrideInternalRender](input.md#protected-overrideinternalrender)*
+
+*Defined in [card-elements.ts:3022](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3022)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Overrides [Input](input.md).[parse](input.md#parse)*
+
+*Defined in [card-elements.ts:3110](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3110)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*
+
+___
+
+### `Protected` parseInputValue
+
+▸ **parseInputValue**(`value`: string): *string*
+
+*Inherited from [Input](input.md).[parseInputValue](input.md#protected-parseinputvalue)*
+
+*Defined in [card-elements.ts:2868](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2868)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *string*
+
+___
+
+###  remove
+
+▸ **remove**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
+
+*Defined in [card-elements.ts:698](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L698)*
+
+**Returns:** *boolean*
+
+___
+
+###  render
+
+▸ **render**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[render](cardelement.md#render)*
+
+*Defined in [card-elements.ts:706](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L706)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` resetValidationFailureCue
+
+▸ **resetValidationFailureCue**(): *void*
+
+*Inherited from [Input](input.md).[resetValidationFailureCue](input.md#protected-resetvalidationfailurecue)*
+
+*Defined in [card-elements.ts:2846](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2846)*
+
+**Returns:** *void*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setPadding
+
+▸ **setPadding**(`value`: [PaddingDefinition](paddingdefinition.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
+
+*Defined in [card-elements.ts:478](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L478)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [PaddingDefinition](paddingdefinition.md) |
+
+**Returns:** *void*
+
+___
+
+###  setParent
+
+▸ **setParent**(`value`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setParent](cardelement.md#setparent)*
+
+*Overrides [CardObject](cardobject.md).[setParent](cardobject.md#abstract-setparent)*
+
+*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+###  setShouldFallback
+
+▸ **setShouldFallback**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[setShouldFallback](cardelement.md#setshouldfallback)*
+
+*Defined in [card-elements.ts:843](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L843)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  shouldFallback
+
+▸ **shouldFallback**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[shouldFallback](cardelement.md#shouldfallback)*
+
+*Overrides [CardObject](cardobject.md).[shouldFallback](cardobject.md#abstract-shouldfallback)*
+
+*Defined in [card-elements.ts:839](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L839)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` showValidationErrorMessage
+
+▸ **showValidationErrorMessage**(): *void*
+
+*Inherited from [Input](input.md).[showValidationErrorMessage](input.md#protected-showvalidationerrormessage)*
+
+*Defined in [card-elements.ts:2858](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2858)*
+
+**Returns:** *void*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [Input](input.md).[toJSON](input.md#tojson)*
+
+*Defined in [card-elements.ts:3095](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3095)*
+
+**Returns:** *any*
+
+___
+
+### `Protected` truncateOverflow
+
+▸ **truncateOverflow**(`maxHeight`: number): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
+
+*Defined in [card-elements.ts:454](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L454)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`maxHeight` | number |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` undoOverflowTruncation
+
+▸ **undoOverflowTruncation**(): *void*
+
+*Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
+
+*Defined in [card-elements.ts:464](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L464)*
+
+**Returns:** *void*
+
+___
+
+###  updateLayout
+
+▸ **updateLayout**(`processChildren`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
+
+*Defined in [card-elements.ts:728](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L728)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`processChildren` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  validateProperties
+
+▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
+
+*Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
+
+*Defined in [card-elements.ts:284](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L284)*
+
+**Returns:** *[ValidationResults](validationresults.md)*
+
+___
+
+###  validateValue
+
+▸ **validateValue**(): *boolean*
+
+*Implementation of [IInput](../interfaces/iinput.md)*
+
+*Inherited from [Input](input.md).[validateValue](input.md#validatevalue)*
+
+*Defined in [card-elements.ts:2906](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2906)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` valueChanged
+
+▸ **valueChanged**(): *void*
+
+*Inherited from [Input](input.md).[valueChanged](input.md#protected-valuechanged)*
+
+*Defined in [card-elements.ts:2836](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2836)*
+
+**Returns:** *void*

--- a/source/nodejs/adaptivecards/docs/classes/textrun.md
+++ b/source/nodejs/adaptivecards/docs/classes/textrun.md
@@ -1,0 +1,1450 @@
+[Adaptive Cards Javascript SDK](../README.md) › [TextRun](textrun.md)
+
+# Class: TextRun
+
+## Hierarchy
+
+  ↳ [BaseTextBlock](basetextblock.md)
+
+  ↳ **TextRun**
+
+## Index
+
+### Properties
+
+* [color](textrun.md#color)
+* [customCssSelector](textrun.md#customcssselector)
+* [fontType](textrun.md#optional-fonttype)
+* [height](textrun.md#height)
+* [highlight](textrun.md#highlight)
+* [horizontalAlignment](textrun.md#optional-horizontalalignment)
+* [id](textrun.md#id)
+* [isSubtle](textrun.md#issubtle)
+* [italic](textrun.md#italic)
+* [minPixelHeight](textrun.md#optional-minpixelheight)
+* [requires](textrun.md#requires)
+* [separator](textrun.md#separator)
+* [size](textrun.md#size)
+* [spacing](textrun.md#spacing)
+* [strikethrough](textrun.md#strikethrough)
+* [weight](textrun.md#weight)
+
+### Accessors
+
+* [allowCustomPadding](textrun.md#protected-allowcustompadding)
+* [defaultStyle](textrun.md#protected-defaultstyle)
+* [effectiveColor](textrun.md#effectivecolor)
+* [hasVisibleSeparator](textrun.md#hasvisibleseparator)
+* [hostConfig](textrun.md#hostconfig)
+* [index](textrun.md#index)
+* [isInline](textrun.md#isinline)
+* [isInteractive](textrun.md#isinteractive)
+* [isStandalone](textrun.md#isstandalone)
+* [isVisible](textrun.md#isvisible)
+* [lang](textrun.md#lang)
+* [parent](textrun.md#parent)
+* [renderedElement](textrun.md#renderedelement)
+* [selectAction](textrun.md#selectaction)
+* [separatorElement](textrun.md#separatorelement)
+* [separatorOrientation](textrun.md#protected-separatororientation)
+* [supportsMinHeight](textrun.md#protected-supportsminheight)
+* [text](textrun.md#text)
+* [useDefaultSizing](textrun.md#protected-usedefaultsizing)
+
+### Methods
+
+* [adjustRenderedElementSize](textrun.md#protected-adjustrenderedelementsize)
+* [applyPadding](textrun.md#protected-applypadding)
+* [applyStylesTo](textrun.md#applystylesto)
+* [asString](textrun.md#asstring)
+* [createPlaceholderElement](textrun.md#protected-createplaceholderelement)
+* [getActionAt](textrun.md#getactionat)
+* [getActionById](textrun.md#getactionbyid)
+* [getActionCount](textrun.md#getactioncount)
+* [getAllInputs](textrun.md#getallinputs)
+* [getColorDefinition](textrun.md#protected-getcolordefinition)
+* [getCustomProperty](textrun.md#getcustomproperty)
+* [getDefaultPadding](textrun.md#protected-getdefaultpadding)
+* [getEffectivePadding](textrun.md#geteffectivepadding)
+* [getEffectiveStyle](textrun.md#geteffectivestyle)
+* [getEffectiveStyleDefinition](textrun.md#protected-geteffectivestyledefinition)
+* [getElementById](textrun.md#getelementbyid)
+* [getFontSize](textrun.md#protected-getfontsize)
+* [getForbiddenActionTypes](textrun.md#getforbiddenactiontypes)
+* [getForbiddenElementTypes](textrun.md#getforbiddenelementtypes)
+* [getHasBackground](textrun.md#protected-gethasbackground)
+* [getImmediateSurroundingPadding](textrun.md#getimmediatesurroundingpadding)
+* [getJsonTypeName](textrun.md#getjsontypename)
+* [getPadding](textrun.md#protected-getpadding)
+* [getParentContainer](textrun.md#getparentcontainer)
+* [getResourceInformation](textrun.md#getresourceinformation)
+* [getRootElement](textrun.md#getrootelement)
+* [indexOf](textrun.md#indexof)
+* [internalRender](textrun.md#protected-internalrender)
+* [internalValidateProperties](textrun.md#internalvalidateproperties)
+* [isAtTheVeryBottom](textrun.md#isattheverybottom)
+* [isAtTheVeryLeft](textrun.md#isattheveryleft)
+* [isAtTheVeryRight](textrun.md#isattheveryright)
+* [isAtTheVeryTop](textrun.md#isattheverytop)
+* [isBleeding](textrun.md#isbleeding)
+* [isBleedingAtBottom](textrun.md#isbleedingatbottom)
+* [isBleedingAtTop](textrun.md#isbleedingattop)
+* [isBottomElement](textrun.md#isbottomelement)
+* [isDesignMode](textrun.md#isdesignmode)
+* [isFirstElement](textrun.md#isfirstelement)
+* [isHiddenDueToOverflow](textrun.md#ishiddenduetooverflow)
+* [isLastElement](textrun.md#islastelement)
+* [isLeftMostElement](textrun.md#isleftmostelement)
+* [isRendered](textrun.md#isrendered)
+* [isRightMostElement](textrun.md#isrightmostelement)
+* [isTopElement](textrun.md#istopelement)
+* [overrideInternalRender](textrun.md#protected-overrideinternalrender)
+* [parse](textrun.md#parse)
+* [remove](textrun.md#remove)
+* [render](textrun.md#render)
+* [setCustomProperty](textrun.md#setcustomproperty)
+* [setPadding](textrun.md#protected-setpadding)
+* [setParent](textrun.md#setparent)
+* [setShouldFallback](textrun.md#setshouldfallback)
+* [setText](textrun.md#protected-settext)
+* [shouldFallback](textrun.md#shouldfallback)
+* [toJSON](textrun.md#tojson)
+* [truncateOverflow](textrun.md#protected-truncateoverflow)
+* [undoOverflowTruncation](textrun.md#protected-undooverflowtruncation)
+* [updateLayout](textrun.md#updatelayout)
+* [validateProperties](textrun.md#validateproperties)
+
+## Properties
+
+###  color
+
+• **color**: *[TextColor](../enums/textcolor.md)* = Enums.TextColor.Default
+
+*Inherited from [BaseTextBlock](basetextblock.md).[color](basetextblock.md#color)*
+
+*Defined in [card-elements.ts:1013](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1013)*
+
+___
+
+###  customCssSelector
+
+• **customCssSelector**: *string* = null
+
+*Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#customcssselector)*
+
+*Defined in [card-elements.ts:507](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L507)*
+
+___
+
+### `Optional` fontType
+
+• **fontType**? : *[FontType](../enums/fonttype.md)* = null
+
+*Inherited from [BaseTextBlock](basetextblock.md).[fontType](basetextblock.md#optional-fonttype)*
+
+*Defined in [card-elements.ts:1015](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1015)*
+
+___
+
+###  height
+
+• **height**: *[CardElementHeight](../README.md#cardelementheight)* = "auto"
+
+*Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
+
+*Defined in [card-elements.ts:508](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L508)*
+
+___
+
+###  highlight
+
+• **highlight**: *boolean* = false
+
+*Defined in [card-elements.ts:1495](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1495)*
+
+___
+
+### `Optional` horizontalAlignment
+
+• **horizontalAlignment**? : *[HorizontalAlignment](../enums/horizontalalignment.md)* = null
+
+*Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#optional-horizontalalignment)*
+
+*Defined in [card-elements.ts:504](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L504)*
+
+___
+
+###  id
+
+• **id**: *string*
+
+*Inherited from [CardObject](cardobject.md).[id](cardobject.md#id)*
+
+*Defined in [card-elements.ts:247](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L247)*
+
+___
+
+###  isSubtle
+
+• **isSubtle**: *boolean* = false
+
+*Inherited from [BaseTextBlock](basetextblock.md).[isSubtle](basetextblock.md#issubtle)*
+
+*Defined in [card-elements.ts:1014](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1014)*
+
+___
+
+###  italic
+
+• **italic**: *boolean* = false
+
+*Defined in [card-elements.ts:1493](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1493)*
+
+___
+
+### `Optional` minPixelHeight
+
+• **minPixelHeight**? : *number* = null
+
+*Inherited from [CardElement](cardelement.md).[minPixelHeight](cardelement.md#optional-minpixelheight)*
+
+*Defined in [card-elements.ts:509](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L509)*
+
+___
+
+###  requires
+
+• **requires**: *[HostCapabilities](hostcapabilities.md)‹›* = new HostConfig.HostCapabilities()
+
+*Inherited from [CardElement](cardelement.md).[requires](cardelement.md#requires)*
+
+*Defined in [card-elements.ts:502](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L502)*
+
+___
+
+###  separator
+
+• **separator**: *boolean* = false
+
+*Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
+
+*Defined in [card-elements.ts:506](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L506)*
+
+___
+
+###  size
+
+• **size**: *[TextSize](../enums/textsize.md)* = Enums.TextSize.Default
+
+*Inherited from [BaseTextBlock](basetextblock.md).[size](basetextblock.md#size)*
+
+*Defined in [card-elements.ts:1011](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1011)*
+
+___
+
+###  spacing
+
+• **spacing**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.Default
+
+*Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
+
+*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
+
+___
+
+###  strikethrough
+
+• **strikethrough**: *boolean* = false
+
+*Defined in [card-elements.ts:1494](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1494)*
+
+___
+
+###  weight
+
+• **weight**: *[TextWeight](../enums/textweight.md)* = Enums.TextWeight.Default
+
+*Inherited from [BaseTextBlock](basetextblock.md).[weight](basetextblock.md#weight)*
+
+*Defined in [card-elements.ts:1012](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1012)*
+
+## Accessors
+
+### `Protected` allowCustomPadding
+
+• **get allowCustomPadding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
+
+*Defined in [card-elements.ts:490](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L490)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` defaultStyle
+
+• **get defaultStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
+
+*Defined in [card-elements.ts:498](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L498)*
+
+**Returns:** *string*
+
+___
+
+###  effectiveColor
+
+• **get effectiveColor**(): *[TextColor](../enums/textcolor.md)*
+
+*Inherited from [BaseTextBlock](basetextblock.md).[effectiveColor](basetextblock.md#effectivecolor)*
+
+*Defined in [card-elements.ts:1128](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1128)*
+
+**Returns:** *[TextColor](../enums/textcolor.md)*
+
+___
+
+###  hasVisibleSeparator
+
+• **get hasVisibleSeparator**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
+
+*Defined in [card-elements.ts:928](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L928)*
+
+**Returns:** *boolean*
+
+___
+
+###  hostConfig
+
+• **get hostConfig**(): *[HostConfig](hostconfig.md)*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:881](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L881)*
+
+**Returns:** *[HostConfig](hostconfig.md)*
+
+• **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:895](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L895)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [HostConfig](hostconfig.md) |
+
+**Returns:** *void*
+
+___
+
+###  index
+
+• **get index**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
+
+*Defined in [card-elements.ts:899](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L899)*
+
+**Returns:** *number*
+
+___
+
+###  isInline
+
+• **get isInline**(): *boolean*
+
+*Overrides [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
+
+*Defined in [card-elements.ts:1551](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1551)*
+
+**Returns:** *boolean*
+
+___
+
+###  isInteractive
+
+• **get isInteractive**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
+
+*Defined in [card-elements.ts:908](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L908)*
+
+**Returns:** *boolean*
+
+___
+
+###  isStandalone
+
+• **get isStandalone**(): *boolean*
+
+*Overrides [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
+
+*Defined in [card-elements.ts:1547](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1547)*
+
+**Returns:** *boolean*
+
+___
+
+###  isVisible
+
+• **get isVisible**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:924](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L924)*
+
+**Returns:** *boolean*
+
+• **set isVisible**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:937](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L937)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  lang
+
+• **get lang**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:853](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L853)*
+
+**Returns:** *string*
+
+• **set lang**(`value`: string): *void*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:867](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L867)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  parent
+
+• **get parent**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[parent](cardelement.md#parent)*
+
+*Defined in [card-elements.ts:920](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L920)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  renderedElement
+
+• **get renderedElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[renderedElement](cardelement.md#renderedelement)*
+
+*Defined in [card-elements.ts:956](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L956)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  selectAction
+
+• **get selectAction**(): *[Action](action.md)*
+
+*Inherited from [BaseTextBlock](basetextblock.md).[selectAction](basetextblock.md#selectaction)*
+
+*Defined in [card-elements.ts:1140](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1140)*
+
+**Returns:** *[Action](action.md)*
+
+• **set selectAction**(`value`: [Action](action.md)): *void*
+
+*Inherited from [BaseTextBlock](basetextblock.md).[selectAction](basetextblock.md#selectaction)*
+
+*Defined in [card-elements.ts:1144](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1144)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [Action](action.md) |
+
+**Returns:** *void*
+
+___
+
+###  separatorElement
+
+• **get separatorElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
+
+*Defined in [card-elements.ts:960](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L960)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` separatorOrientation
+
+• **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
+
+*Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
+
+*Defined in [card-elements.ts:494](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L494)*
+
+**Returns:** *[Orientation](../enums/orientation.md)*
+
+___
+
+### `Protected` supportsMinHeight
+
+• **get supportsMinHeight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[supportsMinHeight](cardelement.md#protected-supportsminheight)*
+
+*Defined in [card-elements.ts:482](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L482)*
+
+**Returns:** *boolean*
+
+___
+
+###  text
+
+• **get text**(): *string*
+
+*Inherited from [BaseTextBlock](basetextblock.md).[text](basetextblock.md#text)*
+
+*Defined in [card-elements.ts:1132](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1132)*
+
+**Returns:** *string*
+
+• **set text**(`value`: string): *void*
+
+*Inherited from [BaseTextBlock](basetextblock.md).[text](basetextblock.md#text)*
+
+*Defined in [card-elements.ts:1136](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1136)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+### `Protected` useDefaultSizing
+
+• **get useDefaultSizing**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
+
+*Defined in [card-elements.ts:486](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L486)*
+
+**Returns:** *boolean*
+
+## Methods
+
+### `Protected` adjustRenderedElementSize
+
+▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
+
+*Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
+
+*Defined in [card-elements.ts:411](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L411)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`renderedElement` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+### `Protected` applyPadding
+
+▸ **applyPadding**(): *void*
+
+*Inherited from [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
+
+*Defined in [card-elements.ts:430](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L430)*
+
+**Returns:** *void*
+
+___
+
+###  applyStylesTo
+
+▸ **applyStylesTo**(`targetElement`: HTMLElement): *void*
+
+*Overrides [BaseTextBlock](basetextblock.md).[applyStylesTo](basetextblock.md#applystylesto)*
+
+*Defined in [card-elements.ts:1497](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1497)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`targetElement` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+###  asString
+
+▸ **asString**(): *string*
+
+*Inherited from [BaseTextBlock](basetextblock.md).[asString](basetextblock.md#asstring)*
+
+*Overrides [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
+
+*Defined in [card-elements.ts:1017](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1017)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` createPlaceholderElement
+
+▸ **createPlaceholderElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
+
+*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  getActionAt
+
+▸ **getActionAt**(`index`: number): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
+
+*Defined in [card-elements.ts:694](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L694)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionById
+
+▸ **getActionById**(`id`: string): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
+
+*Defined in [card-elements.ts:835](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L835)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionCount
+
+▸ **getActionCount**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
+
+*Defined in [card-elements.ts:690](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L690)*
+
+**Returns:** *number*
+
+___
+
+###  getAllInputs
+
+▸ **getAllInputs**(): *Array‹[Input](input.md)›*
+
+*Inherited from [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
+
+*Defined in [card-elements.ts:823](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L823)*
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+### `Protected` getColorDefinition
+
+▸ **getColorDefinition**(`colorSet`: [ColorSetDefinition](colorsetdefinition.md), `color`: [TextColor](../enums/textcolor.md)): *[TextColorDefinition](textcolordefinition.md)*
+
+*Inherited from [BaseTextBlock](basetextblock.md).[getColorDefinition](basetextblock.md#protected-getcolordefinition)*
+
+*Defined in [card-elements.ts:988](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L988)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`colorSet` | [ColorSetDefinition](colorsetdefinition.md) |
+`color` | [TextColor](../enums/textcolor.md) |
+
+**Returns:** *[TextColorDefinition](textcolordefinition.md)*
+
+___
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+### `Protected` getDefaultPadding
+
+▸ **getDefaultPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
+
+*Defined in [card-elements.ts:466](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L466)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectivePadding
+
+▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
+
+*Defined in [card-elements.ts:847](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L847)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectiveStyle
+
+▸ **getEffectiveStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
+
+*Defined in [card-elements.ts:545](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L545)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` getEffectiveStyleDefinition
+
+▸ **getEffectiveStyleDefinition**(): *[ContainerStyleDefinition](containerstyledefinition.md)‹›*
+
+*Inherited from [BaseTextBlock](basetextblock.md).[getEffectiveStyleDefinition](basetextblock.md#protected-geteffectivestyledefinition)*
+
+*Defined in [card-elements.ts:969](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L969)*
+
+**Returns:** *[ContainerStyleDefinition](containerstyledefinition.md)‹›*
+
+___
+
+###  getElementById
+
+▸ **getElementById**(`id`: string): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
+
+*Defined in [card-elements.ts:831](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L831)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+### `Protected` getFontSize
+
+▸ **getFontSize**(`fontType`: [FontTypeDefinition](fonttypedefinition.md)): *number*
+
+*Inherited from [BaseTextBlock](basetextblock.md).[getFontSize](basetextblock.md#protected-getfontsize)*
+
+*Defined in [card-elements.ts:973](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L973)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`fontType` | [FontTypeDefinition](fonttypedefinition.md) |
+
+**Returns:** *number*
+
+___
+
+###  getForbiddenActionTypes
+
+▸ **getForbiddenActionTypes**(): *Array‹any›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
+
+*Defined in [card-elements.ts:557](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L557)*
+
+**Returns:** *Array‹any›*
+
+___
+
+###  getForbiddenElementTypes
+
+▸ **getForbiddenElementTypes**(): *Array‹string›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenElementTypes](cardelement.md#getforbiddenelementtypes)*
+
+*Defined in [card-elements.ts:553](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L553)*
+
+**Returns:** *Array‹string›*
+
+___
+
+### `Protected` getHasBackground
+
+▸ **getHasBackground**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
+
+*Defined in [card-elements.ts:470](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L470)*
+
+**Returns:** *boolean*
+
+___
+
+###  getImmediateSurroundingPadding
+
+▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
+
+*Defined in [card-elements.ts:561](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L561)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`result` | [PaddingDefinition](paddingdefinition.md) | - |
+`processTop` | boolean | true |
+`processRight` | boolean | true |
+`processBottom` | boolean | true |
+`processLeft` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  getJsonTypeName
+
+▸ **getJsonTypeName**(): *string*
+
+*Overrides [CardElement](cardelement.md).[getJsonTypeName](cardelement.md#abstract-getjsontypename)*
+
+*Defined in [card-elements.ts:1543](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1543)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` getPadding
+
+▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
+
+*Defined in [card-elements.ts:474](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L474)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getParentContainer
+
+▸ **getParentContainer**(): *[Container](container.md)*
+
+*Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
+
+*Defined in [card-elements.ts:809](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L809)*
+
+**Returns:** *[Container](container.md)*
+
+___
+
+###  getResourceInformation
+
+▸ **getResourceInformation**(): *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+*Inherited from [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
+
+*Defined in [card-elements.ts:827](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L827)*
+
+**Returns:** *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+___
+
+###  getRootElement
+
+▸ **getRootElement**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
+
+*Defined in [card-elements.ts:799](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L799)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  indexOf
+
+▸ **indexOf**(`cardElement`: [CardElement](cardelement.md)): *number*
+
+*Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
+
+*Defined in [card-elements.ts:733](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L733)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`cardElement` | [CardElement](cardelement.md) |
+
+**Returns:** *number*
+
+___
+
+### `Protected` internalRender
+
+▸ **internalRender**(): *HTMLElement*
+
+*Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
+
+*Defined in [card-elements.ts:1455](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1455)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  internalValidateProperties
+
+▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
+
+*Inherited from [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
+
+*Defined in [card-elements.ts:249](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L249)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [ValidationResults](validationresults.md) |
+
+**Returns:** *void*
+
+___
+
+###  isAtTheVeryBottom
+
+▸ **isAtTheVeryBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
+
+*Defined in [card-elements.ts:767](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L767)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryLeft
+
+▸ **isAtTheVeryLeft**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
+
+*Defined in [card-elements.ts:755](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L755)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryRight
+
+▸ **isAtTheVeryRight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
+
+*Defined in [card-elements.ts:759](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L759)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryTop
+
+▸ **isAtTheVeryTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
+
+*Defined in [card-elements.ts:763](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L763)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleeding
+
+▸ **isBleeding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
+
+*Defined in [card-elements.ts:517](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L517)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtBottom
+
+▸ **isBleedingAtBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
+
+*Defined in [card-elements.ts:775](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L775)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtTop
+
+▸ **isBleedingAtTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
+
+*Defined in [card-elements.ts:771](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L771)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBottomElement
+
+▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
+
+*Defined in [card-elements.ts:791](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L791)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isDesignMode
+
+▸ **isDesignMode**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
+
+*Defined in [card-elements.ts:737](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L737)*
+
+**Returns:** *boolean*
+
+___
+
+###  isFirstElement
+
+▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
+
+*Defined in [card-elements.ts:747](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L747)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isHiddenDueToOverflow
+
+▸ **isHiddenDueToOverflow**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
+
+*Defined in [card-elements.ts:795](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L795)*
+
+**Returns:** *boolean*
+
+___
+
+###  isLastElement
+
+▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
+
+*Defined in [card-elements.ts:751](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L751)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isLeftMostElement
+
+▸ **isLeftMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
+
+*Defined in [card-elements.ts:779](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L779)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isRendered
+
+▸ **isRendered**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRendered](cardelement.md#isrendered)*
+
+*Defined in [card-elements.ts:743](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L743)*
+
+**Returns:** *boolean*
+
+___
+
+###  isRightMostElement
+
+▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
+
+*Defined in [card-elements.ts:783](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L783)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isTopElement
+
+▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
+
+*Defined in [card-elements.ts:787](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L787)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` overrideInternalRender
+
+▸ **overrideInternalRender**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
+
+*Defined in [card-elements.ts:426](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L426)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Overrides [BaseTextBlock](basetextblock.md).[parse](basetextblock.md#parse)*
+
+*Defined in [card-elements.ts:1529](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1529)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*
+
+___
+
+###  remove
+
+▸ **remove**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
+
+*Defined in [card-elements.ts:698](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L698)*
+
+**Returns:** *boolean*
+
+___
+
+###  render
+
+▸ **render**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[render](cardelement.md#render)*
+
+*Defined in [card-elements.ts:706](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L706)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setPadding
+
+▸ **setPadding**(`value`: [PaddingDefinition](paddingdefinition.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
+
+*Defined in [card-elements.ts:478](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L478)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [PaddingDefinition](paddingdefinition.md) |
+
+**Returns:** *void*
+
+___
+
+###  setParent
+
+▸ **setParent**(`value`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setParent](cardelement.md#setparent)*
+
+*Overrides [CardObject](cardobject.md).[setParent](cardobject.md#abstract-setparent)*
+
+*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+###  setShouldFallback
+
+▸ **setShouldFallback**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[setShouldFallback](cardelement.md#setshouldfallback)*
+
+*Defined in [card-elements.ts:843](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L843)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setText
+
+▸ **setText**(`value`: string): *void*
+
+*Inherited from [BaseTextBlock](basetextblock.md).[setText](basetextblock.md#protected-settext)*
+
+*Defined in [card-elements.ts:1007](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1007)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  shouldFallback
+
+▸ **shouldFallback**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[shouldFallback](cardelement.md#shouldfallback)*
+
+*Overrides [CardObject](cardobject.md).[shouldFallback](cardobject.md#abstract-shouldfallback)*
+
+*Defined in [card-elements.ts:839](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L839)*
+
+**Returns:** *boolean*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [BaseTextBlock](basetextblock.md).[toJSON](basetextblock.md#tojson)*
+
+*Defined in [card-elements.ts:1515](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L1515)*
+
+**Returns:** *any*
+
+___
+
+### `Protected` truncateOverflow
+
+▸ **truncateOverflow**(`maxHeight`: number): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
+
+*Defined in [card-elements.ts:454](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L454)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`maxHeight` | number |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` undoOverflowTruncation
+
+▸ **undoOverflowTruncation**(): *void*
+
+*Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
+
+*Defined in [card-elements.ts:464](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L464)*
+
+**Returns:** *void*
+
+___
+
+###  updateLayout
+
+▸ **updateLayout**(`processChildren`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
+
+*Defined in [card-elements.ts:728](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L728)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`processChildren` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  validateProperties
+
+▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
+
+*Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
+
+*Defined in [card-elements.ts:284](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L284)*
+
+**Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/timeinput.md
+++ b/source/nodejs/adaptivecards/docs/classes/timeinput.md
@@ -1,0 +1,1464 @@
+[Adaptive Cards Javascript SDK](../README.md) › [TimeInput](timeinput.md)
+
+# Class: TimeInput
+
+## Hierarchy
+
+  ↳ [Input](input.md)
+
+  ↳ **TimeInput**
+
+## Implements
+
+* [IInput](../interfaces/iinput.md)
+
+## Index
+
+### Properties
+
+* [customCssSelector](timeinput.md#customcssselector)
+* [height](timeinput.md#height)
+* [horizontalAlignment](timeinput.md#optional-horizontalalignment)
+* [id](timeinput.md#id)
+* [minPixelHeight](timeinput.md#optional-minpixelheight)
+* [onValueChanged](timeinput.md#onvaluechanged)
+* [requires](timeinput.md#requires)
+* [separator](timeinput.md#separator)
+* [spacing](timeinput.md#spacing)
+* [title](timeinput.md#title)
+* [validation](timeinput.md#validation)
+
+### Accessors
+
+* [allowCustomPadding](timeinput.md#protected-allowcustompadding)
+* [defaultStyle](timeinput.md#protected-defaultstyle)
+* [defaultValue](timeinput.md#defaultvalue)
+* [hasVisibleSeparator](timeinput.md#hasvisibleseparator)
+* [hostConfig](timeinput.md#hostconfig)
+* [index](timeinput.md#index)
+* [inputControlContainerElement](timeinput.md#protected-inputcontrolcontainerelement)
+* [isInline](timeinput.md#isinline)
+* [isInteractive](timeinput.md#isinteractive)
+* [isNullable](timeinput.md#protected-isnullable)
+* [isStandalone](timeinput.md#isstandalone)
+* [isVisible](timeinput.md#isvisible)
+* [lang](timeinput.md#lang)
+* [max](timeinput.md#max)
+* [min](timeinput.md#min)
+* [parent](timeinput.md#parent)
+* [renderedElement](timeinput.md#renderedelement)
+* [renderedInputControlElement](timeinput.md#protected-renderedinputcontrolelement)
+* [separatorElement](timeinput.md#separatorelement)
+* [separatorOrientation](timeinput.md#protected-separatororientation)
+* [supportsMinHeight](timeinput.md#protected-supportsminheight)
+* [useDefaultSizing](timeinput.md#protected-usedefaultsizing)
+* [value](timeinput.md#value)
+
+### Methods
+
+* [adjustRenderedElementSize](timeinput.md#protected-adjustrenderedelementsize)
+* [applyPadding](timeinput.md#protected-applypadding)
+* [asString](timeinput.md#asstring)
+* [createPlaceholderElement](timeinput.md#protected-createplaceholderelement)
+* [getActionAt](timeinput.md#getactionat)
+* [getActionById](timeinput.md#getactionbyid)
+* [getActionCount](timeinput.md#getactioncount)
+* [getAllInputs](timeinput.md#getallinputs)
+* [getCustomProperty](timeinput.md#getcustomproperty)
+* [getDefaultPadding](timeinput.md#protected-getdefaultpadding)
+* [getEffectivePadding](timeinput.md#geteffectivepadding)
+* [getEffectiveStyle](timeinput.md#geteffectivestyle)
+* [getElementById](timeinput.md#getelementbyid)
+* [getForbiddenActionTypes](timeinput.md#getforbiddenactiontypes)
+* [getForbiddenElementTypes](timeinput.md#getforbiddenelementtypes)
+* [getHasBackground](timeinput.md#protected-gethasbackground)
+* [getImmediateSurroundingPadding](timeinput.md#getimmediatesurroundingpadding)
+* [getJsonTypeName](timeinput.md#getjsontypename)
+* [getPadding](timeinput.md#protected-getpadding)
+* [getParentContainer](timeinput.md#getparentcontainer)
+* [getResourceInformation](timeinput.md#getresourceinformation)
+* [getRootElement](timeinput.md#getrootelement)
+* [indexOf](timeinput.md#indexof)
+* [internalRender](timeinput.md#protected-internalrender)
+* [internalValidateProperties](timeinput.md#internalvalidateproperties)
+* [isAtTheVeryBottom](timeinput.md#isattheverybottom)
+* [isAtTheVeryLeft](timeinput.md#isattheveryleft)
+* [isAtTheVeryRight](timeinput.md#isattheveryright)
+* [isAtTheVeryTop](timeinput.md#isattheverytop)
+* [isBleeding](timeinput.md#isbleeding)
+* [isBleedingAtBottom](timeinput.md#isbleedingatbottom)
+* [isBleedingAtTop](timeinput.md#isbleedingattop)
+* [isBottomElement](timeinput.md#isbottomelement)
+* [isDesignMode](timeinput.md#isdesignmode)
+* [isFirstElement](timeinput.md#isfirstelement)
+* [isHiddenDueToOverflow](timeinput.md#ishiddenduetooverflow)
+* [isLastElement](timeinput.md#islastelement)
+* [isLeftMostElement](timeinput.md#isleftmostelement)
+* [isRendered](timeinput.md#isrendered)
+* [isRightMostElement](timeinput.md#isrightmostelement)
+* [isTopElement](timeinput.md#istopelement)
+* [overrideInternalRender](timeinput.md#protected-overrideinternalrender)
+* [parse](timeinput.md#parse)
+* [parseInputValue](timeinput.md#protected-parseinputvalue)
+* [remove](timeinput.md#remove)
+* [render](timeinput.md#render)
+* [resetValidationFailureCue](timeinput.md#protected-resetvalidationfailurecue)
+* [setCustomProperty](timeinput.md#setcustomproperty)
+* [setPadding](timeinput.md#protected-setpadding)
+* [setParent](timeinput.md#setparent)
+* [setShouldFallback](timeinput.md#setshouldfallback)
+* [shouldFallback](timeinput.md#shouldfallback)
+* [showValidationErrorMessage](timeinput.md#protected-showvalidationerrormessage)
+* [toJSON](timeinput.md#tojson)
+* [truncateOverflow](timeinput.md#protected-truncateoverflow)
+* [undoOverflowTruncation](timeinput.md#protected-undooverflowtruncation)
+* [updateLayout](timeinput.md#updatelayout)
+* [validateProperties](timeinput.md#validateproperties)
+* [validateValue](timeinput.md#validatevalue)
+* [valueChanged](timeinput.md#protected-valuechanged)
+
+## Properties
+
+###  customCssSelector
+
+• **customCssSelector**: *string* = null
+
+*Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#customcssselector)*
+
+*Defined in [card-elements.ts:507](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L507)*
+
+___
+
+###  height
+
+• **height**: *[CardElementHeight](../README.md#cardelementheight)* = "auto"
+
+*Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
+
+*Defined in [card-elements.ts:508](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L508)*
+
+___
+
+### `Optional` horizontalAlignment
+
+• **horizontalAlignment**? : *[HorizontalAlignment](../enums/horizontalalignment.md)* = null
+
+*Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#optional-horizontalalignment)*
+
+*Defined in [card-elements.ts:504](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L504)*
+
+___
+
+###  id
+
+• **id**: *string*
+
+*Implementation of [IInput](../interfaces/iinput.md).[id](../interfaces/iinput.md#id)*
+
+*Inherited from [CardObject](cardobject.md).[id](cardobject.md#id)*
+
+*Defined in [card-elements.ts:247](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L247)*
+
+___
+
+### `Optional` minPixelHeight
+
+• **minPixelHeight**? : *number* = null
+
+*Inherited from [CardElement](cardelement.md).[minPixelHeight](cardelement.md#optional-minpixelheight)*
+
+*Defined in [card-elements.ts:509](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L509)*
+
+___
+
+###  onValueChanged
+
+• **onValueChanged**: *function*
+
+*Inherited from [Input](input.md).[onValueChanged](input.md#onvaluechanged)*
+
+*Defined in [card-elements.ts:2874](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2874)*
+
+#### Type declaration:
+
+▸ (`sender`: [Input](input.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`sender` | [Input](input.md) |
+
+___
+
+###  requires
+
+• **requires**: *[HostCapabilities](hostcapabilities.md)‹›* = new HostConfig.HostCapabilities()
+
+*Inherited from [CardElement](cardelement.md).[requires](cardelement.md#requires)*
+
+*Defined in [card-elements.ts:502](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L502)*
+
+___
+
+###  separator
+
+• **separator**: *boolean* = false
+
+*Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
+
+*Defined in [card-elements.ts:506](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L506)*
+
+___
+
+###  spacing
+
+• **spacing**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.Default
+
+*Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
+
+*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
+
+___
+
+###  title
+
+• **title**: *string*
+
+*Inherited from [Input](input.md).[title](input.md#title)*
+
+*Defined in [card-elements.ts:2878](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2878)*
+
+___
+
+###  validation
+
+• **validation**: *[InputValidationOptions](inputvalidationoptions.md)‹›* = new InputValidationOptions()
+
+*Inherited from [Input](input.md).[validation](input.md#validation)*
+
+*Defined in [card-elements.ts:2876](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2876)*
+
+## Accessors
+
+### `Protected` allowCustomPadding
+
+• **get allowCustomPadding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
+
+*Defined in [card-elements.ts:490](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L490)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` defaultStyle
+
+• **get defaultStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
+
+*Defined in [card-elements.ts:498](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L498)*
+
+**Returns:** *string*
+
+___
+
+###  defaultValue
+
+• **get defaultValue**(): *string*
+
+*Inherited from [Input](input.md).[defaultValue](input.md#defaultvalue)*
+
+*Defined in [card-elements.ts:2944](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2944)*
+
+**Returns:** *string*
+
+• **set defaultValue**(`value`: string): *void*
+
+*Inherited from [Input](input.md).[defaultValue](input.md#defaultvalue)*
+
+*Defined in [card-elements.ts:2948](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2948)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  hasVisibleSeparator
+
+• **get hasVisibleSeparator**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
+
+*Defined in [card-elements.ts:928](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L928)*
+
+**Returns:** *boolean*
+
+___
+
+###  hostConfig
+
+• **get hostConfig**(): *[HostConfig](hostconfig.md)*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:881](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L881)*
+
+**Returns:** *[HostConfig](hostconfig.md)*
+
+• **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:895](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L895)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [HostConfig](hostconfig.md) |
+
+**Returns:** *void*
+
+___
+
+###  index
+
+• **get index**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
+
+*Defined in [card-elements.ts:899](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L899)*
+
+**Returns:** *number*
+
+___
+
+### `Protected` inputControlContainerElement
+
+• **get inputControlContainerElement**(): *HTMLElement*
+
+*Inherited from [Input](input.md).[inputControlContainerElement](input.md#protected-inputcontrolcontainerelement)*
+
+*Defined in [card-elements.ts:2807](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2807)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  isInline
+
+• **get isInline**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
+
+*Defined in [card-elements.ts:916](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L916)*
+
+**Returns:** *boolean*
+
+___
+
+###  isInteractive
+
+• **get isInteractive**(): *boolean*
+
+*Inherited from [Input](input.md).[isInteractive](input.md#isinteractive)*
+
+*Overrides [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
+
+*Defined in [card-elements.ts:2952](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2952)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` isNullable
+
+• **get isNullable**(): *boolean*
+
+*Inherited from [Input](input.md).[isNullable](input.md#protected-isnullable)*
+
+*Defined in [card-elements.ts:2799](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2799)*
+
+**Returns:** *boolean*
+
+___
+
+###  isStandalone
+
+• **get isStandalone**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
+
+*Defined in [card-elements.ts:912](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L912)*
+
+**Returns:** *boolean*
+
+___
+
+###  isVisible
+
+• **get isVisible**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:924](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L924)*
+
+**Returns:** *boolean*
+
+• **set isVisible**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:937](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L937)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  lang
+
+• **get lang**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:853](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L853)*
+
+**Returns:** *string*
+
+• **set lang**(`value`: string): *void*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:867](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L867)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  max
+
+• **get max**(): *string*
+
+*Defined in [card-elements.ts:3766](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3766)*
+
+**Returns:** *string*
+
+• **set max**(`value`: string): *void*
+
+*Defined in [card-elements.ts:3770](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3770)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  min
+
+• **get min**(): *string*
+
+*Defined in [card-elements.ts:3758](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3758)*
+
+**Returns:** *string*
+
+• **set min**(`value`: string): *void*
+
+*Defined in [card-elements.ts:3762](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3762)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  parent
+
+• **get parent**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[parent](cardelement.md#parent)*
+
+*Defined in [card-elements.ts:920](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L920)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  renderedElement
+
+• **get renderedElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[renderedElement](cardelement.md#renderedelement)*
+
+*Defined in [card-elements.ts:956](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L956)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` renderedInputControlElement
+
+• **get renderedInputControlElement**(): *HTMLElement*
+
+*Inherited from [Input](input.md).[renderedInputControlElement](input.md#protected-renderedinputcontrolelement)*
+
+*Defined in [card-elements.ts:2803](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2803)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  separatorElement
+
+• **get separatorElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
+
+*Defined in [card-elements.ts:960](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L960)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` separatorOrientation
+
+• **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
+
+*Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
+
+*Defined in [card-elements.ts:494](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L494)*
+
+**Returns:** *[Orientation](../enums/orientation.md)*
+
+___
+
+### `Protected` supportsMinHeight
+
+• **get supportsMinHeight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[supportsMinHeight](cardelement.md#protected-supportsminheight)*
+
+*Defined in [card-elements.ts:482](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L482)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` useDefaultSizing
+
+• **get useDefaultSizing**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
+
+*Defined in [card-elements.ts:486](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L486)*
+
+**Returns:** *boolean*
+
+___
+
+###  value
+
+• **get value**(): *string*
+
+*Overrides [Input](input.md).[value](input.md#value)*
+
+*Defined in [card-elements.ts:3774](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3774)*
+
+**Returns:** *string*
+
+## Methods
+
+### `Protected` adjustRenderedElementSize
+
+▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
+
+*Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
+
+*Defined in [card-elements.ts:411](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L411)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`renderedElement` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+### `Protected` applyPadding
+
+▸ **applyPadding**(): *void*
+
+*Inherited from [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
+
+*Defined in [card-elements.ts:430](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L430)*
+
+**Returns:** *void*
+
+___
+
+###  asString
+
+▸ **asString**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
+
+*Defined in [card-elements.ts:513](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L513)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` createPlaceholderElement
+
+▸ **createPlaceholderElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
+
+*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  getActionAt
+
+▸ **getActionAt**(`index`: number): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
+
+*Defined in [card-elements.ts:694](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L694)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionById
+
+▸ **getActionById**(`id`: string): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
+
+*Defined in [card-elements.ts:835](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L835)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionCount
+
+▸ **getActionCount**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
+
+*Defined in [card-elements.ts:690](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L690)*
+
+**Returns:** *number*
+
+___
+
+###  getAllInputs
+
+▸ **getAllInputs**(): *Array‹[Input](input.md)›*
+
+*Inherited from [Input](input.md).[getAllInputs](input.md#getallinputs)*
+
+*Overrides [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
+
+*Defined in [card-elements.ts:2940](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2940)*
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+### `Protected` getDefaultPadding
+
+▸ **getDefaultPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
+
+*Defined in [card-elements.ts:466](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L466)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectivePadding
+
+▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
+
+*Defined in [card-elements.ts:847](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L847)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectiveStyle
+
+▸ **getEffectiveStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
+
+*Defined in [card-elements.ts:545](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L545)*
+
+**Returns:** *string*
+
+___
+
+###  getElementById
+
+▸ **getElementById**(`id`: string): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
+
+*Defined in [card-elements.ts:831](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L831)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getForbiddenActionTypes
+
+▸ **getForbiddenActionTypes**(): *Array‹any›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
+
+*Defined in [card-elements.ts:557](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L557)*
+
+**Returns:** *Array‹any›*
+
+___
+
+###  getForbiddenElementTypes
+
+▸ **getForbiddenElementTypes**(): *Array‹string›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenElementTypes](cardelement.md#getforbiddenelementtypes)*
+
+*Defined in [card-elements.ts:553](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L553)*
+
+**Returns:** *Array‹string›*
+
+___
+
+### `Protected` getHasBackground
+
+▸ **getHasBackground**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
+
+*Defined in [card-elements.ts:470](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L470)*
+
+**Returns:** *boolean*
+
+___
+
+###  getImmediateSurroundingPadding
+
+▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
+
+*Defined in [card-elements.ts:561](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L561)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`result` | [PaddingDefinition](paddingdefinition.md) | - |
+`processTop` | boolean | true |
+`processRight` | boolean | true |
+`processBottom` | boolean | true |
+`processLeft` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  getJsonTypeName
+
+▸ **getJsonTypeName**(): *string*
+
+*Overrides [CardElement](cardelement.md).[getJsonTypeName](cardelement.md#abstract-getjsontypename)*
+
+*Defined in [card-elements.ts:3738](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3738)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` getPadding
+
+▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
+
+*Defined in [card-elements.ts:474](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L474)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getParentContainer
+
+▸ **getParentContainer**(): *[Container](container.md)*
+
+*Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
+
+*Defined in [card-elements.ts:809](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L809)*
+
+**Returns:** *[Container](container.md)*
+
+___
+
+###  getResourceInformation
+
+▸ **getResourceInformation**(): *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+*Inherited from [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
+
+*Defined in [card-elements.ts:827](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L827)*
+
+**Returns:** *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+___
+
+###  getRootElement
+
+▸ **getRootElement**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
+
+*Defined in [card-elements.ts:799](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L799)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  indexOf
+
+▸ **indexOf**(`cardElement`: [CardElement](cardelement.md)): *number*
+
+*Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
+
+*Defined in [card-elements.ts:733](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L733)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`cardElement` | [CardElement](cardelement.md) |
+
+**Returns:** *number*
+
+___
+
+### `Protected` internalRender
+
+▸ **internalRender**(): *HTMLElement*
+
+*Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
+
+*Defined in [card-elements.ts:3713](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3713)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  internalValidateProperties
+
+▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
+
+*Inherited from [Input](input.md).[internalValidateProperties](input.md#internalvalidateproperties)*
+
+*Overrides [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
+
+*Defined in [card-elements.ts:2893](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2893)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [ValidationResults](validationresults.md) |
+
+**Returns:** *void*
+
+___
+
+###  isAtTheVeryBottom
+
+▸ **isAtTheVeryBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
+
+*Defined in [card-elements.ts:767](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L767)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryLeft
+
+▸ **isAtTheVeryLeft**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
+
+*Defined in [card-elements.ts:755](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L755)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryRight
+
+▸ **isAtTheVeryRight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
+
+*Defined in [card-elements.ts:759](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L759)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryTop
+
+▸ **isAtTheVeryTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
+
+*Defined in [card-elements.ts:763](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L763)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleeding
+
+▸ **isBleeding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
+
+*Defined in [card-elements.ts:517](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L517)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtBottom
+
+▸ **isBleedingAtBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
+
+*Defined in [card-elements.ts:775](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L775)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtTop
+
+▸ **isBleedingAtTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
+
+*Defined in [card-elements.ts:771](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L771)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBottomElement
+
+▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
+
+*Defined in [card-elements.ts:791](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L791)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isDesignMode
+
+▸ **isDesignMode**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
+
+*Defined in [card-elements.ts:737](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L737)*
+
+**Returns:** *boolean*
+
+___
+
+###  isFirstElement
+
+▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
+
+*Defined in [card-elements.ts:747](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L747)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isHiddenDueToOverflow
+
+▸ **isHiddenDueToOverflow**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
+
+*Defined in [card-elements.ts:795](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L795)*
+
+**Returns:** *boolean*
+
+___
+
+###  isLastElement
+
+▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
+
+*Defined in [card-elements.ts:751](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L751)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isLeftMostElement
+
+▸ **isLeftMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
+
+*Defined in [card-elements.ts:779](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L779)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isRendered
+
+▸ **isRendered**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRendered](cardelement.md#isrendered)*
+
+*Defined in [card-elements.ts:743](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L743)*
+
+**Returns:** *boolean*
+
+___
+
+###  isRightMostElement
+
+▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
+
+*Defined in [card-elements.ts:783](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L783)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isTopElement
+
+▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
+
+*Defined in [card-elements.ts:787](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L787)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` overrideInternalRender
+
+▸ **overrideInternalRender**(): *HTMLElement*
+
+*Inherited from [Input](input.md).[overrideInternalRender](input.md#protected-overrideinternalrender)*
+
+*Overrides [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
+
+*Defined in [card-elements.ts:2811](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2811)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Overrides [Input](input.md).[parse](input.md#parse)*
+
+*Defined in [card-elements.ts:3751](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3751)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*
+
+___
+
+### `Protected` parseInputValue
+
+▸ **parseInputValue**(`value`: string): *string*
+
+*Overrides [Input](input.md).[parseInputValue](input.md#protected-parseinputvalue)*
+
+*Defined in [card-elements.ts:3729](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3729)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *string*
+
+___
+
+###  remove
+
+▸ **remove**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
+
+*Defined in [card-elements.ts:698](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L698)*
+
+**Returns:** *boolean*
+
+___
+
+###  render
+
+▸ **render**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[render](cardelement.md#render)*
+
+*Defined in [card-elements.ts:706](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L706)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` resetValidationFailureCue
+
+▸ **resetValidationFailureCue**(): *void*
+
+*Inherited from [Input](input.md).[resetValidationFailureCue](input.md#protected-resetvalidationfailurecue)*
+
+*Defined in [card-elements.ts:2846](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2846)*
+
+**Returns:** *void*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setPadding
+
+▸ **setPadding**(`value`: [PaddingDefinition](paddingdefinition.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
+
+*Defined in [card-elements.ts:478](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L478)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [PaddingDefinition](paddingdefinition.md) |
+
+**Returns:** *void*
+
+___
+
+###  setParent
+
+▸ **setParent**(`value`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setParent](cardelement.md#setparent)*
+
+*Overrides [CardObject](cardobject.md).[setParent](cardobject.md#abstract-setparent)*
+
+*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+###  setShouldFallback
+
+▸ **setShouldFallback**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[setShouldFallback](cardelement.md#setshouldfallback)*
+
+*Defined in [card-elements.ts:843](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L843)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  shouldFallback
+
+▸ **shouldFallback**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[shouldFallback](cardelement.md#shouldfallback)*
+
+*Overrides [CardObject](cardobject.md).[shouldFallback](cardobject.md#abstract-shouldfallback)*
+
+*Defined in [card-elements.ts:839](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L839)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` showValidationErrorMessage
+
+▸ **showValidationErrorMessage**(): *void*
+
+*Inherited from [Input](input.md).[showValidationErrorMessage](input.md#protected-showvalidationerrormessage)*
+
+*Defined in [card-elements.ts:2858](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2858)*
+
+**Returns:** *void*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [Input](input.md).[toJSON](input.md#tojson)*
+
+*Defined in [card-elements.ts:3742](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3742)*
+
+**Returns:** *any*
+
+___
+
+### `Protected` truncateOverflow
+
+▸ **truncateOverflow**(`maxHeight`: number): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
+
+*Defined in [card-elements.ts:454](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L454)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`maxHeight` | number |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` undoOverflowTruncation
+
+▸ **undoOverflowTruncation**(): *void*
+
+*Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
+
+*Defined in [card-elements.ts:464](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L464)*
+
+**Returns:** *void*
+
+___
+
+###  updateLayout
+
+▸ **updateLayout**(`processChildren`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
+
+*Defined in [card-elements.ts:728](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L728)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`processChildren` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  validateProperties
+
+▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
+
+*Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
+
+*Defined in [card-elements.ts:284](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L284)*
+
+**Returns:** *[ValidationResults](validationresults.md)*
+
+___
+
+###  validateValue
+
+▸ **validateValue**(): *boolean*
+
+*Implementation of [IInput](../interfaces/iinput.md)*
+
+*Inherited from [Input](input.md).[validateValue](input.md#validatevalue)*
+
+*Defined in [card-elements.ts:2906](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2906)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` valueChanged
+
+▸ **valueChanged**(): *void*
+
+*Inherited from [Input](input.md).[valueChanged](input.md#protected-valuechanged)*
+
+*Defined in [card-elements.ts:2836](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2836)*
+
+**Returns:** *void*

--- a/source/nodejs/adaptivecards/docs/classes/toggleinput.md
+++ b/source/nodejs/adaptivecards/docs/classes/toggleinput.md
@@ -1,0 +1,1445 @@
+[Adaptive Cards Javascript SDK](../README.md) › [ToggleInput](toggleinput.md)
+
+# Class: ToggleInput
+
+## Hierarchy
+
+  ↳ [Input](input.md)
+
+  ↳ **ToggleInput**
+
+## Implements
+
+* [IInput](../interfaces/iinput.md)
+
+## Index
+
+### Properties
+
+* [customCssSelector](toggleinput.md#customcssselector)
+* [height](toggleinput.md#height)
+* [horizontalAlignment](toggleinput.md#optional-horizontalalignment)
+* [id](toggleinput.md#id)
+* [minPixelHeight](toggleinput.md#optional-minpixelheight)
+* [onValueChanged](toggleinput.md#onvaluechanged)
+* [requires](toggleinput.md#requires)
+* [separator](toggleinput.md#separator)
+* [spacing](toggleinput.md#spacing)
+* [title](toggleinput.md#title)
+* [validation](toggleinput.md#validation)
+* [valueOff](toggleinput.md#valueoff)
+* [valueOn](toggleinput.md#valueon)
+* [wrap](toggleinput.md#wrap)
+
+### Accessors
+
+* [allowCustomPadding](toggleinput.md#protected-allowcustompadding)
+* [defaultStyle](toggleinput.md#protected-defaultstyle)
+* [defaultValue](toggleinput.md#defaultvalue)
+* [hasVisibleSeparator](toggleinput.md#hasvisibleseparator)
+* [hostConfig](toggleinput.md#hostconfig)
+* [index](toggleinput.md#index)
+* [inputControlContainerElement](toggleinput.md#protected-inputcontrolcontainerelement)
+* [isInline](toggleinput.md#isinline)
+* [isInteractive](toggleinput.md#isinteractive)
+* [isNullable](toggleinput.md#protected-isnullable)
+* [isStandalone](toggleinput.md#isstandalone)
+* [isVisible](toggleinput.md#isvisible)
+* [lang](toggleinput.md#lang)
+* [parent](toggleinput.md#parent)
+* [renderedElement](toggleinput.md#renderedelement)
+* [renderedInputControlElement](toggleinput.md#protected-renderedinputcontrolelement)
+* [separatorElement](toggleinput.md#separatorelement)
+* [separatorOrientation](toggleinput.md#protected-separatororientation)
+* [supportsMinHeight](toggleinput.md#protected-supportsminheight)
+* [useDefaultSizing](toggleinput.md#protected-usedefaultsizing)
+* [value](toggleinput.md#value)
+
+### Methods
+
+* [adjustRenderedElementSize](toggleinput.md#protected-adjustrenderedelementsize)
+* [applyPadding](toggleinput.md#protected-applypadding)
+* [asString](toggleinput.md#asstring)
+* [createPlaceholderElement](toggleinput.md#protected-createplaceholderelement)
+* [getActionAt](toggleinput.md#getactionat)
+* [getActionById](toggleinput.md#getactionbyid)
+* [getActionCount](toggleinput.md#getactioncount)
+* [getAllInputs](toggleinput.md#getallinputs)
+* [getCustomProperty](toggleinput.md#getcustomproperty)
+* [getDefaultPadding](toggleinput.md#protected-getdefaultpadding)
+* [getEffectivePadding](toggleinput.md#geteffectivepadding)
+* [getEffectiveStyle](toggleinput.md#geteffectivestyle)
+* [getElementById](toggleinput.md#getelementbyid)
+* [getForbiddenActionTypes](toggleinput.md#getforbiddenactiontypes)
+* [getForbiddenElementTypes](toggleinput.md#getforbiddenelementtypes)
+* [getHasBackground](toggleinput.md#protected-gethasbackground)
+* [getImmediateSurroundingPadding](toggleinput.md#getimmediatesurroundingpadding)
+* [getJsonTypeName](toggleinput.md#getjsontypename)
+* [getPadding](toggleinput.md#protected-getpadding)
+* [getParentContainer](toggleinput.md#getparentcontainer)
+* [getResourceInformation](toggleinput.md#getresourceinformation)
+* [getRootElement](toggleinput.md#getrootelement)
+* [indexOf](toggleinput.md#indexof)
+* [internalRender](toggleinput.md#protected-internalrender)
+* [internalValidateProperties](toggleinput.md#internalvalidateproperties)
+* [isAtTheVeryBottom](toggleinput.md#isattheverybottom)
+* [isAtTheVeryLeft](toggleinput.md#isattheveryleft)
+* [isAtTheVeryRight](toggleinput.md#isattheveryright)
+* [isAtTheVeryTop](toggleinput.md#isattheverytop)
+* [isBleeding](toggleinput.md#isbleeding)
+* [isBleedingAtBottom](toggleinput.md#isbleedingatbottom)
+* [isBleedingAtTop](toggleinput.md#isbleedingattop)
+* [isBottomElement](toggleinput.md#isbottomelement)
+* [isDesignMode](toggleinput.md#isdesignmode)
+* [isFirstElement](toggleinput.md#isfirstelement)
+* [isHiddenDueToOverflow](toggleinput.md#ishiddenduetooverflow)
+* [isLastElement](toggleinput.md#islastelement)
+* [isLeftMostElement](toggleinput.md#isleftmostelement)
+* [isRendered](toggleinput.md#isrendered)
+* [isRightMostElement](toggleinput.md#isrightmostelement)
+* [isTopElement](toggleinput.md#istopelement)
+* [overrideInternalRender](toggleinput.md#protected-overrideinternalrender)
+* [parse](toggleinput.md#parse)
+* [parseInputValue](toggleinput.md#protected-parseinputvalue)
+* [remove](toggleinput.md#remove)
+* [render](toggleinput.md#render)
+* [resetValidationFailureCue](toggleinput.md#protected-resetvalidationfailurecue)
+* [setCustomProperty](toggleinput.md#setcustomproperty)
+* [setPadding](toggleinput.md#protected-setpadding)
+* [setParent](toggleinput.md#setparent)
+* [setShouldFallback](toggleinput.md#setshouldfallback)
+* [shouldFallback](toggleinput.md#shouldfallback)
+* [showValidationErrorMessage](toggleinput.md#protected-showvalidationerrormessage)
+* [toJSON](toggleinput.md#tojson)
+* [truncateOverflow](toggleinput.md#protected-truncateoverflow)
+* [undoOverflowTruncation](toggleinput.md#protected-undooverflowtruncation)
+* [updateLayout](toggleinput.md#updatelayout)
+* [validateProperties](toggleinput.md#validateproperties)
+* [validateValue](toggleinput.md#validatevalue)
+* [valueChanged](toggleinput.md#protected-valuechanged)
+
+## Properties
+
+###  customCssSelector
+
+• **customCssSelector**: *string* = null
+
+*Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#customcssselector)*
+
+*Defined in [card-elements.ts:507](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L507)*
+
+___
+
+###  height
+
+• **height**: *[CardElementHeight](../README.md#cardelementheight)* = "auto"
+
+*Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
+
+*Defined in [card-elements.ts:508](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L508)*
+
+___
+
+### `Optional` horizontalAlignment
+
+• **horizontalAlignment**? : *[HorizontalAlignment](../enums/horizontalalignment.md)* = null
+
+*Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#optional-horizontalalignment)*
+
+*Defined in [card-elements.ts:504](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L504)*
+
+___
+
+###  id
+
+• **id**: *string*
+
+*Implementation of [IInput](../interfaces/iinput.md).[id](../interfaces/iinput.md#id)*
+
+*Inherited from [CardObject](cardobject.md).[id](cardobject.md#id)*
+
+*Defined in [card-elements.ts:247](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L247)*
+
+___
+
+### `Optional` minPixelHeight
+
+• **minPixelHeight**? : *number* = null
+
+*Inherited from [CardElement](cardelement.md).[minPixelHeight](cardelement.md#optional-minpixelheight)*
+
+*Defined in [card-elements.ts:509](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L509)*
+
+___
+
+###  onValueChanged
+
+• **onValueChanged**: *function*
+
+*Inherited from [Input](input.md).[onValueChanged](input.md#onvaluechanged)*
+
+*Defined in [card-elements.ts:2874](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2874)*
+
+#### Type declaration:
+
+▸ (`sender`: [Input](input.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`sender` | [Input](input.md) |
+
+___
+
+###  requires
+
+• **requires**: *[HostCapabilities](hostcapabilities.md)‹›* = new HostConfig.HostCapabilities()
+
+*Inherited from [CardElement](cardelement.md).[requires](cardelement.md#requires)*
+
+*Defined in [card-elements.ts:502](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L502)*
+
+___
+
+###  separator
+
+• **separator**: *boolean* = false
+
+*Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
+
+*Defined in [card-elements.ts:506](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L506)*
+
+___
+
+###  spacing
+
+• **spacing**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.Default
+
+*Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
+
+*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
+
+___
+
+###  title
+
+• **title**: *string*
+
+*Inherited from [Input](input.md).[title](input.md#title)*
+
+*Defined in [card-elements.ts:2878](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2878)*
+
+___
+
+###  validation
+
+• **validation**: *[InputValidationOptions](inputvalidationoptions.md)‹›* = new InputValidationOptions()
+
+*Inherited from [Input](input.md).[validation](input.md#validation)*
+
+*Defined in [card-elements.ts:2876](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2876)*
+
+___
+
+###  valueOff
+
+• **valueOff**: *string* = "false"
+
+*Defined in [card-elements.ts:3210](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3210)*
+
+___
+
+###  valueOn
+
+• **valueOn**: *string* = "true"
+
+*Defined in [card-elements.ts:3209](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3209)*
+
+___
+
+###  wrap
+
+• **wrap**: *boolean* = false
+
+*Defined in [card-elements.ts:3211](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3211)*
+
+## Accessors
+
+### `Protected` allowCustomPadding
+
+• **get allowCustomPadding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
+
+*Defined in [card-elements.ts:490](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L490)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` defaultStyle
+
+• **get defaultStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
+
+*Defined in [card-elements.ts:498](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L498)*
+
+**Returns:** *string*
+
+___
+
+###  defaultValue
+
+• **get defaultValue**(): *string*
+
+*Inherited from [Input](input.md).[defaultValue](input.md#defaultvalue)*
+
+*Defined in [card-elements.ts:2944](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2944)*
+
+**Returns:** *string*
+
+• **set defaultValue**(`value`: string): *void*
+
+*Inherited from [Input](input.md).[defaultValue](input.md#defaultvalue)*
+
+*Defined in [card-elements.ts:2948](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2948)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  hasVisibleSeparator
+
+• **get hasVisibleSeparator**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
+
+*Defined in [card-elements.ts:928](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L928)*
+
+**Returns:** *boolean*
+
+___
+
+###  hostConfig
+
+• **get hostConfig**(): *[HostConfig](hostconfig.md)*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:881](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L881)*
+
+**Returns:** *[HostConfig](hostconfig.md)*
+
+• **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
+
+*Defined in [card-elements.ts:895](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L895)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [HostConfig](hostconfig.md) |
+
+**Returns:** *void*
+
+___
+
+###  index
+
+• **get index**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
+
+*Defined in [card-elements.ts:899](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L899)*
+
+**Returns:** *number*
+
+___
+
+### `Protected` inputControlContainerElement
+
+• **get inputControlContainerElement**(): *HTMLElement*
+
+*Inherited from [Input](input.md).[inputControlContainerElement](input.md#protected-inputcontrolcontainerelement)*
+
+*Defined in [card-elements.ts:2807](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2807)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  isInline
+
+• **get isInline**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
+
+*Defined in [card-elements.ts:916](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L916)*
+
+**Returns:** *boolean*
+
+___
+
+###  isInteractive
+
+• **get isInteractive**(): *boolean*
+
+*Inherited from [Input](input.md).[isInteractive](input.md#isinteractive)*
+
+*Overrides [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
+
+*Defined in [card-elements.ts:2952](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2952)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` isNullable
+
+• **get isNullable**(): *boolean*
+
+*Overrides [Input](input.md).[isNullable](input.md#protected-isnullable)*
+
+*Defined in [card-elements.ts:3205](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3205)*
+
+**Returns:** *boolean*
+
+___
+
+###  isStandalone
+
+• **get isStandalone**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
+
+*Defined in [card-elements.ts:912](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L912)*
+
+**Returns:** *boolean*
+
+___
+
+###  isVisible
+
+• **get isVisible**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:924](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L924)*
+
+**Returns:** *boolean*
+
+• **set isVisible**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
+
+*Defined in [card-elements.ts:937](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L937)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  lang
+
+• **get lang**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:853](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L853)*
+
+**Returns:** *string*
+
+• **set lang**(`value`: string): *void*
+
+*Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
+
+*Defined in [card-elements.ts:867](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L867)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *void*
+
+___
+
+###  parent
+
+• **get parent**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[parent](cardelement.md#parent)*
+
+*Defined in [card-elements.ts:920](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L920)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  renderedElement
+
+• **get renderedElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[renderedElement](cardelement.md#renderedelement)*
+
+*Defined in [card-elements.ts:956](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L956)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` renderedInputControlElement
+
+• **get renderedInputControlElement**(): *HTMLElement*
+
+*Inherited from [Input](input.md).[renderedInputControlElement](input.md#protected-renderedinputcontrolelement)*
+
+*Defined in [card-elements.ts:2803](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2803)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  separatorElement
+
+• **get separatorElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
+
+*Defined in [card-elements.ts:960](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L960)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` separatorOrientation
+
+• **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
+
+*Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
+
+*Defined in [card-elements.ts:494](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L494)*
+
+**Returns:** *[Orientation](../enums/orientation.md)*
+
+___
+
+### `Protected` supportsMinHeight
+
+• **get supportsMinHeight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[supportsMinHeight](cardelement.md#protected-supportsminheight)*
+
+*Defined in [card-elements.ts:482](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L482)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` useDefaultSizing
+
+• **get useDefaultSizing**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
+
+*Defined in [card-elements.ts:486](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L486)*
+
+**Returns:** *boolean*
+
+___
+
+###  value
+
+• **get value**(): *string*
+
+*Overrides [Input](input.md).[value](input.md#value)*
+
+*Defined in [card-elements.ts:3236](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3236)*
+
+**Returns:** *string*
+
+## Methods
+
+### `Protected` adjustRenderedElementSize
+
+▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
+
+*Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
+
+*Defined in [card-elements.ts:411](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L411)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`renderedElement` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+### `Protected` applyPadding
+
+▸ **applyPadding**(): *void*
+
+*Inherited from [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
+
+*Defined in [card-elements.ts:430](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L430)*
+
+**Returns:** *void*
+
+___
+
+###  asString
+
+▸ **asString**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
+
+*Defined in [card-elements.ts:513](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L513)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` createPlaceholderElement
+
+▸ **createPlaceholderElement**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
+
+*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  getActionAt
+
+▸ **getActionAt**(`index`: number): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
+
+*Defined in [card-elements.ts:694](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L694)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionById
+
+▸ **getActionById**(`id`: string): *[Action](action.md)*
+
+*Inherited from [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
+
+*Defined in [card-elements.ts:835](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L835)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getActionCount
+
+▸ **getActionCount**(): *number*
+
+*Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
+
+*Defined in [card-elements.ts:690](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L690)*
+
+**Returns:** *number*
+
+___
+
+###  getAllInputs
+
+▸ **getAllInputs**(): *Array‹[Input](input.md)›*
+
+*Inherited from [Input](input.md).[getAllInputs](input.md#getallinputs)*
+
+*Overrides [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
+
+*Defined in [card-elements.ts:2940](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2940)*
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+### `Protected` getDefaultPadding
+
+▸ **getDefaultPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
+
+*Defined in [card-elements.ts:466](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L466)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectivePadding
+
+▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
+
+*Defined in [card-elements.ts:847](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L847)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getEffectiveStyle
+
+▸ **getEffectiveStyle**(): *string*
+
+*Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
+
+*Defined in [card-elements.ts:545](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L545)*
+
+**Returns:** *string*
+
+___
+
+###  getElementById
+
+▸ **getElementById**(`id`: string): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
+
+*Defined in [card-elements.ts:831](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L831)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  getForbiddenActionTypes
+
+▸ **getForbiddenActionTypes**(): *Array‹any›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
+
+*Defined in [card-elements.ts:557](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L557)*
+
+**Returns:** *Array‹any›*
+
+___
+
+###  getForbiddenElementTypes
+
+▸ **getForbiddenElementTypes**(): *Array‹string›*
+
+*Inherited from [CardElement](cardelement.md).[getForbiddenElementTypes](cardelement.md#getforbiddenelementtypes)*
+
+*Defined in [card-elements.ts:553](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L553)*
+
+**Returns:** *Array‹string›*
+
+___
+
+### `Protected` getHasBackground
+
+▸ **getHasBackground**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
+
+*Defined in [card-elements.ts:470](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L470)*
+
+**Returns:** *boolean*
+
+___
+
+###  getImmediateSurroundingPadding
+
+▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
+
+*Defined in [card-elements.ts:561](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L561)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`result` | [PaddingDefinition](paddingdefinition.md) | - |
+`processTop` | boolean | true |
+`processRight` | boolean | true |
+`processBottom` | boolean | true |
+`processLeft` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  getJsonTypeName
+
+▸ **getJsonTypeName**(): *string*
+
+*Overrides [CardElement](cardelement.md).[getJsonTypeName](cardelement.md#abstract-getjsontypename)*
+
+*Defined in [card-elements.ts:3213](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3213)*
+
+**Returns:** *string*
+
+___
+
+### `Protected` getPadding
+
+▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md)*
+
+*Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
+
+*Defined in [card-elements.ts:474](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L474)*
+
+**Returns:** *[PaddingDefinition](paddingdefinition.md)*
+
+___
+
+###  getParentContainer
+
+▸ **getParentContainer**(): *[Container](container.md)*
+
+*Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
+
+*Defined in [card-elements.ts:809](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L809)*
+
+**Returns:** *[Container](container.md)*
+
+___
+
+###  getResourceInformation
+
+▸ **getResourceInformation**(): *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+*Inherited from [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
+
+*Defined in [card-elements.ts:827](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L827)*
+
+**Returns:** *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+___
+
+###  getRootElement
+
+▸ **getRootElement**(): *[CardElement](cardelement.md)*
+
+*Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
+
+*Defined in [card-elements.ts:799](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L799)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  indexOf
+
+▸ **indexOf**(`cardElement`: [CardElement](cardelement.md)): *number*
+
+*Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
+
+*Defined in [card-elements.ts:733](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L733)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`cardElement` | [CardElement](cardelement.md) |
+
+**Returns:** *number*
+
+___
+
+### `Protected` internalRender
+
+▸ **internalRender**(): *HTMLElement*
+
+*Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
+
+*Defined in [card-elements.ts:3155](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3155)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  internalValidateProperties
+
+▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
+
+*Inherited from [Input](input.md).[internalValidateProperties](input.md#internalvalidateproperties)*
+
+*Overrides [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
+
+*Defined in [card-elements.ts:2893](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2893)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [ValidationResults](validationresults.md) |
+
+**Returns:** *void*
+
+___
+
+###  isAtTheVeryBottom
+
+▸ **isAtTheVeryBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
+
+*Defined in [card-elements.ts:767](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L767)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryLeft
+
+▸ **isAtTheVeryLeft**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
+
+*Defined in [card-elements.ts:755](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L755)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryRight
+
+▸ **isAtTheVeryRight**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
+
+*Defined in [card-elements.ts:759](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L759)*
+
+**Returns:** *boolean*
+
+___
+
+###  isAtTheVeryTop
+
+▸ **isAtTheVeryTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
+
+*Defined in [card-elements.ts:763](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L763)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleeding
+
+▸ **isBleeding**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
+
+*Defined in [card-elements.ts:517](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L517)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtBottom
+
+▸ **isBleedingAtBottom**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
+
+*Defined in [card-elements.ts:775](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L775)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBleedingAtTop
+
+▸ **isBleedingAtTop**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
+
+*Defined in [card-elements.ts:771](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L771)*
+
+**Returns:** *boolean*
+
+___
+
+###  isBottomElement
+
+▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
+
+*Defined in [card-elements.ts:791](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L791)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isDesignMode
+
+▸ **isDesignMode**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
+
+*Defined in [card-elements.ts:737](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L737)*
+
+**Returns:** *boolean*
+
+___
+
+###  isFirstElement
+
+▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
+
+*Defined in [card-elements.ts:747](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L747)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isHiddenDueToOverflow
+
+▸ **isHiddenDueToOverflow**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
+
+*Defined in [card-elements.ts:795](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L795)*
+
+**Returns:** *boolean*
+
+___
+
+###  isLastElement
+
+▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
+
+*Defined in [card-elements.ts:751](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L751)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isLeftMostElement
+
+▸ **isLeftMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
+
+*Defined in [card-elements.ts:779](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L779)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isRendered
+
+▸ **isRendered**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRendered](cardelement.md#isrendered)*
+
+*Defined in [card-elements.ts:743](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L743)*
+
+**Returns:** *boolean*
+
+___
+
+###  isRightMostElement
+
+▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
+
+*Defined in [card-elements.ts:783](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L783)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+###  isTopElement
+
+▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
+
+*Defined in [card-elements.ts:787](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L787)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | [CardElement](cardelement.md) |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` overrideInternalRender
+
+▸ **overrideInternalRender**(): *HTMLElement*
+
+*Inherited from [Input](input.md).[overrideInternalRender](input.md#protected-overrideinternalrender)*
+
+*Overrides [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
+
+*Defined in [card-elements.ts:2811](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2811)*
+
+**Returns:** *HTMLElement*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *void*
+
+*Overrides [Input](input.md).[parse](input.md#parse)*
+
+*Defined in [card-elements.ts:3227](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3227)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *void*
+
+___
+
+### `Protected` parseInputValue
+
+▸ **parseInputValue**(`value`: string): *string*
+
+*Inherited from [Input](input.md).[parseInputValue](input.md#protected-parseinputvalue)*
+
+*Defined in [card-elements.ts:2868](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2868)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | string |
+
+**Returns:** *string*
+
+___
+
+###  remove
+
+▸ **remove**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
+
+*Defined in [card-elements.ts:698](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L698)*
+
+**Returns:** *boolean*
+
+___
+
+###  render
+
+▸ **render**(): *HTMLElement*
+
+*Inherited from [CardElement](cardelement.md).[render](cardelement.md#render)*
+
+*Defined in [card-elements.ts:706](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L706)*
+
+**Returns:** *HTMLElement*
+
+___
+
+### `Protected` resetValidationFailureCue
+
+▸ **resetValidationFailureCue**(): *void*
+
+*Inherited from [Input](input.md).[resetValidationFailureCue](input.md#protected-resetvalidationfailurecue)*
+
+*Defined in [card-elements.ts:2846](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2846)*
+
+**Returns:** *void*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+### `Protected` setPadding
+
+▸ **setPadding**(`value`: [PaddingDefinition](paddingdefinition.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
+
+*Defined in [card-elements.ts:478](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L478)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [PaddingDefinition](paddingdefinition.md) |
+
+**Returns:** *void*
+
+___
+
+###  setParent
+
+▸ **setParent**(`value`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [CardElement](cardelement.md).[setParent](cardelement.md#setparent)*
+
+*Overrides [CardObject](cardobject.md).[setParent](cardobject.md#abstract-setparent)*
+
+*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+###  setShouldFallback
+
+▸ **setShouldFallback**(`value`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[setShouldFallback](cardelement.md#setshouldfallback)*
+
+*Defined in [card-elements.ts:843](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L843)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  shouldFallback
+
+▸ **shouldFallback**(): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[shouldFallback](cardelement.md#shouldfallback)*
+
+*Overrides [CardObject](cardobject.md).[shouldFallback](cardobject.md#abstract-shouldfallback)*
+
+*Defined in [card-elements.ts:839](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L839)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` showValidationErrorMessage
+
+▸ **showValidationErrorMessage**(): *void*
+
+*Inherited from [Input](input.md).[showValidationErrorMessage](input.md#protected-showvalidationerrormessage)*
+
+*Defined in [card-elements.ts:2858](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2858)*
+
+**Returns:** *void*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [Input](input.md).[toJSON](input.md#tojson)*
+
+*Defined in [card-elements.ts:3217](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3217)*
+
+**Returns:** *any*
+
+___
+
+### `Protected` truncateOverflow
+
+▸ **truncateOverflow**(`maxHeight`: number): *boolean*
+
+*Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
+
+*Defined in [card-elements.ts:454](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L454)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`maxHeight` | number |
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` undoOverflowTruncation
+
+▸ **undoOverflowTruncation**(): *void*
+
+*Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
+
+*Defined in [card-elements.ts:464](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L464)*
+
+**Returns:** *void*
+
+___
+
+###  updateLayout
+
+▸ **updateLayout**(`processChildren`: boolean): *void*
+
+*Inherited from [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
+
+*Defined in [card-elements.ts:728](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L728)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`processChildren` | boolean | true |
+
+**Returns:** *void*
+
+___
+
+###  validateProperties
+
+▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
+
+*Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
+
+*Defined in [card-elements.ts:284](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L284)*
+
+**Returns:** *[ValidationResults](validationresults.md)*
+
+___
+
+###  validateValue
+
+▸ **validateValue**(): *boolean*
+
+*Implementation of [IInput](../interfaces/iinput.md)*
+
+*Inherited from [Input](input.md).[validateValue](input.md#validatevalue)*
+
+*Defined in [card-elements.ts:2906](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2906)*
+
+**Returns:** *boolean*
+
+___
+
+### `Protected` valueChanged
+
+▸ **valueChanged**(): *void*
+
+*Inherited from [Input](input.md).[valueChanged](input.md#protected-valuechanged)*
+
+*Defined in [card-elements.ts:2836](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L2836)*
+
+**Returns:** *void*

--- a/source/nodejs/adaptivecards/docs/classes/togglevisibilityaction.md
+++ b/source/nodejs/adaptivecards/docs/classes/togglevisibilityaction.md
@@ -1,0 +1,587 @@
+[Adaptive Cards Javascript SDK](../README.md) › [ToggleVisibilityAction](togglevisibilityaction.md)
+
+# Class: ToggleVisibilityAction
+
+## Hierarchy
+
+  ↳ [Action](action.md)
+
+  ↳ **ToggleVisibilityAction**
+
+## Index
+
+### Properties
+
+* [iconUrl](togglevisibilityaction.md#iconurl)
+* [id](togglevisibilityaction.md#id)
+* [onExecute](togglevisibilityaction.md#onexecute)
+* [requires](togglevisibilityaction.md#requires)
+* [style](togglevisibilityaction.md#style)
+* [targetElements](togglevisibilityaction.md#targetelements)
+* [title](togglevisibilityaction.md#title)
+* [JsonTypeName](togglevisibilityaction.md#static-jsontypename)
+
+### Accessors
+
+* [ignoreInputValidation](togglevisibilityaction.md#ignoreinputvalidation)
+* [isPrimary](togglevisibilityaction.md#isprimary)
+* [parent](togglevisibilityaction.md#parent)
+* [renderedElement](togglevisibilityaction.md#renderedelement)
+
+### Methods
+
+* [addCssClasses](togglevisibilityaction.md#protected-addcssclasses)
+* [addTargetElement](togglevisibilityaction.md#addtargetelement)
+* [execute](togglevisibilityaction.md#execute)
+* [getActionById](togglevisibilityaction.md#getactionbyid)
+* [getAllInputs](togglevisibilityaction.md#getallinputs)
+* [getCustomProperty](togglevisibilityaction.md#getcustomproperty)
+* [getHref](togglevisibilityaction.md#gethref)
+* [getJsonTypeName](togglevisibilityaction.md#getjsontypename)
+* [getReferencedInputs](togglevisibilityaction.md#getreferencedinputs)
+* [getResourceInformation](togglevisibilityaction.md#getresourceinformation)
+* [internalGetReferencedInputs](togglevisibilityaction.md#protected-internalgetreferencedinputs)
+* [internalPrepareForExecution](togglevisibilityaction.md#protected-internalprepareforexecution)
+* [internalValidateInputs](togglevisibilityaction.md#protected-internalvalidateinputs)
+* [internalValidateProperties](togglevisibilityaction.md#internalvalidateproperties)
+* [parse](togglevisibilityaction.md#parse)
+* [prepareForExecution](togglevisibilityaction.md#prepareforexecution)
+* [remove](togglevisibilityaction.md#remove)
+* [removeTargetElement](togglevisibilityaction.md#removetargetelement)
+* [render](togglevisibilityaction.md#render)
+* [setCustomProperty](togglevisibilityaction.md#setcustomproperty)
+* [setParent](togglevisibilityaction.md#setparent)
+* [shouldFallback](togglevisibilityaction.md#shouldfallback)
+* [toJSON](togglevisibilityaction.md#tojson)
+* [validateInputs](togglevisibilityaction.md#validateinputs)
+* [validateProperties](togglevisibilityaction.md#validateproperties)
+
+## Properties
+
+###  iconUrl
+
+• **iconUrl**: *string*
+
+*Inherited from [Action](action.md).[iconUrl](action.md#iconurl)*
+
+*Defined in [card-elements.ts:3905](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3905)*
+
+___
+
+###  id
+
+• **id**: *string*
+
+*Inherited from [CardObject](cardobject.md).[id](cardobject.md#id)*
+
+*Defined in [card-elements.ts:247](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L247)*
+
+___
+
+###  onExecute
+
+• **onExecute**: *function*
+
+*Inherited from [Action](action.md).[onExecute](action.md#onexecute)*
+
+*Defined in [card-elements.ts:3908](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3908)*
+
+#### Type declaration:
+
+▸ (`sender`: [Action](action.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`sender` | [Action](action.md) |
+
+___
+
+###  requires
+
+• **requires**: *[HostCapabilities](hostcapabilities.md)‹›* = new HostConfig.HostCapabilities()
+
+*Inherited from [Action](action.md).[requires](action.md#requires)*
+
+*Defined in [card-elements.ts:3902](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3902)*
+
+___
+
+###  style
+
+• **style**: *string* = Enums.ActionStyle.Default
+
+*Inherited from [Action](action.md).[style](action.md#style)*
+
+*Defined in [card-elements.ts:3906](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3906)*
+
+___
+
+###  targetElements
+
+• **targetElements**: *object*
+
+*Defined in [card-elements.ts:4226](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4226)*
+
+#### Type declaration:
+
+___
+
+###  title
+
+• **title**: *string*
+
+*Inherited from [Action](action.md).[title](action.md#title)*
+
+*Defined in [card-elements.ts:3904](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3904)*
+
+___
+
+### `Static` JsonTypeName
+
+▪ **JsonTypeName**: *"Action.ToggleVisibility"* = "Action.ToggleVisibility"
+
+*Defined in [card-elements.ts:4224](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4224)*
+
+## Accessors
+
+###  ignoreInputValidation
+
+• **get ignoreInputValidation**(): *boolean*
+
+*Inherited from [Action](action.md).[ignoreInputValidation](action.md#ignoreinputvalidation)*
+
+*Defined in [card-elements.ts:4088](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4088)*
+
+**Returns:** *boolean*
+
+___
+
+###  isPrimary
+
+• **get isPrimary**(): *boolean*
+
+*Inherited from [Action](action.md).[isPrimary](action.md#isprimary)*
+
+*Defined in [card-elements.ts:4073](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4073)*
+
+**Returns:** *boolean*
+
+• **set isPrimary**(`value`: boolean): *void*
+
+*Inherited from [Action](action.md).[isPrimary](action.md#isprimary)*
+
+*Defined in [card-elements.ts:4077](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4077)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | boolean |
+
+**Returns:** *void*
+
+___
+
+###  parent
+
+• **get parent**(): *[CardElement](cardelement.md)*
+
+*Inherited from [Action](action.md).[parent](action.md#parent)*
+
+*Defined in [card-elements.ts:4092](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4092)*
+
+**Returns:** *[CardElement](cardelement.md)*
+
+___
+
+###  renderedElement
+
+• **get renderedElement**(): *HTMLElement*
+
+*Inherited from [Action](action.md).[renderedElement](action.md#renderedelement)*
+
+*Defined in [card-elements.ts:4096](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4096)*
+
+**Returns:** *HTMLElement*
+
+## Methods
+
+### `Protected` addCssClasses
+
+▸ **addCssClasses**(`element`: HTMLElement): *void*
+
+*Inherited from [Action](action.md).[addCssClasses](action.md#protected-addcssclasses)*
+
+*Defined in [card-elements.ts:3872](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3872)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`element` | HTMLElement |
+
+**Returns:** *void*
+
+___
+
+###  addTargetElement
+
+▸ **addTargetElement**(`elementId`: string, `isVisible`: boolean): *void*
+
+*Defined in [card-elements.ts:4294](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4294)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`elementId` | string | - |
+`isVisible` | boolean | undefined |
+
+**Returns:** *void*
+
+___
+
+###  execute
+
+▸ **execute**(): *void*
+
+*Overrides [Action](action.md).[execute](action.md#execute)*
+
+*Defined in [card-elements.ts:4232](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4232)*
+
+**Returns:** *void*
+
+___
+
+###  getActionById
+
+▸ **getActionById**(`id`: string): *[Action](action.md)*
+
+*Inherited from [Action](action.md).[getActionById](action.md#getactionbyid)*
+
+*Defined in [card-elements.ts:4055](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4055)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`id` | string |
+
+**Returns:** *[Action](action.md)*
+
+___
+
+###  getAllInputs
+
+▸ **getAllInputs**(): *Array‹[Input](input.md)›*
+
+*Inherited from [Action](action.md).[getAllInputs](action.md#getallinputs)*
+
+*Defined in [card-elements.ts:4042](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4042)*
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+###  getCustomProperty
+
+▸ **getCustomProperty**(`name`: string): *any*
+
+*Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
+
+*Defined in [card-elements.ts:200](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L200)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *any*
+
+___
+
+###  getHref
+
+▸ **getHref**(): *string*
+
+*Inherited from [Action](action.md).[getHref](action.md#gethref)*
+
+*Defined in [card-elements.ts:3910](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3910)*
+
+**Returns:** *string*
+
+___
+
+###  getJsonTypeName
+
+▸ **getJsonTypeName**(): *string*
+
+*Overrides [Action](action.md).[getJsonTypeName](action.md#abstract-getjsontypename)*
+
+*Defined in [card-elements.ts:4228](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4228)*
+
+**Returns:** *string*
+
+___
+
+###  getReferencedInputs
+
+▸ **getReferencedInputs**(): *Shared.Dictionary‹[Input](input.md)›*
+
+*Inherited from [Action](action.md).[getReferencedInputs](action.md#getreferencedinputs)*
+
+*Defined in [card-elements.ts:4061](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4061)*
+
+**Returns:** *Shared.Dictionary‹[Input](input.md)›*
+
+___
+
+###  getResourceInformation
+
+▸ **getResourceInformation**(): *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+*Inherited from [Action](action.md).[getResourceInformation](action.md#getresourceinformation)*
+
+*Defined in [card-elements.ts:4046](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4046)*
+
+**Returns:** *Array‹[IResourceInformation](../interfaces/iresourceinformation.md)›*
+
+___
+
+### `Protected` internalGetReferencedInputs
+
+▸ **internalGetReferencedInputs**(`allInputs`: Array‹[Input](input.md)›): *Shared.Dictionary‹[Input](input.md)›*
+
+*Inherited from [Action](action.md).[internalGetReferencedInputs](action.md#protected-internalgetreferencedinputs)*
+
+*Defined in [card-elements.ts:3876](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3876)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`allInputs` | Array‹[Input](input.md)› |
+
+**Returns:** *Shared.Dictionary‹[Input](input.md)›*
+
+___
+
+### `Protected` internalPrepareForExecution
+
+▸ **internalPrepareForExecution**(`inputs`: Shared.Dictionary‹[Input](input.md)›): *void*
+
+*Inherited from [Action](action.md).[internalPrepareForExecution](action.md#protected-internalprepareforexecution)*
+
+*Defined in [card-elements.ts:3880](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3880)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`inputs` | Shared.Dictionary‹[Input](input.md)› |
+
+**Returns:** *void*
+
+___
+
+### `Protected` internalValidateInputs
+
+▸ **internalValidateInputs**(`referencedInputs`: Shared.Dictionary‹[Input](input.md)›): *Array‹[Input](input.md)›*
+
+*Inherited from [Action](action.md).[internalValidateInputs](action.md#protected-internalvalidateinputs)*
+
+*Defined in [card-elements.ts:3884](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3884)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`referencedInputs` | Shared.Dictionary‹[Input](input.md)› |
+
+**Returns:** *Array‹[Input](input.md)›*
+
+___
+
+###  internalValidateProperties
+
+▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
+
+*Inherited from [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
+
+*Defined in [card-elements.ts:249](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L249)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [ValidationResults](validationresults.md) |
+
+**Returns:** *void*
+
+___
+
+###  parse
+
+▸ **parse**(`json`: any): *void*
+
+*Overrides [Action](action.md).[parse](action.md#parse)*
+
+*Defined in [card-elements.ts:4247](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4247)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`json` | any |
+
+**Returns:** *void*
+
+___
+
+###  prepareForExecution
+
+▸ **prepareForExecution**(): *boolean*
+
+*Inherited from [Action](action.md).[prepareForExecution](action.md#prepareforexecution)*
+
+*Defined in [card-elements.ts:4000](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4000)*
+
+**Returns:** *boolean*
+
+___
+
+###  remove
+
+▸ **remove**(): *boolean*
+
+*Inherited from [Action](action.md).[remove](action.md#remove)*
+
+*Defined in [card-elements.ts:4034](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4034)*
+
+**Returns:** *boolean*
+
+___
+
+###  removeTargetElement
+
+▸ **removeTargetElement**(`elementId`: any): *void*
+
+*Defined in [card-elements.ts:4298](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4298)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`elementId` | any |
+
+**Returns:** *void*
+
+___
+
+###  render
+
+▸ **render**(`baseCssClass`: string): *void*
+
+*Inherited from [Action](action.md).[render](action.md#render)*
+
+*Defined in [card-elements.ts:3925](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3925)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`baseCssClass` | string | "ac-pushButton" |
+
+**Returns:** *void*
+
+___
+
+###  setCustomProperty
+
+▸ **setCustomProperty**(`name`: string, `value`: any): *void*
+
+*Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
+
+*Defined in [card-elements.ts:189](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L189)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`value` | any |
+
+**Returns:** *void*
+
+___
+
+###  setParent
+
+▸ **setParent**(`value`: [CardElement](cardelement.md)): *void*
+
+*Inherited from [Action](action.md).[setParent](action.md#setparent)*
+
+*Overrides [CardObject](cardobject.md).[setParent](cardobject.md#abstract-setparent)*
+
+*Defined in [card-elements.ts:3988](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L3988)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value` | [CardElement](cardelement.md) |
+
+**Returns:** *void*
+
+___
+
+###  shouldFallback
+
+▸ **shouldFallback**(): *boolean*
+
+*Inherited from [Action](action.md).[shouldFallback](action.md#shouldfallback)*
+
+*Overrides [CardObject](cardobject.md).[shouldFallback](cardobject.md#abstract-shouldfallback)*
+
+*Defined in [card-elements.ts:4069](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4069)*
+
+**Returns:** *boolean*
+
+___
+
+###  toJSON
+
+▸ **toJSON**(): *any*
+
+*Overrides [Action](action.md).[toJSON](action.md#tojson)*
+
+*Defined in [card-elements.ts:4270](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4270)*
+
+**Returns:** *any*
+
+___
+
+###  validateInputs
+
+▸ **validateInputs**(): *[Input](input.md)‹›[]*
+
+*Inherited from [Action](action.md).[validateInputs](action.md#validateinputs)*
+
+*Defined in [card-elements.ts:4065](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L4065)*
+
+**Returns:** *[Input](input.md)‹›[]*
+
+___
+
+###  validateProperties
+
+▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
+
+*Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
+
+*Defined in [card-elements.ts:284](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L284)*
+
+**Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/typeregistry.md
+++ b/source/nodejs/adaptivecards/docs/classes/typeregistry.md
@@ -1,0 +1,137 @@
+[Adaptive Cards Javascript SDK](../README.md) › [TypeRegistry](typeregistry.md)
+
+# Class: TypeRegistry <**T**>
+
+## Type parameters
+
+▪ **T**
+
+## Hierarchy
+
+* **TypeRegistry**
+
+  ↳ [ElementTypeRegistry](elementtyperegistry.md)
+
+  ↳ [ActionTypeRegistry](actiontyperegistry.md)
+
+## Index
+
+### Constructors
+
+* [constructor](typeregistry.md#constructor)
+
+### Methods
+
+* [clear](typeregistry.md#clear)
+* [createInstance](typeregistry.md#createinstance)
+* [getItemAt](typeregistry.md#getitemat)
+* [getItemCount](typeregistry.md#getitemcount)
+* [registerType](typeregistry.md#registertype)
+* [reset](typeregistry.md#abstract-reset)
+* [unregisterType](typeregistry.md#unregistertype)
+
+## Constructors
+
+###  constructor
+
+\+ **new TypeRegistry**(): *[TypeRegistry](typeregistry.md)*
+
+*Defined in [card-elements.ts:6539](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6539)*
+
+**Returns:** *[TypeRegistry](typeregistry.md)*
+
+## Methods
+
+###  clear
+
+▸ **clear**(): *void*
+
+*Defined in [card-elements.ts:6545](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6545)*
+
+**Returns:** *void*
+
+___
+
+###  createInstance
+
+▸ **createInstance**(`typeName`: string): *T*
+
+*Defined in [card-elements.ts:6577](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6577)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`typeName` | string |
+
+**Returns:** *T*
+
+___
+
+###  getItemAt
+
+▸ **getItemAt**(`index`: number): *[ITypeRegistration](../interfaces/ityperegistration.md)‹T›*
+
+*Defined in [card-elements.ts:6587](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6587)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+
+**Returns:** *[ITypeRegistration](../interfaces/ityperegistration.md)‹T›*
+
+___
+
+###  getItemCount
+
+▸ **getItemCount**(): *number*
+
+*Defined in [card-elements.ts:6583](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6583)*
+
+**Returns:** *number*
+
+___
+
+###  registerType
+
+▸ **registerType**(`typeName`: string, `createInstance`: function): *void*
+
+*Defined in [card-elements.ts:6551](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6551)*
+
+**Parameters:**
+
+▪ **typeName**: *string*
+
+▪ **createInstance**: *function*
+
+▸ (): *T*
+
+**Returns:** *void*
+
+___
+
+### `Abstract` reset
+
+▸ **reset**(): *any*
+
+*Defined in [card-elements.ts:6549](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6549)*
+
+**Returns:** *any*
+
+___
+
+###  unregisterType
+
+▸ **unregisterType**(`typeName`: string): *void*
+
+*Defined in [card-elements.ts:6567](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6567)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`typeName` | string |
+
+**Returns:** *void*

--- a/source/nodejs/adaptivecards/docs/classes/uuid.md
+++ b/source/nodejs/adaptivecards/docs/classes/uuid.md
@@ -1,0 +1,42 @@
+[Adaptive Cards Javascript SDK](../README.md) › [UUID](uuid.md)
+
+# Class: UUID
+
+Fast UUID generator, RFC4122 version 4 compliant.
+
+**`author`** Jeff Ward (jcward.com).
+
+**`license`** MIT license
+
+**`link`** http://stackoverflow.com/questions/105034/how-to-create-a-guid-uuid-in-javascript/21963136#21963136
+
+## Hierarchy
+
+* **UUID**
+
+## Index
+
+### Methods
+
+* [generate](uuid.md#static-generate)
+* [initialize](uuid.md#static-initialize)
+
+## Methods
+
+### `Static` generate
+
+▸ **generate**(): *string*
+
+*Defined in [shared.ts:187](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/shared.ts#L187)*
+
+**Returns:** *string*
+
+___
+
+### `Static` initialize
+
+▸ **initialize**(): *void*
+
+*Defined in [shared.ts:199](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/shared.ts#L199)*
+
+**Returns:** *void*

--- a/source/nodejs/adaptivecards/docs/classes/validationfailure.md
+++ b/source/nodejs/adaptivecards/docs/classes/validationfailure.md
@@ -1,0 +1,50 @@
+[Adaptive Cards Javascript SDK](../README.md) › [ValidationFailure](validationfailure.md)
+
+# Class: ValidationFailure
+
+## Hierarchy
+
+* **ValidationFailure**
+
+## Index
+
+### Constructors
+
+* [constructor](validationfailure.md#constructor)
+
+### Properties
+
+* [cardObject](validationfailure.md#cardobject)
+* [errors](validationfailure.md#errors)
+
+## Constructors
+
+###  constructor
+
+\+ **new ValidationFailure**(`cardObject`: [CardObject](cardobject.md)): *[ValidationFailure](validationfailure.md)*
+
+*Defined in [card-elements.ts:206](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L206)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`cardObject` | [CardObject](cardobject.md) |
+
+**Returns:** *[ValidationFailure](validationfailure.md)*
+
+## Properties
+
+###  cardObject
+
+• **cardObject**: *[CardObject](cardobject.md)*
+
+*Defined in [card-elements.ts:208](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L208)*
+
+___
+
+###  errors
+
+• **errors**: *[IValidationError](../interfaces/ivalidationerror.md)[]* = []
+
+*Defined in [card-elements.ts:206](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L206)*

--- a/source/nodejs/adaptivecards/docs/classes/validationresults.md
+++ b/source/nodejs/adaptivecards/docs/classes/validationresults.md
@@ -1,0 +1,51 @@
+[Adaptive Cards Javascript SDK](../README.md) › [ValidationResults](validationresults.md)
+
+# Class: ValidationResults
+
+## Hierarchy
+
+* **ValidationResults**
+
+## Index
+
+### Properties
+
+* [allIds](validationresults.md#allids)
+* [failures](validationresults.md#failures)
+
+### Methods
+
+* [addFailure](validationresults.md#addfailure)
+
+## Properties
+
+###  allIds
+
+• **allIds**: *Shared.Dictionary‹number›*
+
+*Defined in [card-elements.ts:222](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L222)*
+
+___
+
+###  failures
+
+• **failures**: *[ValidationFailure](validationfailure.md)[]* = []
+
+*Defined in [card-elements.ts:223](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L223)*
+
+## Methods
+
+###  addFailure
+
+▸ **addFailure**(`cardObject`: [CardObject](cardobject.md), `error`: [IValidationError](../interfaces/ivalidationerror.md)): *void*
+
+*Defined in [card-elements.ts:225](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L225)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`cardObject` | [CardObject](cardobject.md) |
+`error` | [IValidationError](../interfaces/ivalidationerror.md) |
+
+**Returns:** *void*

--- a/source/nodejs/adaptivecards/docs/classes/version.md
+++ b/source/nodejs/adaptivecards/docs/classes/version.md
@@ -1,0 +1,127 @@
+[Adaptive Cards Javascript SDK](../README.md) › [Version](version.md)
+
+# Class: Version
+
+## Hierarchy
+
+* **Version**
+
+## Index
+
+### Constructors
+
+* [constructor](version.md#constructor)
+
+### Accessors
+
+* [isValid](version.md#isvalid)
+* [label](version.md#label)
+* [major](version.md#major)
+* [minor](version.md#minor)
+
+### Methods
+
+* [compareTo](version.md#compareto)
+* [toString](version.md#tostring)
+* [parse](version.md#static-parse)
+
+## Constructors
+
+###  constructor
+
+\+ **new Version**(`major`: number, `minor`: number, `label?`: string): *[Version](version.md)*
+
+*Defined in [host-config.ts:397](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L397)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`major` | number | 1 |
+`minor` | number | 1 |
+`label?` | string | - |
+
+**Returns:** *[Version](version.md)*
+
+## Accessors
+
+###  isValid
+
+• **get isValid**(): *boolean*
+
+*Defined in [host-config.ts:473](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L473)*
+
+**Returns:** *boolean*
+
+___
+
+###  label
+
+• **get label**(): *string*
+
+*Defined in [host-config.ts:461](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L461)*
+
+**Returns:** *string*
+
+___
+
+###  major
+
+• **get major**(): *number*
+
+*Defined in [host-config.ts:465](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L465)*
+
+**Returns:** *number*
+
+___
+
+###  minor
+
+• **get minor**(): *number*
+
+*Defined in [host-config.ts:469](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L469)*
+
+**Returns:** *number*
+
+## Methods
+
+###  compareTo
+
+▸ **compareTo**(`otherVersion`: [Version](version.md)): *number*
+
+*Defined in [host-config.ts:440](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L440)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`otherVersion` | [Version](version.md) |
+
+**Returns:** *number*
+
+___
+
+###  toString
+
+▸ **toString**(): *string*
+
+*Defined in [host-config.ts:436](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L436)*
+
+**Returns:** *string*
+
+___
+
+### `Static` parse
+
+▸ **parse**(`versionString`: string, `errors?`: Array‹[IValidationError](../interfaces/ivalidationerror.md)›): *[Version](version.md)*
+
+*Defined in [host-config.ts:405](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L405)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`versionString` | string |
+`errors?` | Array‹[IValidationError](../interfaces/ivalidationerror.md)› |
+
+**Returns:** *[Version](version.md)*

--- a/source/nodejs/adaptivecards/docs/enums/actionalignment.md
+++ b/source/nodejs/adaptivecards/docs/enums/actionalignment.md
@@ -1,0 +1,44 @@
+[Adaptive Cards Javascript SDK](../README.md) › [ActionAlignment](actionalignment.md)
+
+# Enumeration: ActionAlignment
+
+## Index
+
+### Enumeration members
+
+* [Center](actionalignment.md#center)
+* [Left](actionalignment.md#left)
+* [Right](actionalignment.md#right)
+* [Stretch](actionalignment.md#stretch)
+
+## Enumeration members
+
+###  Center
+
+• **Center**:
+
+*Defined in [enums.ts:79](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L79)*
+
+___
+
+###  Left
+
+• **Left**:
+
+*Defined in [enums.ts:78](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L78)*
+
+___
+
+###  Right
+
+• **Right**:
+
+*Defined in [enums.ts:80](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L80)*
+
+___
+
+###  Stretch
+
+• **Stretch**:
+
+*Defined in [enums.ts:81](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L81)*

--- a/source/nodejs/adaptivecards/docs/enums/actioniconplacement.md
+++ b/source/nodejs/adaptivecards/docs/enums/actioniconplacement.md
@@ -1,0 +1,26 @@
+[Adaptive Cards Javascript SDK](../README.md) › [ActionIconPlacement](actioniconplacement.md)
+
+# Enumeration: ActionIconPlacement
+
+## Index
+
+### Enumeration members
+
+* [AboveTitle](actioniconplacement.md#abovetitle)
+* [LeftOfTitle](actioniconplacement.md#leftoftitle)
+
+## Enumeration members
+
+###  AboveTitle
+
+• **AboveTitle**:
+
+*Defined in [enums.ts:108](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L108)*
+
+___
+
+###  LeftOfTitle
+
+• **LeftOfTitle**:
+
+*Defined in [enums.ts:107](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L107)*

--- a/source/nodejs/adaptivecards/docs/enums/containerfitstatus.md
+++ b/source/nodejs/adaptivecards/docs/enums/containerfitstatus.md
@@ -1,0 +1,35 @@
+[Adaptive Cards Javascript SDK](../README.md) › [ContainerFitStatus](containerfitstatus.md)
+
+# Enumeration: ContainerFitStatus
+
+## Index
+
+### Enumeration members
+
+* [FullyInContainer](containerfitstatus.md#fullyincontainer)
+* [FullyOutOfContainer](containerfitstatus.md#fullyoutofcontainer)
+* [Overflowing](containerfitstatus.md#overflowing)
+
+## Enumeration members
+
+###  FullyInContainer
+
+• **FullyInContainer**:
+
+*Defined in [enums.ts:168](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L168)*
+
+___
+
+###  FullyOutOfContainer
+
+• **FullyOutOfContainer**:
+
+*Defined in [enums.ts:170](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L170)*
+
+___
+
+###  Overflowing
+
+• **Overflowing**:
+
+*Defined in [enums.ts:169](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L169)*

--- a/source/nodejs/adaptivecards/docs/enums/fillmode.md
+++ b/source/nodejs/adaptivecards/docs/enums/fillmode.md
@@ -1,0 +1,44 @@
+[Adaptive Cards Javascript SDK](../README.md) › [FillMode](fillmode.md)
+
+# Enumeration: FillMode
+
+## Index
+
+### Enumeration members
+
+* [Cover](fillmode.md#cover)
+* [Repeat](fillmode.md#repeat)
+* [RepeatHorizontally](fillmode.md#repeathorizontally)
+* [RepeatVertically](fillmode.md#repeatvertically)
+
+## Enumeration members
+
+###  Cover
+
+• **Cover**:
+
+*Defined in [enums.ts:100](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L100)*
+
+___
+
+###  Repeat
+
+• **Repeat**:
+
+*Defined in [enums.ts:103](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L103)*
+
+___
+
+###  RepeatHorizontally
+
+• **RepeatHorizontally**:
+
+*Defined in [enums.ts:101](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L101)*
+
+___
+
+###  RepeatVertically
+
+• **RepeatVertically**:
+
+*Defined in [enums.ts:102](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L102)*

--- a/source/nodejs/adaptivecards/docs/enums/fonttype.md
+++ b/source/nodejs/adaptivecards/docs/enums/fonttype.md
@@ -1,0 +1,26 @@
+[Adaptive Cards Javascript SDK](../README.md) › [FontType](fonttype.md)
+
+# Enumeration: FontType
+
+## Index
+
+### Enumeration members
+
+* [Default](fonttype.md#default)
+* [Monospace](fonttype.md#monospace)
+
+## Enumeration members
+
+###  Default
+
+• **Default**:
+
+*Defined in [enums.ts:41](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L41)*
+
+___
+
+###  Monospace
+
+• **Monospace**:
+
+*Defined in [enums.ts:42](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L42)*

--- a/source/nodejs/adaptivecards/docs/enums/horizontalalignment.md
+++ b/source/nodejs/adaptivecards/docs/enums/horizontalalignment.md
@@ -1,0 +1,35 @@
+[Adaptive Cards Javascript SDK](../README.md) › [HorizontalAlignment](horizontalalignment.md)
+
+# Enumeration: HorizontalAlignment
+
+## Index
+
+### Enumeration members
+
+* [Center](horizontalalignment.md#center)
+* [Left](horizontalalignment.md#left)
+* [Right](horizontalalignment.md#right)
+
+## Enumeration members
+
+###  Center
+
+• **Center**:
+
+*Defined in [enums.ts:67](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L67)*
+
+___
+
+###  Left
+
+• **Left**:
+
+*Defined in [enums.ts:66](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L66)*
+
+___
+
+###  Right
+
+• **Right**:
+
+*Defined in [enums.ts:68](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L68)*

--- a/source/nodejs/adaptivecards/docs/enums/imagestyle.md
+++ b/source/nodejs/adaptivecards/docs/enums/imagestyle.md
@@ -1,0 +1,26 @@
+[Adaptive Cards Javascript SDK](../README.md) › [ImageStyle](imagestyle.md)
+
+# Enumeration: ImageStyle
+
+## Index
+
+### Enumeration members
+
+* [Default](imagestyle.md#default)
+* [Person](imagestyle.md#person)
+
+## Enumeration members
+
+###  Default
+
+• **Default**:
+
+*Defined in [enums.ts:85](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L85)*
+
+___
+
+###  Person
+
+• **Person**:
+
+*Defined in [enums.ts:86](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L86)*

--- a/source/nodejs/adaptivecards/docs/enums/inputtextstyle.md
+++ b/source/nodejs/adaptivecards/docs/enums/inputtextstyle.md
@@ -1,0 +1,44 @@
+[Adaptive Cards Javascript SDK](../README.md) › [InputTextStyle](inputtextstyle.md)
+
+# Enumeration: InputTextStyle
+
+## Index
+
+### Enumeration members
+
+* [Email](inputtextstyle.md#email)
+* [Tel](inputtextstyle.md#tel)
+* [Text](inputtextstyle.md#text)
+* [Url](inputtextstyle.md#url)
+
+## Enumeration members
+
+###  Email
+
+• **Email**:
+
+*Defined in [enums.ts:115](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L115)*
+
+___
+
+###  Tel
+
+• **Tel**:
+
+*Defined in [enums.ts:113](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L113)*
+
+___
+
+###  Text
+
+• **Text**:
+
+*Defined in [enums.ts:112](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L112)*
+
+___
+
+###  Url
+
+• **Url**:
+
+*Defined in [enums.ts:114](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L114)*

--- a/source/nodejs/adaptivecards/docs/enums/inputvalidationnecessity.md
+++ b/source/nodejs/adaptivecards/docs/enums/inputvalidationnecessity.md
@@ -1,0 +1,35 @@
+[Adaptive Cards Javascript SDK](../README.md) › [InputValidationNecessity](inputvalidationnecessity.md)
+
+# Enumeration: InputValidationNecessity
+
+## Index
+
+### Enumeration members
+
+* [Optional](inputvalidationnecessity.md#optional)
+* [Required](inputvalidationnecessity.md#required)
+* [RequiredWithVisualCue](inputvalidationnecessity.md#requiredwithvisualcue)
+
+## Enumeration members
+
+###  Optional
+
+• **Optional**:
+
+*Defined in [enums.ts:119](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L119)*
+
+___
+
+###  Required
+
+• **Required**:
+
+*Defined in [enums.ts:120](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L120)*
+
+___
+
+###  RequiredWithVisualCue
+
+• **RequiredWithVisualCue**:
+
+*Defined in [enums.ts:121](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L121)*

--- a/source/nodejs/adaptivecards/docs/enums/orientation.md
+++ b/source/nodejs/adaptivecards/docs/enums/orientation.md
@@ -1,0 +1,26 @@
+[Adaptive Cards Javascript SDK](../README.md) › [Orientation](orientation.md)
+
+# Enumeration: Orientation
+
+## Index
+
+### Enumeration members
+
+* [Horizontal](orientation.md#horizontal)
+* [Vertical](orientation.md#vertical)
+
+## Enumeration members
+
+###  Horizontal
+
+• **Horizontal**:
+
+*Defined in [enums.ts:95](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L95)*
+
+___
+
+###  Vertical
+
+• **Vertical**:
+
+*Defined in [enums.ts:96](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L96)*

--- a/source/nodejs/adaptivecards/docs/enums/showcardactionmode.md
+++ b/source/nodejs/adaptivecards/docs/enums/showcardactionmode.md
@@ -1,0 +1,26 @@
+[Adaptive Cards Javascript SDK](../README.md) › [ShowCardActionMode](showcardactionmode.md)
+
+# Enumeration: ShowCardActionMode
+
+## Index
+
+### Enumeration members
+
+* [Inline](showcardactionmode.md#inline)
+* [Popup](showcardactionmode.md#popup)
+
+## Enumeration members
+
+###  Inline
+
+• **Inline**:
+
+*Defined in [enums.ts:90](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L90)*
+
+___
+
+###  Popup
+
+• **Popup**:
+
+*Defined in [enums.ts:91](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L91)*

--- a/source/nodejs/adaptivecards/docs/enums/size.md
+++ b/source/nodejs/adaptivecards/docs/enums/size.md
@@ -1,0 +1,53 @@
+[Adaptive Cards Javascript SDK](../README.md) › [Size](size.md)
+
+# Enumeration: Size
+
+## Index
+
+### Enumeration members
+
+* [Auto](size.md#auto)
+* [Large](size.md#large)
+* [Medium](size.md#medium)
+* [Small](size.md#small)
+* [Stretch](size.md#stretch)
+
+## Enumeration members
+
+###  Auto
+
+• **Auto**:
+
+*Defined in [enums.ts:14](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L14)*
+
+___
+
+###  Large
+
+• **Large**:
+
+*Defined in [enums.ts:18](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L18)*
+
+___
+
+###  Medium
+
+• **Medium**:
+
+*Defined in [enums.ts:17](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L17)*
+
+___
+
+###  Small
+
+• **Small**:
+
+*Defined in [enums.ts:16](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L16)*
+
+___
+
+###  Stretch
+
+• **Stretch**:
+
+*Defined in [enums.ts:15](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L15)*

--- a/source/nodejs/adaptivecards/docs/enums/sizeunit.md
+++ b/source/nodejs/adaptivecards/docs/enums/sizeunit.md
@@ -1,0 +1,26 @@
+[Adaptive Cards Javascript SDK](../README.md) › [SizeUnit](sizeunit.md)
+
+# Enumeration: SizeUnit
+
+## Index
+
+### Enumeration members
+
+* [Pixel](sizeunit.md#pixel)
+* [Weight](sizeunit.md#weight)
+
+## Enumeration members
+
+###  Pixel
+
+• **Pixel**:
+
+*Defined in [enums.ts:23](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L23)*
+
+___
+
+###  Weight
+
+• **Weight**:
+
+*Defined in [enums.ts:22](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L22)*

--- a/source/nodejs/adaptivecards/docs/enums/spacing.md
+++ b/source/nodejs/adaptivecards/docs/enums/spacing.md
@@ -1,0 +1,71 @@
+[Adaptive Cards Javascript SDK](../README.md) › [Spacing](spacing.md)
+
+# Enumeration: Spacing
+
+## Index
+
+### Enumeration members
+
+* [Default](spacing.md#default)
+* [ExtraLarge](spacing.md#extralarge)
+* [Large](spacing.md#large)
+* [Medium](spacing.md#medium)
+* [None](spacing.md#none)
+* [Padding](spacing.md#padding)
+* [Small](spacing.md#small)
+
+## Enumeration members
+
+###  Default
+
+• **Default**:
+
+*Defined in [enums.ts:48](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L48)*
+
+___
+
+###  ExtraLarge
+
+• **ExtraLarge**:
+
+*Defined in [enums.ts:51](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L51)*
+
+___
+
+###  Large
+
+• **Large**:
+
+*Defined in [enums.ts:50](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L50)*
+
+___
+
+###  Medium
+
+• **Medium**:
+
+*Defined in [enums.ts:49](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L49)*
+
+___
+
+###  None
+
+• **None**:
+
+*Defined in [enums.ts:46](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L46)*
+
+___
+
+###  Padding
+
+• **Padding**:
+
+*Defined in [enums.ts:52](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L52)*
+
+___
+
+###  Small
+
+• **Small**:
+
+*Defined in [enums.ts:47](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L47)*

--- a/source/nodejs/adaptivecards/docs/enums/textcolor.md
+++ b/source/nodejs/adaptivecards/docs/enums/textcolor.md
@@ -1,0 +1,71 @@
+[Adaptive Cards Javascript SDK](../README.md) › [TextColor](textcolor.md)
+
+# Enumeration: TextColor
+
+## Index
+
+### Enumeration members
+
+* [Accent](textcolor.md#accent)
+* [Attention](textcolor.md#attention)
+* [Dark](textcolor.md#dark)
+* [Default](textcolor.md#default)
+* [Good](textcolor.md#good)
+* [Light](textcolor.md#light)
+* [Warning](textcolor.md#warning)
+
+## Enumeration members
+
+###  Accent
+
+• **Accent**:
+
+*Defined in [enums.ts:59](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L59)*
+
+___
+
+###  Attention
+
+• **Attention**:
+
+*Defined in [enums.ts:62](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L62)*
+
+___
+
+###  Dark
+
+• **Dark**:
+
+*Defined in [enums.ts:57](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L57)*
+
+___
+
+###  Default
+
+• **Default**:
+
+*Defined in [enums.ts:56](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L56)*
+
+___
+
+###  Good
+
+• **Good**:
+
+*Defined in [enums.ts:60](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L60)*
+
+___
+
+###  Light
+
+• **Light**:
+
+*Defined in [enums.ts:58](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L58)*
+
+___
+
+###  Warning
+
+• **Warning**:
+
+*Defined in [enums.ts:61](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L61)*

--- a/source/nodejs/adaptivecards/docs/enums/textsize.md
+++ b/source/nodejs/adaptivecards/docs/enums/textsize.md
@@ -1,0 +1,53 @@
+[Adaptive Cards Javascript SDK](../README.md) › [TextSize](textsize.md)
+
+# Enumeration: TextSize
+
+## Index
+
+### Enumeration members
+
+* [Default](textsize.md#default)
+* [ExtraLarge](textsize.md#extralarge)
+* [Large](textsize.md#large)
+* [Medium](textsize.md#medium)
+* [Small](textsize.md#small)
+
+## Enumeration members
+
+###  Default
+
+• **Default**:
+
+*Defined in [enums.ts:28](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L28)*
+
+___
+
+###  ExtraLarge
+
+• **ExtraLarge**:
+
+*Defined in [enums.ts:31](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L31)*
+
+___
+
+###  Large
+
+• **Large**:
+
+*Defined in [enums.ts:30](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L30)*
+
+___
+
+###  Medium
+
+• **Medium**:
+
+*Defined in [enums.ts:29](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L29)*
+
+___
+
+###  Small
+
+• **Small**:
+
+*Defined in [enums.ts:27](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L27)*

--- a/source/nodejs/adaptivecards/docs/enums/textweight.md
+++ b/source/nodejs/adaptivecards/docs/enums/textweight.md
@@ -1,0 +1,35 @@
+[Adaptive Cards Javascript SDK](../README.md) › [TextWeight](textweight.md)
+
+# Enumeration: TextWeight
+
+## Index
+
+### Enumeration members
+
+* [Bolder](textweight.md#bolder)
+* [Default](textweight.md#default)
+* [Lighter](textweight.md#lighter)
+
+## Enumeration members
+
+###  Bolder
+
+• **Bolder**:
+
+*Defined in [enums.ts:37](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L37)*
+
+___
+
+###  Default
+
+• **Default**:
+
+*Defined in [enums.ts:36](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L36)*
+
+___
+
+###  Lighter
+
+• **Lighter**:
+
+*Defined in [enums.ts:35](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L35)*

--- a/source/nodejs/adaptivecards/docs/enums/validationerror.md
+++ b/source/nodejs/adaptivecards/docs/enums/validationerror.md
@@ -1,0 +1,134 @@
+[Adaptive Cards Javascript SDK](../README.md) › [ValidationError](validationerror.md)
+
+# Enumeration: ValidationError
+
+## Index
+
+### Enumeration members
+
+* [ActionTypeNotAllowed](validationerror.md#actiontypenotallowed)
+* [CollectionCantBeEmpty](validationerror.md#collectioncantbeempty)
+* [Deprecated](validationerror.md#deprecated)
+* [DuplicateId](validationerror.md#duplicateid)
+* [ElementTypeNotAllowed](validationerror.md#elementtypenotallowed)
+* [Hint](validationerror.md#hint)
+* [InteractivityNotAllowed](validationerror.md#interactivitynotallowed)
+* [InvalidPropertyValue](validationerror.md#invalidpropertyvalue)
+* [MissingCardType](validationerror.md#missingcardtype)
+* [PropertyCantBeNull](validationerror.md#propertycantbenull)
+* [TooManyActions](validationerror.md#toomanyactions)
+* [UnknownActionType](validationerror.md#unknownactiontype)
+* [UnknownElementType](validationerror.md#unknownelementtype)
+* [UnsupportedCardVersion](validationerror.md#unsupportedcardversion)
+
+## Enumeration members
+
+###  ActionTypeNotAllowed
+
+• **ActionTypeNotAllowed**:
+
+*Defined in [enums.ts:152](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L152)*
+
+___
+
+###  CollectionCantBeEmpty
+
+• **CollectionCantBeEmpty**:
+
+*Defined in [enums.ts:153](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L153)*
+
+___
+
+###  Deprecated
+
+• **Deprecated**:
+
+*Defined in [enums.ts:154](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L154)*
+
+___
+
+###  DuplicateId
+
+• **DuplicateId**:
+
+*Defined in [enums.ts:164](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L164)*
+
+___
+
+###  ElementTypeNotAllowed
+
+• **ElementTypeNotAllowed**:
+
+*Defined in [enums.ts:155](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L155)*
+
+___
+
+###  Hint
+
+• **Hint**:
+
+*Defined in [enums.ts:151](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L151)*
+
+___
+
+###  InteractivityNotAllowed
+
+• **InteractivityNotAllowed**:
+
+*Defined in [enums.ts:156](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L156)*
+
+___
+
+###  InvalidPropertyValue
+
+• **InvalidPropertyValue**:
+
+*Defined in [enums.ts:157](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L157)*
+
+___
+
+###  MissingCardType
+
+• **MissingCardType**:
+
+*Defined in [enums.ts:158](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L158)*
+
+___
+
+###  PropertyCantBeNull
+
+• **PropertyCantBeNull**:
+
+*Defined in [enums.ts:159](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L159)*
+
+___
+
+###  TooManyActions
+
+• **TooManyActions**:
+
+*Defined in [enums.ts:160](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L160)*
+
+___
+
+###  UnknownActionType
+
+• **UnknownActionType**:
+
+*Defined in [enums.ts:161](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L161)*
+
+___
+
+###  UnknownElementType
+
+• **UnknownElementType**:
+
+*Defined in [enums.ts:162](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L162)*
+
+___
+
+###  UnsupportedCardVersion
+
+• **UnsupportedCardVersion**:
+
+*Defined in [enums.ts:163](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L163)*

--- a/source/nodejs/adaptivecards/docs/enums/verticalalignment.md
+++ b/source/nodejs/adaptivecards/docs/enums/verticalalignment.md
@@ -1,0 +1,35 @@
+[Adaptive Cards Javascript SDK](../README.md) › [VerticalAlignment](verticalalignment.md)
+
+# Enumeration: VerticalAlignment
+
+## Index
+
+### Enumeration members
+
+* [Bottom](verticalalignment.md#bottom)
+* [Center](verticalalignment.md#center)
+* [Top](verticalalignment.md#top)
+
+## Enumeration members
+
+###  Bottom
+
+• **Bottom**:
+
+*Defined in [enums.ts:74](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L74)*
+
+___
+
+###  Center
+
+• **Center**:
+
+*Defined in [enums.ts:73](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L73)*
+
+___
+
+###  Top
+
+• **Top**:
+
+*Defined in [enums.ts:72](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/enums.ts#L72)*

--- a/source/nodejs/adaptivecards/docs/interfaces/iadaptivecard.md
+++ b/source/nodejs/adaptivecards/docs/interfaces/iadaptivecard.md
@@ -1,0 +1,129 @@
+[Adaptive Cards Javascript SDK](../README.md) › [IAdaptiveCard](iadaptivecard.md)
+
+# Interface: IAdaptiveCard
+
+## Hierarchy
+
+* [ICardElement](icardelement.md)
+
+  ↳ **IAdaptiveCard**
+
+## Indexable
+
+* \[ **propName**: *string*\]: any
+
+## Index
+
+### Properties
+
+* [actions](iadaptivecard.md#optional-actions)
+* [backgroundImage](iadaptivecard.md#optional-backgroundimage)
+* [body](iadaptivecard.md#optional-body)
+* [height](iadaptivecard.md#optional-height)
+* [horizontalAlignment](iadaptivecard.md#optional-horizontalalignment)
+* [id](iadaptivecard.md#optional-id)
+* [separator](iadaptivecard.md#optional-separator)
+* [spacing](iadaptivecard.md#optional-spacing)
+* [speak](iadaptivecard.md#optional-speak)
+* [type](iadaptivecard.md#type)
+* [version](iadaptivecard.md#optional-version)
+
+## Properties
+
+### `Optional` actions
+
+• **actions**? : *ISubmitAction | IOpenUrlAction | IShowCardAction[]*
+
+*Defined in [schema.ts:170](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/schema.ts#L170)*
+
+___
+
+### `Optional` backgroundImage
+
+• **backgroundImage**? : *IBackgroundImage | string*
+
+*Defined in [schema.ts:168](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/schema.ts#L168)*
+
+___
+
+### `Optional` body
+
+• **body**? : *ITextBlock | IImage | IImageSet | IFactSet | IColumnSet | IContainer[]*
+
+*Defined in [schema.ts:169](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/schema.ts#L169)*
+
+___
+
+### `Optional` height
+
+• **height**? : *"auto" | "stretch"*
+
+*Inherited from [IAdaptiveCard](iadaptivecard.md).[height](iadaptivecard.md#optional-height)*
+
+*Defined in [schema.ts:39](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/schema.ts#L39)*
+
+___
+
+### `Optional` horizontalAlignment
+
+• **horizontalAlignment**? : *[HorizontalAlignment](../enums/horizontalalignment.md)*
+
+*Inherited from [IAdaptiveCard](iadaptivecard.md).[horizontalAlignment](iadaptivecard.md#optional-horizontalalignment)*
+
+*Defined in [schema.ts:36](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/schema.ts#L36)*
+
+___
+
+### `Optional` id
+
+• **id**? : *string*
+
+*Inherited from [IAdaptiveCard](iadaptivecard.md).[id](iadaptivecard.md#optional-id)*
+
+*Defined in [schema.ts:34](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/schema.ts#L34)*
+
+___
+
+### `Optional` separator
+
+• **separator**? : *boolean*
+
+*Inherited from [IAdaptiveCard](iadaptivecard.md).[separator](iadaptivecard.md#optional-separator)*
+
+*Defined in [schema.ts:38](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/schema.ts#L38)*
+
+___
+
+### `Optional` spacing
+
+• **spacing**? : *[Spacing](../enums/spacing.md)*
+
+*Inherited from [IAdaptiveCard](iadaptivecard.md).[spacing](iadaptivecard.md#optional-spacing)*
+
+*Defined in [schema.ts:37](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/schema.ts#L37)*
+
+___
+
+### `Optional` speak
+
+• **speak**? : *string*
+
+*Overrides [ICardElement](icardelement.md).[speak](icardelement.md#optional-speak)*
+
+*Defined in [schema.ts:171](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/schema.ts#L171)*
+
+___
+
+###  type
+
+• **type**: *"AdaptiveCard"*
+
+*Defined in [schema.ts:166](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/schema.ts#L166)*
+
+___
+
+### `Optional` version
+
+• **version**? : *IVersion | string*
+
+*Defined in [schema.ts:167](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/schema.ts#L167)*

--- a/source/nodejs/adaptivecards/docs/interfaces/icardelement.md
+++ b/source/nodejs/adaptivecards/docs/interfaces/icardelement.md
@@ -1,0 +1,72 @@
+[Adaptive Cards Javascript SDK](../README.md) › [ICardElement](icardelement.md)
+
+# Interface: ICardElement
+
+## Hierarchy
+
+* **ICardElement**
+
+  ↳ [IAdaptiveCard](iadaptivecard.md)
+
+## Indexable
+
+* \[ **propName**: *string*\]: any
+
+## Index
+
+### Properties
+
+* [height](icardelement.md#optional-height)
+* [horizontalAlignment](icardelement.md#optional-horizontalalignment)
+* [id](icardelement.md#optional-id)
+* [separator](icardelement.md#optional-separator)
+* [spacing](icardelement.md#optional-spacing)
+* [speak](icardelement.md#optional-speak)
+
+## Properties
+
+### `Optional` height
+
+• **height**? : *"auto" | "stretch"*
+
+*Defined in [schema.ts:39](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/schema.ts#L39)*
+
+___
+
+### `Optional` horizontalAlignment
+
+• **horizontalAlignment**? : *[HorizontalAlignment](../enums/horizontalalignment.md)*
+
+*Defined in [schema.ts:36](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/schema.ts#L36)*
+
+___
+
+### `Optional` id
+
+• **id**? : *string*
+
+*Defined in [schema.ts:34](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/schema.ts#L34)*
+
+___
+
+### `Optional` separator
+
+• **separator**? : *boolean*
+
+*Defined in [schema.ts:38](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/schema.ts#L38)*
+
+___
+
+### `Optional` spacing
+
+• **spacing**? : *[Spacing](../enums/spacing.md)*
+
+*Defined in [schema.ts:37](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/schema.ts#L37)*
+
+___
+
+### `Optional` speak
+
+• **speak**? : *string*
+
+*Defined in [schema.ts:35](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/schema.ts#L35)*

--- a/source/nodejs/adaptivecards/docs/interfaces/ifontsizedefinitions.md
+++ b/source/nodejs/adaptivecards/docs/interfaces/ifontsizedefinitions.md
@@ -1,0 +1,57 @@
+[Adaptive Cards Javascript SDK](../README.md) › [IFontSizeDefinitions](ifontsizedefinitions.md)
+
+# Interface: IFontSizeDefinitions
+
+## Hierarchy
+
+* **IFontSizeDefinitions**
+
+## Index
+
+### Properties
+
+* [default](ifontsizedefinitions.md#default)
+* [extraLarge](ifontsizedefinitions.md#extralarge)
+* [large](ifontsizedefinitions.md#large)
+* [medium](ifontsizedefinitions.md#medium)
+* [small](ifontsizedefinitions.md#small)
+
+## Properties
+
+###  default
+
+• **default**: *number*
+
+*Defined in [host-config.ts:540](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L540)*
+
+___
+
+###  extraLarge
+
+• **extraLarge**: *number*
+
+*Defined in [host-config.ts:543](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L543)*
+
+___
+
+###  large
+
+• **large**: *number*
+
+*Defined in [host-config.ts:542](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L542)*
+
+___
+
+###  medium
+
+• **medium**: *number*
+
+*Defined in [host-config.ts:541](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L541)*
+
+___
+
+###  small
+
+• **small**: *number*
+
+*Defined in [host-config.ts:539](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L539)*

--- a/source/nodejs/adaptivecards/docs/interfaces/ifontweightdefinitions.md
+++ b/source/nodejs/adaptivecards/docs/interfaces/ifontweightdefinitions.md
@@ -1,0 +1,39 @@
+[Adaptive Cards Javascript SDK](../README.md) › [IFontWeightDefinitions](ifontweightdefinitions.md)
+
+# Interface: IFontWeightDefinitions
+
+## Hierarchy
+
+* **IFontWeightDefinitions**
+
+## Index
+
+### Properties
+
+* [bolder](ifontweightdefinitions.md#bolder)
+* [default](ifontweightdefinitions.md#default)
+* [lighter](ifontweightdefinitions.md#lighter)
+
+## Properties
+
+###  bolder
+
+• **bolder**: *number*
+
+*Defined in [host-config.ts:549](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L549)*
+
+___
+
+###  default
+
+• **default**: *number*
+
+*Defined in [host-config.ts:548](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L548)*
+
+___
+
+###  lighter
+
+• **lighter**: *number*
+
+*Defined in [host-config.ts:547](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L547)*

--- a/source/nodejs/adaptivecards/docs/interfaces/iinput.md
+++ b/source/nodejs/adaptivecards/docs/interfaces/iinput.md
@@ -1,0 +1,54 @@
+[Adaptive Cards Javascript SDK](../README.md) › [IInput](iinput.md)
+
+# Interface: IInput
+
+## Hierarchy
+
+* **IInput**
+
+## Implemented by
+
+* [ChoiceSetInput](../classes/choicesetinput.md)
+* [DateInput](../classes/dateinput.md)
+* [Input](../classes/input.md)
+* [NumberInput](../classes/numberinput.md)
+* [TextInput](../classes/textinput.md)
+* [TimeInput](../classes/timeinput.md)
+* [ToggleInput](../classes/toggleinput.md)
+
+## Index
+
+### Properties
+
+* [id](iinput.md#id)
+* [value](iinput.md#value)
+
+### Methods
+
+* [validateValue](iinput.md#validatevalue)
+
+## Properties
+
+###  id
+
+• **id**: *string*
+
+*Defined in [shared.ts:17](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/shared.ts#L17)*
+
+___
+
+###  value
+
+• **value**: *string*
+
+*Defined in [shared.ts:18](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/shared.ts#L18)*
+
+## Methods
+
+###  validateValue
+
+▸ **validateValue**(): *boolean*
+
+*Defined in [shared.ts:19](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/shared.ts#L19)*
+
+**Returns:** *boolean*

--- a/source/nodejs/adaptivecards/docs/interfaces/ilineheightdefinitions.md
+++ b/source/nodejs/adaptivecards/docs/interfaces/ilineheightdefinitions.md
@@ -1,0 +1,57 @@
+[Adaptive Cards Javascript SDK](../README.md) › [ILineHeightDefinitions](ilineheightdefinitions.md)
+
+# Interface: ILineHeightDefinitions
+
+## Hierarchy
+
+* **ILineHeightDefinitions**
+
+## Index
+
+### Properties
+
+* [default](ilineheightdefinitions.md#default)
+* [extraLarge](ilineheightdefinitions.md#extralarge)
+* [large](ilineheightdefinitions.md#large)
+* [medium](ilineheightdefinitions.md#medium)
+* [small](ilineheightdefinitions.md#small)
+
+## Properties
+
+###  default
+
+• **default**: *number*
+
+*Defined in [host-config.ts:309](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L309)*
+
+___
+
+###  extraLarge
+
+• **extraLarge**: *number*
+
+*Defined in [host-config.ts:311](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L311)*
+
+___
+
+###  large
+
+• **large**: *number*
+
+*Defined in [host-config.ts:310](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L310)*
+
+___
+
+###  medium
+
+• **medium**: *number*
+
+*Defined in [host-config.ts:308](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L308)*
+
+___
+
+###  small
+
+• **small**: *number*
+
+*Defined in [host-config.ts:307](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L307)*

--- a/source/nodejs/adaptivecards/docs/interfaces/imarkdownprocessingresult.md
+++ b/source/nodejs/adaptivecards/docs/interfaces/imarkdownprocessingresult.md
@@ -1,0 +1,30 @@
+[Adaptive Cards Javascript SDK](../README.md) › [IMarkdownProcessingResult](imarkdownprocessingresult.md)
+
+# Interface: IMarkdownProcessingResult
+
+## Hierarchy
+
+* **IMarkdownProcessingResult**
+
+## Index
+
+### Properties
+
+* [didProcess](imarkdownprocessingresult.md#didprocess)
+* [outputHtml](imarkdownprocessingresult.md#optional-outputhtml)
+
+## Properties
+
+###  didProcess
+
+• **didProcess**: *boolean*
+
+*Defined in [card-elements.ts:6627](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6627)*
+
+___
+
+### `Optional` outputHtml
+
+• **outputHtml**? : *any*
+
+*Defined in [card-elements.ts:6628](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6628)*

--- a/source/nodejs/adaptivecards/docs/interfaces/iresourceinformation.md
+++ b/source/nodejs/adaptivecards/docs/interfaces/iresourceinformation.md
@@ -1,0 +1,30 @@
+[Adaptive Cards Javascript SDK](../README.md) › [IResourceInformation](iresourceinformation.md)
+
+# Interface: IResourceInformation
+
+## Hierarchy
+
+* **IResourceInformation**
+
+## Index
+
+### Properties
+
+* [mimeType](iresourceinformation.md#mimetype)
+* [url](iresourceinformation.md#url)
+
+## Properties
+
+###  mimeType
+
+• **mimeType**: *string*
+
+*Defined in [shared.ts:175](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/shared.ts#L175)*
+
+___
+
+###  url
+
+• **url**: *string*
+
+*Defined in [shared.ts:174](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/shared.ts#L174)*

--- a/source/nodejs/adaptivecards/docs/interfaces/iseparationdefinition.md
+++ b/source/nodejs/adaptivecards/docs/interfaces/iseparationdefinition.md
@@ -1,0 +1,39 @@
+[Adaptive Cards Javascript SDK](../README.md) › [ISeparationDefinition](iseparationdefinition.md)
+
+# Interface: ISeparationDefinition
+
+## Hierarchy
+
+* **ISeparationDefinition**
+
+## Index
+
+### Properties
+
+* [lineColor](iseparationdefinition.md#optional-linecolor)
+* [lineThickness](iseparationdefinition.md#optional-linethickness)
+* [spacing](iseparationdefinition.md#spacing)
+
+## Properties
+
+### `Optional` lineColor
+
+• **lineColor**? : *string*
+
+*Defined in [shared.ts:13](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/shared.ts#L13)*
+
+___
+
+### `Optional` lineThickness
+
+• **lineThickness**? : *number*
+
+*Defined in [shared.ts:12](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/shared.ts#L12)*
+
+___
+
+###  spacing
+
+• **spacing**: *number*
+
+*Defined in [shared.ts:11](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/shared.ts#L11)*

--- a/source/nodejs/adaptivecards/docs/interfaces/ityperegistration.md
+++ b/source/nodejs/adaptivecards/docs/interfaces/ityperegistration.md
@@ -1,0 +1,38 @@
+[Adaptive Cards Javascript SDK](../README.md) › [ITypeRegistration](ityperegistration.md)
+
+# Interface: ITypeRegistration <**T**>
+
+## Type parameters
+
+▪ **T**
+
+## Hierarchy
+
+* **ITypeRegistration**
+
+## Index
+
+### Properties
+
+* [createInstance](ityperegistration.md#createinstance)
+* [typeName](ityperegistration.md#typename)
+
+## Properties
+
+###  createInstance
+
+• **createInstance**: *function*
+
+*Defined in [card-elements.ts:6387](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6387)*
+
+#### Type declaration:
+
+▸ (): *T*
+
+___
+
+###  typeName
+
+• **typeName**: *string*
+
+*Defined in [card-elements.ts:6386](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/card-elements.ts#L6386)*

--- a/source/nodejs/adaptivecards/docs/interfaces/ivalidationerror.md
+++ b/source/nodejs/adaptivecards/docs/interfaces/ivalidationerror.md
@@ -1,0 +1,30 @@
+[Adaptive Cards Javascript SDK](../README.md) › [IValidationError](ivalidationerror.md)
+
+# Interface: IValidationError
+
+## Hierarchy
+
+* **IValidationError**
+
+## Index
+
+### Properties
+
+* [error](ivalidationerror.md#error)
+* [message](ivalidationerror.md#message)
+
+## Properties
+
+###  error
+
+• **error**: *[ValidationError](../enums/validationerror.md)*
+
+*Defined in [host-config.ts:8](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L8)*
+
+___
+
+###  message
+
+• **message**: *string*
+
+*Defined in [host-config.ts:9](https://github.com/microsoft/AdaptiveCards/blob/a61c5fd56/source/nodejs/adaptivecards/src/host-config.ts#L9)*

--- a/source/nodejs/adaptivecards/package-lock.json
+++ b/source/nodejs/adaptivecards/package-lock.json
@@ -1006,6 +1006,15 @@
 				"babel-plugin-jest-hoist": "^24.6.0"
 			}
 		},
+		"backbone": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.0.tgz",
+			"integrity": "sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==",
+			"dev": true,
+			"requires": {
+				"underscore": ">=1.8.3"
+			}
+		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -2731,6 +2740,17 @@
 				"readable-stream": "^2.0.0"
 			}
 		},
+		"fs-extra": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			}
+		},
 		"fs-write-stream-atomic": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
@@ -3548,6 +3568,12 @@
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.1"
 			}
+		},
+		"highlight.js": {
+			"version": "9.18.1",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.1.tgz",
+			"integrity": "sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg==",
+			"dev": true
 		},
 		"hmac-drbg": {
 			"version": "1.0.1",
@@ -4542,6 +4568,12 @@
 				}
 			}
 		},
+		"jquery": {
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+			"integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
+			"dev": true
+		},
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4631,6 +4663,15 @@
 			"dev": true,
 			"requires": {
 				"minimist": "^1.2.0"
+			}
+		},
+		"jsonfile": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.6"
 			}
 		},
 		"jsprim": {
@@ -4780,6 +4821,12 @@
 				"yallist": "^3.0.2"
 			}
 		},
+		"lunr": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.8.tgz",
+			"integrity": "sha512-oxMeX/Y35PNFuZoHp+jUj5OSEmLCaIH4KTFJh7a93cHBoFmpw2IoPs22VIz7vyO2YUnx2Tn9dzIwO2P/4quIRg==",
+			"dev": true
+		},
 		"make-dir": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -4836,6 +4883,12 @@
 			"requires": {
 				"object-visit": "^1.0.0"
 			}
+		},
+		"marked": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
+			"integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
+			"dev": true
 		},
 		"md5.js": {
 			"version": "1.3.5",
@@ -5722,6 +5775,12 @@
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 			"dev": true
 		},
+		"progress": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+			"dev": true
+		},
 		"promise-inflight": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -5942,6 +6001,15 @@
 			"dev": true,
 			"requires": {
 				"util.promisify": "^1.0.0"
+			}
+		},
+		"rechoir": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+			"dev": true,
+			"requires": {
+				"resolve": "^1.1.6"
 			}
 		},
 		"regex-not": {
@@ -6384,6 +6452,17 @@
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
 			"dev": true
+		},
+		"shelljs": {
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
+			"integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.0.0",
+				"interpret": "^1.0.0",
+				"rechoir": "^0.6.2"
+			}
 		},
 		"shellwords": {
 			"version": "0.1.1",
@@ -7150,10 +7229,84 @@
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
 			"dev": true
 		},
+		"typedoc": {
+			"version": "0.17.0-3",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.17.0-3.tgz",
+			"integrity": "sha512-DO2djkR4NHgzAWfNbJb2eQKsFMs+gOuYBXlQ8dOSCjkAK5DRI7ZywDufBGPUw7Ue9Qwi2Cw1DxLd3reDq8wFuQ==",
+			"dev": true,
+			"requires": {
+				"@types/minimatch": "3.0.3",
+				"fs-extra": "^8.1.0",
+				"handlebars": "^4.7.2",
+				"highlight.js": "^9.18.0",
+				"lodash": "^4.17.15",
+				"marked": "^0.8.0",
+				"minimatch": "^3.0.0",
+				"progress": "^2.0.3",
+				"shelljs": "^0.8.3",
+				"typedoc-default-themes": "0.8.0-0"
+			},
+			"dependencies": {
+				"handlebars": {
+					"version": "4.7.3",
+					"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.3.tgz",
+					"integrity": "sha512-SRGwSYuNfx8DwHD/6InAPzD6RgeruWLT+B8e8a7gGs8FWgHzlExpTFMEq2IA6QpAfOClpKHy6+8IqTjeBCu6Kg==",
+					"dev": true,
+					"requires": {
+						"neo-async": "^2.6.0",
+						"optimist": "^0.6.1",
+						"source-map": "^0.6.1",
+						"uglify-js": "^3.1.4"
+					}
+				},
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				}
+			}
+		},
+		"typedoc-default-themes": {
+			"version": "0.8.0-0",
+			"resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.8.0-0.tgz",
+			"integrity": "sha512-blFWppm5aKnaPOa1tpGO9MLu+njxq7P3rtkXK4QxJBNszA+Jg7x0b+Qx0liXU1acErur6r/iZdrwxp5DUFdSXw==",
+			"dev": true,
+			"requires": {
+				"backbone": "^1.4.0",
+				"jquery": "^3.4.1",
+				"lunr": "^2.3.8",
+				"underscore": "^1.9.1"
+			}
+		},
+		"typedoc-plugin-markdown": {
+			"version": "2.2.17",
+			"resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-2.2.17.tgz",
+			"integrity": "sha512-eE6cTeqsZIbjur6RG91Lhx1vTwjR49OHwVPRlmsxY3dthS4FNRL8sHxT5Y9pkosBwv1kSmNGQEPHjMYy1Ag6DQ==",
+			"dev": true,
+			"requires": {
+				"fs-extra": "^8.1.0",
+				"handlebars": "^4.7.3"
+			},
+			"dependencies": {
+				"handlebars": {
+					"version": "4.7.3",
+					"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.3.tgz",
+					"integrity": "sha512-SRGwSYuNfx8DwHD/6InAPzD6RgeruWLT+B8e8a7gGs8FWgHzlExpTFMEq2IA6QpAfOClpKHy6+8IqTjeBCu6Kg==",
+					"dev": true,
+					"requires": {
+						"neo-async": "^2.6.0",
+						"optimist": "^0.6.1",
+						"source-map": "^0.6.1",
+						"uglify-js": "^3.1.4"
+					}
+				}
+			}
+		},
 		"typescript": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-			"integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
 			"dev": true
 		},
 		"uglify-js": {
@@ -7166,6 +7319,12 @@
 				"commander": "~2.20.0",
 				"source-map": "~0.6.1"
 			}
+		},
+		"underscore": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.0.tgz",
+			"integrity": "sha512-D2q0sRbIZkDZqVtYpfP9R6lH66RrR7oe1xLpGY+CxYVPZ2etRUjKvVDLq5WFp+jK9jtflF511zv3/Yl936zHUw==",
+			"dev": true
 		},
 		"union-value": {
 			"version": "1.0.1",
@@ -7196,6 +7355,12 @@
 			"requires": {
 				"imurmurhash": "^0.1.4"
 			}
+		},
+		"universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"dev": true
 		},
 		"unpipe": {
 			"version": "1.0.0",

--- a/source/nodejs/adaptivecards/package.json
+++ b/source/nodejs/adaptivecards/package.json
@@ -28,7 +28,8 @@
 		"start": "webpack-dev-server --open",
 		"dts": "dts-generator --name adaptivecards --project . --out dist/adaptivecards.d.ts",
 		"lint": "tslint -c tslint.json 'src/**/*.{ts,tsx}'",
-		"release": "npm run clean && npm run build && npm test && webpack --mode=production && npm run dts"
+		"release": "npm run clean && npm run build && npm test && webpack --mode=production && npm run dts",
+		"docs": "typedoc"
 	},
 	"repository": {
 		"type": "git",
@@ -38,7 +39,9 @@
 		"@types/jest": "^23.3.14",
 		"jest": "^24.8.0",
 		"rimraf": "^2.6.3",
-		"typescript": "^3.5.3",
+		"typedoc": "^0.17.0-3",
+		"typedoc-plugin-markdown": "^2.2.17",
+		"typescript": "^3.8.3",
 		"webpack": "^4.38.0",
 		"webpack-cli": "^3.3.6",
 		"webpack-dev-server": "^3.7.2"

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as Enums from "./enums";
 import * as Shared from "./shared";
@@ -88,6 +88,14 @@ function createCardObjectInstance<T extends CardObject>(
     return result;
 }
 
+/**
+ * Instantiates an {@linkcode Action} for a {@linkcode CardElement}
+ * @param parent - The {@linkcode CardElement} for which to create an {@linkcode Action}
+ * @param json - A json object containing {@linkcode Action} properties
+ * @param forbiddenActionTypes - A list of action types that are not allowed to be created
+ * @param allowFallback - Whether to allow element fallback to occur
+ * @param errors - A list of validation errors encountered while parsing the action
+ */
 export function createActionInstance(
     parent: CardElement,
     json: any,
@@ -117,6 +125,13 @@ export function createActionInstance(
         errors);
 }
 
+/**
+ * Instantiates a {@linkcode CardElement}
+ * @param parent - The parent of this {@linkcode CardElement}
+ * @param json - A json object containing {@linkcode CardElement} properties
+ * @param allowFallback - Whether to allow element fallback to occur
+ * @param errors - A list of validation errors encountered while parsing the action
+ */
 export function createElementInstance(
     parent: CardElement,
     json: any,
@@ -145,9 +160,15 @@ export function createElementInstance(
         errors);
 }
 
+/**
+ * Represents an object that can be serialized to/from JSON
+ */
 export abstract class SerializableObject {
     private _rawProperties = {};
 
+    /**
+     *
+     */
     parse(json: any, errors?: Array<HostConfig.IValidationError>) {
         this._rawProperties = AdaptiveCard.enableFullJsonRoundTrip ? json : {};
     }

--- a/source/nodejs/adaptivecards/src/utils.ts
+++ b/source/nodejs/adaptivecards/src/utils.ts
@@ -4,28 +4,47 @@ import * as Enums from "./enums";
 import * as Shared from "./shared";
 import { HostConfig } from "./host-config";
 
+/**
+ * Generate a UUID prepended with "__ac-"
+ */
 export function generateUniqueId(): string {
     return "__ac-" + Shared.UUID.generate();
 }
 
+/**
+ * @param value - string to test
+ * @return `true` if `string` is `undefined`, `null`, or `""`
+ */
 export function isNullOrEmpty(value: string): boolean {
     return value === undefined || value === null || value === "";
 }
 
+/**
+ * Appends `child` to `node` if `child` is valid
+ */
 export function appendChild(node: Node, child: Node) {
     if (child != null && child != undefined) {
         node.appendChild(child);
     }
 }
 
+/**
+ * @return `obj.toString()` if `obj` is of type `string`. Otherwise, returns `defaultValue || undefined`
+ */
 export function getStringValue(obj: any, defaultValue: string = undefined): string {
     return typeof obj === "string" ? obj.toString() : defaultValue;
 }
 
+/**
+ * @return `obj` if `obj` is of type `number`. Otherwise, returns `defaultValue || undefined`
+ */
 export function getNumberValue(obj: any, defaultValue: number = undefined): number {
     return typeof obj === "number" ? obj : defaultValue;
 }
 
+/**
+ * @return `value` if it's a `boolean` or if it's `"true"` or `"false"`. Otherwise returns `defaultValue || undefined`
+ */
 export function getBoolValue(value: any, defaultValue: boolean): boolean {
     if (typeof value === "boolean") {
         return value;
@@ -44,6 +63,22 @@ export function getBoolValue(value: any, defaultValue: boolean): boolean {
     return defaultValue;
 }
 
+/**
+ * Convert from a `string` to an `enum` value
+ * ``` typescript
+ * enum Test {
+ *      Pass,
+ *      Fail,
+ *      Unknown
+ * }
+ * getEnumValue(Test, "Fail", Test.Unknown); // returns 1 (Test.Fail)
+ * getEnumValue(Test, "Not an enum value", Test.Unknown); // returns 2 (Test.Unknown)
+ * ```
+ * @param targetEnum - `enum` to resolve against
+ * @param name - `string` to look up
+ * @param defaultValue - value to use if lookup fails
+ * @return Numeric `enum` value if lookup succeeded. Otherwise `defaultValue`
+ */
 export function getEnumValue(targetEnum: { [s: number]: string }, name: string, defaultValue: number): number {
     if (isNullOrEmpty(name)) {
         return defaultValue;
@@ -66,6 +101,12 @@ export function getEnumValue(targetEnum: { [s: number]: string }, name: string, 
     return defaultValue;
 }
 
+/**
+ * @param target - `object` to set property on
+ * @param propertyName - Name of property to set
+ * @param propertyValue - Value to set property to
+ * @param defaultValue - Value to use if `propertyValue` isn't valid
+ */
 export function setProperty(target: object, propertyName: string, propertyValue: any, defaultValue: any = undefined) {
     if (propertyValue === null || propertyValue === undefined || propertyValue === defaultValue) {
         delete target[propertyName];
@@ -75,6 +116,12 @@ export function setProperty(target: object, propertyName: string, propertyValue:
     }
 }
 
+/**
+ * @param target - `object` to set property on
+ * @param propertyName - Name of property to set
+ * @param propertyValue - Value to set property to
+ * @param defaultValue - Value to use if `propertyValue` isn't valid
+ */
 export function setNumberProperty(target: object, propertyName: string, propertyValue: number, defaultValue: number = undefined) {
     if (propertyValue === null || propertyValue === undefined || propertyValue === defaultValue || isNaN(propertyValue)) {
         delete target[propertyName];

--- a/source/nodejs/adaptivecards/typedoc.json
+++ b/source/nodejs/adaptivecards/typedoc.json
@@ -1,0 +1,17 @@
+{
+	"name": "Adaptive Cards Javascript SDK",
+	"inputFiles": "./src",
+	"mode": "library",
+	"out": "docs",
+	"exclude": [
+		"__tests__"
+	],
+	"excludeNotExported": true,
+	"excludePrivate": true,
+	"readme": "none",
+	"plugin": [
+		"typedoc-plugin-markdown"
+	],
+	"theme": "markdown",
+	"stripInternal": true
+}


### PR DESCRIPTION
## Description
Recently I did a little side project standing up the scaffolding for an Adaptive Cards linting tool. In writing the tool, I found that our docs are sorely lacking at the API level (this isn't unique to our Typescript codebase -- we should visit each platform in turn). Thankfully, for Typescript projects, there's a solution: [TypeDoc](https://typedoc.org/). TypeDoc uses Typescript's type information in combination with Typescript's flavor of [JSDoc](https://www.typescriptlang.org/docs/handbook/type-checking-javascript-files.html#supported-jsdoc) comments to generate API docs. By default, the output is static HTML, but through a plugin we're able to get markdown output.

The [initial commit](https://github.com/microsoft/AdaptiveCards/pull/3893/commits/a61c5fd56bd6a9d95f319d9a9d73738aca111c6e) here has all of the relevant configuration and setup (this is the part that really needs review), and the [second commit](https://github.com/microsoft/AdaptiveCards/pull/3893/commits/6a70a4ae37f13dd8e241ec9a5e88b1747e5df91d) contains the output. A couple of notes:

* Because of the way our source is structured, the shipping version of TypeDoc doesn't generate great structure (it's assumed that you have one module per file *or* that each file is an independent collection of code). `typedoc@next` has support for `library` output, which actually merges everything across files. This is a much better structure, even if we have to depend on prerelease software for now.
* There are a lot of [options](https://typedoc.org/guides/options/) that can be tweaked. I chose what I believe to the be the right set of defaults
* For now we don't have any CI provisions for doc generation. We need to decide how we want to distribute the docs. We can either continue to have them checked in to our repo and point our official docs to them (easy but perhaps a bit odd, though it may endear us to some devs), *or* we can consume them into our website (harder, but more official-looking).
* The docs are generated based on type information, but are greatly aided by additional comments. Bonus points: markdown is supported in comments. For a decent example, check out `getEnumValue`: https://github.com/microsoft/AdaptiveCards/blob/6a70a4ae37f13dd8e241ec9a5e88b1747e5df91d/source/nodejs/adaptivecards/src/utils.ts#L66-L82 and the resulting [output](https://github.com/microsoft/AdaptiveCards/blob/paulcam/ac-docs-infra/source/nodejs/adaptivecards/docs/README.md#getenumvalue).
* The easiest way to see the output is probably to just navigate to the first run of docs [here](https://github.com/microsoft/AdaptiveCards/tree/paulcam/ac-docs-infra/source/nodejs/adaptivecards/docs).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3893)