### PR TITLE
[JS] Only assign img alt text if it's supplied

### DIFF
--- a/source/nodejs/adaptivecards/src/__tests__/components/image.spec.ts
+++ b/source/nodejs/adaptivecards/src/__tests__/components/image.spec.ts
@@ -5,4 +5,5 @@ import {Image} from "../../card-elements";
 test('Image should be instantiated', ()=>{
     const image = new Image();
     expect(image).toEqual(expect.anything());
+    expect(image.altText).toBeUndefined();
 })

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -1699,7 +1699,11 @@ export class Image extends CardElement {
 
             imageElement.style.backgroundColor = <string>Utils.stringToCssColor(this.backgroundColor);
             imageElement.src = <string>this.preProcessPropertyValue(Image.urlProperty);
-            imageElement.alt = <string>this.preProcessPropertyValue(Image.altTextProperty);
+
+            const altTextProperty = this.preProcessPropertyValue(Image.altTextProperty);
+            if (altTextProperty) {
+                imageElement.alt = <string>altTextProperty;
+            }
 
             element.appendChild(imageElement);
         }


### PR DESCRIPTION
## Related Issue
Fixes #2235

## Description
When a card author fails to supply alt text, we actually create an img element with the alt text set to `"undefined"` rather than not set the property in the first place.

## How Verified
How you verified the fix, including one or all of the following: 
1. New unit test
2. Local repro and inspection with F12 tools

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4010)