### PR TITLE
[Proposed] Update issue templates to include one for Question types

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,36 @@
+---
+name: Question
+about: Template for questions for the AdaptiveCards feature team or community
+title: "[Question]Type your question here"
+labels: Question
+assignees: almedina-ms, dclaux, jwoo-msft, matthidinger, paulcam206, RebeccaAnne,
+  shalinijoshi19
+
+---
+
+# Tried StackOverflow?
+If you just have a question, please post [on StackOverflow instead](https://stackoverflow.com/questions/tagged/adaptive-cards). If you prefer github instead, please continue on..
+
+# Platform
+What platform is your question related to? Specify in the issue title please. Eg:
+* .NET HTML
+* .NET WPF
+* Android
+* iOS
+* JavaScript
+* UWP
+* React etc 
+
+# Author or host
+
+Are you an author (like sending something to Outlook), or a host that is rendering your own cards? If host, please specify the corresponding host (app) name.
+
+If you're an author, who are you sending cards to?
+
+# Version of SDK
+
+What version are you using? Ex: NuGet 1.0.2, or latest master, etc...
+
+# Details
+
+Explain your issue/question.


### PR DESCRIPTION
Since we seem to have a question label here, and are on top of github issues more proposing to have a similar question template added. 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3955)