### PR TITLE
Adding config.yml to enable Question template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+--- 
+blank_issues_enabled: true
+contact_links: 
+  - 
+    about: "Please ask and answer usage questions on Stack Overflow."
+    name: Question
+    url: "https://stackoverflow.com/questions/tagged/adaptive-cards"
+  - 


### PR DESCRIPTION
## Description
Following along the lines of the [typescript repo](https://github.com/microsoft/TypeScript/issues/new/choose) adding a redirect-only question template via config.yml that redirects the community to StackOverflow for questions.
For now, allowing for blank issues as a catch-all but eventually goal is to only enable issues that fit our allowed templates for better project management/tracking.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3968)