### PR TITLE
[.NET] Stub out _CheckForGenerateAppxPackageOnBuild target

### DIFF
--- a/source/dotnet/Library/AdaptiveCards/AdaptiveCards.csproj
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveCards.csproj
@@ -54,4 +54,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
+
+  <!-- workaround for multiple TargetFramework regression -->
+  <Target Name="_CheckForGenerateAppxPackageOnBuild" />
 </Project>


### PR DESCRIPTION
## Description

This is a workaround for a [regression](https://developercommunity.visualstudio.com/content/problem/954242/appx-packaging-project-fails-with-multi-targeted-l.html) in VS2019 16.5.0. A fix (one that was recommended in the report link) has been checked in, but won't ship for a while, so this workaround will have to do for now.

## How Verified
* Built clean locally
* Built clean in CI

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3966)