### PR TITLE
[UWP] Port RichTextBlock selectAction accessibility name fix

### DIFF
--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -2139,6 +2139,19 @@ namespace AdaptiveNamespace
                 ComPtr<IAdaptiveActionInvoker> actionInvoker;
                 renderContext->get_ActionInvoker(&actionInvoker);
 
+                // Use the selectAction's title as the accessibility name for this link.
+                HString actionTitle;
+                RETURN_IF_FAILED(selectAction->get_Title(actionTitle.ReleaseAndGetAddressOf()));
+                if (actionTitle.IsValid() && !WindowsIsStringEmpty(actionTitle.Get()))
+                {
+                    ComPtr<IAutomationPropertiesStatics> automationProperties;
+                    RETURN_IF_FAILED(GetActivationFactory(
+                        HStringReference(RuntimeClass_Windows_UI_Xaml_Automation_AutomationProperties).Get(), &automationProperties));
+                    ComPtr<IDependencyObject> linkAsDependencyObject;
+                    RETURN_IF_FAILED(hyperlink.As(&linkAsDependencyObject));
+                    RETURN_IF_FAILED(automationProperties->SetName(linkAsDependencyObject.Get(), actionTitle.Get()));
+                }
+
                 EventRegistrationToken clickToken;
                 RETURN_IF_FAILED(
                     hyperlink->add_Click(Callback<ABI::Windows::Foundation::ITypedEventHandler<Hyperlink*, HyperlinkClickEventArgs*>>(


### PR DESCRIPTION
## Related Issue
Fixes #3950 in `release/1.2`
Original PR: #4046
Original commit: e7f8c6b675d416aceede32c3bb8446b87d7d9e91

## Description
Manual port of original change (no edits required). When a `TextRun` has a `selectAction`, use the action's `title` as the accessible name, if available.

## How Verified
* Local build and inspection with Accessibility Insights

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4067)