### PR TITLE
Fixed RichTextBlock's TextRun's Color Issue

### DIFF
--- a/samples/v1.2/Elements/RichTextBlock.json
+++ b/samples/v1.2/Elements/RichTextBlock.json
@@ -9,12 +9,12 @@
 				"This is the first inline. ",
 				{
 					"type": "TextRun",
-					"text": "We support colors, ",
+					"text": "We support colors,",
 					"color": "good"
 				},
 				{
 					"type": "TextRun",
-					"text": "both regular and subtle. ",
+					"text": " both regular and subtle. ",
 					"isSubtle": true
 				},
 				{

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRichTextBlockRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRichTextBlockRenderer.mm
@@ -169,7 +169,7 @@
                     NSParagraphStyleAttributeName : paragraphStyle,
                     NSForegroundColorAttributeName : foregroundColor,
                 }
-                                        range:NSMakeRange(0, textRunContent.length - 1)];
+                                        range:NSMakeRange(0, textRunContent.length)];
 
                 [content appendAttributedString:textRunContent];
             }


### PR DESCRIPTION
## Related Issue
Fixed #3953 

## Description
1. Color attribute did not applied to the end of string.
2. Updated test payload to remove space at the end; the spacing at the end enabled false negative; the look of card hasn't changed since overall text is maintained.

## How Verified
1. Tested all RichTextBlock json for verification.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/3987)