### PR TITLE
[JS] Add docs and generation support to templating library

### DIFF
--- a/source/nodejs/adaptivecards-templating/docs/README.md
+++ b/source/nodejs/adaptivecards-templating/docs/README.md
@@ -1,0 +1,13 @@
+[Adaptive Cards Templating Javascript SDK](README.md)
+
+# Adaptive Cards Templating Javascript SDK
+
+## Index
+
+### Classes
+
+* [Binding](classes/binding.md)
+* [EvaluationContext](classes/evaluationcontext.md)
+* [ExpressionParser](classes/expressionparser.md)
+* [GlobalSettings](classes/globalsettings.md)
+* [Template](classes/template.md)

--- a/source/nodejs/adaptivecards-templating/docs/classes/binding.md
+++ b/source/nodejs/adaptivecards-templating/docs/classes/binding.md
@@ -1,0 +1,72 @@
+[Adaptive Cards Templating Javascript SDK](../README.md) › [Binding](binding.md)
+
+# Class: Binding
+
+## Hierarchy
+
+* **Binding**
+
+## Index
+
+### Constructors
+
+* [constructor](binding.md#constructor)
+
+### Properties
+
+* [allowNull](binding.md#allownull)
+* [expressionString](binding.md#expressionstring)
+
+### Methods
+
+* [evaluate](binding.md#evaluate)
+
+## Constructors
+
+###  constructor
+
+\+ **new Binding**(`expressionString`: string, `expression`: EvaluationNode, `allowNull`: boolean): *[Binding](binding.md)*
+
+*Defined in [expression-parser.ts:874](https://github.com/microsoft/AdaptiveCards/blob/689f58229/source/nodejs/adaptivecards-templating/src/expression-parser.ts#L874)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`expressionString` | string | - |
+`expression` | EvaluationNode | - |
+`allowNull` | boolean | true |
+
+**Returns:** *[Binding](binding.md)*
+
+## Properties
+
+###  allowNull
+
+• **allowNull**: *boolean*
+
+*Defined in [expression-parser.ts:875](https://github.com/microsoft/AdaptiveCards/blob/689f58229/source/nodejs/adaptivecards-templating/src/expression-parser.ts#L875)*
+
+___
+
+###  expressionString
+
+• **expressionString**: *string*
+
+*Defined in [expression-parser.ts:875](https://github.com/microsoft/AdaptiveCards/blob/689f58229/source/nodejs/adaptivecards-templating/src/expression-parser.ts#L875)*
+
+## Methods
+
+###  evaluate
+
+▸ **evaluate**(`context`: [EvaluationContext](evaluationcontext.md)): *LiteralValue*
+
+*Defined in [expression-parser.ts:877](https://github.com/microsoft/AdaptiveCards/blob/689f58229/source/nodejs/adaptivecards-templating/src/expression-parser.ts#L877)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [EvaluationContext](evaluationcontext.md) |
+
+**Returns:** *LiteralValue*

--- a/source/nodejs/adaptivecards-templating/docs/classes/evaluationcontext.md
+++ b/source/nodejs/adaptivecards-templating/docs/classes/evaluationcontext.md
@@ -1,0 +1,158 @@
+[Adaptive Cards Templating Javascript SDK](../README.md) › [EvaluationContext](evaluationcontext.md)
+
+# Class: EvaluationContext
+
+## Hierarchy
+
+* **EvaluationContext**
+
+## Index
+
+### Properties
+
+* [$data](evaluationcontext.md#data)
+* [$index](evaluationcontext.md#index)
+* [$root](evaluationcontext.md#root)
+
+### Accessors
+
+* [currentDataContext](evaluationcontext.md#currentdatacontext)
+
+### Methods
+
+* [getFunction](evaluationcontext.md#getfunction)
+* [isReservedField](evaluationcontext.md#isreservedfield)
+* [registerFunction](evaluationcontext.md#registerfunction)
+* [restoreLastState](evaluationcontext.md#restorelaststate)
+* [saveState](evaluationcontext.md#savestate)
+* [unregisterFunction](evaluationcontext.md#unregisterfunction)
+* [init](evaluationcontext.md#static-init)
+
+## Properties
+
+###  $data
+
+• **$data**: *any*
+
+*Defined in [expression-parser.ts:340](https://github.com/microsoft/AdaptiveCards/blob/689f58229/source/nodejs/adaptivecards-templating/src/expression-parser.ts#L340)*
+
+___
+
+###  $index
+
+• **$index**: *number*
+
+*Defined in [expression-parser.ts:341](https://github.com/microsoft/AdaptiveCards/blob/689f58229/source/nodejs/adaptivecards-templating/src/expression-parser.ts#L341)*
+
+___
+
+###  $root
+
+• **$root**: *any*
+
+*Defined in [expression-parser.ts:339](https://github.com/microsoft/AdaptiveCards/blob/689f58229/source/nodejs/adaptivecards-templating/src/expression-parser.ts#L339)*
+
+## Accessors
+
+###  currentDataContext
+
+• **get currentDataContext**(): *any*
+
+*Defined in [expression-parser.ts:380](https://github.com/microsoft/AdaptiveCards/blob/689f58229/source/nodejs/adaptivecards-templating/src/expression-parser.ts#L380)*
+
+**Returns:** *any*
+
+## Methods
+
+###  getFunction
+
+▸ **getFunction**(`name`: string): *FunctionCallback*
+
+*Defined in [expression-parser.ts:351](https://github.com/microsoft/AdaptiveCards/blob/689f58229/source/nodejs/adaptivecards-templating/src/expression-parser.ts#L351)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *FunctionCallback*
+
+___
+
+###  isReservedField
+
+▸ **isReservedField**(`name`: string): *boolean*
+
+*Defined in [expression-parser.ts:361](https://github.com/microsoft/AdaptiveCards/blob/689f58229/source/nodejs/adaptivecards-templating/src/expression-parser.ts#L361)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *boolean*
+
+___
+
+###  registerFunction
+
+▸ **registerFunction**(`name`: string, `callback`: FunctionCallback): *void*
+
+*Defined in [expression-parser.ts:343](https://github.com/microsoft/AdaptiveCards/blob/689f58229/source/nodejs/adaptivecards-templating/src/expression-parser.ts#L343)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+`callback` | FunctionCallback |
+
+**Returns:** *void*
+
+___
+
+###  restoreLastState
+
+▸ **restoreLastState**(): *void*
+
+*Defined in [expression-parser.ts:369](https://github.com/microsoft/AdaptiveCards/blob/689f58229/source/nodejs/adaptivecards-templating/src/expression-parser.ts#L369)*
+
+**Returns:** *void*
+
+___
+
+###  saveState
+
+▸ **saveState**(): *void*
+
+*Defined in [expression-parser.ts:365](https://github.com/microsoft/AdaptiveCards/blob/689f58229/source/nodejs/adaptivecards-templating/src/expression-parser.ts#L365)*
+
+**Returns:** *void*
+
+___
+
+###  unregisterFunction
+
+▸ **unregisterFunction**(`name`: string): *void*
+
+*Defined in [expression-parser.ts:347](https://github.com/microsoft/AdaptiveCards/blob/689f58229/source/nodejs/adaptivecards-templating/src/expression-parser.ts#L347)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`name` | string |
+
+**Returns:** *void*
+
+___
+
+### `Static` init
+
+▸ **init**(): *void*
+
+*Defined in [expression-parser.ts:201](https://github.com/microsoft/AdaptiveCards/blob/689f58229/source/nodejs/adaptivecards-templating/src/expression-parser.ts#L201)*
+
+**Returns:** *void*

--- a/source/nodejs/adaptivecards-templating/docs/classes/expressionparser.md
+++ b/source/nodejs/adaptivecards-templating/docs/classes/expressionparser.md
@@ -1,0 +1,49 @@
+[Adaptive Cards Templating Javascript SDK](../README.md) › [ExpressionParser](expressionparser.md)
+
+# Class: ExpressionParser
+
+## Hierarchy
+
+* **ExpressionParser**
+
+## Index
+
+### Constructors
+
+* [constructor](expressionparser.md#constructor)
+
+### Methods
+
+* [parseBinding](expressionparser.md#static-parsebinding)
+
+## Constructors
+
+###  constructor
+
+\+ **new ExpressionParser**(`tokens`: Token[]): *[ExpressionParser](expressionparser.md)*
+
+*Defined in [expression-parser.ts:867](https://github.com/microsoft/AdaptiveCards/blob/689f58229/source/nodejs/adaptivecards-templating/src/expression-parser.ts#L867)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`tokens` | Token[] |
+
+**Returns:** *[ExpressionParser](expressionparser.md)*
+
+## Methods
+
+### `Static` parseBinding
+
+▸ **parseBinding**(`expressionString`: string): *[Binding](binding.md)*
+
+*Defined in [expression-parser.ts:857](https://github.com/microsoft/AdaptiveCards/blob/689f58229/source/nodejs/adaptivecards-templating/src/expression-parser.ts#L857)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`expressionString` | string |
+
+**Returns:** *[Binding](binding.md)*

--- a/source/nodejs/adaptivecards-templating/docs/classes/globalsettings.md
+++ b/source/nodejs/adaptivecards-templating/docs/classes/globalsettings.md
@@ -1,0 +1,21 @@
+[Adaptive Cards Templating Javascript SDK](../README.md) › [GlobalSettings](globalsettings.md)
+
+# Class: GlobalSettings
+
+## Hierarchy
+
+* **GlobalSettings**
+
+## Index
+
+### Properties
+
+* [undefinedExpressionValueSubstitutionString](globalsettings.md#static-optional-undefinedexpressionvaluesubstitutionstring)
+
+## Properties
+
+### `Static` `Optional` undefinedExpressionValueSubstitutionString
+
+▪ **undefinedExpressionValueSubstitutionString**? : *string* = undefined
+
+*Defined in [shared.ts:4](https://github.com/microsoft/AdaptiveCards/blob/689f58229/source/nodejs/adaptivecards-templating/src/shared.ts#L4)*

--- a/source/nodejs/adaptivecards-templating/docs/classes/template.md
+++ b/source/nodejs/adaptivecards-templating/docs/classes/template.md
@@ -1,0 +1,61 @@
+[Adaptive Cards Templating Javascript SDK](../README.md) › [Template](template.md)
+
+# Class: Template
+
+## Hierarchy
+
+* **Template**
+
+## Index
+
+### Constructors
+
+* [constructor](template.md#constructor)
+
+### Properties
+
+* [preparedPayload](template.md#preparedpayload)
+
+### Methods
+
+* [expand](template.md#expand)
+
+## Constructors
+
+###  constructor
+
+\+ **new Template**(`payload`: any): *[Template](template.md)*
+
+*Defined in [template-engine.ts:284](https://github.com/microsoft/AdaptiveCards/blob/689f58229/source/nodejs/adaptivecards-templating/src/template-engine.ts#L284)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`payload` | any |
+
+**Returns:** *[Template](template.md)*
+
+## Properties
+
+###  preparedPayload
+
+• **preparedPayload**: *any*
+
+*Defined in [template-engine.ts:284](https://github.com/microsoft/AdaptiveCards/blob/689f58229/source/nodejs/adaptivecards-templating/src/template-engine.ts#L284)*
+
+## Methods
+
+###  expand
+
+▸ **expand**(`context`: [EvaluationContext](evaluationcontext.md)): *any*
+
+*Defined in [template-engine.ts:290](https://github.com/microsoft/AdaptiveCards/blob/689f58229/source/nodejs/adaptivecards-templating/src/template-engine.ts#L290)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [EvaluationContext](evaluationcontext.md) |
+
+**Returns:** *any*

--- a/source/nodejs/adaptivecards-templating/package-lock.json
+++ b/source/nodejs/adaptivecards-templating/package-lock.json
@@ -444,6 +444,15 @@
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
 			"dev": true
 		},
+		"backbone": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.0.tgz",
+			"integrity": "sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==",
+			"dev": true,
+			"requires": {
+				"underscore": ">=1.8.3"
+			}
+		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -1884,6 +1893,17 @@
 				"readable-stream": "^2.0.0"
 			}
 		},
+		"fs-extra": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			}
+		},
 		"fs-write-stream-atomic": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
@@ -2582,6 +2602,50 @@
 			"integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==",
 			"dev": true
 		},
+		"handlebars": {
+			"version": "4.7.6",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
+			"integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+			"dev": true,
+			"requires": {
+				"minimist": "^1.2.5",
+				"neo-async": "^2.6.0",
+				"source-map": "^0.6.1",
+				"uglify-js": "^3.1.4",
+				"wordwrap": "^1.0.0"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+					"dev": true,
+					"optional": true
+				},
+				"minimist": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"uglify-js": {
+					"version": "3.9.0",
+					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.0.tgz",
+					"integrity": "sha512-j5wNQBWaql8gr06dOUrfaohHlscboQZ9B8sNsoK5o4sBjm7Ht9dxSbrMXyktQpA16Acaij8AcoozteaPYZON0g==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"commander": "~2.20.3"
+					}
+				}
+			}
+		},
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -2639,6 +2703,12 @@
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.1"
 			}
+		},
+		"highlight.js": {
+			"version": "9.18.1",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.1.tgz",
+			"integrity": "sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg==",
+			"dev": true
 		},
 		"hmac-drbg": {
 			"version": "1.0.1",
@@ -3027,6 +3097,12 @@
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 			"dev": true
 		},
+		"jquery": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
+			"integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==",
+			"dev": true
+		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -3052,6 +3128,15 @@
 			"dev": true,
 			"requires": {
 				"minimist": "^1.2.0"
+			}
+		},
+		"jsonfile": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.6"
 			}
 		},
 		"killable": {
@@ -3123,6 +3208,12 @@
 				"yallist": "^3.0.2"
 			}
 		},
+		"lunr": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.8.tgz",
+			"integrity": "sha512-oxMeX/Y35PNFuZoHp+jUj5OSEmLCaIH4KTFJh7a93cHBoFmpw2IoPs22VIz7vyO2YUnx2Tn9dzIwO2P/4quIRg==",
+			"dev": true
+		},
 		"make-dir": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -3162,6 +3253,12 @@
 			"requires": {
 				"object-visit": "^1.0.0"
 			}
+		},
+		"marked": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
+			"integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
+			"dev": true
 		},
 		"md5.js": {
 			"version": "1.3.5",
@@ -3768,6 +3865,12 @@
 			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
 			"dev": true
 		},
+		"path-parse": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"dev": true
+		},
 		"path-to-regexp": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -3861,6 +3964,12 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true
+		},
+		"progress": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
 			"dev": true
 		},
 		"promise-inflight": {
@@ -4033,6 +4142,15 @@
 				"readable-stream": "^2.0.2"
 			}
 		},
+		"rechoir": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+			"dev": true,
+			"requires": {
+				"resolve": "^1.1.6"
+			}
+		},
 		"regex-not": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -4078,6 +4196,15 @@
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
 			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
 			"dev": true
+		},
+		"resolve": {
+			"version": "1.15.1",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+			"integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+			"dev": true,
+			"requires": {
+				"path-parse": "^1.0.6"
+			}
 		},
 		"resolve-cwd": {
 			"version": "2.0.0",
@@ -4363,6 +4490,17 @@
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
 			"dev": true
+		},
+		"shelljs": {
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
+			"integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.0.0",
+				"interpret": "^1.0.0",
+				"rechoir": "^0.6.2"
+			}
 		},
 		"signal-exit": {
 			"version": "3.0.2",
@@ -4940,6 +5078,54 @@
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
 			"dev": true
 		},
+		"typedoc": {
+			"version": "0.17.0-3",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.17.0-3.tgz",
+			"integrity": "sha512-DO2djkR4NHgzAWfNbJb2eQKsFMs+gOuYBXlQ8dOSCjkAK5DRI7ZywDufBGPUw7Ue9Qwi2Cw1DxLd3reDq8wFuQ==",
+			"dev": true,
+			"requires": {
+				"@types/minimatch": "3.0.3",
+				"fs-extra": "^8.1.0",
+				"handlebars": "^4.7.2",
+				"highlight.js": "^9.18.0",
+				"lodash": "^4.17.15",
+				"marked": "^0.8.0",
+				"minimatch": "^3.0.0",
+				"progress": "^2.0.3",
+				"shelljs": "^0.8.3",
+				"typedoc-default-themes": "0.8.0-0"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				}
+			}
+		},
+		"typedoc-default-themes": {
+			"version": "0.8.0-0",
+			"resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.8.0-0.tgz",
+			"integrity": "sha512-blFWppm5aKnaPOa1tpGO9MLu+njxq7P3rtkXK4QxJBNszA+Jg7x0b+Qx0liXU1acErur6r/iZdrwxp5DUFdSXw==",
+			"dev": true,
+			"requires": {
+				"backbone": "^1.4.0",
+				"jquery": "^3.4.1",
+				"lunr": "^2.3.8",
+				"underscore": "^1.9.1"
+			}
+		},
+		"typedoc-plugin-markdown": {
+			"version": "2.2.17",
+			"resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-2.2.17.tgz",
+			"integrity": "sha512-eE6cTeqsZIbjur6RG91Lhx1vTwjR49OHwVPRlmsxY3dthS4FNRL8sHxT5Y9pkosBwv1kSmNGQEPHjMYy1Ag6DQ==",
+			"dev": true,
+			"requires": {
+				"fs-extra": "^8.1.0",
+				"handlebars": "^4.7.3"
+			}
+		},
 		"typescript": {
 			"version": "3.5.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
@@ -4970,6 +5156,12 @@
 				}
 			}
 		},
+		"underscore": {
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
+			"integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==",
+			"dev": true
+		},
 		"union-value": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -4999,6 +5191,12 @@
 			"requires": {
 				"imurmurhash": "^0.1.4"
 			}
+		},
+		"universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"dev": true
 		},
 		"unpipe": {
 			"version": "1.0.0",
@@ -5525,6 +5723,12 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+			"dev": true
+		},
+		"wordwrap": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
 			"dev": true
 		},
 		"worker-farm": {

--- a/source/nodejs/adaptivecards-templating/package.json
+++ b/source/nodejs/adaptivecards-templating/package.json
@@ -19,10 +19,13 @@
 		"start": "webpack-dev-server --open",
 		"dts": "dts-generator --name adaptivecards-templating --project . --out dist/adaptivecards-templating.d.ts",
 		"lint": "tslint -c tslint.json 'src/**/*.{ts,tsx}'",
-		"release": "npm run build && webpack --mode=production && npm run dts"
+		"release": "npm run build && webpack --mode=production && npm run dts",
+		"docs": "npx typedoc"
 	},
 	"devDependencies": {
 		"rimraf": "^2.6.2",
+		"typedoc": "^0.17.0-3",
+		"typedoc-plugin-markdown": "^2.2.17",
 		"typescript": "^3.5.3",
 		"webpack": "^4.38.0",
 		"webpack-cli": "^3.3.6",

--- a/source/nodejs/adaptivecards-templating/typedoc.json
+++ b/source/nodejs/adaptivecards-templating/typedoc.json
@@ -1,0 +1,17 @@
+{
+	"name": "Adaptive Cards Templating Javascript SDK",
+	"inputFiles": "./src",
+	"mode": "library",
+	"out": "docs",
+	"exclude": [
+		"__tests__"
+	],
+	"excludeNotExported": true,
+	"excludePrivate": true,
+	"readme": "none",
+	"plugin": [
+		"typedoc-plugin-markdown"
+	],
+	"theme": "markdown",
+	"stripInternal": true
+}

--- a/source/nodejs/adaptivecards/package.json
+++ b/source/nodejs/adaptivecards/package.json
@@ -29,7 +29,7 @@
 		"dts": "dts-generator --name adaptivecards --project . --out dist/adaptivecards.d.ts",
 		"lint": "tslint -c tslint.json 'src/**/*.{ts,tsx}'",
 		"release": "npm run clean && npm run build && npm test && webpack --mode=production && npm run dts",
-		"docs": "typedoc"
+		"docs": "npx typedoc"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
## Description
As per the last docs PR, this one adds doc generation support and generated docs (as two commits) to the `adaptivecards-templating` project. Note that I have not opted to make this project-wide via lerna. This is because it looks like we need to reconcile our projects before hoisting our dependencies up.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3925)