### PR TITLE
[JS] Paint aria-current attribute on selected ChoiceSet option

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -2806,18 +2806,18 @@ export class ChoiceSetInput extends Input {
     private static uniqueCategoryCounter = 0;
 
     private static getUniqueCategoryName(): string {
-        let uniqueCwtegoryName = "__ac-category" + ChoiceSetInput.uniqueCategoryCounter;
+        let uniqueCategoryName = "__ac-category" + ChoiceSetInput.uniqueCategoryCounter;
 
         ChoiceSetInput.uniqueCategoryCounter++;
 
-        return uniqueCwtegoryName;
+        return uniqueCategoryName;
     }
 
     private _uniqueCategoryName: string;
     private _selectElement: HTMLSelectElement;
     private _toggleInputs: HTMLInputElement[];
 
-    private renderCompundInput(cssClassName: string, type: "checkbox" | "radio", defaultValues: string[] | undefined): HTMLElement {
+    private renderCompoundInput(cssClassName: string, type: "checkbox" | "radio", defaultValues: string[] | undefined): HTMLElement {
         let element = document.createElement("div");
         element.className = this.hostConfig.makeCssClassName("ac-input", cssClassName);
         element.style.width = "100%";
@@ -2887,12 +2887,26 @@ export class ChoiceSetInput extends Input {
         return element;
     }
 
+    // Make sure `aria-current` is applied to the currently-selected item
+    protected internalApplyAriaCurrent(): void {
+        const options = this._selectElement.options;
+        if (options) {
+            for (const i in options) {
+                if (options[i].selected) {
+                    options[i].setAttribute("aria-current", "true");
+                } else {
+                    options[i].removeAttribute("aria-current");
+                }
+            }
+        }
+    }
+
     protected internalRender(): HTMLElement | undefined {
         this._uniqueCategoryName = ChoiceSetInput.getUniqueCategoryName();
 
         if (this.isMultiSelect) {
             // Render as a list of toggle inputs
-            return this.renderCompundInput(
+            return this.renderCompoundInput(
                 "ac-choiceSetInput-multiSelect",
                 "checkbox",
                 this.defaultValue ? this.defaultValue.split(this.hostConfig.choiceSetInputValueSeparator) : undefined);
@@ -2900,7 +2914,7 @@ export class ChoiceSetInput extends Input {
         else {
             if (this.style === "expanded") {
                 // Render as a series of radio buttons
-                return this.renderCompundInput(
+                return this.renderCompoundInput(
                     "ac-choiceSetInput-expanded",
                     "radio",
                     this.defaultValue ? [ this.defaultValue ] : undefined);
@@ -2936,7 +2950,10 @@ export class ChoiceSetInput extends Input {
                     Utils.appendChild(this._selectElement, option);
                 }
 
-                this._selectElement.onchange = () => { this.valueChanged(); }
+                this._selectElement.onchange = () => {
+                    this.internalApplyAriaCurrent();
+                    this.valueChanged();
+                }
 
                 return this._selectElement;
             }

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -2890,11 +2890,13 @@ export class ChoiceSetInput extends Input {
     // Make sure `aria-current` is applied to the currently-selected item
     protected internalApplyAriaCurrent(): void {
         const options = this._selectElement.options;
+
         if (options) {
             for (const i in options) {
                 if (options[i].selected) {
                     options[i].setAttribute("aria-current", "true");
-                } else {
+                }
+                else {
                     options[i].removeAttribute("aria-current");
                 }
             }

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -2892,7 +2892,7 @@ export class ChoiceSetInput extends Input {
         const options = this._selectElement.options;
 
         if (options) {
-            for (const i in options) {
+            for (let i = 0; i < options.length; i++) {
                 if (options[i].selected) {
                     options[i].setAttribute("aria-current", "true");
                 }
@@ -2957,6 +2957,7 @@ export class ChoiceSetInput extends Input {
                     this.valueChanged();
                 }
 
+                this.internalApplyAriaCurrent();
                 return this._selectElement;
             }
         }


### PR DESCRIPTION
## Related Issue
Fixes #4027

## Description
For accessibility purposes, we need to apply the `aria-current` attribute to the `<option/>` that's currently selected.

Also fixed a couple of minor typos while I was in there :)

## How Verified
* Manually verified properties in F12 tools
* Verified speech output for Narrator
* Verified speech output for NVDA

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4045)