### PR TITLE
[JS][Renderer][Accessibility] Action.OpenUrl rendered buttons should have the "link" aria role

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -4206,6 +4206,13 @@ export class OpenUrlAction extends Action {
         this.url = Utils.getStringValue(json["url"]);
     }
 
+    render(baseCssClass: string = "ac-pushButton") {
+        super.render(baseCssClass);
+
+        // OpenUrl actions behave like a hyperlink. Make sure screenreaders treat them that way.
+        this.renderedElement.setAttribute("role", "link");
+    }
+
     getHref(): string {
         return this.url;
     }


### PR DESCRIPTION
# Details
Currently all actions get rendered as `<button>` elements with role "button". When a button opens a link, as is the case for `Action.OpenUrl`, it should have the "link" role instead.

**Important**
Just a note on the weirdness of this PR. I used a new tool to create this PR, which converted the issue into a PR rather than creating a new PR. I won't use it again, but it's why this looks weird. 👍 

# Description
Simple fix to have `OpenUrlAction` objects set `role="link"`.

# How verified
* Accessibility Insights
* F12 tools
* Tests (adding shortly)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3914)