### PR TITLE
[JS] Render Action.OpenUrl with role=link (#3914)

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -4216,6 +4216,13 @@ export class OpenUrlAction extends Action {
         this.url = Utils.getStringValue(json["url"]);
     }
 
+    render(baseCssClass: string = "ac-pushButton") {
+        super.render(baseCssClass);
+
+        // OpenUrl actions behave like a hyperlink. Make sure screenreaders treat them that way.
+        this.renderedElement.setAttribute("role", "link");
+    }
+
     getHref(): string {
         return this.url;
     }


### PR DESCRIPTION
## Related Issue
Fixes #3914 in `release/1.2` (direct cherry-pick)

## Description
Render `Action.OpenUrl` buttons with `role="link"`

## How Verified
* local build and inspection

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4066)