### PR TITLE
[JS] Make tabIndex on root card turnoffable (#4020)

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -6866,7 +6866,15 @@ export class AdaptiveCard extends ContainerWithActions {
 
             if (renderedCard) {
                 renderedCard.classList.add(this.hostConfig.makeCssClassName("ac-adaptiveCard"));
-                renderedCard.tabIndex = 0;
+
+                // Having a tabIndex on the root container for a card can mess up accessibility in some scenarios.
+                // However, we've shipped this behavior before, and so can't just turn it off in a point release. For
+                // now, to unblock accessibility scenarios for our customers, we've got an option to turn it off. In a
+                // future release, we should strongly consider flipping the default such that we *don't* emit a tabIndex
+                // by default.
+                if (Shared.GlobalSettings.setTabIndexAtCardRoot) {
+                    renderedCard.tabIndex = 0;
+                }
 
                 if (!Utils.isNullOrEmpty(this.speak)) {
                     renderedCard.setAttribute("aria-label", this.speak);

--- a/source/nodejs/adaptivecards/src/shared.ts
+++ b/source/nodejs/adaptivecards/src/shared.ts
@@ -2,6 +2,10 @@
 // Licensed under the MIT License.
 import * as Enums from "./enums";
 
+export class GlobalSettings {
+    static setTabIndexAtCardRoot: boolean = true;
+}
+
 export const ContentTypes = {
 	applicationJson: "application/json",
 	applicationXWwwFormUrlencoded: "application/x-www-form-urlencoded"


### PR DESCRIPTION
## Description
Fixes #2236 in `release/1.2`
Original commit 73e12713b0a3a0b1964ee187156ccb6efa07c63d
Original PR #4020

## How Verified
* Local build, testing, and verification with F12 tools

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4068)