### PR TITLE
[JS] Remove source links from generated docs

### DIFF
--- a/source/nodejs/adaptivecards/docs/README.md
+++ b/source/nodejs/adaptivecards/docs/README.md
@@ -169,8 +169,6 @@
 
 Ƭ **ActionType**: *object*
 
-*Defined in [card-elements.ts:3336](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3336)*
-
 #### Type declaration:
 
 * **new __type**(): *[Action](classes/action.md)*
@@ -181,15 +179,11 @@ ___
 
 Ƭ **CardElementHeight**: *"auto" | "stretch"*
 
-*Defined in [card-elements.ts:16](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L16)*
-
 ___
 
 ###  CardObjectType
 
 Ƭ **CardObjectType**: *object*
-
-*Defined in [card-object.ts:25](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L25)*
 
 #### Type declaration:
 
@@ -201,15 +195,11 @@ ___
 
 Ƭ **ColumnWidth**: *[SizeAndUnit](classes/sizeandunit.md) | "auto" | "stretch"*
 
-*Defined in [card-elements.ts:5265](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5265)*
-
 ___
 
 ###  Dictionary
 
 Ƭ **Dictionary**: *object*
-
-*Defined in [shared.ts:35](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L35)*
 
 #### Type declaration:
 
@@ -221,8 +211,6 @@ ___
 
 Ƭ **PropertyBag**: *object*
 
-*Defined in [serialization.ts:726](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L726)*
-
 #### Type declaration:
 
 * \[ **propertyName**: *string*\]: any
@@ -233,8 +221,6 @@ ___
 
 Ƭ **SerializableObjectType**: *object*
 
-*Defined in [serialization.ts:561](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L561)*
-
 #### Type declaration:
 
 * **new __type**(): *[SerializableObject](classes/serializableobject.md)*
@@ -244,8 +230,6 @@ ___
 ###  TargetVersion
 
 Ƭ **TargetVersion**: *[Version](classes/version.md) | "*"*
-
-*Defined in [serialization.ts:101](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L101)*
 
 ## Variables
 
@@ -541,15 +525,11 @@ ___
         }
     })
 
-*Defined in [host-config.ts:651](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L651)*
-
 ## Functions
 
 ###  appendChild
 
 ▸ **appendChild**(`node`: Node, `child`: Node | undefined): *void*
-
-*Defined in [utils.ts:20](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/utils.ts#L20)*
 
 **Parameters:**
 
@@ -566,8 +546,6 @@ ___
 
 ▸ **generateUniqueId**(): *string*
 
-*Defined in [utils.ts:16](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/utils.ts#L16)*
-
 Generate a UUID prepended with "__ac-"
 
 **Returns:** *string*
@@ -577,8 +555,6 @@ ___
 ###  getEnumValueByName
 
 ▸ **getEnumValueByName**(`enumType`: object, `name`: string): *number | undefined*
-
-*Defined in [utils.ts:52](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/utils.ts#L52)*
 
 **Parameters:**
 
@@ -595,8 +571,6 @@ ___
 
 ▸ **getFitStatus**(`element`: HTMLElement, `containerEnd`: number): *[ContainerFitStatus](enums/containerfitstatus.md)*
 
-*Defined in [utils.ts:219](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/utils.ts#L219)*
-
 **Parameters:**
 
 Name | Type |
@@ -612,8 +586,6 @@ ___
 
 ▸ **isMobileOS**(): *boolean*
 
-*Defined in [utils.ts:7](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/utils.ts#L7)*
-
 **Returns:** *boolean*
 
 ___
@@ -621,8 +593,6 @@ ___
 ###  isVersionLessOrEqual
 
 ▸ **isVersionLessOrEqual**(`version`: [TargetVersion](README.md#targetversion), `targetVersion`: [TargetVersion](README.md#targetversion)): *boolean*
-
-*Defined in [serialization.ts:111](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L111)*
 
 **Parameters:**
 
@@ -639,8 +609,6 @@ ___
 
 ▸ **parseBool**(`value`: any, `defaultValue?`: undefined | false | true): *boolean | undefined*
 
-*Defined in [utils.ts:34](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/utils.ts#L34)*
-
 **Parameters:**
 
 Name | Type |
@@ -655,8 +623,6 @@ ___
 ###  parseEnum
 
 ▸ **parseEnum**(`enumType`: object, `name`: string, `defaultValue?`: undefined | number): *number | undefined*
-
-*Defined in [utils.ts:68](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/utils.ts#L68)*
 
 **Parameters:**
 
@@ -674,8 +640,6 @@ ___
 
 ▸ **parseNumber**(`obj`: any, `defaultValue?`: undefined | number): *number | undefined*
 
-*Defined in [utils.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/utils.ts#L30)*
-
 **Parameters:**
 
 Name | Type |
@@ -690,8 +654,6 @@ ___
 ###  parseString
 
 ▸ **parseString**(`obj`: any, `defaultValue?`: undefined | string): *string | undefined*
-
-*Defined in [utils.ts:26](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/utils.ts#L26)*
 
 **Parameters:**
 
@@ -708,8 +670,6 @@ ___
 
 ▸ **property**(`property`: [PropertyDefinition](classes/propertydefinition.md)): *(Anonymous function)*
 
-*Defined in [serialization.ts:713](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L713)*
-
 **Parameters:**
 
 Name | Type |
@@ -723,8 +683,6 @@ ___
 ###  renderSeparation
 
 ▸ **renderSeparation**(`hostConfig`: [HostConfig](classes/hostconfig.md), `separationDefinition`: [ISeparationDefinition](interfaces/iseparationdefinition.md), `orientation`: [Orientation](enums/orientation.md)): *HTMLElement | undefined*
-
-*Defined in [utils.ts:78](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/utils.ts#L78)*
 
 **Parameters:**
 
@@ -742,8 +700,6 @@ ___
 
 ▸ **stringToCssColor**(`color`: string | undefined): *string | undefined*
 
-*Defined in [utils.ts:116](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/utils.ts#L116)*
-
 **Parameters:**
 
 Name | Type |
@@ -757,8 +713,6 @@ ___
 ###  truncate
 
 ▸ **truncate**(`element`: HTMLElement, `maxHeight`: number, `lineHeight?`: undefined | number): *void*
-
-*Defined in [utils.ts:134](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/utils.ts#L134)*
 
 **Parameters:**
 
@@ -776,16 +730,10 @@ Name | Type |
 
 ### ▪ **ContentTypes**: *object*
 
-*Defined in [shared.ts:18](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L18)*
-
 ###  applicationJson
 
 • **applicationJson**: *string* = "application/json"
 
-*Defined in [shared.ts:19](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L19)*
-
 ###  applicationXWwwFormUrlencoded
 
 • **applicationXWwwFormUrlencoded**: *string* = "application/x-www-form-urlencoded"
-
-*Defined in [shared.ts:20](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L20)*

--- a/source/nodejs/adaptivecards/docs/classes/action.md
+++ b/source/nodejs/adaptivecards/docs/classes/action.md
@@ -59,6 +59,7 @@
 * [execute](action.md#execute)
 * [getActionById](action.md#getactionbyid)
 * [getAllInputs](action.md#getallinputs)
+* [getAriaRole](action.md#getariarole)
 * [getCustomProperty](action.md#getcustomproperty)
 * [getHref](action.md#gethref)
 * [getJsonTypeName](action.md#abstract-getjsontypename)
@@ -102,8 +103,6 @@
 
 *Inherited from [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 **Returns:** *[Action](action.md)*
 
 ## Properties
@@ -114,8 +113,6 @@
 
 *Inherited from [CardObject](cardobject.md).[_parent](cardobject.md#protected-optional-_parent)*
 
-*Defined in [card-object.ts:61](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L61)*
-
 ___
 
 ### `Protected` `Optional` _renderedElement
@@ -124,15 +121,11 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[_renderedElement](cardobject.md#protected-optional-_renderedelement)*
 
-*Defined in [card-object.ts:62](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L62)*
-
 ___
 
 ### `Optional` iconUrl
 
 • **iconUrl**? : *undefined | string*
-
-*Defined in [card-elements.ts:3359](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3359)*
 
 ___
 
@@ -142,8 +135,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[id](cardobject.md#optional-id)*
 
-*Defined in [card-object.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L50)*
-
 ___
 
 ###  maxVersion
@@ -152,15 +143,11 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 ___
 
 ###  onExecute
 
 • **onExecute**: *function*
-
-*Defined in [card-elements.ts:3400](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3400)*
 
 #### Type declaration:
 
@@ -180,15 +167,11 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[onPreProcessPropertyValue](cardobject.md#optional-onpreprocesspropertyvalue)*
 
-*Defined in [card-object.ts:64](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L64)*
-
 ___
 
 ###  style
 
 • **style**: *string* = Enums.ActionStyle.Default
-
-*Defined in [card-elements.ts:3362](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3362)*
 
 ___
 
@@ -196,15 +179,11 @@ ___
 
 • **title**? : *undefined | string*
 
-*Defined in [card-elements.ts:3356](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3356)*
-
 ___
 
 ### `Static` iconUrlProperty
 
 ▪ **iconUrlProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_1, "iconUrl")
-
-*Defined in [card-elements.ts:3342](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3342)*
 
 ___
 
@@ -214,15 +193,11 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[idProperty](cardobject.md#static-idproperty)*
 
-*Defined in [card-object.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L39)*
-
 ___
 
 ### `Static` ignoreInputValidationProperty
 
 ▪ **ignoreInputValidationProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.vNext, "ignoreInputValidation", false)
-
-*Defined in [card-elements.ts:3353](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3353)*
 
 ___
 
@@ -231,8 +206,6 @@ ___
 ▪ **onRegisterCustomProperties**? : *undefined | function*
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
-
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
 
 ___
 
@@ -244,8 +217,6 @@ ___
         HostCapabilities)
 
 *Inherited from [CardObject](cardobject.md).[requiresProperty](cardobject.md#static-requiresproperty)*
-
-*Defined in [card-object.ts:40](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L40)*
 
 ___
 
@@ -261,15 +232,11 @@ ___
         ],
         Enums.ActionStyle.Default)
 
-*Defined in [card-elements.ts:3343](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3343)*
-
 ___
 
 ### `Static` titleProperty
 
 ▪ **titleProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "title")
-
-*Defined in [card-elements.ts:3341](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3341)*
 
 ___
 
@@ -287,8 +254,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[typeNameProperty](cardobject.md#static-typenameproperty)*
 
-*Defined in [card-object.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L30)*
-
 ## Accessors
 
 ###  hostConfig
@@ -296,8 +261,6 @@ ___
 • **get hostConfig**(): *[HostConfig](hostconfig.md)*
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
-
-*Defined in [card-elements.ts:3551](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3551)*
 
 **Returns:** *[HostConfig](hostconfig.md)*
 
@@ -307,8 +270,6 @@ ___
 
 • **get ignoreInputValidation**(): *boolean*
 
-*Defined in [card-elements.ts:3547](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3547)*
-
 **Returns:** *boolean*
 
 ___
@@ -317,13 +278,9 @@ ___
 
 • **get isPrimary**(): *boolean*
 
-*Defined in [card-elements.ts:3532](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3532)*
-
 **Returns:** *boolean*
 
 • **set isPrimary**(`value`: boolean): *void*
-
-*Defined in [card-elements.ts:3536](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3536)*
 
 **Parameters:**
 
@@ -341,8 +298,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[parent](cardobject.md#parent)*
 
-*Defined in [card-elements.ts:3555](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3555)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -352,8 +307,6 @@ ___
 • **get renderedElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardObject](cardobject.md).[renderedElement](cardobject.md#renderedelement)*
-
-*Defined in [card-object.ts:140](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L140)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -365,8 +318,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requires](cardobject.md#requires)*
 
-*Defined in [card-object.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L53)*
-
 **Returns:** *HostCapabilities*
 
 ## Methods
@@ -374,8 +325,6 @@ ___
 ### `Protected` addCssClasses
 
 ▸ **addCssClasses**(`element`: HTMLElement): *void*
-
-*Defined in [card-elements.ts:3368](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3368)*
 
 **Parameters:**
 
@@ -391,8 +340,6 @@ ___
 
 ▸ **execute**(): *void*
 
-*Defined in [card-elements.ts:3484](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3484)*
-
 **Returns:** *void*
 
 ___
@@ -400,8 +347,6 @@ ___
 ###  getActionById
 
 ▸ **getActionById**(`id`: string): *[Action](action.md) | undefined*
-
-*Defined in [card-elements.ts:3520](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3520)*
 
 **Parameters:**
 
@@ -417,9 +362,15 @@ ___
 
 ▸ **getAllInputs**(): *[Input](input.md)[]*
 
-*Defined in [card-elements.ts:3512](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3512)*
-
 **Returns:** *[Input](input.md)[]*
+
+___
+
+###  getAriaRole
+
+▸ **getAriaRole**(): *string*
+
+**Returns:** *string*
 
 ___
 
@@ -428,8 +379,6 @@ ___
 ▸ **getCustomProperty**(`name`: string): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
-
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
 
 **Parameters:**
 
@@ -445,8 +394,6 @@ ___
 
 ▸ **getHref**(): *string | undefined*
 
-*Defined in [card-elements.ts:3402](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3402)*
-
 **Returns:** *string | undefined*
 
 ___
@@ -457,8 +404,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
 
-*Defined in [card-object.ts:66](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L66)*
-
 **Returns:** *string*
 
 ___
@@ -467,8 +412,6 @@ ___
 
 ▸ **getReferencedInputs**(): *[Dictionary](../README.md#dictionary)‹[Input](input.md)› | undefined*
 
-*Defined in [card-elements.ts:3524](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3524)*
-
 **Returns:** *[Dictionary](../README.md#dictionary)‹[Input](input.md)› | undefined*
 
 ___
@@ -476,8 +419,6 @@ ___
 ###  getResourceInformation
 
 ▸ **getResourceInformation**(): *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
-
-*Defined in [card-elements.ts:3516](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3516)*
 
 **Returns:** *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
@@ -489,8 +430,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getRootObject](cardobject.md#getrootobject)*
 
-*Defined in [card-object.ts:100](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L100)*
-
 **Returns:** *[CardObject](cardobject.md)*
 
 ___
@@ -500,8 +439,6 @@ ___
 ▸ **getSchema**(): *[SerializableObjectSchema](serializableobjectschema.md)*
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
-
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
 
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
@@ -515,8 +452,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-object.ts:45](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L45)*
-
 **Returns:** *string*
 
 ___
@@ -526,8 +461,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -545,8 +478,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -556,8 +487,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -572,8 +501,6 @@ ___
 ### `Protected` internalGetReferencedInputs
 
 ▸ **internalGetReferencedInputs**(`allInputs`: [Input](input.md)[]): *[Dictionary](../README.md#dictionary)‹[Input](input.md)›*
-
-*Defined in [card-elements.ts:3372](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3372)*
 
 **Parameters:**
 
@@ -591,8 +518,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
 
-*Defined in [serialization.ts:789](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L789)*
-
 **Parameters:**
 
 Name | Type |
@@ -607,8 +532,6 @@ ___
 ### `Protected` internalPrepareForExecution
 
 ▸ **internalPrepareForExecution**(`inputs`: [Dictionary](../README.md#dictionary)‹[Input](input.md)› | undefined): *void*
-
-*Defined in [card-elements.ts:3376](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3376)*
 
 **Parameters:**
 
@@ -626,8 +549,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
 
-*Defined in [serialization.ts:821](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L821)*
-
 **Parameters:**
 
 Name | Type |
@@ -642,8 +563,6 @@ ___
 ### `Protected` internalValidateInputs
 
 ▸ **internalValidateInputs**(`referencedInputs`: [Dictionary](../README.md#dictionary)‹[Input](input.md)› | undefined): *[Input](input.md)[]*
-
-*Defined in [card-elements.ts:3380](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3380)*
 
 **Parameters:**
 
@@ -661,8 +580,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
 
-*Defined in [card-object.ts:110](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L110)*
-
 **Parameters:**
 
 Name | Type |
@@ -678,8 +595,6 @@ ___
 ▸ **parse**(`source`: any, `context?`: [SerializationContext](serializationcontext.md)): *void*
 
 *Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
-
-*Defined in [card-elements.ts:3410](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3410)*
 
 **Parameters:**
 
@@ -698,8 +613,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [serialization.ts:738](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L738)*
-
 **Parameters:**
 
 Name | Type |
@@ -716,8 +629,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[preProcessPropertyValue](cardobject.md#preprocesspropertyvalue)*
 
-*Defined in [card-object.ts:70](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L70)*
-
 **Parameters:**
 
 Name | Type |
@@ -733,8 +644,6 @@ ___
 
 ▸ **prepareForExecution**(): *boolean*
 
-*Defined in [card-elements.ts:3492](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3492)*
-
 **Returns:** *boolean*
 
 ___
@@ -743,8 +652,6 @@ ___
 
 ▸ **remove**(): *boolean*
 
-*Defined in [card-elements.ts:3504](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3504)*
-
 **Returns:** *boolean*
 
 ___
@@ -752,8 +659,6 @@ ___
 ###  render
 
 ▸ **render**(`baseCssClass`: string): *void*
-
-*Defined in [card-elements.ts:3418](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3418)*
 
 **Parameters:**
 
@@ -771,8 +676,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -782,8 +685,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -802,8 +703,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setParent](cardobject.md#setparent)*
 
-*Defined in [card-object.ts:88](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L88)*
-
 **Parameters:**
 
 Name | Type |
@@ -820,8 +719,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setShouldFallback](cardobject.md#setshouldfallback)*
 
-*Defined in [card-object.ts:92](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L92)*
-
 **Parameters:**
 
 Name | Type |
@@ -837,8 +734,6 @@ ___
 ▸ **setValue**(`property`: [PropertyDefinition](propertydefinition.md), `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
-
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
 
 **Parameters:**
 
@@ -857,8 +752,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[shouldFallback](cardobject.md#shouldfallback)*
 
-*Defined in [card-object.ts:96](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L96)*
-
 **Returns:** *boolean*
 
 ___
@@ -868,8 +761,6 @@ ___
 ▸ **shouldSerialize**(`context`: [SerializationContext](serializationcontext.md)): *boolean*
 
 *Overrides [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
-
-*Defined in [card-elements.ts:3396](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3396)*
 
 **Parameters:**
 
@@ -887,8 +778,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
 
-*Defined in [card-elements.ts:3414](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3414)*
-
 **Parameters:**
 
 Name | Type |
@@ -902,8 +791,6 @@ ___
 ###  updateActionButtonCssStyle
 
 ▸ **updateActionButtonCssStyle**(`actionButtonElement`: HTMLElement): *void*
-
-*Defined in [card-elements.ts:3406](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3406)*
 
 **Parameters:**
 
@@ -919,8 +806,6 @@ ___
 
 ▸ **validateInputs**(): *[Input](input.md)‹›[]*
 
-*Defined in [card-elements.ts:3528](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3528)*
-
 **Returns:** *[Input](input.md)‹›[]*
 
 ___
@@ -930,7 +815,5 @@ ___
 ▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
 
 *Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
-
-*Defined in [card-object.ts:128](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L128)*
 
 **Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/actionproperty.md
+++ b/source/nodejs/adaptivecards/docs/classes/actionproperty.md
@@ -37,8 +37,6 @@
 
 *Overrides [PropertyDefinition](propertydefinition.md).[constructor](propertydefinition.md#constructor)*
 
-*Defined in [card-elements.ts:611](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L611)*
-
 **Parameters:**
 
 Name | Type | Default |
@@ -57,15 +55,11 @@ Name | Type | Default |
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[defaultValue](propertydefinition.md#optional-defaultvalue)*
 
-*Defined in [serialization.ts:263](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L263)*
-
 ___
 
 ###  forbiddenActionTypes
 
 • **forbiddenActionTypes**: *string[]*
-
-*Defined in [card-elements.ts:616](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L616)*
 
 ___
 
@@ -75,8 +69,6 @@ ___
 
 *Overrides [PropertyDefinition](propertydefinition.md).[name](propertydefinition.md#name)*
 
-*Defined in [card-elements.ts:615](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L615)*
-
 ___
 
 ### `Optional` onGetInitialValue
@@ -84,8 +76,6 @@ ___
 • **onGetInitialValue**? : *undefined | function*
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[onGetInitialValue](propertydefinition.md#optional-ongetinitialvalue)*
-
-*Defined in [serialization.ts:264](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L264)*
 
 ___
 
@@ -95,8 +85,6 @@ ___
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[sequentialNumber](propertydefinition.md#sequentialnumber)*
 
-*Defined in [serialization.ts:258](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L258)*
-
 ___
 
 ###  targetVersion
@@ -105,8 +93,6 @@ ___
 
 *Overrides [PropertyDefinition](propertydefinition.md).[targetVersion](propertydefinition.md#targetversion)*
 
-*Defined in [card-elements.ts:614](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L614)*
-
 ## Methods
 
 ###  getInternalName
@@ -114,8 +100,6 @@ ___
 ▸ **getInternalName**(): *string*
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[getInternalName](propertydefinition.md#getinternalname)*
-
-*Defined in [serialization.ts:246](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L246)*
 
 **Returns:** *string*
 
@@ -126,8 +110,6 @@ ___
 ▸ **parse**(`sender`: [SerializableObject](serializableobject.md), `source`: [PropertyBag](../README.md#propertybag), `context`: [SerializationContext](serializationcontext.md)): *[Action](action.md) | undefined*
 
 *Overrides [PropertyDefinition](propertydefinition.md).[parse](propertydefinition.md#parse)*
-
-*Defined in [card-elements.ts:599](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L599)*
 
 **Parameters:**
 
@@ -146,8 +128,6 @@ ___
 ▸ **toJSON**(`sender`: [SerializableObject](serializableobject.md), `target`: [PropertyBag](../README.md#propertybag), `value`: [Action](action.md) | undefined, `context`: [SerializationContext](serializationcontext.md)): *void*
 
 *Overrides [PropertyDefinition](propertydefinition.md).[toJSON](propertydefinition.md#tojson)*
-
-*Defined in [card-elements.ts:609](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L609)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/docs/classes/actionsconfig.md
+++ b/source/nodejs/adaptivecards/docs/classes/actionsconfig.md
@@ -35,8 +35,6 @@
 
 \+ **new ActionsConfig**(`obj?`: any): *[ActionsConfig](actionsconfig.md)*
 
-*Defined in [host-config.ts:200](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L200)*
-
 **Parameters:**
 
 Name | Type |
@@ -51,15 +49,11 @@ Name | Type |
 
 • **actionAlignment**: *[ActionAlignment](../enums/actionalignment.md)* = Enums.ActionAlignment.Left
 
-*Defined in [host-config.ts:197](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L197)*
-
 ___
 
 ###  actionsOrientation
 
 • **actionsOrientation**: *[Orientation](../enums/orientation.md)* = Enums.Orientation.Horizontal
-
-*Defined in [host-config.ts:196](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L196)*
 
 ___
 
@@ -67,15 +61,11 @@ ___
 
 • **allowTitleToWrap**: *boolean* = false
 
-*Defined in [host-config.ts:199](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L199)*
-
 ___
 
 ###  buttonSpacing
 
 • **buttonSpacing**: *number* = 20
-
-*Defined in [host-config.ts:193](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L193)*
 
 ___
 
@@ -83,15 +73,11 @@ ___
 
 • **iconPlacement**: *[ActionIconPlacement](../enums/actioniconplacement.md)* = Enums.ActionIconPlacement.LeftOfTitle
 
-*Defined in [host-config.ts:198](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L198)*
-
 ___
 
 ###  iconSize
 
 • **iconSize**: *number* = 16
-
-*Defined in [host-config.ts:200](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L200)*
 
 ___
 
@@ -99,15 +85,11 @@ ___
 
 • **maxActions**: *number* = 5
 
-*Defined in [host-config.ts:191](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L191)*
-
 ___
 
 ### `Optional` preExpandSingleShowCardAction
 
 • **preExpandSingleShowCardAction**? : *undefined | false | true* = false
-
-*Defined in [host-config.ts:195](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L195)*
 
 ___
 
@@ -115,23 +97,17 @@ ___
 
 • **showCard**: *[ShowCardActionConfig](showcardactionconfig.md)* = new ShowCardActionConfig()
 
-*Defined in [host-config.ts:194](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L194)*
-
 ___
 
 ###  spacing
 
 • **spacing**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.Default
 
-*Defined in [host-config.ts:192](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L192)*
-
 ## Methods
 
 ###  toJSON
 
 ▸ **toJSON**(): *object*
-
-*Defined in [host-config.ts:227](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L227)*
 
 **Returns:** *object*
 

--- a/source/nodejs/adaptivecards/docs/classes/actionset.md
+++ b/source/nodejs/adaptivecards/docs/classes/actionset.md
@@ -138,8 +138,6 @@
 
 *Overrides [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [card-elements.ts:4521](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4521)*
-
 **Returns:** *[ActionSet](actionset.md)*
 
 ## Properties
@@ -150,8 +148,6 @@
 
 *Inherited from [CardObject](cardobject.md).[_parent](cardobject.md#protected-optional-_parent)*
 
-*Defined in [card-object.ts:61](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L61)*
-
 ___
 
 ### `Protected` `Optional` _renderedElement
@@ -159,8 +155,6 @@ ___
 • **_renderedElement**? : *HTMLElement*
 
 *Inherited from [CardObject](cardobject.md).[_renderedElement](cardobject.md#protected-optional-_renderedelement)*
-
-*Defined in [card-object.ts:62](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L62)*
 
 ___
 
@@ -170,8 +164,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#optional-customcssselector)*
 
-*Defined in [card-elements.ts:311](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L311)*
-
 ___
 
 ###  height
@@ -179,8 +171,6 @@ ___
 • **height**: *[CardElementHeight](../README.md#cardelementheight)*
 
 *Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
-
-*Defined in [card-elements.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L53)*
 
 ___
 
@@ -190,8 +180,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#horizontalalignment)*
 
-*Defined in [card-elements.ts:44](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L44)*
-
 ___
 
 ### `Optional` id
@@ -199,8 +187,6 @@ ___
 • **id**? : *undefined | string*
 
 *Inherited from [CardObject](cardobject.md).[id](cardobject.md#optional-id)*
-
-*Defined in [card-object.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L50)*
 
 ___
 
@@ -210,8 +196,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 ___
 
 ### `Optional` onPreProcessPropertyValue
@@ -220,15 +204,11 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[onPreProcessPropertyValue](cardobject.md#optional-onpreprocesspropertyvalue)*
 
-*Defined in [card-object.ts:64](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L64)*
-
 ___
 
 ### `Optional` orientation
 
 • **orientation**? : *Enums.Orientation*
-
-*Defined in [card-elements.ts:4501](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4501)*
 
 ___
 
@@ -238,8 +218,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
 
-*Defined in [card-elements.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L50)*
-
 ___
 
 ###  spacing
@@ -247,8 +225,6 @@ ___
 • **spacing**: *[Spacing](../enums/spacing.md)*
 
 *Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
-
-*Defined in [card-elements.ts:47](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L47)*
 
 ___
 
@@ -265,8 +241,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[heightProperty](cardelement.md#static-heightproperty)*
 
-*Defined in [card-elements.ts:24](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L24)*
-
 ___
 
 ### `Static` horizontalAlignmentProperty
@@ -279,8 +253,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignmentProperty](cardelement.md#static-horizontalalignmentproperty)*
 
-*Defined in [card-elements.ts:32](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L32)*
-
 ___
 
 ### `Static` idProperty
@@ -288,8 +260,6 @@ ___
 ▪ **idProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "id")
 
 *Inherited from [CardObject](cardobject.md).[idProperty](cardobject.md#static-idproperty)*
-
-*Defined in [card-object.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L39)*
 
 ___
 
@@ -299,8 +269,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisibleProperty](cardelement.md#static-isvisibleproperty)*
 
-*Defined in [card-elements.ts:22](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L22)*
-
 ___
 
 ### `Static` langProperty
@@ -308,8 +276,6 @@ ___
 ▪ **langProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_1, "lang", true, /^[a-z]{2,3}$/ig)
 
 *Inherited from [CardElement](cardelement.md).[langProperty](cardelement.md#static-langproperty)*
-
-*Defined in [card-elements.ts:21](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L21)*
 
 ___
 
@@ -319,15 +285,11 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
 
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
-
 ___
 
 ### `Static` orientationProperty
 
 ▪ **orientationProperty**: *[EnumProperty](enumproperty.md)‹[Orientation](../enums/orientation.md)›* = new EnumProperty(Versions.v1_1, "orientation", Enums.Orientation)
-
-*Defined in [card-elements.ts:4498](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4498)*
 
 ___
 
@@ -340,8 +302,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requiresProperty](cardobject.md#static-requiresproperty)*
 
-*Defined in [card-object.ts:40](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L40)*
-
 ___
 
 ### `Static` separatorProperty
@@ -349,8 +309,6 @@ ___
 ▪ **separatorProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_0, "separator", false)
 
 *Inherited from [CardElement](cardelement.md).[separatorProperty](cardelement.md#static-separatorproperty)*
-
-*Defined in [card-elements.ts:23](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L23)*
 
 ___
 
@@ -363,8 +321,6 @@ ___
         Enums.Spacing.Default)
 
 *Inherited from [CardElement](cardelement.md).[spacingProperty](cardelement.md#static-spacingproperty)*
-
-*Defined in [card-elements.ts:37](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L37)*
 
 ___
 
@@ -382,8 +338,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[typeNameProperty](cardobject.md#static-typenameproperty)*
 
-*Defined in [card-object.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L30)*
-
 ## Accessors
 
 ### `Protected` allowCustomPadding
@@ -391,8 +345,6 @@ ___
 • **get allowCustomPadding**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
-
-*Defined in [card-elements.ts:299](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L299)*
 
 **Returns:** *boolean*
 
@@ -404,8 +356,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
 
-*Defined in [card-elements.ts:307](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L307)*
-
 **Returns:** *string*
 
 ___
@@ -415,8 +365,6 @@ ___
 • **get hasVisibleSeparator**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
-
-*Defined in [card-elements.ts:580](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L580)*
 
 **Returns:** *boolean*
 
@@ -430,8 +378,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
 
-*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
-
 **Returns:** *[HostConfig](hostconfig.md)*
 
 • **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
@@ -439,8 +385,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
-
-*Defined in [card-elements.ts:555](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L555)*
 
 **Parameters:**
 
@@ -458,8 +402,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
 
-*Defined in [card-elements.ts:559](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L559)*
-
 **Returns:** *number*
 
 ___
@@ -469,8 +411,6 @@ ___
 • **get isInline**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
-
-*Defined in [card-elements.ts:576](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L576)*
 
 **Returns:** *boolean*
 
@@ -482,8 +422,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
 
-*Defined in [card-elements.ts:4578](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4578)*
-
 **Returns:** *boolean*
 
 ___
@@ -493,8 +431,6 @@ ___
 • **get isStandalone**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
-
-*Defined in [card-elements.ts:572](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L572)*
 
 **Returns:** *boolean*
 
@@ -506,15 +442,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
 
-*Defined in [card-elements.ts:77](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L77)*
-
 **Returns:** *boolean*
 
 • **set isVisible**(`value`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
-
-*Defined in [card-elements.ts:81](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L81)*
 
 **Parameters:**
 
@@ -532,15 +464,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
 
-*Defined in [card-elements.ts:56](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L56)*
-
 **Returns:** *string | undefined*
 
 • **set lang**(`value`: string | undefined): *void*
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
-
-*Defined in [card-elements.ts:72](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L72)*
 
 **Parameters:**
 
@@ -560,8 +488,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[parent](cardobject.md#parent)*
 
-*Defined in [card-elements.ts:593](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L593)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -571,8 +497,6 @@ ___
 • **get renderedElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardObject](cardobject.md).[renderedElement](cardobject.md#renderedelement)*
-
-*Defined in [card-object.ts:140](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L140)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -584,8 +508,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requires](cardobject.md#requires)*
 
-*Defined in [card-object.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L53)*
-
 **Returns:** *HostCapabilities*
 
 ___
@@ -595,8 +517,6 @@ ___
 • **get separatorElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
-
-*Defined in [card-elements.ts:589](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L589)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -608,8 +528,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
 
-*Defined in [card-elements.ts:303](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L303)*
-
 **Returns:** *[Orientation](../enums/orientation.md)*
 
 ___
@@ -620,8 +538,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
 
-*Defined in [card-elements.ts:295](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L295)*
-
 **Returns:** *boolean*
 
 ## Methods
@@ -629,8 +545,6 @@ ___
 ###  addAction
 
 ▸ **addAction**(`action`: [Action](action.md)): *void*
-
-*Defined in [card-elements.ts:4566](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4566)*
 
 **Parameters:**
 
@@ -648,8 +562,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
 
-*Defined in [card-elements.ts:220](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L220)*
-
 **Parameters:**
 
 Name | Type |
@@ -666,8 +578,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
 
-*Defined in [card-elements.ts:239](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L239)*
-
 **Returns:** *void*
 
 ___
@@ -677,8 +587,6 @@ ___
 ▸ **asString**(): *string | undefined*
 
 *Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
-
-*Defined in [card-elements.ts:321](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L321)*
 
 **Returns:** *string | undefined*
 
@@ -690,8 +598,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
 
-*Defined in [card-elements.ts:205](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L205)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -701,8 +607,6 @@ ___
 ▸ **getActionAt**(`index`: number): *[Action](action.md) | undefined*
 
 *Overrides [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
-
-*Defined in [card-elements.ts:4551](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4551)*
 
 **Parameters:**
 
@@ -720,8 +624,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
 
-*Defined in [card-elements.ts:531](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L531)*
-
 **Parameters:**
 
 Name | Type |
@@ -738,8 +640,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
 
-*Defined in [card-elements.ts:4547](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4547)*
-
 **Returns:** *number*
 
 ___
@@ -750,8 +650,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
 
-*Defined in [card-elements.ts:4570](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4570)*
-
 **Returns:** *[Input](input.md)[]*
 
 ___
@@ -761,8 +659,6 @@ ___
 ▸ **getCustomProperty**(`name`: string): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
-
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
 
 **Parameters:**
 
@@ -780,8 +676,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
 
-*Defined in [card-elements.ts:275](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L275)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
 ___
@@ -791,8 +685,6 @@ ___
 ▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
 
 *Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
-
-*Defined in [card-elements.ts:535](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L535)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
@@ -804,8 +696,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
 
-*Defined in [card-elements.ts:329](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L329)*
-
 **Returns:** *string*
 
 ___
@@ -816,8 +706,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyleDefinition](cardelement.md#geteffectivestyledefinition)*
 
-*Defined in [card-elements.ts:337](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L337)*
-
 **Returns:** *[ContainerStyleDefinition](containerstyledefinition.md)*
 
 ___
@@ -827,8 +715,6 @@ ___
 ▸ **getElementById**(`id`: string): *[CardElement](cardelement.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
-
-*Defined in [card-elements.ts:527](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L527)*
 
 **Parameters:**
 
@@ -846,8 +732,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
 
-*Defined in [card-elements.ts:341](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L341)*
-
 **Returns:** *[ActionType](../README.md#actiontype)[]*
 
 ___
@@ -858,8 +742,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
 
-*Defined in [card-elements.ts:279](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L279)*
-
 **Returns:** *boolean*
 
 ___
@@ -869,8 +751,6 @@ ___
 ▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
-
-*Defined in [card-elements.ts:345](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L345)*
 
 **Parameters:**
 
@@ -892,8 +772,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
 
-*Defined in [card-elements.ts:4543](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4543)*
-
 **Returns:** *string*
 
 ___
@@ -903,8 +781,6 @@ ___
 ▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
-
-*Defined in [card-elements.ts:283](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L283)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md) | undefined*
 
@@ -916,8 +792,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
 
-*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
-
 **Returns:** *[Container](container.md) | undefined*
 
 ___
@@ -927,8 +801,6 @@ ___
 ▸ **getResourceInformation**(): *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
 *Overrides [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
-
-*Defined in [card-elements.ts:4574](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4574)*
 
 **Returns:** *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
@@ -940,8 +812,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
 
-*Defined in [card-elements.ts:501](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L501)*
-
 **Returns:** *[CardElement](cardelement.md)*
 
 ___
@@ -952,8 +822,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getRootObject](cardobject.md#getrootobject)*
 
-*Defined in [card-object.ts:100](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L100)*
-
 **Returns:** *[CardObject](cardobject.md)*
 
 ___
@@ -963,8 +831,6 @@ ___
 ▸ **getSchema**(): *[SerializableObjectSchema](serializableobjectschema.md)*
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
-
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
 
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
@@ -978,8 +844,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-object.ts:45](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L45)*
-
 **Returns:** *string*
 
 ___
@@ -989,8 +853,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -1008,8 +870,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -1019,8 +879,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -1038,8 +896,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
 
-*Defined in [card-elements.ts:439](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L439)*
-
 **Parameters:**
 
 Name | Type |
@@ -1055,8 +911,6 @@ ___
 ▸ **internalParse**(`source`: any, `context`: [SerializationContext](serializationcontext.md)): *void*
 
 *Overrides [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
-
-*Defined in [card-elements.ts:4507](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4507)*
 
 **Parameters:**
 
@@ -1075,8 +929,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
 
-*Defined in [card-elements.ts:4519](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4519)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1086,8 +938,6 @@ ___
 ▸ **internalToJSON**(`target`: [PropertyBag](../README.md#propertybag), `context`: [SerializationContext](serializationcontext.md)): *void*
 
 *Overrides [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
-
-*Defined in [card-elements.ts:4513](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4513)*
 
 **Parameters:**
 
@@ -1106,8 +956,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
 
-*Defined in [card-elements.ts:4560](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4560)*
-
 **Parameters:**
 
 Name | Type |
@@ -1124,8 +972,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
 
-*Defined in [card-elements.ts:469](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L469)*
-
 **Returns:** *boolean*
 
 ___
@@ -1135,8 +981,6 @@ ___
 ▸ **isAtTheVeryLeft**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
-
-*Defined in [card-elements.ts:457](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L457)*
 
 **Returns:** *boolean*
 
@@ -1148,8 +992,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
 
-*Defined in [card-elements.ts:461](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L461)*
-
 **Returns:** *boolean*
 
 ___
@@ -1159,8 +1001,6 @@ ___
 ▸ **isAtTheVeryTop**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
-
-*Defined in [card-elements.ts:465](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L465)*
 
 **Returns:** *boolean*
 
@@ -1172,8 +1012,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
 
-*Defined in [card-elements.ts:325](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L325)*
-
 **Returns:** *boolean*
 
 ___
@@ -1183,8 +1021,6 @@ ___
 ▸ **isBleedingAtBottom**(): *boolean*
 
 *Overrides [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
-
-*Defined in [card-elements.ts:4529](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4529)*
 
 **Returns:** *boolean*
 
@@ -1196,8 +1032,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
 
-*Defined in [card-elements.ts:473](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L473)*
-
 **Returns:** *boolean*
 
 ___
@@ -1207,8 +1041,6 @@ ___
 ▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
-
-*Defined in [card-elements.ts:493](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L493)*
 
 **Parameters:**
 
@@ -1226,8 +1058,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
 
-*Defined in [card-elements.ts:443](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L443)*
-
 **Returns:** *boolean*
 
 ___
@@ -1238,8 +1068,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDisplayed](cardelement.md#protected-isdisplayed)*
 
-*Defined in [card-elements.ts:229](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L229)*
-
 **Returns:** *boolean*
 
 ___
@@ -1249,8 +1077,6 @@ ___
 ▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
-
-*Defined in [card-elements.ts:449](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L449)*
 
 **Parameters:**
 
@@ -1268,8 +1094,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
 
-*Defined in [card-elements.ts:497](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L497)*
-
 **Returns:** *boolean*
 
 ___
@@ -1279,8 +1103,6 @@ ___
 ▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
-
-*Defined in [card-elements.ts:453](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L453)*
 
 **Parameters:**
 
@@ -1298,8 +1120,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
 
-*Defined in [card-elements.ts:481](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L481)*
-
 **Parameters:**
 
 Name | Type |
@@ -1315,8 +1135,6 @@ ___
 ▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
-
-*Defined in [card-elements.ts:485](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L485)*
 
 **Parameters:**
 
@@ -1334,8 +1152,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
 
-*Defined in [card-elements.ts:489](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L489)*
-
 **Parameters:**
 
 Name | Type |
@@ -1352,8 +1168,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
 
-*Defined in [card-elements.ts:235](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L235)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1365,8 +1179,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[parse](cardelement.md#parse)*
 
 *Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
-
-*Defined in [card-elements.ts:313](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L313)*
 
 **Parameters:**
 
@@ -1385,8 +1197,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [serialization.ts:738](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L738)*
-
 **Parameters:**
 
 Name | Type |
@@ -1402,8 +1212,6 @@ ___
 ▸ **preProcessPropertyValue**(`property`: [PropertyDefinition](propertydefinition.md), `propertyValue?`: any): *any*
 
 *Inherited from [CardObject](cardobject.md).[preProcessPropertyValue](cardobject.md#preprocesspropertyvalue)*
-
-*Defined in [card-object.ts:70](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L70)*
 
 **Parameters:**
 
@@ -1422,8 +1230,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
 
-*Defined in [card-elements.ts:404](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L404)*
-
 **Returns:** *boolean*
 
 ___
@@ -1433,8 +1239,6 @@ ___
 ▸ **render**(): *HTMLElement | undefined*
 
 *Inherited from [CardElement](cardelement.md).[render](cardelement.md#render)*
-
-*Defined in [card-elements.ts:412](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L412)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -1446,8 +1250,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -1457,8 +1259,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -1477,8 +1277,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
 
-*Defined in [card-elements.ts:287](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L287)*
-
 **Parameters:**
 
 Name | Type |
@@ -1494,8 +1292,6 @@ ___
 ▸ **setParent**(`value`: [CardObject](cardobject.md) | undefined): *void*
 
 *Inherited from [CardObject](cardobject.md).[setParent](cardobject.md#setparent)*
-
-*Defined in [card-object.ts:88](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L88)*
 
 **Parameters:**
 
@@ -1513,8 +1309,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setShouldFallback](cardobject.md#setshouldfallback)*
 
-*Defined in [card-object.ts:92](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L92)*
-
 **Parameters:**
 
 Name | Type |
@@ -1530,8 +1324,6 @@ ___
 ▸ **setValue**(`property`: [PropertyDefinition](propertydefinition.md), `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
-
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
 
 **Parameters:**
 
@@ -1550,8 +1342,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[shouldFallback](cardobject.md#shouldfallback)*
 
-*Defined in [card-object.ts:96](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L96)*
-
 **Returns:** *boolean*
 
 ___
@@ -1563,8 +1353,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[shouldSerialize](cardelement.md#protected-shouldserialize)*
 
 *Overrides [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
-
-*Defined in [card-elements.ts:291](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L291)*
 
 **Parameters:**
 
@@ -1584,8 +1372,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
 
-*Defined in [card-elements.ts:317](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L317)*
-
 **Parameters:**
 
 Name | Type |
@@ -1601,8 +1387,6 @@ ___
 ▸ **truncateOverflow**(`maxHeight`: number): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
-
-*Defined in [card-elements.ts:263](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L263)*
 
 **Parameters:**
 
@@ -1620,8 +1404,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
 
-*Defined in [card-elements.ts:273](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L273)*
-
 **Returns:** *void*
 
 ___
@@ -1631,8 +1413,6 @@ ___
 ▸ **updateLayout**(`processChildren`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
-
-*Defined in [card-elements.ts:434](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L434)*
 
 **Parameters:**
 
@@ -1649,7 +1429,5 @@ ___
 ▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
 
 *Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
-
-*Defined in [card-object.ts:128](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L128)*
 
 **Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/actionstyle.md
+++ b/source/nodejs/adaptivecards/docs/classes/actionstyle.md
@@ -20,20 +20,14 @@
 
 ▪ **Default**: *"default"* = "default"
 
-*Defined in [enums.ts:8](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L8)*
-
 ___
 
 ### `Static` Destructive
 
 ▪ **Destructive**: *"destructive"* = "destructive"
 
-*Defined in [enums.ts:10](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L10)*
-
 ___
 
 ### `Static` Positive
 
 ▪ **Positive**: *"positive"* = "positive"
-
-*Defined in [enums.ts:9](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L9)*

--- a/source/nodejs/adaptivecards/docs/classes/adaptivecard.md
+++ b/source/nodejs/adaptivecards/docs/classes/adaptivecard.md
@@ -203,8 +203,6 @@
 
 *Overrides [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [card-elements.ts:5835](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5835)*
-
 **Returns:** *[AdaptiveCard](adaptivecard.md)*
 
 ## Properties
@@ -215,8 +213,6 @@
 
 *Inherited from [CardObject](cardobject.md).[_parent](cardobject.md#protected-optional-_parent)*
 
-*Defined in [card-object.ts:61](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L61)*
-
 ___
 
 ### `Protected` `Optional` _renderedElement
@@ -224,8 +220,6 @@ ___
 • **_renderedElement**? : *HTMLElement*
 
 *Inherited from [CardObject](cardobject.md).[_renderedElement](cardobject.md#protected-optional-_renderedelement)*
-
-*Defined in [card-object.ts:62](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L62)*
 
 ___
 
@@ -235,8 +229,6 @@ ___
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[_selectAction](cardelementcontainer.md#protected-optional-_selectaction)*
 
-*Defined in [card-elements.ts:1747](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1747)*
-
 ___
 
 ###  allowVerticalOverflow
@@ -244,8 +236,6 @@ ___
 • **allowVerticalOverflow**: *boolean* = false
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[allowVerticalOverflow](cardelementcontainer.md#allowverticaloverflow)*
-
-*Defined in [card-elements.ts:1787](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1787)*
 
 ___
 
@@ -255,23 +245,17 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#optional-customcssselector)*
 
-*Defined in [card-elements.ts:311](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L311)*
-
 ___
 
 ###  designMode
 
 • **designMode**: *boolean* = false
 
-*Defined in [card-elements.ts:6097](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6097)*
-
 ___
 
 ### `Optional` fallbackText
 
 • **fallbackText**? : *undefined | string*
-
-*Defined in [card-elements.ts:5961](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5961)*
 
 ___
 
@@ -281,8 +265,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
 
-*Defined in [card-elements.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L53)*
-
 ___
 
 ###  horizontalAlignment
@@ -290,8 +272,6 @@ ___
 • **horizontalAlignment**: *[HorizontalAlignment](../enums/horizontalalignment.md)*
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#horizontalalignment)*
-
-*Defined in [card-elements.ts:44](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L44)*
 
 ___
 
@@ -301,8 +281,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[id](cardobject.md#optional-id)*
 
-*Defined in [card-object.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L50)*
-
 ___
 
 ###  maxVersion
@@ -310,8 +288,6 @@ ___
 • **maxVersion**: *[Version](version.md)* = Versions.latest
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
-
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
 
 ___
 
@@ -321,15 +297,11 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[minPixelHeight](stylablecardelementcontainer.md#optional-minpixelheight)*
 
-*Defined in [card-elements.ts:4621](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4621)*
-
 ___
 
 ### `Optional` onAnchorClicked
 
 • **onAnchorClicked**? : *undefined | function*
-
-*Defined in [card-elements.ts:6090](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6090)*
 
 ___
 
@@ -337,15 +309,11 @@ ___
 
 • **onElementVisibilityChanged**? : *undefined | function*
 
-*Defined in [card-elements.ts:6092](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6092)*
-
 ___
 
 ### `Optional` onExecuteAction
 
 • **onExecuteAction**? : *undefined | function*
-
-*Defined in [card-elements.ts:6091](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6091)*
 
 ___
 
@@ -353,23 +321,17 @@ ___
 
 • **onImageLoaded**? : *undefined | function*
 
-*Defined in [card-elements.ts:6093](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6093)*
-
 ___
 
 ### `Optional` onInlineCardExpanded
 
 • **onInlineCardExpanded**? : *undefined | function*
 
-*Defined in [card-elements.ts:6094](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6094)*
-
 ___
 
 ### `Optional` onInputValueChanged
 
 • **onInputValueChanged**? : *undefined | function*
-
-*Defined in [card-elements.ts:6095](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6095)*
 
 ___
 
@@ -379,8 +341,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[onPreProcessPropertyValue](cardobject.md#optional-onpreprocesspropertyvalue)*
 
-*Defined in [card-object.ts:64](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L64)*
-
 ___
 
 ### `Optional` rtl
@@ -388,8 +348,6 @@ ___
 • **rtl**? : *undefined | false | true*
 
 *Inherited from [Container](container.md).[rtl](container.md#optional-rtl)*
-
-*Defined in [card-elements.ts:4885](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4885)*
 
 ___
 
@@ -399,8 +357,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
 
-*Defined in [card-elements.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L50)*
-
 ___
 
 ###  spacing
@@ -409,23 +365,17 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
 
-*Defined in [card-elements.ts:47](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L47)*
-
 ___
 
 ### `Optional` speak
 
 • **speak**? : *undefined | string*
 
-*Defined in [card-elements.ts:5964](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5964)*
-
 ___
 
 ###  version
 
 • **version**: *[Version](version.md)*
-
-*Defined in [card-elements.ts:5958](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5958)*
 
 ___
 
@@ -434,8 +384,6 @@ ___
 • **verticalContentAlignment**: *[VerticalAlignment](../enums/verticalalignment.md)* = Enums.VerticalAlignment.Top
 
 *Inherited from [Container](container.md).[verticalContentAlignment](container.md#verticalcontentalignment)*
-
-*Defined in [card-elements.ts:4882](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4882)*
 
 ___
 
@@ -451,8 +399,6 @@ ___
             context.serializeValue(target, property.name, AdaptiveCard.schemaUrl);
         })
 
-*Defined in [card-elements.ts:5922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5922)*
-
 ___
 
 ### `Static` backgroundImageProperty
@@ -464,8 +410,6 @@ ___
 
 *Inherited from [Container](container.md).[backgroundImageProperty](container.md#static-backgroundimageproperty)*
 
-*Defined in [card-elements.ts:4869](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4869)*
-
 ___
 
 ### `Static` bleedProperty
@@ -474,15 +418,11 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[bleedProperty](stylablecardelementcontainer.md#static-bleedproperty)*
 
-*Defined in [card-elements.ts:4597](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4597)*
-
 ___
 
 ### `Static` fallbackTextProperty
 
 ▪ **fallbackTextProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "fallbackText")
-
-*Defined in [card-elements.ts:5954](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5954)*
 
 ___
 
@@ -499,8 +439,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[heightProperty](cardelement.md#static-heightproperty)*
 
-*Defined in [card-elements.ts:24](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L24)*
-
 ___
 
 ### `Static` horizontalAlignmentProperty
@@ -513,8 +451,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignmentProperty](cardelement.md#static-horizontalalignmentproperty)*
 
-*Defined in [card-elements.ts:32](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L32)*
-
 ___
 
 ### `Static` idProperty
@@ -522,8 +458,6 @@ ___
 ▪ **idProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "id")
 
 *Inherited from [CardObject](cardobject.md).[idProperty](cardobject.md#static-idproperty)*
-
-*Defined in [card-object.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L39)*
 
 ___
 
@@ -533,8 +467,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisibleProperty](cardelement.md#static-isvisibleproperty)*
 
-*Defined in [card-elements.ts:22](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L22)*
-
 ___
 
 ### `Static` langProperty
@@ -542,8 +474,6 @@ ___
 ▪ **langProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_1, "lang", true, /^[a-z]{2,3}$/ig)
 
 *Inherited from [CardElement](cardelement.md).[langProperty](cardelement.md#static-langproperty)*
-
-*Defined in [card-elements.ts:21](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L21)*
 
 ___
 
@@ -553,15 +483,11 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[minHeightProperty](stylablecardelementcontainer.md#static-minheightproperty)*
 
-*Defined in [card-elements.ts:4598](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4598)*
-
 ___
 
 ### `Static` `Optional` onAnchorClicked
 
 ▪ **onAnchorClicked**? : *undefined | function*
-
-*Defined in [card-elements.ts:5968](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5968)*
 
 ___
 
@@ -569,15 +495,11 @@ ___
 
 ▪ **onElementVisibilityChanged**? : *undefined | function*
 
-*Defined in [card-elements.ts:5970](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5970)*
-
 ___
 
 ### `Static` `Optional` onExecuteAction
 
 ▪ **onExecuteAction**? : *undefined | function*
-
-*Defined in [card-elements.ts:5969](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5969)*
 
 ___
 
@@ -585,15 +507,11 @@ ___
 
 ▪ **onImageLoaded**? : *undefined | function*
 
-*Defined in [card-elements.ts:5971](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5971)*
-
 ___
 
 ### `Static` `Optional` onInlineCardExpanded
 
 ▪ **onInlineCardExpanded**? : *undefined | function*
-
-*Defined in [card-elements.ts:5972](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5972)*
 
 ___
 
@@ -601,15 +519,11 @@ ___
 
 ▪ **onInputValueChanged**? : *undefined | function*
 
-*Defined in [card-elements.ts:5973](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5973)*
-
 ___
 
 ### `Static` `Optional` onProcessMarkdown
 
 ▪ **onProcessMarkdown**? : *undefined | function*
-
-*Defined in [card-elements.ts:5974](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5974)*
 
 ___
 
@@ -618,8 +532,6 @@ ___
 ▪ **onRegisterCustomProperties**? : *undefined | function*
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
-
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
 
 ___
 
@@ -632,8 +544,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requiresProperty](cardobject.md#static-requiresproperty)*
 
-*Defined in [card-object.ts:40](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L40)*
-
 ___
 
 ### `Static` rtlProperty
@@ -642,15 +552,11 @@ ___
 
 *Inherited from [Container](container.md).[rtlProperty](container.md#static-rtlproperty)*
 
-*Defined in [card-elements.ts:4874](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4874)*
-
 ___
 
 ### `Static` schemaUrl
 
 ▪ **schemaUrl**: *"http://adaptivecards.io/schemas/adaptive-card.json"* = "http://adaptivecards.io/schemas/adaptive-card.json"
-
-*Defined in [card-elements.ts:5918](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5918)*
 
 ___
 
@@ -660,8 +566,6 @@ ___
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[selectActionProperty](cardelementcontainer.md#static-selectactionproperty)*
 
-*Defined in [card-elements.ts:1736](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1736)*
-
 ___
 
 ### `Static` separatorProperty
@@ -669,8 +573,6 @@ ___
 ▪ **separatorProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_0, "separator", false)
 
 *Inherited from [CardElement](cardelement.md).[separatorProperty](cardelement.md#static-separatorproperty)*
-
-*Defined in [card-elements.ts:23](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L23)*
 
 ___
 
@@ -684,15 +586,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[spacingProperty](cardelement.md#static-spacingproperty)*
 
-*Defined in [card-elements.ts:37](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L37)*
-
 ___
 
 ### `Static` speakProperty
 
 ▪ **speakProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "speak")
-
-*Defined in [card-elements.ts:5955](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5955)*
 
 ___
 
@@ -712,8 +610,6 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[styleProperty](stylablecardelementcontainer.md#static-styleproperty)*
 
-*Defined in [card-elements.ts:4586](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4586)*
-
 ___
 
 ### `Static` typeNameProperty
@@ -729,8 +625,6 @@ ___
         })
 
 *Inherited from [CardObject](cardobject.md).[typeNameProperty](cardobject.md#static-typenameproperty)*
-
-*Defined in [card-object.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L30)*
 
 ___
 
@@ -759,8 +653,6 @@ ___
         },
         Versions.v1_0)
 
-*Defined in [card-elements.ts:5932](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5932)*
-
 ___
 
 ### `Static` verticalContentAlignmentProperty
@@ -769,8 +661,6 @@ ___
 
 *Inherited from [Container](container.md).[verticalContentAlignmentProperty](container.md#static-verticalcontentalignmentproperty)*
 
-*Defined in [card-elements.ts:4873](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4873)*
-
 ## Accessors
 
 ### `Protected` allowCustomPadding
@@ -778,8 +668,6 @@ ___
 • **get allowCustomPadding**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
-
-*Defined in [card-elements.ts:299](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L299)*
 
 **Returns:** *boolean*
 
@@ -791,8 +679,6 @@ ___
 
 *Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[allowCustomStyle](stylablecardelementcontainer.md#protected-allowcustomstyle)*
 
-*Defined in [card-elements.ts:6082](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6082)*
-
 **Returns:** *boolean*
 
 ___
@@ -802,8 +688,6 @@ ___
 • **get backgroundImage**(): *[BackgroundImage](backgroundimage.md)*
 
 *Inherited from [Container](container.md).[backgroundImage](container.md#backgroundimage)*
-
-*Defined in [card-elements.ts:4877](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4877)*
 
 **Returns:** *[BackgroundImage](backgroundimage.md)*
 
@@ -815,15 +699,11 @@ ___
 
 *Inherited from [Container](container.md).[bleed](container.md#bleed)*
 
-*Defined in [card-elements.ts:5256](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5256)*
-
 **Returns:** *boolean*
 
 • **set bleed**(`value`: boolean): *void*
 
 *Inherited from [Container](container.md).[bleed](container.md#bleed)*
-
-*Defined in [card-elements.ts:5260](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5260)*
 
 **Parameters:**
 
@@ -839,8 +719,6 @@ ___
 
 • **get bypassVersionCheck**(): *boolean*
 
-*Defined in [card-elements.ts:6078](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6078)*
-
 **Returns:** *boolean*
 
 ___
@@ -851,8 +729,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
 
-*Defined in [card-elements.ts:307](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L307)*
-
 **Returns:** *string*
 
 ___
@@ -860,8 +736,6 @@ ___
 ### `Protected` hasBackground
 
 • **get hasBackground**(): *boolean*
-
-*Defined in [card-elements.ts:6086](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6086)*
 
 **Returns:** *boolean*
 
@@ -873,8 +747,6 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[hasExplicitStyle](stylablecardelementcontainer.md#protected-hasexplicitstyle)*
 
-*Defined in [card-elements.ts:4738](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4738)*
-
 **Returns:** *boolean*
 
 ___
@@ -884,8 +756,6 @@ ___
 • **get hasVisibleSeparator**(): *boolean*
 
 *Overrides [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
-
-*Defined in [card-elements.ts:6179](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6179)*
 
 **Returns:** *boolean*
 
@@ -899,8 +769,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
 
-*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
-
 **Returns:** *[HostConfig](hostconfig.md)*
 
 • **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
@@ -908,8 +776,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
-
-*Defined in [card-elements.ts:555](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L555)*
 
 **Parameters:**
 
@@ -927,8 +793,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
 
-*Defined in [card-elements.ts:559](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L559)*
-
 **Returns:** *number*
 
 ___
@@ -939,8 +803,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
 
-*Defined in [card-elements.ts:576](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L576)*
-
 **Returns:** *boolean*
 
 ___
@@ -950,8 +812,6 @@ ___
 • **get isInteractive**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
-
-*Defined in [card-elements.ts:568](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L568)*
 
 **Returns:** *boolean*
 
@@ -965,8 +825,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[isSelectable](cardelementcontainer.md#protected-isselectable)*
 
-*Defined in [card-elements.ts:5079](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5079)*
-
 **Returns:** *boolean*
 
 ___
@@ -979,8 +837,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
 
-*Defined in [card-elements.ts:5906](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5906)*
-
 **Returns:** *boolean*
 
 ___
@@ -991,15 +847,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
 
-*Defined in [card-elements.ts:77](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L77)*
-
 **Returns:** *boolean*
 
 • **set isVisible**(`value`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
-
-*Defined in [card-elements.ts:81](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L81)*
 
 **Parameters:**
 
@@ -1017,15 +869,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
 
-*Defined in [card-elements.ts:56](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L56)*
-
 **Returns:** *string | undefined*
 
 • **set lang**(`value`: string | undefined): *void*
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
-
-*Defined in [card-elements.ts:72](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L72)*
 
 **Parameters:**
 
@@ -1043,15 +891,11 @@ ___
 
 *Inherited from [Container](container.md).[padding](container.md#padding)*
 
-*Defined in [card-elements.ts:5240](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5240)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md) | undefined*
 
 • **set padding**(`value`: [PaddingDefinition](paddingdefinition.md) | undefined): *void*
 
 *Inherited from [Container](container.md).[padding](container.md#padding)*
-
-*Defined in [card-elements.ts:5244](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5244)*
 
 **Parameters:**
 
@@ -1071,8 +915,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[parent](cardobject.md#parent)*
 
-*Defined in [card-elements.ts:593](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L593)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -1082,8 +924,6 @@ ___
 • **get renderIfEmpty**(): *boolean*
 
 *Overrides [ContainerWithActions](containerwithactions.md).[renderIfEmpty](containerwithactions.md#protected-renderifempty)*
-
-*Defined in [card-elements.ts:6074](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6074)*
 
 **Returns:** *boolean*
 
@@ -1097,8 +937,6 @@ ___
 
 *Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[renderedActionCount](stylablecardelementcontainer.md#protected-renderedactioncount)*
 
-*Defined in [card-elements.ts:5829](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5829)*
-
 **Returns:** *number*
 
 ___
@@ -1108,8 +946,6 @@ ___
 • **get renderedElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardObject](cardobject.md).[renderedElement](cardobject.md#renderedelement)*
-
-*Defined in [card-object.ts:140](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L140)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -1121,8 +957,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requires](cardobject.md#requires)*
 
-*Defined in [card-object.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L53)*
-
 **Returns:** *HostCapabilities*
 
 ___
@@ -1133,15 +967,11 @@ ___
 
 *Inherited from [Container](container.md).[selectAction](container.md#selectaction)*
 
-*Defined in [card-elements.ts:5248](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5248)*
-
 **Returns:** *[Action](action.md) | undefined*
 
 • **set selectAction**(`value`: [Action](action.md) | undefined): *void*
 
 *Inherited from [Container](container.md).[selectAction](container.md#selectaction)*
-
-*Defined in [card-elements.ts:5252](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5252)*
 
 **Parameters:**
 
@@ -1159,8 +989,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
 
-*Defined in [card-elements.ts:589](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L589)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1170,8 +998,6 @@ ___
 • **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
 
 *Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
-
-*Defined in [card-elements.ts:303](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L303)*
 
 **Returns:** *[Orientation](../enums/orientation.md)*
 
@@ -1183,15 +1009,11 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[style](stylablecardelementcontainer.md#style)*
 
-*Defined in [card-elements.ts:4601](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4601)*
-
 **Returns:** *string | undefined*
 
 • **set style**(`value`: string | undefined): *void*
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[style](stylablecardelementcontainer.md#style)*
-
-*Defined in [card-elements.ts:4613](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4613)*
 
 **Parameters:**
 
@@ -1209,8 +1031,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
 
-*Defined in [card-elements.ts:295](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L295)*
-
 **Returns:** *boolean*
 
 ___
@@ -1218,8 +1038,6 @@ ___
 ### `Static` processMarkdown
 
 • **get processMarkdown**(): *function*
-
-*Defined in [card-elements.ts:5976](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5976)*
 
 **Returns:** *function*
 
@@ -1232,8 +1050,6 @@ Name | Type |
 `text` | string |
 
 • **set processMarkdown**(`value`: function): *void*
-
-*Defined in [card-elements.ts:5980](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5980)*
 
 **Parameters:**
 
@@ -1257,8 +1073,6 @@ Name | Type |
 
 *Inherited from [ContainerWithActions](containerwithactions.md).[addAction](containerwithactions.md#addaction)*
 
-*Defined in [card-elements.ts:5874](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5874)*
-
 **Parameters:**
 
 Name | Type |
@@ -1274,8 +1088,6 @@ ___
 ▸ **addItem**(`item`: [CardElement](cardelement.md)): *void*
 
 *Inherited from [Container](container.md).[addItem](container.md#additem)*
-
-*Defined in [card-elements.ts:5170](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5170)*
 
 **Parameters:**
 
@@ -1295,8 +1107,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
 
-*Defined in [card-elements.ts:4625](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4625)*
-
 **Parameters:**
 
 Name | Type |
@@ -1315,8 +1125,6 @@ ___
 
 *Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[applyBackground](stylablecardelementcontainer.md#protected-applybackground)*
 
-*Defined in [card-elements.ts:4924](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4924)*
-
 **Returns:** *void*
 
 ___
@@ -1329,8 +1137,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[applyPadding](cardelementcontainer.md#protected-applypadding)*
 
-*Defined in [card-elements.ts:4643](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4643)*
-
 **Returns:** *void*
 
 ___
@@ -1340,8 +1146,6 @@ ___
 ▸ **asString**(): *string | undefined*
 
 *Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
-
-*Defined in [card-elements.ts:321](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L321)*
 
 **Returns:** *string | undefined*
 
@@ -1355,8 +1159,6 @@ ___
 
 *Overrides [Container](container.md).[clear](container.md#clear)*
 
-*Defined in [card-elements.ts:5878](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5878)*
-
 **Returns:** *void*
 
 ___
@@ -1366,8 +1168,6 @@ ___
 ▸ **createPlaceholderElement**(): *HTMLElement*
 
 *Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
-
-*Defined in [card-elements.ts:205](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L205)*
 
 **Returns:** *HTMLElement*
 
@@ -1380,8 +1180,6 @@ ___
 *Inherited from [ContainerWithActions](containerwithactions.md).[getActionAt](containerwithactions.md#getactionat)*
 
 *Overrides [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
-
-*Defined in [card-elements.ts:5847](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5847)*
 
 **Parameters:**
 
@@ -1401,8 +1199,6 @@ ___
 
 *Overrides [Container](container.md).[getActionById](container.md#getactionbyid)*
 
-*Defined in [card-elements.ts:5856](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5856)*
-
 **Parameters:**
 
 Name | Type |
@@ -1421,8 +1217,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
 
-*Defined in [card-elements.ts:5843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5843)*
-
 **Returns:** *number*
 
 ___
@@ -1435,8 +1229,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[getAllInputs](cardelementcontainer.md#getallinputs)*
 
-*Defined in [card-elements.ts:5884](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5884)*
-
 **Returns:** *[Input](input.md)[]*
 
 ___
@@ -1447,8 +1239,6 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[getBleed](stylablecardelementcontainer.md#protected-getbleed)*
 
-*Defined in [card-elements.ts:4726](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4726)*
-
 **Returns:** *boolean*
 
 ___
@@ -1458,8 +1248,6 @@ ___
 ▸ **getCustomProperty**(`name`: string): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
-
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
 
 **Parameters:**
 
@@ -1477,8 +1265,6 @@ ___
 
 *Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[getDefaultPadding](stylablecardelementcontainer.md#protected-getdefaultpadding)*
 
-*Defined in [card-elements.ts:6062](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6062)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
 ___
@@ -1488,8 +1274,6 @@ ___
 ▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
 
 *Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
-
-*Defined in [card-elements.ts:535](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L535)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
@@ -1503,8 +1287,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
 
-*Defined in [card-elements.ts:4777](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4777)*
-
 **Returns:** *string*
 
 ___
@@ -1514,8 +1296,6 @@ ___
 ▸ **getEffectiveStyleDefinition**(): *[ContainerStyleDefinition](containerstyledefinition.md)*
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyleDefinition](cardelement.md#geteffectivestyledefinition)*
-
-*Defined in [card-elements.ts:337](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L337)*
 
 **Returns:** *[ContainerStyleDefinition](containerstyledefinition.md)*
 
@@ -1528,8 +1308,6 @@ ___
 *Inherited from [CardElementContainer](cardelementcontainer.md).[getElementById](cardelementcontainer.md#getelementbyid)*
 
 *Overrides [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
-
-*Defined in [card-elements.ts:1891](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1891)*
 
 **Parameters:**
 
@@ -1549,8 +1327,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[getFirstVisibleRenderedItem](cardelementcontainer.md#abstract-getfirstvisiblerendereditem)*
 
-*Defined in [card-elements.ts:5091](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5091)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -1561,8 +1337,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
 
-*Defined in [card-elements.ts:341](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L341)*
-
 **Returns:** *[ActionType](../README.md#actiontype)[]*
 
 ___
@@ -1572,8 +1346,6 @@ ___
 ▸ **getHasBackground**(): *boolean*
 
 *Overrides [Container](container.md).[getHasBackground](container.md#protected-gethasbackground)*
-
-*Defined in [card-elements.ts:6058](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6058)*
 
 **Returns:** *boolean*
 
@@ -1587,8 +1359,6 @@ ___
 
 *Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[getHasExpandedAction](stylablecardelementcontainer.md#protected-gethasexpandedaction)*
 
-*Defined in [card-elements.ts:5817](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5817)*
-
 **Returns:** *boolean*
 
 ___
@@ -1598,8 +1368,6 @@ ___
 ▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
-
-*Defined in [card-elements.ts:345](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L345)*
 
 **Parameters:**
 
@@ -1623,8 +1391,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[getItemAt](cardelementcontainer.md#abstract-getitemat)*
 
-*Defined in [card-elements.ts:5087](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5087)*
-
 **Parameters:**
 
 Name | Type |
@@ -1643,8 +1409,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[getItemCount](cardelementcontainer.md#abstract-getitemcount)*
 
-*Defined in [card-elements.ts:5083](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5083)*
-
 **Returns:** *number*
 
 ___
@@ -1655,8 +1419,6 @@ ___
 
 *Overrides [Container](container.md).[getItemsCollectionPropertyName](container.md#protected-getitemscollectionpropertyname)*
 
-*Defined in [card-elements.ts:6022](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6022)*
-
 **Returns:** *string*
 
 ___
@@ -1666,8 +1428,6 @@ ___
 ▸ **getJsonTypeName**(): *string*
 
 *Overrides [Container](container.md).[getJsonTypeName](container.md#getjsontypename)*
-
-*Defined in [card-elements.ts:6099](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6099)*
 
 **Returns:** *string*
 
@@ -1681,8 +1441,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[getLastVisibleRenderedItem](cardelementcontainer.md#abstract-getlastvisiblerendereditem)*
 
-*Defined in [card-elements.ts:5103](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5103)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -1693,8 +1451,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
 
-*Defined in [card-elements.ts:283](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L283)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md) | undefined*
 
 ___
@@ -1704,8 +1460,6 @@ ___
 ▸ **getParentContainer**(): *[Container](container.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
-
-*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
 
 **Returns:** *[Container](container.md) | undefined*
 
@@ -1719,8 +1473,6 @@ ___
 
 *Overrides [Container](container.md).[getResourceInformation](container.md#getresourceinformation)*
 
-*Defined in [card-elements.ts:5888](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5888)*
-
 **Returns:** *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
 ___
@@ -1730,8 +1482,6 @@ ___
 ▸ **getRootElement**(): *[CardElement](cardelement.md)*
 
 *Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
-
-*Defined in [card-elements.ts:501](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L501)*
 
 **Returns:** *[CardElement](cardelement.md)*
 
@@ -1743,8 +1493,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getRootObject](cardobject.md#getrootobject)*
 
-*Defined in [card-object.ts:100](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L100)*
-
 **Returns:** *[CardObject](cardobject.md)*
 
 ___
@@ -1754,8 +1502,6 @@ ___
 ▸ **getSchema**(): *[SerializableObjectSchema](serializableobjectschema.md)*
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
-
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
 
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
@@ -1769,8 +1515,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-object.ts:45](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L45)*
-
 **Returns:** *string*
 
 ___
@@ -1780,8 +1524,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -1799,8 +1541,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -1810,8 +1550,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -1831,8 +1569,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
 
-*Defined in [card-elements.ts:5166](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5166)*
-
 **Parameters:**
 
 Name | Type |
@@ -1848,8 +1584,6 @@ ___
 ▸ **insertItemAfter**(`item`: [CardElement](cardelement.md), `insertAfter`: [CardElement](cardelement.md)): *void*
 
 *Inherited from [Container](container.md).[insertItemAfter](container.md#insertitemafter)*
-
-*Defined in [card-elements.ts:5178](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5178)*
 
 **Parameters:**
 
@@ -1868,8 +1602,6 @@ ___
 
 *Inherited from [Container](container.md).[insertItemBefore](container.md#insertitembefore)*
 
-*Defined in [card-elements.ts:5174](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5174)*
-
 **Parameters:**
 
 Name | Type |
@@ -1886,8 +1618,6 @@ ___
 ▸ **internalParse**(`source`: any, `context`: [SerializationContext](serializationcontext.md)): *void*
 
 *Overrides [ContainerWithActions](containerwithactions.md).[internalParse](containerwithactions.md#protected-internalparse)*
-
-*Defined in [card-elements.ts:6026](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6026)*
 
 **Parameters:**
 
@@ -1906,8 +1636,6 @@ ___
 
 *Overrides [ContainerWithActions](containerwithactions.md).[internalRender](containerwithactions.md#protected-internalrender)*
 
-*Defined in [card-elements.ts:6045](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6045)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1917,8 +1645,6 @@ ___
 ▸ **internalToJSON**(`target`: [PropertyBag](../README.md#propertybag), `context`: [SerializationContext](serializationcontext.md)): *void*
 
 *Overrides [ContainerWithActions](containerwithactions.md).[internalToJSON](containerwithactions.md#protected-internaltojson)*
-
-*Defined in [card-elements.ts:6039](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6039)*
 
 **Parameters:**
 
@@ -1937,8 +1663,6 @@ ___
 
 *Overrides [ContainerWithActions](containerwithactions.md).[internalValidateProperties](containerwithactions.md#internalvalidateproperties)*
 
-*Defined in [card-elements.ts:6103](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6103)*
-
 **Parameters:**
 
 Name | Type |
@@ -1955,8 +1679,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
 
-*Defined in [card-elements.ts:469](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L469)*
-
 **Returns:** *boolean*
 
 ___
@@ -1966,8 +1688,6 @@ ___
 ▸ **isAtTheVeryLeft**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
-
-*Defined in [card-elements.ts:457](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L457)*
 
 **Returns:** *boolean*
 
@@ -1979,8 +1699,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
 
-*Defined in [card-elements.ts:461](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L461)*
-
 **Returns:** *boolean*
 
 ___
@@ -1990,8 +1708,6 @@ ___
 ▸ **isAtTheVeryTop**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
-
-*Defined in [card-elements.ts:465](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L465)*
 
 **Returns:** *boolean*
 
@@ -2005,8 +1721,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
 
-*Defined in [card-elements.ts:4746](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4746)*
-
 **Returns:** *boolean*
 
 ___
@@ -2018,8 +1732,6 @@ ___
 *Inherited from [ContainerWithActions](containerwithactions.md).[isBleedingAtBottom](containerwithactions.md#isbleedingatbottom)*
 
 *Overrides [Container](container.md).[isBleedingAtBottom](container.md#isbleedingatbottom)*
-
-*Defined in [card-elements.ts:5892](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5892)*
 
 **Returns:** *boolean*
 
@@ -2033,8 +1745,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
 
-*Defined in [card-elements.ts:5154](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5154)*
-
 **Returns:** *boolean*
 
 ___
@@ -2044,8 +1754,6 @@ ___
 ▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
-
-*Defined in [card-elements.ts:493](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L493)*
 
 **Parameters:**
 
@@ -2063,8 +1771,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
 
-*Defined in [card-elements.ts:443](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L443)*
-
 **Returns:** *boolean*
 
 ___
@@ -2075,8 +1781,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDisplayed](cardelement.md#protected-isdisplayed)*
 
-*Defined in [card-elements.ts:229](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L229)*
-
 **Returns:** *boolean*
 
 ___
@@ -2086,8 +1790,6 @@ ___
 ▸ **isElementAllowed**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[isElementAllowed](cardelementcontainer.md#protected-iselementallowed)*
-
-*Defined in [card-elements.ts:1751](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1751)*
 
 **Parameters:**
 
@@ -2107,8 +1809,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
 
-*Defined in [card-elements.ts:5119](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5119)*
-
 **Parameters:**
 
 Name | Type |
@@ -2125,8 +1825,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
 
-*Defined in [card-elements.ts:497](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L497)*
-
 **Returns:** *boolean*
 
 ___
@@ -2138,8 +1836,6 @@ ___
 *Inherited from [ContainerWithActions](containerwithactions.md).[isLastElement](containerwithactions.md#islastelement)*
 
 *Overrides [Container](container.md).[isLastElement](container.md#islastelement)*
-
-*Defined in [card-elements.ts:5870](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5870)*
 
 **Parameters:**
 
@@ -2157,8 +1853,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
 
-*Defined in [card-elements.ts:481](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L481)*
-
 **Parameters:**
 
 Name | Type |
@@ -2174,8 +1868,6 @@ ___
 ▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
-
-*Defined in [card-elements.ts:485](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L485)*
 
 **Parameters:**
 
@@ -2193,8 +1885,6 @@ ___
 
 *Inherited from [Container](container.md).[isRtl](container.md#isrtl)*
 
-*Defined in [card-elements.ts:5143](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5143)*
-
 **Returns:** *boolean*
 
 ___
@@ -2204,8 +1894,6 @@ ___
 ▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
-
-*Defined in [card-elements.ts:489](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L489)*
 
 **Parameters:**
 
@@ -2223,8 +1911,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
 
-*Defined in [card-elements.ts:235](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L235)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -2236,8 +1922,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[parse](cardelement.md#parse)*
 
 *Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
-
-*Defined in [card-elements.ts:313](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L313)*
 
 **Parameters:**
 
@@ -2258,8 +1942,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [card-elements.ts:1738](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1738)*
-
 **Parameters:**
 
 Name | Type |
@@ -2275,8 +1957,6 @@ ___
 ▸ **preProcessPropertyValue**(`property`: [PropertyDefinition](propertydefinition.md), `propertyValue?`: any): *any*
 
 *Inherited from [CardObject](cardobject.md).[preProcessPropertyValue](cardobject.md#preprocesspropertyvalue)*
-
-*Defined in [card-object.ts:70](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L70)*
 
 **Parameters:**
 
@@ -2295,8 +1975,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
 
-*Defined in [card-elements.ts:404](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L404)*
-
 **Returns:** *boolean*
 
 ___
@@ -2308,8 +1986,6 @@ ___
 *Inherited from [Container](container.md).[removeItem](container.md#removeitem)*
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[removeItem](cardelementcontainer.md#abstract-removeitem)*
-
-*Defined in [card-elements.ts:5182](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5182)*
 
 **Parameters:**
 
@@ -2327,8 +2003,6 @@ ___
 
 *Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[render](stylablecardelementcontainer.md#render)*
 
-*Defined in [card-elements.ts:6127](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6127)*
-
 **Parameters:**
 
 Name | Type |
@@ -2345,8 +2019,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -2356,8 +2028,6 @@ ___
 ▸ **setBleed**(`value`: boolean): *void*
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[setBleed](stylablecardelementcontainer.md#protected-setbleed)*
-
-*Defined in [card-elements.ts:4730](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4730)*
 
 **Parameters:**
 
@@ -2374,8 +2044,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -2394,8 +2062,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
 
-*Defined in [card-elements.ts:287](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L287)*
-
 **Parameters:**
 
 Name | Type |
@@ -2411,8 +2077,6 @@ ___
 ▸ **setParent**(`value`: [CardObject](cardobject.md) | undefined): *void*
 
 *Inherited from [CardObject](cardobject.md).[setParent](cardobject.md#setparent)*
-
-*Defined in [card-object.ts:88](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L88)*
 
 **Parameters:**
 
@@ -2430,8 +2094,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setShouldFallback](cardobject.md#setshouldfallback)*
 
-*Defined in [card-object.ts:92](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L92)*
-
 **Parameters:**
 
 Name | Type |
@@ -2447,8 +2109,6 @@ ___
 ▸ **setValue**(`property`: [PropertyDefinition](propertydefinition.md), `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
-
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
 
 **Parameters:**
 
@@ -2467,8 +2127,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[shouldFallback](cardobject.md#shouldfallback)*
 
-*Defined in [card-elements.ts:6175](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6175)*
-
 **Returns:** *boolean*
 
 ___
@@ -2478,8 +2136,6 @@ ___
 ▸ **shouldSerialize**(`context`: [SerializationContext](serializationcontext.md)): *boolean*
 
 *Overrides [CardElement](cardelement.md).[shouldSerialize](cardelement.md#protected-shouldserialize)*
-
-*Defined in [card-elements.ts:6070](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6070)*
 
 **Parameters:**
 
@@ -2497,8 +2153,6 @@ ___
 
 *Inherited from [Container](container.md).[supportsExcplitiHeight](container.md#protected-supportsexcplitiheight)*
 
-*Defined in [card-elements.ts:4916](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4916)*
-
 **Returns:** *boolean*
 
 ___
@@ -2510,8 +2164,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[toJSON](cardelement.md#tojson)*
 
 *Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
-
-*Defined in [card-elements.ts:317](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L317)*
 
 **Parameters:**
 
@@ -2531,8 +2183,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
 
-*Defined in [card-elements.ts:5005](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5005)*
-
 **Parameters:**
 
 Name | Type |
@@ -2551,8 +2201,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
 
-*Defined in [card-elements.ts:5044](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5044)*
-
 **Returns:** *void*
 
 ___
@@ -2562,8 +2210,6 @@ ___
 ▸ **updateLayout**(`processChildren`: boolean): *void*
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[updateLayout](cardelementcontainer.md#updatelayout)*
-
-*Defined in [card-elements.ts:6165](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6165)*
 
 **Parameters:**
 
@@ -2581,8 +2227,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
 
-*Defined in [card-object.ts:128](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L128)*
-
 **Returns:** *[ValidationResults](validationresults.md)*
 
 ___
@@ -2590,8 +2234,6 @@ ___
 ### `Static` applyMarkdown
 
 ▸ **applyMarkdown**(`text`: string): *[IMarkdownProcessingResult](../interfaces/imarkdownprocessingresult.md)*
-
-*Defined in [card-elements.ts:5984](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5984)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/docs/classes/adaptivecardconfig.md
+++ b/source/nodejs/adaptivecards/docs/classes/adaptivecardconfig.md
@@ -22,8 +22,6 @@
 
 \+ **new AdaptiveCardConfig**(`obj?`: any): *[AdaptiveCardConfig](adaptivecardconfig.md)*
 
-*Defined in [host-config.ts:57](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L57)*
-
 **Parameters:**
 
 Name | Type |
@@ -37,5 +35,3 @@ Name | Type |
 ###  allowCustomStyle
 
 • **allowCustomStyle**: *boolean* = false
-
-*Defined in [host-config.ts:57](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L57)*

--- a/source/nodejs/adaptivecards/docs/classes/backgroundimage.md
+++ b/source/nodejs/adaptivecards/docs/classes/backgroundimage.md
@@ -55,8 +55,6 @@
 
 *Inherited from [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 **Returns:** *[BackgroundImage](backgroundimage.md)*
 
 ## Properties
@@ -65,15 +63,11 @@
 
 • **fillMode**: *[FillMode](../enums/fillmode.md)*
 
-*Defined in [card-elements.ts:4796](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4796)*
-
 ___
 
 ###  horizontalAlignment
 
 • **horizontalAlignment**: *[HorizontalAlignment](../enums/horizontalalignment.md)*
-
-*Defined in [card-elements.ts:4799](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4799)*
 
 ___
 
@@ -83,15 +77,11 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 ___
 
 ### `Optional` url
 
 • **url**? : *undefined | string*
-
-*Defined in [card-elements.ts:4793](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4793)*
 
 ___
 
@@ -99,23 +89,17 @@ ___
 
 • **verticalAlignment**: *[VerticalAlignment](../enums/verticalalignment.md)*
 
-*Defined in [card-elements.ts:4802](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4802)*
-
 ___
 
 ### `Static` fillModeProperty
 
 ▪ **fillModeProperty**: *[EnumProperty](enumproperty.md)‹[FillMode](../enums/fillmode.md)›* = new EnumProperty(Versions.v1_2, "fillMode", Enums.FillMode, Enums.FillMode.Cover)
 
-*Defined in [card-elements.ts:4788](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4788)*
-
 ___
 
 ### `Static` horizontalAlignmentProperty
 
 ▪ **horizontalAlignmentProperty**: *[EnumProperty](enumproperty.md)‹[HorizontalAlignment](../enums/horizontalalignment.md)›* = new EnumProperty(Versions.v1_2, "horizontalAlignment", Enums.HorizontalAlignment, Enums.HorizontalAlignment.Left)
-
-*Defined in [card-elements.ts:4789](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4789)*
 
 ___
 
@@ -125,15 +109,11 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
 
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
-
 ___
 
 ### `Static` urlProperty
 
 ▪ **urlProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "url")
-
-*Defined in [card-elements.ts:4787](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4787)*
 
 ___
 
@@ -141,15 +121,11 @@ ___
 
 ▪ **verticalAlignmentProperty**: *[EnumProperty](enumproperty.md)‹[VerticalAlignment](../enums/verticalalignment.md)›* = new EnumProperty(Versions.v1_2, "verticalAlignment", Enums.VerticalAlignment, Enums.VerticalAlignment.Top)
 
-*Defined in [card-elements.ts:4790](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4790)*
-
 ## Methods
 
 ###  apply
 
 ▸ **apply**(`element`: [CardElement](cardelement.md)): *void*
-
-*Defined in [card-elements.ts:4820](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4820)*
 
 **Parameters:**
 
@@ -167,8 +143,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
 
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
-
 **Parameters:**
 
 Name | Type |
@@ -185,8 +159,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
 
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
-
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
 ___
@@ -197,8 +169,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-elements.ts:4806](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4806)*
-
 **Returns:** *string*
 
 ___
@@ -208,8 +178,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -227,8 +195,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -238,8 +204,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -256,8 +220,6 @@ ___
 ▸ **internalParse**(`source`: any, `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Overrides [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
-
-*Defined in [card-elements.ts:4810](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4810)*
 
 **Parameters:**
 
@@ -276,8 +238,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
 
-*Defined in [serialization.ts:821](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L821)*
-
 **Parameters:**
 
 Name | Type |
@@ -293,8 +253,6 @@ ___
 
 ▸ **isValid**(): *boolean*
 
-*Defined in [card-elements.ts:4861](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4861)*
-
 **Returns:** *boolean*
 
 ___
@@ -304,8 +262,6 @@ ___
 ▸ **parse**(`source`: [PropertyBag](../README.md#propertybag), `context?`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
-
-*Defined in [serialization.ts:857](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L857)*
 
 **Parameters:**
 
@@ -324,8 +280,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [serialization.ts:738](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L738)*
-
 **Parameters:**
 
 Name | Type |
@@ -342,8 +296,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -353,8 +305,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -373,8 +323,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
 
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
-
 **Parameters:**
 
 Name | Type |
@@ -392,8 +340,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
 
-*Defined in [serialization.ts:839](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L839)*
-
 **Parameters:**
 
 Name | Type |
@@ -409,8 +355,6 @@ ___
 ▸ **toJSON**(`context?`: [BaseSerializationContext](baseserializationcontext.md)): *[PropertyBag](../README.md#propertybag) | undefined*
 
 *Inherited from [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
-
-*Defined in [serialization.ts:861](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L861)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/docs/classes/baseserializationcontext.md
+++ b/source/nodejs/adaptivecards/docs/classes/baseserializationcontext.md
@@ -39,8 +39,6 @@
 
 \+ **new BaseSerializationContext**(`targetVersion`: [Version](version.md)): *[BaseSerializationContext](baseserializationcontext.md)*
 
-*Defined in [serialization.ts:232](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L232)*
-
 **Parameters:**
 
 Name | Type | Default |
@@ -55,15 +53,11 @@ Name | Type | Default |
 
 • **targetVersion**: *[Version](version.md)*
 
-*Defined in [serialization.ts:234](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L234)*
-
 ## Accessors
 
 ###  eventCount
 
 • **get eventCount**(): *number*
-
-*Defined in [serialization.ts:236](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L236)*
 
 **Returns:** *number*
 
@@ -73,8 +67,6 @@ Name | Type | Default |
 
 ▸ **clearEvents**(): *void*
 
-*Defined in [serialization.ts:208](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L208)*
-
 **Returns:** *void*
 
 ___
@@ -82,8 +74,6 @@ ___
 ###  getEventAt
 
 ▸ **getEventAt**(`index`: number): *[IValidationEvent](../interfaces/ivalidationevent.md)*
-
-*Defined in [serialization.ts:230](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L230)*
 
 **Parameters:**
 
@@ -98,8 +88,6 @@ ___
 ###  logEvent
 
 ▸ **logEvent**(`phase`: [ValidationPhase](../enums/validationphase.md), `event`: [ValidationEvent](../enums/validationevent.md), `message`: string, `source?`: [SerializableObject](serializableobject.md)): *void*
-
-*Defined in [serialization.ts:212](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L212)*
 
 **Parameters:**
 
@@ -118,8 +106,6 @@ ___
 
 ▸ **logParseEvent**(`event`: [ValidationEvent](../enums/validationevent.md), `message`: string, `source?`: [SerializableObject](serializableobject.md)): *void*
 
-*Defined in [serialization.ts:226](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L226)*
-
 **Parameters:**
 
 Name | Type |
@@ -136,8 +122,6 @@ ___
 
 ▸ **serializeArray**(`target`: object, `propertyName`: string, `propertyValue`: any[] | undefined): *void*
 
-*Defined in [serialization.ts:175](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L175)*
-
 **Parameters:**
 
 Name | Type |
@@ -153,8 +137,6 @@ ___
 ###  serializeEnum
 
 ▸ **serializeEnum**(`enumType`: object, `target`: object, `propertyName`: string, `propertyValue`: number | undefined, `defaultValue`: number | undefined): *void*
-
-*Defined in [serialization.ts:148](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L148)*
 
 **Parameters:**
 
@@ -174,8 +156,6 @@ ___
 
 ▸ **serializeNumber**(`target`: object, `propertyName`: string, `propertyValue`: number | undefined, `defaultValue`: number | undefined): *void*
 
-*Defined in [serialization.ts:139](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L139)*
-
 **Parameters:**
 
 Name | Type | Default |
@@ -192,8 +172,6 @@ ___
 ###  serializeValue
 
 ▸ **serializeValue**(`target`: object, `propertyName`: string, `propertyValue`: any, `defaultValue`: any): *void*
-
-*Defined in [serialization.ts:130](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L130)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/docs/classes/basetextblock.md
+++ b/source/nodejs/adaptivecards/docs/classes/basetextblock.md
@@ -158,8 +158,6 @@
 
 *Inherited from [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 **Returns:** *[BaseTextBlock](basetextblock.md)*
 
 ## Properties
@@ -170,8 +168,6 @@
 
 *Inherited from [CardObject](cardobject.md).[_parent](cardobject.md#protected-optional-_parent)*
 
-*Defined in [card-object.ts:61](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L61)*
-
 ___
 
 ### `Protected` `Optional` _renderedElement
@@ -180,15 +176,11 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[_renderedElement](cardobject.md#protected-optional-_renderedelement)*
 
-*Defined in [card-object.ts:62](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L62)*
-
 ___
 
 ###  color
 
 • **color**: *[TextColor](../enums/textcolor.md)* = Enums.TextColor.Default
-
-*Defined in [card-elements.ts:668](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L668)*
 
 ___
 
@@ -198,15 +190,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#optional-customcssselector)*
 
-*Defined in [card-elements.ts:311](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L311)*
-
 ___
 
 ### `Optional` fontType
 
 • **fontType**? : *Enums.FontType*
-
-*Defined in [card-elements.ts:671](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L671)*
 
 ___
 
@@ -216,8 +204,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
 
-*Defined in [card-elements.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L53)*
-
 ___
 
 ###  horizontalAlignment
@@ -225,8 +211,6 @@ ___
 • **horizontalAlignment**: *[HorizontalAlignment](../enums/horizontalalignment.md)*
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#horizontalalignment)*
-
-*Defined in [card-elements.ts:44](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L44)*
 
 ___
 
@@ -236,15 +220,11 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[id](cardobject.md#optional-id)*
 
-*Defined in [card-object.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L50)*
-
 ___
 
 ###  isSubtle
 
 • **isSubtle**: *boolean* = false
-
-*Defined in [card-elements.ts:674](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L674)*
 
 ___
 
@@ -254,8 +234,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 ___
 
 ### `Optional` onPreProcessPropertyValue
@@ -264,15 +242,11 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[onPreProcessPropertyValue](cardobject.md#optional-onpreprocesspropertyvalue)*
 
-*Defined in [card-object.ts:64](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L64)*
-
 ___
 
 ### `Optional` selectAction
 
 • **selectAction**? : *[Action](action.md)*
-
-*Defined in [card-elements.ts:686](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L686)*
 
 ___
 
@@ -282,15 +256,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
 
-*Defined in [card-elements.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L50)*
-
 ___
 
 ###  size
 
 • **size**: *[TextSize](../enums/textsize.md)* = Enums.TextSize.Default
-
-*Defined in [card-elements.ts:662](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L662)*
 
 ___
 
@@ -300,15 +270,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
 
-*Defined in [card-elements.ts:47](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L47)*
-
 ___
 
 ###  weight
 
 • **weight**: *[TextWeight](../enums/textweight.md)* = Enums.TextWeight.Default
-
-*Defined in [card-elements.ts:665](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L665)*
 
 ___
 
@@ -320,8 +286,6 @@ ___
         Enums.TextColor,
         Enums.TextColor.Default)
 
-*Defined in [card-elements.ts:638](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L638)*
-
 ___
 
 ### `Static` fontTypeProperty
@@ -330,8 +294,6 @@ ___
         Versions.v1_2,
         "fontType",
         Enums.FontType)
-
-*Defined in [card-elements.ts:647](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L647)*
 
 ___
 
@@ -348,8 +310,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[heightProperty](cardelement.md#static-heightproperty)*
 
-*Defined in [card-elements.ts:24](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L24)*
-
 ___
 
 ### `Static` horizontalAlignmentProperty
@@ -362,8 +322,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignmentProperty](cardelement.md#static-horizontalalignmentproperty)*
 
-*Defined in [card-elements.ts:32](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L32)*
-
 ___
 
 ### `Static` idProperty
@@ -371,8 +329,6 @@ ___
 ▪ **idProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "id")
 
 *Inherited from [CardObject](cardobject.md).[idProperty](cardobject.md#static-idproperty)*
-
-*Defined in [card-object.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L39)*
 
 ___
 
@@ -383,8 +339,6 @@ ___
         "isSubtle",
         false)
 
-*Defined in [card-elements.ts:643](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L643)*
-
 ___
 
 ### `Static` isVisibleProperty
@@ -392,8 +346,6 @@ ___
 ▪ **isVisibleProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_2, "isVisible", true)
 
 *Inherited from [CardElement](cardelement.md).[isVisibleProperty](cardelement.md#static-isvisibleproperty)*
-
-*Defined in [card-elements.ts:22](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L22)*
 
 ___
 
@@ -403,8 +355,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[langProperty](cardelement.md#static-langproperty)*
 
-*Defined in [card-elements.ts:21](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L21)*
-
 ___
 
 ### `Static` `Optional` onRegisterCustomProperties
@@ -412,8 +362,6 @@ ___
 ▪ **onRegisterCustomProperties**? : *undefined | function*
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
-
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
 
 ___
 
@@ -426,15 +374,11 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requiresProperty](cardobject.md#static-requiresproperty)*
 
-*Defined in [card-object.ts:40](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L40)*
-
 ___
 
 ### `Static` selectActionProperty
 
 ▪ **selectActionProperty**: *[ActionProperty](actionproperty.md)‹›* = new ActionProperty(Versions.v1_0, "selectAction", [ "Action.ShowCard" ])
-
-*Defined in [card-elements.ts:651](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L651)*
 
 ___
 
@@ -443,8 +387,6 @@ ___
 ▪ **separatorProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_0, "separator", false)
 
 *Inherited from [CardElement](cardelement.md).[separatorProperty](cardelement.md#static-separatorproperty)*
-
-*Defined in [card-elements.ts:23](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L23)*
 
 ___
 
@@ -455,8 +397,6 @@ ___
         "size",
         Enums.TextSize,
         Enums.TextSize.Default)
-
-*Defined in [card-elements.ts:628](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L628)*
 
 ___
 
@@ -470,8 +410,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[spacingProperty](cardelement.md#static-spacingproperty)*
 
-*Defined in [card-elements.ts:37](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L37)*
-
 ___
 
 ### `Static` textProperty
@@ -480,8 +418,6 @@ ___
         Versions.v1_0,
         "text",
         true)
-
-*Defined in [card-elements.ts:624](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L624)*
 
 ___
 
@@ -499,8 +435,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[typeNameProperty](cardobject.md#static-typenameproperty)*
 
-*Defined in [card-object.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L30)*
-
 ___
 
 ### `Static` weightProperty
@@ -511,8 +445,6 @@ ___
         Enums.TextWeight,
         Enums.TextWeight.Default)
 
-*Defined in [card-elements.ts:633](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L633)*
-
 ## Accessors
 
 ### `Protected` allowCustomPadding
@@ -520,8 +452,6 @@ ___
 • **get allowCustomPadding**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
-
-*Defined in [card-elements.ts:299](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L299)*
 
 **Returns:** *boolean*
 
@@ -533,8 +463,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
 
-*Defined in [card-elements.ts:307](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L307)*
-
 **Returns:** *string*
 
 ___
@@ -542,8 +470,6 @@ ___
 ###  effectiveColor
 
 • **get effectiveColor**(): *[TextColor](../enums/textcolor.md)*
-
-*Defined in [card-elements.ts:782](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L782)*
 
 **Returns:** *[TextColor](../enums/textcolor.md)*
 
@@ -554,8 +480,6 @@ ___
 • **get hasVisibleSeparator**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
-
-*Defined in [card-elements.ts:580](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L580)*
 
 **Returns:** *boolean*
 
@@ -569,8 +493,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
 
-*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
-
 **Returns:** *[HostConfig](hostconfig.md)*
 
 • **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
@@ -578,8 +500,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
-
-*Defined in [card-elements.ts:555](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L555)*
 
 **Parameters:**
 
@@ -597,8 +517,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
 
-*Defined in [card-elements.ts:559](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L559)*
-
 **Returns:** *number*
 
 ___
@@ -608,8 +526,6 @@ ___
 • **get isInline**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
-
-*Defined in [card-elements.ts:576](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L576)*
 
 **Returns:** *boolean*
 
@@ -621,8 +537,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
 
-*Defined in [card-elements.ts:568](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L568)*
-
 **Returns:** *boolean*
 
 ___
@@ -632,8 +546,6 @@ ___
 • **get isStandalone**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
-
-*Defined in [card-elements.ts:572](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L572)*
 
 **Returns:** *boolean*
 
@@ -645,15 +557,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
 
-*Defined in [card-elements.ts:77](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L77)*
-
 **Returns:** *boolean*
 
 • **set isVisible**(`value`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
-
-*Defined in [card-elements.ts:81](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L81)*
 
 **Parameters:**
 
@@ -671,15 +579,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
 
-*Defined in [card-elements.ts:56](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L56)*
-
 **Returns:** *string | undefined*
 
 • **set lang**(`value`: string | undefined): *void*
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
-
-*Defined in [card-elements.ts:72](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L72)*
 
 **Parameters:**
 
@@ -699,8 +603,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[parent](cardobject.md#parent)*
 
-*Defined in [card-elements.ts:593](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L593)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -710,8 +612,6 @@ ___
 • **get renderedElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardObject](cardobject.md).[renderedElement](cardobject.md#renderedelement)*
-
-*Defined in [card-object.ts:140](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L140)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -723,8 +623,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requires](cardobject.md#requires)*
 
-*Defined in [card-object.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L53)*
-
 **Returns:** *HostCapabilities*
 
 ___
@@ -734,8 +632,6 @@ ___
 • **get separatorElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
-
-*Defined in [card-elements.ts:589](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L589)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -747,8 +643,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
 
-*Defined in [card-elements.ts:303](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L303)*
-
 **Returns:** *[Orientation](../enums/orientation.md)*
 
 ___
@@ -757,13 +651,9 @@ ___
 
 • **get text**(): *string | undefined*
 
-*Defined in [card-elements.ts:677](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L677)*
-
 **Returns:** *string | undefined*
 
 • **set text**(`value`: string | undefined): *void*
-
-*Defined in [card-elements.ts:681](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L681)*
 
 **Parameters:**
 
@@ -781,8 +671,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
 
-*Defined in [card-elements.ts:295](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L295)*
-
 **Returns:** *boolean*
 
 ## Methods
@@ -792,8 +680,6 @@ ___
 ▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
 
 *Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
-
-*Defined in [card-elements.ts:220](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L220)*
 
 **Parameters:**
 
@@ -811,8 +697,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
 
-*Defined in [card-elements.ts:239](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L239)*
-
 **Returns:** *void*
 
 ___
@@ -820,8 +704,6 @@ ___
 ###  applyStylesTo
 
 ▸ **applyStylesTo**(`targetElement`: HTMLElement): *void*
-
-*Defined in [card-elements.ts:732](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L732)*
 
 **Parameters:**
 
@@ -839,8 +721,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
 
-*Defined in [card-elements.ts:728](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L728)*
-
 **Returns:** *string | undefined*
 
 ___
@@ -851,8 +731,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
 
-*Defined in [card-elements.ts:205](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L205)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -862,8 +740,6 @@ ___
 ▸ **getActionAt**(`index`: number): *[Action](action.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
-
-*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
 
 **Parameters:**
 
@@ -881,8 +757,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
 
-*Defined in [card-elements.ts:531](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L531)*
-
 **Parameters:**
 
 Name | Type |
@@ -899,8 +773,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
 
-*Defined in [card-elements.ts:396](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L396)*
-
 **Returns:** *number*
 
 ___
@@ -911,8 +783,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
 
-*Defined in [card-elements.ts:519](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L519)*
-
 **Returns:** *[Input](input.md)[]*
 
 ___
@@ -920,8 +790,6 @@ ___
 ### `Protected` getColorDefinition
 
 ▸ **getColorDefinition**(`colorSet`: [ColorSetDefinition](colorsetdefinition.md), `color`: [TextColor](../enums/textcolor.md)): *[TextColorDefinition](textcolordefinition.md)*
-
-*Defined in [card-elements.ts:705](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L705)*
 
 **Parameters:**
 
@@ -940,8 +808,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
 
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
-
 **Parameters:**
 
 Name | Type |
@@ -958,8 +824,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
 
-*Defined in [card-elements.ts:275](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L275)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
 ___
@@ -969,8 +833,6 @@ ___
 ▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
 
 *Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
-
-*Defined in [card-elements.ts:535](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L535)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
@@ -982,8 +844,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
 
-*Defined in [card-elements.ts:329](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L329)*
-
 **Returns:** *string*
 
 ___
@@ -994,8 +854,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyleDefinition](cardelement.md#geteffectivestyledefinition)*
 
-*Defined in [card-elements.ts:337](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L337)*
-
 **Returns:** *[ContainerStyleDefinition](containerstyledefinition.md)*
 
 ___
@@ -1005,8 +863,6 @@ ___
 ▸ **getElementById**(`id`: string): *[CardElement](cardelement.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
-
-*Defined in [card-elements.ts:527](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L527)*
 
 **Parameters:**
 
@@ -1021,8 +877,6 @@ ___
 ### `Protected` getFontSize
 
 ▸ **getFontSize**(`fontType`: [FontTypeDefinition](fonttypedefinition.md)): *number*
-
-*Defined in [card-elements.ts:690](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L690)*
 
 **Parameters:**
 
@@ -1040,8 +894,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
 
-*Defined in [card-elements.ts:341](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L341)*
-
 **Returns:** *[ActionType](../README.md#actiontype)[]*
 
 ___
@@ -1052,8 +904,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
 
-*Defined in [card-elements.ts:279](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L279)*
-
 **Returns:** *boolean*
 
 ___
@@ -1063,8 +913,6 @@ ___
 ▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
-
-*Defined in [card-elements.ts:345](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L345)*
 
 **Parameters:**
 
@@ -1086,8 +934,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
 
-*Defined in [card-object.ts:66](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L66)*
-
 **Returns:** *string*
 
 ___
@@ -1097,8 +943,6 @@ ___
 ▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
-
-*Defined in [card-elements.ts:283](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L283)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md) | undefined*
 
@@ -1110,8 +954,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
 
-*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
-
 **Returns:** *[Container](container.md) | undefined*
 
 ___
@@ -1121,8 +963,6 @@ ___
 ▸ **getResourceInformation**(): *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
 *Inherited from [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
-
-*Defined in [card-elements.ts:523](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L523)*
 
 **Returns:** *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
@@ -1134,8 +974,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
 
-*Defined in [card-elements.ts:501](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L501)*
-
 **Returns:** *[CardElement](cardelement.md)*
 
 ___
@@ -1146,8 +984,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getRootObject](cardobject.md#getrootobject)*
 
-*Defined in [card-object.ts:100](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L100)*
-
 **Returns:** *[CardObject](cardobject.md)*
 
 ___
@@ -1157,8 +993,6 @@ ___
 ▸ **getSchema**(): *[SerializableObjectSchema](serializableobjectschema.md)*
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
-
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
 
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
@@ -1172,8 +1006,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-object.ts:45](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L45)*
-
 **Returns:** *string*
 
 ___
@@ -1183,8 +1015,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -1202,8 +1032,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -1213,8 +1041,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -1232,8 +1058,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
 
-*Defined in [card-elements.ts:439](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L439)*
-
 **Parameters:**
 
 Name | Type |
@@ -1249,8 +1073,6 @@ ___
 ▸ **internalParse**(`source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
-
-*Defined in [serialization.ts:789](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L789)*
 
 **Parameters:**
 
@@ -1269,8 +1091,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
 
-*Defined in [card-elements.ts:233](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L233)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1280,8 +1100,6 @@ ___
 ▸ **internalToJSON**(`target`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
-
-*Defined in [serialization.ts:821](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L821)*
 
 **Parameters:**
 
@@ -1300,8 +1118,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
 
-*Defined in [card-object.ts:110](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L110)*
-
 **Parameters:**
 
 Name | Type |
@@ -1318,8 +1134,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
 
-*Defined in [card-elements.ts:469](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L469)*
-
 **Returns:** *boolean*
 
 ___
@@ -1329,8 +1143,6 @@ ___
 ▸ **isAtTheVeryLeft**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
-
-*Defined in [card-elements.ts:457](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L457)*
 
 **Returns:** *boolean*
 
@@ -1342,8 +1154,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
 
-*Defined in [card-elements.ts:461](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L461)*
-
 **Returns:** *boolean*
 
 ___
@@ -1353,8 +1163,6 @@ ___
 ▸ **isAtTheVeryTop**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
-
-*Defined in [card-elements.ts:465](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L465)*
 
 **Returns:** *boolean*
 
@@ -1366,8 +1174,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
 
-*Defined in [card-elements.ts:325](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L325)*
-
 **Returns:** *boolean*
 
 ___
@@ -1377,8 +1183,6 @@ ___
 ▸ **isBleedingAtBottom**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
-
-*Defined in [card-elements.ts:477](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L477)*
 
 **Returns:** *boolean*
 
@@ -1390,8 +1194,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
 
-*Defined in [card-elements.ts:473](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L473)*
-
 **Returns:** *boolean*
 
 ___
@@ -1401,8 +1203,6 @@ ___
 ▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
-
-*Defined in [card-elements.ts:493](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L493)*
 
 **Parameters:**
 
@@ -1420,8 +1220,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
 
-*Defined in [card-elements.ts:443](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L443)*
-
 **Returns:** *boolean*
 
 ___
@@ -1432,8 +1230,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDisplayed](cardelement.md#protected-isdisplayed)*
 
-*Defined in [card-elements.ts:229](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L229)*
-
 **Returns:** *boolean*
 
 ___
@@ -1443,8 +1239,6 @@ ___
 ▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
-
-*Defined in [card-elements.ts:449](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L449)*
 
 **Parameters:**
 
@@ -1462,8 +1256,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
 
-*Defined in [card-elements.ts:497](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L497)*
-
 **Returns:** *boolean*
 
 ___
@@ -1473,8 +1265,6 @@ ___
 ▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
-
-*Defined in [card-elements.ts:453](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L453)*
 
 **Parameters:**
 
@@ -1492,8 +1282,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
 
-*Defined in [card-elements.ts:481](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L481)*
-
 **Parameters:**
 
 Name | Type |
@@ -1509,8 +1297,6 @@ ___
 ▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
-
-*Defined in [card-elements.ts:485](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L485)*
 
 **Parameters:**
 
@@ -1528,8 +1314,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
 
-*Defined in [card-elements.ts:489](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L489)*
-
 **Parameters:**
 
 Name | Type |
@@ -1546,8 +1330,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
 
-*Defined in [card-elements.ts:235](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L235)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1559,8 +1341,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[parse](cardelement.md#parse)*
 
 *Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
-
-*Defined in [card-elements.ts:313](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L313)*
 
 **Parameters:**
 
@@ -1579,8 +1359,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [card-elements.ts:653](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L653)*
-
 **Parameters:**
 
 Name | Type |
@@ -1596,8 +1374,6 @@ ___
 ▸ **preProcessPropertyValue**(`property`: [PropertyDefinition](propertydefinition.md), `propertyValue?`: any): *any*
 
 *Inherited from [CardObject](cardobject.md).[preProcessPropertyValue](cardobject.md#preprocesspropertyvalue)*
-
-*Defined in [card-object.ts:70](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L70)*
 
 **Parameters:**
 
@@ -1616,8 +1392,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
 
-*Defined in [card-elements.ts:404](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L404)*
-
 **Returns:** *boolean*
 
 ___
@@ -1627,8 +1401,6 @@ ___
 ▸ **render**(): *HTMLElement | undefined*
 
 *Inherited from [CardElement](cardelement.md).[render](cardelement.md#render)*
-
-*Defined in [card-elements.ts:412](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L412)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -1640,8 +1412,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -1651,8 +1421,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -1671,8 +1439,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
 
-*Defined in [card-elements.ts:287](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L287)*
-
 **Parameters:**
 
 Name | Type |
@@ -1688,8 +1454,6 @@ ___
 ▸ **setParent**(`value`: [CardObject](cardobject.md) | undefined): *void*
 
 *Inherited from [CardObject](cardobject.md).[setParent](cardobject.md#setparent)*
-
-*Defined in [card-object.ts:88](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L88)*
 
 **Parameters:**
 
@@ -1707,8 +1471,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setShouldFallback](cardobject.md#setshouldfallback)*
 
-*Defined in [card-object.ts:92](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L92)*
-
 **Parameters:**
 
 Name | Type |
@@ -1722,8 +1484,6 @@ ___
 ### `Protected` setText
 
 ▸ **setText**(`value`: string | undefined): *void*
-
-*Defined in [card-elements.ts:724](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L724)*
 
 **Parameters:**
 
@@ -1740,8 +1500,6 @@ ___
 ▸ **setValue**(`property`: [PropertyDefinition](propertydefinition.md), `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
-
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
 
 **Parameters:**
 
@@ -1760,8 +1518,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[shouldFallback](cardobject.md#shouldfallback)*
 
-*Defined in [card-object.ts:96](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L96)*
-
 **Returns:** *boolean*
 
 ___
@@ -1773,8 +1529,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[shouldSerialize](cardelement.md#protected-shouldserialize)*
 
 *Overrides [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
-
-*Defined in [card-elements.ts:291](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L291)*
 
 **Parameters:**
 
@@ -1794,8 +1548,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
 
-*Defined in [card-elements.ts:317](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L317)*
-
 **Parameters:**
 
 Name | Type |
@@ -1811,8 +1563,6 @@ ___
 ▸ **truncateOverflow**(`maxHeight`: number): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
-
-*Defined in [card-elements.ts:263](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L263)*
 
 **Parameters:**
 
@@ -1830,8 +1580,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
 
-*Defined in [card-elements.ts:273](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L273)*
-
 **Returns:** *void*
 
 ___
@@ -1841,8 +1589,6 @@ ___
 ▸ **updateLayout**(`processChildren`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
-
-*Defined in [card-elements.ts:434](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L434)*
 
 **Parameters:**
 
@@ -1859,7 +1605,5 @@ ___
 ▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
 
 *Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
-
-*Defined in [card-object.ts:128](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L128)*
 
 **Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/boolproperty.md
+++ b/source/nodejs/adaptivecards/docs/classes/boolproperty.md
@@ -36,8 +36,6 @@
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[constructor](propertydefinition.md#constructor)*
 
-*Defined in [serialization.ts:258](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L258)*
-
 **Parameters:**
 
 Name | Type |
@@ -57,8 +55,6 @@ Name | Type |
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[defaultValue](propertydefinition.md#optional-defaultvalue)*
 
-*Defined in [serialization.ts:263](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L263)*
-
 ___
 
 ###  name
@@ -66,8 +62,6 @@ ___
 • **name**: *string*
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[name](propertydefinition.md#name)*
-
-*Defined in [serialization.ts:262](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L262)*
 
 ___
 
@@ -77,8 +71,6 @@ ___
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[onGetInitialValue](propertydefinition.md#optional-ongetinitialvalue)*
 
-*Defined in [serialization.ts:264](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L264)*
-
 ___
 
 ###  sequentialNumber
@@ -86,8 +78,6 @@ ___
 • **sequentialNumber**: *number*
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[sequentialNumber](propertydefinition.md#sequentialnumber)*
-
-*Defined in [serialization.ts:258](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L258)*
 
 ___
 
@@ -97,8 +87,6 @@ ___
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[targetVersion](propertydefinition.md#targetversion)*
 
-*Defined in [serialization.ts:261](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L261)*
-
 ## Methods
 
 ###  getInternalName
@@ -106,8 +94,6 @@ ___
 ▸ **getInternalName**(): *string*
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[getInternalName](propertydefinition.md#getinternalname)*
-
-*Defined in [serialization.ts:246](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L246)*
 
 **Returns:** *string*
 
@@ -118,8 +104,6 @@ ___
 ▸ **parse**(`sender`: [SerializableObject](serializableobject.md), `source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *boolean | undefined*
 
 *Overrides [PropertyDefinition](propertydefinition.md).[parse](propertydefinition.md#parse)*
-
-*Defined in [serialization.ts:312](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L312)*
 
 **Parameters:**
 
@@ -138,8 +122,6 @@ ___
 ▸ **toJSON**(`sender`: [SerializableObject](serializableobject.md), `target`: object, `value`: boolean | undefined, `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Overrides [PropertyDefinition](propertydefinition.md).[toJSON](propertydefinition.md#tojson)*
-
-*Defined in [serialization.ts:316](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L316)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/docs/classes/cardelement.md
+++ b/source/nodejs/adaptivecards/docs/classes/cardelement.md
@@ -151,8 +151,6 @@
 
 *Inherited from [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 **Returns:** *[CardElement](cardelement.md)*
 
 ## Properties
@@ -163,8 +161,6 @@
 
 *Inherited from [CardObject](cardobject.md).[_parent](cardobject.md#protected-optional-_parent)*
 
-*Defined in [card-object.ts:61](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L61)*
-
 ___
 
 ### `Protected` `Optional` _renderedElement
@@ -173,15 +169,11 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[_renderedElement](cardobject.md#protected-optional-_renderedelement)*
 
-*Defined in [card-object.ts:62](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L62)*
-
 ___
 
 ### `Optional` customCssSelector
 
 • **customCssSelector**? : *undefined | string*
-
-*Defined in [card-elements.ts:311](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L311)*
 
 ___
 
@@ -189,15 +181,11 @@ ___
 
 • **height**: *[CardElementHeight](../README.md#cardelementheight)*
 
-*Defined in [card-elements.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L53)*
-
 ___
 
 ###  horizontalAlignment
 
 • **horizontalAlignment**: *[HorizontalAlignment](../enums/horizontalalignment.md)*
-
-*Defined in [card-elements.ts:44](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L44)*
 
 ___
 
@@ -207,8 +195,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[id](cardobject.md#optional-id)*
 
-*Defined in [card-object.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L50)*
-
 ___
 
 ###  maxVersion
@@ -216,8 +202,6 @@ ___
 • **maxVersion**: *[Version](version.md)* = Versions.latest
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
-
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
 
 ___
 
@@ -227,23 +211,17 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[onPreProcessPropertyValue](cardobject.md#optional-onpreprocesspropertyvalue)*
 
-*Defined in [card-object.ts:64](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L64)*
-
 ___
 
 ###  separator
 
 • **separator**: *boolean*
 
-*Defined in [card-elements.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L50)*
-
 ___
 
 ###  spacing
 
 • **spacing**: *[Spacing](../enums/spacing.md)*
-
-*Defined in [card-elements.ts:47](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L47)*
 
 ___
 
@@ -258,8 +236,6 @@ ___
         ],
         "auto")
 
-*Defined in [card-elements.ts:24](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L24)*
-
 ___
 
 ### `Static` horizontalAlignmentProperty
@@ -270,8 +246,6 @@ ___
         Enums.HorizontalAlignment,
         Enums.HorizontalAlignment.Left)
 
-*Defined in [card-elements.ts:32](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L32)*
-
 ___
 
 ### `Static` idProperty
@@ -280,23 +254,17 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[idProperty](cardobject.md#static-idproperty)*
 
-*Defined in [card-object.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L39)*
-
 ___
 
 ### `Static` isVisibleProperty
 
 ▪ **isVisibleProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_2, "isVisible", true)
 
-*Defined in [card-elements.ts:22](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L22)*
-
 ___
 
 ### `Static` langProperty
 
 ▪ **langProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_1, "lang", true, /^[a-z]{2,3}$/ig)
-
-*Defined in [card-elements.ts:21](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L21)*
 
 ___
 
@@ -305,8 +273,6 @@ ___
 ▪ **onRegisterCustomProperties**? : *undefined | function*
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
-
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
 
 ___
 
@@ -319,15 +285,11 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requiresProperty](cardobject.md#static-requiresproperty)*
 
-*Defined in [card-object.ts:40](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L40)*
-
 ___
 
 ### `Static` separatorProperty
 
 ▪ **separatorProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_0, "separator", false)
-
-*Defined in [card-elements.ts:23](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L23)*
 
 ___
 
@@ -338,8 +300,6 @@ ___
         "spacing",
         Enums.Spacing,
         Enums.Spacing.Default)
-
-*Defined in [card-elements.ts:37](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L37)*
 
 ___
 
@@ -357,15 +317,11 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[typeNameProperty](cardobject.md#static-typenameproperty)*
 
-*Defined in [card-object.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L30)*
-
 ## Accessors
 
 ### `Protected` allowCustomPadding
 
 • **get allowCustomPadding**(): *boolean*
-
-*Defined in [card-elements.ts:299](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L299)*
 
 **Returns:** *boolean*
 
@@ -375,8 +331,6 @@ ___
 
 • **get defaultStyle**(): *string*
 
-*Defined in [card-elements.ts:307](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L307)*
-
 **Returns:** *string*
 
 ___
@@ -384,8 +338,6 @@ ___
 ###  hasVisibleSeparator
 
 • **get hasVisibleSeparator**(): *boolean*
-
-*Defined in [card-elements.ts:580](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L580)*
 
 **Returns:** *boolean*
 
@@ -397,15 +349,11 @@ ___
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
 
-*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
-
 **Returns:** *[HostConfig](hostconfig.md)*
 
 • **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
-
-*Defined in [card-elements.ts:555](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L555)*
 
 **Parameters:**
 
@@ -421,8 +369,6 @@ ___
 
 • **get index**(): *number*
 
-*Defined in [card-elements.ts:559](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L559)*
-
 **Returns:** *number*
 
 ___
@@ -430,8 +376,6 @@ ___
 ###  isInline
 
 • **get isInline**(): *boolean*
-
-*Defined in [card-elements.ts:576](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L576)*
 
 **Returns:** *boolean*
 
@@ -441,8 +385,6 @@ ___
 
 • **get isInteractive**(): *boolean*
 
-*Defined in [card-elements.ts:568](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L568)*
-
 **Returns:** *boolean*
 
 ___
@@ -450,8 +392,6 @@ ___
 ###  isStandalone
 
 • **get isStandalone**(): *boolean*
-
-*Defined in [card-elements.ts:572](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L572)*
 
 **Returns:** *boolean*
 
@@ -461,13 +401,9 @@ ___
 
 • **get isVisible**(): *boolean*
 
-*Defined in [card-elements.ts:77](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L77)*
-
 **Returns:** *boolean*
 
 • **set isVisible**(`value`: boolean): *void*
-
-*Defined in [card-elements.ts:81](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L81)*
 
 **Parameters:**
 
@@ -483,13 +419,9 @@ ___
 
 • **get lang**(): *string | undefined*
 
-*Defined in [card-elements.ts:56](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L56)*
-
 **Returns:** *string | undefined*
 
 • **set lang**(`value`: string | undefined): *void*
-
-*Defined in [card-elements.ts:72](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L72)*
 
 **Parameters:**
 
@@ -507,8 +439,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[parent](cardobject.md#parent)*
 
-*Defined in [card-elements.ts:593](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L593)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -518,8 +448,6 @@ ___
 • **get renderedElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardObject](cardobject.md).[renderedElement](cardobject.md#renderedelement)*
-
-*Defined in [card-object.ts:140](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L140)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -531,8 +459,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requires](cardobject.md#requires)*
 
-*Defined in [card-object.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L53)*
-
 **Returns:** *HostCapabilities*
 
 ___
@@ -540,8 +466,6 @@ ___
 ###  separatorElement
 
 • **get separatorElement**(): *HTMLElement | undefined*
-
-*Defined in [card-elements.ts:589](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L589)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -551,8 +475,6 @@ ___
 
 • **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
 
-*Defined in [card-elements.ts:303](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L303)*
-
 **Returns:** *[Orientation](../enums/orientation.md)*
 
 ___
@@ -561,8 +483,6 @@ ___
 
 • **get useDefaultSizing**(): *boolean*
 
-*Defined in [card-elements.ts:295](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L295)*
-
 **Returns:** *boolean*
 
 ## Methods
@@ -570,8 +490,6 @@ ___
 ### `Protected` adjustRenderedElementSize
 
 ▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
-
-*Defined in [card-elements.ts:220](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L220)*
 
 **Parameters:**
 
@@ -587,8 +505,6 @@ ___
 
 ▸ **applyPadding**(): *void*
 
-*Defined in [card-elements.ts:239](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L239)*
-
 **Returns:** *void*
 
 ___
@@ -596,8 +512,6 @@ ___
 ###  asString
 
 ▸ **asString**(): *string | undefined*
-
-*Defined in [card-elements.ts:321](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L321)*
 
 **Returns:** *string | undefined*
 
@@ -607,8 +521,6 @@ ___
 
 ▸ **createPlaceholderElement**(): *HTMLElement*
 
-*Defined in [card-elements.ts:205](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L205)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -616,8 +528,6 @@ ___
 ###  getActionAt
 
 ▸ **getActionAt**(`index`: number): *[Action](action.md) | undefined*
-
-*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
 
 **Parameters:**
 
@@ -633,8 +543,6 @@ ___
 
 ▸ **getActionById**(`id`: string): *[Action](action.md) | undefined*
 
-*Defined in [card-elements.ts:531](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L531)*
-
 **Parameters:**
 
 Name | Type |
@@ -649,8 +557,6 @@ ___
 
 ▸ **getActionCount**(): *number*
 
-*Defined in [card-elements.ts:396](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L396)*
-
 **Returns:** *number*
 
 ___
@@ -658,8 +564,6 @@ ___
 ###  getAllInputs
 
 ▸ **getAllInputs**(): *[Input](input.md)[]*
-
-*Defined in [card-elements.ts:519](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L519)*
 
 **Returns:** *[Input](input.md)[]*
 
@@ -670,8 +574,6 @@ ___
 ▸ **getCustomProperty**(`name`: string): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
-
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
 
 **Parameters:**
 
@@ -687,8 +589,6 @@ ___
 
 ▸ **getDefaultPadding**(): *[PaddingDefinition](paddingdefinition.md)*
 
-*Defined in [card-elements.ts:275](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L275)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
 ___
@@ -696,8 +596,6 @@ ___
 ###  getEffectivePadding
 
 ▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
-
-*Defined in [card-elements.ts:535](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L535)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
@@ -707,8 +605,6 @@ ___
 
 ▸ **getEffectiveStyle**(): *string*
 
-*Defined in [card-elements.ts:329](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L329)*
-
 **Returns:** *string*
 
 ___
@@ -717,8 +613,6 @@ ___
 
 ▸ **getEffectiveStyleDefinition**(): *[ContainerStyleDefinition](containerstyledefinition.md)*
 
-*Defined in [card-elements.ts:337](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L337)*
-
 **Returns:** *[ContainerStyleDefinition](containerstyledefinition.md)*
 
 ___
@@ -726,8 +620,6 @@ ___
 ###  getElementById
 
 ▸ **getElementById**(`id`: string): *[CardElement](cardelement.md) | undefined*
-
-*Defined in [card-elements.ts:527](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L527)*
 
 **Parameters:**
 
@@ -743,8 +635,6 @@ ___
 
 ▸ **getForbiddenActionTypes**(): *[ActionType](../README.md#actiontype)[]*
 
-*Defined in [card-elements.ts:341](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L341)*
-
 **Returns:** *[ActionType](../README.md#actiontype)[]*
 
 ___
@@ -753,8 +643,6 @@ ___
 
 ▸ **getHasBackground**(): *boolean*
 
-*Defined in [card-elements.ts:279](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L279)*
-
 **Returns:** *boolean*
 
 ___
@@ -762,8 +650,6 @@ ___
 ###  getImmediateSurroundingPadding
 
 ▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
-
-*Defined in [card-elements.ts:345](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L345)*
 
 **Parameters:**
 
@@ -785,8 +671,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
 
-*Defined in [card-object.ts:66](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L66)*
-
 **Returns:** *string*
 
 ___
@@ -794,8 +678,6 @@ ___
 ### `Protected` getPadding
 
 ▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md) | undefined*
-
-*Defined in [card-elements.ts:283](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L283)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md) | undefined*
 
@@ -805,8 +687,6 @@ ___
 
 ▸ **getParentContainer**(): *[Container](container.md) | undefined*
 
-*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
-
 **Returns:** *[Container](container.md) | undefined*
 
 ___
@@ -815,8 +695,6 @@ ___
 
 ▸ **getResourceInformation**(): *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
-*Defined in [card-elements.ts:523](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L523)*
-
 **Returns:** *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
 ___
@@ -824,8 +702,6 @@ ___
 ###  getRootElement
 
 ▸ **getRootElement**(): *[CardElement](cardelement.md)*
-
-*Defined in [card-elements.ts:501](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L501)*
 
 **Returns:** *[CardElement](cardelement.md)*
 
@@ -837,8 +713,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getRootObject](cardobject.md#getrootobject)*
 
-*Defined in [card-object.ts:100](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L100)*
-
 **Returns:** *[CardObject](cardobject.md)*
 
 ___
@@ -848,8 +722,6 @@ ___
 ▸ **getSchema**(): *[SerializableObjectSchema](serializableobjectschema.md)*
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
-
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
 
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
@@ -863,8 +735,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-object.ts:45](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L45)*
-
 **Returns:** *string*
 
 ___
@@ -874,8 +744,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -893,8 +761,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -904,8 +770,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -920,8 +784,6 @@ ___
 ###  indexOf
 
 ▸ **indexOf**(`cardElement`: [CardElement](cardelement.md)): *number*
-
-*Defined in [card-elements.ts:439](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L439)*
 
 **Parameters:**
 
@@ -939,8 +801,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
 
-*Defined in [serialization.ts:789](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L789)*
-
 **Parameters:**
 
 Name | Type |
@@ -956,8 +816,6 @@ ___
 
 ▸ **internalRender**(): *HTMLElement | undefined*
 
-*Defined in [card-elements.ts:233](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L233)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -967,8 +825,6 @@ ___
 ▸ **internalToJSON**(`target`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
-
-*Defined in [serialization.ts:821](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L821)*
 
 **Parameters:**
 
@@ -987,8 +843,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
 
-*Defined in [card-object.ts:110](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L110)*
-
 **Parameters:**
 
 Name | Type |
@@ -1003,8 +857,6 @@ ___
 
 ▸ **isAtTheVeryBottom**(): *boolean*
 
-*Defined in [card-elements.ts:469](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L469)*
-
 **Returns:** *boolean*
 
 ___
@@ -1012,8 +864,6 @@ ___
 ###  isAtTheVeryLeft
 
 ▸ **isAtTheVeryLeft**(): *boolean*
-
-*Defined in [card-elements.ts:457](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L457)*
 
 **Returns:** *boolean*
 
@@ -1023,8 +873,6 @@ ___
 
 ▸ **isAtTheVeryRight**(): *boolean*
 
-*Defined in [card-elements.ts:461](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L461)*
-
 **Returns:** *boolean*
 
 ___
@@ -1032,8 +880,6 @@ ___
 ###  isAtTheVeryTop
 
 ▸ **isAtTheVeryTop**(): *boolean*
-
-*Defined in [card-elements.ts:465](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L465)*
 
 **Returns:** *boolean*
 
@@ -1043,8 +889,6 @@ ___
 
 ▸ **isBleeding**(): *boolean*
 
-*Defined in [card-elements.ts:325](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L325)*
-
 **Returns:** *boolean*
 
 ___
@@ -1052,8 +896,6 @@ ___
 ###  isBleedingAtBottom
 
 ▸ **isBleedingAtBottom**(): *boolean*
-
-*Defined in [card-elements.ts:477](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L477)*
 
 **Returns:** *boolean*
 
@@ -1063,8 +905,6 @@ ___
 
 ▸ **isBleedingAtTop**(): *boolean*
 
-*Defined in [card-elements.ts:473](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L473)*
-
 **Returns:** *boolean*
 
 ___
@@ -1072,8 +912,6 @@ ___
 ###  isBottomElement
 
 ▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
-
-*Defined in [card-elements.ts:493](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L493)*
 
 **Parameters:**
 
@@ -1089,8 +927,6 @@ ___
 
 ▸ **isDesignMode**(): *boolean*
 
-*Defined in [card-elements.ts:443](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L443)*
-
 **Returns:** *boolean*
 
 ___
@@ -1099,8 +935,6 @@ ___
 
 ▸ **isDisplayed**(): *boolean*
 
-*Defined in [card-elements.ts:229](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L229)*
-
 **Returns:** *boolean*
 
 ___
@@ -1108,8 +942,6 @@ ___
 ###  isFirstElement
 
 ▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
-
-*Defined in [card-elements.ts:449](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L449)*
 
 **Parameters:**
 
@@ -1125,8 +957,6 @@ ___
 
 ▸ **isHiddenDueToOverflow**(): *boolean*
 
-*Defined in [card-elements.ts:497](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L497)*
-
 **Returns:** *boolean*
 
 ___
@@ -1134,8 +964,6 @@ ___
 ###  isLastElement
 
 ▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
-
-*Defined in [card-elements.ts:453](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L453)*
 
 **Parameters:**
 
@@ -1151,8 +979,6 @@ ___
 
 ▸ **isLeftMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
-*Defined in [card-elements.ts:481](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L481)*
-
 **Parameters:**
 
 Name | Type |
@@ -1166,8 +992,6 @@ ___
 ###  isRightMostElement
 
 ▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
-
-*Defined in [card-elements.ts:485](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L485)*
 
 **Parameters:**
 
@@ -1183,8 +1007,6 @@ ___
 
 ▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
-*Defined in [card-elements.ts:489](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L489)*
-
 **Parameters:**
 
 Name | Type |
@@ -1199,8 +1021,6 @@ ___
 
 ▸ **overrideInternalRender**(): *HTMLElement | undefined*
 
-*Defined in [card-elements.ts:235](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L235)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1210,8 +1030,6 @@ ___
 ▸ **parse**(`source`: any, `context?`: [SerializationContext](serializationcontext.md)): *void*
 
 *Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
-
-*Defined in [card-elements.ts:313](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L313)*
 
 **Parameters:**
 
@@ -1230,8 +1048,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [serialization.ts:738](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L738)*
-
 **Parameters:**
 
 Name | Type |
@@ -1248,8 +1064,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[preProcessPropertyValue](cardobject.md#preprocesspropertyvalue)*
 
-*Defined in [card-object.ts:70](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L70)*
-
 **Parameters:**
 
 Name | Type |
@@ -1265,8 +1079,6 @@ ___
 
 ▸ **remove**(): *boolean*
 
-*Defined in [card-elements.ts:404](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L404)*
-
 **Returns:** *boolean*
 
 ___
@@ -1274,8 +1086,6 @@ ___
 ###  render
 
 ▸ **render**(): *HTMLElement | undefined*
-
-*Defined in [card-elements.ts:412](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L412)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -1287,8 +1097,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -1298,8 +1106,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -1315,8 +1121,6 @@ ___
 ### `Protected` setPadding
 
 ▸ **setPadding**(`value`: [PaddingDefinition](paddingdefinition.md) | undefined): *void*
-
-*Defined in [card-elements.ts:287](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L287)*
 
 **Parameters:**
 
@@ -1334,8 +1138,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setParent](cardobject.md#setparent)*
 
-*Defined in [card-object.ts:88](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L88)*
-
 **Parameters:**
 
 Name | Type |
@@ -1352,8 +1154,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setShouldFallback](cardobject.md#setshouldfallback)*
 
-*Defined in [card-object.ts:92](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L92)*
-
 **Parameters:**
 
 Name | Type |
@@ -1369,8 +1169,6 @@ ___
 ▸ **setValue**(`property`: [PropertyDefinition](propertydefinition.md), `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
-
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
 
 **Parameters:**
 
@@ -1389,8 +1187,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[shouldFallback](cardobject.md#shouldfallback)*
 
-*Defined in [card-object.ts:96](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L96)*
-
 **Returns:** *boolean*
 
 ___
@@ -1400,8 +1196,6 @@ ___
 ▸ **shouldSerialize**(`context`: [SerializationContext](serializationcontext.md)): *boolean*
 
 *Overrides [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
-
-*Defined in [card-elements.ts:291](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L291)*
 
 **Parameters:**
 
@@ -1419,8 +1213,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
 
-*Defined in [card-elements.ts:317](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L317)*
-
 **Parameters:**
 
 Name | Type |
@@ -1434,8 +1226,6 @@ ___
 ### `Protected` truncateOverflow
 
 ▸ **truncateOverflow**(`maxHeight`: number): *boolean*
-
-*Defined in [card-elements.ts:263](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L263)*
 
 **Parameters:**
 
@@ -1451,8 +1241,6 @@ ___
 
 ▸ **undoOverflowTruncation**(): *void*
 
-*Defined in [card-elements.ts:273](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L273)*
-
 **Returns:** *void*
 
 ___
@@ -1460,8 +1248,6 @@ ___
 ###  updateLayout
 
 ▸ **updateLayout**(`processChildren`: boolean): *void*
-
-*Defined in [card-elements.ts:434](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L434)*
 
 **Parameters:**
 
@@ -1478,7 +1264,5 @@ ___
 ▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
 
 *Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
-
-*Defined in [card-object.ts:128](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L128)*
 
 **Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/cardelementcontainer.md
+++ b/source/nodejs/adaptivecards/docs/classes/cardelementcontainer.md
@@ -149,8 +149,6 @@
 
 *Inherited from [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 **Returns:** *[CardElementContainer](cardelementcontainer.md)*
 
 ## Properties
@@ -161,8 +159,6 @@
 
 *Inherited from [CardObject](cardobject.md).[_parent](cardobject.md#protected-optional-_parent)*
 
-*Defined in [card-object.ts:61](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L61)*
-
 ___
 
 ### `Protected` `Optional` _renderedElement
@@ -171,23 +167,17 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[_renderedElement](cardobject.md#protected-optional-_renderedelement)*
 
-*Defined in [card-object.ts:62](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L62)*
-
 ___
 
 ### `Protected` `Optional` _selectAction
 
 • **_selectAction**? : *[Action](action.md)*
 
-*Defined in [card-elements.ts:1747](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1747)*
-
 ___
 
 ###  allowVerticalOverflow
 
 • **allowVerticalOverflow**: *boolean* = false
-
-*Defined in [card-elements.ts:1787](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1787)*
 
 ___
 
@@ -197,8 +187,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#optional-customcssselector)*
 
-*Defined in [card-elements.ts:311](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L311)*
-
 ___
 
 ###  height
@@ -206,8 +194,6 @@ ___
 • **height**: *[CardElementHeight](../README.md#cardelementheight)*
 
 *Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
-
-*Defined in [card-elements.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L53)*
 
 ___
 
@@ -217,8 +203,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#horizontalalignment)*
 
-*Defined in [card-elements.ts:44](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L44)*
-
 ___
 
 ### `Optional` id
@@ -226,8 +210,6 @@ ___
 • **id**? : *undefined | string*
 
 *Inherited from [CardObject](cardobject.md).[id](cardobject.md#optional-id)*
-
-*Defined in [card-object.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L50)*
 
 ___
 
@@ -237,8 +219,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 ___
 
 ### `Optional` onPreProcessPropertyValue
@@ -246,8 +226,6 @@ ___
 • **onPreProcessPropertyValue**? : *undefined | function*
 
 *Inherited from [CardObject](cardobject.md).[onPreProcessPropertyValue](cardobject.md#optional-onpreprocesspropertyvalue)*
-
-*Defined in [card-object.ts:64](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L64)*
 
 ___
 
@@ -257,8 +235,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
 
-*Defined in [card-elements.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L50)*
-
 ___
 
 ###  spacing
@@ -266,8 +242,6 @@ ___
 • **spacing**: *[Spacing](../enums/spacing.md)*
 
 *Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
-
-*Defined in [card-elements.ts:47](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L47)*
 
 ___
 
@@ -284,8 +258,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[heightProperty](cardelement.md#static-heightproperty)*
 
-*Defined in [card-elements.ts:24](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L24)*
-
 ___
 
 ### `Static` horizontalAlignmentProperty
@@ -298,8 +270,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignmentProperty](cardelement.md#static-horizontalalignmentproperty)*
 
-*Defined in [card-elements.ts:32](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L32)*
-
 ___
 
 ### `Static` idProperty
@@ -307,8 +277,6 @@ ___
 ▪ **idProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "id")
 
 *Inherited from [CardObject](cardobject.md).[idProperty](cardobject.md#static-idproperty)*
-
-*Defined in [card-object.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L39)*
 
 ___
 
@@ -318,8 +286,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisibleProperty](cardelement.md#static-isvisibleproperty)*
 
-*Defined in [card-elements.ts:22](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L22)*
-
 ___
 
 ### `Static` langProperty
@@ -328,8 +294,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[langProperty](cardelement.md#static-langproperty)*
 
-*Defined in [card-elements.ts:21](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L21)*
-
 ___
 
 ### `Static` `Optional` onRegisterCustomProperties
@@ -337,8 +301,6 @@ ___
 ▪ **onRegisterCustomProperties**? : *undefined | function*
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
-
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
 
 ___
 
@@ -351,15 +313,11 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requiresProperty](cardobject.md#static-requiresproperty)*
 
-*Defined in [card-object.ts:40](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L40)*
-
 ___
 
 ### `Static` selectActionProperty
 
 ▪ **selectActionProperty**: *[ActionProperty](actionproperty.md)‹›* = new ActionProperty(Versions.v1_0, "selectAction", [ "Action.ShowCard" ])
-
-*Defined in [card-elements.ts:1736](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1736)*
 
 ___
 
@@ -368,8 +326,6 @@ ___
 ▪ **separatorProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_0, "separator", false)
 
 *Inherited from [CardElement](cardelement.md).[separatorProperty](cardelement.md#static-separatorproperty)*
-
-*Defined in [card-elements.ts:23](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L23)*
 
 ___
 
@@ -382,8 +338,6 @@ ___
         Enums.Spacing.Default)
 
 *Inherited from [CardElement](cardelement.md).[spacingProperty](cardelement.md#static-spacingproperty)*
-
-*Defined in [card-elements.ts:37](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L37)*
 
 ___
 
@@ -401,8 +355,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[typeNameProperty](cardobject.md#static-typenameproperty)*
 
-*Defined in [card-object.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L30)*
-
 ## Accessors
 
 ### `Protected` allowCustomPadding
@@ -410,8 +362,6 @@ ___
 • **get allowCustomPadding**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
-
-*Defined in [card-elements.ts:299](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L299)*
 
 **Returns:** *boolean*
 
@@ -423,8 +373,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
 
-*Defined in [card-elements.ts:307](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L307)*
-
 **Returns:** *string*
 
 ___
@@ -434,8 +382,6 @@ ___
 • **get hasVisibleSeparator**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
-
-*Defined in [card-elements.ts:580](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L580)*
 
 **Returns:** *boolean*
 
@@ -449,8 +395,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
 
-*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
-
 **Returns:** *[HostConfig](hostconfig.md)*
 
 • **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
@@ -458,8 +402,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
-
-*Defined in [card-elements.ts:555](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L555)*
 
 **Parameters:**
 
@@ -477,8 +419,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
 
-*Defined in [card-elements.ts:559](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L559)*
-
 **Returns:** *number*
 
 ___
@@ -488,8 +428,6 @@ ___
 • **get isInline**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
-
-*Defined in [card-elements.ts:576](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L576)*
 
 **Returns:** *boolean*
 
@@ -501,8 +439,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
 
-*Defined in [card-elements.ts:568](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L568)*
-
 **Returns:** *boolean*
 
 ___
@@ -510,8 +446,6 @@ ___
 ### `Protected` isSelectable
 
 • **get isSelectable**(): *boolean*
-
-*Defined in [card-elements.ts:1777](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1777)*
 
 **Returns:** *boolean*
 
@@ -523,8 +457,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
 
-*Defined in [card-elements.ts:572](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L572)*
-
 **Returns:** *boolean*
 
 ___
@@ -535,15 +467,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
 
-*Defined in [card-elements.ts:77](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L77)*
-
 **Returns:** *boolean*
 
 • **set isVisible**(`value`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
-
-*Defined in [card-elements.ts:81](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L81)*
 
 **Parameters:**
 
@@ -561,15 +489,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
 
-*Defined in [card-elements.ts:56](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L56)*
-
 **Returns:** *string | undefined*
 
 • **set lang**(`value`: string | undefined): *void*
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
-
-*Defined in [card-elements.ts:72](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L72)*
 
 **Parameters:**
 
@@ -589,8 +513,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[parent](cardobject.md#parent)*
 
-*Defined in [card-elements.ts:593](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L593)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -600,8 +522,6 @@ ___
 • **get renderedElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardObject](cardobject.md).[renderedElement](cardobject.md#renderedelement)*
-
-*Defined in [card-object.ts:140](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L140)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -613,8 +533,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requires](cardobject.md#requires)*
 
-*Defined in [card-object.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L53)*
-
 **Returns:** *HostCapabilities*
 
 ___
@@ -624,8 +542,6 @@ ___
 • **get separatorElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
-
-*Defined in [card-elements.ts:589](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L589)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -637,8 +553,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
 
-*Defined in [card-elements.ts:303](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L303)*
-
 **Returns:** *[Orientation](../enums/orientation.md)*
 
 ___
@@ -649,8 +563,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
 
-*Defined in [card-elements.ts:295](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L295)*
-
 **Returns:** *boolean*
 
 ## Methods
@@ -660,8 +572,6 @@ ___
 ▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
 
 *Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
-
-*Defined in [card-elements.ts:220](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L220)*
 
 **Parameters:**
 
@@ -679,8 +589,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
 
-*Defined in [card-elements.ts:1755](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1755)*
-
 **Returns:** *void*
 
 ___
@@ -690,8 +598,6 @@ ___
 ▸ **asString**(): *string | undefined*
 
 *Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
-
-*Defined in [card-elements.ts:321](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L321)*
 
 **Returns:** *string | undefined*
 
@@ -703,8 +609,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
 
-*Defined in [card-elements.ts:205](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L205)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -714,8 +618,6 @@ ___
 ▸ **getActionAt**(`index`: number): *[Action](action.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
-
-*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
 
 **Parameters:**
 
@@ -733,8 +635,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
 
-*Defined in [card-elements.ts:531](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L531)*
-
 **Parameters:**
 
 Name | Type |
@@ -751,8 +651,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
 
-*Defined in [card-elements.ts:396](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L396)*
-
 **Returns:** *number*
 
 ___
@@ -763,8 +661,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
 
-*Defined in [card-elements.ts:1871](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1871)*
-
 **Returns:** *[Input](input.md)[]*
 
 ___
@@ -774,8 +670,6 @@ ___
 ▸ **getCustomProperty**(`name`: string): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
-
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
 
 **Parameters:**
 
@@ -793,8 +687,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
 
-*Defined in [card-elements.ts:275](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L275)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
 ___
@@ -804,8 +696,6 @@ ___
 ▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
 
 *Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
-
-*Defined in [card-elements.ts:535](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L535)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
@@ -817,8 +707,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
 
-*Defined in [card-elements.ts:329](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L329)*
-
 **Returns:** *string*
 
 ___
@@ -829,8 +717,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyleDefinition](cardelement.md#geteffectivestyledefinition)*
 
-*Defined in [card-elements.ts:337](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L337)*
-
 **Returns:** *[ContainerStyleDefinition](containerstyledefinition.md)*
 
 ___
@@ -840,8 +726,6 @@ ___
 ▸ **getElementById**(`id`: string): *[CardElement](cardelement.md) | undefined*
 
 *Overrides [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
-
-*Defined in [card-elements.ts:1891](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1891)*
 
 **Parameters:**
 
@@ -857,8 +741,6 @@ ___
 
 ▸ **getFirstVisibleRenderedItem**(): *[CardElement](cardelement.md) | undefined*
 
-*Defined in [card-elements.ts:1783](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1783)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -868,8 +750,6 @@ ___
 ▸ **getForbiddenActionTypes**(): *[ActionType](../README.md#actiontype)[]*
 
 *Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
-
-*Defined in [card-elements.ts:341](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L341)*
 
 **Returns:** *[ActionType](../README.md#actiontype)[]*
 
@@ -881,8 +761,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
 
-*Defined in [card-elements.ts:279](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L279)*
-
 **Returns:** *boolean*
 
 ___
@@ -892,8 +770,6 @@ ___
 ▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
-
-*Defined in [card-elements.ts:345](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L345)*
 
 **Parameters:**
 
@@ -913,8 +789,6 @@ ___
 
 ▸ **getItemAt**(`index`: number): *[CardElement](cardelement.md)*
 
-*Defined in [card-elements.ts:1782](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1782)*
-
 **Parameters:**
 
 Name | Type |
@@ -929,8 +803,6 @@ ___
 
 ▸ **getItemCount**(): *number*
 
-*Defined in [card-elements.ts:1781](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1781)*
-
 **Returns:** *number*
 
 ___
@@ -941,8 +813,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
 
-*Defined in [card-object.ts:66](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L66)*
-
 **Returns:** *string*
 
 ___
@@ -950,8 +820,6 @@ ___
 ### `Abstract` getLastVisibleRenderedItem
 
 ▸ **getLastVisibleRenderedItem**(): *[CardElement](cardelement.md) | undefined*
-
-*Defined in [card-elements.ts:1784](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1784)*
 
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
@@ -963,8 +831,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
 
-*Defined in [card-elements.ts:283](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L283)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md) | undefined*
 
 ___
@@ -974,8 +840,6 @@ ___
 ▸ **getParentContainer**(): *[Container](container.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
-
-*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
 
 **Returns:** *[Container](container.md) | undefined*
 
@@ -987,8 +851,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
 
-*Defined in [card-elements.ts:1881](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1881)*
-
 **Returns:** *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
 ___
@@ -998,8 +860,6 @@ ___
 ▸ **getRootElement**(): *[CardElement](cardelement.md)*
 
 *Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
-
-*Defined in [card-elements.ts:501](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L501)*
 
 **Returns:** *[CardElement](cardelement.md)*
 
@@ -1011,8 +871,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getRootObject](cardobject.md#getrootobject)*
 
-*Defined in [card-object.ts:100](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L100)*
-
 **Returns:** *[CardObject](cardobject.md)*
 
 ___
@@ -1022,8 +880,6 @@ ___
 ▸ **getSchema**(): *[SerializableObjectSchema](serializableobjectschema.md)*
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
-
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
 
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
@@ -1037,8 +893,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-object.ts:45](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L45)*
-
 **Returns:** *string*
 
 ___
@@ -1048,8 +902,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -1067,8 +919,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -1078,8 +928,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -1097,8 +945,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
 
-*Defined in [card-elements.ts:439](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L439)*
-
 **Parameters:**
 
 Name | Type |
@@ -1114,8 +960,6 @@ ___
 ▸ **internalParse**(`source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
-
-*Defined in [serialization.ts:789](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L789)*
 
 **Parameters:**
 
@@ -1134,8 +978,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
 
-*Defined in [card-elements.ts:233](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L233)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1145,8 +987,6 @@ ___
 ▸ **internalToJSON**(`target`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
-
-*Defined in [serialization.ts:821](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L821)*
 
 **Parameters:**
 
@@ -1165,8 +1005,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
 
-*Defined in [card-elements.ts:1789](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1789)*
-
 **Parameters:**
 
 Name | Type |
@@ -1183,8 +1021,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
 
-*Defined in [card-elements.ts:469](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L469)*
-
 **Returns:** *boolean*
 
 ___
@@ -1194,8 +1030,6 @@ ___
 ▸ **isAtTheVeryLeft**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
-
-*Defined in [card-elements.ts:457](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L457)*
 
 **Returns:** *boolean*
 
@@ -1207,8 +1041,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
 
-*Defined in [card-elements.ts:461](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L461)*
-
 **Returns:** *boolean*
 
 ___
@@ -1218,8 +1050,6 @@ ___
 ▸ **isAtTheVeryTop**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
-
-*Defined in [card-elements.ts:465](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L465)*
 
 **Returns:** *boolean*
 
@@ -1231,8 +1061,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
 
-*Defined in [card-elements.ts:325](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L325)*
-
 **Returns:** *boolean*
 
 ___
@@ -1242,8 +1070,6 @@ ___
 ▸ **isBleedingAtBottom**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
-
-*Defined in [card-elements.ts:477](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L477)*
 
 **Returns:** *boolean*
 
@@ -1255,8 +1081,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
 
-*Defined in [card-elements.ts:473](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L473)*
-
 **Returns:** *boolean*
 
 ___
@@ -1266,8 +1090,6 @@ ___
 ▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
-
-*Defined in [card-elements.ts:493](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L493)*
 
 **Parameters:**
 
@@ -1285,8 +1107,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
 
-*Defined in [card-elements.ts:443](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L443)*
-
 **Returns:** *boolean*
 
 ___
@@ -1297,8 +1117,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDisplayed](cardelement.md#protected-isdisplayed)*
 
-*Defined in [card-elements.ts:229](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L229)*
-
 **Returns:** *boolean*
 
 ___
@@ -1306,8 +1124,6 @@ ___
 ### `Protected` isElementAllowed
 
 ▸ **isElementAllowed**(`element`: [CardElement](cardelement.md)): *boolean*
-
-*Defined in [card-elements.ts:1751](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1751)*
 
 **Parameters:**
 
@@ -1325,8 +1141,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
 
-*Defined in [card-elements.ts:449](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L449)*
-
 **Parameters:**
 
 Name | Type |
@@ -1343,8 +1157,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
 
-*Defined in [card-elements.ts:497](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L497)*
-
 **Returns:** *boolean*
 
 ___
@@ -1354,8 +1166,6 @@ ___
 ▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
-
-*Defined in [card-elements.ts:453](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L453)*
 
 **Parameters:**
 
@@ -1373,8 +1183,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
 
-*Defined in [card-elements.ts:481](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L481)*
-
 **Parameters:**
 
 Name | Type |
@@ -1390,8 +1198,6 @@ ___
 ▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
-
-*Defined in [card-elements.ts:485](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L485)*
 
 **Parameters:**
 
@@ -1409,8 +1215,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
 
-*Defined in [card-elements.ts:489](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L489)*
-
 **Parameters:**
 
 Name | Type |
@@ -1427,8 +1231,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
 
-*Defined in [card-elements.ts:235](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L235)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1440,8 +1242,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[parse](cardelement.md#parse)*
 
 *Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
-
-*Defined in [card-elements.ts:313](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L313)*
 
 **Parameters:**
 
@@ -1460,8 +1260,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [card-elements.ts:1738](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1738)*
-
 **Parameters:**
 
 Name | Type |
@@ -1477,8 +1275,6 @@ ___
 ▸ **preProcessPropertyValue**(`property`: [PropertyDefinition](propertydefinition.md), `propertyValue?`: any): *any*
 
 *Inherited from [CardObject](cardobject.md).[preProcessPropertyValue](cardobject.md#preprocesspropertyvalue)*
-
-*Defined in [card-object.ts:70](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L70)*
 
 **Parameters:**
 
@@ -1497,8 +1293,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
 
-*Defined in [card-elements.ts:404](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L404)*
-
 **Returns:** *boolean*
 
 ___
@@ -1506,8 +1300,6 @@ ___
 ### `Abstract` removeItem
 
 ▸ **removeItem**(`item`: [CardElement](cardelement.md)): *boolean*
-
-*Defined in [card-elements.ts:1785](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1785)*
 
 **Parameters:**
 
@@ -1525,8 +1317,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[render](cardelement.md#render)*
 
-*Defined in [card-elements.ts:1817](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1817)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1537,8 +1327,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -1548,8 +1336,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -1568,8 +1354,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
 
-*Defined in [card-elements.ts:287](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L287)*
-
 **Parameters:**
 
 Name | Type |
@@ -1585,8 +1369,6 @@ ___
 ▸ **setParent**(`value`: [CardObject](cardobject.md) | undefined): *void*
 
 *Inherited from [CardObject](cardobject.md).[setParent](cardobject.md#setparent)*
-
-*Defined in [card-object.ts:88](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L88)*
 
 **Parameters:**
 
@@ -1604,8 +1386,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setShouldFallback](cardobject.md#setshouldfallback)*
 
-*Defined in [card-object.ts:92](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L92)*
-
 **Parameters:**
 
 Name | Type |
@@ -1621,8 +1401,6 @@ ___
 ▸ **setValue**(`property`: [PropertyDefinition](propertydefinition.md), `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
-
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
 
 **Parameters:**
 
@@ -1641,8 +1419,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[shouldFallback](cardobject.md#shouldfallback)*
 
-*Defined in [card-object.ts:96](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L96)*
-
 **Returns:** *boolean*
 
 ___
@@ -1654,8 +1430,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[shouldSerialize](cardelement.md#protected-shouldserialize)*
 
 *Overrides [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
-
-*Defined in [card-elements.ts:291](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L291)*
 
 **Parameters:**
 
@@ -1675,8 +1449,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
 
-*Defined in [card-elements.ts:317](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L317)*
-
 **Parameters:**
 
 Name | Type |
@@ -1692,8 +1464,6 @@ ___
 ▸ **truncateOverflow**(`maxHeight`: number): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
-
-*Defined in [card-elements.ts:263](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L263)*
 
 **Parameters:**
 
@@ -1711,8 +1481,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
 
-*Defined in [card-elements.ts:273](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L273)*
-
 **Returns:** *void*
 
 ___
@@ -1722,8 +1490,6 @@ ___
 ▸ **updateLayout**(`processChildren`: boolean): *void*
 
 *Overrides [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
-
-*Defined in [card-elements.ts:1861](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1861)*
 
 **Parameters:**
 
@@ -1740,7 +1506,5 @@ ___
 ▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
 
 *Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
-
-*Defined in [card-object.ts:128](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L128)*
 
 **Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/cardobject.md
+++ b/source/nodejs/adaptivecards/docs/classes/cardobject.md
@@ -71,8 +71,6 @@
 
 *Inherited from [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 **Returns:** *[CardObject](cardobject.md)*
 
 ## Properties
@@ -81,23 +79,17 @@
 
 • **_parent**? : *[CardObject](cardobject.md)*
 
-*Defined in [card-object.ts:61](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L61)*
-
 ___
 
 ### `Protected` `Optional` _renderedElement
 
 • **_renderedElement**? : *HTMLElement*
 
-*Defined in [card-object.ts:62](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L62)*
-
 ___
 
 ### `Optional` id
 
 • **id**? : *undefined | string*
-
-*Defined in [card-object.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L50)*
 
 ___
 
@@ -107,23 +99,17 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 ___
 
 ### `Optional` onPreProcessPropertyValue
 
 • **onPreProcessPropertyValue**? : *undefined | function*
 
-*Defined in [card-object.ts:64](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L64)*
-
 ___
 
 ### `Static` idProperty
 
 ▪ **idProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "id")
-
-*Defined in [card-object.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L39)*
 
 ___
 
@@ -133,8 +119,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
 
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
-
 ___
 
 ### `Static` requiresProperty
@@ -143,8 +127,6 @@ ___
         Versions.v1_2,
         "requires",
         HostCapabilities)
-
-*Defined in [card-object.ts:40](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L40)*
 
 ___
 
@@ -160,15 +142,11 @@ ___
             return (<CardObject>sender).getJsonTypeName()
         })
 
-*Defined in [card-object.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L30)*
-
 ## Accessors
 
 ###  hostConfig
 
 • **get hostConfig**(): *[HostConfig](hostconfig.md)*
-
-*Defined in [card-object.ts:68](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L68)*
 
 **Returns:** *[HostConfig](hostconfig.md)*
 
@@ -178,8 +156,6 @@ ___
 
 • **get parent**(): *[CardObject](cardobject.md) | undefined*
 
-*Defined in [card-object.ts:136](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L136)*
-
 **Returns:** *[CardObject](cardobject.md) | undefined*
 
 ___
@@ -188,8 +164,6 @@ ___
 
 • **get renderedElement**(): *HTMLElement | undefined*
 
-*Defined in [card-object.ts:140](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L140)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -197,8 +171,6 @@ ___
 ###  requires
 
 • **get requires**(): *HostCapabilities*
-
-*Defined in [card-object.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L53)*
 
 **Returns:** *HostCapabilities*
 
@@ -209,8 +181,6 @@ ___
 ▸ **getCustomProperty**(`name`: string): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
-
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
 
 **Parameters:**
 
@@ -226,8 +196,6 @@ ___
 
 ▸ **getJsonTypeName**(): *string*
 
-*Defined in [card-object.ts:66](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L66)*
-
 **Returns:** *string*
 
 ___
@@ -235,8 +203,6 @@ ___
 ###  getRootObject
 
 ▸ **getRootObject**(): *[CardObject](cardobject.md)*
-
-*Defined in [card-object.ts:100](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L100)*
 
 **Returns:** *[CardObject](cardobject.md)*
 
@@ -248,8 +214,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
 
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
-
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
 ___
@@ -260,8 +224,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-object.ts:45](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L45)*
-
 **Returns:** *string*
 
 ___
@@ -271,8 +233,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -290,8 +250,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -301,8 +259,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -319,8 +275,6 @@ ___
 ▸ **internalParse**(`source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
-
-*Defined in [serialization.ts:789](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L789)*
 
 **Parameters:**
 
@@ -339,8 +293,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
 
-*Defined in [serialization.ts:821](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L821)*
-
 **Parameters:**
 
 Name | Type |
@@ -355,8 +307,6 @@ ___
 ###  internalValidateProperties
 
 ▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
-
-*Defined in [card-object.ts:110](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L110)*
 
 **Parameters:**
 
@@ -373,8 +323,6 @@ ___
 ▸ **parse**(`source`: [PropertyBag](../README.md#propertybag), `context?`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
-
-*Defined in [serialization.ts:857](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L857)*
 
 **Parameters:**
 
@@ -393,8 +341,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [serialization.ts:738](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L738)*
-
 **Parameters:**
 
 Name | Type |
@@ -408,8 +354,6 @@ ___
 ###  preProcessPropertyValue
 
 ▸ **preProcessPropertyValue**(`property`: [PropertyDefinition](propertydefinition.md), `propertyValue?`: any): *any*
-
-*Defined in [card-object.ts:70](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L70)*
 
 **Parameters:**
 
@@ -428,8 +372,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -439,8 +381,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -457,8 +397,6 @@ ___
 
 ▸ **setParent**(`value`: [CardObject](cardobject.md) | undefined): *void*
 
-*Defined in [card-object.ts:88](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L88)*
-
 **Parameters:**
 
 Name | Type |
@@ -472,8 +410,6 @@ ___
 ###  setShouldFallback
 
 ▸ **setShouldFallback**(`value`: boolean): *void*
-
-*Defined in [card-object.ts:92](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L92)*
 
 **Parameters:**
 
@@ -491,8 +427,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
 
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
-
 **Parameters:**
 
 Name | Type |
@@ -508,8 +442,6 @@ ___
 
 ▸ **shouldFallback**(): *boolean*
 
-*Defined in [card-object.ts:96](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L96)*
-
 **Returns:** *boolean*
 
 ___
@@ -519,8 +451,6 @@ ___
 ▸ **shouldSerialize**(`context`: [BaseSerializationContext](baseserializationcontext.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
-
-*Defined in [serialization.ts:839](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L839)*
 
 **Parameters:**
 
@@ -538,8 +468,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
 
-*Defined in [serialization.ts:861](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L861)*
-
 **Parameters:**
 
 Name | Type |
@@ -553,7 +481,5 @@ ___
 ###  validateProperties
 
 ▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
-
-*Defined in [card-object.ts:128](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L128)*
 
 **Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/cardobjectregistry.md
+++ b/source/nodejs/adaptivecards/docs/classes/cardobjectregistry.md
@@ -28,8 +28,6 @@
 
 ▸ **clear**(): *void*
 
-*Defined in [registry.ts:18](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/registry.ts#L18)*
-
 **Returns:** *void*
 
 ___
@@ -37,8 +35,6 @@ ___
 ###  createInstance
 
 ▸ **createInstance**(`typeName`: string, `targetVersion`: [Version](version.md)): *T | undefined*
-
-*Defined in [registry.ts:43](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/registry.ts#L43)*
 
 **Parameters:**
 
@@ -55,8 +51,6 @@ ___
 
 ▸ **findByName**(`typeName`: string): *[ITypeRegistration](../interfaces/ityperegistration.md)‹T› | undefined*
 
-*Defined in [registry.ts:14](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/registry.ts#L14)*
-
 **Parameters:**
 
 Name | Type |
@@ -70,8 +64,6 @@ ___
 ###  getItemAt
 
 ▸ **getItemAt**(`index`: number): *[ITypeRegistration](../interfaces/ityperegistration.md)‹T›*
-
-*Defined in [registry.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/registry.ts#L53)*
 
 **Parameters:**
 
@@ -87,8 +79,6 @@ ___
 
 ▸ **getItemCount**(): *number*
 
-*Defined in [registry.ts:49](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/registry.ts#L49)*
-
 **Returns:** *number*
 
 ___
@@ -96,8 +86,6 @@ ___
 ###  register
 
 ▸ **register**(`typeName`: string, `objectType`: object, `schemaVersion`: [Version](version.md)): *void*
-
-*Defined in [registry.ts:22](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/registry.ts#L22)*
 
 **Parameters:**
 
@@ -118,8 +106,6 @@ ___
 ###  unregister
 
 ▸ **unregister**(`typeName`: string): *void*
-
-*Defined in [registry.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/registry.ts#L39)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/docs/classes/choice.md
+++ b/source/nodejs/adaptivecards/docs/classes/choice.md
@@ -49,8 +49,6 @@
 
 *Overrides [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [card-elements.ts:2751](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2751)*
-
 **Parameters:**
 
 Name | Type |
@@ -68,23 +66,17 @@ Name | Type |
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 ___
 
 ### `Optional` title
 
 • **title**? : *undefined | string*
 
-*Defined in [card-elements.ts:2742](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2742)*
-
 ___
 
 ### `Optional` value
 
 • **value**? : *undefined | string*
-
-*Defined in [card-elements.ts:2745](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2745)*
 
 ___
 
@@ -94,23 +86,17 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
 
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
-
 ___
 
 ### `Static` titleProperty
 
 ▪ **titleProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "title")
 
-*Defined in [card-elements.ts:2738](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2738)*
-
 ___
 
 ### `Static` valueProperty
 
 ▪ **valueProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "value")
-
-*Defined in [card-elements.ts:2739](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2739)*
 
 ## Methods
 
@@ -119,8 +105,6 @@ ___
 ▸ **getCustomProperty**(`name`: string): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
-
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
 
 **Parameters:**
 
@@ -138,8 +122,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
 
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
-
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
 ___
@@ -150,8 +132,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-elements.ts:2749](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2749)*
-
 **Returns:** *string*
 
 ___
@@ -161,8 +141,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -180,8 +158,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -191,8 +167,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -209,8 +183,6 @@ ___
 ▸ **internalParse**(`source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
-
-*Defined in [serialization.ts:789](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L789)*
 
 **Parameters:**
 
@@ -229,8 +201,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
 
-*Defined in [serialization.ts:821](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L821)*
-
 **Parameters:**
 
 Name | Type |
@@ -247,8 +217,6 @@ ___
 ▸ **parse**(`source`: [PropertyBag](../README.md#propertybag), `context?`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
-
-*Defined in [serialization.ts:857](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L857)*
 
 **Parameters:**
 
@@ -267,8 +235,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [serialization.ts:738](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L738)*
-
 **Parameters:**
 
 Name | Type |
@@ -285,8 +251,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -296,8 +260,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -316,8 +278,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
 
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
-
 **Parameters:**
 
 Name | Type |
@@ -335,8 +295,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
 
-*Defined in [serialization.ts:839](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L839)*
-
 **Parameters:**
 
 Name | Type |
@@ -352,8 +310,6 @@ ___
 ▸ **toJSON**(`context?`: [BaseSerializationContext](baseserializationcontext.md)): *[PropertyBag](../README.md#propertybag) | undefined*
 
 *Inherited from [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
-
-*Defined in [serialization.ts:861](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L861)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/docs/classes/choicesetinput.md
+++ b/source/nodejs/adaptivecards/docs/classes/choicesetinput.md
@@ -165,8 +165,6 @@
 
 *Inherited from [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 **Returns:** *[ChoiceSetInput](choicesetinput.md)*
 
 ## Properties
@@ -177,8 +175,6 @@
 
 *Inherited from [CardObject](cardobject.md).[_parent](cardobject.md#protected-optional-_parent)*
 
-*Defined in [card-object.ts:61](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L61)*
-
 ___
 
 ### `Protected` `Optional` _renderedElement
@@ -187,15 +183,11 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[_renderedElement](cardobject.md#protected-optional-_renderedelement)*
 
-*Defined in [card-object.ts:62](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L62)*
-
 ___
 
 ###  choices
 
 • **choices**: *[Choice](choice.md)[]* = []
-
-*Defined in [card-elements.ts:2802](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2802)*
 
 ___
 
@@ -205,15 +197,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#optional-customcssselector)*
 
-*Defined in [card-elements.ts:311](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L311)*
-
 ___
 
 ### `Optional` defaultValue
 
 • **defaultValue**? : *undefined | string*
-
-*Defined in [card-elements.ts:2779](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2779)*
 
 ___
 
@@ -223,8 +211,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
 
-*Defined in [card-elements.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L53)*
-
 ___
 
 ###  horizontalAlignment
@@ -232,8 +218,6 @@ ___
 • **horizontalAlignment**: *[HorizontalAlignment](../enums/horizontalalignment.md)*
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#horizontalalignment)*
-
-*Defined in [card-elements.ts:44](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L44)*
 
 ___
 
@@ -245,15 +229,11 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[id](cardobject.md#optional-id)*
 
-*Defined in [card-object.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L50)*
-
 ___
 
 ###  isMultiSelect
 
 • **isMultiSelect**: *boolean* = false
-
-*Defined in [card-elements.ts:2793](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2793)*
 
 ___
 
@@ -263,8 +243,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 ___
 
 ### `Optional` onPreProcessPropertyValue
@@ -273,8 +251,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[onPreProcessPropertyValue](cardobject.md#optional-onpreprocesspropertyvalue)*
 
-*Defined in [card-object.ts:64](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L64)*
-
 ___
 
 ###  onValueChanged
@@ -282,8 +258,6 @@ ___
 • **onValueChanged**: *function*
 
 *Inherited from [Input](input.md).[onValueChanged](input.md#onvaluechanged)*
-
-*Defined in [card-elements.ts:2415](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2415)*
 
 #### Type declaration:
 
@@ -301,8 +275,6 @@ ___
 
 • **placeholder**? : *undefined | string*
 
-*Defined in [card-elements.ts:2796](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2796)*
-
 ___
 
 ###  separator
@@ -310,8 +282,6 @@ ___
 • **separator**: *boolean*
 
 *Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
-
-*Defined in [card-elements.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L50)*
 
 ___
 
@@ -321,15 +291,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
 
-*Defined in [card-elements.ts:47](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L47)*
-
 ___
 
 ### `Optional` style
 
 • **style**? : *"compact" | "expanded"*
-
-*Defined in [card-elements.ts:2782](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2782)*
 
 ___
 
@@ -337,15 +303,11 @@ ___
 
 • **wrap**: *boolean* = false
 
-*Defined in [card-elements.ts:2799](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2799)*
-
 ___
 
 ### `Static` choicesProperty
 
 ▪ **choicesProperty**: *[SerializableObjectCollectionProperty](serializableobjectcollectionproperty.md)‹›* = new SerializableObjectCollectionProperty(Versions.v1_0, "choices", Choice)
-
-*Defined in [card-elements.ts:2765](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2765)*
 
 ___
 
@@ -362,8 +324,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[heightProperty](cardelement.md#static-heightproperty)*
 
-*Defined in [card-elements.ts:24](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L24)*
-
 ___
 
 ### `Static` horizontalAlignmentProperty
@@ -376,8 +336,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignmentProperty](cardelement.md#static-horizontalalignmentproperty)*
 
-*Defined in [card-elements.ts:32](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L32)*
-
 ___
 
 ### `Static` idProperty
@@ -386,15 +344,11 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[idProperty](cardobject.md#static-idproperty)*
 
-*Defined in [card-object.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L39)*
-
 ___
 
 ### `Static` isMultiSelectProperty
 
 ▪ **isMultiSelectProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_0, "isMultiSelect", false)
-
-*Defined in [card-elements.ts:2774](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2774)*
 
 ___
 
@@ -404,8 +358,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisibleProperty](cardelement.md#static-isvisibleproperty)*
 
-*Defined in [card-elements.ts:22](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L22)*
-
 ___
 
 ### `Static` langProperty
@@ -413,8 +365,6 @@ ___
 ▪ **langProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_1, "lang", true, /^[a-z]{2,3}$/ig)
 
 *Inherited from [CardElement](cardelement.md).[langProperty](cardelement.md#static-langproperty)*
-
-*Defined in [card-elements.ts:21](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L21)*
 
 ___
 
@@ -424,15 +374,11 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
 
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
-
 ___
 
 ### `Static` placeholderProperty
 
 ▪ **placeholderProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "placeholder")
-
-*Defined in [card-elements.ts:2775](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2775)*
 
 ___
 
@@ -445,8 +391,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requiresProperty](cardobject.md#static-requiresproperty)*
 
-*Defined in [card-object.ts:40](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L40)*
-
 ___
 
 ### `Static` separatorProperty
@@ -454,8 +398,6 @@ ___
 ▪ **separatorProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_0, "separator", false)
 
 *Inherited from [CardElement](cardelement.md).[separatorProperty](cardelement.md#static-separatorproperty)*
-
-*Defined in [card-elements.ts:23](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L23)*
 
 ___
 
@@ -469,8 +411,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[spacingProperty](cardelement.md#static-spacingproperty)*
 
-*Defined in [card-elements.ts:37](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L37)*
-
 ___
 
 ### `Static` styleProperty
@@ -483,8 +423,6 @@ ___
             { value: "expanded" }
         ],
         "compact")
-
-*Defined in [card-elements.ts:2766](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2766)*
 
 ___
 
@@ -502,8 +440,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[typeNameProperty](cardobject.md#static-typenameproperty)*
 
-*Defined in [card-object.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L30)*
-
 ___
 
 ### `Static` validationProperty
@@ -515,23 +451,17 @@ ___
 
 *Inherited from [Input](input.md).[validationProperty](input.md#static-validationproperty)*
 
-*Defined in [card-elements.ts:2313](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2313)*
-
 ___
 
 ### `Static` valueProperty
 
 ▪ **valueProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "value")
 
-*Defined in [card-elements.ts:2764](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2764)*
-
 ___
 
 ### `Static` wrapProperty
 
 ▪ **wrapProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_2, "wrap", false)
-
-*Defined in [card-elements.ts:2776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2776)*
 
 ## Accessors
 
@@ -540,8 +470,6 @@ ___
 • **get allowCustomPadding**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
-
-*Defined in [card-elements.ts:299](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L299)*
 
 **Returns:** *boolean*
 
@@ -553,8 +481,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
 
-*Defined in [card-elements.ts:307](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L307)*
-
 **Returns:** *string*
 
 ___
@@ -564,8 +490,6 @@ ___
 • **get hasVisibleSeparator**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
-
-*Defined in [card-elements.ts:580](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L580)*
 
 **Returns:** *boolean*
 
@@ -579,8 +503,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
 
-*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
-
 **Returns:** *[HostConfig](hostconfig.md)*
 
 • **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
@@ -588,8 +510,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
-
-*Defined in [card-elements.ts:555](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L555)*
 
 **Parameters:**
 
@@ -607,8 +527,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
 
-*Defined in [card-elements.ts:559](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L559)*
-
 **Returns:** *number*
 
 ___
@@ -619,8 +537,6 @@ ___
 
 *Inherited from [Input](input.md).[inputControlContainerElement](input.md#protected-inputcontrolcontainerelement)*
 
-*Defined in [card-elements.ts:2346](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2346)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -629,13 +545,9 @@ ___
 
 • **get isCompact**(): *boolean*
 
-*Defined in [card-elements.ts:2784](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2784)*
-
 **Returns:** *boolean*
 
 • **set isCompact**(`value`: boolean): *void*
-
-*Defined in [card-elements.ts:2788](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2788)*
 
 **Parameters:**
 
@@ -653,8 +565,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
 
-*Defined in [card-elements.ts:576](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L576)*
-
 **Returns:** *boolean*
 
 ___
@@ -667,8 +577,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
 
-*Defined in [card-elements.ts:2453](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2453)*
-
 **Returns:** *boolean*
 
 ___
@@ -678,8 +586,6 @@ ___
 • **get isNullable**(): *boolean*
 
 *Inherited from [Input](input.md).[isNullable](input.md#protected-isnullable)*
-
-*Defined in [card-elements.ts:2338](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2338)*
 
 **Returns:** *boolean*
 
@@ -691,8 +597,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
 
-*Defined in [card-elements.ts:572](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L572)*
-
 **Returns:** *boolean*
 
 ___
@@ -703,15 +607,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
 
-*Defined in [card-elements.ts:77](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L77)*
-
 **Returns:** *boolean*
 
 • **set isVisible**(`value`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
-
-*Defined in [card-elements.ts:81](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L81)*
 
 **Parameters:**
 
@@ -729,15 +629,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
 
-*Defined in [card-elements.ts:56](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L56)*
-
 **Returns:** *string | undefined*
 
 • **set lang**(`value`: string | undefined): *void*
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
-
-*Defined in [card-elements.ts:72](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L72)*
 
 **Parameters:**
 
@@ -757,8 +653,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[parent](cardobject.md#parent)*
 
-*Defined in [card-elements.ts:593](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L593)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -768,8 +662,6 @@ ___
 • **get renderedElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardObject](cardobject.md).[renderedElement](cardobject.md#renderedelement)*
-
-*Defined in [card-object.ts:140](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L140)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -781,8 +673,6 @@ ___
 
 *Inherited from [Input](input.md).[renderedInputControlElement](input.md#protected-renderedinputcontrolelement)*
 
-*Defined in [card-elements.ts:2342](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2342)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -792,8 +682,6 @@ ___
 • **get requires**(): *HostCapabilities*
 
 *Inherited from [CardObject](cardobject.md).[requires](cardobject.md#requires)*
-
-*Defined in [card-object.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L53)*
 
 **Returns:** *HostCapabilities*
 
@@ -805,8 +693,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
 
-*Defined in [card-elements.ts:589](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L589)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -816,8 +702,6 @@ ___
 • **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
 
 *Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
-
-*Defined in [card-elements.ts:303](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L303)*
 
 **Returns:** *[Orientation](../enums/orientation.md)*
 
@@ -829,8 +713,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
 
-*Defined in [card-elements.ts:295](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L295)*
-
 **Returns:** *boolean*
 
 ___
@@ -840,8 +722,6 @@ ___
 • **get validation**(): *[InputValidationOptions](inputvalidationoptions.md)*
 
 *Inherited from [Input](input.md).[validation](input.md#validation)*
-
-*Defined in [card-elements.ts:2327](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2327)*
 
 **Returns:** *[InputValidationOptions](inputvalidationoptions.md)*
 
@@ -853,8 +733,6 @@ ___
 
 *Overrides [Input](input.md).[value](input.md#value)*
 
-*Defined in [card-elements.ts:2994](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2994)*
-
 **Returns:** *string | undefined*
 
 ## Methods
@@ -864,8 +742,6 @@ ___
 ▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
 
 *Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
-
-*Defined in [card-elements.ts:220](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L220)*
 
 **Parameters:**
 
@@ -883,8 +759,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
 
-*Defined in [card-elements.ts:239](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L239)*
-
 **Returns:** *void*
 
 ___
@@ -894,8 +768,6 @@ ___
 ▸ **asString**(): *string | undefined*
 
 *Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
-
-*Defined in [card-elements.ts:321](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L321)*
 
 **Returns:** *string | undefined*
 
@@ -907,8 +779,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
 
-*Defined in [card-elements.ts:205](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L205)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -918,8 +788,6 @@ ___
 ▸ **getActionAt**(`index`: number): *[Action](action.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
-
-*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
 
 **Parameters:**
 
@@ -937,8 +805,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
 
-*Defined in [card-elements.ts:531](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L531)*
-
 **Parameters:**
 
 Name | Type |
@@ -955,8 +821,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
 
-*Defined in [card-elements.ts:396](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L396)*
-
 **Returns:** *number*
 
 ___
@@ -969,8 +833,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
 
-*Defined in [card-elements.ts:2449](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2449)*
-
 **Returns:** *[Input](input.md)[]*
 
 ___
@@ -980,8 +842,6 @@ ___
 ▸ **getCustomProperty**(`name`: string): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
-
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
 
 **Parameters:**
 
@@ -999,8 +859,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
 
-*Defined in [card-elements.ts:275](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L275)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
 ___
@@ -1010,8 +868,6 @@ ___
 ▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
 
 *Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
-
-*Defined in [card-elements.ts:535](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L535)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
@@ -1023,8 +879,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
 
-*Defined in [card-elements.ts:329](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L329)*
-
 **Returns:** *string*
 
 ___
@@ -1035,8 +889,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyleDefinition](cardelement.md#geteffectivestyledefinition)*
 
-*Defined in [card-elements.ts:337](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L337)*
-
 **Returns:** *[ContainerStyleDefinition](containerstyledefinition.md)*
 
 ___
@@ -1046,8 +898,6 @@ ___
 ▸ **getElementById**(`id`: string): *[CardElement](cardelement.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
-
-*Defined in [card-elements.ts:527](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L527)*
 
 **Parameters:**
 
@@ -1065,8 +915,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
 
-*Defined in [card-elements.ts:341](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L341)*
-
 **Returns:** *[ActionType](../README.md#actiontype)[]*
 
 ___
@@ -1077,8 +925,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
 
-*Defined in [card-elements.ts:279](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L279)*
-
 **Returns:** *boolean*
 
 ___
@@ -1088,8 +934,6 @@ ___
 ▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
-
-*Defined in [card-elements.ts:345](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L345)*
 
 **Parameters:**
 
@@ -1111,8 +955,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
 
-*Defined in [card-elements.ts:2966](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2966)*
-
 **Returns:** *string*
 
 ___
@@ -1122,8 +964,6 @@ ___
 ▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
-
-*Defined in [card-elements.ts:283](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L283)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md) | undefined*
 
@@ -1135,8 +975,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
 
-*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
-
 **Returns:** *[Container](container.md) | undefined*
 
 ___
@@ -1146,8 +984,6 @@ ___
 ▸ **getResourceInformation**(): *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
 *Inherited from [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
-
-*Defined in [card-elements.ts:523](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L523)*
 
 **Returns:** *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
@@ -1159,8 +995,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
 
-*Defined in [card-elements.ts:501](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L501)*
-
 **Returns:** *[CardElement](cardelement.md)*
 
 ___
@@ -1171,8 +1005,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getRootObject](cardobject.md#getrootobject)*
 
-*Defined in [card-object.ts:100](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L100)*
-
 **Returns:** *[CardObject](cardobject.md)*
 
 ___
@@ -1182,8 +1014,6 @@ ___
 ▸ **getSchema**(): *[SerializableObjectSchema](serializableobjectschema.md)*
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
-
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
 
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
@@ -1197,8 +1027,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-object.ts:45](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L45)*
-
 **Returns:** *string*
 
 ___
@@ -1208,8 +1036,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -1227,8 +1053,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -1238,8 +1062,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -1257,8 +1079,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
 
-*Defined in [card-elements.ts:439](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L439)*
-
 **Parameters:**
 
 Name | Type |
@@ -1273,8 +1093,6 @@ ___
 
 ▸ **internalApplyAriaCurrent**(): *void*
 
-*Defined in [card-elements.ts:2891](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2891)*
-
 **Returns:** *void*
 
 ___
@@ -1284,8 +1102,6 @@ ___
 ▸ **internalParse**(`source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
-
-*Defined in [serialization.ts:789](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L789)*
 
 **Parameters:**
 
@@ -1304,8 +1120,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
 
-*Defined in [card-elements.ts:2906](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2906)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1315,8 +1129,6 @@ ___
 ▸ **internalToJSON**(`target`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
-
-*Defined in [serialization.ts:821](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L821)*
 
 **Parameters:**
 
@@ -1335,8 +1147,6 @@ ___
 
 *Overrides [Input](input.md).[internalValidateProperties](input.md#internalvalidateproperties)*
 
-*Defined in [card-elements.ts:2970](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2970)*
-
 **Parameters:**
 
 Name | Type |
@@ -1353,8 +1163,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
 
-*Defined in [card-elements.ts:469](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L469)*
-
 **Returns:** *boolean*
 
 ___
@@ -1364,8 +1172,6 @@ ___
 ▸ **isAtTheVeryLeft**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
-
-*Defined in [card-elements.ts:457](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L457)*
 
 **Returns:** *boolean*
 
@@ -1377,8 +1183,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
 
-*Defined in [card-elements.ts:461](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L461)*
-
 **Returns:** *boolean*
 
 ___
@@ -1388,8 +1192,6 @@ ___
 ▸ **isAtTheVeryTop**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
-
-*Defined in [card-elements.ts:465](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L465)*
 
 **Returns:** *boolean*
 
@@ -1401,8 +1203,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
 
-*Defined in [card-elements.ts:325](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L325)*
-
 **Returns:** *boolean*
 
 ___
@@ -1412,8 +1212,6 @@ ___
 ▸ **isBleedingAtBottom**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
-
-*Defined in [card-elements.ts:477](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L477)*
 
 **Returns:** *boolean*
 
@@ -1425,8 +1223,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
 
-*Defined in [card-elements.ts:473](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L473)*
-
 **Returns:** *boolean*
 
 ___
@@ -1436,8 +1232,6 @@ ___
 ▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
-
-*Defined in [card-elements.ts:493](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L493)*
 
 **Parameters:**
 
@@ -1455,8 +1249,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
 
-*Defined in [card-elements.ts:443](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L443)*
-
 **Returns:** *boolean*
 
 ___
@@ -1467,8 +1259,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDisplayed](cardelement.md#protected-isdisplayed)*
 
-*Defined in [card-elements.ts:229](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L229)*
-
 **Returns:** *boolean*
 
 ___
@@ -1478,8 +1268,6 @@ ___
 ▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
-
-*Defined in [card-elements.ts:449](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L449)*
 
 **Parameters:**
 
@@ -1497,8 +1285,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
 
-*Defined in [card-elements.ts:497](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L497)*
-
 **Returns:** *boolean*
 
 ___
@@ -1508,8 +1294,6 @@ ___
 ▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
-
-*Defined in [card-elements.ts:453](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L453)*
 
 **Parameters:**
 
@@ -1527,8 +1311,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
 
-*Defined in [card-elements.ts:481](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L481)*
-
 **Parameters:**
 
 Name | Type |
@@ -1544,8 +1326,6 @@ ___
 ▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
-
-*Defined in [card-elements.ts:485](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L485)*
 
 **Parameters:**
 
@@ -1563,8 +1343,6 @@ ___
 
 *Overrides [Input](input.md).[isSet](input.md#abstract-isset)*
 
-*Defined in [card-elements.ts:2990](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2990)*
-
 **Returns:** *boolean*
 
 ___
@@ -1574,8 +1352,6 @@ ___
 ▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
-
-*Defined in [card-elements.ts:489](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L489)*
 
 **Parameters:**
 
@@ -1595,8 +1371,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
 
-*Defined in [card-elements.ts:2350](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2350)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1608,8 +1382,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[parse](cardelement.md#parse)*
 
 *Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
-
-*Defined in [card-elements.ts:313](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L313)*
 
 **Parameters:**
 
@@ -1630,8 +1402,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [card-elements.ts:2318](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2318)*
-
 **Parameters:**
 
 Name | Type |
@@ -1647,8 +1417,6 @@ ___
 ▸ **preProcessPropertyValue**(`property`: [PropertyDefinition](propertydefinition.md), `propertyValue?`: any): *any*
 
 *Inherited from [CardObject](cardobject.md).[preProcessPropertyValue](cardobject.md#preprocesspropertyvalue)*
-
-*Defined in [card-object.ts:70](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L70)*
 
 **Parameters:**
 
@@ -1667,8 +1435,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
 
-*Defined in [card-elements.ts:404](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L404)*
-
 **Returns:** *boolean*
 
 ___
@@ -1678,8 +1444,6 @@ ___
 ▸ **render**(): *HTMLElement | undefined*
 
 *Inherited from [CardElement](cardelement.md).[render](cardelement.md#render)*
-
-*Defined in [card-elements.ts:412](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L412)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -1691,8 +1455,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -1703,8 +1465,6 @@ ___
 
 *Inherited from [Input](input.md).[resetValidationFailureCue](input.md#protected-resetvalidationfailurecue)*
 
-*Defined in [card-elements.ts:2391](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2391)*
-
 **Returns:** *void*
 
 ___
@@ -1714,8 +1474,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -1734,8 +1492,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
 
-*Defined in [card-elements.ts:287](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L287)*
-
 **Parameters:**
 
 Name | Type |
@@ -1751,8 +1507,6 @@ ___
 ▸ **setParent**(`value`: [CardObject](cardobject.md) | undefined): *void*
 
 *Inherited from [CardObject](cardobject.md).[setParent](cardobject.md#setparent)*
-
-*Defined in [card-object.ts:88](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L88)*
 
 **Parameters:**
 
@@ -1770,8 +1524,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setShouldFallback](cardobject.md#setshouldfallback)*
 
-*Defined in [card-object.ts:92](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L92)*
-
 **Parameters:**
 
 Name | Type |
@@ -1787,8 +1539,6 @@ ___
 ▸ **setValue**(`property`: [PropertyDefinition](propertydefinition.md), `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
-
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
 
 **Parameters:**
 
@@ -1807,8 +1557,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[shouldFallback](cardobject.md#shouldfallback)*
 
-*Defined in [card-object.ts:96](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L96)*
-
 **Returns:** *boolean*
 
 ___
@@ -1820,8 +1568,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[shouldSerialize](cardelement.md#protected-shouldserialize)*
 
 *Overrides [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
-
-*Defined in [card-elements.ts:291](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L291)*
 
 **Parameters:**
 
@@ -1839,8 +1585,6 @@ ___
 
 *Inherited from [Input](input.md).[showValidationErrorMessage](input.md#protected-showvalidationerrormessage)*
 
-*Defined in [card-elements.ts:2403](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2403)*
-
 **Returns:** *void*
 
 ___
@@ -1852,8 +1596,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[toJSON](cardelement.md#tojson)*
 
 *Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
-
-*Defined in [card-elements.ts:317](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L317)*
 
 **Parameters:**
 
@@ -1871,8 +1613,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
 
-*Defined in [card-elements.ts:263](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L263)*
-
 **Parameters:**
 
 Name | Type |
@@ -1889,8 +1629,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
 
-*Defined in [card-elements.ts:273](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L273)*
-
 **Returns:** *void*
 
 ___
@@ -1900,8 +1638,6 @@ ___
 ▸ **updateLayout**(`processChildren`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
-
-*Defined in [card-elements.ts:434](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L434)*
 
 **Parameters:**
 
@@ -1919,8 +1655,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
 
-*Defined in [card-object.ts:128](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L128)*
-
 **Returns:** *[ValidationResults](validationresults.md)*
 
 ___
@@ -1933,8 +1667,6 @@ ___
 
 *Inherited from [Input](input.md).[validateValue](input.md#validatevalue)*
 
-*Defined in [card-elements.ts:2430](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2430)*
-
 **Returns:** *boolean*
 
 ___
@@ -1944,7 +1676,5 @@ ___
 ▸ **valueChanged**(): *void*
 
 *Inherited from [Input](input.md).[valueChanged](input.md#protected-valuechanged)*
-
-*Defined in [card-elements.ts:2381](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2381)*
 
 **Returns:** *void*

--- a/source/nodejs/adaptivecards/docs/classes/colordefinition.md
+++ b/source/nodejs/adaptivecards/docs/classes/colordefinition.md
@@ -29,8 +29,6 @@
 
 \+ **new ColorDefinition**(`defaultColor?`: undefined | string, `subtleColor?`: undefined | string): *[ColorDefinition](colordefinition.md)*
 
-*Defined in [host-config.ts:24](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L24)*
-
 **Parameters:**
 
 Name | Type |
@@ -46,23 +44,17 @@ Name | Type |
 
 • **default**: *string* = "#000000"
 
-*Defined in [host-config.ts:23](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L23)*
-
 ___
 
 ###  subtle
 
 • **subtle**: *string* = "#666666"
 
-*Defined in [host-config.ts:24](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L24)*
-
 ## Methods
 
 ###  parse
 
 ▸ **parse**(`obj?`: any): *void*
-
-*Defined in [host-config.ts:36](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L36)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/docs/classes/colorsetdefinition.md
+++ b/source/nodejs/adaptivecards/docs/classes/colorsetdefinition.md
@@ -32,8 +32,6 @@
 
 \+ **new ColorSetDefinition**(`obj?`: any): *[ColorSetDefinition](colorsetdefinition.md)*
 
-*Defined in [host-config.ts:253](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L253)*
-
 **Parameters:**
 
 Name | Type |
@@ -48,15 +46,11 @@ Name | Type |
 
 • **accent**: *[TextColorDefinition](textcolordefinition.md)* = new TextColorDefinition()
 
-*Defined in [host-config.ts:250](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L250)*
-
 ___
 
 ###  attention
 
 • **attention**: *[TextColorDefinition](textcolordefinition.md)* = new TextColorDefinition()
-
-*Defined in [host-config.ts:253](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L253)*
 
 ___
 
@@ -64,15 +58,11 @@ ___
 
 • **dark**: *[TextColorDefinition](textcolordefinition.md)* = new TextColorDefinition()
 
-*Defined in [host-config.ts:248](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L248)*
-
 ___
 
 ###  default
 
 • **default**: *[TextColorDefinition](textcolordefinition.md)* = new TextColorDefinition()
-
-*Defined in [host-config.ts:247](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L247)*
 
 ___
 
@@ -80,15 +70,11 @@ ___
 
 • **good**: *[TextColorDefinition](textcolordefinition.md)* = new TextColorDefinition()
 
-*Defined in [host-config.ts:251](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L251)*
-
 ___
 
 ###  light
 
 • **light**: *[TextColorDefinition](textcolordefinition.md)* = new TextColorDefinition()
-
-*Defined in [host-config.ts:249](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L249)*
 
 ___
 
@@ -96,15 +82,11 @@ ___
 
 • **warning**: *[TextColorDefinition](textcolordefinition.md)* = new TextColorDefinition()
 
-*Defined in [host-config.ts:252](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L252)*
-
 ## Methods
 
 ###  parse
 
 ▸ **parse**(`obj`: any): *void*
-
-*Defined in [host-config.ts:259](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L259)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/docs/classes/column.md
+++ b/source/nodejs/adaptivecards/docs/classes/column.md
@@ -175,8 +175,6 @@
 
 *Overrides [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [card-elements.ts:5371](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5371)*
-
 **Parameters:**
 
 Name | Type | Default |
@@ -193,8 +191,6 @@ Name | Type | Default |
 
 *Inherited from [CardObject](cardobject.md).[_parent](cardobject.md#protected-optional-_parent)*
 
-*Defined in [card-object.ts:61](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L61)*
-
 ___
 
 ### `Protected` `Optional` _renderedElement
@@ -202,8 +198,6 @@ ___
 • **_renderedElement**? : *HTMLElement*
 
 *Inherited from [CardObject](cardobject.md).[_renderedElement](cardobject.md#protected-optional-_renderedelement)*
-
-*Defined in [card-object.ts:62](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L62)*
 
 ___
 
@@ -213,8 +207,6 @@ ___
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[_selectAction](cardelementcontainer.md#protected-optional-_selectaction)*
 
-*Defined in [card-elements.ts:1747](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1747)*
-
 ___
 
 ###  allowVerticalOverflow
@@ -222,8 +214,6 @@ ___
 • **allowVerticalOverflow**: *boolean* = false
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[allowVerticalOverflow](cardelementcontainer.md#allowverticaloverflow)*
-
-*Defined in [card-elements.ts:1787](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1787)*
 
 ___
 
@@ -233,8 +223,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#optional-customcssselector)*
 
-*Defined in [card-elements.ts:311](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L311)*
-
 ___
 
 ###  height
@@ -242,8 +230,6 @@ ___
 • **height**: *[CardElementHeight](../README.md#cardelementheight)*
 
 *Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
-
-*Defined in [card-elements.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L53)*
 
 ___
 
@@ -253,8 +239,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#horizontalalignment)*
 
-*Defined in [card-elements.ts:44](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L44)*
-
 ___
 
 ### `Optional` id
@@ -262,8 +246,6 @@ ___
 • **id**? : *undefined | string*
 
 *Inherited from [CardObject](cardobject.md).[id](cardobject.md#optional-id)*
-
-*Defined in [card-object.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L50)*
 
 ___
 
@@ -273,8 +255,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 ___
 
 ### `Optional` minPixelHeight
@@ -282,8 +262,6 @@ ___
 • **minPixelHeight**? : *undefined | number*
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[minPixelHeight](stylablecardelementcontainer.md#optional-minpixelheight)*
-
-*Defined in [card-elements.ts:4621](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4621)*
 
 ___
 
@@ -293,8 +271,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[onPreProcessPropertyValue](cardobject.md#optional-onpreprocesspropertyvalue)*
 
-*Defined in [card-object.ts:64](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L64)*
-
 ___
 
 ### `Optional` rtl
@@ -302,8 +278,6 @@ ___
 • **rtl**? : *undefined | false | true*
 
 *Inherited from [Container](container.md).[rtl](container.md#optional-rtl)*
-
-*Defined in [card-elements.ts:4885](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4885)*
 
 ___
 
@@ -313,8 +287,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
 
-*Defined in [card-elements.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L50)*
-
 ___
 
 ###  spacing
@@ -322,8 +294,6 @@ ___
 • **spacing**: *[Spacing](../enums/spacing.md)*
 
 *Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
-
-*Defined in [card-elements.ts:47](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L47)*
 
 ___
 
@@ -333,15 +303,11 @@ ___
 
 *Inherited from [Container](container.md).[verticalContentAlignment](container.md#verticalcontentalignment)*
 
-*Defined in [card-elements.ts:4882](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4882)*
-
 ___
 
 ###  width
 
 • **width**: *[ColumnWidth](../README.md#columnwidth)* = "stretch"
-
-*Defined in [card-elements.ts:5327](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5327)*
 
 ___
 
@@ -354,8 +320,6 @@ ___
 
 *Inherited from [Container](container.md).[backgroundImageProperty](container.md#static-backgroundimageproperty)*
 
-*Defined in [card-elements.ts:4869](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4869)*
-
 ___
 
 ### `Static` bleedProperty
@@ -363,8 +327,6 @@ ___
 ▪ **bleedProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_2, "bleed", false)
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[bleedProperty](stylablecardelementcontainer.md#static-bleedproperty)*
-
-*Defined in [card-elements.ts:4597](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4597)*
 
 ___
 
@@ -381,8 +343,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[heightProperty](cardelement.md#static-heightproperty)*
 
-*Defined in [card-elements.ts:24](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L24)*
-
 ___
 
 ### `Static` horizontalAlignmentProperty
@@ -395,8 +355,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignmentProperty](cardelement.md#static-horizontalalignmentproperty)*
 
-*Defined in [card-elements.ts:32](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L32)*
-
 ___
 
 ### `Static` idProperty
@@ -404,8 +362,6 @@ ___
 ▪ **idProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "id")
 
 *Inherited from [CardObject](cardobject.md).[idProperty](cardobject.md#static-idproperty)*
-
-*Defined in [card-object.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L39)*
 
 ___
 
@@ -415,8 +371,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisibleProperty](cardelement.md#static-isvisibleproperty)*
 
-*Defined in [card-elements.ts:22](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L22)*
-
 ___
 
 ### `Static` langProperty
@@ -424,8 +378,6 @@ ___
 ▪ **langProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_1, "lang", true, /^[a-z]{2,3}$/ig)
 
 *Inherited from [CardElement](cardelement.md).[langProperty](cardelement.md#static-langproperty)*
-
-*Defined in [card-elements.ts:21](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L21)*
 
 ___
 
@@ -435,8 +387,6 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[minHeightProperty](stylablecardelementcontainer.md#static-minheightproperty)*
 
-*Defined in [card-elements.ts:4598](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4598)*
-
 ___
 
 ### `Static` `Optional` onRegisterCustomProperties
@@ -444,8 +394,6 @@ ___
 ▪ **onRegisterCustomProperties**? : *undefined | function*
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
-
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
 
 ___
 
@@ -458,8 +406,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requiresProperty](cardobject.md#static-requiresproperty)*
 
-*Defined in [card-object.ts:40](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L40)*
-
 ___
 
 ### `Static` rtlProperty
@@ -467,8 +413,6 @@ ___
 ▪ **rtlProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_0, "rtl")
 
 *Inherited from [Container](container.md).[rtlProperty](container.md#static-rtlproperty)*
-
-*Defined in [card-elements.ts:4874](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4874)*
 
 ___
 
@@ -478,8 +422,6 @@ ___
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[selectActionProperty](cardelementcontainer.md#static-selectactionproperty)*
 
-*Defined in [card-elements.ts:1736](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1736)*
-
 ___
 
 ### `Static` separatorProperty
@@ -487,8 +429,6 @@ ___
 ▪ **separatorProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_0, "separator", false)
 
 *Inherited from [CardElement](cardelement.md).[separatorProperty](cardelement.md#static-separatorproperty)*
-
-*Defined in [card-elements.ts:23](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L23)*
 
 ___
 
@@ -501,8 +441,6 @@ ___
         Enums.Spacing.Default)
 
 *Inherited from [CardElement](cardelement.md).[spacingProperty](cardelement.md#static-spacingproperty)*
-
-*Defined in [card-elements.ts:37](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L37)*
 
 ___
 
@@ -522,8 +460,6 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[styleProperty](stylablecardelementcontainer.md#static-styleproperty)*
 
-*Defined in [card-elements.ts:4586](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4586)*
-
 ___
 
 ### `Static` typeNameProperty
@@ -540,8 +476,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[typeNameProperty](cardobject.md#static-typenameproperty)*
 
-*Defined in [card-object.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L30)*
-
 ___
 
 ### `Static` verticalContentAlignmentProperty
@@ -549,8 +483,6 @@ ___
 ▪ **verticalContentAlignmentProperty**: *[EnumProperty](enumproperty.md)‹[VerticalAlignment](../enums/verticalalignment.md)›* = new EnumProperty(Versions.v1_1, "verticalContentAlignment", Enums.VerticalAlignment, Enums.VerticalAlignment.Top)
 
 *Inherited from [Container](container.md).[verticalContentAlignmentProperty](container.md#static-verticalcontentalignmentproperty)*
-
-*Defined in [card-elements.ts:4873](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4873)*
 
 ___
 
@@ -612,8 +544,6 @@ ___
         },
         "stretch")
 
-*Defined in [card-elements.ts:5270](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5270)*
-
 ## Accessors
 
 ### `Protected` allowCustomPadding
@@ -621,8 +551,6 @@ ___
 • **get allowCustomPadding**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
-
-*Defined in [card-elements.ts:299](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L299)*
 
 **Returns:** *boolean*
 
@@ -634,8 +562,6 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[allowCustomStyle](stylablecardelementcontainer.md#protected-allowcustomstyle)*
 
-*Defined in [card-elements.ts:4742](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4742)*
-
 **Returns:** *boolean*
 
 ___
@@ -645,8 +571,6 @@ ___
 • **get backgroundImage**(): *[BackgroundImage](backgroundimage.md)*
 
 *Inherited from [Container](container.md).[backgroundImage](container.md#backgroundimage)*
-
-*Defined in [card-elements.ts:4877](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4877)*
 
 **Returns:** *[BackgroundImage](backgroundimage.md)*
 
@@ -658,15 +582,11 @@ ___
 
 *Inherited from [Container](container.md).[bleed](container.md#bleed)*
 
-*Defined in [card-elements.ts:5256](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5256)*
-
 **Returns:** *boolean*
 
 • **set bleed**(`value`: boolean): *void*
 
 *Inherited from [Container](container.md).[bleed](container.md#bleed)*
-
-*Defined in [card-elements.ts:5260](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5260)*
 
 **Parameters:**
 
@@ -684,8 +604,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
 
-*Defined in [card-elements.ts:307](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L307)*
-
 **Returns:** *string*
 
 ___
@@ -696,8 +614,6 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[hasExplicitStyle](stylablecardelementcontainer.md#protected-hasexplicitstyle)*
 
-*Defined in [card-elements.ts:4738](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4738)*
-
 **Returns:** *boolean*
 
 ___
@@ -707,8 +623,6 @@ ___
 • **get hasVisibleSeparator**(): *boolean*
 
 *Overrides [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
-
-*Defined in [card-elements.ts:5383](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5383)*
 
 **Returns:** *boolean*
 
@@ -722,8 +636,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
 
-*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
-
 **Returns:** *[HostConfig](hostconfig.md)*
 
 • **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
@@ -731,8 +643,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
-
-*Defined in [card-elements.ts:555](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L555)*
 
 **Parameters:**
 
@@ -750,8 +660,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
 
-*Defined in [card-elements.ts:559](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L559)*
-
 **Returns:** *number*
 
 ___
@@ -762,8 +670,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
 
-*Defined in [card-elements.ts:576](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L576)*
-
 **Returns:** *boolean*
 
 ___
@@ -773,8 +679,6 @@ ___
 • **get isInteractive**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
-
-*Defined in [card-elements.ts:568](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L568)*
 
 **Returns:** *boolean*
 
@@ -788,8 +692,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[isSelectable](cardelementcontainer.md#protected-isselectable)*
 
-*Defined in [card-elements.ts:5079](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5079)*
-
 **Returns:** *boolean*
 
 ___
@@ -799,8 +701,6 @@ ___
 • **get isStandalone**(): *boolean*
 
 *Overrides [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
-
-*Defined in [card-elements.ts:5392](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5392)*
 
 **Returns:** *boolean*
 
@@ -812,15 +712,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
 
-*Defined in [card-elements.ts:77](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L77)*
-
 **Returns:** *boolean*
 
 • **set isVisible**(`value`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
-
-*Defined in [card-elements.ts:81](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L81)*
 
 **Parameters:**
 
@@ -838,15 +734,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
 
-*Defined in [card-elements.ts:56](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L56)*
-
 **Returns:** *string | undefined*
 
 • **set lang**(`value`: string | undefined): *void*
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
-
-*Defined in [card-elements.ts:72](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L72)*
 
 **Parameters:**
 
@@ -864,15 +756,11 @@ ___
 
 *Inherited from [Container](container.md).[padding](container.md#padding)*
 
-*Defined in [card-elements.ts:5240](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5240)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md) | undefined*
 
 • **set padding**(`value`: [PaddingDefinition](paddingdefinition.md) | undefined): *void*
 
 *Inherited from [Container](container.md).[padding](container.md#padding)*
-
-*Defined in [card-elements.ts:5244](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5244)*
 
 **Parameters:**
 
@@ -892,8 +780,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[parent](cardobject.md#parent)*
 
-*Defined in [card-elements.ts:593](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L593)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -903,8 +789,6 @@ ___
 • **get renderedActionCount**(): *number*
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[renderedActionCount](stylablecardelementcontainer.md#protected-renderedactioncount)*
-
-*Defined in [card-elements.ts:4734](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4734)*
 
 **Returns:** *number*
 
@@ -916,8 +800,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[renderedElement](cardobject.md#renderedelement)*
 
-*Defined in [card-object.ts:140](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L140)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -927,8 +809,6 @@ ___
 • **get requires**(): *HostCapabilities*
 
 *Inherited from [CardObject](cardobject.md).[requires](cardobject.md#requires)*
-
-*Defined in [card-object.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L53)*
 
 **Returns:** *HostCapabilities*
 
@@ -940,15 +820,11 @@ ___
 
 *Inherited from [Container](container.md).[selectAction](container.md#selectaction)*
 
-*Defined in [card-elements.ts:5248](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5248)*
-
 **Returns:** *[Action](action.md) | undefined*
 
 • **set selectAction**(`value`: [Action](action.md) | undefined): *void*
 
 *Inherited from [Container](container.md).[selectAction](container.md#selectaction)*
-
-*Defined in [card-elements.ts:5252](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5252)*
 
 **Parameters:**
 
@@ -966,8 +842,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
 
-*Defined in [card-elements.ts:589](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L589)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -977,8 +851,6 @@ ___
 • **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
 
 *Overrides [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
-
-*Defined in [card-elements.ts:5369](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5369)*
 
 **Returns:** *[Orientation](../enums/orientation.md)*
 
@@ -990,15 +862,11 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[style](stylablecardelementcontainer.md#style)*
 
-*Defined in [card-elements.ts:4601](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4601)*
-
 **Returns:** *string | undefined*
 
 • **set style**(`value`: string | undefined): *void*
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[style](stylablecardelementcontainer.md#style)*
-
-*Defined in [card-elements.ts:4613](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4613)*
 
 **Parameters:**
 
@@ -1016,8 +884,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
 
-*Defined in [card-elements.ts:295](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L295)*
-
 **Returns:** *boolean*
 
 ## Methods
@@ -1027,8 +893,6 @@ ___
 ▸ **addItem**(`item`: [CardElement](cardelement.md)): *void*
 
 *Inherited from [Container](container.md).[addItem](container.md#additem)*
-
-*Defined in [card-elements.ts:5170](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5170)*
 
 **Parameters:**
 
@@ -1045,8 +909,6 @@ ___
 ▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
 
 *Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[adjustRenderedElementSize](stylablecardelementcontainer.md#protected-adjustrenderedelementsize)*
-
-*Defined in [card-elements.ts:5333](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5333)*
 
 **Parameters:**
 
@@ -1066,8 +928,6 @@ ___
 
 *Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[applyBackground](stylablecardelementcontainer.md#protected-applybackground)*
 
-*Defined in [card-elements.ts:4924](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4924)*
-
 **Returns:** *void*
 
 ___
@@ -1080,8 +940,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[applyPadding](cardelementcontainer.md#protected-applypadding)*
 
-*Defined in [card-elements.ts:4643](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4643)*
-
 **Returns:** *void*
 
 ___
@@ -1091,8 +949,6 @@ ___
 ▸ **asString**(): *string | undefined*
 
 *Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
-
-*Defined in [card-elements.ts:321](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L321)*
 
 **Returns:** *string | undefined*
 
@@ -1104,8 +960,6 @@ ___
 
 *Inherited from [Container](container.md).[clear](container.md#clear)*
 
-*Defined in [card-elements.ts:5198](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5198)*
-
 **Returns:** *void*
 
 ___
@@ -1116,8 +970,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
 
-*Defined in [card-elements.ts:205](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L205)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -1127,8 +979,6 @@ ___
 ▸ **getActionAt**(`index`: number): *[Action](action.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
-
-*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
 
 **Parameters:**
 
@@ -1148,8 +998,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
 
-*Defined in [card-elements.ts:5218](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5218)*
-
 **Parameters:**
 
 Name | Type |
@@ -1166,8 +1014,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
 
-*Defined in [card-elements.ts:396](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L396)*
-
 **Returns:** *number*
 
 ___
@@ -1180,8 +1026,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
 
-*Defined in [card-elements.ts:1871](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1871)*
-
 **Returns:** *[Input](input.md)[]*
 
 ___
@@ -1192,8 +1036,6 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[getBleed](stylablecardelementcontainer.md#protected-getbleed)*
 
-*Defined in [card-elements.ts:4726](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4726)*
-
 **Returns:** *boolean*
 
 ___
@@ -1203,8 +1045,6 @@ ___
 ▸ **getCustomProperty**(`name`: string): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
-
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
 
 **Parameters:**
 
@@ -1224,8 +1064,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
 
-*Defined in [card-elements.ts:4713](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4713)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
 ___
@@ -1235,8 +1073,6 @@ ___
 ▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
 
 *Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
-
-*Defined in [card-elements.ts:535](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L535)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
@@ -1250,8 +1086,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
 
-*Defined in [card-elements.ts:4777](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4777)*
-
 **Returns:** *string*
 
 ___
@@ -1261,8 +1095,6 @@ ___
 ▸ **getEffectiveStyleDefinition**(): *[ContainerStyleDefinition](containerstyledefinition.md)*
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyleDefinition](cardelement.md#geteffectivestyledefinition)*
-
-*Defined in [card-elements.ts:337](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L337)*
 
 **Returns:** *[ContainerStyleDefinition](containerstyledefinition.md)*
 
@@ -1275,8 +1107,6 @@ ___
 *Inherited from [CardElementContainer](cardelementcontainer.md).[getElementById](cardelementcontainer.md#getelementbyid)*
 
 *Overrides [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
-
-*Defined in [card-elements.ts:1891](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1891)*
 
 **Parameters:**
 
@@ -1296,8 +1126,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[getFirstVisibleRenderedItem](cardelementcontainer.md#abstract-getfirstvisiblerendereditem)*
 
-*Defined in [card-elements.ts:5091](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5091)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -1307,8 +1135,6 @@ ___
 ▸ **getForbiddenActionTypes**(): *[ActionType](../README.md#actiontype)[]*
 
 *Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
-
-*Defined in [card-elements.ts:341](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L341)*
 
 **Returns:** *[ActionType](../README.md#actiontype)[]*
 
@@ -1322,8 +1148,6 @@ ___
 
 *Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[getHasBackground](stylablecardelementcontainer.md#protected-gethasbackground)*
 
-*Defined in [card-elements.ts:5050](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5050)*
-
 **Returns:** *boolean*
 
 ___
@@ -1334,8 +1158,6 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[getHasExpandedAction](stylablecardelementcontainer.md#protected-gethasexpandedaction)*
 
-*Defined in [card-elements.ts:4722](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4722)*
-
 **Returns:** *boolean*
 
 ___
@@ -1345,8 +1167,6 @@ ___
 ▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
-
-*Defined in [card-elements.ts:345](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L345)*
 
 **Parameters:**
 
@@ -1370,8 +1190,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[getItemAt](cardelementcontainer.md#abstract-getitemat)*
 
-*Defined in [card-elements.ts:5087](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5087)*
-
 **Parameters:**
 
 Name | Type |
@@ -1390,8 +1208,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[getItemCount](cardelementcontainer.md#abstract-getitemcount)*
 
-*Defined in [card-elements.ts:5083](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5083)*
-
 **Returns:** *number*
 
 ___
@@ -1402,8 +1218,6 @@ ___
 
 *Inherited from [Container](container.md).[getItemsCollectionPropertyName](container.md#protected-getitemscollectionpropertyname)*
 
-*Defined in [card-elements.ts:4920](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4920)*
-
 **Returns:** *string*
 
 ___
@@ -1413,8 +1227,6 @@ ___
 ▸ **getJsonTypeName**(): *string*
 
 *Overrides [Container](container.md).[getJsonTypeName](container.md#getjsontypename)*
-
-*Defined in [card-elements.ts:5379](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5379)*
 
 **Returns:** *string*
 
@@ -1428,8 +1240,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[getLastVisibleRenderedItem](cardelementcontainer.md#abstract-getlastvisiblerendereditem)*
 
-*Defined in [card-elements.ts:5103](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5103)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -1440,8 +1250,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
 
-*Defined in [card-elements.ts:283](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L283)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md) | undefined*
 
 ___
@@ -1451,8 +1259,6 @@ ___
 ▸ **getParentContainer**(): *[Container](container.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
-
-*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
 
 **Returns:** *[Container](container.md) | undefined*
 
@@ -1466,8 +1272,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[getResourceInformation](cardelementcontainer.md#getresourceinformation)*
 
-*Defined in [card-elements.ts:5203](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5203)*
-
 **Returns:** *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
 ___
@@ -1477,8 +1281,6 @@ ___
 ▸ **getRootElement**(): *[CardElement](cardelement.md)*
 
 *Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
-
-*Defined in [card-elements.ts:501](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L501)*
 
 **Returns:** *[CardElement](cardelement.md)*
 
@@ -1490,8 +1292,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getRootObject](cardobject.md#getrootobject)*
 
-*Defined in [card-object.ts:100](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L100)*
-
 **Returns:** *[CardObject](cardobject.md)*
 
 ___
@@ -1501,8 +1301,6 @@ ___
 ▸ **getSchema**(): *[SerializableObjectSchema](serializableobjectschema.md)*
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
-
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
 
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
@@ -1516,8 +1314,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-object.ts:45](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L45)*
-
 **Returns:** *string*
 
 ___
@@ -1527,8 +1323,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -1546,8 +1340,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -1557,8 +1349,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -1578,8 +1368,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
 
-*Defined in [card-elements.ts:5166](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5166)*
-
 **Parameters:**
 
 Name | Type |
@@ -1595,8 +1383,6 @@ ___
 ▸ **insertItemAfter**(`item`: [CardElement](cardelement.md), `insertAfter`: [CardElement](cardelement.md)): *void*
 
 *Inherited from [Container](container.md).[insertItemAfter](container.md#insertitemafter)*
-
-*Defined in [card-elements.ts:5178](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5178)*
 
 **Parameters:**
 
@@ -1614,8 +1400,6 @@ ___
 ▸ **insertItemBefore**(`item`: [CardElement](cardelement.md), `insertBefore`: [CardElement](cardelement.md)): *void*
 
 *Inherited from [Container](container.md).[insertItemBefore](container.md#insertitembefore)*
-
-*Defined in [card-elements.ts:5174](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5174)*
 
 **Parameters:**
 
@@ -1636,8 +1420,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
 
-*Defined in [card-elements.ts:5054](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5054)*
-
 **Parameters:**
 
 Name | Type |
@@ -1657,8 +1439,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
 
-*Defined in [card-elements.ts:4932](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4932)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1670,8 +1450,6 @@ ___
 *Inherited from [Container](container.md).[internalToJSON](container.md#protected-internaltojson)*
 
 *Overrides [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
-
-*Defined in [card-elements.ts:5073](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5073)*
 
 **Parameters:**
 
@@ -1692,8 +1470,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[internalValidateProperties](cardelementcontainer.md#internalvalidateproperties)*
 
-*Defined in [card-elements.ts:4750](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4750)*
-
 **Parameters:**
 
 Name | Type |
@@ -1710,8 +1486,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
 
-*Defined in [card-elements.ts:469](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L469)*
-
 **Returns:** *boolean*
 
 ___
@@ -1721,8 +1495,6 @@ ___
 ▸ **isAtTheVeryLeft**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
-
-*Defined in [card-elements.ts:457](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L457)*
 
 **Returns:** *boolean*
 
@@ -1734,8 +1506,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
 
-*Defined in [card-elements.ts:461](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L461)*
-
 **Returns:** *boolean*
 
 ___
@@ -1745,8 +1515,6 @@ ___
 ▸ **isAtTheVeryTop**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
-
-*Defined in [card-elements.ts:465](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L465)*
 
 **Returns:** *boolean*
 
@@ -1760,8 +1528,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
 
-*Defined in [card-elements.ts:4746](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4746)*
-
 **Returns:** *boolean*
 
 ___
@@ -1773,8 +1539,6 @@ ___
 *Inherited from [Container](container.md).[isBleedingAtBottom](container.md#isbleedingatbottom)*
 
 *Overrides [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
-
-*Defined in [card-elements.ts:5160](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5160)*
 
 **Returns:** *boolean*
 
@@ -1788,8 +1552,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
 
-*Defined in [card-elements.ts:5154](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5154)*
-
 **Returns:** *boolean*
 
 ___
@@ -1799,8 +1561,6 @@ ___
 ▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
-
-*Defined in [card-elements.ts:493](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L493)*
 
 **Parameters:**
 
@@ -1818,8 +1578,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
 
-*Defined in [card-elements.ts:443](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L443)*
-
 **Returns:** *boolean*
 
 ___
@@ -1830,8 +1588,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDisplayed](cardelement.md#protected-isdisplayed)*
 
-*Defined in [card-elements.ts:229](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L229)*
-
 **Returns:** *boolean*
 
 ___
@@ -1841,8 +1597,6 @@ ___
 ▸ **isElementAllowed**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[isElementAllowed](cardelementcontainer.md#protected-iselementallowed)*
-
-*Defined in [card-elements.ts:1751](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1751)*
 
 **Parameters:**
 
@@ -1862,8 +1616,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
 
-*Defined in [card-elements.ts:5119](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5119)*
-
 **Parameters:**
 
 Name | Type |
@@ -1880,8 +1632,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
 
-*Defined in [card-elements.ts:497](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L497)*
-
 **Returns:** *boolean*
 
 ___
@@ -1893,8 +1643,6 @@ ___
 *Inherited from [Container](container.md).[isLastElement](container.md#islastelement)*
 
 *Overrides [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
-
-*Defined in [card-elements.ts:5131](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5131)*
 
 **Parameters:**
 
@@ -1912,8 +1660,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
 
-*Defined in [card-elements.ts:481](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L481)*
-
 **Parameters:**
 
 Name | Type |
@@ -1929,8 +1675,6 @@ ___
 ▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
-
-*Defined in [card-elements.ts:485](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L485)*
 
 **Parameters:**
 
@@ -1948,8 +1692,6 @@ ___
 
 *Inherited from [Container](container.md).[isRtl](container.md#isrtl)*
 
-*Defined in [card-elements.ts:5143](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5143)*
-
 **Returns:** *boolean*
 
 ___
@@ -1959,8 +1701,6 @@ ___
 ▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
-
-*Defined in [card-elements.ts:489](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L489)*
 
 **Parameters:**
 
@@ -1978,8 +1718,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
 
-*Defined in [card-elements.ts:235](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L235)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1991,8 +1729,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[parse](cardelement.md#parse)*
 
 *Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
-
-*Defined in [card-elements.ts:313](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L313)*
 
 **Parameters:**
 
@@ -2013,8 +1749,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [card-elements.ts:1738](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1738)*
-
 **Parameters:**
 
 Name | Type |
@@ -2030,8 +1764,6 @@ ___
 ▸ **preProcessPropertyValue**(`property`: [PropertyDefinition](propertydefinition.md), `propertyValue?`: any): *any*
 
 *Inherited from [CardObject](cardobject.md).[preProcessPropertyValue](cardobject.md#preprocesspropertyvalue)*
-
-*Defined in [card-object.ts:70](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L70)*
 
 **Parameters:**
 
@@ -2050,8 +1782,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
 
-*Defined in [card-elements.ts:404](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L404)*
-
 **Returns:** *boolean*
 
 ___
@@ -2063,8 +1793,6 @@ ___
 *Inherited from [Container](container.md).[removeItem](container.md#removeitem)*
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[removeItem](cardelementcontainer.md#abstract-removeitem)*
-
-*Defined in [card-elements.ts:5182](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5182)*
 
 **Parameters:**
 
@@ -2084,8 +1812,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[render](cardelementcontainer.md#render)*
 
-*Defined in [card-elements.ts:4767](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4767)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -2096,8 +1822,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -2107,8 +1831,6 @@ ___
 ▸ **setBleed**(`value`: boolean): *void*
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[setBleed](stylablecardelementcontainer.md#protected-setbleed)*
-
-*Defined in [card-elements.ts:4730](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4730)*
 
 **Parameters:**
 
@@ -2125,8 +1847,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -2145,8 +1865,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
 
-*Defined in [card-elements.ts:287](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L287)*
-
 **Parameters:**
 
 Name | Type |
@@ -2162,8 +1880,6 @@ ___
 ▸ **setParent**(`value`: [CardObject](cardobject.md) | undefined): *void*
 
 *Inherited from [CardObject](cardobject.md).[setParent](cardobject.md#setparent)*
-
-*Defined in [card-object.ts:88](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L88)*
 
 **Parameters:**
 
@@ -2181,8 +1897,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setShouldFallback](cardobject.md#setshouldfallback)*
 
-*Defined in [card-object.ts:92](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L92)*
-
 **Parameters:**
 
 Name | Type |
@@ -2198,8 +1912,6 @@ ___
 ▸ **setValue**(`property`: [PropertyDefinition](propertydefinition.md), `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
-
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
 
 **Parameters:**
 
@@ -2218,8 +1930,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[shouldFallback](cardobject.md#shouldfallback)*
 
-*Defined in [card-object.ts:96](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L96)*
-
 **Returns:** *boolean*
 
 ___
@@ -2229,8 +1939,6 @@ ___
 ▸ **shouldSerialize**(`context`: [SerializationContext](serializationcontext.md)): *boolean*
 
 *Overrides [CardElement](cardelement.md).[shouldSerialize](cardelement.md#protected-shouldserialize)*
-
-*Defined in [card-elements.ts:5365](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5365)*
 
 **Parameters:**
 
@@ -2248,8 +1956,6 @@ ___
 
 *Inherited from [Container](container.md).[supportsExcplitiHeight](container.md#protected-supportsexcplitiheight)*
 
-*Defined in [card-elements.ts:4916](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4916)*
-
 **Returns:** *boolean*
 
 ___
@@ -2261,8 +1967,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[toJSON](cardelement.md#tojson)*
 
 *Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
-
-*Defined in [card-elements.ts:317](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L317)*
 
 **Parameters:**
 
@@ -2282,8 +1986,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
 
-*Defined in [card-elements.ts:5005](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5005)*
-
 **Parameters:**
 
 Name | Type |
@@ -2302,8 +2004,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
 
-*Defined in [card-elements.ts:5044](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5044)*
-
 **Returns:** *void*
 
 ___
@@ -2315,8 +2015,6 @@ ___
 *Inherited from [CardElementContainer](cardelementcontainer.md).[updateLayout](cardelementcontainer.md#updatelayout)*
 
 *Overrides [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
-
-*Defined in [card-elements.ts:1861](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1861)*
 
 **Parameters:**
 
@@ -2333,7 +2031,5 @@ ___
 ▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
 
 *Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
-
-*Defined in [card-object.ts:128](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L128)*
 
 **Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/columnset.md
+++ b/source/nodejs/adaptivecards/docs/classes/columnset.md
@@ -162,8 +162,6 @@
 
 *Inherited from [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 **Returns:** *[ColumnSet](columnset.md)*
 
 ## Properties
@@ -174,8 +172,6 @@
 
 *Inherited from [CardObject](cardobject.md).[_parent](cardobject.md#protected-optional-_parent)*
 
-*Defined in [card-object.ts:61](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L61)*
-
 ___
 
 ### `Protected` `Optional` _renderedElement
@@ -183,8 +179,6 @@ ___
 • **_renderedElement**? : *HTMLElement*
 
 *Inherited from [CardObject](cardobject.md).[_renderedElement](cardobject.md#protected-optional-_renderedelement)*
-
-*Defined in [card-object.ts:62](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L62)*
 
 ___
 
@@ -194,8 +188,6 @@ ___
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[_selectAction](cardelementcontainer.md#protected-optional-_selectaction)*
 
-*Defined in [card-elements.ts:1747](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1747)*
-
 ___
 
 ###  allowVerticalOverflow
@@ -203,8 +195,6 @@ ___
 • **allowVerticalOverflow**: *boolean* = false
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[allowVerticalOverflow](cardelementcontainer.md#allowverticaloverflow)*
-
-*Defined in [card-elements.ts:1787](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1787)*
 
 ___
 
@@ -214,8 +204,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#optional-customcssselector)*
 
-*Defined in [card-elements.ts:311](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L311)*
-
 ___
 
 ###  height
@@ -223,8 +211,6 @@ ___
 • **height**: *[CardElementHeight](../README.md#cardelementheight)*
 
 *Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
-
-*Defined in [card-elements.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L53)*
 
 ___
 
@@ -234,8 +220,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#horizontalalignment)*
 
-*Defined in [card-elements.ts:44](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L44)*
-
 ___
 
 ### `Optional` id
@@ -243,8 +227,6 @@ ___
 • **id**? : *undefined | string*
 
 *Inherited from [CardObject](cardobject.md).[id](cardobject.md#optional-id)*
-
-*Defined in [card-object.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L50)*
 
 ___
 
@@ -254,8 +236,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 ___
 
 ### `Optional` minPixelHeight
@@ -263,8 +243,6 @@ ___
 • **minPixelHeight**? : *undefined | number*
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[minPixelHeight](stylablecardelementcontainer.md#optional-minpixelheight)*
-
-*Defined in [card-elements.ts:4621](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4621)*
 
 ___
 
@@ -274,8 +252,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[onPreProcessPropertyValue](cardobject.md#optional-onpreprocesspropertyvalue)*
 
-*Defined in [card-object.ts:64](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L64)*
-
 ___
 
 ###  separator
@@ -283,8 +259,6 @@ ___
 • **separator**: *boolean*
 
 *Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
-
-*Defined in [card-elements.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L50)*
 
 ___
 
@@ -294,8 +268,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
 
-*Defined in [card-elements.ts:47](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L47)*
-
 ___
 
 ### `Static` bleedProperty
@@ -303,8 +275,6 @@ ___
 ▪ **bleedProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_2, "bleed", false)
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[bleedProperty](stylablecardelementcontainer.md#static-bleedproperty)*
-
-*Defined in [card-elements.ts:4597](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4597)*
 
 ___
 
@@ -321,8 +291,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[heightProperty](cardelement.md#static-heightproperty)*
 
-*Defined in [card-elements.ts:24](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L24)*
-
 ___
 
 ### `Static` horizontalAlignmentProperty
@@ -335,8 +303,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignmentProperty](cardelement.md#static-horizontalalignmentproperty)*
 
-*Defined in [card-elements.ts:32](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L32)*
-
 ___
 
 ### `Static` idProperty
@@ -344,8 +310,6 @@ ___
 ▪ **idProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "id")
 
 *Inherited from [CardObject](cardobject.md).[idProperty](cardobject.md#static-idproperty)*
-
-*Defined in [card-object.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L39)*
 
 ___
 
@@ -355,8 +319,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisibleProperty](cardelement.md#static-isvisibleproperty)*
 
-*Defined in [card-elements.ts:22](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L22)*
-
 ___
 
 ### `Static` langProperty
@@ -364,8 +326,6 @@ ___
 ▪ **langProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_1, "lang", true, /^[a-z]{2,3}$/ig)
 
 *Inherited from [CardElement](cardelement.md).[langProperty](cardelement.md#static-langproperty)*
-
-*Defined in [card-elements.ts:21](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L21)*
 
 ___
 
@@ -375,8 +335,6 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[minHeightProperty](stylablecardelementcontainer.md#static-minheightproperty)*
 
-*Defined in [card-elements.ts:4598](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4598)*
-
 ___
 
 ### `Static` `Optional` onRegisterCustomProperties
@@ -384,8 +342,6 @@ ___
 ▪ **onRegisterCustomProperties**? : *undefined | function*
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
-
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
 
 ___
 
@@ -398,8 +354,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requiresProperty](cardobject.md#static-requiresproperty)*
 
-*Defined in [card-object.ts:40](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L40)*
-
 ___
 
 ### `Static` selectActionProperty
@@ -408,8 +362,6 @@ ___
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[selectActionProperty](cardelementcontainer.md#static-selectactionproperty)*
 
-*Defined in [card-elements.ts:1736](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1736)*
-
 ___
 
 ### `Static` separatorProperty
@@ -417,8 +369,6 @@ ___
 ▪ **separatorProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_0, "separator", false)
 
 *Inherited from [CardElement](cardelement.md).[separatorProperty](cardelement.md#static-separatorproperty)*
-
-*Defined in [card-elements.ts:23](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L23)*
 
 ___
 
@@ -431,8 +381,6 @@ ___
         Enums.Spacing.Default)
 
 *Inherited from [CardElement](cardelement.md).[spacingProperty](cardelement.md#static-spacingproperty)*
-
-*Defined in [card-elements.ts:37](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L37)*
 
 ___
 
@@ -452,8 +400,6 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[styleProperty](stylablecardelementcontainer.md#static-styleproperty)*
 
-*Defined in [card-elements.ts:4586](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4586)*
-
 ___
 
 ### `Static` typeNameProperty
@@ -470,8 +416,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[typeNameProperty](cardobject.md#static-typenameproperty)*
 
-*Defined in [card-object.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L30)*
-
 ## Accessors
 
 ### `Protected` allowCustomPadding
@@ -479,8 +423,6 @@ ___
 • **get allowCustomPadding**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
-
-*Defined in [card-elements.ts:299](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L299)*
 
 **Returns:** *boolean*
 
@@ -492,8 +434,6 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[allowCustomStyle](stylablecardelementcontainer.md#protected-allowcustomstyle)*
 
-*Defined in [card-elements.ts:4742](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4742)*
-
 **Returns:** *boolean*
 
 ___
@@ -502,13 +442,9 @@ ___
 
 • **get bleed**(): *boolean*
 
-*Defined in [card-elements.ts:5689](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5689)*
-
 **Returns:** *boolean*
 
 • **set bleed**(`value`: boolean): *void*
-
-*Defined in [card-elements.ts:5693](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5693)*
 
 **Parameters:**
 
@@ -526,8 +462,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
 
-*Defined in [card-elements.ts:307](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L307)*
-
 **Returns:** *string*
 
 ___
@@ -538,8 +472,6 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[hasExplicitStyle](stylablecardelementcontainer.md#protected-hasexplicitstyle)*
 
-*Defined in [card-elements.ts:4738](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4738)*
-
 **Returns:** *boolean*
 
 ___
@@ -549,8 +481,6 @@ ___
 • **get hasVisibleSeparator**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
-
-*Defined in [card-elements.ts:580](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L580)*
 
 **Returns:** *boolean*
 
@@ -564,8 +494,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
 
-*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
-
 **Returns:** *[HostConfig](hostconfig.md)*
 
 • **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
@@ -573,8 +501,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
-
-*Defined in [card-elements.ts:555](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L555)*
 
 **Parameters:**
 
@@ -592,8 +518,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
 
-*Defined in [card-elements.ts:559](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L559)*
-
 **Returns:** *number*
 
 ___
@@ -603,8 +527,6 @@ ___
 • **get isInline**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
-
-*Defined in [card-elements.ts:576](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L576)*
 
 **Returns:** *boolean*
 
@@ -616,8 +538,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
 
-*Defined in [card-elements.ts:568](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L568)*
-
 **Returns:** *boolean*
 
 ___
@@ -627,8 +547,6 @@ ___
 • **get isSelectable**(): *boolean*
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[isSelectable](cardelementcontainer.md#protected-isselectable)*
-
-*Defined in [card-elements.ts:5498](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5498)*
 
 **Returns:** *boolean*
 
@@ -640,8 +558,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
 
-*Defined in [card-elements.ts:572](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L572)*
-
 **Returns:** *boolean*
 
 ___
@@ -652,15 +568,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
 
-*Defined in [card-elements.ts:77](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L77)*
-
 **Returns:** *boolean*
 
 • **set isVisible**(`value`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
-
-*Defined in [card-elements.ts:81](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L81)*
 
 **Parameters:**
 
@@ -678,15 +590,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
 
-*Defined in [card-elements.ts:56](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L56)*
-
 **Returns:** *string | undefined*
 
 • **set lang**(`value`: string | undefined): *void*
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
-
-*Defined in [card-elements.ts:72](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L72)*
 
 **Parameters:**
 
@@ -702,13 +610,9 @@ ___
 
 • **get padding**(): *[PaddingDefinition](paddingdefinition.md) | undefined*
 
-*Defined in [card-elements.ts:5697](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5697)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md) | undefined*
 
 • **set padding**(`value`: [PaddingDefinition](paddingdefinition.md) | undefined): *void*
-
-*Defined in [card-elements.ts:5701](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5701)*
 
 **Parameters:**
 
@@ -728,8 +632,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[parent](cardobject.md#parent)*
 
-*Defined in [card-elements.ts:593](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L593)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -739,8 +641,6 @@ ___
 • **get renderedActionCount**(): *number*
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[renderedActionCount](stylablecardelementcontainer.md#protected-renderedactioncount)*
-
-*Defined in [card-elements.ts:4734](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4734)*
 
 **Returns:** *number*
 
@@ -752,8 +652,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[renderedElement](cardobject.md#renderedelement)*
 
-*Defined in [card-object.ts:140](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L140)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -764,8 +662,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requires](cardobject.md#requires)*
 
-*Defined in [card-object.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L53)*
-
 **Returns:** *HostCapabilities*
 
 ___
@@ -774,13 +670,9 @@ ___
 
 • **get selectAction**(): *[Action](action.md) | undefined*
 
-*Defined in [card-elements.ts:5705](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5705)*
-
 **Returns:** *[Action](action.md) | undefined*
 
 • **set selectAction**(`value`: [Action](action.md) | undefined): *void*
-
-*Defined in [card-elements.ts:5709](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5709)*
 
 **Parameters:**
 
@@ -798,8 +690,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
 
-*Defined in [card-elements.ts:589](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L589)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -809,8 +699,6 @@ ___
 • **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
 
 *Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
-
-*Defined in [card-elements.ts:303](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L303)*
 
 **Returns:** *[Orientation](../enums/orientation.md)*
 
@@ -822,15 +710,11 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[style](stylablecardelementcontainer.md#style)*
 
-*Defined in [card-elements.ts:4601](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4601)*
-
 **Returns:** *string | undefined*
 
 • **set style**(`value`: string | undefined): *void*
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[style](stylablecardelementcontainer.md#style)*
-
-*Defined in [card-elements.ts:4613](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4613)*
 
 **Parameters:**
 
@@ -848,8 +732,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
 
-*Defined in [card-elements.ts:295](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L295)*
-
 **Returns:** *boolean*
 
 ## Methods
@@ -857,8 +739,6 @@ ___
 ###  addColumn
 
 ▸ **addColumn**(`column`: [Column](column.md)): *void*
-
-*Defined in [card-elements.ts:5626](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5626)*
 
 **Parameters:**
 
@@ -878,8 +758,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
 
-*Defined in [card-elements.ts:4625](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4625)*
-
 **Parameters:**
 
 Name | Type |
@@ -896,8 +774,6 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[applyBackground](stylablecardelementcontainer.md#protected-applybackground)*
 
-*Defined in [card-elements.ts:4633](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4633)*
-
 **Returns:** *void*
 
 ___
@@ -910,8 +786,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[applyPadding](cardelementcontainer.md#protected-applypadding)*
 
-*Defined in [card-elements.ts:4643](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4643)*
-
 **Returns:** *void*
 
 ___
@@ -921,8 +795,6 @@ ___
 ▸ **asString**(): *string | undefined*
 
 *Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
-
-*Defined in [card-elements.ts:321](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L321)*
 
 **Returns:** *string | undefined*
 
@@ -934,8 +806,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
 
-*Defined in [card-elements.ts:205](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L205)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -945,8 +815,6 @@ ___
 ▸ **getActionAt**(`index`: number): *[Action](action.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
-
-*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
 
 **Parameters:**
 
@@ -964,8 +832,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
 
-*Defined in [card-elements.ts:5675](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5675)*
-
 **Parameters:**
 
 Name | Type |
@@ -982,8 +848,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
 
-*Defined in [card-elements.ts:396](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L396)*
-
 **Returns:** *number*
 
 ___
@@ -996,8 +860,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
 
-*Defined in [card-elements.ts:1871](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1871)*
-
 **Returns:** *[Input](input.md)[]*
 
 ___
@@ -1008,8 +870,6 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[getBleed](stylablecardelementcontainer.md#protected-getbleed)*
 
-*Defined in [card-elements.ts:4726](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4726)*
-
 **Returns:** *boolean*
 
 ___
@@ -1017,8 +877,6 @@ ___
 ###  getColumnAt
 
 ▸ **getColumnAt**(`index`: number): *[Column](column.md)*
-
-*Defined in [card-elements.ts:5591](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5591)*
 
 **Parameters:**
 
@@ -1035,8 +893,6 @@ ___
 ▸ **getCustomProperty**(`name`: string): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
-
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
 
 **Parameters:**
 
@@ -1056,8 +912,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
 
-*Defined in [card-elements.ts:4713](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4713)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
 ___
@@ -1067,8 +921,6 @@ ___
 ▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
 
 *Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
-
-*Defined in [card-elements.ts:535](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L535)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
@@ -1082,8 +934,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
 
-*Defined in [card-elements.ts:4777](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4777)*
-
 **Returns:** *string*
 
 ___
@@ -1093,8 +943,6 @@ ___
 ▸ **getEffectiveStyleDefinition**(): *[ContainerStyleDefinition](containerstyledefinition.md)*
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyleDefinition](cardelement.md#geteffectivestyledefinition)*
-
-*Defined in [card-elements.ts:337](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L337)*
 
 **Returns:** *[ContainerStyleDefinition](containerstyledefinition.md)*
 
@@ -1107,8 +955,6 @@ ___
 *Inherited from [CardElementContainer](cardelementcontainer.md).[getElementById](cardelementcontainer.md#getelementbyid)*
 
 *Overrides [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
-
-*Defined in [card-elements.ts:1891](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1891)*
 
 **Parameters:**
 
@@ -1126,8 +972,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[getFirstVisibleRenderedItem](cardelementcontainer.md#abstract-getfirstvisiblerendereditem)*
 
-*Defined in [card-elements.ts:5573](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5573)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -1137,8 +981,6 @@ ___
 ▸ **getForbiddenActionTypes**(): *[ActionType](../README.md#actiontype)[]*
 
 *Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
-
-*Defined in [card-elements.ts:341](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L341)*
 
 **Returns:** *[ActionType](../README.md#actiontype)[]*
 
@@ -1152,8 +994,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
 
-*Defined in [card-elements.ts:4695](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4695)*
-
 **Returns:** *boolean*
 
 ___
@@ -1164,8 +1004,6 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[getHasExpandedAction](stylablecardelementcontainer.md#protected-gethasexpandedaction)*
 
-*Defined in [card-elements.ts:4722](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4722)*
-
 **Returns:** *boolean*
 
 ___
@@ -1175,8 +1013,6 @@ ___
 ▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
-
-*Defined in [card-elements.ts:345](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L345)*
 
 **Parameters:**
 
@@ -1198,8 +1034,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[getItemAt](cardelementcontainer.md#abstract-getitemat)*
 
-*Defined in [card-elements.ts:5595](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5595)*
-
 **Parameters:**
 
 Name | Type |
@@ -1216,8 +1050,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[getItemCount](cardelementcontainer.md#abstract-getitemcount)*
 
-*Defined in [card-elements.ts:5569](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5569)*
-
 **Returns:** *number*
 
 ___
@@ -1227,8 +1059,6 @@ ___
 ▸ **getJsonTypeName**(): *string*
 
 *Overrides [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
-
-*Defined in [card-elements.ts:5599](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5599)*
 
 **Returns:** *string*
 
@@ -1240,8 +1070,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[getLastVisibleRenderedItem](cardelementcontainer.md#abstract-getlastvisiblerendereditem)*
 
-*Defined in [card-elements.ts:5582](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5582)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -1252,8 +1080,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
 
-*Defined in [card-elements.ts:283](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L283)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md) | undefined*
 
 ___
@@ -1263,8 +1089,6 @@ ___
 ▸ **getParentContainer**(): *[Container](container.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
-
-*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
 
 **Returns:** *[Container](container.md) | undefined*
 
@@ -1278,8 +1102,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
 
-*Defined in [card-elements.ts:1881](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1881)*
-
 **Returns:** *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
 ___
@@ -1289,8 +1111,6 @@ ___
 ▸ **getRootElement**(): *[CardElement](cardelement.md)*
 
 *Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
-
-*Defined in [card-elements.ts:501](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L501)*
 
 **Returns:** *[CardElement](cardelement.md)*
 
@@ -1302,8 +1122,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getRootObject](cardobject.md#getrootobject)*
 
-*Defined in [card-object.ts:100](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L100)*
-
 **Returns:** *[CardObject](cardobject.md)*
 
 ___
@@ -1313,8 +1131,6 @@ ___
 ▸ **getSchema**(): *[SerializableObjectSchema](serializableobjectschema.md)*
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
-
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
 
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
@@ -1328,8 +1144,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-object.ts:45](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L45)*
-
 **Returns:** *string*
 
 ___
@@ -1339,8 +1153,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -1358,8 +1170,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -1369,8 +1179,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -1388,8 +1196,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
 
-*Defined in [card-elements.ts:5655](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5655)*
-
 **Parameters:**
 
 Name | Type |
@@ -1405,8 +1211,6 @@ ___
 ▸ **internalParse**(`source`: any, `context`: [SerializationContext](serializationcontext.md)): *void*
 
 *Overrides [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
-
-*Defined in [card-elements.ts:5502](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5502)*
 
 **Parameters:**
 
@@ -1425,8 +1229,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
 
-*Defined in [card-elements.ts:5418](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5418)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1436,8 +1238,6 @@ ___
 ▸ **internalToJSON**(`target`: [PropertyBag](../README.md#propertybag), `context`: [SerializationContext](serializationcontext.md)): *void*
 
 *Overrides [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
-
-*Defined in [card-elements.ts:5521](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5521)*
 
 **Parameters:**
 
@@ -1456,8 +1256,6 @@ ___
 
 *Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[internalValidateProperties](stylablecardelementcontainer.md#internalvalidateproperties)*
 
-*Defined in [card-elements.ts:5603](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5603)*
-
 **Parameters:**
 
 Name | Type |
@@ -1474,8 +1272,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
 
-*Defined in [card-elements.ts:469](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L469)*
-
 **Returns:** *boolean*
 
 ___
@@ -1485,8 +1281,6 @@ ___
 ▸ **isAtTheVeryLeft**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
-
-*Defined in [card-elements.ts:457](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L457)*
 
 **Returns:** *boolean*
 
@@ -1498,8 +1292,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
 
-*Defined in [card-elements.ts:461](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L461)*
-
 **Returns:** *boolean*
 
 ___
@@ -1509,8 +1301,6 @@ ___
 ▸ **isAtTheVeryTop**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
-
-*Defined in [card-elements.ts:465](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L465)*
 
 **Returns:** *boolean*
 
@@ -1524,8 +1314,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
 
-*Defined in [card-elements.ts:4746](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4746)*
-
 **Returns:** *boolean*
 
 ___
@@ -1535,8 +1323,6 @@ ___
 ▸ **isBleedingAtBottom**(): *boolean*
 
 *Overrides [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
-
-*Defined in [card-elements.ts:5553](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5553)*
 
 **Returns:** *boolean*
 
@@ -1548,8 +1334,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
 
-*Defined in [card-elements.ts:5537](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5537)*
-
 **Returns:** *boolean*
 
 ___
@@ -1559,8 +1343,6 @@ ___
 ▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Overrides [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
-
-*Defined in [card-elements.ts:5671](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5671)*
 
 **Parameters:**
 
@@ -1578,8 +1360,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
 
-*Defined in [card-elements.ts:443](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L443)*
-
 **Returns:** *boolean*
 
 ___
@@ -1590,8 +1370,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDisplayed](cardelement.md#protected-isdisplayed)*
 
-*Defined in [card-elements.ts:229](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L229)*
-
 **Returns:** *boolean*
 
 ___
@@ -1601,8 +1379,6 @@ ___
 ▸ **isElementAllowed**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[isElementAllowed](cardelementcontainer.md#protected-iselementallowed)*
-
-*Defined in [card-elements.ts:1751](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1751)*
 
 **Parameters:**
 
@@ -1620,8 +1396,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
 
-*Defined in [card-elements.ts:5527](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5527)*
-
 **Parameters:**
 
 Name | Type |
@@ -1638,8 +1412,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
 
-*Defined in [card-elements.ts:497](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L497)*
-
 **Returns:** *boolean*
 
 ___
@@ -1649,8 +1421,6 @@ ___
 ▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
-
-*Defined in [card-elements.ts:453](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L453)*
 
 **Parameters:**
 
@@ -1668,8 +1438,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
 
-*Defined in [card-elements.ts:5659](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5659)*
-
 **Parameters:**
 
 Name | Type |
@@ -1685,8 +1453,6 @@ ___
 ▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Overrides [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
-
-*Defined in [card-elements.ts:5663](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5663)*
 
 **Parameters:**
 
@@ -1704,8 +1470,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
 
-*Defined in [card-elements.ts:5667](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5667)*
-
 **Parameters:**
 
 Name | Type |
@@ -1722,8 +1486,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
 
-*Defined in [card-elements.ts:235](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L235)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1735,8 +1497,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[parse](cardelement.md#parse)*
 
 *Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
-
-*Defined in [card-elements.ts:313](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L313)*
 
 **Parameters:**
 
@@ -1757,8 +1517,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [card-elements.ts:1738](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1738)*
-
 **Parameters:**
 
 Name | Type |
@@ -1774,8 +1532,6 @@ ___
 ▸ **preProcessPropertyValue**(`property`: [PropertyDefinition](propertydefinition.md), `propertyValue?`: any): *any*
 
 *Inherited from [CardObject](cardobject.md).[preProcessPropertyValue](cardobject.md#preprocesspropertyvalue)*
-
-*Defined in [card-object.ts:70](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L70)*
 
 **Parameters:**
 
@@ -1794,8 +1550,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
 
-*Defined in [card-elements.ts:404](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L404)*
-
 **Returns:** *boolean*
 
 ___
@@ -1805,8 +1559,6 @@ ___
 ▸ **removeItem**(`item`: [CardElement](cardelement.md)): *boolean*
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[removeItem](cardelementcontainer.md#abstract-removeitem)*
-
-*Defined in [card-elements.ts:5637](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5637)*
 
 **Parameters:**
 
@@ -1826,8 +1578,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[render](cardelementcontainer.md#render)*
 
-*Defined in [card-elements.ts:4767](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4767)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1838,8 +1588,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -1849,8 +1597,6 @@ ___
 ▸ **setBleed**(`value`: boolean): *void*
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[setBleed](stylablecardelementcontainer.md#protected-setbleed)*
-
-*Defined in [card-elements.ts:4730](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4730)*
 
 **Parameters:**
 
@@ -1867,8 +1613,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -1887,8 +1631,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
 
-*Defined in [card-elements.ts:287](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L287)*
-
 **Parameters:**
 
 Name | Type |
@@ -1904,8 +1646,6 @@ ___
 ▸ **setParent**(`value`: [CardObject](cardobject.md) | undefined): *void*
 
 *Inherited from [CardObject](cardobject.md).[setParent](cardobject.md#setparent)*
-
-*Defined in [card-object.ts:88](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L88)*
 
 **Parameters:**
 
@@ -1923,8 +1663,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setShouldFallback](cardobject.md#setshouldfallback)*
 
-*Defined in [card-object.ts:92](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L92)*
-
 **Parameters:**
 
 Name | Type |
@@ -1940,8 +1678,6 @@ ___
 ▸ **setValue**(`property`: [PropertyDefinition](propertydefinition.md), `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
-
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
 
 **Parameters:**
 
@@ -1960,8 +1696,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[shouldFallback](cardobject.md#shouldfallback)*
 
-*Defined in [card-object.ts:96](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L96)*
-
 **Returns:** *boolean*
 
 ___
@@ -1973,8 +1707,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[shouldSerialize](cardelement.md#protected-shouldserialize)*
 
 *Overrides [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
-
-*Defined in [card-elements.ts:291](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L291)*
 
 **Parameters:**
 
@@ -1994,8 +1726,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
 
-*Defined in [card-elements.ts:317](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L317)*
-
 **Parameters:**
 
 Name | Type |
@@ -2011,8 +1741,6 @@ ___
 ▸ **truncateOverflow**(`maxHeight`: number): *boolean*
 
 *Overrides [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
-
-*Defined in [card-elements.ts:5484](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5484)*
 
 **Parameters:**
 
@@ -2030,8 +1758,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
 
-*Defined in [card-elements.ts:5492](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5492)*
-
 **Returns:** *void*
 
 ___
@@ -2043,8 +1769,6 @@ ___
 *Inherited from [CardElementContainer](cardelementcontainer.md).[updateLayout](cardelementcontainer.md#updatelayout)*
 
 *Overrides [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
-
-*Defined in [card-elements.ts:1861](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1861)*
 
 **Parameters:**
 
@@ -2061,7 +1785,5 @@ ___
 ▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
 
 *Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
-
-*Defined in [card-object.ts:128](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L128)*
 
 **Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/container.md
+++ b/source/nodejs/adaptivecards/docs/classes/container.md
@@ -177,8 +177,6 @@
 
 *Inherited from [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 **Returns:** *[Container](container.md)*
 
 ## Properties
@@ -189,8 +187,6 @@
 
 *Inherited from [CardObject](cardobject.md).[_parent](cardobject.md#protected-optional-_parent)*
 
-*Defined in [card-object.ts:61](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L61)*
-
 ___
 
 ### `Protected` `Optional` _renderedElement
@@ -198,8 +194,6 @@ ___
 • **_renderedElement**? : *HTMLElement*
 
 *Inherited from [CardObject](cardobject.md).[_renderedElement](cardobject.md#protected-optional-_renderedelement)*
-
-*Defined in [card-object.ts:62](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L62)*
 
 ___
 
@@ -209,8 +203,6 @@ ___
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[_selectAction](cardelementcontainer.md#protected-optional-_selectaction)*
 
-*Defined in [card-elements.ts:1747](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1747)*
-
 ___
 
 ###  allowVerticalOverflow
@@ -218,8 +210,6 @@ ___
 • **allowVerticalOverflow**: *boolean* = false
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[allowVerticalOverflow](cardelementcontainer.md#allowverticaloverflow)*
-
-*Defined in [card-elements.ts:1787](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1787)*
 
 ___
 
@@ -229,8 +219,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#optional-customcssselector)*
 
-*Defined in [card-elements.ts:311](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L311)*
-
 ___
 
 ###  height
@@ -238,8 +226,6 @@ ___
 • **height**: *[CardElementHeight](../README.md#cardelementheight)*
 
 *Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
-
-*Defined in [card-elements.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L53)*
 
 ___
 
@@ -249,8 +235,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#horizontalalignment)*
 
-*Defined in [card-elements.ts:44](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L44)*
-
 ___
 
 ### `Optional` id
@@ -258,8 +242,6 @@ ___
 • **id**? : *undefined | string*
 
 *Inherited from [CardObject](cardobject.md).[id](cardobject.md#optional-id)*
-
-*Defined in [card-object.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L50)*
 
 ___
 
@@ -269,8 +251,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 ___
 
 ### `Optional` minPixelHeight
@@ -278,8 +258,6 @@ ___
 • **minPixelHeight**? : *undefined | number*
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[minPixelHeight](stylablecardelementcontainer.md#optional-minpixelheight)*
-
-*Defined in [card-elements.ts:4621](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4621)*
 
 ___
 
@@ -289,15 +267,11 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[onPreProcessPropertyValue](cardobject.md#optional-onpreprocesspropertyvalue)*
 
-*Defined in [card-object.ts:64](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L64)*
-
 ___
 
 ### `Optional` rtl
 
 • **rtl**? : *undefined | false | true*
-
-*Defined in [card-elements.ts:4885](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4885)*
 
 ___
 
@@ -307,8 +281,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
 
-*Defined in [card-elements.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L50)*
-
 ___
 
 ###  spacing
@@ -317,15 +289,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
 
-*Defined in [card-elements.ts:47](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L47)*
-
 ___
 
 ###  verticalContentAlignment
 
 • **verticalContentAlignment**: *[VerticalAlignment](../enums/verticalalignment.md)* = Enums.VerticalAlignment.Top
-
-*Defined in [card-elements.ts:4882](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4882)*
 
 ___
 
@@ -336,8 +304,6 @@ ___
         "backgroundImage",
         BackgroundImage)
 
-*Defined in [card-elements.ts:4869](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4869)*
-
 ___
 
 ### `Static` bleedProperty
@@ -345,8 +311,6 @@ ___
 ▪ **bleedProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_2, "bleed", false)
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[bleedProperty](stylablecardelementcontainer.md#static-bleedproperty)*
-
-*Defined in [card-elements.ts:4597](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4597)*
 
 ___
 
@@ -363,8 +327,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[heightProperty](cardelement.md#static-heightproperty)*
 
-*Defined in [card-elements.ts:24](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L24)*
-
 ___
 
 ### `Static` horizontalAlignmentProperty
@@ -377,8 +339,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignmentProperty](cardelement.md#static-horizontalalignmentproperty)*
 
-*Defined in [card-elements.ts:32](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L32)*
-
 ___
 
 ### `Static` idProperty
@@ -386,8 +346,6 @@ ___
 ▪ **idProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "id")
 
 *Inherited from [CardObject](cardobject.md).[idProperty](cardobject.md#static-idproperty)*
-
-*Defined in [card-object.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L39)*
 
 ___
 
@@ -397,8 +355,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisibleProperty](cardelement.md#static-isvisibleproperty)*
 
-*Defined in [card-elements.ts:22](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L22)*
-
 ___
 
 ### `Static` langProperty
@@ -406,8 +362,6 @@ ___
 ▪ **langProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_1, "lang", true, /^[a-z]{2,3}$/ig)
 
 *Inherited from [CardElement](cardelement.md).[langProperty](cardelement.md#static-langproperty)*
-
-*Defined in [card-elements.ts:21](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L21)*
 
 ___
 
@@ -417,8 +371,6 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[minHeightProperty](stylablecardelementcontainer.md#static-minheightproperty)*
 
-*Defined in [card-elements.ts:4598](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4598)*
-
 ___
 
 ### `Static` `Optional` onRegisterCustomProperties
@@ -426,8 +378,6 @@ ___
 ▪ **onRegisterCustomProperties**? : *undefined | function*
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
-
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
 
 ___
 
@@ -440,15 +390,11 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requiresProperty](cardobject.md#static-requiresproperty)*
 
-*Defined in [card-object.ts:40](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L40)*
-
 ___
 
 ### `Static` rtlProperty
 
 ▪ **rtlProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_0, "rtl")
-
-*Defined in [card-elements.ts:4874](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4874)*
 
 ___
 
@@ -458,8 +404,6 @@ ___
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[selectActionProperty](cardelementcontainer.md#static-selectactionproperty)*
 
-*Defined in [card-elements.ts:1736](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1736)*
-
 ___
 
 ### `Static` separatorProperty
@@ -467,8 +411,6 @@ ___
 ▪ **separatorProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_0, "separator", false)
 
 *Inherited from [CardElement](cardelement.md).[separatorProperty](cardelement.md#static-separatorproperty)*
-
-*Defined in [card-elements.ts:23](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L23)*
 
 ___
 
@@ -481,8 +423,6 @@ ___
         Enums.Spacing.Default)
 
 *Inherited from [CardElement](cardelement.md).[spacingProperty](cardelement.md#static-spacingproperty)*
-
-*Defined in [card-elements.ts:37](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L37)*
 
 ___
 
@@ -502,8 +442,6 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[styleProperty](stylablecardelementcontainer.md#static-styleproperty)*
 
-*Defined in [card-elements.ts:4586](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4586)*
-
 ___
 
 ### `Static` typeNameProperty
@@ -520,15 +458,11 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[typeNameProperty](cardobject.md#static-typenameproperty)*
 
-*Defined in [card-object.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L30)*
-
 ___
 
 ### `Static` verticalContentAlignmentProperty
 
 ▪ **verticalContentAlignmentProperty**: *[EnumProperty](enumproperty.md)‹[VerticalAlignment](../enums/verticalalignment.md)›* = new EnumProperty(Versions.v1_1, "verticalContentAlignment", Enums.VerticalAlignment, Enums.VerticalAlignment.Top)
-
-*Defined in [card-elements.ts:4873](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4873)*
 
 ## Accessors
 
@@ -537,8 +471,6 @@ ___
 • **get allowCustomPadding**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
-
-*Defined in [card-elements.ts:299](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L299)*
 
 **Returns:** *boolean*
 
@@ -550,8 +482,6 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[allowCustomStyle](stylablecardelementcontainer.md#protected-allowcustomstyle)*
 
-*Defined in [card-elements.ts:4742](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4742)*
-
 **Returns:** *boolean*
 
 ___
@@ -559,8 +489,6 @@ ___
 ###  backgroundImage
 
 • **get backgroundImage**(): *[BackgroundImage](backgroundimage.md)*
-
-*Defined in [card-elements.ts:4877](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4877)*
 
 **Returns:** *[BackgroundImage](backgroundimage.md)*
 
@@ -570,13 +498,9 @@ ___
 
 • **get bleed**(): *boolean*
 
-*Defined in [card-elements.ts:5256](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5256)*
-
 **Returns:** *boolean*
 
 • **set bleed**(`value`: boolean): *void*
-
-*Defined in [card-elements.ts:5260](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5260)*
 
 **Parameters:**
 
@@ -594,8 +518,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
 
-*Defined in [card-elements.ts:307](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L307)*
-
 **Returns:** *string*
 
 ___
@@ -606,8 +528,6 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[hasExplicitStyle](stylablecardelementcontainer.md#protected-hasexplicitstyle)*
 
-*Defined in [card-elements.ts:4738](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4738)*
-
 **Returns:** *boolean*
 
 ___
@@ -617,8 +537,6 @@ ___
 • **get hasVisibleSeparator**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
-
-*Defined in [card-elements.ts:580](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L580)*
 
 **Returns:** *boolean*
 
@@ -632,8 +550,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
 
-*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
-
 **Returns:** *[HostConfig](hostconfig.md)*
 
 • **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
@@ -641,8 +557,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
-
-*Defined in [card-elements.ts:555](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L555)*
 
 **Parameters:**
 
@@ -660,8 +574,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
 
-*Defined in [card-elements.ts:559](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L559)*
-
 **Returns:** *number*
 
 ___
@@ -671,8 +583,6 @@ ___
 • **get isInline**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
-
-*Defined in [card-elements.ts:576](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L576)*
 
 **Returns:** *boolean*
 
@@ -684,8 +594,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
 
-*Defined in [card-elements.ts:568](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L568)*
-
 **Returns:** *boolean*
 
 ___
@@ -695,8 +603,6 @@ ___
 • **get isSelectable**(): *boolean*
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[isSelectable](cardelementcontainer.md#protected-isselectable)*
-
-*Defined in [card-elements.ts:5079](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5079)*
 
 **Returns:** *boolean*
 
@@ -708,8 +614,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
 
-*Defined in [card-elements.ts:572](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L572)*
-
 **Returns:** *boolean*
 
 ___
@@ -720,15 +624,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
 
-*Defined in [card-elements.ts:77](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L77)*
-
 **Returns:** *boolean*
 
 • **set isVisible**(`value`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
-
-*Defined in [card-elements.ts:81](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L81)*
 
 **Parameters:**
 
@@ -746,15 +646,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
 
-*Defined in [card-elements.ts:56](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L56)*
-
 **Returns:** *string | undefined*
 
 • **set lang**(`value`: string | undefined): *void*
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
-
-*Defined in [card-elements.ts:72](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L72)*
 
 **Parameters:**
 
@@ -770,13 +666,9 @@ ___
 
 • **get padding**(): *[PaddingDefinition](paddingdefinition.md) | undefined*
 
-*Defined in [card-elements.ts:5240](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5240)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md) | undefined*
 
 • **set padding**(`value`: [PaddingDefinition](paddingdefinition.md) | undefined): *void*
-
-*Defined in [card-elements.ts:5244](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5244)*
 
 **Parameters:**
 
@@ -796,8 +688,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[parent](cardobject.md#parent)*
 
-*Defined in [card-elements.ts:593](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L593)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -807,8 +697,6 @@ ___
 • **get renderedActionCount**(): *number*
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[renderedActionCount](stylablecardelementcontainer.md#protected-renderedactioncount)*
-
-*Defined in [card-elements.ts:4734](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4734)*
 
 **Returns:** *number*
 
@@ -820,8 +708,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[renderedElement](cardobject.md#renderedelement)*
 
-*Defined in [card-object.ts:140](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L140)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -832,8 +718,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requires](cardobject.md#requires)*
 
-*Defined in [card-object.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L53)*
-
 **Returns:** *HostCapabilities*
 
 ___
@@ -842,13 +726,9 @@ ___
 
 • **get selectAction**(): *[Action](action.md) | undefined*
 
-*Defined in [card-elements.ts:5248](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5248)*
-
 **Returns:** *[Action](action.md) | undefined*
 
 • **set selectAction**(`value`: [Action](action.md) | undefined): *void*
-
-*Defined in [card-elements.ts:5252](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5252)*
 
 **Parameters:**
 
@@ -866,8 +746,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
 
-*Defined in [card-elements.ts:589](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L589)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -877,8 +755,6 @@ ___
 • **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
 
 *Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
-
-*Defined in [card-elements.ts:303](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L303)*
 
 **Returns:** *[Orientation](../enums/orientation.md)*
 
@@ -890,15 +766,11 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[style](stylablecardelementcontainer.md#style)*
 
-*Defined in [card-elements.ts:4601](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4601)*
-
 **Returns:** *string | undefined*
 
 • **set style**(`value`: string | undefined): *void*
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[style](stylablecardelementcontainer.md#style)*
-
-*Defined in [card-elements.ts:4613](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4613)*
 
 **Parameters:**
 
@@ -916,8 +788,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
 
-*Defined in [card-elements.ts:295](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L295)*
-
 **Returns:** *boolean*
 
 ## Methods
@@ -925,8 +795,6 @@ ___
 ###  addItem
 
 ▸ **addItem**(`item`: [CardElement](cardelement.md)): *void*
-
-*Defined in [card-elements.ts:5170](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5170)*
 
 **Parameters:**
 
@@ -946,8 +814,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
 
-*Defined in [card-elements.ts:4625](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4625)*
-
 **Parameters:**
 
 Name | Type |
@@ -964,8 +830,6 @@ ___
 
 *Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[applyBackground](stylablecardelementcontainer.md#protected-applybackground)*
 
-*Defined in [card-elements.ts:4924](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4924)*
-
 **Returns:** *void*
 
 ___
@@ -978,8 +842,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[applyPadding](cardelementcontainer.md#protected-applypadding)*
 
-*Defined in [card-elements.ts:4643](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4643)*
-
 **Returns:** *void*
 
 ___
@@ -990,8 +852,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
 
-*Defined in [card-elements.ts:321](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L321)*
-
 **Returns:** *string | undefined*
 
 ___
@@ -999,8 +859,6 @@ ___
 ###  clear
 
 ▸ **clear**(): *void*
-
-*Defined in [card-elements.ts:5198](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5198)*
 
 **Returns:** *void*
 
@@ -1012,8 +870,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
 
-*Defined in [card-elements.ts:205](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L205)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -1023,8 +879,6 @@ ___
 ▸ **getActionAt**(`index`: number): *[Action](action.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
-
-*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
 
 **Parameters:**
 
@@ -1042,8 +896,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
 
-*Defined in [card-elements.ts:5218](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5218)*
-
 **Parameters:**
 
 Name | Type |
@@ -1060,8 +912,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
 
-*Defined in [card-elements.ts:396](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L396)*
-
 **Returns:** *number*
 
 ___
@@ -1074,8 +924,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
 
-*Defined in [card-elements.ts:1871](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1871)*
-
 **Returns:** *[Input](input.md)[]*
 
 ___
@@ -1086,8 +934,6 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[getBleed](stylablecardelementcontainer.md#protected-getbleed)*
 
-*Defined in [card-elements.ts:4726](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4726)*
-
 **Returns:** *boolean*
 
 ___
@@ -1097,8 +943,6 @@ ___
 ▸ **getCustomProperty**(`name`: string): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
-
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
 
 **Parameters:**
 
@@ -1118,8 +962,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
 
-*Defined in [card-elements.ts:4713](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4713)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
 ___
@@ -1129,8 +971,6 @@ ___
 ▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
 
 *Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
-
-*Defined in [card-elements.ts:535](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L535)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
@@ -1144,8 +984,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
 
-*Defined in [card-elements.ts:4777](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4777)*
-
 **Returns:** *string*
 
 ___
@@ -1155,8 +993,6 @@ ___
 ▸ **getEffectiveStyleDefinition**(): *[ContainerStyleDefinition](containerstyledefinition.md)*
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyleDefinition](cardelement.md#geteffectivestyledefinition)*
-
-*Defined in [card-elements.ts:337](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L337)*
 
 **Returns:** *[ContainerStyleDefinition](containerstyledefinition.md)*
 
@@ -1169,8 +1005,6 @@ ___
 *Inherited from [CardElementContainer](cardelementcontainer.md).[getElementById](cardelementcontainer.md#getelementbyid)*
 
 *Overrides [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
-
-*Defined in [card-elements.ts:1891](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1891)*
 
 **Parameters:**
 
@@ -1188,8 +1022,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[getFirstVisibleRenderedItem](cardelementcontainer.md#abstract-getfirstvisiblerendereditem)*
 
-*Defined in [card-elements.ts:5091](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5091)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -1199,8 +1031,6 @@ ___
 ▸ **getForbiddenActionTypes**(): *[ActionType](../README.md#actiontype)[]*
 
 *Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
-
-*Defined in [card-elements.ts:341](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L341)*
 
 **Returns:** *[ActionType](../README.md#actiontype)[]*
 
@@ -1212,8 +1042,6 @@ ___
 
 *Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[getHasBackground](stylablecardelementcontainer.md#protected-gethasbackground)*
 
-*Defined in [card-elements.ts:5050](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5050)*
-
 **Returns:** *boolean*
 
 ___
@@ -1224,8 +1052,6 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[getHasExpandedAction](stylablecardelementcontainer.md#protected-gethasexpandedaction)*
 
-*Defined in [card-elements.ts:4722](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4722)*
-
 **Returns:** *boolean*
 
 ___
@@ -1235,8 +1061,6 @@ ___
 ▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
-
-*Defined in [card-elements.ts:345](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L345)*
 
 **Parameters:**
 
@@ -1258,8 +1082,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[getItemAt](cardelementcontainer.md#abstract-getitemat)*
 
-*Defined in [card-elements.ts:5087](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5087)*
-
 **Parameters:**
 
 Name | Type |
@@ -1276,8 +1098,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[getItemCount](cardelementcontainer.md#abstract-getitemcount)*
 
-*Defined in [card-elements.ts:5083](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5083)*
-
 **Returns:** *number*
 
 ___
@@ -1285,8 +1105,6 @@ ___
 ### `Protected` getItemsCollectionPropertyName
 
 ▸ **getItemsCollectionPropertyName**(): *string*
-
-*Defined in [card-elements.ts:4920](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4920)*
 
 **Returns:** *string*
 
@@ -1298,8 +1116,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
 
-*Defined in [card-elements.ts:5115](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5115)*
-
 **Returns:** *string*
 
 ___
@@ -1309,8 +1125,6 @@ ___
 ▸ **getLastVisibleRenderedItem**(): *[CardElement](cardelement.md) | undefined*
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[getLastVisibleRenderedItem](cardelementcontainer.md#abstract-getlastvisiblerendereditem)*
-
-*Defined in [card-elements.ts:5103](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5103)*
 
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
@@ -1322,8 +1136,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
 
-*Defined in [card-elements.ts:283](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L283)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md) | undefined*
 
 ___
@@ -1333,8 +1145,6 @@ ___
 ▸ **getParentContainer**(): *[Container](container.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
-
-*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
 
 **Returns:** *[Container](container.md) | undefined*
 
@@ -1346,8 +1156,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[getResourceInformation](cardelementcontainer.md#getresourceinformation)*
 
-*Defined in [card-elements.ts:5203](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5203)*
-
 **Returns:** *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
 ___
@@ -1357,8 +1165,6 @@ ___
 ▸ **getRootElement**(): *[CardElement](cardelement.md)*
 
 *Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
-
-*Defined in [card-elements.ts:501](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L501)*
 
 **Returns:** *[CardElement](cardelement.md)*
 
@@ -1370,8 +1176,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getRootObject](cardobject.md#getrootobject)*
 
-*Defined in [card-object.ts:100](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L100)*
-
 **Returns:** *[CardObject](cardobject.md)*
 
 ___
@@ -1381,8 +1185,6 @@ ___
 ▸ **getSchema**(): *[SerializableObjectSchema](serializableobjectschema.md)*
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
-
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
 
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
@@ -1396,8 +1198,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-object.ts:45](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L45)*
-
 **Returns:** *string*
 
 ___
@@ -1407,8 +1207,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -1426,8 +1224,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -1437,8 +1233,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -1456,8 +1250,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
 
-*Defined in [card-elements.ts:5166](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5166)*
-
 **Parameters:**
 
 Name | Type |
@@ -1471,8 +1263,6 @@ ___
 ###  insertItemAfter
 
 ▸ **insertItemAfter**(`item`: [CardElement](cardelement.md), `insertAfter`: [CardElement](cardelement.md)): *void*
-
-*Defined in [card-elements.ts:5178](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5178)*
 
 **Parameters:**
 
@@ -1488,8 +1278,6 @@ ___
 ###  insertItemBefore
 
 ▸ **insertItemBefore**(`item`: [CardElement](cardelement.md), `insertBefore`: [CardElement](cardelement.md)): *void*
-
-*Defined in [card-elements.ts:5174](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5174)*
 
 **Parameters:**
 
@@ -1508,8 +1296,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
 
-*Defined in [card-elements.ts:5054](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5054)*
-
 **Parameters:**
 
 Name | Type |
@@ -1527,8 +1313,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
 
-*Defined in [card-elements.ts:4932](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4932)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1538,8 +1322,6 @@ ___
 ▸ **internalToJSON**(`target`: [PropertyBag](../README.md#propertybag), `context`: [SerializationContext](serializationcontext.md)): *void*
 
 *Overrides [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
-
-*Defined in [card-elements.ts:5073](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5073)*
 
 **Parameters:**
 
@@ -1560,8 +1342,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[internalValidateProperties](cardelementcontainer.md#internalvalidateproperties)*
 
-*Defined in [card-elements.ts:4750](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4750)*
-
 **Parameters:**
 
 Name | Type |
@@ -1578,8 +1358,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
 
-*Defined in [card-elements.ts:469](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L469)*
-
 **Returns:** *boolean*
 
 ___
@@ -1589,8 +1367,6 @@ ___
 ▸ **isAtTheVeryLeft**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
-
-*Defined in [card-elements.ts:457](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L457)*
 
 **Returns:** *boolean*
 
@@ -1602,8 +1378,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
 
-*Defined in [card-elements.ts:461](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L461)*
-
 **Returns:** *boolean*
 
 ___
@@ -1613,8 +1387,6 @@ ___
 ▸ **isAtTheVeryTop**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
-
-*Defined in [card-elements.ts:465](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L465)*
 
 **Returns:** *boolean*
 
@@ -1628,8 +1400,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
 
-*Defined in [card-elements.ts:4746](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4746)*
-
 **Returns:** *boolean*
 
 ___
@@ -1639,8 +1409,6 @@ ___
 ▸ **isBleedingAtBottom**(): *boolean*
 
 *Overrides [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
-
-*Defined in [card-elements.ts:5160](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5160)*
 
 **Returns:** *boolean*
 
@@ -1652,8 +1420,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
 
-*Defined in [card-elements.ts:5154](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5154)*
-
 **Returns:** *boolean*
 
 ___
@@ -1663,8 +1429,6 @@ ___
 ▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
-
-*Defined in [card-elements.ts:493](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L493)*
 
 **Parameters:**
 
@@ -1682,8 +1446,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
 
-*Defined in [card-elements.ts:443](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L443)*
-
 **Returns:** *boolean*
 
 ___
@@ -1694,8 +1456,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDisplayed](cardelement.md#protected-isdisplayed)*
 
-*Defined in [card-elements.ts:229](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L229)*
-
 **Returns:** *boolean*
 
 ___
@@ -1705,8 +1465,6 @@ ___
 ▸ **isElementAllowed**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[isElementAllowed](cardelementcontainer.md#protected-iselementallowed)*
-
-*Defined in [card-elements.ts:1751](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1751)*
 
 **Parameters:**
 
@@ -1724,8 +1482,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
 
-*Defined in [card-elements.ts:5119](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5119)*
-
 **Parameters:**
 
 Name | Type |
@@ -1742,8 +1498,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
 
-*Defined in [card-elements.ts:497](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L497)*
-
 **Returns:** *boolean*
 
 ___
@@ -1753,8 +1507,6 @@ ___
 ▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Overrides [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
-
-*Defined in [card-elements.ts:5131](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5131)*
 
 **Parameters:**
 
@@ -1772,8 +1524,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
 
-*Defined in [card-elements.ts:481](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L481)*
-
 **Parameters:**
 
 Name | Type |
@@ -1790,8 +1540,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
 
-*Defined in [card-elements.ts:485](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L485)*
-
 **Parameters:**
 
 Name | Type |
@@ -1806,8 +1554,6 @@ ___
 
 ▸ **isRtl**(): *boolean*
 
-*Defined in [card-elements.ts:5143](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5143)*
-
 **Returns:** *boolean*
 
 ___
@@ -1817,8 +1563,6 @@ ___
 ▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
-
-*Defined in [card-elements.ts:489](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L489)*
 
 **Parameters:**
 
@@ -1836,8 +1580,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
 
-*Defined in [card-elements.ts:235](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L235)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1849,8 +1591,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[parse](cardelement.md#parse)*
 
 *Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
-
-*Defined in [card-elements.ts:313](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L313)*
 
 **Parameters:**
 
@@ -1871,8 +1611,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [card-elements.ts:1738](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1738)*
-
 **Parameters:**
 
 Name | Type |
@@ -1888,8 +1626,6 @@ ___
 ▸ **preProcessPropertyValue**(`property`: [PropertyDefinition](propertydefinition.md), `propertyValue?`: any): *any*
 
 *Inherited from [CardObject](cardobject.md).[preProcessPropertyValue](cardobject.md#preprocesspropertyvalue)*
-
-*Defined in [card-object.ts:70](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L70)*
 
 **Parameters:**
 
@@ -1908,8 +1644,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
 
-*Defined in [card-elements.ts:404](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L404)*
-
 **Returns:** *boolean*
 
 ___
@@ -1919,8 +1653,6 @@ ___
 ▸ **removeItem**(`item`: [CardElement](cardelement.md)): *boolean*
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[removeItem](cardelementcontainer.md#abstract-removeitem)*
-
-*Defined in [card-elements.ts:5182](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5182)*
 
 **Parameters:**
 
@@ -1940,8 +1672,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[render](cardelementcontainer.md#render)*
 
-*Defined in [card-elements.ts:4767](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4767)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1952,8 +1682,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -1963,8 +1691,6 @@ ___
 ▸ **setBleed**(`value`: boolean): *void*
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[setBleed](stylablecardelementcontainer.md#protected-setbleed)*
-
-*Defined in [card-elements.ts:4730](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4730)*
 
 **Parameters:**
 
@@ -1981,8 +1707,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -2001,8 +1725,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
 
-*Defined in [card-elements.ts:287](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L287)*
-
 **Parameters:**
 
 Name | Type |
@@ -2018,8 +1740,6 @@ ___
 ▸ **setParent**(`value`: [CardObject](cardobject.md) | undefined): *void*
 
 *Inherited from [CardObject](cardobject.md).[setParent](cardobject.md#setparent)*
-
-*Defined in [card-object.ts:88](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L88)*
 
 **Parameters:**
 
@@ -2037,8 +1757,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setShouldFallback](cardobject.md#setshouldfallback)*
 
-*Defined in [card-object.ts:92](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L92)*
-
 **Parameters:**
 
 Name | Type |
@@ -2054,8 +1772,6 @@ ___
 ▸ **setValue**(`property`: [PropertyDefinition](propertydefinition.md), `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
-
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
 
 **Parameters:**
 
@@ -2074,8 +1790,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[shouldFallback](cardobject.md#shouldfallback)*
 
-*Defined in [card-object.ts:96](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L96)*
-
 **Returns:** *boolean*
 
 ___
@@ -2087,8 +1801,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[shouldSerialize](cardelement.md#protected-shouldserialize)*
 
 *Overrides [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
-
-*Defined in [card-elements.ts:291](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L291)*
 
 **Parameters:**
 
@@ -2104,8 +1816,6 @@ ___
 
 ▸ **supportsExcplitiHeight**(): *boolean*
 
-*Defined in [card-elements.ts:4916](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4916)*
-
 **Returns:** *boolean*
 
 ___
@@ -2117,8 +1827,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[toJSON](cardelement.md#tojson)*
 
 *Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
-
-*Defined in [card-elements.ts:317](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L317)*
 
 **Parameters:**
 
@@ -2136,8 +1844,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
 
-*Defined in [card-elements.ts:5005](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5005)*
-
 **Parameters:**
 
 Name | Type |
@@ -2154,8 +1860,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
 
-*Defined in [card-elements.ts:5044](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5044)*
-
 **Returns:** *void*
 
 ___
@@ -2167,8 +1871,6 @@ ___
 *Inherited from [CardElementContainer](cardelementcontainer.md).[updateLayout](cardelementcontainer.md#updatelayout)*
 
 *Overrides [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
-
-*Defined in [card-elements.ts:1861](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1861)*
 
 **Parameters:**
 
@@ -2185,7 +1887,5 @@ ___
 ▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
 
 *Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
-
-*Defined in [card-object.ts:128](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L128)*
 
 **Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/containerstyle.md
+++ b/source/nodejs/adaptivecards/docs/classes/containerstyle.md
@@ -23,15 +23,11 @@
 
 ▪ **Accent**: *"accent"* = "accent"
 
-*Defined in [enums.ts:144](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L144)*
-
 ___
 
 ### `Static` Attention
 
 ▪ **Attention**: *"attention"* = "attention"
-
-*Defined in [enums.ts:146](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L146)*
 
 ___
 
@@ -39,15 +35,11 @@ ___
 
 ▪ **Default**: *"default"* = "default"
 
-*Defined in [enums.ts:142](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L142)*
-
 ___
 
 ### `Static` Emphasis
 
 ▪ **Emphasis**: *"emphasis"* = "emphasis"
-
-*Defined in [enums.ts:143](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L143)*
 
 ___
 
@@ -55,12 +47,8 @@ ___
 
 ▪ **Good**: *"good"* = "good"
 
-*Defined in [enums.ts:145](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L145)*
-
 ___
 
 ### `Static` Warning
 
 ▪ **Warning**: *"warning"* = "warning"
-
-*Defined in [enums.ts:147](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L147)*

--- a/source/nodejs/adaptivecards/docs/classes/containerstyledefinition.md
+++ b/source/nodejs/adaptivecards/docs/classes/containerstyledefinition.md
@@ -33,8 +33,6 @@
 
 \+ **new ContainerStyleDefinition**(`obj?`: any): *[ContainerStyleDefinition](containerstyledefinition.md)*
 
-*Defined in [host-config.ts:299](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L299)*
-
 **Parameters:**
 
 Name | Type |
@@ -48,8 +46,6 @@ Name | Type |
 ### `Optional` backgroundColor
 
 • **backgroundColor**? : *undefined | string*
-
-*Defined in [host-config.ts:273](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L273)*
 
 ___
 
@@ -67,15 +63,11 @@ ___
         }
     )
 
-*Defined in [host-config.ts:275](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L275)*
-
 ___
 
 ### `Optional` highlightBackgroundColor
 
 • **highlightBackgroundColor**? : *undefined | string*
-
-*Defined in [host-config.ts:287](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L287)*
 
 ___
 
@@ -83,15 +75,11 @@ ___
 
 • **highlightForegroundColor**? : *undefined | string*
 
-*Defined in [host-config.ts:288](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L288)*
-
 ## Accessors
 
 ###  isBuiltIn
 
 • **get isBuiltIn**(): *boolean*
-
-*Defined in [host-config.ts:305](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L305)*
 
 **Returns:** *boolean*
 
@@ -100,8 +88,6 @@ ___
 ###  parse
 
 ▸ **parse**(`obj`: any): *void*
-
-*Defined in [host-config.ts:290](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L290)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/docs/classes/containerstyleset.md
+++ b/source/nodejs/adaptivecards/docs/classes/containerstyleset.md
@@ -28,8 +28,6 @@
 
 \+ **new ContainerStyleSet**(`obj?`: any): *[ContainerStyleSet](containerstyleset.md)*
 
-*Defined in [host-config.ts:325](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L325)*
-
 **Parameters:**
 
 Name | Type |
@@ -44,8 +42,6 @@ Name | Type |
 
 • **get default**(): *[ContainerStyleDefinition](containerstyledefinition.md)*
 
-*Defined in [host-config.ts:398](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L398)*
-
 **Returns:** *[ContainerStyleDefinition](containerstyledefinition.md)*
 
 ___
@@ -54,8 +50,6 @@ ___
 
 • **get emphasis**(): *[ContainerStyleDefinition](containerstyledefinition.md)*
 
-*Defined in [host-config.ts:402](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L402)*
-
 **Returns:** *[ContainerStyleDefinition](containerstyledefinition.md)*
 
 ## Methods
@@ -63,8 +57,6 @@ ___
 ###  getStyleByName
 
 ▸ **getStyleByName**(`name`: string | undefined, `defaultValue?`: [ContainerStyleDefinition](containerstyledefinition.md)): *[ContainerStyleDefinition](containerstyledefinition.md)*
-
-*Defined in [host-config.ts:389](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L389)*
 
 **Parameters:**
 
@@ -80,7 +72,5 @@ ___
 ###  toJSON
 
 ▸ **toJSON**(): *any*
-
-*Defined in [host-config.ts:364](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L364)*
 
 **Returns:** *any*

--- a/source/nodejs/adaptivecards/docs/classes/containerwithactions.md
+++ b/source/nodejs/adaptivecards/docs/classes/containerwithactions.md
@@ -177,8 +177,6 @@
 
 *Overrides [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [card-elements.ts:5835](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5835)*
-
 **Returns:** *[ContainerWithActions](containerwithactions.md)*
 
 ## Properties
@@ -189,8 +187,6 @@
 
 *Inherited from [CardObject](cardobject.md).[_parent](cardobject.md#protected-optional-_parent)*
 
-*Defined in [card-object.ts:61](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L61)*
-
 ___
 
 ### `Protected` `Optional` _renderedElement
@@ -198,8 +194,6 @@ ___
 • **_renderedElement**? : *HTMLElement*
 
 *Inherited from [CardObject](cardobject.md).[_renderedElement](cardobject.md#protected-optional-_renderedelement)*
-
-*Defined in [card-object.ts:62](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L62)*
 
 ___
 
@@ -209,8 +203,6 @@ ___
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[_selectAction](cardelementcontainer.md#protected-optional-_selectaction)*
 
-*Defined in [card-elements.ts:1747](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1747)*
-
 ___
 
 ###  allowVerticalOverflow
@@ -218,8 +210,6 @@ ___
 • **allowVerticalOverflow**: *boolean* = false
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[allowVerticalOverflow](cardelementcontainer.md#allowverticaloverflow)*
-
-*Defined in [card-elements.ts:1787](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1787)*
 
 ___
 
@@ -229,8 +219,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#optional-customcssselector)*
 
-*Defined in [card-elements.ts:311](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L311)*
-
 ___
 
 ###  height
@@ -238,8 +226,6 @@ ___
 • **height**: *[CardElementHeight](../README.md#cardelementheight)*
 
 *Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
-
-*Defined in [card-elements.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L53)*
 
 ___
 
@@ -249,8 +235,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#horizontalalignment)*
 
-*Defined in [card-elements.ts:44](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L44)*
-
 ___
 
 ### `Optional` id
@@ -258,8 +242,6 @@ ___
 • **id**? : *undefined | string*
 
 *Inherited from [CardObject](cardobject.md).[id](cardobject.md#optional-id)*
-
-*Defined in [card-object.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L50)*
 
 ___
 
@@ -269,8 +251,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 ___
 
 ### `Optional` minPixelHeight
@@ -278,8 +258,6 @@ ___
 • **minPixelHeight**? : *undefined | number*
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[minPixelHeight](stylablecardelementcontainer.md#optional-minpixelheight)*
-
-*Defined in [card-elements.ts:4621](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4621)*
 
 ___
 
@@ -289,8 +267,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[onPreProcessPropertyValue](cardobject.md#optional-onpreprocesspropertyvalue)*
 
-*Defined in [card-object.ts:64](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L64)*
-
 ___
 
 ### `Optional` rtl
@@ -298,8 +274,6 @@ ___
 • **rtl**? : *undefined | false | true*
 
 *Inherited from [Container](container.md).[rtl](container.md#optional-rtl)*
-
-*Defined in [card-elements.ts:4885](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4885)*
 
 ___
 
@@ -309,8 +283,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
 
-*Defined in [card-elements.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L50)*
-
 ___
 
 ###  spacing
@@ -319,8 +291,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
 
-*Defined in [card-elements.ts:47](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L47)*
-
 ___
 
 ###  verticalContentAlignment
@@ -328,8 +298,6 @@ ___
 • **verticalContentAlignment**: *[VerticalAlignment](../enums/verticalalignment.md)* = Enums.VerticalAlignment.Top
 
 *Inherited from [Container](container.md).[verticalContentAlignment](container.md#verticalcontentalignment)*
-
-*Defined in [card-elements.ts:4882](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4882)*
 
 ___
 
@@ -342,8 +310,6 @@ ___
 
 *Inherited from [Container](container.md).[backgroundImageProperty](container.md#static-backgroundimageproperty)*
 
-*Defined in [card-elements.ts:4869](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4869)*
-
 ___
 
 ### `Static` bleedProperty
@@ -351,8 +317,6 @@ ___
 ▪ **bleedProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_2, "bleed", false)
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[bleedProperty](stylablecardelementcontainer.md#static-bleedproperty)*
-
-*Defined in [card-elements.ts:4597](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4597)*
 
 ___
 
@@ -369,8 +333,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[heightProperty](cardelement.md#static-heightproperty)*
 
-*Defined in [card-elements.ts:24](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L24)*
-
 ___
 
 ### `Static` horizontalAlignmentProperty
@@ -383,8 +345,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignmentProperty](cardelement.md#static-horizontalalignmentproperty)*
 
-*Defined in [card-elements.ts:32](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L32)*
-
 ___
 
 ### `Static` idProperty
@@ -392,8 +352,6 @@ ___
 ▪ **idProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "id")
 
 *Inherited from [CardObject](cardobject.md).[idProperty](cardobject.md#static-idproperty)*
-
-*Defined in [card-object.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L39)*
 
 ___
 
@@ -403,8 +361,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisibleProperty](cardelement.md#static-isvisibleproperty)*
 
-*Defined in [card-elements.ts:22](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L22)*
-
 ___
 
 ### `Static` langProperty
@@ -412,8 +368,6 @@ ___
 ▪ **langProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_1, "lang", true, /^[a-z]{2,3}$/ig)
 
 *Inherited from [CardElement](cardelement.md).[langProperty](cardelement.md#static-langproperty)*
-
-*Defined in [card-elements.ts:21](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L21)*
 
 ___
 
@@ -423,8 +377,6 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[minHeightProperty](stylablecardelementcontainer.md#static-minheightproperty)*
 
-*Defined in [card-elements.ts:4598](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4598)*
-
 ___
 
 ### `Static` `Optional` onRegisterCustomProperties
@@ -432,8 +384,6 @@ ___
 ▪ **onRegisterCustomProperties**? : *undefined | function*
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
-
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
 
 ___
 
@@ -446,8 +396,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requiresProperty](cardobject.md#static-requiresproperty)*
 
-*Defined in [card-object.ts:40](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L40)*
-
 ___
 
 ### `Static` rtlProperty
@@ -455,8 +403,6 @@ ___
 ▪ **rtlProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_0, "rtl")
 
 *Inherited from [Container](container.md).[rtlProperty](container.md#static-rtlproperty)*
-
-*Defined in [card-elements.ts:4874](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4874)*
 
 ___
 
@@ -466,8 +412,6 @@ ___
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[selectActionProperty](cardelementcontainer.md#static-selectactionproperty)*
 
-*Defined in [card-elements.ts:1736](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1736)*
-
 ___
 
 ### `Static` separatorProperty
@@ -475,8 +419,6 @@ ___
 ▪ **separatorProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_0, "separator", false)
 
 *Inherited from [CardElement](cardelement.md).[separatorProperty](cardelement.md#static-separatorproperty)*
-
-*Defined in [card-elements.ts:23](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L23)*
 
 ___
 
@@ -489,8 +431,6 @@ ___
         Enums.Spacing.Default)
 
 *Inherited from [CardElement](cardelement.md).[spacingProperty](cardelement.md#static-spacingproperty)*
-
-*Defined in [card-elements.ts:37](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L37)*
 
 ___
 
@@ -510,8 +450,6 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[styleProperty](stylablecardelementcontainer.md#static-styleproperty)*
 
-*Defined in [card-elements.ts:4586](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4586)*
-
 ___
 
 ### `Static` typeNameProperty
@@ -528,8 +466,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[typeNameProperty](cardobject.md#static-typenameproperty)*
 
-*Defined in [card-object.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L30)*
-
 ___
 
 ### `Static` verticalContentAlignmentProperty
@@ -538,8 +474,6 @@ ___
 
 *Inherited from [Container](container.md).[verticalContentAlignmentProperty](container.md#static-verticalcontentalignmentproperty)*
 
-*Defined in [card-elements.ts:4873](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4873)*
-
 ## Accessors
 
 ### `Protected` allowCustomPadding
@@ -547,8 +481,6 @@ ___
 • **get allowCustomPadding**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
-
-*Defined in [card-elements.ts:299](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L299)*
 
 **Returns:** *boolean*
 
@@ -560,8 +492,6 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[allowCustomStyle](stylablecardelementcontainer.md#protected-allowcustomstyle)*
 
-*Defined in [card-elements.ts:4742](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4742)*
-
 **Returns:** *boolean*
 
 ___
@@ -571,8 +501,6 @@ ___
 • **get backgroundImage**(): *[BackgroundImage](backgroundimage.md)*
 
 *Inherited from [Container](container.md).[backgroundImage](container.md#backgroundimage)*
-
-*Defined in [card-elements.ts:4877](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4877)*
 
 **Returns:** *[BackgroundImage](backgroundimage.md)*
 
@@ -584,15 +512,11 @@ ___
 
 *Inherited from [Container](container.md).[bleed](container.md#bleed)*
 
-*Defined in [card-elements.ts:5256](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5256)*
-
 **Returns:** *boolean*
 
 • **set bleed**(`value`: boolean): *void*
 
 *Inherited from [Container](container.md).[bleed](container.md#bleed)*
-
-*Defined in [card-elements.ts:5260](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5260)*
 
 **Parameters:**
 
@@ -610,8 +534,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
 
-*Defined in [card-elements.ts:307](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L307)*
-
 **Returns:** *string*
 
 ___
@@ -622,8 +544,6 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[hasExplicitStyle](stylablecardelementcontainer.md#protected-hasexplicitstyle)*
 
-*Defined in [card-elements.ts:4738](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4738)*
-
 **Returns:** *boolean*
 
 ___
@@ -633,8 +553,6 @@ ___
 • **get hasVisibleSeparator**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
-
-*Defined in [card-elements.ts:580](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L580)*
 
 **Returns:** *boolean*
 
@@ -648,8 +566,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
 
-*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
-
 **Returns:** *[HostConfig](hostconfig.md)*
 
 • **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
@@ -657,8 +573,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
-
-*Defined in [card-elements.ts:555](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L555)*
 
 **Parameters:**
 
@@ -676,8 +590,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
 
-*Defined in [card-elements.ts:559](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L559)*
-
 **Returns:** *number*
 
 ___
@@ -688,8 +600,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
 
-*Defined in [card-elements.ts:576](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L576)*
-
 **Returns:** *boolean*
 
 ___
@@ -699,8 +609,6 @@ ___
 • **get isInteractive**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
-
-*Defined in [card-elements.ts:568](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L568)*
 
 **Returns:** *boolean*
 
@@ -714,8 +622,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[isSelectable](cardelementcontainer.md#protected-isselectable)*
 
-*Defined in [card-elements.ts:5079](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5079)*
-
 **Returns:** *boolean*
 
 ___
@@ -725,8 +631,6 @@ ___
 • **get isStandalone**(): *boolean*
 
 *Overrides [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
-
-*Defined in [card-elements.ts:5906](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5906)*
 
 **Returns:** *boolean*
 
@@ -738,15 +642,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
 
-*Defined in [card-elements.ts:77](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L77)*
-
 **Returns:** *boolean*
 
 • **set isVisible**(`value`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
-
-*Defined in [card-elements.ts:81](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L81)*
 
 **Parameters:**
 
@@ -764,15 +664,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
 
-*Defined in [card-elements.ts:56](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L56)*
-
 **Returns:** *string | undefined*
 
 • **set lang**(`value`: string | undefined): *void*
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
-
-*Defined in [card-elements.ts:72](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L72)*
 
 **Parameters:**
 
@@ -790,15 +686,11 @@ ___
 
 *Inherited from [Container](container.md).[padding](container.md#padding)*
 
-*Defined in [card-elements.ts:5240](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5240)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md) | undefined*
 
 • **set padding**(`value`: [PaddingDefinition](paddingdefinition.md) | undefined): *void*
 
 *Inherited from [Container](container.md).[padding](container.md#padding)*
-
-*Defined in [card-elements.ts:5244](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5244)*
 
 **Parameters:**
 
@@ -818,8 +710,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[parent](cardobject.md#parent)*
 
-*Defined in [card-elements.ts:593](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L593)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -827,8 +717,6 @@ ___
 ### `Protected` renderIfEmpty
 
 • **get renderIfEmpty**(): *boolean*
-
-*Defined in [card-elements.ts:5833](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5833)*
 
 **Returns:** *boolean*
 
@@ -840,8 +728,6 @@ ___
 
 *Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[renderedActionCount](stylablecardelementcontainer.md#protected-renderedactioncount)*
 
-*Defined in [card-elements.ts:5829](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5829)*
-
 **Returns:** *number*
 
 ___
@@ -851,8 +737,6 @@ ___
 • **get renderedElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardObject](cardobject.md).[renderedElement](cardobject.md#renderedelement)*
-
-*Defined in [card-object.ts:140](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L140)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -864,8 +748,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requires](cardobject.md#requires)*
 
-*Defined in [card-object.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L53)*
-
 **Returns:** *HostCapabilities*
 
 ___
@@ -876,15 +758,11 @@ ___
 
 *Inherited from [Container](container.md).[selectAction](container.md#selectaction)*
 
-*Defined in [card-elements.ts:5248](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5248)*
-
 **Returns:** *[Action](action.md) | undefined*
 
 • **set selectAction**(`value`: [Action](action.md) | undefined): *void*
 
 *Inherited from [Container](container.md).[selectAction](container.md#selectaction)*
-
-*Defined in [card-elements.ts:5252](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5252)*
 
 **Parameters:**
 
@@ -902,8 +780,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
 
-*Defined in [card-elements.ts:589](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L589)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -913,8 +789,6 @@ ___
 • **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
 
 *Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
-
-*Defined in [card-elements.ts:303](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L303)*
 
 **Returns:** *[Orientation](../enums/orientation.md)*
 
@@ -926,15 +800,11 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[style](stylablecardelementcontainer.md#style)*
 
-*Defined in [card-elements.ts:4601](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4601)*
-
 **Returns:** *string | undefined*
 
 • **set style**(`value`: string | undefined): *void*
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[style](stylablecardelementcontainer.md#style)*
-
-*Defined in [card-elements.ts:4613](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4613)*
 
 **Parameters:**
 
@@ -952,8 +822,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
 
-*Defined in [card-elements.ts:295](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L295)*
-
 **Returns:** *boolean*
 
 ## Methods
@@ -961,8 +829,6 @@ ___
 ###  addAction
 
 ▸ **addAction**(`action`: [Action](action.md)): *void*
-
-*Defined in [card-elements.ts:5874](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5874)*
 
 **Parameters:**
 
@@ -979,8 +845,6 @@ ___
 ▸ **addItem**(`item`: [CardElement](cardelement.md)): *void*
 
 *Inherited from [Container](container.md).[addItem](container.md#additem)*
-
-*Defined in [card-elements.ts:5170](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5170)*
 
 **Parameters:**
 
@@ -1000,8 +864,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
 
-*Defined in [card-elements.ts:4625](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4625)*
-
 **Parameters:**
 
 Name | Type |
@@ -1020,8 +882,6 @@ ___
 
 *Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[applyBackground](stylablecardelementcontainer.md#protected-applybackground)*
 
-*Defined in [card-elements.ts:4924](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4924)*
-
 **Returns:** *void*
 
 ___
@@ -1034,8 +894,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[applyPadding](cardelementcontainer.md#protected-applypadding)*
 
-*Defined in [card-elements.ts:4643](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4643)*
-
 **Returns:** *void*
 
 ___
@@ -1045,8 +903,6 @@ ___
 ▸ **asString**(): *string | undefined*
 
 *Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
-
-*Defined in [card-elements.ts:321](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L321)*
 
 **Returns:** *string | undefined*
 
@@ -1058,8 +914,6 @@ ___
 
 *Overrides [Container](container.md).[clear](container.md#clear)*
 
-*Defined in [card-elements.ts:5878](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5878)*
-
 **Returns:** *void*
 
 ___
@@ -1070,8 +924,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
 
-*Defined in [card-elements.ts:205](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L205)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -1081,8 +933,6 @@ ___
 ▸ **getActionAt**(`index`: number): *[Action](action.md) | undefined*
 
 *Overrides [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
-
-*Defined in [card-elements.ts:5847](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5847)*
 
 **Parameters:**
 
@@ -1100,8 +950,6 @@ ___
 
 *Overrides [Container](container.md).[getActionById](container.md#getactionbyid)*
 
-*Defined in [card-elements.ts:5856](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5856)*
-
 **Parameters:**
 
 Name | Type |
@@ -1118,8 +966,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
 
-*Defined in [card-elements.ts:5843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5843)*
-
 **Returns:** *number*
 
 ___
@@ -1129,8 +975,6 @@ ___
 ▸ **getAllInputs**(): *[Input](input.md)[]*
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[getAllInputs](cardelementcontainer.md#getallinputs)*
-
-*Defined in [card-elements.ts:5884](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5884)*
 
 **Returns:** *[Input](input.md)[]*
 
@@ -1142,8 +986,6 @@ ___
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[getBleed](stylablecardelementcontainer.md#protected-getbleed)*
 
-*Defined in [card-elements.ts:4726](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4726)*
-
 **Returns:** *boolean*
 
 ___
@@ -1153,8 +995,6 @@ ___
 ▸ **getCustomProperty**(`name`: string): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
-
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
 
 **Parameters:**
 
@@ -1174,8 +1014,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
 
-*Defined in [card-elements.ts:4713](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4713)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
 ___
@@ -1185,8 +1023,6 @@ ___
 ▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
 
 *Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
-
-*Defined in [card-elements.ts:535](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L535)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
@@ -1200,8 +1036,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
 
-*Defined in [card-elements.ts:4777](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4777)*
-
 **Returns:** *string*
 
 ___
@@ -1211,8 +1045,6 @@ ___
 ▸ **getEffectiveStyleDefinition**(): *[ContainerStyleDefinition](containerstyledefinition.md)*
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyleDefinition](cardelement.md#geteffectivestyledefinition)*
-
-*Defined in [card-elements.ts:337](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L337)*
 
 **Returns:** *[ContainerStyleDefinition](containerstyledefinition.md)*
 
@@ -1225,8 +1057,6 @@ ___
 *Inherited from [CardElementContainer](cardelementcontainer.md).[getElementById](cardelementcontainer.md#getelementbyid)*
 
 *Overrides [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
-
-*Defined in [card-elements.ts:1891](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1891)*
 
 **Parameters:**
 
@@ -1246,8 +1076,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[getFirstVisibleRenderedItem](cardelementcontainer.md#abstract-getfirstvisiblerendereditem)*
 
-*Defined in [card-elements.ts:5091](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5091)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -1257,8 +1085,6 @@ ___
 ▸ **getForbiddenActionTypes**(): *[ActionType](../README.md#actiontype)[]*
 
 *Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
-
-*Defined in [card-elements.ts:341](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L341)*
 
 **Returns:** *[ActionType](../README.md#actiontype)[]*
 
@@ -1272,8 +1098,6 @@ ___
 
 *Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[getHasBackground](stylablecardelementcontainer.md#protected-gethasbackground)*
 
-*Defined in [card-elements.ts:5050](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5050)*
-
 **Returns:** *boolean*
 
 ___
@@ -1284,8 +1108,6 @@ ___
 
 *Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[getHasExpandedAction](stylablecardelementcontainer.md#protected-gethasexpandedaction)*
 
-*Defined in [card-elements.ts:5817](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5817)*
-
 **Returns:** *boolean*
 
 ___
@@ -1295,8 +1117,6 @@ ___
 ▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
-
-*Defined in [card-elements.ts:345](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L345)*
 
 **Parameters:**
 
@@ -1320,8 +1140,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[getItemAt](cardelementcontainer.md#abstract-getitemat)*
 
-*Defined in [card-elements.ts:5087](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5087)*
-
 **Parameters:**
 
 Name | Type |
@@ -1340,8 +1158,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[getItemCount](cardelementcontainer.md#abstract-getitemcount)*
 
-*Defined in [card-elements.ts:5083](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5083)*
-
 **Returns:** *number*
 
 ___
@@ -1351,8 +1167,6 @@ ___
 ▸ **getItemsCollectionPropertyName**(): *string*
 
 *Inherited from [Container](container.md).[getItemsCollectionPropertyName](container.md#protected-getitemscollectionpropertyname)*
-
-*Defined in [card-elements.ts:4920](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4920)*
 
 **Returns:** *string*
 
@@ -1366,8 +1180,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
 
-*Defined in [card-elements.ts:5115](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5115)*
-
 **Returns:** *string*
 
 ___
@@ -1380,8 +1192,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[getLastVisibleRenderedItem](cardelementcontainer.md#abstract-getlastvisiblerendereditem)*
 
-*Defined in [card-elements.ts:5103](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5103)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -1391,8 +1201,6 @@ ___
 ▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
-
-*Defined in [card-elements.ts:283](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L283)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md) | undefined*
 
@@ -1404,8 +1212,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
 
-*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
-
 **Returns:** *[Container](container.md) | undefined*
 
 ___
@@ -1415,8 +1221,6 @@ ___
 ▸ **getResourceInformation**(): *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
 *Overrides [Container](container.md).[getResourceInformation](container.md#getresourceinformation)*
-
-*Defined in [card-elements.ts:5888](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5888)*
 
 **Returns:** *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
@@ -1428,8 +1232,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
 
-*Defined in [card-elements.ts:501](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L501)*
-
 **Returns:** *[CardElement](cardelement.md)*
 
 ___
@@ -1440,8 +1242,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getRootObject](cardobject.md#getrootobject)*
 
-*Defined in [card-object.ts:100](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L100)*
-
 **Returns:** *[CardObject](cardobject.md)*
 
 ___
@@ -1451,8 +1251,6 @@ ___
 ▸ **getSchema**(): *[SerializableObjectSchema](serializableobjectschema.md)*
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
-
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
 
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
@@ -1466,8 +1264,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-object.ts:45](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L45)*
-
 **Returns:** *string*
 
 ___
@@ -1477,8 +1273,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -1496,8 +1290,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -1507,8 +1299,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -1528,8 +1318,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
 
-*Defined in [card-elements.ts:5166](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5166)*
-
 **Parameters:**
 
 Name | Type |
@@ -1545,8 +1333,6 @@ ___
 ▸ **insertItemAfter**(`item`: [CardElement](cardelement.md), `insertAfter`: [CardElement](cardelement.md)): *void*
 
 *Inherited from [Container](container.md).[insertItemAfter](container.md#insertitemafter)*
-
-*Defined in [card-elements.ts:5178](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5178)*
 
 **Parameters:**
 
@@ -1565,8 +1351,6 @@ ___
 
 *Inherited from [Container](container.md).[insertItemBefore](container.md#insertitembefore)*
 
-*Defined in [card-elements.ts:5174](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5174)*
-
 **Parameters:**
 
 Name | Type |
@@ -1583,8 +1367,6 @@ ___
 ▸ **internalParse**(`source`: any, `context`: [SerializationContext](serializationcontext.md)): *void*
 
 *Overrides [Container](container.md).[internalParse](container.md#protected-internalparse)*
-
-*Defined in [card-elements.ts:5775](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5775)*
 
 **Parameters:**
 
@@ -1603,8 +1385,6 @@ ___
 
 *Overrides [Container](container.md).[internalRender](container.md#protected-internalrender)*
 
-*Defined in [card-elements.ts:5787](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5787)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1614,8 +1394,6 @@ ___
 ▸ **internalToJSON**(`target`: [PropertyBag](../README.md#propertybag), `context`: [SerializationContext](serializationcontext.md)): *void*
 
 *Overrides [Container](container.md).[internalToJSON](container.md#protected-internaltojson)*
-
-*Defined in [card-elements.ts:5781](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5781)*
 
 **Parameters:**
 
@@ -1634,8 +1412,6 @@ ___
 
 *Overrides [StylableCardElementContainer](stylablecardelementcontainer.md).[internalValidateProperties](stylablecardelementcontainer.md#internalvalidateproperties)*
 
-*Defined in [card-elements.ts:5862](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5862)*
-
 **Parameters:**
 
 Name | Type |
@@ -1652,8 +1428,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
 
-*Defined in [card-elements.ts:469](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L469)*
-
 **Returns:** *boolean*
 
 ___
@@ -1663,8 +1437,6 @@ ___
 ▸ **isAtTheVeryLeft**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
-
-*Defined in [card-elements.ts:457](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L457)*
 
 **Returns:** *boolean*
 
@@ -1676,8 +1448,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
 
-*Defined in [card-elements.ts:461](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L461)*
-
 **Returns:** *boolean*
 
 ___
@@ -1687,8 +1457,6 @@ ___
 ▸ **isAtTheVeryTop**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
-
-*Defined in [card-elements.ts:465](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L465)*
 
 **Returns:** *boolean*
 
@@ -1702,8 +1470,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
 
-*Defined in [card-elements.ts:4746](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4746)*
-
 **Returns:** *boolean*
 
 ___
@@ -1713,8 +1479,6 @@ ___
 ▸ **isBleedingAtBottom**(): *boolean*
 
 *Overrides [Container](container.md).[isBleedingAtBottom](container.md#isbleedingatbottom)*
-
-*Defined in [card-elements.ts:5892](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5892)*
 
 **Returns:** *boolean*
 
@@ -1728,8 +1492,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
 
-*Defined in [card-elements.ts:5154](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5154)*
-
 **Returns:** *boolean*
 
 ___
@@ -1739,8 +1501,6 @@ ___
 ▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
-
-*Defined in [card-elements.ts:493](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L493)*
 
 **Parameters:**
 
@@ -1758,8 +1518,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
 
-*Defined in [card-elements.ts:443](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L443)*
-
 **Returns:** *boolean*
 
 ___
@@ -1770,8 +1528,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDisplayed](cardelement.md#protected-isdisplayed)*
 
-*Defined in [card-elements.ts:229](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L229)*
-
 **Returns:** *boolean*
 
 ___
@@ -1781,8 +1537,6 @@ ___
 ▸ **isElementAllowed**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[isElementAllowed](cardelementcontainer.md#protected-iselementallowed)*
-
-*Defined in [card-elements.ts:1751](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1751)*
 
 **Parameters:**
 
@@ -1802,8 +1556,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
 
-*Defined in [card-elements.ts:5119](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5119)*
-
 **Parameters:**
 
 Name | Type |
@@ -1820,8 +1572,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
 
-*Defined in [card-elements.ts:497](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L497)*
-
 **Returns:** *boolean*
 
 ___
@@ -1831,8 +1581,6 @@ ___
 ▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Overrides [Container](container.md).[isLastElement](container.md#islastelement)*
-
-*Defined in [card-elements.ts:5870](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5870)*
 
 **Parameters:**
 
@@ -1850,8 +1598,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
 
-*Defined in [card-elements.ts:481](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L481)*
-
 **Parameters:**
 
 Name | Type |
@@ -1867,8 +1613,6 @@ ___
 ▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
-
-*Defined in [card-elements.ts:485](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L485)*
 
 **Parameters:**
 
@@ -1886,8 +1630,6 @@ ___
 
 *Inherited from [Container](container.md).[isRtl](container.md#isrtl)*
 
-*Defined in [card-elements.ts:5143](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5143)*
-
 **Returns:** *boolean*
 
 ___
@@ -1897,8 +1639,6 @@ ___
 ▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
-
-*Defined in [card-elements.ts:489](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L489)*
 
 **Parameters:**
 
@@ -1916,8 +1656,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
 
-*Defined in [card-elements.ts:235](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L235)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1929,8 +1667,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[parse](cardelement.md#parse)*
 
 *Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
-
-*Defined in [card-elements.ts:313](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L313)*
 
 **Parameters:**
 
@@ -1951,8 +1687,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [card-elements.ts:1738](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1738)*
-
 **Parameters:**
 
 Name | Type |
@@ -1968,8 +1702,6 @@ ___
 ▸ **preProcessPropertyValue**(`property`: [PropertyDefinition](propertydefinition.md), `propertyValue?`: any): *any*
 
 *Inherited from [CardObject](cardobject.md).[preProcessPropertyValue](cardobject.md#preprocesspropertyvalue)*
-
-*Defined in [card-object.ts:70](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L70)*
 
 **Parameters:**
 
@@ -1988,8 +1720,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
 
-*Defined in [card-elements.ts:404](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L404)*
-
 **Returns:** *boolean*
 
 ___
@@ -2001,8 +1731,6 @@ ___
 *Inherited from [Container](container.md).[removeItem](container.md#removeitem)*
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[removeItem](cardelementcontainer.md#abstract-removeitem)*
-
-*Defined in [card-elements.ts:5182](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5182)*
 
 **Parameters:**
 
@@ -2022,8 +1750,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[render](cardelementcontainer.md#render)*
 
-*Defined in [card-elements.ts:4767](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4767)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -2034,8 +1760,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -2045,8 +1769,6 @@ ___
 ▸ **setBleed**(`value`: boolean): *void*
 
 *Inherited from [StylableCardElementContainer](stylablecardelementcontainer.md).[setBleed](stylablecardelementcontainer.md#protected-setbleed)*
-
-*Defined in [card-elements.ts:4730](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4730)*
 
 **Parameters:**
 
@@ -2063,8 +1785,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -2083,8 +1803,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
 
-*Defined in [card-elements.ts:287](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L287)*
-
 **Parameters:**
 
 Name | Type |
@@ -2100,8 +1818,6 @@ ___
 ▸ **setParent**(`value`: [CardObject](cardobject.md) | undefined): *void*
 
 *Inherited from [CardObject](cardobject.md).[setParent](cardobject.md#setparent)*
-
-*Defined in [card-object.ts:88](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L88)*
 
 **Parameters:**
 
@@ -2119,8 +1835,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setShouldFallback](cardobject.md#setshouldfallback)*
 
-*Defined in [card-object.ts:92](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L92)*
-
 **Parameters:**
 
 Name | Type |
@@ -2136,8 +1850,6 @@ ___
 ▸ **setValue**(`property`: [PropertyDefinition](propertydefinition.md), `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
-
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
 
 **Parameters:**
 
@@ -2156,8 +1868,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[shouldFallback](cardobject.md#shouldfallback)*
 
-*Defined in [card-object.ts:96](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L96)*
-
 **Returns:** *boolean*
 
 ___
@@ -2169,8 +1879,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[shouldSerialize](cardelement.md#protected-shouldserialize)*
 
 *Overrides [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
-
-*Defined in [card-elements.ts:291](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L291)*
 
 **Parameters:**
 
@@ -2188,8 +1896,6 @@ ___
 
 *Inherited from [Container](container.md).[supportsExcplitiHeight](container.md#protected-supportsexcplitiheight)*
 
-*Defined in [card-elements.ts:4916](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4916)*
-
 **Returns:** *boolean*
 
 ___
@@ -2201,8 +1907,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[toJSON](cardelement.md#tojson)*
 
 *Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
-
-*Defined in [card-elements.ts:317](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L317)*
 
 **Parameters:**
 
@@ -2222,8 +1926,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
 
-*Defined in [card-elements.ts:5005](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5005)*
-
 **Parameters:**
 
 Name | Type |
@@ -2242,8 +1944,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
 
-*Defined in [card-elements.ts:5044](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5044)*
-
 **Returns:** *void*
 
 ___
@@ -2255,8 +1955,6 @@ ___
 *Inherited from [CardElementContainer](cardelementcontainer.md).[updateLayout](cardelementcontainer.md#updatelayout)*
 
 *Overrides [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
-
-*Defined in [card-elements.ts:1861](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1861)*
 
 **Parameters:**
 
@@ -2273,7 +1971,5 @@ ___
 ▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
 
 *Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
-
-*Defined in [card-object.ts:128](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L128)*
 
 **Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/customproperty.md
+++ b/source/nodejs/adaptivecards/docs/classes/customproperty.md
@@ -44,8 +44,6 @@
 
 *Overrides [PropertyDefinition](propertydefinition.md).[constructor](propertydefinition.md#constructor)*
 
-*Defined in [serialization.ts:645](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L645)*
-
 **Parameters:**
 
 ▪ **targetVersion**: *[Version](version.md)*
@@ -93,8 +91,6 @@ Name | Type |
 
 *Overrides [PropertyDefinition](propertydefinition.md).[defaultValue](propertydefinition.md#optional-defaultvalue)*
 
-*Defined in [serialization.ts:652](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L652)*
-
 ___
 
 ###  name
@@ -102,8 +98,6 @@ ___
 • **name**: *string*
 
 *Overrides [PropertyDefinition](propertydefinition.md).[name](propertydefinition.md#name)*
-
-*Defined in [serialization.ts:649](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L649)*
 
 ___
 
@@ -113,15 +107,11 @@ ___
 
 *Overrides [PropertyDefinition](propertydefinition.md).[onGetInitialValue](propertydefinition.md#optional-ongetinitialvalue)*
 
-*Defined in [serialization.ts:653](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L653)*
-
 ___
 
 ###  onParse
 
 • **onParse**: *function*
-
-*Defined in [serialization.ts:650](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L650)*
 
 #### Type declaration:
 
@@ -141,8 +131,6 @@ ___
 ###  onToJSON
 
 • **onToJSON**: *function*
-
-*Defined in [serialization.ts:651](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L651)*
 
 #### Type declaration:
 
@@ -166,8 +154,6 @@ ___
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[sequentialNumber](propertydefinition.md#sequentialnumber)*
 
-*Defined in [serialization.ts:258](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L258)*
-
 ___
 
 ###  targetVersion
@@ -176,8 +162,6 @@ ___
 
 *Overrides [PropertyDefinition](propertydefinition.md).[targetVersion](propertydefinition.md#targetversion)*
 
-*Defined in [serialization.ts:648](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L648)*
-
 ## Methods
 
 ###  getInternalName
@@ -185,8 +169,6 @@ ___
 ▸ **getInternalName**(): *string*
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[getInternalName](propertydefinition.md#getinternalname)*
-
-*Defined in [serialization.ts:246](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L246)*
 
 **Returns:** *string*
 
@@ -197,8 +179,6 @@ ___
 ▸ **parse**(`sender`: [SerializableObject](serializableobject.md), `source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *T*
 
 *Overrides [PropertyDefinition](propertydefinition.md).[parse](propertydefinition.md#parse)*
-
-*Defined in [serialization.ts:639](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L639)*
 
 **Parameters:**
 
@@ -217,8 +197,6 @@ ___
 ▸ **toJSON**(`sender`: [SerializableObject](serializableobject.md), `target`: [PropertyBag](../README.md#propertybag), `value`: T, `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Overrides [PropertyDefinition](propertydefinition.md).[toJSON](propertydefinition.md#tojson)*
-
-*Defined in [serialization.ts:643](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L643)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/docs/classes/dateinput.md
+++ b/source/nodejs/adaptivecards/docs/classes/dateinput.md
@@ -159,8 +159,6 @@
 
 *Inherited from [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 **Returns:** *[DateInput](dateinput.md)*
 
 ## Properties
@@ -171,8 +169,6 @@
 
 *Inherited from [CardObject](cardobject.md).[_parent](cardobject.md#protected-optional-_parent)*
 
-*Defined in [card-object.ts:61](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L61)*
-
 ___
 
 ### `Protected` `Optional` _renderedElement
@@ -180,8 +176,6 @@ ___
 • **_renderedElement**? : *HTMLElement*
 
 *Inherited from [CardObject](cardobject.md).[_renderedElement](cardobject.md#protected-optional-_renderedelement)*
-
-*Defined in [card-object.ts:62](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L62)*
 
 ___
 
@@ -191,15 +185,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#optional-customcssselector)*
 
-*Defined in [card-elements.ts:311](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L311)*
-
 ___
 
 ### `Optional` defaultValue
 
 • **defaultValue**? : *undefined | string*
-
-*Defined in [card-elements.ts:3115](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3115)*
 
 ___
 
@@ -209,8 +199,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
 
-*Defined in [card-elements.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L53)*
-
 ___
 
 ###  horizontalAlignment
@@ -218,8 +206,6 @@ ___
 • **horizontalAlignment**: *[HorizontalAlignment](../enums/horizontalalignment.md)*
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#horizontalalignment)*
-
-*Defined in [card-elements.ts:44](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L44)*
 
 ___
 
@@ -231,15 +217,11 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[id](cardobject.md#optional-id)*
 
-*Defined in [card-object.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L50)*
-
 ___
 
 ### `Optional` max
 
 • **max**? : *undefined | string*
-
-*Defined in [card-elements.ts:3121](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3121)*
 
 ___
 
@@ -249,15 +231,11 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 ___
 
 ### `Optional` min
 
 • **min**? : *undefined | string*
-
-*Defined in [card-elements.ts:3118](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3118)*
 
 ___
 
@@ -267,8 +245,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[onPreProcessPropertyValue](cardobject.md#optional-onpreprocesspropertyvalue)*
 
-*Defined in [card-object.ts:64](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L64)*
-
 ___
 
 ###  onValueChanged
@@ -276,8 +252,6 @@ ___
 • **onValueChanged**: *function*
 
 *Inherited from [Input](input.md).[onValueChanged](input.md#onvaluechanged)*
-
-*Defined in [card-elements.ts:2415](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2415)*
 
 #### Type declaration:
 
@@ -295,8 +269,6 @@ ___
 
 • **placeholder**? : *undefined | string*
 
-*Defined in [card-elements.ts:3124](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3124)*
-
 ___
 
 ###  separator
@@ -305,8 +277,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
 
-*Defined in [card-elements.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L50)*
-
 ___
 
 ###  spacing
@@ -314,8 +284,6 @@ ___
 • **spacing**: *[Spacing](../enums/spacing.md)*
 
 *Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
-
-*Defined in [card-elements.ts:47](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L47)*
 
 ___
 
@@ -332,8 +300,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[heightProperty](cardelement.md#static-heightproperty)*
 
-*Defined in [card-elements.ts:24](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L24)*
-
 ___
 
 ### `Static` horizontalAlignmentProperty
@@ -346,8 +312,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignmentProperty](cardelement.md#static-horizontalalignmentproperty)*
 
-*Defined in [card-elements.ts:32](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L32)*
-
 ___
 
 ### `Static` idProperty
@@ -355,8 +319,6 @@ ___
 ▪ **idProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "id")
 
 *Inherited from [CardObject](cardobject.md).[idProperty](cardobject.md#static-idproperty)*
-
-*Defined in [card-object.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L39)*
 
 ___
 
@@ -366,8 +328,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisibleProperty](cardelement.md#static-isvisibleproperty)*
 
-*Defined in [card-elements.ts:22](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L22)*
-
 ___
 
 ### `Static` langProperty
@@ -376,23 +336,17 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[langProperty](cardelement.md#static-langproperty)*
 
-*Defined in [card-elements.ts:21](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L21)*
-
 ___
 
 ### `Static` maxProperty
 
 ▪ **maxProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "max")
 
-*Defined in [card-elements.ts:3112](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3112)*
-
 ___
 
 ### `Static` minProperty
 
 ▪ **minProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "min")
-
-*Defined in [card-elements.ts:3111](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3111)*
 
 ___
 
@@ -402,15 +356,11 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
 
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
-
 ___
 
 ### `Static` placeholderProperty
 
 ▪ **placeholderProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "placeholder")
-
-*Defined in [card-elements.ts:3110](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3110)*
 
 ___
 
@@ -423,8 +373,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requiresProperty](cardobject.md#static-requiresproperty)*
 
-*Defined in [card-object.ts:40](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L40)*
-
 ___
 
 ### `Static` separatorProperty
@@ -432,8 +380,6 @@ ___
 ▪ **separatorProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_0, "separator", false)
 
 *Inherited from [CardElement](cardelement.md).[separatorProperty](cardelement.md#static-separatorproperty)*
-
-*Defined in [card-elements.ts:23](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L23)*
 
 ___
 
@@ -446,8 +392,6 @@ ___
         Enums.Spacing.Default)
 
 *Inherited from [CardElement](cardelement.md).[spacingProperty](cardelement.md#static-spacingproperty)*
-
-*Defined in [card-elements.ts:37](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L37)*
 
 ___
 
@@ -465,8 +409,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[typeNameProperty](cardobject.md#static-typenameproperty)*
 
-*Defined in [card-object.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L30)*
-
 ___
 
 ### `Static` validationProperty
@@ -478,15 +420,11 @@ ___
 
 *Inherited from [Input](input.md).[validationProperty](input.md#static-validationproperty)*
 
-*Defined in [card-elements.ts:2313](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2313)*
-
 ___
 
 ### `Static` valueProperty
 
 ▪ **valueProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "value")
-
-*Defined in [card-elements.ts:3109](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3109)*
 
 ## Accessors
 
@@ -495,8 +433,6 @@ ___
 • **get allowCustomPadding**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
-
-*Defined in [card-elements.ts:299](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L299)*
 
 **Returns:** *boolean*
 
@@ -508,8 +444,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
 
-*Defined in [card-elements.ts:307](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L307)*
-
 **Returns:** *string*
 
 ___
@@ -519,8 +453,6 @@ ___
 • **get hasVisibleSeparator**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
-
-*Defined in [card-elements.ts:580](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L580)*
 
 **Returns:** *boolean*
 
@@ -534,8 +466,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
 
-*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
-
 **Returns:** *[HostConfig](hostconfig.md)*
 
 • **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
@@ -543,8 +473,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
-
-*Defined in [card-elements.ts:555](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L555)*
 
 **Parameters:**
 
@@ -562,8 +490,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
 
-*Defined in [card-elements.ts:559](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L559)*
-
 **Returns:** *number*
 
 ___
@@ -574,8 +500,6 @@ ___
 
 *Inherited from [Input](input.md).[inputControlContainerElement](input.md#protected-inputcontrolcontainerelement)*
 
-*Defined in [card-elements.ts:2346](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2346)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -585,8 +509,6 @@ ___
 • **get isInline**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
-
-*Defined in [card-elements.ts:576](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L576)*
 
 **Returns:** *boolean*
 
@@ -600,8 +522,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
 
-*Defined in [card-elements.ts:2453](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2453)*
-
 **Returns:** *boolean*
 
 ___
@@ -611,8 +531,6 @@ ___
 • **get isNullable**(): *boolean*
 
 *Inherited from [Input](input.md).[isNullable](input.md#protected-isnullable)*
-
-*Defined in [card-elements.ts:2338](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2338)*
 
 **Returns:** *boolean*
 
@@ -624,8 +542,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
 
-*Defined in [card-elements.ts:572](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L572)*
-
 **Returns:** *boolean*
 
 ___
@@ -636,15 +552,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
 
-*Defined in [card-elements.ts:77](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L77)*
-
 **Returns:** *boolean*
 
 • **set isVisible**(`value`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
-
-*Defined in [card-elements.ts:81](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L81)*
 
 **Parameters:**
 
@@ -662,15 +574,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
 
-*Defined in [card-elements.ts:56](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L56)*
-
 **Returns:** *string | undefined*
 
 • **set lang**(`value`: string | undefined): *void*
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
-
-*Defined in [card-elements.ts:72](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L72)*
 
 **Parameters:**
 
@@ -690,8 +598,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[parent](cardobject.md#parent)*
 
-*Defined in [card-elements.ts:593](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L593)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -701,8 +607,6 @@ ___
 • **get renderedElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardObject](cardobject.md).[renderedElement](cardobject.md#renderedelement)*
-
-*Defined in [card-object.ts:140](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L140)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -714,8 +618,6 @@ ___
 
 *Inherited from [Input](input.md).[renderedInputControlElement](input.md#protected-renderedinputcontrolelement)*
 
-*Defined in [card-elements.ts:2342](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2342)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -725,8 +627,6 @@ ___
 • **get requires**(): *HostCapabilities*
 
 *Inherited from [CardObject](cardobject.md).[requires](cardobject.md#requires)*
-
-*Defined in [card-object.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L53)*
 
 **Returns:** *HostCapabilities*
 
@@ -738,8 +638,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
 
-*Defined in [card-elements.ts:589](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L589)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -749,8 +647,6 @@ ___
 • **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
 
 *Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
-
-*Defined in [card-elements.ts:303](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L303)*
 
 **Returns:** *[Orientation](../enums/orientation.md)*
 
@@ -762,8 +658,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
 
-*Defined in [card-elements.ts:295](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L295)*
-
 **Returns:** *boolean*
 
 ___
@@ -773,8 +667,6 @@ ___
 • **get validation**(): *[InputValidationOptions](inputvalidationoptions.md)*
 
 *Inherited from [Input](input.md).[validation](input.md#validation)*
-
-*Defined in [card-elements.ts:2327](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2327)*
 
 **Returns:** *[InputValidationOptions](inputvalidationoptions.md)*
 
@@ -786,8 +678,6 @@ ___
 
 *Overrides [Input](input.md).[value](input.md#value)*
 
-*Defined in [card-elements.ts:3167](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3167)*
-
 **Returns:** *string | undefined*
 
 ## Methods
@@ -797,8 +687,6 @@ ___
 ▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
 
 *Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
-
-*Defined in [card-elements.ts:220](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L220)*
 
 **Parameters:**
 
@@ -816,8 +704,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
 
-*Defined in [card-elements.ts:239](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L239)*
-
 **Returns:** *void*
 
 ___
@@ -827,8 +713,6 @@ ___
 ▸ **asString**(): *string | undefined*
 
 *Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
-
-*Defined in [card-elements.ts:321](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L321)*
 
 **Returns:** *string | undefined*
 
@@ -840,8 +724,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
 
-*Defined in [card-elements.ts:205](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L205)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -851,8 +733,6 @@ ___
 ▸ **getActionAt**(`index`: number): *[Action](action.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
-
-*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
 
 **Parameters:**
 
@@ -870,8 +750,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
 
-*Defined in [card-elements.ts:531](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L531)*
-
 **Parameters:**
 
 Name | Type |
@@ -888,8 +766,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
 
-*Defined in [card-elements.ts:396](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L396)*
-
 **Returns:** *number*
 
 ___
@@ -902,8 +778,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
 
-*Defined in [card-elements.ts:2449](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2449)*
-
 **Returns:** *[Input](input.md)[]*
 
 ___
@@ -913,8 +787,6 @@ ___
 ▸ **getCustomProperty**(`name`: string): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
-
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
 
 **Parameters:**
 
@@ -932,8 +804,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
 
-*Defined in [card-elements.ts:275](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L275)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
 ___
@@ -943,8 +813,6 @@ ___
 ▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
 
 *Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
-
-*Defined in [card-elements.ts:535](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L535)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
@@ -956,8 +824,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
 
-*Defined in [card-elements.ts:329](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L329)*
-
 **Returns:** *string*
 
 ___
@@ -968,8 +834,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyleDefinition](cardelement.md#geteffectivestyledefinition)*
 
-*Defined in [card-elements.ts:337](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L337)*
-
 **Returns:** *[ContainerStyleDefinition](containerstyledefinition.md)*
 
 ___
@@ -979,8 +843,6 @@ ___
 ▸ **getElementById**(`id`: string): *[CardElement](cardelement.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
-
-*Defined in [card-elements.ts:527](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L527)*
 
 **Parameters:**
 
@@ -998,8 +860,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
 
-*Defined in [card-elements.ts:341](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L341)*
-
 **Returns:** *[ActionType](../README.md#actiontype)[]*
 
 ___
@@ -1010,8 +870,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
 
-*Defined in [card-elements.ts:279](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L279)*
-
 **Returns:** *boolean*
 
 ___
@@ -1021,8 +879,6 @@ ___
 ▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
-
-*Defined in [card-elements.ts:345](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L345)*
 
 **Parameters:**
 
@@ -1044,8 +900,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
 
-*Defined in [card-elements.ts:3159](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3159)*
-
 **Returns:** *string*
 
 ___
@@ -1055,8 +909,6 @@ ___
 ▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
-
-*Defined in [card-elements.ts:283](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L283)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md) | undefined*
 
@@ -1068,8 +920,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
 
-*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
-
 **Returns:** *[Container](container.md) | undefined*
 
 ___
@@ -1079,8 +929,6 @@ ___
 ▸ **getResourceInformation**(): *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
 *Inherited from [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
-
-*Defined in [card-elements.ts:523](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L523)*
 
 **Returns:** *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
@@ -1092,8 +940,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
 
-*Defined in [card-elements.ts:501](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L501)*
-
 **Returns:** *[CardElement](cardelement.md)*
 
 ___
@@ -1104,8 +950,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getRootObject](cardobject.md#getrootobject)*
 
-*Defined in [card-object.ts:100](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L100)*
-
 **Returns:** *[CardObject](cardobject.md)*
 
 ___
@@ -1115,8 +959,6 @@ ___
 ▸ **getSchema**(): *[SerializableObjectSchema](serializableobjectschema.md)*
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
-
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
 
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
@@ -1130,8 +972,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-object.ts:45](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L45)*
-
 **Returns:** *string*
 
 ___
@@ -1141,8 +981,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -1160,8 +998,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -1171,8 +1007,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -1190,8 +1024,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
 
-*Defined in [card-elements.ts:439](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L439)*
-
 **Parameters:**
 
 Name | Type |
@@ -1207,8 +1039,6 @@ ___
 ▸ **internalParse**(`source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
-
-*Defined in [serialization.ts:789](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L789)*
 
 **Parameters:**
 
@@ -1227,8 +1057,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
 
-*Defined in [card-elements.ts:3130](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3130)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1238,8 +1066,6 @@ ___
 ▸ **internalToJSON**(`target`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
-
-*Defined in [serialization.ts:821](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L821)*
 
 **Parameters:**
 
@@ -1260,8 +1086,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
 
-*Defined in [card-elements.ts:2419](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2419)*
-
 **Parameters:**
 
 Name | Type |
@@ -1278,8 +1102,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
 
-*Defined in [card-elements.ts:469](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L469)*
-
 **Returns:** *boolean*
 
 ___
@@ -1289,8 +1111,6 @@ ___
 ▸ **isAtTheVeryLeft**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
-
-*Defined in [card-elements.ts:457](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L457)*
 
 **Returns:** *boolean*
 
@@ -1302,8 +1122,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
 
-*Defined in [card-elements.ts:461](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L461)*
-
 **Returns:** *boolean*
 
 ___
@@ -1313,8 +1131,6 @@ ___
 ▸ **isAtTheVeryTop**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
-
-*Defined in [card-elements.ts:465](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L465)*
 
 **Returns:** *boolean*
 
@@ -1326,8 +1142,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
 
-*Defined in [card-elements.ts:325](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L325)*
-
 **Returns:** *boolean*
 
 ___
@@ -1337,8 +1151,6 @@ ___
 ▸ **isBleedingAtBottom**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
-
-*Defined in [card-elements.ts:477](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L477)*
 
 **Returns:** *boolean*
 
@@ -1350,8 +1162,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
 
-*Defined in [card-elements.ts:473](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L473)*
-
 **Returns:** *boolean*
 
 ___
@@ -1361,8 +1171,6 @@ ___
 ▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
-
-*Defined in [card-elements.ts:493](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L493)*
 
 **Parameters:**
 
@@ -1380,8 +1188,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
 
-*Defined in [card-elements.ts:443](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L443)*
-
 **Returns:** *boolean*
 
 ___
@@ -1392,8 +1198,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDisplayed](cardelement.md#protected-isdisplayed)*
 
-*Defined in [card-elements.ts:229](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L229)*
-
 **Returns:** *boolean*
 
 ___
@@ -1403,8 +1207,6 @@ ___
 ▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
-
-*Defined in [card-elements.ts:449](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L449)*
 
 **Parameters:**
 
@@ -1422,8 +1224,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
 
-*Defined in [card-elements.ts:497](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L497)*
-
 **Returns:** *boolean*
 
 ___
@@ -1433,8 +1233,6 @@ ___
 ▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
-
-*Defined in [card-elements.ts:453](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L453)*
 
 **Parameters:**
 
@@ -1452,8 +1250,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
 
-*Defined in [card-elements.ts:481](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L481)*
-
 **Parameters:**
 
 Name | Type |
@@ -1469,8 +1265,6 @@ ___
 ▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
-
-*Defined in [card-elements.ts:485](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L485)*
 
 **Parameters:**
 
@@ -1488,8 +1282,6 @@ ___
 
 *Overrides [Input](input.md).[isSet](input.md#abstract-isset)*
 
-*Defined in [card-elements.ts:3163](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3163)*
-
 **Returns:** *boolean*
 
 ___
@@ -1499,8 +1291,6 @@ ___
 ▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
-
-*Defined in [card-elements.ts:489](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L489)*
 
 **Parameters:**
 
@@ -1520,8 +1310,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
 
-*Defined in [card-elements.ts:2350](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2350)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1533,8 +1321,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[parse](cardelement.md#parse)*
 
 *Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
-
-*Defined in [card-elements.ts:313](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L313)*
 
 **Parameters:**
 
@@ -1555,8 +1341,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [card-elements.ts:2318](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2318)*
-
 **Parameters:**
 
 Name | Type |
@@ -1572,8 +1356,6 @@ ___
 ▸ **preProcessPropertyValue**(`property`: [PropertyDefinition](propertydefinition.md), `propertyValue?`: any): *any*
 
 *Inherited from [CardObject](cardobject.md).[preProcessPropertyValue](cardobject.md#preprocesspropertyvalue)*
-
-*Defined in [card-object.ts:70](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L70)*
 
 **Parameters:**
 
@@ -1592,8 +1374,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
 
-*Defined in [card-elements.ts:404](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L404)*
-
 **Returns:** *boolean*
 
 ___
@@ -1603,8 +1383,6 @@ ___
 ▸ **render**(): *HTMLElement | undefined*
 
 *Inherited from [CardElement](cardelement.md).[render](cardelement.md#render)*
-
-*Defined in [card-elements.ts:412](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L412)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -1616,8 +1394,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -1628,8 +1404,6 @@ ___
 
 *Inherited from [Input](input.md).[resetValidationFailureCue](input.md#protected-resetvalidationfailurecue)*
 
-*Defined in [card-elements.ts:2391](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2391)*
-
 **Returns:** *void*
 
 ___
@@ -1639,8 +1413,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -1659,8 +1431,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
 
-*Defined in [card-elements.ts:287](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L287)*
-
 **Parameters:**
 
 Name | Type |
@@ -1676,8 +1446,6 @@ ___
 ▸ **setParent**(`value`: [CardObject](cardobject.md) | undefined): *void*
 
 *Inherited from [CardObject](cardobject.md).[setParent](cardobject.md#setparent)*
-
-*Defined in [card-object.ts:88](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L88)*
 
 **Parameters:**
 
@@ -1695,8 +1463,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setShouldFallback](cardobject.md#setshouldfallback)*
 
-*Defined in [card-object.ts:92](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L92)*
-
 **Parameters:**
 
 Name | Type |
@@ -1712,8 +1478,6 @@ ___
 ▸ **setValue**(`property`: [PropertyDefinition](propertydefinition.md), `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
-
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
 
 **Parameters:**
 
@@ -1732,8 +1496,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[shouldFallback](cardobject.md#shouldfallback)*
 
-*Defined in [card-object.ts:96](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L96)*
-
 **Returns:** *boolean*
 
 ___
@@ -1745,8 +1507,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[shouldSerialize](cardelement.md#protected-shouldserialize)*
 
 *Overrides [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
-
-*Defined in [card-elements.ts:291](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L291)*
 
 **Parameters:**
 
@@ -1764,8 +1524,6 @@ ___
 
 *Inherited from [Input](input.md).[showValidationErrorMessage](input.md#protected-showvalidationerrormessage)*
 
-*Defined in [card-elements.ts:2403](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2403)*
-
 **Returns:** *void*
 
 ___
@@ -1777,8 +1535,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[toJSON](cardelement.md#tojson)*
 
 *Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
-
-*Defined in [card-elements.ts:317](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L317)*
 
 **Parameters:**
 
@@ -1796,8 +1552,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
 
-*Defined in [card-elements.ts:263](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L263)*
-
 **Parameters:**
 
 Name | Type |
@@ -1814,8 +1568,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
 
-*Defined in [card-elements.ts:273](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L273)*
-
 **Returns:** *void*
 
 ___
@@ -1825,8 +1577,6 @@ ___
 ▸ **updateLayout**(`processChildren`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
-
-*Defined in [card-elements.ts:434](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L434)*
 
 **Parameters:**
 
@@ -1844,8 +1594,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
 
-*Defined in [card-object.ts:128](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L128)*
-
 **Returns:** *[ValidationResults](validationresults.md)*
 
 ___
@@ -1858,8 +1606,6 @@ ___
 
 *Inherited from [Input](input.md).[validateValue](input.md#validatevalue)*
 
-*Defined in [card-elements.ts:2430](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2430)*
-
 **Returns:** *boolean*
 
 ___
@@ -1869,7 +1615,5 @@ ___
 ▸ **valueChanged**(): *void*
 
 *Inherited from [Input](input.md).[valueChanged](input.md#protected-valuechanged)*
-
-*Defined in [card-elements.ts:2381](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2381)*
 
 **Returns:** *void*

--- a/source/nodejs/adaptivecards/docs/classes/enumproperty.md
+++ b/source/nodejs/adaptivecards/docs/classes/enumproperty.md
@@ -45,8 +45,6 @@
 
 *Overrides [PropertyDefinition](propertydefinition.md).[constructor](propertydefinition.md#constructor)*
 
-*Defined in [serialization.ts:531](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L531)*
-
 **Parameters:**
 
 Name | Type |
@@ -68,15 +66,11 @@ Name | Type |
 
 *Overrides [PropertyDefinition](propertydefinition.md).[defaultValue](propertydefinition.md#optional-defaultvalue)*
 
-*Defined in [serialization.ts:537](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L537)*
-
 ___
 
 ###  enumType
 
 • **enumType**: *TEnum*
-
-*Defined in [serialization.ts:536](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L536)*
 
 ___
 
@@ -86,8 +80,6 @@ ___
 
 *Overrides [PropertyDefinition](propertydefinition.md).[name](propertydefinition.md#name)*
 
-*Defined in [serialization.ts:535](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L535)*
-
 ___
 
 ### `Optional` onGetInitialValue
@@ -95,8 +87,6 @@ ___
 • **onGetInitialValue**? : *undefined | function*
 
 *Overrides [PropertyDefinition](propertydefinition.md).[onGetInitialValue](propertydefinition.md#optional-ongetinitialvalue)*
-
-*Defined in [serialization.ts:539](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L539)*
 
 ___
 
@@ -106,8 +96,6 @@ ___
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[sequentialNumber](propertydefinition.md#sequentialnumber)*
 
-*Defined in [serialization.ts:258](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L258)*
-
 ___
 
 ###  targetVersion
@@ -116,15 +104,11 @@ ___
 
 *Overrides [PropertyDefinition](propertydefinition.md).[targetVersion](propertydefinition.md#targetversion)*
 
-*Defined in [serialization.ts:534](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L534)*
-
 ## Accessors
 
 ###  values
 
 • **get values**(): *[IVersionedValue](../interfaces/iversionedvalue.md)‹number›[]*
-
-*Defined in [serialization.ts:556](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L556)*
 
 **Returns:** *[IVersionedValue](../interfaces/iversionedvalue.md)‹number›[]*
 
@@ -136,8 +120,6 @@ ___
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[getInternalName](propertydefinition.md#getinternalname)*
 
-*Defined in [serialization.ts:246](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L246)*
-
 **Returns:** *string*
 
 ___
@@ -147,8 +129,6 @@ ___
 ▸ **parse**(`sender`: [SerializableObject](serializableobject.md), `source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *number | undefined*
 
 *Overrides [PropertyDefinition](propertydefinition.md).[parse](propertydefinition.md#parse)*
-
-*Defined in [serialization.ts:462](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L462)*
 
 **Parameters:**
 
@@ -167,8 +147,6 @@ ___
 ▸ **toJSON**(`sender`: [SerializableObject](serializableobject.md), `target`: [PropertyBag](../README.md#propertybag), `value`: number | undefined, `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Overrides [PropertyDefinition](propertydefinition.md).[toJSON](propertydefinition.md#tojson)*
-
-*Defined in [serialization.ts:499](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L499)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/docs/classes/fact.md
+++ b/source/nodejs/adaptivecards/docs/classes/fact.md
@@ -49,8 +49,6 @@
 
 *Overrides [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [card-elements.ts:1361](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1361)*
-
 **Parameters:**
 
 Name | Type |
@@ -68,23 +66,17 @@ Name | Type |
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 ___
 
 ### `Optional` name
 
 • **name**? : *undefined | string*
 
-*Defined in [card-elements.ts:1352](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1352)*
-
 ___
 
 ### `Optional` value
 
 • **value**? : *undefined | string*
-
-*Defined in [card-elements.ts:1355](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1355)*
 
 ___
 
@@ -94,23 +86,17 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
 
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
-
 ___
 
 ### `Static` titleProperty
 
 ▪ **titleProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "title")
 
-*Defined in [card-elements.ts:1347](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1347)*
-
 ___
 
 ### `Static` valueProperty
 
 ▪ **valueProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "value")
-
-*Defined in [card-elements.ts:1348](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1348)*
 
 ## Methods
 
@@ -119,8 +105,6 @@ ___
 ▸ **getCustomProperty**(`name`: string): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
-
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
 
 **Parameters:**
 
@@ -138,8 +122,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
 
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
-
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
 ___
@@ -150,8 +132,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-elements.ts:1359](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1359)*
-
 **Returns:** *string*
 
 ___
@@ -161,8 +141,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -180,8 +158,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -191,8 +167,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -209,8 +183,6 @@ ___
 ▸ **internalParse**(`source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
-
-*Defined in [serialization.ts:789](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L789)*
 
 **Parameters:**
 
@@ -229,8 +201,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
 
-*Defined in [serialization.ts:821](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L821)*
-
 **Parameters:**
 
 Name | Type |
@@ -247,8 +217,6 @@ ___
 ▸ **parse**(`source`: [PropertyBag](../README.md#propertybag), `context?`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
-
-*Defined in [serialization.ts:857](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L857)*
 
 **Parameters:**
 
@@ -267,8 +235,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [serialization.ts:738](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L738)*
-
 **Parameters:**
 
 Name | Type |
@@ -285,8 +251,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -296,8 +260,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -316,8 +278,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
 
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
-
 **Parameters:**
 
 Name | Type |
@@ -335,8 +295,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
 
-*Defined in [serialization.ts:839](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L839)*
-
 **Parameters:**
 
 Name | Type |
@@ -352,8 +310,6 @@ ___
 ▸ **toJSON**(`context?`: [BaseSerializationContext](baseserializationcontext.md)): *[PropertyBag](../README.md#propertybag) | undefined*
 
 *Inherited from [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
-
-*Defined in [serialization.ts:861](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L861)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/docs/classes/factset.md
+++ b/source/nodejs/adaptivecards/docs/classes/factset.md
@@ -137,8 +137,6 @@
 
 *Inherited from [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 **Returns:** *[FactSet](factset.md)*
 
 ## Properties
@@ -149,8 +147,6 @@
 
 *Inherited from [CardObject](cardobject.md).[_parent](cardobject.md#protected-optional-_parent)*
 
-*Defined in [card-object.ts:61](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L61)*
-
 ___
 
 ### `Protected` `Optional` _renderedElement
@@ -158,8 +154,6 @@ ___
 • **_renderedElement**? : *HTMLElement*
 
 *Inherited from [CardObject](cardobject.md).[_renderedElement](cardobject.md#protected-optional-_renderedelement)*
-
-*Defined in [card-object.ts:62](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L62)*
 
 ___
 
@@ -169,15 +163,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#optional-customcssselector)*
 
-*Defined in [card-elements.ts:311](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L311)*
-
 ___
 
 ###  facts
 
 • **facts**: *[Fact](fact.md)[]*
-
-*Defined in [card-elements.ts:1377](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1377)*
 
 ___
 
@@ -187,8 +177,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
 
-*Defined in [card-elements.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L53)*
-
 ___
 
 ###  horizontalAlignment
@@ -196,8 +184,6 @@ ___
 • **horizontalAlignment**: *[HorizontalAlignment](../enums/horizontalalignment.md)*
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#horizontalalignment)*
-
-*Defined in [card-elements.ts:44](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L44)*
 
 ___
 
@@ -207,8 +193,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[id](cardobject.md#optional-id)*
 
-*Defined in [card-object.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L50)*
-
 ___
 
 ###  maxVersion
@@ -216,8 +200,6 @@ ___
 • **maxVersion**: *[Version](version.md)* = Versions.latest
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
-
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
 
 ___
 
@@ -227,8 +209,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[onPreProcessPropertyValue](cardobject.md#optional-onpreprocesspropertyvalue)*
 
-*Defined in [card-object.ts:64](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L64)*
-
 ___
 
 ###  separator
@@ -236,8 +216,6 @@ ___
 • **separator**: *boolean*
 
 *Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
-
-*Defined in [card-elements.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L50)*
 
 ___
 
@@ -247,15 +225,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
 
-*Defined in [card-elements.ts:47](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L47)*
-
 ___
 
 ### `Static` factsProperty
 
 ▪ **factsProperty**: *[SerializableObjectCollectionProperty](serializableobjectcollectionproperty.md)‹›* = new SerializableObjectCollectionProperty(Versions.v1_0, "facts", Fact)
-
-*Defined in [card-elements.ts:1374](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1374)*
 
 ___
 
@@ -272,8 +246,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[heightProperty](cardelement.md#static-heightproperty)*
 
-*Defined in [card-elements.ts:24](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L24)*
-
 ___
 
 ### `Static` horizontalAlignmentProperty
@@ -286,8 +258,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignmentProperty](cardelement.md#static-horizontalalignmentproperty)*
 
-*Defined in [card-elements.ts:32](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L32)*
-
 ___
 
 ### `Static` idProperty
@@ -295,8 +265,6 @@ ___
 ▪ **idProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "id")
 
 *Inherited from [CardObject](cardobject.md).[idProperty](cardobject.md#static-idproperty)*
-
-*Defined in [card-object.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L39)*
 
 ___
 
@@ -306,8 +274,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisibleProperty](cardelement.md#static-isvisibleproperty)*
 
-*Defined in [card-elements.ts:22](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L22)*
-
 ___
 
 ### `Static` langProperty
@@ -316,8 +282,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[langProperty](cardelement.md#static-langproperty)*
 
-*Defined in [card-elements.ts:21](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L21)*
-
 ___
 
 ### `Static` `Optional` onRegisterCustomProperties
@@ -325,8 +289,6 @@ ___
 ▪ **onRegisterCustomProperties**? : *undefined | function*
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
-
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
 
 ___
 
@@ -339,8 +301,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requiresProperty](cardobject.md#static-requiresproperty)*
 
-*Defined in [card-object.ts:40](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L40)*
-
 ___
 
 ### `Static` separatorProperty
@@ -348,8 +308,6 @@ ___
 ▪ **separatorProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_0, "separator", false)
 
 *Inherited from [CardElement](cardelement.md).[separatorProperty](cardelement.md#static-separatorproperty)*
-
-*Defined in [card-elements.ts:23](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L23)*
 
 ___
 
@@ -362,8 +320,6 @@ ___
         Enums.Spacing.Default)
 
 *Inherited from [CardElement](cardelement.md).[spacingProperty](cardelement.md#static-spacingproperty)*
-
-*Defined in [card-elements.ts:37](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L37)*
 
 ___
 
@@ -381,8 +337,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[typeNameProperty](cardobject.md#static-typenameproperty)*
 
-*Defined in [card-object.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L30)*
-
 ## Accessors
 
 ### `Protected` allowCustomPadding
@@ -390,8 +344,6 @@ ___
 • **get allowCustomPadding**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
-
-*Defined in [card-elements.ts:299](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L299)*
 
 **Returns:** *boolean*
 
@@ -403,8 +355,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
 
-*Defined in [card-elements.ts:307](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L307)*
-
 **Returns:** *string*
 
 ___
@@ -414,8 +364,6 @@ ___
 • **get hasVisibleSeparator**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
-
-*Defined in [card-elements.ts:580](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L580)*
 
 **Returns:** *boolean*
 
@@ -429,8 +377,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
 
-*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
-
 **Returns:** *[HostConfig](hostconfig.md)*
 
 • **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
@@ -438,8 +384,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
-
-*Defined in [card-elements.ts:555](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L555)*
 
 **Parameters:**
 
@@ -457,8 +401,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
 
-*Defined in [card-elements.ts:559](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L559)*
-
 **Returns:** *number*
 
 ___
@@ -468,8 +410,6 @@ ___
 • **get isInline**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
-
-*Defined in [card-elements.ts:576](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L576)*
 
 **Returns:** *boolean*
 
@@ -481,8 +421,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
 
-*Defined in [card-elements.ts:568](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L568)*
-
 **Returns:** *boolean*
 
 ___
@@ -492,8 +430,6 @@ ___
 • **get isStandalone**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
-
-*Defined in [card-elements.ts:572](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L572)*
 
 **Returns:** *boolean*
 
@@ -505,15 +441,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
 
-*Defined in [card-elements.ts:77](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L77)*
-
 **Returns:** *boolean*
 
 • **set isVisible**(`value`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
-
-*Defined in [card-elements.ts:81](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L81)*
 
 **Parameters:**
 
@@ -531,15 +463,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
 
-*Defined in [card-elements.ts:56](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L56)*
-
 **Returns:** *string | undefined*
 
 • **set lang**(`value`: string | undefined): *void*
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
-
-*Defined in [card-elements.ts:72](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L72)*
 
 **Parameters:**
 
@@ -559,8 +487,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[parent](cardobject.md#parent)*
 
-*Defined in [card-elements.ts:593](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L593)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -570,8 +496,6 @@ ___
 • **get renderedElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardObject](cardobject.md).[renderedElement](cardobject.md#renderedelement)*
-
-*Defined in [card-object.ts:140](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L140)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -583,8 +507,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requires](cardobject.md#requires)*
 
-*Defined in [card-object.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L53)*
-
 **Returns:** *HostCapabilities*
 
 ___
@@ -594,8 +516,6 @@ ___
 • **get separatorElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
-
-*Defined in [card-elements.ts:589](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L589)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -607,8 +527,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
 
-*Defined in [card-elements.ts:303](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L303)*
-
 **Returns:** *[Orientation](../enums/orientation.md)*
 
 ___
@@ -619,8 +537,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
 
-*Defined in [card-elements.ts:1381](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1381)*
-
 **Returns:** *boolean*
 
 ## Methods
@@ -630,8 +546,6 @@ ___
 ▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
 
 *Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
-
-*Defined in [card-elements.ts:220](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L220)*
 
 **Parameters:**
 
@@ -649,8 +563,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
 
-*Defined in [card-elements.ts:239](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L239)*
-
 **Returns:** *void*
 
 ___
@@ -660,8 +572,6 @@ ___
 ▸ **asString**(): *string | undefined*
 
 *Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
-
-*Defined in [card-elements.ts:321](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L321)*
 
 **Returns:** *string | undefined*
 
@@ -673,8 +583,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
 
-*Defined in [card-elements.ts:205](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L205)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -684,8 +592,6 @@ ___
 ▸ **getActionAt**(`index`: number): *[Action](action.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
-
-*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
 
 **Parameters:**
 
@@ -703,8 +609,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
 
-*Defined in [card-elements.ts:531](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L531)*
-
 **Parameters:**
 
 Name | Type |
@@ -721,8 +625,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
 
-*Defined in [card-elements.ts:396](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L396)*
-
 **Returns:** *number*
 
 ___
@@ -733,8 +635,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
 
-*Defined in [card-elements.ts:519](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L519)*
-
 **Returns:** *[Input](input.md)[]*
 
 ___
@@ -744,8 +644,6 @@ ___
 ▸ **getCustomProperty**(`name`: string): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
-
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
 
 **Parameters:**
 
@@ -763,8 +661,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
 
-*Defined in [card-elements.ts:275](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L275)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
 ___
@@ -774,8 +670,6 @@ ___
 ▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
 
 *Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
-
-*Defined in [card-elements.ts:535](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L535)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
@@ -787,8 +681,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
 
-*Defined in [card-elements.ts:329](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L329)*
-
 **Returns:** *string*
 
 ___
@@ -799,8 +691,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyleDefinition](cardelement.md#geteffectivestyledefinition)*
 
-*Defined in [card-elements.ts:337](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L337)*
-
 **Returns:** *[ContainerStyleDefinition](containerstyledefinition.md)*
 
 ___
@@ -810,8 +700,6 @@ ___
 ▸ **getElementById**(`id`: string): *[CardElement](cardelement.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
-
-*Defined in [card-elements.ts:527](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L527)*
 
 **Parameters:**
 
@@ -829,8 +717,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
 
-*Defined in [card-elements.ts:341](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L341)*
-
 **Returns:** *[ActionType](../README.md#actiontype)[]*
 
 ___
@@ -841,8 +727,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
 
-*Defined in [card-elements.ts:279](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L279)*
-
 **Returns:** *boolean*
 
 ___
@@ -852,8 +736,6 @@ ___
 ▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
-
-*Defined in [card-elements.ts:345](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L345)*
 
 **Parameters:**
 
@@ -875,8 +757,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
 
-*Defined in [card-elements.ts:1461](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1461)*
-
 **Returns:** *string*
 
 ___
@@ -886,8 +766,6 @@ ___
 ▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
-
-*Defined in [card-elements.ts:283](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L283)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md) | undefined*
 
@@ -899,8 +777,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
 
-*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
-
 **Returns:** *[Container](container.md) | undefined*
 
 ___
@@ -910,8 +786,6 @@ ___
 ▸ **getResourceInformation**(): *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
 *Inherited from [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
-
-*Defined in [card-elements.ts:523](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L523)*
 
 **Returns:** *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
@@ -923,8 +797,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
 
-*Defined in [card-elements.ts:501](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L501)*
-
 **Returns:** *[CardElement](cardelement.md)*
 
 ___
@@ -935,8 +807,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getRootObject](cardobject.md#getrootobject)*
 
-*Defined in [card-object.ts:100](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L100)*
-
 **Returns:** *[CardObject](cardobject.md)*
 
 ___
@@ -946,8 +816,6 @@ ___
 ▸ **getSchema**(): *[SerializableObjectSchema](serializableobjectschema.md)*
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
-
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
 
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
@@ -961,8 +829,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-object.ts:45](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L45)*
-
 **Returns:** *string*
 
 ___
@@ -972,8 +838,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -991,8 +855,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -1002,8 +864,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -1021,8 +881,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
 
-*Defined in [card-elements.ts:439](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L439)*
-
 **Parameters:**
 
 Name | Type |
@@ -1038,8 +896,6 @@ ___
 ▸ **internalParse**(`source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
-
-*Defined in [serialization.ts:789](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L789)*
 
 **Parameters:**
 
@@ -1058,8 +914,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
 
-*Defined in [card-elements.ts:1385](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1385)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1069,8 +923,6 @@ ___
 ▸ **internalToJSON**(`target`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
-
-*Defined in [serialization.ts:821](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L821)*
 
 **Parameters:**
 
@@ -1089,8 +941,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
 
-*Defined in [card-object.ts:110](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L110)*
-
 **Parameters:**
 
 Name | Type |
@@ -1107,8 +957,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
 
-*Defined in [card-elements.ts:469](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L469)*
-
 **Returns:** *boolean*
 
 ___
@@ -1118,8 +966,6 @@ ___
 ▸ **isAtTheVeryLeft**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
-
-*Defined in [card-elements.ts:457](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L457)*
 
 **Returns:** *boolean*
 
@@ -1131,8 +977,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
 
-*Defined in [card-elements.ts:461](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L461)*
-
 **Returns:** *boolean*
 
 ___
@@ -1142,8 +986,6 @@ ___
 ▸ **isAtTheVeryTop**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
-
-*Defined in [card-elements.ts:465](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L465)*
 
 **Returns:** *boolean*
 
@@ -1155,8 +997,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
 
-*Defined in [card-elements.ts:325](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L325)*
-
 **Returns:** *boolean*
 
 ___
@@ -1166,8 +1006,6 @@ ___
 ▸ **isBleedingAtBottom**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
-
-*Defined in [card-elements.ts:477](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L477)*
 
 **Returns:** *boolean*
 
@@ -1179,8 +1017,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
 
-*Defined in [card-elements.ts:473](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L473)*
-
 **Returns:** *boolean*
 
 ___
@@ -1190,8 +1026,6 @@ ___
 ▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
-
-*Defined in [card-elements.ts:493](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L493)*
 
 **Parameters:**
 
@@ -1209,8 +1043,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
 
-*Defined in [card-elements.ts:443](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L443)*
-
 **Returns:** *boolean*
 
 ___
@@ -1221,8 +1053,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDisplayed](cardelement.md#protected-isdisplayed)*
 
-*Defined in [card-elements.ts:229](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L229)*
-
 **Returns:** *boolean*
 
 ___
@@ -1232,8 +1062,6 @@ ___
 ▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
-
-*Defined in [card-elements.ts:449](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L449)*
 
 **Parameters:**
 
@@ -1251,8 +1079,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
 
-*Defined in [card-elements.ts:497](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L497)*
-
 **Returns:** *boolean*
 
 ___
@@ -1262,8 +1088,6 @@ ___
 ▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
-
-*Defined in [card-elements.ts:453](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L453)*
 
 **Parameters:**
 
@@ -1281,8 +1105,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
 
-*Defined in [card-elements.ts:481](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L481)*
-
 **Parameters:**
 
 Name | Type |
@@ -1298,8 +1120,6 @@ ___
 ▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
-
-*Defined in [card-elements.ts:485](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L485)*
 
 **Parameters:**
 
@@ -1317,8 +1137,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
 
-*Defined in [card-elements.ts:489](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L489)*
-
 **Parameters:**
 
 Name | Type |
@@ -1335,8 +1153,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
 
-*Defined in [card-elements.ts:235](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L235)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1348,8 +1164,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[parse](cardelement.md#parse)*
 
 *Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
-
-*Defined in [card-elements.ts:313](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L313)*
 
 **Parameters:**
 
@@ -1368,8 +1182,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [serialization.ts:738](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L738)*
-
 **Parameters:**
 
 Name | Type |
@@ -1385,8 +1197,6 @@ ___
 ▸ **preProcessPropertyValue**(`property`: [PropertyDefinition](propertydefinition.md), `propertyValue?`: any): *any*
 
 *Inherited from [CardObject](cardobject.md).[preProcessPropertyValue](cardobject.md#preprocesspropertyvalue)*
-
-*Defined in [card-object.ts:70](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L70)*
 
 **Parameters:**
 
@@ -1405,8 +1215,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
 
-*Defined in [card-elements.ts:404](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L404)*
-
 **Returns:** *boolean*
 
 ___
@@ -1416,8 +1224,6 @@ ___
 ▸ **render**(): *HTMLElement | undefined*
 
 *Inherited from [CardElement](cardelement.md).[render](cardelement.md#render)*
-
-*Defined in [card-elements.ts:412](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L412)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -1429,8 +1235,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -1440,8 +1244,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -1460,8 +1262,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
 
-*Defined in [card-elements.ts:287](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L287)*
-
 **Parameters:**
 
 Name | Type |
@@ -1477,8 +1277,6 @@ ___
 ▸ **setParent**(`value`: [CardObject](cardobject.md) | undefined): *void*
 
 *Inherited from [CardObject](cardobject.md).[setParent](cardobject.md#setparent)*
-
-*Defined in [card-object.ts:88](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L88)*
 
 **Parameters:**
 
@@ -1496,8 +1294,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setShouldFallback](cardobject.md#setshouldfallback)*
 
-*Defined in [card-object.ts:92](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L92)*
-
 **Parameters:**
 
 Name | Type |
@@ -1513,8 +1309,6 @@ ___
 ▸ **setValue**(`property`: [PropertyDefinition](propertydefinition.md), `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
-
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
 
 **Parameters:**
 
@@ -1533,8 +1327,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[shouldFallback](cardobject.md#shouldfallback)*
 
-*Defined in [card-object.ts:96](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L96)*
-
 **Returns:** *boolean*
 
 ___
@@ -1546,8 +1338,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[shouldSerialize](cardelement.md#protected-shouldserialize)*
 
 *Overrides [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
-
-*Defined in [card-elements.ts:291](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L291)*
 
 **Parameters:**
 
@@ -1567,8 +1357,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
 
-*Defined in [card-elements.ts:317](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L317)*
-
 **Parameters:**
 
 Name | Type |
@@ -1584,8 +1372,6 @@ ___
 ▸ **truncateOverflow**(`maxHeight`: number): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
-
-*Defined in [card-elements.ts:263](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L263)*
 
 **Parameters:**
 
@@ -1603,8 +1389,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
 
-*Defined in [card-elements.ts:273](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L273)*
-
 **Returns:** *void*
 
 ___
@@ -1614,8 +1398,6 @@ ___
 ▸ **updateLayout**(`processChildren`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
-
-*Defined in [card-elements.ts:434](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L434)*
 
 **Parameters:**
 
@@ -1632,7 +1414,5 @@ ___
 ▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
 
 *Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
-
-*Defined in [card-object.ts:128](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L128)*
 
 **Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/factsetconfig.md
+++ b/source/nodejs/adaptivecards/docs/classes/factsetconfig.md
@@ -24,8 +24,6 @@
 
 \+ **new FactSetConfig**(`obj?`: any): *[FactSetConfig](factsetconfig.md)*
 
-*Defined in [host-config.ts:157](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L157)*
-
 **Parameters:**
 
 Name | Type |
@@ -40,20 +38,14 @@ Name | Type |
 
 • **spacing**: *number* = 10
 
-*Defined in [host-config.ts:157](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L157)*
-
 ___
 
 ###  title
 
 • **title**: *[FactTitleDefinition](facttitledefinition.md)* = new FactTitleDefinition()
 
-*Defined in [host-config.ts:155](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L155)*
-
 ___
 
 ###  value
 
 • **value**: *[FactTextDefinition](facttextdefinition.md)* = new FactTextDefinition()
-
-*Defined in [host-config.ts:156](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L156)*

--- a/source/nodejs/adaptivecards/docs/classes/facttextdefinition.md
+++ b/source/nodejs/adaptivecards/docs/classes/facttextdefinition.md
@@ -33,8 +33,6 @@
 
 \+ **new FactTextDefinition**(`obj?`: any): *[FactTextDefinition](facttextdefinition.md)*
 
-*Defined in [host-config.ts:109](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L109)*
-
 **Parameters:**
 
 Name | Type |
@@ -49,15 +47,11 @@ Name | Type |
 
 • **color**: *[TextColor](../enums/textcolor.md)* = Enums.TextColor.Default
 
-*Defined in [host-config.ts:106](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L106)*
-
 ___
 
 ###  isSubtle
 
 • **isSubtle**: *boolean* = false
-
-*Defined in [host-config.ts:107](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L107)*
 
 ___
 
@@ -65,15 +59,11 @@ ___
 
 • **size**: *[TextSize](../enums/textsize.md)* = Enums.TextSize.Default
 
-*Defined in [host-config.ts:105](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L105)*
-
 ___
 
 ###  weight
 
 • **weight**: *[TextWeight](../enums/textweight.md)* = Enums.TextWeight.Default
-
-*Defined in [host-config.ts:108](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L108)*
 
 ___
 
@@ -81,15 +71,11 @@ ___
 
 • **wrap**: *boolean* = true
 
-*Defined in [host-config.ts:109](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L109)*
-
 ## Methods
 
 ###  getDefaultWeight
 
 ▸ **getDefaultWeight**(): *[TextWeight](../enums/textweight.md)*
-
-*Defined in [host-config.ts:121](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L121)*
 
 **Returns:** *[TextWeight](../enums/textweight.md)*
 
@@ -98,7 +84,5 @@ ___
 ###  toJSON
 
 ▸ **toJSON**(): *any*
-
-*Defined in [host-config.ts:125](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L125)*
 
 **Returns:** *any*

--- a/source/nodejs/adaptivecards/docs/classes/facttitledefinition.md
+++ b/source/nodejs/adaptivecards/docs/classes/facttitledefinition.md
@@ -36,8 +36,6 @@
 
 *Overrides [FactTextDefinition](facttextdefinition.md).[constructor](facttextdefinition.md#constructor)*
 
-*Defined in [host-config.ts:138](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L138)*
-
 **Parameters:**
 
 Name | Type |
@@ -54,8 +52,6 @@ Name | Type |
 
 *Inherited from [FactTextDefinition](facttextdefinition.md).[color](facttextdefinition.md#color)*
 
-*Defined in [host-config.ts:106](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L106)*
-
 ___
 
 ###  isSubtle
@@ -64,15 +60,11 @@ ___
 
 *Inherited from [FactTextDefinition](facttextdefinition.md).[isSubtle](facttextdefinition.md#issubtle)*
 
-*Defined in [host-config.ts:107](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L107)*
-
 ___
 
 ### `Optional` maxWidth
 
 • **maxWidth**? : *undefined | number* = 150
-
-*Defined in [host-config.ts:137](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L137)*
 
 ___
 
@@ -82,8 +74,6 @@ ___
 
 *Inherited from [FactTextDefinition](facttextdefinition.md).[size](facttextdefinition.md#size)*
 
-*Defined in [host-config.ts:105](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L105)*
-
 ___
 
 ###  weight
@@ -91,8 +81,6 @@ ___
 • **weight**: *[TextWeight](../enums/textweight.md)* = Enums.TextWeight.Bolder
 
 *Overrides [FactTextDefinition](facttextdefinition.md).[weight](facttextdefinition.md#weight)*
-
-*Defined in [host-config.ts:138](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L138)*
 
 ___
 
@@ -102,8 +90,6 @@ ___
 
 *Inherited from [FactTextDefinition](facttextdefinition.md).[wrap](facttextdefinition.md#wrap)*
 
-*Defined in [host-config.ts:109](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L109)*
-
 ## Methods
 
 ###  getDefaultWeight
@@ -111,8 +97,6 @@ ___
 ▸ **getDefaultWeight**(): *[TextWeight](../enums/textweight.md)*
 
 *Overrides [FactTextDefinition](facttextdefinition.md).[getDefaultWeight](facttextdefinition.md#getdefaultweight)*
-
-*Defined in [host-config.ts:149](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L149)*
 
 **Returns:** *[TextWeight](../enums/textweight.md)*
 
@@ -123,7 +107,5 @@ ___
 ▸ **toJSON**(): *any*
 
 *Inherited from [FactTextDefinition](facttextdefinition.md).[toJSON](facttextdefinition.md#tojson)*
-
-*Defined in [host-config.ts:125](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L125)*
 
 **Returns:** *any*

--- a/source/nodejs/adaptivecards/docs/classes/fonttypedefinition.md
+++ b/source/nodejs/adaptivecards/docs/classes/fonttypedefinition.md
@@ -32,8 +32,6 @@
 
 \+ **new FontTypeDefinition**(`fontFamily?`: undefined | string): *[FontTypeDefinition](fonttypedefinition.md)*
 
-*Defined in [host-config.ts:438](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L438)*
-
 **Parameters:**
 
 Name | Type |
@@ -48,23 +46,17 @@ Name | Type |
 
 • **fontFamily**? : *undefined | string* = "Segoe UI,Segoe,Segoe WP,Helvetica Neue,Helvetica,sans-serif"
 
-*Defined in [host-config.ts:424](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L424)*
-
 ___
 
 ### `Static` monospace
 
 ▪ **monospace**: *[FontTypeDefinition](fonttypedefinition.md)‹›* = new FontTypeDefinition("'Courier New', Courier, monospace")
 
-*Defined in [host-config.ts:422](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L422)*
-
 ## Methods
 
 ###  parse
 
 ▸ **parse**(`obj?`: any): *void*
-
-*Defined in [host-config.ts:446](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L446)*
 
 **Parameters:**
 
@@ -80,37 +72,25 @@ Name | Type |
 
 ### ▪ **fontSizes**: *object*
 
-*Defined in [host-config.ts:426](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L426)*
-
 ###  default
 
 • **default**: *number* = 14
-
-*Defined in [host-config.ts:428](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L428)*
 
 ###  extraLarge
 
 • **extraLarge**: *number* = 26
 
-*Defined in [host-config.ts:431](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L431)*
-
 ###  large
 
 • **large**: *number* = 21
-
-*Defined in [host-config.ts:430](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L430)*
 
 ###  medium
 
 • **medium**: *number* = 17
 
-*Defined in [host-config.ts:429](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L429)*
-
 ###  small
 
 • **small**: *number* = 12
-
-*Defined in [host-config.ts:427](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L427)*
 
 ___
 
@@ -118,22 +98,14 @@ ___
 
 ### ▪ **fontWeights**: *object*
 
-*Defined in [host-config.ts:434](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L434)*
-
 ###  bolder
 
 • **bolder**: *number* = 600
-
-*Defined in [host-config.ts:437](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L437)*
 
 ###  default
 
 • **default**: *number* = 400
 
-*Defined in [host-config.ts:436](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L436)*
-
 ###  lighter
 
 • **lighter**: *number* = 200
-
-*Defined in [host-config.ts:435](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L435)*

--- a/source/nodejs/adaptivecards/docs/classes/fonttypeset.md
+++ b/source/nodejs/adaptivecards/docs/classes/fonttypeset.md
@@ -27,8 +27,6 @@
 
 \+ **new FontTypeSet**(`obj?`: any): *[FontTypeSet](fonttypeset.md)*
 
-*Defined in [host-config.ts:465](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L465)*
-
 **Parameters:**
 
 Name | Type |
@@ -43,23 +41,17 @@ Name | Type |
 
 • **default**: *[FontTypeDefinition](fonttypedefinition.md)*
 
-*Defined in [host-config.ts:464](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L464)*
-
 ___
 
 ###  monospace
 
 • **monospace**: *[FontTypeDefinition](fonttypedefinition.md)*
 
-*Defined in [host-config.ts:465](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L465)*
-
 ## Methods
 
 ###  getStyleDefinition
 
 ▸ **getStyleDefinition**(`style`: [FontType](../enums/fonttype.md) | undefined): *[FontTypeDefinition](fonttypedefinition.md)*
-
-*Defined in [host-config.ts:477](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L477)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/docs/classes/globalregistry.md
+++ b/source/nodejs/adaptivecards/docs/classes/globalregistry.md
@@ -25,23 +25,17 @@
 
 ▪ **actions**: *[CardObjectRegistry](cardobjectregistry.md)‹[Action](action.md)‹››* = new CardObjectRegistry<Action>()
 
-*Defined in [card-elements.ts:6272](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6272)*
-
 ___
 
 ### `Static` elements
 
 ▪ **elements**: *[CardObjectRegistry](cardobjectregistry.md)‹[CardElement](cardelement.md)‹››* = new CardObjectRegistry<CardElement>()
 
-*Defined in [card-elements.ts:6271](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6271)*
-
 ## Methods
 
 ### `Static` populateWithDefaultActions
 
 ▸ **populateWithDefaultActions**(`registry`: [CardObjectRegistry](cardobjectregistry.md)‹[Action](action.md)›): *void*
-
-*Defined in [card-elements.ts:6262](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6262)*
 
 **Parameters:**
 
@@ -57,8 +51,6 @@ ___
 
 ▸ **populateWithDefaultElements**(`registry`: [CardObjectRegistry](cardobjectregistry.md)‹[CardElement](cardelement.md)›): *void*
 
-*Defined in [card-elements.ts:6241](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6241)*
-
 **Parameters:**
 
 Name | Type |
@@ -72,7 +64,5 @@ ___
 ### `Static` reset
 
 ▸ **reset**(): *void*
-
-*Defined in [card-elements.ts:6274](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6274)*
 
 **Returns:** *void*

--- a/source/nodejs/adaptivecards/docs/classes/globalsettings.md
+++ b/source/nodejs/adaptivecards/docs/classes/globalsettings.md
@@ -27,15 +27,11 @@
 
 ▪ **allowMarkForTextHighlighting**: *boolean* = false
 
-*Defined in [shared.ts:9](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L9)*
-
 ___
 
 ### `Static` allowPreProcessingPropertyValues
 
 ▪ **allowPreProcessingPropertyValues**: *boolean* = false
-
-*Defined in [shared.ts:14](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L14)*
 
 ___
 
@@ -43,15 +39,11 @@ ___
 
 ▪ **alwaysBleedSeparators**: *boolean* = false
 
-*Defined in [shared.ts:10](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L10)*
-
 ___
 
 ### `Static` displayInputValidationErrors
 
 ▪ **displayInputValidationErrors**: *boolean* = true
-
-*Defined in [shared.ts:13](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L13)*
 
 ___
 
@@ -59,15 +51,11 @@ ___
 
 ▪ **enableFullJsonRoundTrip**: *boolean* = false
 
-*Defined in [shared.ts:11](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L11)*
-
 ___
 
 ### `Static` setTabIndexAtCardRoot
 
 ▪ **setTabIndexAtCardRoot**: *boolean* = true
-
-*Defined in [shared.ts:15](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L15)*
 
 ___
 
@@ -75,15 +63,11 @@ ___
 
 ▪ **useAdvancedCardBottomTruncation**: *boolean* = false
 
-*Defined in [shared.ts:7](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L7)*
-
 ___
 
 ### `Static` useAdvancedTextBlockTruncation
 
 ▪ **useAdvancedTextBlockTruncation**: *boolean* = true
-
-*Defined in [shared.ts:6](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L6)*
 
 ___
 
@@ -91,12 +75,8 @@ ___
 
 ▪ **useBuiltInInputValidation**: *boolean* = true
 
-*Defined in [shared.ts:12](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L12)*
-
 ___
 
 ### `Static` useMarkdownInRadioButtonAndCheckbox
 
 ▪ **useMarkdownInRadioButtonAndCheckbox**: *boolean* = true
-
-*Defined in [shared.ts:8](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L8)*

--- a/source/nodejs/adaptivecards/docs/classes/hostconfig.md
+++ b/source/nodejs/adaptivecards/docs/classes/hostconfig.md
@@ -54,8 +54,6 @@
 
 \+ **new HostConfig**(`obj?`: any): *[HostConfig](hostconfig.md)*
 
-*Defined in [host-config.ts:526](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L526)*
-
 **Parameters:**
 
 Name | Type |
@@ -70,15 +68,11 @@ Name | Type |
 
 • **actions**: *[ActionsConfig](actionsconfig.md)* = new ActionsConfig()
 
-*Defined in [host-config.ts:519](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L519)*
-
 ___
 
 ###  adaptiveCard
 
 • **adaptiveCard**: *[AdaptiveCardConfig](adaptivecardconfig.md)* = new AdaptiveCardConfig()
-
-*Defined in [host-config.ts:520](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L520)*
 
 ___
 
@@ -86,15 +80,11 @@ ___
 
 • **alwaysAllowBleed**: *boolean* = false
 
-*Defined in [host-config.ts:526](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L526)*
-
 ___
 
 ###  choiceSetInputValueSeparator
 
 • **choiceSetInputValueSeparator**: *string* = ","
-
-*Defined in [host-config.ts:493](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L493)*
 
 ___
 
@@ -102,15 +92,11 @@ ___
 
 • **containerStyles**: *[ContainerStyleSet](containerstyleset.md)* = new ContainerStyleSet()
 
-*Defined in [host-config.ts:518](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L518)*
-
 ___
 
 ### `Optional` cssClassNamePrefix
 
 • **cssClassNamePrefix**? : *undefined | string*
-
-*Defined in [host-config.ts:525](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L525)*
 
 ___
 
@@ -118,15 +104,11 @@ ___
 
 • **factSet**: *[FactSetConfig](factsetconfig.md)* = new FactSetConfig()
 
-*Defined in [host-config.ts:523](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L523)*
-
 ___
 
 ### `Optional` fontTypes
 
 • **fontTypes**? : *[FontTypeSet](fonttypeset.md)*
-
-*Defined in [host-config.ts:496](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L496)*
 
 ___
 
@@ -134,15 +116,11 @@ ___
 
 • **hostCapabilities**: *HostCapabilities‹›* = new HostCapabilities()
 
-*Defined in [host-config.ts:489](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L489)*
-
 ___
 
 ###  imageSet
 
 • **imageSet**: *[ImageSetConfig](imagesetconfig.md)* = new ImageSetConfig()
-
-*Defined in [host-config.ts:521](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L521)*
 
 ___
 
@@ -150,15 +128,11 @@ ___
 
 • **lineHeights**? : *[ILineHeightDefinitions](../interfaces/ilineheightdefinitions.md)*
 
-*Defined in [host-config.ts:495](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L495)*
-
 ___
 
 ###  media
 
 • **media**: *[MediaConfig](mediaconfig.md)* = new MediaConfig()
-
-*Defined in [host-config.ts:522](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L522)*
 
 ___
 
@@ -166,21 +140,15 @@ ___
 
 • **supportsInteractivity**: *boolean* = true
 
-*Defined in [host-config.ts:494](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L494)*
-
 ## Accessors
 
 ###  fontFamily
 
 • **get fontFamily**(): *string | undefined*
 
-*Defined in [host-config.ts:634](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L634)*
-
 **Returns:** *string | undefined*
 
 • **set fontFamily**(`value`: string | undefined): *void*
-
-*Defined in [host-config.ts:638](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L638)*
 
 **Parameters:**
 
@@ -196,8 +164,6 @@ ___
 
 • **get fontSizes**(): *[IFontSizeDefinitions](../interfaces/ifontsizedefinitions.md)*
 
-*Defined in [host-config.ts:642](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L642)*
-
 **Returns:** *[IFontSizeDefinitions](../interfaces/ifontsizedefinitions.md)*
 
 ___
@@ -206,8 +172,6 @@ ___
 
 • **get fontWeights**(): *[IFontWeightDefinitions](../interfaces/ifontweightdefinitions.md)*
 
-*Defined in [host-config.ts:646](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L646)*
-
 **Returns:** *[IFontWeightDefinitions](../interfaces/ifontweightdefinitions.md)*
 
 ## Methods
@@ -215,8 +179,6 @@ ___
 ###  getEffectiveSpacing
 
 ▸ **getEffectiveSpacing**(`spacing`: [Spacing](../enums/spacing.md)): *number*
-
-*Defined in [host-config.ts:591](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L591)*
 
 **Parameters:**
 
@@ -232,8 +194,6 @@ ___
 
 ▸ **getFontTypeDefinition**(`style?`: Enums.FontType): *[FontTypeDefinition](fonttypedefinition.md)*
 
-*Defined in [host-config.ts:582](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L582)*
-
 **Parameters:**
 
 Name | Type |
@@ -247,8 +207,6 @@ ___
 ###  makeCssClassName
 
 ▸ **makeCssClassName**(...`classNames`: string[]): *string*
-
-*Defined in [host-config.ts:628](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L628)*
 
 **Parameters:**
 
@@ -264,8 +222,6 @@ ___
 
 ▸ **makeCssClassNames**(...`classNames`: string[]): *string[]*
 
-*Defined in [host-config.ts:618](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L618)*
-
 **Parameters:**
 
 Name | Type |
@@ -279,8 +235,6 @@ ___
 ###  paddingDefinitionToSpacingDefinition
 
 ▸ **paddingDefinitionToSpacingDefinition**(`paddingDefinition`: [PaddingDefinition](paddingdefinition.md)): *[SpacingDefinition](spacingdefinition.md)*
-
-*Defined in [host-config.ts:610](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L610)*
 
 **Parameters:**
 
@@ -296,25 +250,17 @@ Name | Type |
 
 ### ▪ **imageSizes**: *object*
 
-*Defined in [host-config.ts:512](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L512)*
-
 ###  large
 
 • **large**: *number* = 160
-
-*Defined in [host-config.ts:515](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L515)*
 
 ###  medium
 
 • **medium**: *number* = 80
 
-*Defined in [host-config.ts:514](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L514)*
-
 ###  small
 
 • **small**: *number* = 40
-
-*Defined in [host-config.ts:513](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L513)*
 
 ___
 
@@ -322,19 +268,13 @@ ___
 
 ### ▪ **separator**: *object*
 
-*Defined in [host-config.ts:507](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L507)*
-
 ###  lineColor
 
 • **lineColor**: *string* = "#EEEEEE"
 
-*Defined in [host-config.ts:509](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L509)*
-
 ###  lineThickness
 
 • **lineThickness**: *number* = 1
-
-*Defined in [host-config.ts:508](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L508)*
 
 ___
 
@@ -342,40 +282,26 @@ ___
 
 ### ▪ **spacing**: *object*
 
-*Defined in [host-config.ts:498](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L498)*
-
 ###  default
 
 • **default**: *number* = 8
-
-*Defined in [host-config.ts:500](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L500)*
 
 ###  extraLarge
 
 • **extraLarge**: *number* = 40
 
-*Defined in [host-config.ts:503](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L503)*
-
 ###  large
 
 • **large**: *number* = 30
-
-*Defined in [host-config.ts:502](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L502)*
 
 ###  medium
 
 • **medium**: *number* = 20
 
-*Defined in [host-config.ts:501](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L501)*
-
 ###  padding
 
 • **padding**: *number* = 15
 
-*Defined in [host-config.ts:504](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L504)*
-
 ###  small
 
 • **small**: *number* = 3
-
-*Defined in [host-config.ts:499](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L499)*

--- a/source/nodejs/adaptivecards/docs/classes/httpaction.md
+++ b/source/nodejs/adaptivecards/docs/classes/httpaction.md
@@ -58,6 +58,7 @@
 * [execute](httpaction.md#execute)
 * [getActionById](httpaction.md#getactionbyid)
 * [getAllInputs](httpaction.md#getallinputs)
+* [getAriaRole](httpaction.md#getariarole)
 * [getCustomProperty](httpaction.md#getcustomproperty)
 * [getHref](httpaction.md#gethref)
 * [getJsonTypeName](httpaction.md#getjsontypename)
@@ -101,8 +102,6 @@
 
 *Inherited from [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 **Returns:** *[HttpAction](httpaction.md)*
 
 ## Properties
@@ -113,8 +112,6 @@
 
 *Inherited from [CardObject](cardobject.md).[_parent](cardobject.md#protected-optional-_parent)*
 
-*Defined in [card-object.ts:61](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L61)*
-
 ___
 
 ### `Protected` `Optional` _renderedElement
@@ -123,15 +120,11 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[_renderedElement](cardobject.md#protected-optional-_renderedelement)*
 
-*Defined in [card-object.ts:62](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L62)*
-
 ___
 
 ###  headers
 
 • **headers**: *[HttpHeader](httpheader.md)[]*
-
-*Defined in [card-elements.ts:3850](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3850)*
 
 ___
 
@@ -141,8 +134,6 @@ ___
 
 *Inherited from [Action](action.md).[iconUrl](action.md#optional-iconurl)*
 
-*Defined in [card-elements.ts:3359](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3359)*
-
 ___
 
 ### `Optional` id
@@ -150,8 +141,6 @@ ___
 • **id**? : *undefined | string*
 
 *Inherited from [CardObject](cardobject.md).[id](cardobject.md#optional-id)*
-
-*Defined in [card-object.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L50)*
 
 ___
 
@@ -161,15 +150,11 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 ___
 
 ### `Optional` method
 
 • **method**? : *undefined | string*
-
-*Defined in [card-elements.ts:3847](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3847)*
 
 ___
 
@@ -178,8 +163,6 @@ ___
 • **onExecute**: *function*
 
 *Inherited from [Action](action.md).[onExecute](action.md#onexecute)*
-
-*Defined in [card-elements.ts:3400](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3400)*
 
 #### Type declaration:
 
@@ -199,8 +182,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[onPreProcessPropertyValue](cardobject.md#optional-onpreprocesspropertyvalue)*
 
-*Defined in [card-object.ts:64](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L64)*
-
 ___
 
 ###  style
@@ -208,8 +189,6 @@ ___
 • **style**: *string* = Enums.ActionStyle.Default
 
 *Inherited from [Action](action.md).[style](action.md#style)*
-
-*Defined in [card-elements.ts:3362](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3362)*
 
 ___
 
@@ -219,15 +198,11 @@ ___
 
 *Inherited from [Action](action.md).[title](action.md#optional-title)*
 
-*Defined in [card-elements.ts:3356](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3356)*
-
 ___
 
 ### `Static` JsonTypeName
 
 ▪ **JsonTypeName**: *"Action.Http"* = "Action.Http"
-
-*Defined in [card-elements.ts:3859](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3859)*
 
 ___
 
@@ -235,15 +210,11 @@ ___
 
 ▪ **bodyProperty**: *StringWithSubstitutionProperty‹›* = new StringWithSubstitutionProperty(Versions.v1_0, "body")
 
-*Defined in [card-elements.ts:3830](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3830)*
-
 ___
 
 ### `Static` headersProperty
 
 ▪ **headersProperty**: *[SerializableObjectCollectionProperty](serializableobjectcollectionproperty.md)‹›* = new SerializableObjectCollectionProperty(Versions.v1_0, "headers", HttpHeader)
-
-*Defined in [card-elements.ts:3832](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3832)*
 
 ___
 
@@ -253,8 +224,6 @@ ___
 
 *Inherited from [Action](action.md).[iconUrlProperty](action.md#static-iconurlproperty)*
 
-*Defined in [card-elements.ts:3342](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3342)*
-
 ___
 
 ### `Static` idProperty
@@ -262,8 +231,6 @@ ___
 ▪ **idProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "id")
 
 *Inherited from [CardObject](cardobject.md).[idProperty](cardobject.md#static-idproperty)*
-
-*Defined in [card-object.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L39)*
 
 ___
 
@@ -273,15 +240,11 @@ ___
 
 *Inherited from [Action](action.md).[ignoreInputValidationProperty](action.md#static-ignoreinputvalidationproperty)*
 
-*Defined in [card-elements.ts:3353](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3353)*
-
 ___
 
 ### `Static` methodProperty
 
 ▪ **methodProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "method")
-
-*Defined in [card-elements.ts:3831](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3831)*
 
 ___
 
@@ -290,8 +253,6 @@ ___
 ▪ **onRegisterCustomProperties**? : *undefined | function*
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
-
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
 
 ___
 
@@ -303,8 +264,6 @@ ___
         HostCapabilities)
 
 *Inherited from [CardObject](cardobject.md).[requiresProperty](cardobject.md#static-requiresproperty)*
-
-*Defined in [card-object.ts:40](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L40)*
 
 ___
 
@@ -322,8 +281,6 @@ ___
 
 *Inherited from [Action](action.md).[styleProperty](action.md#static-styleproperty)*
 
-*Defined in [card-elements.ts:3343](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3343)*
-
 ___
 
 ### `Static` titleProperty
@@ -331,8 +288,6 @@ ___
 ▪ **titleProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "title")
 
 *Inherited from [Action](action.md).[titleProperty](action.md#static-titleproperty)*
-
-*Defined in [card-elements.ts:3341](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3341)*
 
 ___
 
@@ -350,15 +305,11 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[typeNameProperty](cardobject.md#static-typenameproperty)*
 
-*Defined in [card-object.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L30)*
-
 ___
 
 ### `Static` urlProperty
 
 ▪ **urlProperty**: *StringWithSubstitutionProperty‹›* = new StringWithSubstitutionProperty(Versions.v1_0, "url")
-
-*Defined in [card-elements.ts:3829](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3829)*
 
 ## Accessors
 
@@ -366,13 +317,9 @@ ___
 
 • **get body**(): *string | undefined*
 
-*Defined in [card-elements.ts:3935](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3935)*
-
 **Returns:** *string | undefined*
 
 • **set body**(`value`: string | undefined): *void*
-
-*Defined in [card-elements.ts:3939](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3939)*
 
 **Parameters:**
 
@@ -392,8 +339,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
 
-*Defined in [card-elements.ts:3551](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3551)*
-
 **Returns:** *[HostConfig](hostconfig.md)*
 
 ___
@@ -404,15 +349,11 @@ ___
 
 *Overrides [Action](action.md).[ignoreInputValidation](action.md#ignoreinputvalidation)*
 
-*Defined in [card-elements.ts:3919](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3919)*
-
 **Returns:** *boolean*
 
 • **set ignoreInputValidation**(`value`: boolean): *void*
 
 *Overrides [Action](action.md).[ignoreInputValidation](action.md#ignoreinputvalidation)*
-
-*Defined in [card-elements.ts:3923](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3923)*
 
 **Parameters:**
 
@@ -430,15 +371,11 @@ ___
 
 *Inherited from [Action](action.md).[isPrimary](action.md#isprimary)*
 
-*Defined in [card-elements.ts:3532](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3532)*
-
 **Returns:** *boolean*
 
 • **set isPrimary**(`value`: boolean): *void*
 
 *Inherited from [Action](action.md).[isPrimary](action.md#isprimary)*
-
-*Defined in [card-elements.ts:3536](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3536)*
 
 **Parameters:**
 
@@ -458,8 +395,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[parent](cardobject.md#parent)*
 
-*Defined in [card-elements.ts:3555](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3555)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -469,8 +404,6 @@ ___
 • **get renderedElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardObject](cardobject.md).[renderedElement](cardobject.md#renderedelement)*
-
-*Defined in [card-object.ts:140](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L140)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -482,8 +415,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requires](cardobject.md#requires)*
 
-*Defined in [card-object.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L53)*
-
 **Returns:** *HostCapabilities*
 
 ___
@@ -492,13 +423,9 @@ ___
 
 • **get url**(): *string | undefined*
 
-*Defined in [card-elements.ts:3927](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3927)*
-
 **Returns:** *string | undefined*
 
 • **set url**(`value`: string | undefined): *void*
-
-*Defined in [card-elements.ts:3931](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3931)*
 
 **Parameters:**
 
@@ -516,8 +443,6 @@ Name | Type |
 
 *Inherited from [Action](action.md).[addCssClasses](action.md#protected-addcssclasses)*
 
-*Defined in [card-elements.ts:3368](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3368)*
-
 **Parameters:**
 
 Name | Type |
@@ -534,8 +459,6 @@ ___
 
 *Inherited from [Action](action.md).[execute](action.md#execute)*
 
-*Defined in [card-elements.ts:3484](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3484)*
-
 **Returns:** *void*
 
 ___
@@ -545,8 +468,6 @@ ___
 ▸ **getActionById**(`id`: string): *[Action](action.md) | undefined*
 
 *Inherited from [Action](action.md).[getActionById](action.md#getactionbyid)*
-
-*Defined in [card-elements.ts:3520](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3520)*
 
 **Parameters:**
 
@@ -564,9 +485,17 @@ ___
 
 *Inherited from [Action](action.md).[getAllInputs](action.md#getallinputs)*
 
-*Defined in [card-elements.ts:3512](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3512)*
-
 **Returns:** *[Input](input.md)[]*
+
+___
+
+###  getAriaRole
+
+▸ **getAriaRole**(): *string*
+
+*Inherited from [Action](action.md).[getAriaRole](action.md#getariarole)*
+
+**Returns:** *string*
 
 ___
 
@@ -575,8 +504,6 @@ ___
 ▸ **getCustomProperty**(`name`: string): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
-
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
 
 **Parameters:**
 
@@ -594,8 +521,6 @@ ___
 
 *Inherited from [Action](action.md).[getHref](action.md#gethref)*
 
-*Defined in [card-elements.ts:3402](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3402)*
-
 **Returns:** *string | undefined*
 
 ___
@@ -605,8 +530,6 @@ ___
 ▸ **getJsonTypeName**(): *string*
 
 *Overrides [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
-
-*Defined in [card-elements.ts:3893](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3893)*
 
 **Returns:** *string*
 
@@ -618,8 +541,6 @@ ___
 
 *Inherited from [Action](action.md).[getReferencedInputs](action.md#getreferencedinputs)*
 
-*Defined in [card-elements.ts:3524](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3524)*
-
 **Returns:** *[Dictionary](../README.md#dictionary)‹[Input](input.md)› | undefined*
 
 ___
@@ -629,8 +550,6 @@ ___
 ▸ **getResourceInformation**(): *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
 *Inherited from [Action](action.md).[getResourceInformation](action.md#getresourceinformation)*
-
-*Defined in [card-elements.ts:3516](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3516)*
 
 **Returns:** *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
@@ -642,8 +561,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getRootObject](cardobject.md#getrootobject)*
 
-*Defined in [card-object.ts:100](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L100)*
-
 **Returns:** *[CardObject](cardobject.md)*
 
 ___
@@ -653,8 +570,6 @@ ___
 ▸ **getSchema**(): *[SerializableObjectSchema](serializableobjectschema.md)*
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
-
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
 
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
@@ -668,8 +583,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-object.ts:45](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L45)*
-
 **Returns:** *string*
 
 ___
@@ -679,8 +592,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -698,8 +609,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -709,8 +618,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -728,8 +635,6 @@ ___
 
 *Overrides [Action](action.md).[internalGetReferencedInputs](action.md#protected-internalgetreferencedinputs)*
 
-*Defined in [card-elements.ts:3861](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3861)*
-
 **Parameters:**
 
 Name | Type |
@@ -745,8 +650,6 @@ ___
 ▸ **internalParse**(`source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
-
-*Defined in [serialization.ts:789](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L789)*
 
 **Parameters:**
 
@@ -765,8 +668,6 @@ ___
 
 *Overrides [Action](action.md).[internalPrepareForExecution](action.md#protected-internalprepareforexecution)*
 
-*Defined in [card-elements.ts:3875](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3875)*
-
 **Parameters:**
 
 Name | Type |
@@ -782,8 +683,6 @@ ___
 ▸ **internalToJSON**(`target`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
-
-*Defined in [serialization.ts:821](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L821)*
 
 **Parameters:**
 
@@ -802,8 +701,6 @@ ___
 
 *Inherited from [Action](action.md).[internalValidateInputs](action.md#protected-internalvalidateinputs)*
 
-*Defined in [card-elements.ts:3380](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3380)*
-
 **Parameters:**
 
 Name | Type |
@@ -819,8 +716,6 @@ ___
 ▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
 
 *Overrides [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
-
-*Defined in [card-elements.ts:3897](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3897)*
 
 **Parameters:**
 
@@ -840,8 +735,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
 
-*Defined in [card-elements.ts:3410](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3410)*
-
 **Parameters:**
 
 Name | Type |
@@ -859,8 +752,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [card-elements.ts:3834](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3834)*
-
 **Parameters:**
 
 Name | Type |
@@ -876,8 +767,6 @@ ___
 ▸ **preProcessPropertyValue**(`property`: [PropertyDefinition](propertydefinition.md), `propertyValue?`: any): *any*
 
 *Inherited from [CardObject](cardobject.md).[preProcessPropertyValue](cardobject.md#preprocesspropertyvalue)*
-
-*Defined in [card-object.ts:70](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L70)*
 
 **Parameters:**
 
@@ -896,8 +785,6 @@ ___
 
 *Inherited from [Action](action.md).[prepareForExecution](action.md#prepareforexecution)*
 
-*Defined in [card-elements.ts:3492](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3492)*
-
 **Returns:** *boolean*
 
 ___
@@ -908,8 +795,6 @@ ___
 
 *Inherited from [Action](action.md).[remove](action.md#remove)*
 
-*Defined in [card-elements.ts:3504](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3504)*
-
 **Returns:** *boolean*
 
 ___
@@ -919,8 +804,6 @@ ___
 ▸ **render**(`baseCssClass`: string): *void*
 
 *Inherited from [Action](action.md).[render](action.md#render)*
-
-*Defined in [card-elements.ts:3418](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3418)*
 
 **Parameters:**
 
@@ -938,8 +821,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -949,8 +830,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -969,8 +848,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setParent](cardobject.md#setparent)*
 
-*Defined in [card-object.ts:88](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L88)*
-
 **Parameters:**
 
 Name | Type |
@@ -987,8 +864,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setShouldFallback](cardobject.md#setshouldfallback)*
 
-*Defined in [card-object.ts:92](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L92)*
-
 **Parameters:**
 
 Name | Type |
@@ -1004,8 +879,6 @@ ___
 ▸ **setValue**(`property`: [PropertyDefinition](propertydefinition.md), `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
-
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
 
 **Parameters:**
 
@@ -1024,8 +897,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[shouldFallback](cardobject.md#shouldfallback)*
 
-*Defined in [card-object.ts:96](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L96)*
-
 **Returns:** *boolean*
 
 ___
@@ -1037,8 +908,6 @@ ___
 *Inherited from [Action](action.md).[shouldSerialize](action.md#protected-shouldserialize)*
 
 *Overrides [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
-
-*Defined in [card-elements.ts:3396](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3396)*
 
 **Parameters:**
 
@@ -1058,8 +927,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
 
-*Defined in [card-elements.ts:3414](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3414)*
-
 **Parameters:**
 
 Name | Type |
@@ -1075,8 +942,6 @@ ___
 ▸ **updateActionButtonCssStyle**(`actionButtonElement`: HTMLElement): *void*
 
 *Inherited from [Action](action.md).[updateActionButtonCssStyle](action.md#updateactionbuttoncssstyle)*
-
-*Defined in [card-elements.ts:3406](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3406)*
 
 **Parameters:**
 
@@ -1094,8 +959,6 @@ ___
 
 *Inherited from [Action](action.md).[validateInputs](action.md#validateinputs)*
 
-*Defined in [card-elements.ts:3528](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3528)*
-
 **Returns:** *[Input](input.md)‹›[]*
 
 ___
@@ -1105,7 +968,5 @@ ___
 ▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
 
 *Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
-
-*Defined in [card-object.ts:128](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L128)*
 
 **Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/httpheader.md
+++ b/source/nodejs/adaptivecards/docs/classes/httpheader.md
@@ -54,8 +54,6 @@
 
 *Overrides [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [card-elements.ts:3798](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3798)*
-
 **Parameters:**
 
 Name | Type | Default |
@@ -73,23 +71,17 @@ Name | Type | Default |
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 ___
 
 ###  name
 
 • **name**: *string*
 
-*Defined in [card-elements.ts:3795](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3795)*
-
 ___
 
 ### `Static` nameProperty
 
 ▪ **nameProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "name")
-
-*Defined in [card-elements.ts:3787](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3787)*
 
 ___
 
@@ -99,15 +91,11 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
 
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
-
 ___
 
 ### `Static` valueProperty
 
 ▪ **valueProperty**: *StringWithSubstitutionProperty‹›* = new StringWithSubstitutionProperty(Versions.v1_0, "value")
-
-*Defined in [card-elements.ts:3788](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3788)*
 
 ## Accessors
 
@@ -115,13 +103,9 @@ ___
 
 • **get value**(): *string | undefined*
 
-*Defined in [card-elements.ts:3817](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3817)*
-
 **Returns:** *string | undefined*
 
 • **set value**(`newValue`: string | undefined): *void*
-
-*Defined in [card-elements.ts:3821](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3821)*
 
 **Parameters:**
 
@@ -139,8 +123,6 @@ Name | Type |
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
 
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
-
 **Parameters:**
 
 Name | Type |
@@ -154,8 +136,6 @@ ___
 ###  getReferencedInputs
 
 ▸ **getReferencedInputs**(`inputs`: [Input](input.md)[], `referencedInputs`: [Dictionary](../README.md#dictionary)‹[Input](input.md)›): *void*
-
-*Defined in [card-elements.ts:3809](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3809)*
 
 **Parameters:**
 
@@ -174,8 +154,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
 
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
-
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
 ___
@@ -186,8 +164,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-elements.ts:3790](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3790)*
-
 **Returns:** *string*
 
 ___
@@ -197,8 +173,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -216,8 +190,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -227,8 +199,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -245,8 +215,6 @@ ___
 ▸ **internalParse**(`source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
-
-*Defined in [serialization.ts:789](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L789)*
 
 **Parameters:**
 
@@ -265,8 +233,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
 
-*Defined in [serialization.ts:821](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L821)*
-
 **Parameters:**
 
 Name | Type |
@@ -283,8 +249,6 @@ ___
 ▸ **parse**(`source`: [PropertyBag](../README.md#propertybag), `context?`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
-
-*Defined in [serialization.ts:857](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L857)*
 
 **Parameters:**
 
@@ -303,8 +267,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [serialization.ts:738](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L738)*
-
 **Parameters:**
 
 Name | Type |
@@ -318,8 +280,6 @@ ___
 ###  prepareForExecution
 
 ▸ **prepareForExecution**(`inputs`: [Dictionary](../README.md#dictionary)‹[Input](input.md)›): *void*
-
-*Defined in [card-elements.ts:3813](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3813)*
 
 **Parameters:**
 
@@ -337,8 +297,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -348,8 +306,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -368,8 +324,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
 
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
-
 **Parameters:**
 
 Name | Type |
@@ -387,8 +341,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
 
-*Defined in [serialization.ts:839](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L839)*
-
 **Parameters:**
 
 Name | Type |
@@ -404,8 +356,6 @@ ___
 ▸ **toJSON**(`context?`: [BaseSerializationContext](baseserializationcontext.md)): *[PropertyBag](../README.md#propertybag) | undefined*
 
 *Inherited from [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
-
-*Defined in [serialization.ts:861](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L861)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/docs/classes/image.md
+++ b/source/nodejs/adaptivecards/docs/classes/image.md
@@ -151,8 +151,6 @@
 
 *Inherited from [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 **Returns:** *[Image](image.md)*
 
 ## Properties
@@ -163,8 +161,6 @@
 
 *Inherited from [CardObject](cardobject.md).[_parent](cardobject.md#protected-optional-_parent)*
 
-*Defined in [card-object.ts:61](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L61)*
-
 ___
 
 ### `Protected` `Optional` _renderedElement
@@ -173,23 +169,17 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[_renderedElement](cardobject.md#protected-optional-_renderedelement)*
 
-*Defined in [card-object.ts:62](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L62)*
-
 ___
 
 ### `Optional` altText
 
 • **altText**? : *undefined | string*
 
-*Defined in [card-elements.ts:1551](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1551)*
-
 ___
 
 ### `Optional` backgroundColor
 
 • **backgroundColor**? : *undefined | string*
-
-*Defined in [card-elements.ts:1554](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1554)*
 
 ___
 
@@ -199,8 +189,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#optional-customcssselector)*
 
-*Defined in [card-elements.ts:311](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L311)*
-
 ___
 
 ###  height
@@ -208,8 +196,6 @@ ___
 • **height**: *[CardElementHeight](../README.md#cardelementheight)*
 
 *Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
-
-*Defined in [card-elements.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L53)*
 
 ___
 
@@ -219,8 +205,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#horizontalalignment)*
 
-*Defined in [card-elements.ts:44](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L44)*
-
 ___
 
 ### `Optional` id
@@ -228,8 +212,6 @@ ___
 • **id**? : *undefined | string*
 
 *Inherited from [CardObject](cardobject.md).[id](cardobject.md#optional-id)*
-
-*Defined in [card-object.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L50)*
 
 ___
 
@@ -239,8 +221,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 ___
 
 ### `Optional` onPreProcessPropertyValue
@@ -249,15 +229,11 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[onPreProcessPropertyValue](cardobject.md#optional-onpreprocesspropertyvalue)*
 
-*Defined in [card-object.ts:64](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L64)*
-
 ___
 
 ### `Optional` pixelHeight
 
 • **pixelHeight**? : *undefined | number*
-
-*Defined in [card-elements.ts:1566](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1566)*
 
 ___
 
@@ -265,15 +241,11 @@ ___
 
 • **pixelWidth**? : *undefined | number*
 
-*Defined in [card-elements.ts:1563](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1563)*
-
 ___
 
 ### `Optional` selectAction
 
 • **selectAction**? : *[Action](action.md)*
-
-*Defined in [card-elements.ts:1569](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1569)*
 
 ___
 
@@ -283,15 +255,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
 
-*Defined in [card-elements.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L50)*
-
 ___
 
 ###  size
 
 • **size**: *[Size](../enums/size.md)* = Enums.Size.Auto
-
-*Defined in [card-elements.ts:1557](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1557)*
 
 ___
 
@@ -301,15 +269,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
 
-*Defined in [card-elements.ts:47](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L47)*
-
 ___
 
 ###  style
 
 • **style**: *[ImageStyle](../enums/imagestyle.md)* = Enums.ImageStyle.Default
-
-*Defined in [card-elements.ts:1560](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1560)*
 
 ___
 
@@ -317,23 +281,17 @@ ___
 
 • **url**? : *undefined | string*
 
-*Defined in [card-elements.ts:1548](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1548)*
-
 ___
 
 ### `Static` altTextProperty
 
 ▪ **altTextProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "altText")
 
-*Defined in [card-elements.ts:1525](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1525)*
-
 ___
 
 ### `Static` backgroundColorProperty
 
 ▪ **backgroundColorProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_1, "backgroundColor")
-
-*Defined in [card-elements.ts:1526](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1526)*
 
 ___
 
@@ -350,8 +308,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[heightProperty](cardelement.md#static-heightproperty)*
 
-*Defined in [card-elements.ts:24](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L24)*
-
 ___
 
 ### `Static` horizontalAlignmentProperty
@@ -364,8 +320,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignmentProperty](cardelement.md#static-horizontalalignmentproperty)*
 
-*Defined in [card-elements.ts:32](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L32)*
-
 ___
 
 ### `Static` idProperty
@@ -373,8 +327,6 @@ ___
 ▪ **idProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "id")
 
 *Inherited from [CardObject](cardobject.md).[idProperty](cardobject.md#static-idproperty)*
-
-*Defined in [card-object.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L39)*
 
 ___
 
@@ -384,8 +336,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisibleProperty](cardelement.md#static-isvisibleproperty)*
 
-*Defined in [card-elements.ts:22](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L22)*
-
 ___
 
 ### `Static` langProperty
@@ -393,8 +343,6 @@ ___
 ▪ **langProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_1, "lang", true, /^[a-z]{2,3}$/ig)
 
 *Inherited from [CardElement](cardelement.md).[langProperty](cardelement.md#static-langproperty)*
-
-*Defined in [card-elements.ts:21](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L21)*
 
 ___
 
@@ -404,23 +352,17 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
 
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
-
 ___
 
 ### `Static` pixelHeightProperty
 
 ▪ **pixelHeightProperty**: *ImageDimensionProperty‹›* = new ImageDimensionProperty(Versions.v1_1, "height", "pixelHeight")
 
-*Defined in [card-elements.ts:1538](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1538)*
-
 ___
 
 ### `Static` pixelWidthProperty
 
 ▪ **pixelWidthProperty**: *ImageDimensionProperty‹›* = new ImageDimensionProperty(Versions.v1_1, "width", "pixelWidth")
-
-*Defined in [card-elements.ts:1537](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1537)*
 
 ___
 
@@ -433,15 +375,11 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requiresProperty](cardobject.md#static-requiresproperty)*
 
-*Defined in [card-object.ts:40](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L40)*
-
 ___
 
 ### `Static` selectActionProperty
 
 ▪ **selectActionProperty**: *[ActionProperty](actionproperty.md)‹›* = new ActionProperty(Versions.v1_0, "selectAction", [ "Action.ShowCard" ])
-
-*Defined in [card-elements.ts:1539](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1539)*
 
 ___
 
@@ -450,8 +388,6 @@ ___
 ▪ **separatorProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_0, "separator", false)
 
 *Inherited from [CardElement](cardelement.md).[separatorProperty](cardelement.md#static-separatorproperty)*
-
-*Defined in [card-elements.ts:23](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L23)*
 
 ___
 
@@ -462,8 +398,6 @@ ___
         "size",
         Enums.Size,
         Enums.Size.Auto)
-
-*Defined in [card-elements.ts:1532](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1532)*
 
 ___
 
@@ -477,8 +411,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[spacingProperty](cardelement.md#static-spacingproperty)*
 
-*Defined in [card-elements.ts:37](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L37)*
-
 ___
 
 ### `Static` styleProperty
@@ -488,8 +420,6 @@ ___
         "style",
         Enums.ImageStyle,
         Enums.ImageStyle.Default)
-
-*Defined in [card-elements.ts:1527](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1527)*
 
 ___
 
@@ -507,15 +437,11 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[typeNameProperty](cardobject.md#static-typenameproperty)*
 
-*Defined in [card-object.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L30)*
-
 ___
 
 ### `Static` urlProperty
 
 ▪ **urlProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "url")
-
-*Defined in [card-elements.ts:1524](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1524)*
 
 ## Accessors
 
@@ -524,8 +450,6 @@ ___
 • **get allowCustomPadding**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
-
-*Defined in [card-elements.ts:299](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L299)*
 
 **Returns:** *boolean*
 
@@ -537,8 +461,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
 
-*Defined in [card-elements.ts:307](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L307)*
-
 **Returns:** *string*
 
 ___
@@ -548,8 +470,6 @@ ___
 • **get hasVisibleSeparator**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
-
-*Defined in [card-elements.ts:580](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L580)*
 
 **Returns:** *boolean*
 
@@ -563,8 +483,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
 
-*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
-
 **Returns:** *[HostConfig](hostconfig.md)*
 
 • **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
@@ -572,8 +490,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
-
-*Defined in [card-elements.ts:555](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L555)*
 
 **Parameters:**
 
@@ -591,8 +507,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
 
-*Defined in [card-elements.ts:559](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L559)*
-
 **Returns:** *number*
 
 ___
@@ -602,8 +516,6 @@ ___
 • **get isInline**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
-
-*Defined in [card-elements.ts:576](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L576)*
 
 **Returns:** *boolean*
 
@@ -615,8 +527,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
 
-*Defined in [card-elements.ts:568](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L568)*
-
 **Returns:** *boolean*
 
 ___
@@ -626,8 +536,6 @@ ___
 • **get isStandalone**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
-
-*Defined in [card-elements.ts:572](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L572)*
 
 **Returns:** *boolean*
 
@@ -639,15 +547,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
 
-*Defined in [card-elements.ts:77](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L77)*
-
 **Returns:** *boolean*
 
 • **set isVisible**(`value`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
-
-*Defined in [card-elements.ts:81](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L81)*
 
 **Parameters:**
 
@@ -665,15 +569,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
 
-*Defined in [card-elements.ts:56](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L56)*
-
 **Returns:** *string | undefined*
 
 • **set lang**(`value`: string | undefined): *void*
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
-
-*Defined in [card-elements.ts:72](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L72)*
 
 **Parameters:**
 
@@ -693,8 +593,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[parent](cardobject.md#parent)*
 
-*Defined in [card-elements.ts:593](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L593)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -704,8 +602,6 @@ ___
 • **get renderedElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardObject](cardobject.md).[renderedElement](cardobject.md#renderedelement)*
-
-*Defined in [card-object.ts:140](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L140)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -717,8 +613,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requires](cardobject.md#requires)*
 
-*Defined in [card-object.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L53)*
-
 **Returns:** *HostCapabilities*
 
 ___
@@ -728,8 +622,6 @@ ___
 • **get separatorElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
-
-*Defined in [card-elements.ts:589](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L589)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -741,8 +633,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
 
-*Defined in [card-elements.ts:303](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L303)*
-
 **Returns:** *[Orientation](../enums/orientation.md)*
 
 ___
@@ -753,8 +643,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
 
-*Defined in [card-elements.ts:1604](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1604)*
-
 **Returns:** *boolean*
 
 ## Methods
@@ -764,8 +652,6 @@ ___
 ▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
 
 *Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
-
-*Defined in [card-elements.ts:220](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L220)*
 
 **Parameters:**
 
@@ -783,8 +669,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
 
-*Defined in [card-elements.ts:239](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L239)*
-
 **Returns:** *void*
 
 ___
@@ -794,8 +678,6 @@ ___
 ▸ **asString**(): *string | undefined*
 
 *Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
-
-*Defined in [card-elements.ts:321](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L321)*
 
 **Returns:** *string | undefined*
 
@@ -807,8 +689,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
 
-*Defined in [card-elements.ts:205](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L205)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -818,8 +698,6 @@ ___
 ▸ **getActionAt**(`index`: number): *[Action](action.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
-
-*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
 
 **Parameters:**
 
@@ -837,8 +715,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
 
-*Defined in [card-elements.ts:1718](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1718)*
-
 **Parameters:**
 
 Name | Type |
@@ -855,8 +731,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
 
-*Defined in [card-elements.ts:396](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L396)*
-
 **Returns:** *number*
 
 ___
@@ -867,8 +741,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
 
-*Defined in [card-elements.ts:519](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L519)*
-
 **Returns:** *[Input](input.md)[]*
 
 ___
@@ -878,8 +750,6 @@ ___
 ▸ **getCustomProperty**(`name`: string): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
-
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
 
 **Parameters:**
 
@@ -897,8 +767,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
 
-*Defined in [card-elements.ts:275](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L275)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
 ___
@@ -908,8 +776,6 @@ ___
 ▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
 
 *Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
-
-*Defined in [card-elements.ts:535](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L535)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
@@ -921,8 +787,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
 
-*Defined in [card-elements.ts:329](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L329)*
-
 **Returns:** *string*
 
 ___
@@ -933,8 +797,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyleDefinition](cardelement.md#geteffectivestyledefinition)*
 
-*Defined in [card-elements.ts:337](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L337)*
-
 **Returns:** *[ContainerStyleDefinition](containerstyledefinition.md)*
 
 ___
@@ -944,8 +806,6 @@ ___
 ▸ **getElementById**(`id`: string): *[CardElement](cardelement.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
-
-*Defined in [card-elements.ts:527](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L527)*
 
 **Parameters:**
 
@@ -963,8 +823,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
 
-*Defined in [card-elements.ts:341](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L341)*
-
 **Returns:** *[ActionType](../README.md#actiontype)[]*
 
 ___
@@ -975,8 +833,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
 
-*Defined in [card-elements.ts:279](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L279)*
-
 **Returns:** *boolean*
 
 ___
@@ -986,8 +842,6 @@ ___
 ▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
-
-*Defined in [card-elements.ts:345](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L345)*
 
 **Parameters:**
 
@@ -1009,8 +863,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
 
-*Defined in [card-elements.ts:1714](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1714)*
-
 **Returns:** *string*
 
 ___
@@ -1020,8 +872,6 @@ ___
 ▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
-
-*Defined in [card-elements.ts:283](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L283)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md) | undefined*
 
@@ -1033,8 +883,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
 
-*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
-
 **Returns:** *[Container](container.md) | undefined*
 
 ___
@@ -1044,8 +892,6 @@ ___
 ▸ **getResourceInformation**(): *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
 *Overrides [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
-
-*Defined in [card-elements.ts:1728](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1728)*
 
 **Returns:** *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
@@ -1057,8 +903,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
 
-*Defined in [card-elements.ts:501](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L501)*
-
 **Returns:** *[CardElement](cardelement.md)*
 
 ___
@@ -1069,8 +913,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getRootObject](cardobject.md#getrootobject)*
 
-*Defined in [card-object.ts:100](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L100)*
-
 **Returns:** *[CardObject](cardobject.md)*
 
 ___
@@ -1080,8 +922,6 @@ ___
 ▸ **getSchema**(): *[SerializableObjectSchema](serializableobjectschema.md)*
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
-
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
 
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
@@ -1095,8 +935,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-object.ts:45](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L45)*
-
 **Returns:** *string*
 
 ___
@@ -1106,8 +944,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -1125,8 +961,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -1136,8 +970,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -1155,8 +987,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
 
-*Defined in [card-elements.ts:439](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L439)*
-
 **Parameters:**
 
 Name | Type |
@@ -1172,8 +1002,6 @@ ___
 ▸ **internalParse**(`source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
-
-*Defined in [serialization.ts:789](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L789)*
 
 **Parameters:**
 
@@ -1192,8 +1020,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
 
-*Defined in [card-elements.ts:1608](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1608)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1203,8 +1029,6 @@ ___
 ▸ **internalToJSON**(`target`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
-
-*Defined in [serialization.ts:821](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L821)*
 
 **Parameters:**
 
@@ -1223,8 +1047,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
 
-*Defined in [card-object.ts:110](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L110)*
-
 **Parameters:**
 
 Name | Type |
@@ -1241,8 +1063,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
 
-*Defined in [card-elements.ts:469](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L469)*
-
 **Returns:** *boolean*
 
 ___
@@ -1252,8 +1072,6 @@ ___
 ▸ **isAtTheVeryLeft**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
-
-*Defined in [card-elements.ts:457](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L457)*
 
 **Returns:** *boolean*
 
@@ -1265,8 +1083,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
 
-*Defined in [card-elements.ts:461](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L461)*
-
 **Returns:** *boolean*
 
 ___
@@ -1276,8 +1092,6 @@ ___
 ▸ **isAtTheVeryTop**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
-
-*Defined in [card-elements.ts:465](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L465)*
 
 **Returns:** *boolean*
 
@@ -1289,8 +1103,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
 
-*Defined in [card-elements.ts:325](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L325)*
-
 **Returns:** *boolean*
 
 ___
@@ -1300,8 +1112,6 @@ ___
 ▸ **isBleedingAtBottom**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
-
-*Defined in [card-elements.ts:477](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L477)*
 
 **Returns:** *boolean*
 
@@ -1313,8 +1123,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
 
-*Defined in [card-elements.ts:473](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L473)*
-
 **Returns:** *boolean*
 
 ___
@@ -1324,8 +1132,6 @@ ___
 ▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
-
-*Defined in [card-elements.ts:493](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L493)*
 
 **Parameters:**
 
@@ -1343,8 +1149,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
 
-*Defined in [card-elements.ts:443](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L443)*
-
 **Returns:** *boolean*
 
 ___
@@ -1355,8 +1159,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDisplayed](cardelement.md#protected-isdisplayed)*
 
-*Defined in [card-elements.ts:229](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L229)*
-
 **Returns:** *boolean*
 
 ___
@@ -1366,8 +1168,6 @@ ___
 ▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
-
-*Defined in [card-elements.ts:449](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L449)*
 
 **Parameters:**
 
@@ -1385,8 +1185,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
 
-*Defined in [card-elements.ts:497](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L497)*
-
 **Returns:** *boolean*
 
 ___
@@ -1396,8 +1194,6 @@ ___
 ▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
-
-*Defined in [card-elements.ts:453](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L453)*
 
 **Parameters:**
 
@@ -1415,8 +1211,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
 
-*Defined in [card-elements.ts:481](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L481)*
-
 **Parameters:**
 
 Name | Type |
@@ -1432,8 +1226,6 @@ ___
 ▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
-
-*Defined in [card-elements.ts:485](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L485)*
 
 **Parameters:**
 
@@ -1451,8 +1243,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
 
-*Defined in [card-elements.ts:489](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L489)*
-
 **Parameters:**
 
 Name | Type |
@@ -1469,8 +1259,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
 
-*Defined in [card-elements.ts:235](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L235)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1482,8 +1270,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[parse](cardelement.md#parse)*
 
 *Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
-
-*Defined in [card-elements.ts:313](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L313)*
 
 **Parameters:**
 
@@ -1502,8 +1288,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [card-elements.ts:1541](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1541)*
-
 **Parameters:**
 
 Name | Type |
@@ -1519,8 +1303,6 @@ ___
 ▸ **preProcessPropertyValue**(`property`: [PropertyDefinition](propertydefinition.md), `propertyValue?`: any): *any*
 
 *Inherited from [CardObject](cardobject.md).[preProcessPropertyValue](cardobject.md#preprocesspropertyvalue)*
-
-*Defined in [card-object.ts:70](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L70)*
 
 **Parameters:**
 
@@ -1539,8 +1321,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
 
-*Defined in [card-elements.ts:404](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L404)*
-
 **Returns:** *boolean*
 
 ___
@@ -1550,8 +1330,6 @@ ___
 ▸ **render**(): *HTMLElement | undefined*
 
 *Inherited from [CardElement](cardelement.md).[render](cardelement.md#render)*
-
-*Defined in [card-elements.ts:412](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L412)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -1563,8 +1341,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -1574,8 +1350,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -1594,8 +1368,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
 
-*Defined in [card-elements.ts:287](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L287)*
-
 **Parameters:**
 
 Name | Type |
@@ -1611,8 +1383,6 @@ ___
 ▸ **setParent**(`value`: [CardObject](cardobject.md) | undefined): *void*
 
 *Inherited from [CardObject](cardobject.md).[setParent](cardobject.md#setparent)*
-
-*Defined in [card-object.ts:88](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L88)*
 
 **Parameters:**
 
@@ -1630,8 +1400,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setShouldFallback](cardobject.md#setshouldfallback)*
 
-*Defined in [card-object.ts:92](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L92)*
-
 **Parameters:**
 
 Name | Type |
@@ -1647,8 +1415,6 @@ ___
 ▸ **setValue**(`property`: [PropertyDefinition](propertydefinition.md), `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
-
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
 
 **Parameters:**
 
@@ -1667,8 +1433,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[shouldFallback](cardobject.md#shouldfallback)*
 
-*Defined in [card-object.ts:96](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L96)*
-
 **Returns:** *boolean*
 
 ___
@@ -1680,8 +1444,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[shouldSerialize](cardelement.md#protected-shouldserialize)*
 
 *Overrides [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
-
-*Defined in [card-elements.ts:291](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L291)*
 
 **Parameters:**
 
@@ -1701,8 +1463,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
 
-*Defined in [card-elements.ts:317](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L317)*
-
 **Parameters:**
 
 Name | Type |
@@ -1718,8 +1478,6 @@ ___
 ▸ **truncateOverflow**(`maxHeight`: number): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
-
-*Defined in [card-elements.ts:263](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L263)*
 
 **Parameters:**
 
@@ -1737,8 +1495,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
 
-*Defined in [card-elements.ts:273](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L273)*
-
 **Returns:** *void*
 
 ___
@@ -1748,8 +1504,6 @@ ___
 ▸ **updateLayout**(`processChildren`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
-
-*Defined in [card-elements.ts:434](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L434)*
 
 **Parameters:**
 
@@ -1766,7 +1520,5 @@ ___
 ▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
 
 *Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
-
-*Defined in [card-object.ts:128](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L128)*
 
 **Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/imageset.md
+++ b/source/nodejs/adaptivecards/docs/classes/imageset.md
@@ -149,8 +149,6 @@
 
 *Inherited from [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 **Returns:** *[ImageSet](imageset.md)*
 
 ## Properties
@@ -161,8 +159,6 @@
 
 *Inherited from [CardObject](cardobject.md).[_parent](cardobject.md#protected-optional-_parent)*
 
-*Defined in [card-object.ts:61](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L61)*
-
 ___
 
 ### `Protected` `Optional` _renderedElement
@@ -170,8 +166,6 @@ ___
 • **_renderedElement**? : *HTMLElement*
 
 *Inherited from [CardObject](cardobject.md).[_renderedElement](cardobject.md#protected-optional-_renderedelement)*
-
-*Defined in [card-object.ts:62](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L62)*
 
 ___
 
@@ -181,8 +175,6 @@ ___
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[_selectAction](cardelementcontainer.md#protected-optional-_selectaction)*
 
-*Defined in [card-elements.ts:1747](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1747)*
-
 ___
 
 ###  allowVerticalOverflow
@@ -190,8 +182,6 @@ ___
 • **allowVerticalOverflow**: *boolean* = false
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[allowVerticalOverflow](cardelementcontainer.md#allowverticaloverflow)*
-
-*Defined in [card-elements.ts:1787](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1787)*
 
 ___
 
@@ -201,8 +191,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#optional-customcssselector)*
 
-*Defined in [card-elements.ts:311](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L311)*
-
 ___
 
 ###  height
@@ -210,8 +198,6 @@ ___
 • **height**: *[CardElementHeight](../README.md#cardelementheight)*
 
 *Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
-
-*Defined in [card-elements.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L53)*
 
 ___
 
@@ -221,8 +207,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#horizontalalignment)*
 
-*Defined in [card-elements.ts:44](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L44)*
-
 ___
 
 ### `Optional` id
@@ -231,15 +215,11 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[id](cardobject.md#optional-id)*
 
-*Defined in [card-object.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L50)*
-
 ___
 
 ###  imageSize
 
 • **imageSize**: *[Size](../enums/size.md)* = Enums.Size.Medium
-
-*Defined in [card-elements.ts:1926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1926)*
 
 ___
 
@@ -249,8 +229,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 ___
 
 ### `Optional` onPreProcessPropertyValue
@@ -258,8 +236,6 @@ ___
 • **onPreProcessPropertyValue**? : *undefined | function*
 
 *Inherited from [CardObject](cardobject.md).[onPreProcessPropertyValue](cardobject.md#optional-onpreprocesspropertyvalue)*
-
-*Defined in [card-object.ts:64](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L64)*
 
 ___
 
@@ -269,8 +245,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
 
-*Defined in [card-elements.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L50)*
-
 ___
 
 ###  spacing
@@ -278,8 +252,6 @@ ___
 • **spacing**: *[Spacing](../enums/spacing.md)*
 
 *Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
-
-*Defined in [card-elements.ts:47](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L47)*
 
 ___
 
@@ -296,8 +268,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[heightProperty](cardelement.md#static-heightproperty)*
 
-*Defined in [card-elements.ts:24](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L24)*
-
 ___
 
 ### `Static` horizontalAlignmentProperty
@@ -310,8 +280,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignmentProperty](cardelement.md#static-horizontalalignmentproperty)*
 
-*Defined in [card-elements.ts:32](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L32)*
-
 ___
 
 ### `Static` idProperty
@@ -319,8 +287,6 @@ ___
 ▪ **idProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "id")
 
 *Inherited from [CardObject](cardobject.md).[idProperty](cardobject.md#static-idproperty)*
-
-*Defined in [card-object.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L39)*
 
 ___
 
@@ -332,8 +298,6 @@ ___
         Enums.Size,
         Enums.Size.Medium)
 
-*Defined in [card-elements.ts:1916](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1916)*
-
 ___
 
 ### `Static` imagesProperty
@@ -344,8 +308,6 @@ ___
         Image,
         (sender: SerializableObject, item: Image) => { item.setParent(<CardElement>sender); })
 
-*Defined in [card-elements.ts:1911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1911)*
-
 ___
 
 ### `Static` isVisibleProperty
@@ -353,8 +315,6 @@ ___
 ▪ **isVisibleProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_2, "isVisible", true)
 
 *Inherited from [CardElement](cardelement.md).[isVisibleProperty](cardelement.md#static-isvisibleproperty)*
-
-*Defined in [card-elements.ts:22](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L22)*
 
 ___
 
@@ -364,8 +324,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[langProperty](cardelement.md#static-langproperty)*
 
-*Defined in [card-elements.ts:21](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L21)*
-
 ___
 
 ### `Static` `Optional` onRegisterCustomProperties
@@ -373,8 +331,6 @@ ___
 ▪ **onRegisterCustomProperties**? : *undefined | function*
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
-
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
 
 ___
 
@@ -387,8 +343,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requiresProperty](cardobject.md#static-requiresproperty)*
 
-*Defined in [card-object.ts:40](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L40)*
-
 ___
 
 ### `Static` selectActionProperty
@@ -397,8 +351,6 @@ ___
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[selectActionProperty](cardelementcontainer.md#static-selectactionproperty)*
 
-*Defined in [card-elements.ts:1736](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1736)*
-
 ___
 
 ### `Static` separatorProperty
@@ -406,8 +358,6 @@ ___
 ▪ **separatorProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_0, "separator", false)
 
 *Inherited from [CardElement](cardelement.md).[separatorProperty](cardelement.md#static-separatorproperty)*
-
-*Defined in [card-elements.ts:23](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L23)*
 
 ___
 
@@ -420,8 +370,6 @@ ___
         Enums.Spacing.Default)
 
 *Inherited from [CardElement](cardelement.md).[spacingProperty](cardelement.md#static-spacingproperty)*
-
-*Defined in [card-elements.ts:37](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L37)*
 
 ___
 
@@ -439,8 +387,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[typeNameProperty](cardobject.md#static-typenameproperty)*
 
-*Defined in [card-object.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L30)*
-
 ## Accessors
 
 ### `Protected` allowCustomPadding
@@ -448,8 +394,6 @@ ___
 • **get allowCustomPadding**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
-
-*Defined in [card-elements.ts:299](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L299)*
 
 **Returns:** *boolean*
 
@@ -461,8 +405,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
 
-*Defined in [card-elements.ts:307](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L307)*
-
 **Returns:** *string*
 
 ___
@@ -472,8 +414,6 @@ ___
 • **get hasVisibleSeparator**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
-
-*Defined in [card-elements.ts:580](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L580)*
 
 **Returns:** *boolean*
 
@@ -487,8 +427,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
 
-*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
-
 **Returns:** *[HostConfig](hostconfig.md)*
 
 • **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
@@ -496,8 +434,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
-
-*Defined in [card-elements.ts:555](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L555)*
 
 **Parameters:**
 
@@ -515,8 +451,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
 
-*Defined in [card-elements.ts:559](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L559)*
-
 **Returns:** *number*
 
 ___
@@ -526,8 +460,6 @@ ___
 • **get isInline**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
-
-*Defined in [card-elements.ts:576](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L576)*
 
 **Returns:** *boolean*
 
@@ -539,8 +471,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
 
-*Defined in [card-elements.ts:568](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L568)*
-
 **Returns:** *boolean*
 
 ___
@@ -550,8 +480,6 @@ ___
 • **get isSelectable**(): *boolean*
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[isSelectable](cardelementcontainer.md#protected-isselectable)*
-
-*Defined in [card-elements.ts:1777](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1777)*
 
 **Returns:** *boolean*
 
@@ -563,8 +491,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
 
-*Defined in [card-elements.ts:572](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L572)*
-
 **Returns:** *boolean*
 
 ___
@@ -575,15 +501,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
 
-*Defined in [card-elements.ts:77](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L77)*
-
 **Returns:** *boolean*
 
 • **set isVisible**(`value`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
-
-*Defined in [card-elements.ts:81](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L81)*
 
 **Parameters:**
 
@@ -601,15 +523,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
 
-*Defined in [card-elements.ts:56](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L56)*
-
 **Returns:** *string | undefined*
 
 • **set lang**(`value`: string | undefined): *void*
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
-
-*Defined in [card-elements.ts:72](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L72)*
 
 **Parameters:**
 
@@ -629,8 +547,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[parent](cardobject.md#parent)*
 
-*Defined in [card-elements.ts:593](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L593)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -640,8 +556,6 @@ ___
 • **get renderedElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardObject](cardobject.md).[renderedElement](cardobject.md#renderedelement)*
-
-*Defined in [card-object.ts:140](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L140)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -653,8 +567,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requires](cardobject.md#requires)*
 
-*Defined in [card-object.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L53)*
-
 **Returns:** *HostCapabilities*
 
 ___
@@ -664,8 +576,6 @@ ___
 • **get separatorElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
-
-*Defined in [card-elements.ts:589](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L589)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -677,8 +587,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
 
-*Defined in [card-elements.ts:303](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L303)*
-
 **Returns:** *[Orientation](../enums/orientation.md)*
 
 ___
@@ -689,8 +597,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
 
-*Defined in [card-elements.ts:295](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L295)*
-
 **Returns:** *boolean*
 
 ## Methods
@@ -698,8 +604,6 @@ ___
 ###  addImage
 
 ▸ **addImage**(`image`: [Image](image.md)): *void*
-
-*Defined in [card-elements.ts:1995](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1995)*
 
 **Parameters:**
 
@@ -716,8 +620,6 @@ ___
 ▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
 
 *Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
-
-*Defined in [card-elements.ts:220](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L220)*
 
 **Parameters:**
 
@@ -737,8 +639,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
 
-*Defined in [card-elements.ts:1755](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1755)*
-
 **Returns:** *void*
 
 ___
@@ -748,8 +648,6 @@ ___
 ▸ **asString**(): *string | undefined*
 
 *Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
-
-*Defined in [card-elements.ts:321](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L321)*
 
 **Returns:** *string | undefined*
 
@@ -761,8 +659,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
 
-*Defined in [card-elements.ts:205](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L205)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -772,8 +668,6 @@ ___
 ▸ **getActionAt**(`index`: number): *[Action](action.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
-
-*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
 
 **Parameters:**
 
@@ -791,8 +685,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
 
-*Defined in [card-elements.ts:531](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L531)*
-
 **Parameters:**
 
 Name | Type |
@@ -809,8 +701,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
 
-*Defined in [card-elements.ts:396](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L396)*
-
 **Returns:** *number*
 
 ___
@@ -823,8 +713,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
 
-*Defined in [card-elements.ts:1871](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1871)*
-
 **Returns:** *[Input](input.md)[]*
 
 ___
@@ -834,8 +722,6 @@ ___
 ▸ **getCustomProperty**(`name`: string): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
-
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
 
 **Parameters:**
 
@@ -853,8 +739,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
 
-*Defined in [card-elements.ts:275](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L275)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
 ___
@@ -864,8 +748,6 @@ ___
 ▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
 
 *Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
-
-*Defined in [card-elements.ts:535](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L535)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
@@ -877,8 +759,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
 
-*Defined in [card-elements.ts:329](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L329)*
-
 **Returns:** *string*
 
 ___
@@ -888,8 +768,6 @@ ___
 ▸ **getEffectiveStyleDefinition**(): *[ContainerStyleDefinition](containerstyledefinition.md)*
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyleDefinition](cardelement.md#geteffectivestyledefinition)*
-
-*Defined in [card-elements.ts:337](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L337)*
 
 **Returns:** *[ContainerStyleDefinition](containerstyledefinition.md)*
 
@@ -902,8 +780,6 @@ ___
 *Inherited from [CardElementContainer](cardelementcontainer.md).[getElementById](cardelementcontainer.md#getelementbyid)*
 
 *Overrides [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
-
-*Defined in [card-elements.ts:1891](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1891)*
 
 **Parameters:**
 
@@ -921,8 +797,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[getFirstVisibleRenderedItem](cardelementcontainer.md#abstract-getfirstvisiblerendereditem)*
 
-*Defined in [card-elements.ts:1965](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1965)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -932,8 +806,6 @@ ___
 ▸ **getForbiddenActionTypes**(): *[ActionType](../README.md#actiontype)[]*
 
 *Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
-
-*Defined in [card-elements.ts:341](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L341)*
 
 **Returns:** *[ActionType](../README.md#actiontype)[]*
 
@@ -945,8 +817,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
 
-*Defined in [card-elements.ts:279](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L279)*
-
 **Returns:** *boolean*
 
 ___
@@ -956,8 +826,6 @@ ___
 ▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
-
-*Defined in [card-elements.ts:345](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L345)*
 
 **Parameters:**
 
@@ -979,8 +847,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[getItemAt](cardelementcontainer.md#abstract-getitemat)*
 
-*Defined in [card-elements.ts:1961](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1961)*
-
 **Parameters:**
 
 Name | Type |
@@ -997,8 +863,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[getItemCount](cardelementcontainer.md#abstract-getitemcount)*
 
-*Defined in [card-elements.ts:1957](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1957)*
-
 **Returns:** *number*
 
 ___
@@ -1008,8 +872,6 @@ ___
 ▸ **getJsonTypeName**(): *string*
 
 *Overrides [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
-
-*Defined in [card-elements.ts:1991](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1991)*
 
 **Returns:** *string*
 
@@ -1021,8 +883,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[getLastVisibleRenderedItem](cardelementcontainer.md#abstract-getlastvisiblerendereditem)*
 
-*Defined in [card-elements.ts:1969](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1969)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -1033,8 +893,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
 
-*Defined in [card-elements.ts:283](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L283)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md) | undefined*
 
 ___
@@ -1044,8 +902,6 @@ ___
 ▸ **getParentContainer**(): *[Container](container.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
-
-*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
 
 **Returns:** *[Container](container.md) | undefined*
 
@@ -1059,8 +915,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
 
-*Defined in [card-elements.ts:1881](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1881)*
-
 **Returns:** *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
 ___
@@ -1070,8 +924,6 @@ ___
 ▸ **getRootElement**(): *[CardElement](cardelement.md)*
 
 *Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
-
-*Defined in [card-elements.ts:501](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L501)*
 
 **Returns:** *[CardElement](cardelement.md)*
 
@@ -1083,8 +935,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getRootObject](cardobject.md#getrootobject)*
 
-*Defined in [card-object.ts:100](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L100)*
-
 **Returns:** *[CardObject](cardobject.md)*
 
 ___
@@ -1094,8 +944,6 @@ ___
 ▸ **getSchema**(): *[SerializableObjectSchema](serializableobjectschema.md)*
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
-
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
 
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
@@ -1109,8 +957,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-object.ts:45](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L45)*
-
 **Returns:** *string*
 
 ___
@@ -1120,8 +966,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -1139,8 +983,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -1150,8 +992,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -1169,8 +1009,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
 
-*Defined in [card-elements.ts:2006](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2006)*
-
 **Parameters:**
 
 Name | Type |
@@ -1186,8 +1024,6 @@ ___
 ▸ **internalParse**(`source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
-
-*Defined in [serialization.ts:789](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L789)*
 
 **Parameters:**
 
@@ -1206,8 +1042,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
 
-*Defined in [card-elements.ts:1930](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1930)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1217,8 +1051,6 @@ ___
 ▸ **internalToJSON**(`target`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
-
-*Defined in [serialization.ts:821](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L821)*
 
 **Parameters:**
 
@@ -1239,8 +1071,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
 
-*Defined in [card-elements.ts:1789](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1789)*
-
 **Parameters:**
 
 Name | Type |
@@ -1257,8 +1087,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
 
-*Defined in [card-elements.ts:469](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L469)*
-
 **Returns:** *boolean*
 
 ___
@@ -1268,8 +1096,6 @@ ___
 ▸ **isAtTheVeryLeft**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
-
-*Defined in [card-elements.ts:457](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L457)*
 
 **Returns:** *boolean*
 
@@ -1281,8 +1107,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
 
-*Defined in [card-elements.ts:461](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L461)*
-
 **Returns:** *boolean*
 
 ___
@@ -1292,8 +1116,6 @@ ___
 ▸ **isAtTheVeryTop**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
-
-*Defined in [card-elements.ts:465](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L465)*
 
 **Returns:** *boolean*
 
@@ -1305,8 +1127,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
 
-*Defined in [card-elements.ts:325](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L325)*
-
 **Returns:** *boolean*
 
 ___
@@ -1316,8 +1136,6 @@ ___
 ▸ **isBleedingAtBottom**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
-
-*Defined in [card-elements.ts:477](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L477)*
 
 **Returns:** *boolean*
 
@@ -1329,8 +1147,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
 
-*Defined in [card-elements.ts:473](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L473)*
-
 **Returns:** *boolean*
 
 ___
@@ -1340,8 +1156,6 @@ ___
 ▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
-
-*Defined in [card-elements.ts:493](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L493)*
 
 **Parameters:**
 
@@ -1359,8 +1173,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
 
-*Defined in [card-elements.ts:443](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L443)*
-
 **Returns:** *boolean*
 
 ___
@@ -1371,8 +1183,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDisplayed](cardelement.md#protected-isdisplayed)*
 
-*Defined in [card-elements.ts:229](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L229)*
-
 **Returns:** *boolean*
 
 ___
@@ -1382,8 +1192,6 @@ ___
 ▸ **isElementAllowed**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[isElementAllowed](cardelementcontainer.md#protected-iselementallowed)*
-
-*Defined in [card-elements.ts:1751](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1751)*
 
 **Parameters:**
 
@@ -1401,8 +1209,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
 
-*Defined in [card-elements.ts:449](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L449)*
-
 **Parameters:**
 
 Name | Type |
@@ -1419,8 +1225,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
 
-*Defined in [card-elements.ts:497](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L497)*
-
 **Returns:** *boolean*
 
 ___
@@ -1430,8 +1234,6 @@ ___
 ▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
-
-*Defined in [card-elements.ts:453](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L453)*
 
 **Parameters:**
 
@@ -1449,8 +1251,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
 
-*Defined in [card-elements.ts:481](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L481)*
-
 **Parameters:**
 
 Name | Type |
@@ -1466,8 +1266,6 @@ ___
 ▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
-
-*Defined in [card-elements.ts:485](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L485)*
 
 **Parameters:**
 
@@ -1485,8 +1283,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
 
-*Defined in [card-elements.ts:489](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L489)*
-
 **Parameters:**
 
 Name | Type |
@@ -1503,8 +1299,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
 
-*Defined in [card-elements.ts:235](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L235)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1516,8 +1310,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[parse](cardelement.md#parse)*
 
 *Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
-
-*Defined in [card-elements.ts:313](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L313)*
 
 **Parameters:**
 
@@ -1538,8 +1330,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [card-elements.ts:1738](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1738)*
-
 **Parameters:**
 
 Name | Type |
@@ -1555,8 +1345,6 @@ ___
 ▸ **preProcessPropertyValue**(`property`: [PropertyDefinition](propertydefinition.md), `propertyValue?`: any): *any*
 
 *Inherited from [CardObject](cardobject.md).[preProcessPropertyValue](cardobject.md#preprocesspropertyvalue)*
-
-*Defined in [card-object.ts:70](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L70)*
 
 **Parameters:**
 
@@ -1575,8 +1363,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
 
-*Defined in [card-elements.ts:404](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L404)*
-
 **Returns:** *boolean*
 
 ___
@@ -1586,8 +1372,6 @@ ___
 ▸ **removeItem**(`item`: [CardElement](cardelement.md)): *boolean*
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[removeItem](cardelementcontainer.md#abstract-removeitem)*
-
-*Defined in [card-elements.ts:1973](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1973)*
 
 **Parameters:**
 
@@ -1607,8 +1391,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[render](cardelement.md#render)*
 
-*Defined in [card-elements.ts:1817](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1817)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1619,8 +1401,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -1630,8 +1410,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -1650,8 +1428,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
 
-*Defined in [card-elements.ts:287](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L287)*
-
 **Parameters:**
 
 Name | Type |
@@ -1667,8 +1443,6 @@ ___
 ▸ **setParent**(`value`: [CardObject](cardobject.md) | undefined): *void*
 
 *Inherited from [CardObject](cardobject.md).[setParent](cardobject.md#setparent)*
-
-*Defined in [card-object.ts:88](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L88)*
 
 **Parameters:**
 
@@ -1686,8 +1460,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setShouldFallback](cardobject.md#setshouldfallback)*
 
-*Defined in [card-object.ts:92](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L92)*
-
 **Parameters:**
 
 Name | Type |
@@ -1703,8 +1475,6 @@ ___
 ▸ **setValue**(`property`: [PropertyDefinition](propertydefinition.md), `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
-
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
 
 **Parameters:**
 
@@ -1723,8 +1493,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[shouldFallback](cardobject.md#shouldfallback)*
 
-*Defined in [card-object.ts:96](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L96)*
-
 **Returns:** *boolean*
 
 ___
@@ -1736,8 +1504,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[shouldSerialize](cardelement.md#protected-shouldserialize)*
 
 *Overrides [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
-
-*Defined in [card-elements.ts:291](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L291)*
 
 **Parameters:**
 
@@ -1757,8 +1523,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
 
-*Defined in [card-elements.ts:317](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L317)*
-
 **Parameters:**
 
 Name | Type |
@@ -1774,8 +1538,6 @@ ___
 ▸ **truncateOverflow**(`maxHeight`: number): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
-
-*Defined in [card-elements.ts:263](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L263)*
 
 **Parameters:**
 
@@ -1793,8 +1555,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
 
-*Defined in [card-elements.ts:273](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L273)*
-
 **Returns:** *void*
 
 ___
@@ -1806,8 +1566,6 @@ ___
 *Inherited from [CardElementContainer](cardelementcontainer.md).[updateLayout](cardelementcontainer.md#updatelayout)*
 
 *Overrides [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
-
-*Defined in [card-elements.ts:1861](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1861)*
 
 **Parameters:**
 
@@ -1824,7 +1582,5 @@ ___
 ▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
 
 *Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
-
-*Defined in [card-object.ts:128](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L128)*
 
 **Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/imagesetconfig.md
+++ b/source/nodejs/adaptivecards/docs/classes/imagesetconfig.md
@@ -27,8 +27,6 @@
 
 \+ **new ImageSetConfig**(`obj?`: any): *[ImageSetConfig](imagesetconfig.md)*
 
-*Defined in [host-config.ts:68](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L68)*
-
 **Parameters:**
 
 Name | Type |
@@ -43,23 +41,17 @@ Name | Type |
 
 • **imageSize**: *[Size](../enums/size.md)* = Enums.Size.Medium
 
-*Defined in [host-config.ts:67](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L67)*
-
 ___
 
 ###  maxImageHeight
 
 • **maxImageHeight**: *number* = 100
 
-*Defined in [host-config.ts:68](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L68)*
-
 ## Methods
 
 ###  toJSON
 
 ▸ **toJSON**(): *object*
-
-*Defined in [host-config.ts:77](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L77)*
 
 **Returns:** *object*
 

--- a/source/nodejs/adaptivecards/docs/classes/input.md
+++ b/source/nodejs/adaptivecards/docs/classes/input.md
@@ -163,8 +163,6 @@
 
 *Inherited from [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 **Returns:** *[Input](input.md)*
 
 ## Properties
@@ -175,8 +173,6 @@
 
 *Inherited from [CardObject](cardobject.md).[_parent](cardobject.md#protected-optional-_parent)*
 
-*Defined in [card-object.ts:61](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L61)*
-
 ___
 
 ### `Protected` `Optional` _renderedElement
@@ -184,8 +180,6 @@ ___
 • **_renderedElement**? : *HTMLElement*
 
 *Inherited from [CardObject](cardobject.md).[_renderedElement](cardobject.md#protected-optional-_renderedelement)*
-
-*Defined in [card-object.ts:62](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L62)*
 
 ___
 
@@ -195,8 +189,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#optional-customcssselector)*
 
-*Defined in [card-elements.ts:311](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L311)*
-
 ___
 
 ###  height
@@ -205,8 +197,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
 
-*Defined in [card-elements.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L53)*
-
 ___
 
 ###  horizontalAlignment
@@ -214,8 +204,6 @@ ___
 • **horizontalAlignment**: *[HorizontalAlignment](../enums/horizontalalignment.md)*
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#horizontalalignment)*
-
-*Defined in [card-elements.ts:44](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L44)*
 
 ___
 
@@ -227,8 +215,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[id](cardobject.md#optional-id)*
 
-*Defined in [card-object.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L50)*
-
 ___
 
 ###  maxVersion
@@ -236,8 +222,6 @@ ___
 • **maxVersion**: *[Version](version.md)* = Versions.latest
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
-
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
 
 ___
 
@@ -247,15 +231,11 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[onPreProcessPropertyValue](cardobject.md#optional-onpreprocesspropertyvalue)*
 
-*Defined in [card-object.ts:64](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L64)*
-
 ___
 
 ###  onValueChanged
 
 • **onValueChanged**: *function*
-
-*Defined in [card-elements.ts:2415](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2415)*
 
 #### Type declaration:
 
@@ -275,8 +255,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
 
-*Defined in [card-elements.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L50)*
-
 ___
 
 ###  spacing
@@ -284,8 +262,6 @@ ___
 • **spacing**: *[Spacing](../enums/spacing.md)*
 
 *Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
-
-*Defined in [card-elements.ts:47](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L47)*
 
 ___
 
@@ -302,8 +278,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[heightProperty](cardelement.md#static-heightproperty)*
 
-*Defined in [card-elements.ts:24](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L24)*
-
 ___
 
 ### `Static` horizontalAlignmentProperty
@@ -316,8 +290,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignmentProperty](cardelement.md#static-horizontalalignmentproperty)*
 
-*Defined in [card-elements.ts:32](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L32)*
-
 ___
 
 ### `Static` idProperty
@@ -325,8 +297,6 @@ ___
 ▪ **idProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "id")
 
 *Inherited from [CardObject](cardobject.md).[idProperty](cardobject.md#static-idproperty)*
-
-*Defined in [card-object.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L39)*
 
 ___
 
@@ -336,8 +306,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisibleProperty](cardelement.md#static-isvisibleproperty)*
 
-*Defined in [card-elements.ts:22](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L22)*
-
 ___
 
 ### `Static` langProperty
@@ -346,8 +314,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[langProperty](cardelement.md#static-langproperty)*
 
-*Defined in [card-elements.ts:21](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L21)*
-
 ___
 
 ### `Static` `Optional` onRegisterCustomProperties
@@ -355,8 +321,6 @@ ___
 ▪ **onRegisterCustomProperties**? : *undefined | function*
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
-
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
 
 ___
 
@@ -369,8 +333,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requiresProperty](cardobject.md#static-requiresproperty)*
 
-*Defined in [card-object.ts:40](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L40)*
-
 ___
 
 ### `Static` separatorProperty
@@ -378,8 +340,6 @@ ___
 ▪ **separatorProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_0, "separator", false)
 
 *Inherited from [CardElement](cardelement.md).[separatorProperty](cardelement.md#static-separatorproperty)*
-
-*Defined in [card-elements.ts:23](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L23)*
 
 ___
 
@@ -392,8 +352,6 @@ ___
         Enums.Spacing.Default)
 
 *Inherited from [CardElement](cardelement.md).[spacingProperty](cardelement.md#static-spacingproperty)*
-
-*Defined in [card-elements.ts:37](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L37)*
 
 ___
 
@@ -411,8 +369,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[typeNameProperty](cardobject.md#static-typenameproperty)*
 
-*Defined in [card-object.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L30)*
-
 ___
 
 ### `Static` validationProperty
@@ -422,8 +378,6 @@ ___
         "validation",
         InputValidationOptions)
 
-*Defined in [card-elements.ts:2313](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2313)*
-
 ## Accessors
 
 ### `Protected` allowCustomPadding
@@ -431,8 +385,6 @@ ___
 • **get allowCustomPadding**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
-
-*Defined in [card-elements.ts:299](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L299)*
 
 **Returns:** *boolean*
 
@@ -444,8 +396,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
 
-*Defined in [card-elements.ts:307](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L307)*
-
 **Returns:** *string*
 
 ___
@@ -455,8 +405,6 @@ ___
 • **get hasVisibleSeparator**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
-
-*Defined in [card-elements.ts:580](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L580)*
 
 **Returns:** *boolean*
 
@@ -470,8 +418,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
 
-*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
-
 **Returns:** *[HostConfig](hostconfig.md)*
 
 • **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
@@ -479,8 +425,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
-
-*Defined in [card-elements.ts:555](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L555)*
 
 **Parameters:**
 
@@ -498,8 +442,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
 
-*Defined in [card-elements.ts:559](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L559)*
-
 **Returns:** *number*
 
 ___
@@ -507,8 +449,6 @@ ___
 ### `Protected` inputControlContainerElement
 
 • **get inputControlContainerElement**(): *HTMLElement*
-
-*Defined in [card-elements.ts:2346](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2346)*
 
 **Returns:** *HTMLElement*
 
@@ -520,8 +460,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
 
-*Defined in [card-elements.ts:576](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L576)*
-
 **Returns:** *boolean*
 
 ___
@@ -532,8 +470,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
 
-*Defined in [card-elements.ts:2453](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2453)*
-
 **Returns:** *boolean*
 
 ___
@@ -541,8 +477,6 @@ ___
 ### `Protected` isNullable
 
 • **get isNullable**(): *boolean*
-
-*Defined in [card-elements.ts:2338](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2338)*
 
 **Returns:** *boolean*
 
@@ -554,8 +488,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
 
-*Defined in [card-elements.ts:572](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L572)*
-
 **Returns:** *boolean*
 
 ___
@@ -566,15 +498,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
 
-*Defined in [card-elements.ts:77](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L77)*
-
 **Returns:** *boolean*
 
 • **set isVisible**(`value`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
-
-*Defined in [card-elements.ts:81](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L81)*
 
 **Parameters:**
 
@@ -592,15 +520,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
 
-*Defined in [card-elements.ts:56](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L56)*
-
 **Returns:** *string | undefined*
 
 • **set lang**(`value`: string | undefined): *void*
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
-
-*Defined in [card-elements.ts:72](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L72)*
 
 **Parameters:**
 
@@ -620,8 +544,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[parent](cardobject.md#parent)*
 
-*Defined in [card-elements.ts:593](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L593)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -632,8 +554,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[renderedElement](cardobject.md#renderedelement)*
 
-*Defined in [card-object.ts:140](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L140)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -641,8 +561,6 @@ ___
 ### `Protected` renderedInputControlElement
 
 • **get renderedInputControlElement**(): *HTMLElement*
-
-*Defined in [card-elements.ts:2342](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2342)*
 
 **Returns:** *HTMLElement*
 
@@ -654,8 +572,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requires](cardobject.md#requires)*
 
-*Defined in [card-object.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L53)*
-
 **Returns:** *HostCapabilities*
 
 ___
@@ -665,8 +581,6 @@ ___
 • **get separatorElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
-
-*Defined in [card-elements.ts:589](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L589)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -678,8 +592,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
 
-*Defined in [card-elements.ts:303](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L303)*
-
 **Returns:** *[Orientation](../enums/orientation.md)*
 
 ___
@@ -690,8 +602,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
 
-*Defined in [card-elements.ts:295](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L295)*
-
 **Returns:** *boolean*
 
 ___
@@ -700,8 +610,6 @@ ___
 
 • **get validation**(): *[InputValidationOptions](inputvalidationoptions.md)*
 
-*Defined in [card-elements.ts:2327](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2327)*
-
 **Returns:** *[InputValidationOptions](inputvalidationoptions.md)*
 
 ___
@@ -709,8 +617,6 @@ ___
 ###  value
 
 • **get value**(): *any*
-
-*Defined in [card-elements.ts:2413](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2413)*
 
 **Returns:** *any*
 
@@ -721,8 +627,6 @@ ___
 ▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
 
 *Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
-
-*Defined in [card-elements.ts:220](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L220)*
 
 **Parameters:**
 
@@ -740,8 +644,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
 
-*Defined in [card-elements.ts:239](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L239)*
-
 **Returns:** *void*
 
 ___
@@ -751,8 +653,6 @@ ___
 ▸ **asString**(): *string | undefined*
 
 *Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
-
-*Defined in [card-elements.ts:321](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L321)*
 
 **Returns:** *string | undefined*
 
@@ -764,8 +664,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
 
-*Defined in [card-elements.ts:205](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L205)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -775,8 +673,6 @@ ___
 ▸ **getActionAt**(`index`: number): *[Action](action.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
-
-*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
 
 **Parameters:**
 
@@ -794,8 +690,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
 
-*Defined in [card-elements.ts:531](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L531)*
-
 **Parameters:**
 
 Name | Type |
@@ -812,8 +706,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
 
-*Defined in [card-elements.ts:396](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L396)*
-
 **Returns:** *number*
 
 ___
@@ -824,8 +716,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
 
-*Defined in [card-elements.ts:2449](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2449)*
-
 **Returns:** *[Input](input.md)[]*
 
 ___
@@ -835,8 +725,6 @@ ___
 ▸ **getCustomProperty**(`name`: string): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
-
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
 
 **Parameters:**
 
@@ -854,8 +742,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
 
-*Defined in [card-elements.ts:275](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L275)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
 ___
@@ -865,8 +751,6 @@ ___
 ▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
 
 *Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
-
-*Defined in [card-elements.ts:535](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L535)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
@@ -878,8 +762,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
 
-*Defined in [card-elements.ts:329](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L329)*
-
 **Returns:** *string*
 
 ___
@@ -890,8 +772,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyleDefinition](cardelement.md#geteffectivestyledefinition)*
 
-*Defined in [card-elements.ts:337](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L337)*
-
 **Returns:** *[ContainerStyleDefinition](containerstyledefinition.md)*
 
 ___
@@ -901,8 +781,6 @@ ___
 ▸ **getElementById**(`id`: string): *[CardElement](cardelement.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
-
-*Defined in [card-elements.ts:527](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L527)*
 
 **Parameters:**
 
@@ -920,8 +798,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
 
-*Defined in [card-elements.ts:341](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L341)*
-
 **Returns:** *[ActionType](../README.md#actiontype)[]*
 
 ___
@@ -932,8 +808,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
 
-*Defined in [card-elements.ts:279](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L279)*
-
 **Returns:** *boolean*
 
 ___
@@ -943,8 +817,6 @@ ___
 ▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
-
-*Defined in [card-elements.ts:345](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L345)*
 
 **Parameters:**
 
@@ -966,8 +838,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
 
-*Defined in [card-object.ts:66](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L66)*
-
 **Returns:** *string*
 
 ___
@@ -977,8 +847,6 @@ ___
 ▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
-
-*Defined in [card-elements.ts:283](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L283)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md) | undefined*
 
@@ -990,8 +858,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
 
-*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
-
 **Returns:** *[Container](container.md) | undefined*
 
 ___
@@ -1001,8 +867,6 @@ ___
 ▸ **getResourceInformation**(): *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
 *Inherited from [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
-
-*Defined in [card-elements.ts:523](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L523)*
 
 **Returns:** *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
@@ -1014,8 +878,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
 
-*Defined in [card-elements.ts:501](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L501)*
-
 **Returns:** *[CardElement](cardelement.md)*
 
 ___
@@ -1026,8 +888,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getRootObject](cardobject.md#getrootobject)*
 
-*Defined in [card-object.ts:100](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L100)*
-
 **Returns:** *[CardObject](cardobject.md)*
 
 ___
@@ -1037,8 +897,6 @@ ___
 ▸ **getSchema**(): *[SerializableObjectSchema](serializableobjectschema.md)*
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
-
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
 
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
@@ -1052,8 +910,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-object.ts:45](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L45)*
-
 **Returns:** *string*
 
 ___
@@ -1063,8 +919,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -1082,8 +936,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -1093,8 +945,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -1112,8 +962,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
 
-*Defined in [card-elements.ts:439](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L439)*
-
 **Parameters:**
 
 Name | Type |
@@ -1129,8 +977,6 @@ ___
 ▸ **internalParse**(`source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
-
-*Defined in [serialization.ts:789](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L789)*
 
 **Parameters:**
 
@@ -1149,8 +995,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
 
-*Defined in [card-elements.ts:233](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L233)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1160,8 +1004,6 @@ ___
 ▸ **internalToJSON**(`target`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
-
-*Defined in [serialization.ts:821](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L821)*
 
 **Parameters:**
 
@@ -1180,8 +1022,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
 
-*Defined in [card-elements.ts:2419](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2419)*
-
 **Parameters:**
 
 Name | Type |
@@ -1198,8 +1038,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
 
-*Defined in [card-elements.ts:469](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L469)*
-
 **Returns:** *boolean*
 
 ___
@@ -1209,8 +1047,6 @@ ___
 ▸ **isAtTheVeryLeft**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
-
-*Defined in [card-elements.ts:457](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L457)*
 
 **Returns:** *boolean*
 
@@ -1222,8 +1058,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
 
-*Defined in [card-elements.ts:461](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L461)*
-
 **Returns:** *boolean*
 
 ___
@@ -1233,8 +1067,6 @@ ___
 ▸ **isAtTheVeryTop**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
-
-*Defined in [card-elements.ts:465](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L465)*
 
 **Returns:** *boolean*
 
@@ -1246,8 +1078,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
 
-*Defined in [card-elements.ts:325](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L325)*
-
 **Returns:** *boolean*
 
 ___
@@ -1257,8 +1087,6 @@ ___
 ▸ **isBleedingAtBottom**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
-
-*Defined in [card-elements.ts:477](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L477)*
 
 **Returns:** *boolean*
 
@@ -1270,8 +1098,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
 
-*Defined in [card-elements.ts:473](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L473)*
-
 **Returns:** *boolean*
 
 ___
@@ -1281,8 +1107,6 @@ ___
 ▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
-
-*Defined in [card-elements.ts:493](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L493)*
 
 **Parameters:**
 
@@ -1300,8 +1124,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
 
-*Defined in [card-elements.ts:443](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L443)*
-
 **Returns:** *boolean*
 
 ___
@@ -1312,8 +1134,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDisplayed](cardelement.md#protected-isdisplayed)*
 
-*Defined in [card-elements.ts:229](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L229)*
-
 **Returns:** *boolean*
 
 ___
@@ -1323,8 +1143,6 @@ ___
 ▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
-
-*Defined in [card-elements.ts:449](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L449)*
 
 **Parameters:**
 
@@ -1342,8 +1160,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
 
-*Defined in [card-elements.ts:497](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L497)*
-
 **Returns:** *boolean*
 
 ___
@@ -1353,8 +1169,6 @@ ___
 ▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
-
-*Defined in [card-elements.ts:453](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L453)*
 
 **Parameters:**
 
@@ -1372,8 +1186,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
 
-*Defined in [card-elements.ts:481](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L481)*
-
 **Parameters:**
 
 Name | Type |
@@ -1390,8 +1202,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
 
-*Defined in [card-elements.ts:485](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L485)*
-
 **Parameters:**
 
 Name | Type |
@@ -1406,8 +1216,6 @@ ___
 
 ▸ **isSet**(): *boolean*
 
-*Defined in [card-elements.ts:2417](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2417)*
-
 **Returns:** *boolean*
 
 ___
@@ -1417,8 +1225,6 @@ ___
 ▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
-
-*Defined in [card-elements.ts:489](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L489)*
 
 **Parameters:**
 
@@ -1436,8 +1242,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
 
-*Defined in [card-elements.ts:2350](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2350)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1449,8 +1253,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[parse](cardelement.md#parse)*
 
 *Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
-
-*Defined in [card-elements.ts:313](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L313)*
 
 **Parameters:**
 
@@ -1469,8 +1271,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [card-elements.ts:2318](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2318)*
-
 **Parameters:**
 
 Name | Type |
@@ -1486,8 +1286,6 @@ ___
 ▸ **preProcessPropertyValue**(`property`: [PropertyDefinition](propertydefinition.md), `propertyValue?`: any): *any*
 
 *Inherited from [CardObject](cardobject.md).[preProcessPropertyValue](cardobject.md#preprocesspropertyvalue)*
-
-*Defined in [card-object.ts:70](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L70)*
 
 **Parameters:**
 
@@ -1506,8 +1304,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
 
-*Defined in [card-elements.ts:404](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L404)*
-
 **Returns:** *boolean*
 
 ___
@@ -1517,8 +1313,6 @@ ___
 ▸ **render**(): *HTMLElement | undefined*
 
 *Inherited from [CardElement](cardelement.md).[render](cardelement.md#render)*
-
-*Defined in [card-elements.ts:412](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L412)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -1530,8 +1324,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -1539,8 +1331,6 @@ ___
 ### `Protected` resetValidationFailureCue
 
 ▸ **resetValidationFailureCue**(): *void*
-
-*Defined in [card-elements.ts:2391](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2391)*
 
 **Returns:** *void*
 
@@ -1551,8 +1341,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -1571,8 +1359,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
 
-*Defined in [card-elements.ts:287](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L287)*
-
 **Parameters:**
 
 Name | Type |
@@ -1588,8 +1374,6 @@ ___
 ▸ **setParent**(`value`: [CardObject](cardobject.md) | undefined): *void*
 
 *Inherited from [CardObject](cardobject.md).[setParent](cardobject.md#setparent)*
-
-*Defined in [card-object.ts:88](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L88)*
 
 **Parameters:**
 
@@ -1607,8 +1391,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setShouldFallback](cardobject.md#setshouldfallback)*
 
-*Defined in [card-object.ts:92](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L92)*
-
 **Parameters:**
 
 Name | Type |
@@ -1624,8 +1406,6 @@ ___
 ▸ **setValue**(`property`: [PropertyDefinition](propertydefinition.md), `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
-
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
 
 **Parameters:**
 
@@ -1644,8 +1424,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[shouldFallback](cardobject.md#shouldfallback)*
 
-*Defined in [card-object.ts:96](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L96)*
-
 **Returns:** *boolean*
 
 ___
@@ -1657,8 +1435,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[shouldSerialize](cardelement.md#protected-shouldserialize)*
 
 *Overrides [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
-
-*Defined in [card-elements.ts:291](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L291)*
 
 **Parameters:**
 
@@ -1674,8 +1450,6 @@ ___
 
 ▸ **showValidationErrorMessage**(): *void*
 
-*Defined in [card-elements.ts:2403](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2403)*
-
 **Returns:** *void*
 
 ___
@@ -1687,8 +1461,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[toJSON](cardelement.md#tojson)*
 
 *Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
-
-*Defined in [card-elements.ts:317](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L317)*
 
 **Parameters:**
 
@@ -1706,8 +1478,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
 
-*Defined in [card-elements.ts:263](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L263)*
-
 **Parameters:**
 
 Name | Type |
@@ -1724,8 +1494,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
 
-*Defined in [card-elements.ts:273](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L273)*
-
 **Returns:** *void*
 
 ___
@@ -1735,8 +1503,6 @@ ___
 ▸ **updateLayout**(`processChildren`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
-
-*Defined in [card-elements.ts:434](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L434)*
 
 **Parameters:**
 
@@ -1754,8 +1520,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
 
-*Defined in [card-object.ts:128](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L128)*
-
 **Returns:** *[ValidationResults](validationresults.md)*
 
 ___
@@ -1766,8 +1530,6 @@ ___
 
 *Implementation of [IInput](../interfaces/iinput.md)*
 
-*Defined in [card-elements.ts:2430](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2430)*
-
 **Returns:** *boolean*
 
 ___
@@ -1775,7 +1537,5 @@ ___
 ### `Protected` valueChanged
 
 ▸ **valueChanged**(): *void*
-
-*Defined in [card-elements.ts:2381](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2381)*
 
 **Returns:** *void*

--- a/source/nodejs/adaptivecards/docs/classes/inputvalidationoptions.md
+++ b/source/nodejs/adaptivecards/docs/classes/inputvalidationoptions.md
@@ -49,8 +49,6 @@
 
 *Inherited from [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 **Returns:** *[InputValidationOptions](inputvalidationoptions.md)*
 
 ## Properties
@@ -58,8 +56,6 @@
 ### `Optional` errorMessage
 
 • **errorMessage**? : *undefined | string*
-
-*Defined in [card-elements.ts:2301](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2301)*
 
 ___
 
@@ -69,15 +65,11 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 ___
 
 ###  necessity
 
 • **necessity**: *[InputValidationNecessity](../enums/inputvalidationnecessity.md)* = Enums.InputValidationNecessity.Optional
-
-*Defined in [card-elements.ts:2298](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2298)*
 
 ___
 
@@ -85,15 +77,11 @@ ___
 
 ▪ **errorMessageProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.vNext, "errorMessagwe")
 
-*Defined in [card-elements.ts:2291](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2291)*
-
 ___
 
 ### `Static` necessityProperty
 
 ▪ **necessityProperty**: *[EnumProperty](enumproperty.md)‹[InputValidationNecessity](../enums/inputvalidationnecessity.md)›* = new EnumProperty(Versions.vNext, "necessity", Enums.InputValidationNecessity, Enums.InputValidationNecessity.Optional)
-
-*Defined in [card-elements.ts:2290](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2290)*
 
 ___
 
@@ -103,8 +91,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
 
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
-
 ## Methods
 
 ###  getCustomProperty
@@ -112,8 +98,6 @@ ___
 ▸ **getCustomProperty**(`name`: string): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
-
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
 
 **Parameters:**
 
@@ -131,8 +115,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
 
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
-
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
 ___
@@ -143,8 +125,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-elements.ts:2293](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2293)*
-
 **Returns:** *string*
 
 ___
@@ -154,8 +134,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -173,8 +151,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -184,8 +160,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -202,8 +176,6 @@ ___
 ▸ **internalParse**(`source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
-
-*Defined in [serialization.ts:789](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L789)*
 
 **Parameters:**
 
@@ -222,8 +194,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
 
-*Defined in [card-elements.ts:2305](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2305)*
-
 **Parameters:**
 
 Name | Type |
@@ -240,8 +210,6 @@ ___
 ▸ **parse**(`source`: [PropertyBag](../README.md#propertybag), `context?`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
-
-*Defined in [serialization.ts:857](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L857)*
 
 **Parameters:**
 
@@ -260,8 +228,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [serialization.ts:738](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L738)*
-
 **Parameters:**
 
 Name | Type |
@@ -278,8 +244,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -289,8 +253,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -309,8 +271,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
 
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
-
 **Parameters:**
 
 Name | Type |
@@ -328,8 +288,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
 
-*Defined in [serialization.ts:839](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L839)*
-
 **Parameters:**
 
 Name | Type |
@@ -345,8 +303,6 @@ ___
 ▸ **toJSON**(`context?`: [BaseSerializationContext](baseserializationcontext.md)): *[PropertyBag](../README.md#propertybag) | undefined*
 
 *Inherited from [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
-
-*Defined in [serialization.ts:861](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L861)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/docs/classes/media.md
+++ b/source/nodejs/adaptivecards/docs/classes/media.md
@@ -144,8 +144,6 @@
 
 *Inherited from [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 **Returns:** *[Media](media.md)*
 
 ## Properties
@@ -156,8 +154,6 @@
 
 *Inherited from [CardObject](cardobject.md).[_parent](cardobject.md#protected-optional-_parent)*
 
-*Defined in [card-object.ts:61](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L61)*
-
 ___
 
 ### `Protected` `Optional` _renderedElement
@@ -166,15 +162,11 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[_renderedElement](cardobject.md#protected-optional-_renderedelement)*
 
-*Defined in [card-object.ts:62](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L62)*
-
 ___
 
 ### `Optional` altText
 
 • **altText**? : *undefined | string*
-
-*Defined in [card-elements.ts:2067](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2067)*
 
 ___
 
@@ -184,8 +176,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#optional-customcssselector)*
 
-*Defined in [card-elements.ts:311](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L311)*
-
 ___
 
 ###  height
@@ -193,8 +183,6 @@ ___
 • **height**: *[CardElementHeight](../README.md#cardelementheight)*
 
 *Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
-
-*Defined in [card-elements.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L53)*
 
 ___
 
@@ -204,8 +192,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#horizontalalignment)*
 
-*Defined in [card-elements.ts:44](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L44)*
-
 ___
 
 ### `Optional` id
@@ -213,8 +199,6 @@ ___
 • **id**? : *undefined | string*
 
 *Inherited from [CardObject](cardobject.md).[id](cardobject.md#optional-id)*
-
-*Defined in [card-object.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L50)*
 
 ___
 
@@ -224,8 +208,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 ___
 
 ### `Optional` onPreProcessPropertyValue
@@ -234,15 +216,11 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[onPreProcessPropertyValue](cardobject.md#optional-onpreprocesspropertyvalue)*
 
-*Defined in [card-object.ts:64](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L64)*
-
 ___
 
 ### `Optional` poster
 
 • **poster**? : *undefined | string*
-
-*Defined in [card-elements.ts:2064](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2064)*
 
 ___
 
@@ -252,15 +230,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
 
-*Defined in [card-elements.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L50)*
-
 ___
 
 ###  sources
 
 • **sources**: *[MediaSource](mediasource.md)[]* = []
-
-*Defined in [card-elements.ts:2061](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2061)*
 
 ___
 
@@ -270,15 +244,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
 
-*Defined in [card-elements.ts:47](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L47)*
-
 ___
 
 ### `Static` altTextProperty
 
 ▪ **altTextProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_1, "altText")
-
-*Defined in [card-elements.ts:2058](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2058)*
 
 ___
 
@@ -295,8 +265,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[heightProperty](cardelement.md#static-heightproperty)*
 
-*Defined in [card-elements.ts:24](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L24)*
-
 ___
 
 ### `Static` horizontalAlignmentProperty
@@ -309,8 +277,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignmentProperty](cardelement.md#static-horizontalalignmentproperty)*
 
-*Defined in [card-elements.ts:32](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L32)*
-
 ___
 
 ### `Static` idProperty
@@ -318,8 +284,6 @@ ___
 ▪ **idProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "id")
 
 *Inherited from [CardObject](cardobject.md).[idProperty](cardobject.md#static-idproperty)*
-
-*Defined in [card-object.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L39)*
 
 ___
 
@@ -329,8 +293,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisibleProperty](cardelement.md#static-isvisibleproperty)*
 
-*Defined in [card-elements.ts:22](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L22)*
-
 ___
 
 ### `Static` langProperty
@@ -339,15 +301,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[langProperty](cardelement.md#static-langproperty)*
 
-*Defined in [card-elements.ts:21](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L21)*
-
 ___
 
 ### `Static` `Optional` onPlay
 
 ▪ **onPlay**? : *undefined | function*
-
-*Defined in [card-elements.ts:2253](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2253)*
 
 ___
 
@@ -357,15 +315,11 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
 
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
-
 ___
 
 ### `Static` posterProperty
 
 ▪ **posterProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_1, "poster")
-
-*Defined in [card-elements.ts:2057](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2057)*
 
 ___
 
@@ -378,8 +332,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requiresProperty](cardobject.md#static-requiresproperty)*
 
-*Defined in [card-object.ts:40](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L40)*
-
 ___
 
 ### `Static` separatorProperty
@@ -388,15 +340,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separatorProperty](cardelement.md#static-separatorproperty)*
 
-*Defined in [card-elements.ts:23](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L23)*
-
 ___
 
 ### `Static` sourcesProperty
 
 ▪ **sourcesProperty**: *[SerializableObjectCollectionProperty](serializableobjectcollectionproperty.md)‹›* = new SerializableObjectCollectionProperty(Versions.v1_1, "sources", MediaSource)
-
-*Defined in [card-elements.ts:2056](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2056)*
 
 ___
 
@@ -410,15 +358,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[spacingProperty](cardelement.md#static-spacingproperty)*
 
-*Defined in [card-elements.ts:37](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L37)*
-
 ___
 
 ### `Static` supportedMediaTypes
 
 ▪ **supportedMediaTypes**: *string[]* = ["audio", "video"]
-
-*Defined in [card-elements.ts:2071](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2071)*
 
 ___
 
@@ -436,8 +380,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[typeNameProperty](cardobject.md#static-typenameproperty)*
 
-*Defined in [card-object.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L30)*
-
 ## Accessors
 
 ### `Protected` allowCustomPadding
@@ -445,8 +387,6 @@ ___
 • **get allowCustomPadding**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
-
-*Defined in [card-elements.ts:299](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L299)*
 
 **Returns:** *boolean*
 
@@ -458,8 +398,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
 
-*Defined in [card-elements.ts:307](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L307)*
-
 **Returns:** *string*
 
 ___
@@ -469,8 +407,6 @@ ___
 • **get hasVisibleSeparator**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
-
-*Defined in [card-elements.ts:580](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L580)*
 
 **Returns:** *boolean*
 
@@ -484,8 +420,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
 
-*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
-
 **Returns:** *[HostConfig](hostconfig.md)*
 
 • **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
@@ -493,8 +427,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
-
-*Defined in [card-elements.ts:555](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L555)*
 
 **Parameters:**
 
@@ -512,8 +444,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
 
-*Defined in [card-elements.ts:559](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L559)*
-
 **Returns:** *number*
 
 ___
@@ -523,8 +453,6 @@ ___
 • **get isInline**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
-
-*Defined in [card-elements.ts:576](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L576)*
 
 **Returns:** *boolean*
 
@@ -536,8 +464,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
 
-*Defined in [card-elements.ts:568](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L568)*
-
 **Returns:** *boolean*
 
 ___
@@ -547,8 +473,6 @@ ___
 • **get isStandalone**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
-
-*Defined in [card-elements.ts:572](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L572)*
 
 **Returns:** *boolean*
 
@@ -560,15 +484,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
 
-*Defined in [card-elements.ts:77](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L77)*
-
 **Returns:** *boolean*
 
 • **set isVisible**(`value`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
-
-*Defined in [card-elements.ts:81](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L81)*
 
 **Parameters:**
 
@@ -586,15 +506,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
 
-*Defined in [card-elements.ts:56](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L56)*
-
 **Returns:** *string | undefined*
 
 • **set lang**(`value`: string | undefined): *void*
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
-
-*Defined in [card-elements.ts:72](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L72)*
 
 **Parameters:**
 
@@ -614,8 +530,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[parent](cardobject.md#parent)*
 
-*Defined in [card-elements.ts:593](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L593)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -625,8 +539,6 @@ ___
 • **get renderedElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardObject](cardobject.md).[renderedElement](cardobject.md#renderedelement)*
-
-*Defined in [card-object.ts:140](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L140)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -638,8 +550,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requires](cardobject.md#requires)*
 
-*Defined in [card-object.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L53)*
-
 **Returns:** *HostCapabilities*
 
 ___
@@ -647,8 +557,6 @@ ___
 ###  selectedMediaType
 
 • **get selectedMediaType**(): *string | undefined*
-
-*Defined in [card-elements.ts:2282](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2282)*
 
 **Returns:** *string | undefined*
 
@@ -660,8 +568,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
 
-*Defined in [card-elements.ts:589](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L589)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -671,8 +577,6 @@ ___
 • **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
 
 *Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
-
-*Defined in [card-elements.ts:303](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L303)*
 
 **Returns:** *[Orientation](../enums/orientation.md)*
 
@@ -684,8 +588,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
 
-*Defined in [card-elements.ts:295](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L295)*
-
 **Returns:** *boolean*
 
 ## Methods
@@ -695,8 +597,6 @@ ___
 ▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
 
 *Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
-
-*Defined in [card-elements.ts:220](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L220)*
 
 **Parameters:**
 
@@ -714,8 +614,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
 
-*Defined in [card-elements.ts:239](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L239)*
-
 **Returns:** *void*
 
 ___
@@ -725,8 +623,6 @@ ___
 ▸ **asString**(): *string | undefined*
 
 *Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
-
-*Defined in [card-elements.ts:321](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L321)*
 
 **Returns:** *string | undefined*
 
@@ -738,8 +634,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
 
-*Defined in [card-elements.ts:205](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L205)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -749,8 +643,6 @@ ___
 ▸ **getActionAt**(`index`: number): *[Action](action.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
-
-*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
 
 **Parameters:**
 
@@ -768,8 +660,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
 
-*Defined in [card-elements.ts:531](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L531)*
-
 **Parameters:**
 
 Name | Type |
@@ -786,8 +676,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
 
-*Defined in [card-elements.ts:396](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L396)*
-
 **Returns:** *number*
 
 ___
@@ -798,8 +686,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
 
-*Defined in [card-elements.ts:519](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L519)*
-
 **Returns:** *[Input](input.md)[]*
 
 ___
@@ -809,8 +695,6 @@ ___
 ▸ **getCustomProperty**(`name`: string): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
-
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
 
 **Parameters:**
 
@@ -828,8 +712,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
 
-*Defined in [card-elements.ts:275](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L275)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
 ___
@@ -839,8 +721,6 @@ ___
 ▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
 
 *Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
-
-*Defined in [card-elements.ts:535](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L535)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
@@ -852,8 +732,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
 
-*Defined in [card-elements.ts:329](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L329)*
-
 **Returns:** *string*
 
 ___
@@ -864,8 +742,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyleDefinition](cardelement.md#geteffectivestyledefinition)*
 
-*Defined in [card-elements.ts:337](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L337)*
-
 **Returns:** *[ContainerStyleDefinition](containerstyledefinition.md)*
 
 ___
@@ -875,8 +751,6 @@ ___
 ▸ **getElementById**(`id`: string): *[CardElement](cardelement.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
-
-*Defined in [card-elements.ts:527](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L527)*
 
 **Parameters:**
 
@@ -894,8 +768,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
 
-*Defined in [card-elements.ts:341](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L341)*
-
 **Returns:** *[ActionType](../README.md#actiontype)[]*
 
 ___
@@ -906,8 +778,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
 
-*Defined in [card-elements.ts:279](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L279)*
-
 **Returns:** *boolean*
 
 ___
@@ -917,8 +787,6 @@ ___
 ▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
-
-*Defined in [card-elements.ts:345](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L345)*
 
 **Parameters:**
 
@@ -940,8 +808,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
 
-*Defined in [card-elements.ts:2255](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2255)*
-
 **Returns:** *string*
 
 ___
@@ -951,8 +817,6 @@ ___
 ▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
-
-*Defined in [card-elements.ts:283](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L283)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md) | undefined*
 
@@ -964,8 +828,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
 
-*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
-
 **Returns:** *[Container](container.md) | undefined*
 
 ___
@@ -975,8 +837,6 @@ ___
 ▸ **getResourceInformation**(): *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
 *Overrides [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
-
-*Defined in [card-elements.ts:2259](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2259)*
 
 **Returns:** *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
@@ -988,8 +848,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
 
-*Defined in [card-elements.ts:501](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L501)*
-
 **Returns:** *[CardElement](cardelement.md)*
 
 ___
@@ -1000,8 +858,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getRootObject](cardobject.md#getrootobject)*
 
-*Defined in [card-object.ts:100](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L100)*
-
 **Returns:** *[CardObject](cardobject.md)*
 
 ___
@@ -1011,8 +867,6 @@ ___
 ▸ **getSchema**(): *[SerializableObjectSchema](serializableobjectschema.md)*
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
-
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
 
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
@@ -1026,8 +880,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-object.ts:45](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L45)*
-
 **Returns:** *string*
 
 ___
@@ -1037,8 +889,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -1056,8 +906,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -1067,8 +915,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -1086,8 +932,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
 
-*Defined in [card-elements.ts:439](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L439)*
-
 **Parameters:**
 
 Name | Type |
@@ -1103,8 +947,6 @@ ___
 ▸ **internalParse**(`source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
-
-*Defined in [serialization.ts:789](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L789)*
 
 **Parameters:**
 
@@ -1123,8 +965,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
 
-*Defined in [card-elements.ts:2242](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2242)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1134,8 +974,6 @@ ___
 ▸ **internalToJSON**(`target`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
-
-*Defined in [serialization.ts:821](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L821)*
 
 **Parameters:**
 
@@ -1154,8 +992,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
 
-*Defined in [card-object.ts:110](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L110)*
-
 **Parameters:**
 
 Name | Type |
@@ -1172,8 +1008,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
 
-*Defined in [card-elements.ts:469](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L469)*
-
 **Returns:** *boolean*
 
 ___
@@ -1183,8 +1017,6 @@ ___
 ▸ **isAtTheVeryLeft**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
-
-*Defined in [card-elements.ts:457](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L457)*
 
 **Returns:** *boolean*
 
@@ -1196,8 +1028,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
 
-*Defined in [card-elements.ts:461](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L461)*
-
 **Returns:** *boolean*
 
 ___
@@ -1207,8 +1037,6 @@ ___
 ▸ **isAtTheVeryTop**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
-
-*Defined in [card-elements.ts:465](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L465)*
 
 **Returns:** *boolean*
 
@@ -1220,8 +1048,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
 
-*Defined in [card-elements.ts:325](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L325)*
-
 **Returns:** *boolean*
 
 ___
@@ -1231,8 +1057,6 @@ ___
 ▸ **isBleedingAtBottom**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
-
-*Defined in [card-elements.ts:477](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L477)*
 
 **Returns:** *boolean*
 
@@ -1244,8 +1068,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
 
-*Defined in [card-elements.ts:473](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L473)*
-
 **Returns:** *boolean*
 
 ___
@@ -1255,8 +1077,6 @@ ___
 ▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
-
-*Defined in [card-elements.ts:493](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L493)*
 
 **Parameters:**
 
@@ -1274,8 +1094,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
 
-*Defined in [card-elements.ts:443](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L443)*
-
 **Returns:** *boolean*
 
 ___
@@ -1286,8 +1104,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDisplayed](cardelement.md#protected-isdisplayed)*
 
-*Defined in [card-elements.ts:229](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L229)*
-
 **Returns:** *boolean*
 
 ___
@@ -1297,8 +1113,6 @@ ___
 ▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
-
-*Defined in [card-elements.ts:449](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L449)*
 
 **Parameters:**
 
@@ -1316,8 +1130,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
 
-*Defined in [card-elements.ts:497](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L497)*
-
 **Returns:** *boolean*
 
 ___
@@ -1327,8 +1139,6 @@ ___
 ▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
-
-*Defined in [card-elements.ts:453](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L453)*
 
 **Parameters:**
 
@@ -1346,8 +1156,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
 
-*Defined in [card-elements.ts:481](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L481)*
-
 **Parameters:**
 
 Name | Type |
@@ -1363,8 +1171,6 @@ ___
 ▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
-
-*Defined in [card-elements.ts:485](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L485)*
 
 **Parameters:**
 
@@ -1382,8 +1188,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
 
-*Defined in [card-elements.ts:489](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L489)*
-
 **Parameters:**
 
 Name | Type |
@@ -1400,8 +1204,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
 
-*Defined in [card-elements.ts:235](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L235)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1413,8 +1215,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[parse](cardelement.md#parse)*
 
 *Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
-
-*Defined in [card-elements.ts:313](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L313)*
 
 **Parameters:**
 
@@ -1433,8 +1233,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [serialization.ts:738](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L738)*
-
 **Parameters:**
 
 Name | Type |
@@ -1450,8 +1248,6 @@ ___
 ▸ **preProcessPropertyValue**(`property`: [PropertyDefinition](propertydefinition.md), `propertyValue?`: any): *any*
 
 *Inherited from [CardObject](cardobject.md).[preProcessPropertyValue](cardobject.md#preprocesspropertyvalue)*
-
-*Defined in [card-object.ts:70](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L70)*
 
 **Parameters:**
 
@@ -1470,8 +1266,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
 
-*Defined in [card-elements.ts:404](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L404)*
-
 **Returns:** *boolean*
 
 ___
@@ -1481,8 +1275,6 @@ ___
 ▸ **render**(): *HTMLElement | undefined*
 
 *Inherited from [CardElement](cardelement.md).[render](cardelement.md#render)*
-
-*Defined in [card-elements.ts:412](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L412)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -1494,8 +1286,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -1505,8 +1295,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -1525,8 +1313,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
 
-*Defined in [card-elements.ts:287](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L287)*
-
 **Parameters:**
 
 Name | Type |
@@ -1542,8 +1328,6 @@ ___
 ▸ **setParent**(`value`: [CardObject](cardobject.md) | undefined): *void*
 
 *Inherited from [CardObject](cardobject.md).[setParent](cardobject.md#setparent)*
-
-*Defined in [card-object.ts:88](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L88)*
 
 **Parameters:**
 
@@ -1561,8 +1345,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setShouldFallback](cardobject.md#setshouldfallback)*
 
-*Defined in [card-object.ts:92](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L92)*
-
 **Parameters:**
 
 Name | Type |
@@ -1578,8 +1360,6 @@ ___
 ▸ **setValue**(`property`: [PropertyDefinition](propertydefinition.md), `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
-
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
 
 **Parameters:**
 
@@ -1598,8 +1378,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[shouldFallback](cardobject.md#shouldfallback)*
 
-*Defined in [card-object.ts:96](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L96)*
-
 **Returns:** *boolean*
 
 ___
@@ -1611,8 +1389,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[shouldSerialize](cardelement.md#protected-shouldserialize)*
 
 *Overrides [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
-
-*Defined in [card-elements.ts:291](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L291)*
 
 **Parameters:**
 
@@ -1632,8 +1408,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
 
-*Defined in [card-elements.ts:317](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L317)*
-
 **Parameters:**
 
 Name | Type |
@@ -1649,8 +1423,6 @@ ___
 ▸ **truncateOverflow**(`maxHeight`: number): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
-
-*Defined in [card-elements.ts:263](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L263)*
 
 **Parameters:**
 
@@ -1668,8 +1440,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
 
-*Defined in [card-elements.ts:273](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L273)*
-
 **Returns:** *void*
 
 ___
@@ -1679,8 +1449,6 @@ ___
 ▸ **updateLayout**(`processChildren`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
-
-*Defined in [card-elements.ts:434](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L434)*
 
 **Parameters:**
 
@@ -1697,7 +1465,5 @@ ___
 ▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
 
 *Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
-
-*Defined in [card-object.ts:128](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L128)*
 
 **Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/mediaconfig.md
+++ b/source/nodejs/adaptivecards/docs/classes/mediaconfig.md
@@ -27,8 +27,6 @@
 
 \+ **new MediaConfig**(`obj?`: any): *[MediaConfig](mediaconfig.md)*
 
-*Defined in [host-config.ts:87](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L87)*
-
 **Parameters:**
 
 Name | Type |
@@ -43,23 +41,17 @@ Name | Type |
 
 • **allowInlinePlayback**: *boolean* = true
 
-*Defined in [host-config.ts:87](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L87)*
-
 ___
 
 ### `Optional` defaultPoster
 
 • **defaultPoster**? : *undefined | string*
 
-*Defined in [host-config.ts:86](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L86)*
-
 ## Methods
 
 ###  toJSON
 
 ▸ **toJSON**(): *object*
-
-*Defined in [host-config.ts:96](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L96)*
 
 **Returns:** *object*
 

--- a/source/nodejs/adaptivecards/docs/classes/mediasource.md
+++ b/source/nodejs/adaptivecards/docs/classes/mediasource.md
@@ -51,8 +51,6 @@
 
 *Overrides [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [card-elements.ts:2027](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2027)*
-
 **Parameters:**
 
 Name | Type |
@@ -70,15 +68,11 @@ Name | Type |
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 ___
 
 ### `Optional` mimeType
 
 • **mimeType**? : *undefined | string*
-
-*Defined in [card-elements.ts:2018](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2018)*
 
 ___
 
@@ -86,15 +80,11 @@ ___
 
 • **url**? : *undefined | string*
 
-*Defined in [card-elements.ts:2021](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2021)*
-
 ___
 
 ### `Static` mimeTypeProperty
 
 ▪ **mimeTypeProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_1, "mimeType")
-
-*Defined in [card-elements.ts:2014](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2014)*
 
 ___
 
@@ -104,15 +94,11 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
 
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
-
 ___
 
 ### `Static` urlProperty
 
 ▪ **urlProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_1, "url")
-
-*Defined in [card-elements.ts:2015](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2015)*
 
 ## Methods
 
@@ -121,8 +107,6 @@ ___
 ▸ **getCustomProperty**(`name`: string): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
-
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
 
 **Parameters:**
 
@@ -140,8 +124,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
 
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
-
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
 ___
@@ -152,8 +134,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-elements.ts:2025](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2025)*
-
 **Returns:** *string*
 
 ___
@@ -163,8 +143,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -182,8 +160,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -193,8 +169,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -211,8 +185,6 @@ ___
 ▸ **internalParse**(`source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
-
-*Defined in [serialization.ts:789](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L789)*
 
 **Parameters:**
 
@@ -231,8 +203,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
 
-*Defined in [serialization.ts:821](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L821)*
-
 **Parameters:**
 
 Name | Type |
@@ -248,8 +218,6 @@ ___
 
 ▸ **isValid**(): *boolean*
 
-*Defined in [card-elements.ts:2036](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2036)*
-
 **Returns:** *boolean*
 
 ___
@@ -259,8 +227,6 @@ ___
 ▸ **parse**(`source`: [PropertyBag](../README.md#propertybag), `context?`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
-
-*Defined in [serialization.ts:857](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L857)*
 
 **Parameters:**
 
@@ -279,8 +245,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [serialization.ts:738](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L738)*
-
 **Parameters:**
 
 Name | Type |
@@ -295,8 +259,6 @@ ___
 
 ▸ **render**(): *HTMLElement | undefined*
 
-*Defined in [card-elements.ts:2040](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2040)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -307,8 +269,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -318,8 +278,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -338,8 +296,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
 
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
-
 **Parameters:**
 
 Name | Type |
@@ -357,8 +313,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
 
-*Defined in [serialization.ts:839](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L839)*
-
 **Parameters:**
 
 Name | Type |
@@ -374,8 +328,6 @@ ___
 ▸ **toJSON**(`context?`: [BaseSerializationContext](baseserializationcontext.md)): *[PropertyBag](../README.md#propertybag) | undefined*
 
 *Inherited from [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
-
-*Defined in [serialization.ts:861](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L861)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/docs/classes/numberinput.md
+++ b/source/nodejs/adaptivecards/docs/classes/numberinput.md
@@ -159,8 +159,6 @@
 
 *Inherited from [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 **Returns:** *[NumberInput](numberinput.md)*
 
 ## Properties
@@ -171,8 +169,6 @@
 
 *Inherited from [CardObject](cardobject.md).[_parent](cardobject.md#protected-optional-_parent)*
 
-*Defined in [card-object.ts:61](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L61)*
-
 ___
 
 ### `Protected` `Optional` _renderedElement
@@ -180,8 +176,6 @@ ___
 • **_renderedElement**? : *HTMLElement*
 
 *Inherited from [CardObject](cardobject.md).[_renderedElement](cardobject.md#protected-optional-_renderedelement)*
-
-*Defined in [card-object.ts:62](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L62)*
 
 ___
 
@@ -191,15 +185,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#optional-customcssselector)*
 
-*Defined in [card-elements.ts:311](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L311)*
-
 ___
 
 ### `Optional` defaultValue
 
 • **defaultValue**? : *undefined | number*
-
-*Defined in [card-elements.ts:3048](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3048)*
 
 ___
 
@@ -209,8 +199,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
 
-*Defined in [card-elements.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L53)*
-
 ___
 
 ###  horizontalAlignment
@@ -218,8 +206,6 @@ ___
 • **horizontalAlignment**: *[HorizontalAlignment](../enums/horizontalalignment.md)*
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#horizontalalignment)*
-
-*Defined in [card-elements.ts:44](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L44)*
 
 ___
 
@@ -231,15 +217,11 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[id](cardobject.md#optional-id)*
 
-*Defined in [card-object.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L50)*
-
 ___
 
 ### `Optional` max
 
 • **max**? : *undefined | number*
-
-*Defined in [card-elements.ts:3054](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3054)*
 
 ___
 
@@ -249,15 +231,11 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 ___
 
 ### `Optional` min
 
 • **min**? : *undefined | number*
-
-*Defined in [card-elements.ts:3051](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3051)*
 
 ___
 
@@ -267,8 +245,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[onPreProcessPropertyValue](cardobject.md#optional-onpreprocesspropertyvalue)*
 
-*Defined in [card-object.ts:64](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L64)*
-
 ___
 
 ###  onValueChanged
@@ -276,8 +252,6 @@ ___
 • **onValueChanged**: *function*
 
 *Inherited from [Input](input.md).[onValueChanged](input.md#onvaluechanged)*
-
-*Defined in [card-elements.ts:2415](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2415)*
 
 #### Type declaration:
 
@@ -295,8 +269,6 @@ ___
 
 • **placeholder**? : *undefined | string*
 
-*Defined in [card-elements.ts:3057](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3057)*
-
 ___
 
 ###  separator
@@ -305,8 +277,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
 
-*Defined in [card-elements.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L50)*
-
 ___
 
 ###  spacing
@@ -314,8 +284,6 @@ ___
 • **spacing**: *[Spacing](../enums/spacing.md)*
 
 *Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
-
-*Defined in [card-elements.ts:47](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L47)*
 
 ___
 
@@ -332,8 +300,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[heightProperty](cardelement.md#static-heightproperty)*
 
-*Defined in [card-elements.ts:24](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L24)*
-
 ___
 
 ### `Static` horizontalAlignmentProperty
@@ -346,8 +312,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignmentProperty](cardelement.md#static-horizontalalignmentproperty)*
 
-*Defined in [card-elements.ts:32](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L32)*
-
 ___
 
 ### `Static` idProperty
@@ -355,8 +319,6 @@ ___
 ▪ **idProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "id")
 
 *Inherited from [CardObject](cardobject.md).[idProperty](cardobject.md#static-idproperty)*
-
-*Defined in [card-object.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L39)*
 
 ___
 
@@ -366,8 +328,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisibleProperty](cardelement.md#static-isvisibleproperty)*
 
-*Defined in [card-elements.ts:22](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L22)*
-
 ___
 
 ### `Static` langProperty
@@ -376,23 +336,17 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[langProperty](cardelement.md#static-langproperty)*
 
-*Defined in [card-elements.ts:21](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L21)*
-
 ___
 
 ### `Static` maxProperty
 
 ▪ **maxProperty**: *[NumProperty](numproperty.md)‹›* = new NumProperty(Versions.v1_0, "max")
 
-*Defined in [card-elements.ts:3045](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3045)*
-
 ___
 
 ### `Static` minProperty
 
 ▪ **minProperty**: *[NumProperty](numproperty.md)‹›* = new NumProperty(Versions.v1_0, "min")
-
-*Defined in [card-elements.ts:3044](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3044)*
 
 ___
 
@@ -402,15 +356,11 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
 
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
-
 ___
 
 ### `Static` placeholderProperty
 
 ▪ **placeholderProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "placeholder")
-
-*Defined in [card-elements.ts:3043](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3043)*
 
 ___
 
@@ -423,8 +373,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requiresProperty](cardobject.md#static-requiresproperty)*
 
-*Defined in [card-object.ts:40](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L40)*
-
 ___
 
 ### `Static` separatorProperty
@@ -432,8 +380,6 @@ ___
 ▪ **separatorProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_0, "separator", false)
 
 *Inherited from [CardElement](cardelement.md).[separatorProperty](cardelement.md#static-separatorproperty)*
-
-*Defined in [card-elements.ts:23](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L23)*
 
 ___
 
@@ -446,8 +392,6 @@ ___
         Enums.Spacing.Default)
 
 *Inherited from [CardElement](cardelement.md).[spacingProperty](cardelement.md#static-spacingproperty)*
-
-*Defined in [card-elements.ts:37](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L37)*
 
 ___
 
@@ -465,8 +409,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[typeNameProperty](cardobject.md#static-typenameproperty)*
 
-*Defined in [card-object.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L30)*
-
 ___
 
 ### `Static` validationProperty
@@ -478,15 +420,11 @@ ___
 
 *Inherited from [Input](input.md).[validationProperty](input.md#static-validationproperty)*
 
-*Defined in [card-elements.ts:2313](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2313)*
-
 ___
 
 ### `Static` valueProperty
 
 ▪ **valueProperty**: *[NumProperty](numproperty.md)‹›* = new NumProperty(Versions.v1_0, "value")
-
-*Defined in [card-elements.ts:3042](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3042)*
 
 ## Accessors
 
@@ -495,8 +433,6 @@ ___
 • **get allowCustomPadding**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
-
-*Defined in [card-elements.ts:299](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L299)*
 
 **Returns:** *boolean*
 
@@ -508,8 +444,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
 
-*Defined in [card-elements.ts:307](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L307)*
-
 **Returns:** *string*
 
 ___
@@ -519,8 +453,6 @@ ___
 • **get hasVisibleSeparator**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
-
-*Defined in [card-elements.ts:580](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L580)*
 
 **Returns:** *boolean*
 
@@ -534,8 +466,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
 
-*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
-
 **Returns:** *[HostConfig](hostconfig.md)*
 
 • **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
@@ -543,8 +473,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
-
-*Defined in [card-elements.ts:555](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L555)*
 
 **Parameters:**
 
@@ -562,8 +490,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
 
-*Defined in [card-elements.ts:559](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L559)*
-
 **Returns:** *number*
 
 ___
@@ -574,8 +500,6 @@ ___
 
 *Inherited from [Input](input.md).[inputControlContainerElement](input.md#protected-inputcontrolcontainerelement)*
 
-*Defined in [card-elements.ts:2346](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2346)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -585,8 +509,6 @@ ___
 • **get isInline**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
-
-*Defined in [card-elements.ts:576](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L576)*
 
 **Returns:** *boolean*
 
@@ -600,8 +522,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
 
-*Defined in [card-elements.ts:2453](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2453)*
-
 **Returns:** *boolean*
 
 ___
@@ -611,8 +531,6 @@ ___
 • **get isNullable**(): *boolean*
 
 *Inherited from [Input](input.md).[isNullable](input.md#protected-isnullable)*
-
-*Defined in [card-elements.ts:2338](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2338)*
 
 **Returns:** *boolean*
 
@@ -624,8 +542,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
 
-*Defined in [card-elements.ts:572](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L572)*
-
 **Returns:** *boolean*
 
 ___
@@ -636,15 +552,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
 
-*Defined in [card-elements.ts:77](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L77)*
-
 **Returns:** *boolean*
 
 • **set isVisible**(`value`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
-
-*Defined in [card-elements.ts:81](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L81)*
 
 **Parameters:**
 
@@ -662,15 +574,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
 
-*Defined in [card-elements.ts:56](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L56)*
-
 **Returns:** *string | undefined*
 
 • **set lang**(`value`: string | undefined): *void*
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
-
-*Defined in [card-elements.ts:72](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L72)*
 
 **Parameters:**
 
@@ -690,8 +598,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[parent](cardobject.md#parent)*
 
-*Defined in [card-elements.ts:593](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L593)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -701,8 +607,6 @@ ___
 • **get renderedElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardObject](cardobject.md).[renderedElement](cardobject.md#renderedelement)*
-
-*Defined in [card-object.ts:140](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L140)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -714,8 +618,6 @@ ___
 
 *Inherited from [Input](input.md).[renderedInputControlElement](input.md#protected-renderedinputcontrolelement)*
 
-*Defined in [card-elements.ts:2342](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2342)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -725,8 +627,6 @@ ___
 • **get requires**(): *HostCapabilities*
 
 *Inherited from [CardObject](cardobject.md).[requires](cardobject.md#requires)*
-
-*Defined in [card-object.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L53)*
 
 **Returns:** *HostCapabilities*
 
@@ -738,8 +638,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
 
-*Defined in [card-elements.ts:589](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L589)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -749,8 +647,6 @@ ___
 • **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
 
 *Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
-
-*Defined in [card-elements.ts:303](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L303)*
 
 **Returns:** *[Orientation](../enums/orientation.md)*
 
@@ -762,8 +658,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
 
-*Defined in [card-elements.ts:295](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L295)*
-
 **Returns:** *boolean*
 
 ___
@@ -773,8 +667,6 @@ ___
 • **get validation**(): *[InputValidationOptions](inputvalidationoptions.md)*
 
 *Inherited from [Input](input.md).[validation](input.md#validation)*
-
-*Defined in [card-elements.ts:2327](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2327)*
 
 **Returns:** *[InputValidationOptions](inputvalidationoptions.md)*
 
@@ -786,8 +678,6 @@ ___
 
 *Overrides [Input](input.md).[value](input.md#value)*
 
-*Defined in [card-elements.ts:3101](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3101)*
-
 **Returns:** *number | undefined*
 
 ## Methods
@@ -797,8 +687,6 @@ ___
 ▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
 
 *Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
-
-*Defined in [card-elements.ts:220](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L220)*
 
 **Parameters:**
 
@@ -816,8 +704,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
 
-*Defined in [card-elements.ts:239](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L239)*
-
 **Returns:** *void*
 
 ___
@@ -827,8 +713,6 @@ ___
 ▸ **asString**(): *string | undefined*
 
 *Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
-
-*Defined in [card-elements.ts:321](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L321)*
 
 **Returns:** *string | undefined*
 
@@ -840,8 +724,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
 
-*Defined in [card-elements.ts:205](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L205)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -851,8 +733,6 @@ ___
 ▸ **getActionAt**(`index`: number): *[Action](action.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
-
-*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
 
 **Parameters:**
 
@@ -870,8 +750,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
 
-*Defined in [card-elements.ts:531](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L531)*
-
 **Parameters:**
 
 Name | Type |
@@ -888,8 +766,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
 
-*Defined in [card-elements.ts:396](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L396)*
-
 **Returns:** *number*
 
 ___
@@ -902,8 +778,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
 
-*Defined in [card-elements.ts:2449](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2449)*
-
 **Returns:** *[Input](input.md)[]*
 
 ___
@@ -913,8 +787,6 @@ ___
 ▸ **getCustomProperty**(`name`: string): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
-
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
 
 **Parameters:**
 
@@ -932,8 +804,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
 
-*Defined in [card-elements.ts:275](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L275)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
 ___
@@ -943,8 +813,6 @@ ___
 ▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
 
 *Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
-
-*Defined in [card-elements.ts:535](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L535)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
@@ -956,8 +824,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
 
-*Defined in [card-elements.ts:329](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L329)*
-
 **Returns:** *string*
 
 ___
@@ -968,8 +834,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyleDefinition](cardelement.md#geteffectivestyledefinition)*
 
-*Defined in [card-elements.ts:337](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L337)*
-
 **Returns:** *[ContainerStyleDefinition](containerstyledefinition.md)*
 
 ___
@@ -979,8 +843,6 @@ ___
 ▸ **getElementById**(`id`: string): *[CardElement](cardelement.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
-
-*Defined in [card-elements.ts:527](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L527)*
 
 **Parameters:**
 
@@ -998,8 +860,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
 
-*Defined in [card-elements.ts:341](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L341)*
-
 **Returns:** *[ActionType](../README.md#actiontype)[]*
 
 ___
@@ -1010,8 +870,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
 
-*Defined in [card-elements.ts:279](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L279)*
-
 **Returns:** *boolean*
 
 ___
@@ -1021,8 +879,6 @@ ___
 ▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
-
-*Defined in [card-elements.ts:345](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L345)*
 
 **Parameters:**
 
@@ -1044,8 +900,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
 
-*Defined in [card-elements.ts:3093](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3093)*
-
 **Returns:** *string*
 
 ___
@@ -1055,8 +909,6 @@ ___
 ▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
-
-*Defined in [card-elements.ts:283](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L283)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md) | undefined*
 
@@ -1068,8 +920,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
 
-*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
-
 **Returns:** *[Container](container.md) | undefined*
 
 ___
@@ -1079,8 +929,6 @@ ___
 ▸ **getResourceInformation**(): *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
 *Inherited from [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
-
-*Defined in [card-elements.ts:523](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L523)*
 
 **Returns:** *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
@@ -1092,8 +940,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
 
-*Defined in [card-elements.ts:501](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L501)*
-
 **Returns:** *[CardElement](cardelement.md)*
 
 ___
@@ -1104,8 +950,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getRootObject](cardobject.md#getrootobject)*
 
-*Defined in [card-object.ts:100](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L100)*
-
 **Returns:** *[CardObject](cardobject.md)*
 
 ___
@@ -1115,8 +959,6 @@ ___
 ▸ **getSchema**(): *[SerializableObjectSchema](serializableobjectschema.md)*
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
-
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
 
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
@@ -1130,8 +972,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-object.ts:45](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L45)*
-
 **Returns:** *string*
 
 ___
@@ -1141,8 +981,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -1160,8 +998,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -1171,8 +1007,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -1190,8 +1024,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
 
-*Defined in [card-elements.ts:439](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L439)*
-
 **Parameters:**
 
 Name | Type |
@@ -1207,8 +1039,6 @@ ___
 ▸ **internalParse**(`source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
-
-*Defined in [serialization.ts:789](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L789)*
 
 **Parameters:**
 
@@ -1227,8 +1057,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
 
-*Defined in [card-elements.ts:3063](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3063)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1238,8 +1066,6 @@ ___
 ▸ **internalToJSON**(`target`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
-
-*Defined in [serialization.ts:821](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L821)*
 
 **Parameters:**
 
@@ -1260,8 +1086,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
 
-*Defined in [card-elements.ts:2419](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2419)*
-
 **Parameters:**
 
 Name | Type |
@@ -1278,8 +1102,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
 
-*Defined in [card-elements.ts:469](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L469)*
-
 **Returns:** *boolean*
 
 ___
@@ -1289,8 +1111,6 @@ ___
 ▸ **isAtTheVeryLeft**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
-
-*Defined in [card-elements.ts:457](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L457)*
 
 **Returns:** *boolean*
 
@@ -1302,8 +1122,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
 
-*Defined in [card-elements.ts:461](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L461)*
-
 **Returns:** *boolean*
 
 ___
@@ -1313,8 +1131,6 @@ ___
 ▸ **isAtTheVeryTop**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
-
-*Defined in [card-elements.ts:465](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L465)*
 
 **Returns:** *boolean*
 
@@ -1326,8 +1142,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
 
-*Defined in [card-elements.ts:325](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L325)*
-
 **Returns:** *boolean*
 
 ___
@@ -1337,8 +1151,6 @@ ___
 ▸ **isBleedingAtBottom**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
-
-*Defined in [card-elements.ts:477](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L477)*
 
 **Returns:** *boolean*
 
@@ -1350,8 +1162,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
 
-*Defined in [card-elements.ts:473](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L473)*
-
 **Returns:** *boolean*
 
 ___
@@ -1361,8 +1171,6 @@ ___
 ▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
-
-*Defined in [card-elements.ts:493](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L493)*
 
 **Parameters:**
 
@@ -1380,8 +1188,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
 
-*Defined in [card-elements.ts:443](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L443)*
-
 **Returns:** *boolean*
 
 ___
@@ -1392,8 +1198,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDisplayed](cardelement.md#protected-isdisplayed)*
 
-*Defined in [card-elements.ts:229](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L229)*
-
 **Returns:** *boolean*
 
 ___
@@ -1403,8 +1207,6 @@ ___
 ▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
-
-*Defined in [card-elements.ts:449](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L449)*
 
 **Parameters:**
 
@@ -1422,8 +1224,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
 
-*Defined in [card-elements.ts:497](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L497)*
-
 **Returns:** *boolean*
 
 ___
@@ -1433,8 +1233,6 @@ ___
 ▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
-
-*Defined in [card-elements.ts:453](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L453)*
 
 **Parameters:**
 
@@ -1452,8 +1250,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
 
-*Defined in [card-elements.ts:481](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L481)*
-
 **Parameters:**
 
 Name | Type |
@@ -1469,8 +1265,6 @@ ___
 ▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
-
-*Defined in [card-elements.ts:485](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L485)*
 
 **Parameters:**
 
@@ -1488,8 +1282,6 @@ ___
 
 *Overrides [Input](input.md).[isSet](input.md#abstract-isset)*
 
-*Defined in [card-elements.ts:3097](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3097)*
-
 **Returns:** *boolean*
 
 ___
@@ -1499,8 +1291,6 @@ ___
 ▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
-
-*Defined in [card-elements.ts:489](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L489)*
 
 **Parameters:**
 
@@ -1520,8 +1310,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
 
-*Defined in [card-elements.ts:2350](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2350)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1533,8 +1321,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[parse](cardelement.md#parse)*
 
 *Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
-
-*Defined in [card-elements.ts:313](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L313)*
 
 **Parameters:**
 
@@ -1555,8 +1341,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [card-elements.ts:2318](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2318)*
-
 **Parameters:**
 
 Name | Type |
@@ -1572,8 +1356,6 @@ ___
 ▸ **preProcessPropertyValue**(`property`: [PropertyDefinition](propertydefinition.md), `propertyValue?`: any): *any*
 
 *Inherited from [CardObject](cardobject.md).[preProcessPropertyValue](cardobject.md#preprocesspropertyvalue)*
-
-*Defined in [card-object.ts:70](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L70)*
 
 **Parameters:**
 
@@ -1592,8 +1374,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
 
-*Defined in [card-elements.ts:404](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L404)*
-
 **Returns:** *boolean*
 
 ___
@@ -1603,8 +1383,6 @@ ___
 ▸ **render**(): *HTMLElement | undefined*
 
 *Inherited from [CardElement](cardelement.md).[render](cardelement.md#render)*
-
-*Defined in [card-elements.ts:412](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L412)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -1616,8 +1394,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -1628,8 +1404,6 @@ ___
 
 *Inherited from [Input](input.md).[resetValidationFailureCue](input.md#protected-resetvalidationfailurecue)*
 
-*Defined in [card-elements.ts:2391](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2391)*
-
 **Returns:** *void*
 
 ___
@@ -1639,8 +1413,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -1659,8 +1431,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
 
-*Defined in [card-elements.ts:287](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L287)*
-
 **Parameters:**
 
 Name | Type |
@@ -1676,8 +1446,6 @@ ___
 ▸ **setParent**(`value`: [CardObject](cardobject.md) | undefined): *void*
 
 *Inherited from [CardObject](cardobject.md).[setParent](cardobject.md#setparent)*
-
-*Defined in [card-object.ts:88](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L88)*
 
 **Parameters:**
 
@@ -1695,8 +1463,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setShouldFallback](cardobject.md#setshouldfallback)*
 
-*Defined in [card-object.ts:92](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L92)*
-
 **Parameters:**
 
 Name | Type |
@@ -1712,8 +1478,6 @@ ___
 ▸ **setValue**(`property`: [PropertyDefinition](propertydefinition.md), `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
-
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
 
 **Parameters:**
 
@@ -1732,8 +1496,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[shouldFallback](cardobject.md#shouldfallback)*
 
-*Defined in [card-object.ts:96](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L96)*
-
 **Returns:** *boolean*
 
 ___
@@ -1745,8 +1507,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[shouldSerialize](cardelement.md#protected-shouldserialize)*
 
 *Overrides [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
-
-*Defined in [card-elements.ts:291](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L291)*
 
 **Parameters:**
 
@@ -1764,8 +1524,6 @@ ___
 
 *Inherited from [Input](input.md).[showValidationErrorMessage](input.md#protected-showvalidationerrormessage)*
 
-*Defined in [card-elements.ts:2403](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2403)*
-
 **Returns:** *void*
 
 ___
@@ -1777,8 +1535,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[toJSON](cardelement.md#tojson)*
 
 *Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
-
-*Defined in [card-elements.ts:317](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L317)*
 
 **Parameters:**
 
@@ -1796,8 +1552,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
 
-*Defined in [card-elements.ts:263](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L263)*
-
 **Parameters:**
 
 Name | Type |
@@ -1814,8 +1568,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
 
-*Defined in [card-elements.ts:273](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L273)*
-
 **Returns:** *void*
 
 ___
@@ -1825,8 +1577,6 @@ ___
 ▸ **updateLayout**(`processChildren`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
-
-*Defined in [card-elements.ts:434](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L434)*
 
 **Parameters:**
 
@@ -1844,8 +1594,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
 
-*Defined in [card-object.ts:128](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L128)*
-
 **Returns:** *[ValidationResults](validationresults.md)*
 
 ___
@@ -1858,8 +1606,6 @@ ___
 
 *Inherited from [Input](input.md).[validateValue](input.md#validatevalue)*
 
-*Defined in [card-elements.ts:2430](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2430)*
-
 **Returns:** *boolean*
 
 ___
@@ -1869,7 +1615,5 @@ ___
 ▸ **valueChanged**(): *void*
 
 *Inherited from [Input](input.md).[valueChanged](input.md#protected-valuechanged)*
-
-*Defined in [card-elements.ts:2381](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2381)*
 
 **Returns:** *void*

--- a/source/nodejs/adaptivecards/docs/classes/numproperty.md
+++ b/source/nodejs/adaptivecards/docs/classes/numproperty.md
@@ -36,8 +36,6 @@
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[constructor](propertydefinition.md#constructor)*
 
-*Defined in [serialization.ts:258](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L258)*
-
 **Parameters:**
 
 Name | Type |
@@ -57,8 +55,6 @@ Name | Type |
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[defaultValue](propertydefinition.md#optional-defaultvalue)*
 
-*Defined in [serialization.ts:263](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L263)*
-
 ___
 
 ###  name
@@ -66,8 +62,6 @@ ___
 • **name**: *string*
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[name](propertydefinition.md#name)*
-
-*Defined in [serialization.ts:262](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L262)*
 
 ___
 
@@ -77,8 +71,6 @@ ___
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[onGetInitialValue](propertydefinition.md#optional-ongetinitialvalue)*
 
-*Defined in [serialization.ts:264](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L264)*
-
 ___
 
 ###  sequentialNumber
@@ -86,8 +78,6 @@ ___
 • **sequentialNumber**: *number*
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[sequentialNumber](propertydefinition.md#sequentialnumber)*
-
-*Defined in [serialization.ts:258](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L258)*
 
 ___
 
@@ -97,8 +87,6 @@ ___
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[targetVersion](propertydefinition.md#targetversion)*
 
-*Defined in [serialization.ts:261](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L261)*
-
 ## Methods
 
 ###  getInternalName
@@ -106,8 +94,6 @@ ___
 ▸ **getInternalName**(): *string*
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[getInternalName](propertydefinition.md#getinternalname)*
-
-*Defined in [serialization.ts:246](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L246)*
 
 **Returns:** *string*
 
@@ -118,8 +104,6 @@ ___
 ▸ **parse**(`sender`: [SerializableObject](serializableobject.md), `source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *number | undefined*
 
 *Overrides [PropertyDefinition](propertydefinition.md).[parse](propertydefinition.md#parse)*
-
-*Defined in [serialization.ts:326](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L326)*
 
 **Parameters:**
 
@@ -138,8 +122,6 @@ ___
 ▸ **toJSON**(`sender`: [SerializableObject](serializableobject.md), `target`: [PropertyBag](../README.md#propertybag), `value`: number | undefined, `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Overrides [PropertyDefinition](propertydefinition.md).[toJSON](propertydefinition.md#tojson)*
-
-*Defined in [serialization.ts:330](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L330)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/docs/classes/openurlaction.md
+++ b/source/nodejs/adaptivecards/docs/classes/openurlaction.md
@@ -52,6 +52,7 @@
 * [execute](openurlaction.md#execute)
 * [getActionById](openurlaction.md#getactionbyid)
 * [getAllInputs](openurlaction.md#getallinputs)
+* [getAriaRole](openurlaction.md#getariarole)
 * [getCustomProperty](openurlaction.md#getcustomproperty)
 * [getHref](openurlaction.md#gethref)
 * [getJsonTypeName](openurlaction.md#getjsontypename)
@@ -95,8 +96,6 @@
 
 *Inherited from [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 **Returns:** *[OpenUrlAction](openurlaction.md)*
 
 ## Properties
@@ -107,8 +106,6 @@
 
 *Inherited from [CardObject](cardobject.md).[_parent](cardobject.md#protected-optional-_parent)*
 
-*Defined in [card-object.ts:61](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L61)*
-
 ___
 
 ### `Protected` `Optional` _renderedElement
@@ -116,8 +113,6 @@ ___
 • **_renderedElement**? : *HTMLElement*
 
 *Inherited from [CardObject](cardobject.md).[_renderedElement](cardobject.md#protected-optional-_renderedelement)*
-
-*Defined in [card-object.ts:62](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L62)*
 
 ___
 
@@ -127,8 +122,6 @@ ___
 
 *Inherited from [Action](action.md).[iconUrl](action.md#optional-iconurl)*
 
-*Defined in [card-elements.ts:3359](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3359)*
-
 ___
 
 ### `Optional` id
@@ -136,8 +129,6 @@ ___
 • **id**? : *undefined | string*
 
 *Inherited from [CardObject](cardobject.md).[id](cardobject.md#optional-id)*
-
-*Defined in [card-object.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L50)*
 
 ___
 
@@ -147,8 +138,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 ___
 
 ###  onExecute
@@ -156,8 +145,6 @@ ___
 • **onExecute**: *function*
 
 *Inherited from [Action](action.md).[onExecute](action.md#onexecute)*
-
-*Defined in [card-elements.ts:3400](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3400)*
 
 #### Type declaration:
 
@@ -177,8 +164,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[onPreProcessPropertyValue](cardobject.md#optional-onpreprocesspropertyvalue)*
 
-*Defined in [card-object.ts:64](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L64)*
-
 ___
 
 ###  style
@@ -186,8 +171,6 @@ ___
 • **style**: *string* = Enums.ActionStyle.Default
 
 *Inherited from [Action](action.md).[style](action.md#style)*
-
-*Defined in [card-elements.ts:3362](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3362)*
 
 ___
 
@@ -197,23 +180,17 @@ ___
 
 *Inherited from [Action](action.md).[title](action.md#optional-title)*
 
-*Defined in [card-elements.ts:3356](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3356)*
-
 ___
 
 ### `Optional` url
 
 • **url**? : *undefined | string*
 
-*Defined in [card-elements.ts:3641](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3641)*
-
 ___
 
 ### `Static` JsonTypeName
 
 ▪ **JsonTypeName**: *"Action.OpenUrl"* = "Action.OpenUrl"
-
-*Defined in [card-elements.ts:3647](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3647)*
 
 ___
 
@@ -223,8 +200,6 @@ ___
 
 *Inherited from [Action](action.md).[iconUrlProperty](action.md#static-iconurlproperty)*
 
-*Defined in [card-elements.ts:3342](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3342)*
-
 ___
 
 ### `Static` idProperty
@@ -232,8 +207,6 @@ ___
 ▪ **idProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "id")
 
 *Inherited from [CardObject](cardobject.md).[idProperty](cardobject.md#static-idproperty)*
-
-*Defined in [card-object.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L39)*
 
 ___
 
@@ -243,8 +216,6 @@ ___
 
 *Inherited from [Action](action.md).[ignoreInputValidationProperty](action.md#static-ignoreinputvalidationproperty)*
 
-*Defined in [card-elements.ts:3353](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3353)*
-
 ___
 
 ### `Static` `Optional` onRegisterCustomProperties
@@ -252,8 +223,6 @@ ___
 ▪ **onRegisterCustomProperties**? : *undefined | function*
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
-
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
 
 ___
 
@@ -265,8 +234,6 @@ ___
         HostCapabilities)
 
 *Inherited from [CardObject](cardobject.md).[requiresProperty](cardobject.md#static-requiresproperty)*
-
-*Defined in [card-object.ts:40](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L40)*
 
 ___
 
@@ -284,8 +251,6 @@ ___
 
 *Inherited from [Action](action.md).[styleProperty](action.md#static-styleproperty)*
 
-*Defined in [card-elements.ts:3343](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3343)*
-
 ___
 
 ### `Static` titleProperty
@@ -293,8 +258,6 @@ ___
 ▪ **titleProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "title")
 
 *Inherited from [Action](action.md).[titleProperty](action.md#static-titleproperty)*
-
-*Defined in [card-elements.ts:3341](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3341)*
 
 ___
 
@@ -312,15 +275,11 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[typeNameProperty](cardobject.md#static-typenameproperty)*
 
-*Defined in [card-object.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L30)*
-
 ___
 
 ### `Static` urlProperty
 
 ▪ **urlProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "url")
-
-*Defined in [card-elements.ts:3638](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3638)*
 
 ## Accessors
 
@@ -332,8 +291,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
 
-*Defined in [card-elements.ts:3551](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3551)*
-
 **Returns:** *[HostConfig](hostconfig.md)*
 
 ___
@@ -343,8 +300,6 @@ ___
 • **get ignoreInputValidation**(): *boolean*
 
 *Inherited from [Action](action.md).[ignoreInputValidation](action.md#ignoreinputvalidation)*
-
-*Defined in [card-elements.ts:3547](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3547)*
 
 **Returns:** *boolean*
 
@@ -356,15 +311,11 @@ ___
 
 *Inherited from [Action](action.md).[isPrimary](action.md#isprimary)*
 
-*Defined in [card-elements.ts:3532](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3532)*
-
 **Returns:** *boolean*
 
 • **set isPrimary**(`value`: boolean): *void*
 
 *Inherited from [Action](action.md).[isPrimary](action.md#isprimary)*
-
-*Defined in [card-elements.ts:3536](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3536)*
 
 **Parameters:**
 
@@ -384,8 +335,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[parent](cardobject.md#parent)*
 
-*Defined in [card-elements.ts:3555](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3555)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -395,8 +344,6 @@ ___
 • **get renderedElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardObject](cardobject.md).[renderedElement](cardobject.md#renderedelement)*
-
-*Defined in [card-object.ts:140](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L140)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -408,8 +355,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requires](cardobject.md#requires)*
 
-*Defined in [card-object.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L53)*
-
 **Returns:** *HostCapabilities*
 
 ## Methods
@@ -419,8 +364,6 @@ ___
 ▸ **addCssClasses**(`element`: HTMLElement): *void*
 
 *Inherited from [Action](action.md).[addCssClasses](action.md#protected-addcssclasses)*
-
-*Defined in [card-elements.ts:3368](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3368)*
 
 **Parameters:**
 
@@ -438,8 +381,6 @@ ___
 
 *Inherited from [Action](action.md).[execute](action.md#execute)*
 
-*Defined in [card-elements.ts:3484](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3484)*
-
 **Returns:** *void*
 
 ___
@@ -449,8 +390,6 @@ ___
 ▸ **getActionById**(`id`: string): *[Action](action.md) | undefined*
 
 *Inherited from [Action](action.md).[getActionById](action.md#getactionbyid)*
-
-*Defined in [card-elements.ts:3520](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3520)*
 
 **Parameters:**
 
@@ -468,9 +407,17 @@ ___
 
 *Inherited from [Action](action.md).[getAllInputs](action.md#getallinputs)*
 
-*Defined in [card-elements.ts:3512](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3512)*
-
 **Returns:** *[Input](input.md)[]*
+
+___
+
+###  getAriaRole
+
+▸ **getAriaRole**(): *string*
+
+*Overrides [Action](action.md).[getAriaRole](action.md#getariarole)*
+
+**Returns:** *string*
 
 ___
 
@@ -479,8 +426,6 @@ ___
 ▸ **getCustomProperty**(`name`: string): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
-
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
 
 **Parameters:**
 
@@ -498,8 +443,6 @@ ___
 
 *Overrides [Action](action.md).[getHref](action.md#gethref)*
 
-*Defined in [card-elements.ts:3673](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3673)*
-
 **Returns:** *string | undefined*
 
 ___
@@ -509,8 +452,6 @@ ___
 ▸ **getJsonTypeName**(): *string*
 
 *Overrides [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
-
-*Defined in [card-elements.ts:3649](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3649)*
 
 **Returns:** *string*
 
@@ -522,8 +463,6 @@ ___
 
 *Inherited from [Action](action.md).[getReferencedInputs](action.md#getreferencedinputs)*
 
-*Defined in [card-elements.ts:3524](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3524)*
-
 **Returns:** *[Dictionary](../README.md#dictionary)‹[Input](input.md)› | undefined*
 
 ___
@@ -533,8 +472,6 @@ ___
 ▸ **getResourceInformation**(): *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
 *Inherited from [Action](action.md).[getResourceInformation](action.md#getresourceinformation)*
-
-*Defined in [card-elements.ts:3516](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3516)*
 
 **Returns:** *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
@@ -546,8 +483,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getRootObject](cardobject.md#getrootobject)*
 
-*Defined in [card-object.ts:100](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L100)*
-
 **Returns:** *[CardObject](cardobject.md)*
 
 ___
@@ -557,8 +492,6 @@ ___
 ▸ **getSchema**(): *[SerializableObjectSchema](serializableobjectschema.md)*
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
-
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
 
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
@@ -572,8 +505,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-object.ts:45](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L45)*
-
 **Returns:** *string*
 
 ___
@@ -583,8 +514,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -602,8 +531,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -613,8 +540,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -632,8 +557,6 @@ ___
 
 *Inherited from [Action](action.md).[internalGetReferencedInputs](action.md#protected-internalgetreferencedinputs)*
 
-*Defined in [card-elements.ts:3372](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3372)*
-
 **Parameters:**
 
 Name | Type |
@@ -649,8 +572,6 @@ ___
 ▸ **internalParse**(`source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
-
-*Defined in [serialization.ts:789](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L789)*
 
 **Parameters:**
 
@@ -669,8 +590,6 @@ ___
 
 *Inherited from [Action](action.md).[internalPrepareForExecution](action.md#protected-internalprepareforexecution)*
 
-*Defined in [card-elements.ts:3376](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3376)*
-
 **Parameters:**
 
 Name | Type |
@@ -686,8 +605,6 @@ ___
 ▸ **internalToJSON**(`target`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
-
-*Defined in [serialization.ts:821](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L821)*
 
 **Parameters:**
 
@@ -706,8 +623,6 @@ ___
 
 *Inherited from [Action](action.md).[internalValidateInputs](action.md#protected-internalvalidateinputs)*
 
-*Defined in [card-elements.ts:3380](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3380)*
-
 **Parameters:**
 
 Name | Type |
@@ -723,8 +638,6 @@ ___
 ▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
 
 *Overrides [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
-
-*Defined in [card-elements.ts:3653](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3653)*
 
 **Parameters:**
 
@@ -744,8 +657,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
 
-*Defined in [card-elements.ts:3410](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3410)*
-
 **Parameters:**
 
 Name | Type |
@@ -763,8 +674,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [serialization.ts:738](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L738)*
-
 **Parameters:**
 
 Name | Type |
@@ -780,8 +689,6 @@ ___
 ▸ **preProcessPropertyValue**(`property`: [PropertyDefinition](propertydefinition.md), `propertyValue?`: any): *any*
 
 *Inherited from [CardObject](cardobject.md).[preProcessPropertyValue](cardobject.md#preprocesspropertyvalue)*
-
-*Defined in [card-object.ts:70](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L70)*
 
 **Parameters:**
 
@@ -800,8 +707,6 @@ ___
 
 *Inherited from [Action](action.md).[prepareForExecution](action.md#prepareforexecution)*
 
-*Defined in [card-elements.ts:3492](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3492)*
-
 **Returns:** *boolean*
 
 ___
@@ -812,8 +717,6 @@ ___
 
 *Inherited from [Action](action.md).[remove](action.md#remove)*
 
-*Defined in [card-elements.ts:3504](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3504)*
-
 **Returns:** *boolean*
 
 ___
@@ -823,8 +726,6 @@ ___
 ▸ **render**(`baseCssClass`: string): *void*
 
 *Overrides [Action](action.md).[render](action.md#render)*
-
-*Defined in [card-elements.ts:3664](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3664)*
 
 **Parameters:**
 
@@ -842,8 +743,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -853,8 +752,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -873,8 +770,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setParent](cardobject.md#setparent)*
 
-*Defined in [card-object.ts:88](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L88)*
-
 **Parameters:**
 
 Name | Type |
@@ -891,8 +786,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setShouldFallback](cardobject.md#setshouldfallback)*
 
-*Defined in [card-object.ts:92](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L92)*
-
 **Parameters:**
 
 Name | Type |
@@ -908,8 +801,6 @@ ___
 ▸ **setValue**(`property`: [PropertyDefinition](propertydefinition.md), `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
-
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
 
 **Parameters:**
 
@@ -928,8 +819,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[shouldFallback](cardobject.md#shouldfallback)*
 
-*Defined in [card-object.ts:96](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L96)*
-
 **Returns:** *boolean*
 
 ___
@@ -941,8 +830,6 @@ ___
 *Inherited from [Action](action.md).[shouldSerialize](action.md#protected-shouldserialize)*
 
 *Overrides [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
-
-*Defined in [card-elements.ts:3396](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3396)*
 
 **Parameters:**
 
@@ -962,8 +849,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
 
-*Defined in [card-elements.ts:3414](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3414)*
-
 **Parameters:**
 
 Name | Type |
@@ -979,8 +864,6 @@ ___
 ▸ **updateActionButtonCssStyle**(`actionButtonElement`: HTMLElement): *void*
 
 *Inherited from [Action](action.md).[updateActionButtonCssStyle](action.md#updateactionbuttoncssstyle)*
-
-*Defined in [card-elements.ts:3406](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3406)*
 
 **Parameters:**
 
@@ -998,8 +881,6 @@ ___
 
 *Inherited from [Action](action.md).[validateInputs](action.md#validateinputs)*
 
-*Defined in [card-elements.ts:3528](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3528)*
-
 **Returns:** *[Input](input.md)‹›[]*
 
 ___
@@ -1009,7 +890,5 @@ ___
 ▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
 
 *Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
-
-*Defined in [card-object.ts:128](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L128)*
 
 **Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/paddingdefinition.md
+++ b/source/nodejs/adaptivecards/docs/classes/paddingdefinition.md
@@ -25,8 +25,6 @@
 
 \+ **new PaddingDefinition**(`top`: [Spacing](../enums/spacing.md), `right`: [Spacing](../enums/spacing.md), `bottom`: [Spacing](../enums/spacing.md), `left`: [Spacing](../enums/spacing.md)): *[PaddingDefinition](paddingdefinition.md)*
 
-*Defined in [shared.ts:133](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L133)*
-
 **Parameters:**
 
 Name | Type | Default |
@@ -44,15 +42,11 @@ Name | Type | Default |
 
 • **bottom**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.None
 
-*Defined in [shared.ts:132](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L132)*
-
 ___
 
 ###  left
 
 • **left**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.None
-
-*Defined in [shared.ts:133](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L133)*
 
 ___
 
@@ -60,12 +54,8 @@ ___
 
 • **right**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.None
 
-*Defined in [shared.ts:131](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L131)*
-
 ___
 
 ###  top
 
 • **top**: *[Spacing](../enums/spacing.md)* = Enums.Spacing.None
-
-*Defined in [shared.ts:130](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L130)*

--- a/source/nodejs/adaptivecards/docs/classes/pixelsizeproperty.md
+++ b/source/nodejs/adaptivecards/docs/classes/pixelsizeproperty.md
@@ -36,8 +36,6 @@
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[constructor](propertydefinition.md#constructor)*
 
-*Defined in [serialization.ts:258](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L258)*
-
 **Parameters:**
 
 Name | Type |
@@ -57,8 +55,6 @@ Name | Type |
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[defaultValue](propertydefinition.md#optional-defaultvalue)*
 
-*Defined in [serialization.ts:263](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L263)*
-
 ___
 
 ###  name
@@ -66,8 +62,6 @@ ___
 • **name**: *string*
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[name](propertydefinition.md#name)*
-
-*Defined in [serialization.ts:262](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L262)*
 
 ___
 
@@ -77,8 +71,6 @@ ___
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[onGetInitialValue](propertydefinition.md#optional-ongetinitialvalue)*
 
-*Defined in [serialization.ts:264](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L264)*
-
 ___
 
 ###  sequentialNumber
@@ -86,8 +78,6 @@ ___
 • **sequentialNumber**: *number*
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[sequentialNumber](propertydefinition.md#sequentialnumber)*
-
-*Defined in [serialization.ts:258](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L258)*
 
 ___
 
@@ -97,8 +87,6 @@ ___
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[targetVersion](propertydefinition.md#targetversion)*
 
-*Defined in [serialization.ts:261](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L261)*
-
 ## Methods
 
 ###  getInternalName
@@ -106,8 +94,6 @@ ___
 ▸ **getInternalName**(): *string*
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[getInternalName](propertydefinition.md#getinternalname)*
-
-*Defined in [serialization.ts:246](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L246)*
 
 **Returns:** *string*
 
@@ -118,8 +104,6 @@ ___
 ▸ **parse**(`sender`: [SerializableObject](serializableobject.md), `source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *number | undefined*
 
 *Overrides [PropertyDefinition](propertydefinition.md).[parse](propertydefinition.md#parse)*
-
-*Defined in [serialization.ts:340](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L340)*
 
 **Parameters:**
 
@@ -138,8 +122,6 @@ ___
 ▸ **toJSON**(`sender`: [SerializableObject](serializableobject.md), `target`: [PropertyBag](../README.md#propertybag), `value`: number | undefined, `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Overrides [PropertyDefinition](propertydefinition.md).[toJSON](propertydefinition.md#tojson)*
-
-*Defined in [serialization.ts:371](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L371)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/docs/classes/propertydefinition.md
+++ b/source/nodejs/adaptivecards/docs/classes/propertydefinition.md
@@ -52,8 +52,6 @@
 
 \+ **new PropertyDefinition**(`targetVersion`: [Version](version.md), `name`: string, `defaultValue?`: any, `onGetInitialValue?`: undefined | function): *[PropertyDefinition](propertydefinition.md)*
 
-*Defined in [serialization.ts:258](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L258)*
-
 **Parameters:**
 
 Name | Type |
@@ -71,15 +69,11 @@ Name | Type |
 
 • **defaultValue**? : *any*
 
-*Defined in [serialization.ts:263](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L263)*
-
 ___
 
 ###  name
 
 • **name**: *string*
-
-*Defined in [serialization.ts:262](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L262)*
 
 ___
 
@@ -87,15 +81,11 @@ ___
 
 • **onGetInitialValue**? : *undefined | function*
 
-*Defined in [serialization.ts:264](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L264)*
-
 ___
 
 ###  sequentialNumber
 
 • **sequentialNumber**: *number*
-
-*Defined in [serialization.ts:258](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L258)*
 
 ___
 
@@ -103,15 +93,11 @@ ___
 
 • **targetVersion**: *[Version](version.md)*
 
-*Defined in [serialization.ts:261](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L261)*
-
 ## Methods
 
 ###  getInternalName
 
 ▸ **getInternalName**(): *string*
-
-*Defined in [serialization.ts:246](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L246)*
 
 **Returns:** *string*
 
@@ -120,8 +106,6 @@ ___
 ###  parse
 
 ▸ **parse**(`sender`: [SerializableObject](serializableobject.md), `source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *any*
-
-*Defined in [serialization.ts:250](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L250)*
 
 **Parameters:**
 
@@ -138,8 +122,6 @@ ___
 ###  toJSON
 
 ▸ **toJSON**(`sender`: [SerializableObject](serializableobject.md), `target`: [PropertyBag](../README.md#propertybag), `value`: any, `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
-
-*Defined in [serialization.ts:254](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L254)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/docs/classes/richtextblock.md
+++ b/source/nodejs/adaptivecards/docs/classes/richtextblock.md
@@ -139,8 +139,6 @@
 
 *Inherited from [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 **Returns:** *[RichTextBlock](richtextblock.md)*
 
 ## Properties
@@ -151,8 +149,6 @@
 
 *Inherited from [CardObject](cardobject.md).[_parent](cardobject.md#protected-optional-_parent)*
 
-*Defined in [card-object.ts:61](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L61)*
-
 ___
 
 ### `Protected` `Optional` _renderedElement
@@ -160,8 +156,6 @@ ___
 • **_renderedElement**? : *HTMLElement*
 
 *Inherited from [CardObject](cardobject.md).[_renderedElement](cardobject.md#protected-optional-_renderedelement)*
-
-*Defined in [card-object.ts:62](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L62)*
 
 ___
 
@@ -171,8 +165,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#optional-customcssselector)*
 
-*Defined in [card-elements.ts:311](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L311)*
-
 ___
 
 ###  height
@@ -180,8 +172,6 @@ ___
 • **height**: *[CardElementHeight](../README.md#cardelementheight)*
 
 *Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
-
-*Defined in [card-elements.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L53)*
 
 ___
 
@@ -191,8 +181,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#horizontalalignment)*
 
-*Defined in [card-elements.ts:44](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L44)*
-
 ___
 
 ### `Optional` id
@@ -200,8 +188,6 @@ ___
 • **id**? : *undefined | string*
 
 *Inherited from [CardObject](cardobject.md).[id](cardobject.md#optional-id)*
-
-*Defined in [card-object.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L50)*
 
 ___
 
@@ -211,8 +197,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 ___
 
 ### `Optional` onPreProcessPropertyValue
@@ -220,8 +204,6 @@ ___
 • **onPreProcessPropertyValue**? : *undefined | function*
 
 *Inherited from [CardObject](cardobject.md).[onPreProcessPropertyValue](cardobject.md#optional-onpreprocesspropertyvalue)*
-
-*Defined in [card-object.ts:64](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L64)*
 
 ___
 
@@ -231,8 +213,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
 
-*Defined in [card-elements.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L50)*
-
 ___
 
 ###  spacing
@@ -240,8 +220,6 @@ ___
 • **spacing**: *[Spacing](../enums/spacing.md)*
 
 *Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
-
-*Defined in [card-elements.ts:47](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L47)*
 
 ___
 
@@ -258,8 +236,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[heightProperty](cardelement.md#static-heightproperty)*
 
-*Defined in [card-elements.ts:24](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L24)*
-
 ___
 
 ### `Static` horizontalAlignmentProperty
@@ -272,8 +248,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignmentProperty](cardelement.md#static-horizontalalignmentproperty)*
 
-*Defined in [card-elements.ts:32](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L32)*
-
 ___
 
 ### `Static` idProperty
@@ -281,8 +255,6 @@ ___
 ▪ **idProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "id")
 
 *Inherited from [CardObject](cardobject.md).[idProperty](cardobject.md#static-idproperty)*
-
-*Defined in [card-object.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L39)*
 
 ___
 
@@ -292,8 +264,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisibleProperty](cardelement.md#static-isvisibleproperty)*
 
-*Defined in [card-elements.ts:22](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L22)*
-
 ___
 
 ### `Static` langProperty
@@ -302,8 +272,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[langProperty](cardelement.md#static-langproperty)*
 
-*Defined in [card-elements.ts:21](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L21)*
-
 ___
 
 ### `Static` `Optional` onRegisterCustomProperties
@@ -311,8 +279,6 @@ ___
 ▪ **onRegisterCustomProperties**? : *undefined | function*
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
-
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
 
 ___
 
@@ -325,8 +291,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requiresProperty](cardobject.md#static-requiresproperty)*
 
-*Defined in [card-object.ts:40](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L40)*
-
 ___
 
 ### `Static` separatorProperty
@@ -334,8 +298,6 @@ ___
 ▪ **separatorProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_0, "separator", false)
 
 *Inherited from [CardElement](cardelement.md).[separatorProperty](cardelement.md#static-separatorproperty)*
-
-*Defined in [card-elements.ts:23](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L23)*
 
 ___
 
@@ -348,8 +310,6 @@ ___
         Enums.Spacing.Default)
 
 *Inherited from [CardElement](cardelement.md).[spacingProperty](cardelement.md#static-spacingproperty)*
-
-*Defined in [card-elements.ts:37](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L37)*
 
 ___
 
@@ -367,8 +327,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[typeNameProperty](cardobject.md#static-typenameproperty)*
 
-*Defined in [card-object.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L30)*
-
 ## Accessors
 
 ### `Protected` allowCustomPadding
@@ -376,8 +334,6 @@ ___
 • **get allowCustomPadding**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
-
-*Defined in [card-elements.ts:299](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L299)*
 
 **Returns:** *boolean*
 
@@ -389,8 +345,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
 
-*Defined in [card-elements.ts:307](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L307)*
-
 **Returns:** *string*
 
 ___
@@ -400,8 +354,6 @@ ___
 • **get hasVisibleSeparator**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
-
-*Defined in [card-elements.ts:580](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L580)*
 
 **Returns:** *boolean*
 
@@ -415,8 +367,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
 
-*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
-
 **Returns:** *[HostConfig](hostconfig.md)*
 
 • **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
@@ -424,8 +374,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
-
-*Defined in [card-elements.ts:555](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L555)*
 
 **Parameters:**
 
@@ -443,8 +391,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
 
-*Defined in [card-elements.ts:559](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L559)*
-
 **Returns:** *number*
 
 ___
@@ -454,8 +400,6 @@ ___
 • **get isInline**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
-
-*Defined in [card-elements.ts:576](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L576)*
 
 **Returns:** *boolean*
 
@@ -467,8 +411,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
 
-*Defined in [card-elements.ts:568](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L568)*
-
 **Returns:** *boolean*
 
 ___
@@ -478,8 +420,6 @@ ___
 • **get isStandalone**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
-
-*Defined in [card-elements.ts:572](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L572)*
 
 **Returns:** *boolean*
 
@@ -491,15 +431,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
 
-*Defined in [card-elements.ts:77](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L77)*
-
 **Returns:** *boolean*
 
 • **set isVisible**(`value`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
-
-*Defined in [card-elements.ts:81](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L81)*
 
 **Parameters:**
 
@@ -517,15 +453,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
 
-*Defined in [card-elements.ts:56](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L56)*
-
 **Returns:** *string | undefined*
 
 • **set lang**(`value`: string | undefined): *void*
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
-
-*Defined in [card-elements.ts:72](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L72)*
 
 **Parameters:**
 
@@ -545,8 +477,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[parent](cardobject.md#parent)*
 
-*Defined in [card-elements.ts:593](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L593)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -556,8 +486,6 @@ ___
 • **get renderedElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardObject](cardobject.md).[renderedElement](cardobject.md#renderedelement)*
-
-*Defined in [card-object.ts:140](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L140)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -569,8 +497,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requires](cardobject.md#requires)*
 
-*Defined in [card-object.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L53)*
-
 **Returns:** *HostCapabilities*
 
 ___
@@ -580,8 +506,6 @@ ___
 • **get separatorElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
-
-*Defined in [card-elements.ts:589](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L589)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -593,8 +517,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
 
-*Defined in [card-elements.ts:303](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L303)*
-
 **Returns:** *[Orientation](../enums/orientation.md)*
 
 ___
@@ -605,8 +527,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
 
-*Defined in [card-elements.ts:295](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L295)*
-
 **Returns:** *boolean*
 
 ## Methods
@@ -614,8 +534,6 @@ ___
 ###  addInline
 
 ▸ **addInline**(`inline`: [CardElement](cardelement.md)): *void*
-
-*Defined in [card-elements.ts:1326](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1326)*
 
 **Parameters:**
 
@@ -633,8 +551,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
 
-*Defined in [card-elements.ts:220](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L220)*
-
 **Parameters:**
 
 Name | Type |
@@ -651,8 +567,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
 
-*Defined in [card-elements.ts:239](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L239)*
-
 **Returns:** *void*
 
 ___
@@ -662,8 +576,6 @@ ___
 ▸ **asString**(): *string | undefined*
 
 *Overrides [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
-
-*Defined in [card-elements.ts:1299](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1299)*
 
 **Returns:** *string | undefined*
 
@@ -675,8 +587,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
 
-*Defined in [card-elements.ts:205](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L205)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -686,8 +596,6 @@ ___
 ▸ **getActionAt**(`index`: number): *[Action](action.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
-
-*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
 
 **Parameters:**
 
@@ -705,8 +613,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
 
-*Defined in [card-elements.ts:531](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L531)*
-
 **Parameters:**
 
 Name | Type |
@@ -723,8 +629,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
 
-*Defined in [card-elements.ts:396](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L396)*
-
 **Returns:** *number*
 
 ___
@@ -735,8 +639,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
 
-*Defined in [card-elements.ts:519](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L519)*
-
 **Returns:** *[Input](input.md)[]*
 
 ___
@@ -746,8 +648,6 @@ ___
 ▸ **getCustomProperty**(`name`: string): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
-
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
 
 **Parameters:**
 
@@ -765,8 +665,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
 
-*Defined in [card-elements.ts:275](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L275)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
 ___
@@ -776,8 +674,6 @@ ___
 ▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
 
 *Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
-
-*Defined in [card-elements.ts:535](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L535)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
@@ -789,8 +685,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
 
-*Defined in [card-elements.ts:329](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L329)*
-
 **Returns:** *string*
 
 ___
@@ -801,8 +695,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyleDefinition](cardelement.md#geteffectivestyledefinition)*
 
-*Defined in [card-elements.ts:337](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L337)*
-
 **Returns:** *[ContainerStyleDefinition](containerstyledefinition.md)*
 
 ___
@@ -812,8 +704,6 @@ ___
 ▸ **getElementById**(`id`: string): *[CardElement](cardelement.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
-
-*Defined in [card-elements.ts:527](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L527)*
 
 **Parameters:**
 
@@ -831,8 +721,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
 
-*Defined in [card-elements.ts:341](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L341)*
-
 **Returns:** *[ActionType](../README.md#actiontype)[]*
 
 ___
@@ -843,8 +731,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
 
-*Defined in [card-elements.ts:279](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L279)*
-
 **Returns:** *boolean*
 
 ___
@@ -854,8 +740,6 @@ ___
 ▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
-
-*Defined in [card-elements.ts:345](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L345)*
 
 **Parameters:**
 
@@ -875,8 +759,6 @@ ___
 
 ▸ **getInlineAt**(`index`: number): *[CardElement](cardelement.md)*
 
-*Defined in [card-elements.ts:1317](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1317)*
-
 **Parameters:**
 
 Name | Type |
@@ -891,8 +773,6 @@ ___
 
 ▸ **getInlineCount**(): *number*
 
-*Defined in [card-elements.ts:1313](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1313)*
-
 **Returns:** *number*
 
 ___
@@ -902,8 +782,6 @@ ___
 ▸ **getJsonTypeName**(): *string*
 
 *Overrides [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
-
-*Defined in [card-elements.ts:1309](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1309)*
 
 **Returns:** *string*
 
@@ -915,8 +793,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
 
-*Defined in [card-elements.ts:283](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L283)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md) | undefined*
 
 ___
@@ -926,8 +802,6 @@ ___
 ▸ **getParentContainer**(): *[Container](container.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
-
-*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
 
 **Returns:** *[Container](container.md) | undefined*
 
@@ -939,8 +813,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
 
-*Defined in [card-elements.ts:523](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L523)*
-
 **Returns:** *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
 ___
@@ -950,8 +822,6 @@ ___
 ▸ **getRootElement**(): *[CardElement](cardelement.md)*
 
 *Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
-
-*Defined in [card-elements.ts:501](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L501)*
 
 **Returns:** *[CardElement](cardelement.md)*
 
@@ -963,8 +833,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getRootObject](cardobject.md#getrootobject)*
 
-*Defined in [card-object.ts:100](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L100)*
-
 **Returns:** *[CardObject](cardobject.md)*
 
 ___
@@ -974,8 +842,6 @@ ___
 ▸ **getSchema**(): *[SerializableObjectSchema](serializableobjectschema.md)*
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
-
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
 
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
@@ -989,8 +855,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-object.ts:45](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L45)*
-
 **Returns:** *string*
 
 ___
@@ -1000,8 +864,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -1019,8 +881,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -1030,8 +890,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -1049,8 +907,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
 
-*Defined in [card-elements.ts:439](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L439)*
-
 **Parameters:**
 
 Name | Type |
@@ -1066,8 +922,6 @@ ___
 ▸ **internalParse**(`source`: any, `context`: [SerializationContext](serializationcontext.md)): *void*
 
 *Overrides [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
-
-*Defined in [card-elements.ts:1218](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1218)*
 
 **Parameters:**
 
@@ -1086,8 +940,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
 
-*Defined in [card-elements.ts:1259](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1259)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1097,8 +949,6 @@ ___
 ▸ **internalToJSON**(`target`: [PropertyBag](../README.md#propertybag), `context`: [SerializationContext](serializationcontext.md)): *void*
 
 *Overrides [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
-
-*Defined in [card-elements.ts:1245](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1245)*
 
 **Parameters:**
 
@@ -1117,8 +967,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
 
-*Defined in [card-object.ts:110](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L110)*
-
 **Parameters:**
 
 Name | Type |
@@ -1135,8 +983,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
 
-*Defined in [card-elements.ts:469](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L469)*
-
 **Returns:** *boolean*
 
 ___
@@ -1146,8 +992,6 @@ ___
 ▸ **isAtTheVeryLeft**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
-
-*Defined in [card-elements.ts:457](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L457)*
 
 **Returns:** *boolean*
 
@@ -1159,8 +1003,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
 
-*Defined in [card-elements.ts:461](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L461)*
-
 **Returns:** *boolean*
 
 ___
@@ -1170,8 +1012,6 @@ ___
 ▸ **isAtTheVeryTop**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
-
-*Defined in [card-elements.ts:465](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L465)*
 
 **Returns:** *boolean*
 
@@ -1183,8 +1023,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
 
-*Defined in [card-elements.ts:325](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L325)*
-
 **Returns:** *boolean*
 
 ___
@@ -1194,8 +1032,6 @@ ___
 ▸ **isBleedingAtBottom**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
-
-*Defined in [card-elements.ts:477](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L477)*
 
 **Returns:** *boolean*
 
@@ -1207,8 +1043,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
 
-*Defined in [card-elements.ts:473](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L473)*
-
 **Returns:** *boolean*
 
 ___
@@ -1218,8 +1052,6 @@ ___
 ▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
-
-*Defined in [card-elements.ts:493](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L493)*
 
 **Parameters:**
 
@@ -1237,8 +1069,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
 
-*Defined in [card-elements.ts:443](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L443)*
-
 **Returns:** *boolean*
 
 ___
@@ -1249,8 +1079,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDisplayed](cardelement.md#protected-isdisplayed)*
 
-*Defined in [card-elements.ts:229](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L229)*
-
 **Returns:** *boolean*
 
 ___
@@ -1260,8 +1088,6 @@ ___
 ▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
-
-*Defined in [card-elements.ts:449](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L449)*
 
 **Parameters:**
 
@@ -1279,8 +1105,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
 
-*Defined in [card-elements.ts:497](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L497)*
-
 **Returns:** *boolean*
 
 ___
@@ -1290,8 +1114,6 @@ ___
 ▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
-
-*Defined in [card-elements.ts:453](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L453)*
 
 **Parameters:**
 
@@ -1309,8 +1131,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
 
-*Defined in [card-elements.ts:481](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L481)*
-
 **Parameters:**
 
 Name | Type |
@@ -1326,8 +1146,6 @@ ___
 ▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
-
-*Defined in [card-elements.ts:485](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L485)*
 
 **Parameters:**
 
@@ -1345,8 +1163,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
 
-*Defined in [card-elements.ts:489](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L489)*
-
 **Parameters:**
 
 Name | Type |
@@ -1363,8 +1179,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
 
-*Defined in [card-elements.ts:235](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L235)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1376,8 +1190,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[parse](cardelement.md#parse)*
 
 *Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
-
-*Defined in [card-elements.ts:313](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L313)*
 
 **Parameters:**
 
@@ -1396,8 +1208,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [serialization.ts:738](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L738)*
-
 **Parameters:**
 
 Name | Type |
@@ -1413,8 +1223,6 @@ ___
 ▸ **preProcessPropertyValue**(`property`: [PropertyDefinition](propertydefinition.md), `propertyValue?`: any): *any*
 
 *Inherited from [CardObject](cardobject.md).[preProcessPropertyValue](cardobject.md#preprocesspropertyvalue)*
-
-*Defined in [card-object.ts:70](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L70)*
 
 **Parameters:**
 
@@ -1433,8 +1241,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
 
-*Defined in [card-elements.ts:404](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L404)*
-
 **Returns:** *boolean*
 
 ___
@@ -1442,8 +1248,6 @@ ___
 ###  removeInline
 
 ▸ **removeInline**(`inline`: [CardElement](cardelement.md)): *boolean*
-
-*Defined in [card-elements.ts:1330](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1330)*
 
 **Parameters:**
 
@@ -1461,8 +1265,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[render](cardelement.md#render)*
 
-*Defined in [card-elements.ts:412](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L412)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1473,8 +1275,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -1484,8 +1284,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -1504,8 +1302,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
 
-*Defined in [card-elements.ts:287](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L287)*
-
 **Parameters:**
 
 Name | Type |
@@ -1521,8 +1317,6 @@ ___
 ▸ **setParent**(`value`: [CardObject](cardobject.md) | undefined): *void*
 
 *Inherited from [CardObject](cardobject.md).[setParent](cardobject.md#setparent)*
-
-*Defined in [card-object.ts:88](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L88)*
 
 **Parameters:**
 
@@ -1540,8 +1334,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setShouldFallback](cardobject.md#setshouldfallback)*
 
-*Defined in [card-object.ts:92](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L92)*
-
 **Parameters:**
 
 Name | Type |
@@ -1557,8 +1349,6 @@ ___
 ▸ **setValue**(`property`: [PropertyDefinition](propertydefinition.md), `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
-
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
 
 **Parameters:**
 
@@ -1577,8 +1367,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[shouldFallback](cardobject.md#shouldfallback)*
 
-*Defined in [card-object.ts:96](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L96)*
-
 **Returns:** *boolean*
 
 ___
@@ -1590,8 +1378,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[shouldSerialize](cardelement.md#protected-shouldserialize)*
 
 *Overrides [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
-
-*Defined in [card-elements.ts:291](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L291)*
 
 **Parameters:**
 
@@ -1611,8 +1397,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
 
-*Defined in [card-elements.ts:317](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L317)*
-
 **Parameters:**
 
 Name | Type |
@@ -1628,8 +1412,6 @@ ___
 ▸ **truncateOverflow**(`maxHeight`: number): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
-
-*Defined in [card-elements.ts:263](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L263)*
 
 **Parameters:**
 
@@ -1647,8 +1429,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
 
-*Defined in [card-elements.ts:273](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L273)*
-
 **Returns:** *void*
 
 ___
@@ -1658,8 +1438,6 @@ ___
 ▸ **updateLayout**(`processChildren`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
-
-*Defined in [card-elements.ts:434](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L434)*
 
 **Parameters:**
 
@@ -1676,7 +1454,5 @@ ___
 ▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
 
 *Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
-
-*Defined in [card-object.ts:128](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L128)*
 
 **Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/serializableobject.md
+++ b/source/nodejs/adaptivecards/docs/classes/serializableobject.md
@@ -55,8 +55,6 @@
 
 \+ **new SerializableObject**(): *[SerializableObject](serializableobject.md)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 **Returns:** *[SerializableObject](serializableobject.md)*
 
 ## Properties
@@ -65,23 +63,17 @@
 
 • **maxVersion**: *[Version](version.md)* = Versions.latest
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 ___
 
 ### `Static` `Optional` onRegisterCustomProperties
 
 ▪ **onRegisterCustomProperties**? : *undefined | function*
 
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
-
 ## Methods
 
 ###  getCustomProperty
 
 ▸ **getCustomProperty**(`name`: string): *any*
-
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
 
 **Parameters:**
 
@@ -97,8 +89,6 @@ ___
 
 ▸ **getSchema**(): *[SerializableObjectSchema](serializableobjectschema.md)*
 
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
-
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
 ___
@@ -107,8 +97,6 @@ ___
 
 ▸ **getSchemaKey**(): *string*
 
-*Defined in [serialization.ts:736](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L736)*
-
 **Returns:** *string*
 
 ___
@@ -116,8 +104,6 @@ ___
 ### `Protected` getValue
 
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -133,8 +119,6 @@ ___
 
 ▸ **hasAllDefaultValues**(): *boolean*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -142,8 +126,6 @@ ___
 ###  hasDefaultValue
 
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -158,8 +140,6 @@ ___
 ### `Protected` internalParse
 
 ▸ **internalParse**(`source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
-
-*Defined in [serialization.ts:789](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L789)*
 
 **Parameters:**
 
@@ -176,8 +156,6 @@ ___
 
 ▸ **internalToJSON**(`target`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
-*Defined in [serialization.ts:821](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L821)*
-
 **Parameters:**
 
 Name | Type |
@@ -192,8 +170,6 @@ ___
 ###  parse
 
 ▸ **parse**(`source`: [PropertyBag](../README.md#propertybag), `context?`: [BaseSerializationContext](baseserializationcontext.md)): *void*
-
-*Defined in [serialization.ts:857](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L857)*
 
 **Parameters:**
 
@@ -210,8 +186,6 @@ ___
 
 ▸ **populateSchema**(`schema`: [SerializableObjectSchema](serializableobjectschema.md)): *void*
 
-*Defined in [serialization.ts:738](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L738)*
-
 **Parameters:**
 
 Name | Type |
@@ -226,8 +200,6 @@ ___
 
 ▸ **resetDefaultValues**(): *void*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -235,8 +207,6 @@ ___
 ###  setCustomProperty
 
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -253,8 +223,6 @@ ___
 
 ▸ **setValue**(`property`: [PropertyDefinition](propertydefinition.md), `value`: any): *void*
 
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
-
 **Parameters:**
 
 Name | Type |
@@ -270,8 +238,6 @@ ___
 
 ▸ **shouldSerialize**(`context`: [BaseSerializationContext](baseserializationcontext.md)): *boolean*
 
-*Defined in [serialization.ts:839](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L839)*
-
 **Parameters:**
 
 Name | Type |
@@ -285,8 +251,6 @@ ___
 ###  toJSON
 
 ▸ **toJSON**(`context?`: [BaseSerializationContext](baseserializationcontext.md)): *[PropertyBag](../README.md#propertybag) | undefined*
-
-*Defined in [serialization.ts:861](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L861)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/docs/classes/serializableobjectcollectionproperty.md
+++ b/source/nodejs/adaptivecards/docs/classes/serializableobjectcollectionproperty.md
@@ -38,8 +38,6 @@
 
 *Overrides [PropertyDefinition](propertydefinition.md).[constructor](propertydefinition.md#constructor)*
 
-*Defined in [serialization.ts:623](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L623)*
-
 **Parameters:**
 
 Name | Type |
@@ -59,8 +57,6 @@ Name | Type |
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[defaultValue](propertydefinition.md#optional-defaultvalue)*
 
-*Defined in [serialization.ts:263](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L263)*
-
 ___
 
 ###  name
@@ -69,15 +65,11 @@ ___
 
 *Overrides [PropertyDefinition](propertydefinition.md).[name](propertydefinition.md#name)*
 
-*Defined in [serialization.ts:627](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L627)*
-
 ___
 
 ###  objectType
 
 • **objectType**: *[SerializableObjectType](../README.md#serializableobjecttype)*
-
-*Defined in [serialization.ts:628](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L628)*
 
 ___
 
@@ -87,15 +79,11 @@ ___
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[onGetInitialValue](propertydefinition.md#optional-ongetinitialvalue)*
 
-*Defined in [serialization.ts:264](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L264)*
-
 ___
 
 ### `Optional` onItemAdded
 
 • **onItemAdded**? : *undefined | function*
-
-*Defined in [serialization.ts:629](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L629)*
 
 ___
 
@@ -105,8 +93,6 @@ ___
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[sequentialNumber](propertydefinition.md#sequentialnumber)*
 
-*Defined in [serialization.ts:258](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L258)*
-
 ___
 
 ###  targetVersion
@@ -115,8 +101,6 @@ ___
 
 *Overrides [PropertyDefinition](propertydefinition.md).[targetVersion](propertydefinition.md#targetversion)*
 
-*Defined in [serialization.ts:626](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L626)*
-
 ## Methods
 
 ###  getInternalName
@@ -124,8 +108,6 @@ ___
 ▸ **getInternalName**(): *string*
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[getInternalName](propertydefinition.md#getinternalname)*
-
-*Defined in [serialization.ts:246](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L246)*
 
 **Returns:** *string*
 
@@ -136,8 +118,6 @@ ___
 ▸ **parse**(`sender`: [SerializableObject](serializableobject.md), `source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *[SerializableObject](serializableobject.md)[] | undefined*
 
 *Overrides [PropertyDefinition](propertydefinition.md).[parse](propertydefinition.md#parse)*
-
-*Defined in [serialization.ts:600](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L600)*
 
 **Parameters:**
 
@@ -156,8 +136,6 @@ ___
 ▸ **toJSON**(`sender`: [SerializableObject](serializableobject.md), `target`: [PropertyBag](../README.md#propertybag), `value`: [SerializableObject](serializableobject.md)[] | undefined, `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Overrides [PropertyDefinition](propertydefinition.md).[toJSON](propertydefinition.md#tojson)*
-
-*Defined in [serialization.ts:621](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L621)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/docs/classes/serializableobjectproperty.md
+++ b/source/nodejs/adaptivecards/docs/classes/serializableobjectproperty.md
@@ -37,8 +37,6 @@
 
 *Overrides [PropertyDefinition](propertydefinition.md).[constructor](propertydefinition.md#constructor)*
 
-*Defined in [serialization.ts:585](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L585)*
-
 **Parameters:**
 
 Name | Type |
@@ -57,8 +55,6 @@ Name | Type |
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[defaultValue](propertydefinition.md#optional-defaultvalue)*
 
-*Defined in [serialization.ts:263](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L263)*
-
 ___
 
 ###  name
@@ -67,15 +63,11 @@ ___
 
 *Overrides [PropertyDefinition](propertydefinition.md).[name](propertydefinition.md#name)*
 
-*Defined in [serialization.ts:589](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L589)*
-
 ___
 
 ###  objectType
 
 • **objectType**: *[SerializableObjectType](../README.md#serializableobjecttype)*
-
-*Defined in [serialization.ts:590](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L590)*
 
 ___
 
@@ -85,8 +77,6 @@ ___
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[onGetInitialValue](propertydefinition.md#optional-ongetinitialvalue)*
 
-*Defined in [serialization.ts:264](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L264)*
-
 ___
 
 ###  sequentialNumber
@@ -94,8 +84,6 @@ ___
 • **sequentialNumber**: *number*
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[sequentialNumber](propertydefinition.md#sequentialnumber)*
-
-*Defined in [serialization.ts:258](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L258)*
 
 ___
 
@@ -105,8 +93,6 @@ ___
 
 *Overrides [PropertyDefinition](propertydefinition.md).[targetVersion](propertydefinition.md#targetversion)*
 
-*Defined in [serialization.ts:588](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L588)*
-
 ## Methods
 
 ###  getInternalName
@@ -114,8 +100,6 @@ ___
 ▸ **getInternalName**(): *string*
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[getInternalName](propertydefinition.md#getinternalname)*
-
-*Defined in [serialization.ts:246](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L246)*
 
 **Returns:** *string*
 
@@ -126,8 +110,6 @@ ___
 ▸ **parse**(`sender`: [SerializableObject](serializableobject.md), `source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *[SerializableObject](serializableobject.md) | undefined*
 
 *Overrides [PropertyDefinition](propertydefinition.md).[parse](propertydefinition.md#parse)*
-
-*Defined in [serialization.ts:564](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L564)*
 
 **Parameters:**
 
@@ -146,8 +128,6 @@ ___
 ▸ **toJSON**(`sender`: [SerializableObject](serializableobject.md), `target`: [PropertyBag](../README.md#propertybag), `value`: [SerializableObject](serializableobject.md) | undefined, `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Overrides [PropertyDefinition](propertydefinition.md).[toJSON](propertydefinition.md#tojson)*
-
-*Defined in [serialization.ts:577](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L577)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/docs/classes/serializableobjectschema.md
+++ b/source/nodejs/adaptivecards/docs/classes/serializableobjectschema.md
@@ -22,8 +22,6 @@
 
 ▸ **add**(...`properties`: [PropertyDefinition](propertydefinition.md)[]): *void*
 
-*Defined in [serialization.ts:679](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L679)*
-
 **Parameters:**
 
 Name | Type |
@@ -38,8 +36,6 @@ ___
 
 ▸ **getCount**(): *number*
 
-*Defined in [serialization.ts:706](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L706)*
-
 **Returns:** *number*
 
 ___
@@ -47,8 +43,6 @@ ___
 ###  getItemAt
 
 ▸ **getItemAt**(`index`: number): *[PropertyDefinition](propertydefinition.md)*
-
-*Defined in [serialization.ts:702](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L702)*
 
 **Parameters:**
 
@@ -64,8 +58,6 @@ ___
 
 ▸ **indexOf**(`property`: [PropertyDefinition](propertydefinition.md)): *number*
 
-*Defined in [serialization.ts:669](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L669)*
-
 **Parameters:**
 
 Name | Type |
@@ -79,8 +71,6 @@ ___
 ###  remove
 
 ▸ **remove**(...`properties`: [PropertyDefinition](propertydefinition.md)[]): *void*
-
-*Defined in [serialization.ts:687](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L687)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/docs/classes/serializationcontext.md
+++ b/source/nodejs/adaptivecards/docs/classes/serializationcontext.md
@@ -51,8 +51,6 @@
 
 *Inherited from [BaseSerializationContext](baseserializationcontext.md).[constructor](baseserializationcontext.md#constructor)*
 
-*Defined in [serialization.ts:232](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L232)*
-
 **Parameters:**
 
 Name | Type | Default |
@@ -67,15 +65,11 @@ Name | Type | Default |
 
 • **onParseAction**? : *undefined | function*
 
-*Defined in [card-elements.ts:6358](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6358)*
-
 ___
 
 ### `Optional` onParseElement
 
 • **onParseElement**? : *undefined | function*
-
-*Defined in [card-elements.ts:6359](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6359)*
 
 ___
 
@@ -85,15 +79,11 @@ ___
 
 *Inherited from [BaseSerializationContext](baseserializationcontext.md).[targetVersion](baseserializationcontext.md#targetversion)*
 
-*Defined in [serialization.ts:234](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L234)*
-
 ## Accessors
 
 ###  actionRegistry
 
 • **get actionRegistry**(): *[CardObjectRegistry](cardobjectregistry.md)‹[Action](action.md)›*
-
-*Defined in [card-elements.ts:6445](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6445)*
 
 **Returns:** *[CardObjectRegistry](cardobjectregistry.md)‹[Action](action.md)›*
 
@@ -102,8 +92,6 @@ ___
 ###  elementRegistry
 
 • **get elementRegistry**(): *[CardObjectRegistry](cardobjectregistry.md)‹[CardElement](cardelement.md)›*
-
-*Defined in [card-elements.ts:6435](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6435)*
 
 **Returns:** *[CardObjectRegistry](cardobjectregistry.md)‹[CardElement](cardelement.md)›*
 
@@ -115,8 +103,6 @@ ___
 
 *Inherited from [BaseSerializationContext](baseserializationcontext.md).[eventCount](baseserializationcontext.md#eventcount)*
 
-*Defined in [serialization.ts:236](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L236)*
-
 **Returns:** *number*
 
 ## Methods
@@ -124,8 +110,6 @@ ___
 ### `Protected` cardObjectParsed
 
 ▸ **cardObjectParsed**(`o`: [SerializableObject](serializableobject.md), `source`: any): *void*
-
-*Defined in [card-elements.ts:6349](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6349)*
 
 **Parameters:**
 
@@ -144,8 +128,6 @@ ___
 
 *Inherited from [BaseSerializationContext](baseserializationcontext.md).[clearEvents](baseserializationcontext.md#clearevents)*
 
-*Defined in [serialization.ts:208](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L208)*
-
 **Returns:** *void*
 
 ___
@@ -155,8 +137,6 @@ ___
 ▸ **getEventAt**(`index`: number): *[IValidationEvent](../interfaces/ivalidationevent.md)*
 
 *Inherited from [BaseSerializationContext](baseserializationcontext.md).[getEventAt](baseserializationcontext.md#geteventat)*
-
-*Defined in [serialization.ts:230](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L230)*
 
 **Parameters:**
 
@@ -173,8 +153,6 @@ ___
 ▸ **logEvent**(`phase`: [ValidationPhase](../enums/validationphase.md), `event`: [ValidationEvent](../enums/validationevent.md), `message`: string, `source?`: [SerializableObject](serializableobject.md)): *void*
 
 *Inherited from [BaseSerializationContext](baseserializationcontext.md).[logEvent](baseserializationcontext.md#logevent)*
-
-*Defined in [serialization.ts:212](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L212)*
 
 **Parameters:**
 
@@ -195,8 +173,6 @@ ___
 
 *Inherited from [BaseSerializationContext](baseserializationcontext.md).[logParseEvent](baseserializationcontext.md#logparseevent)*
 
-*Defined in [serialization.ts:226](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L226)*
-
 **Parameters:**
 
 Name | Type |
@@ -212,8 +188,6 @@ ___
 ###  parseAction
 
 ▸ **parseAction**(`parent`: [CardElement](cardelement.md), `source`: any, `forbiddenActionTypes`: string[], `allowFallback`: boolean): *[Action](action.md) | undefined*
-
-*Defined in [card-elements.ts:6406](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6406)*
 
 **Parameters:**
 
@@ -231,8 +205,6 @@ ___
 ###  parseCardObject
 
 ▸ **parseCardObject**<**T**>(`parent`: [CardElement](cardelement.md) | undefined, `source`: any, `forbiddenTypeNames`: string[], `allowFallback`: boolean, `createInstanceCallback`: function, `logParseEvent`: function): *T | undefined*
-
-*Defined in [card-elements.ts:6361](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6361)*
 
 **Type parameters:**
 
@@ -277,8 +249,6 @@ ___
 
 ▸ **parseElement**(`parent`: [CardElement](cardelement.md) | undefined, `source`: any, `allowFallback`: boolean): *[CardElement](cardelement.md) | undefined*
 
-*Defined in [card-elements.ts:6383](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6383)*
-
 **Parameters:**
 
 Name | Type |
@@ -297,8 +267,6 @@ ___
 
 *Inherited from [BaseSerializationContext](baseserializationcontext.md).[serializeArray](baseserializationcontext.md#serializearray)*
 
-*Defined in [serialization.ts:175](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L175)*
-
 **Parameters:**
 
 Name | Type |
@@ -316,8 +284,6 @@ ___
 ▸ **serializeEnum**(`enumType`: object, `target`: object, `propertyName`: string, `propertyValue`: number | undefined, `defaultValue`: number | undefined): *void*
 
 *Inherited from [BaseSerializationContext](baseserializationcontext.md).[serializeEnum](baseserializationcontext.md#serializeenum)*
-
-*Defined in [serialization.ts:148](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L148)*
 
 **Parameters:**
 
@@ -339,8 +305,6 @@ ___
 
 *Inherited from [BaseSerializationContext](baseserializationcontext.md).[serializeNumber](baseserializationcontext.md#serializenumber)*
 
-*Defined in [serialization.ts:139](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L139)*
-
 **Parameters:**
 
 Name | Type | Default |
@@ -360,8 +324,6 @@ ___
 
 *Inherited from [BaseSerializationContext](baseserializationcontext.md).[serializeValue](baseserializationcontext.md#serializevalue)*
 
-*Defined in [serialization.ts:130](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L130)*
-
 **Parameters:**
 
 Name | Type | Default |
@@ -379,8 +341,6 @@ ___
 
 ▸ **setActionRegistry**(`value`: [CardObjectRegistry](cardobjectregistry.md)‹[Action](action.md)› | undefined): *void*
 
-*Defined in [card-elements.ts:6451](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6451)*
-
 **Parameters:**
 
 Name | Type |
@@ -394,8 +354,6 @@ ___
 ###  setElementRegistry
 
 ▸ **setElementRegistry**(`value`: [CardObjectRegistry](cardobjectregistry.md)‹[CardElement](cardelement.md)› | undefined): *void*
-
-*Defined in [card-elements.ts:6441](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L6441)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/docs/classes/showcardaction.md
+++ b/source/nodejs/adaptivecards/docs/classes/showcardaction.md
@@ -51,6 +51,7 @@
 * [execute](showcardaction.md#execute)
 * [getActionById](showcardaction.md#getactionbyid)
 * [getAllInputs](showcardaction.md#getallinputs)
+* [getAriaRole](showcardaction.md#getariarole)
 * [getCustomProperty](showcardaction.md#getcustomproperty)
 * [getHref](showcardaction.md#gethref)
 * [getJsonTypeName](showcardaction.md#getjsontypename)
@@ -94,8 +95,6 @@
 
 *Inherited from [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 **Returns:** *[ShowCardAction](showcardaction.md)*
 
 ## Properties
@@ -106,8 +105,6 @@
 
 *Inherited from [CardObject](cardobject.md).[_parent](cardobject.md#protected-optional-_parent)*
 
-*Defined in [card-object.ts:61](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L61)*
-
 ___
 
 ### `Protected` `Optional` _renderedElement
@@ -116,15 +113,11 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[_renderedElement](cardobject.md#protected-optional-_renderedelement)*
 
-*Defined in [card-object.ts:62](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L62)*
-
 ___
 
 ###  card
 
 • **card**: *[AdaptiveCard](adaptivecard.md)* = new InlineAdaptiveCard()
-
-*Defined in [card-elements.ts:3981](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3981)*
 
 ___
 
@@ -134,8 +127,6 @@ ___
 
 *Inherited from [Action](action.md).[iconUrl](action.md#optional-iconurl)*
 
-*Defined in [card-elements.ts:3359](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3359)*
-
 ___
 
 ### `Optional` id
@@ -143,8 +134,6 @@ ___
 • **id**? : *undefined | string*
 
 *Inherited from [CardObject](cardobject.md).[id](cardobject.md#optional-id)*
-
-*Defined in [card-object.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L50)*
 
 ___
 
@@ -154,8 +143,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 ___
 
 ###  onExecute
@@ -163,8 +150,6 @@ ___
 • **onExecute**: *function*
 
 *Inherited from [Action](action.md).[onExecute](action.md#onexecute)*
-
-*Defined in [card-elements.ts:3400](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3400)*
 
 #### Type declaration:
 
@@ -184,8 +169,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[onPreProcessPropertyValue](cardobject.md#optional-onpreprocesspropertyvalue)*
 
-*Defined in [card-object.ts:64](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L64)*
-
 ___
 
 ###  style
@@ -193,8 +176,6 @@ ___
 • **style**: *string* = Enums.ActionStyle.Default
 
 *Inherited from [Action](action.md).[style](action.md#style)*
-
-*Defined in [card-elements.ts:3362](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3362)*
 
 ___
 
@@ -204,15 +185,11 @@ ___
 
 *Inherited from [Action](action.md).[title](action.md#optional-title)*
 
-*Defined in [card-elements.ts:3356](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3356)*
-
 ___
 
 ### `Static` JsonTypeName
 
 ▪ **JsonTypeName**: *"Action.ShowCard"* = "Action.ShowCard"
-
-*Defined in [card-elements.ts:3947](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3947)*
 
 ___
 
@@ -222,8 +199,6 @@ ___
 
 *Inherited from [Action](action.md).[iconUrlProperty](action.md#static-iconurlproperty)*
 
-*Defined in [card-elements.ts:3342](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3342)*
-
 ___
 
 ### `Static` idProperty
@@ -231,8 +206,6 @@ ___
 ▪ **idProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "id")
 
 *Inherited from [CardObject](cardobject.md).[idProperty](cardobject.md#static-idproperty)*
-
-*Defined in [card-object.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L39)*
 
 ___
 
@@ -242,8 +215,6 @@ ___
 
 *Inherited from [Action](action.md).[ignoreInputValidationProperty](action.md#static-ignoreinputvalidationproperty)*
 
-*Defined in [card-elements.ts:3353](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3353)*
-
 ___
 
 ### `Static` `Optional` onRegisterCustomProperties
@@ -251,8 +222,6 @@ ___
 ▪ **onRegisterCustomProperties**? : *undefined | function*
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
-
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
 
 ___
 
@@ -264,8 +233,6 @@ ___
         HostCapabilities)
 
 *Inherited from [CardObject](cardobject.md).[requiresProperty](cardobject.md#static-requiresproperty)*
-
-*Defined in [card-object.ts:40](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L40)*
 
 ___
 
@@ -283,8 +250,6 @@ ___
 
 *Inherited from [Action](action.md).[styleProperty](action.md#static-styleproperty)*
 
-*Defined in [card-elements.ts:3343](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3343)*
-
 ___
 
 ### `Static` titleProperty
@@ -292,8 +257,6 @@ ___
 ▪ **titleProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "title")
 
 *Inherited from [Action](action.md).[titleProperty](action.md#static-titleproperty)*
-
-*Defined in [card-elements.ts:3341](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3341)*
 
 ___
 
@@ -311,8 +274,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[typeNameProperty](cardobject.md#static-typenameproperty)*
 
-*Defined in [card-object.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L30)*
-
 ## Accessors
 
 ###  hostConfig
@@ -322,8 +283,6 @@ ___
 *Inherited from [Action](action.md).[hostConfig](action.md#hostconfig)*
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
-
-*Defined in [card-elements.ts:3551](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3551)*
 
 **Returns:** *[HostConfig](hostconfig.md)*
 
@@ -335,8 +294,6 @@ ___
 
 *Inherited from [Action](action.md).[ignoreInputValidation](action.md#ignoreinputvalidation)*
 
-*Defined in [card-elements.ts:3547](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3547)*
-
 **Returns:** *boolean*
 
 ___
@@ -347,15 +304,11 @@ ___
 
 *Inherited from [Action](action.md).[isPrimary](action.md#isprimary)*
 
-*Defined in [card-elements.ts:3532](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3532)*
-
 **Returns:** *boolean*
 
 • **set isPrimary**(`value`: boolean): *void*
 
 *Inherited from [Action](action.md).[isPrimary](action.md#isprimary)*
-
-*Defined in [card-elements.ts:3536](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3536)*
 
 **Parameters:**
 
@@ -375,8 +328,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[parent](cardobject.md#parent)*
 
-*Defined in [card-elements.ts:3555](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3555)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -386,8 +337,6 @@ ___
 • **get renderedElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardObject](cardobject.md).[renderedElement](cardobject.md#renderedelement)*
-
-*Defined in [card-object.ts:140](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L140)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -399,8 +348,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requires](cardobject.md#requires)*
 
-*Defined in [card-object.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L53)*
-
 **Returns:** *HostCapabilities*
 
 ## Methods
@@ -410,8 +357,6 @@ ___
 ▸ **addCssClasses**(`element`: HTMLElement): *void*
 
 *Overrides [Action](action.md).[addCssClasses](action.md#protected-addcssclasses)*
-
-*Defined in [card-elements.ts:3973](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3973)*
 
 **Parameters:**
 
@@ -429,8 +374,6 @@ ___
 
 *Inherited from [Action](action.md).[execute](action.md#execute)*
 
-*Defined in [card-elements.ts:3484](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3484)*
-
 **Returns:** *void*
 
 ___
@@ -440,8 +383,6 @@ ___
 ▸ **getActionById**(`id`: string): *[Action](action.md) | undefined*
 
 *Overrides [Action](action.md).[getActionById](action.md#getactionbyid)*
-
-*Defined in [card-elements.ts:4015](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4015)*
 
 **Parameters:**
 
@@ -459,9 +400,17 @@ ___
 
 *Overrides [Action](action.md).[getAllInputs](action.md#getallinputs)*
 
-*Defined in [card-elements.ts:4007](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4007)*
-
 **Returns:** *[Input](input.md)[]*
+
+___
+
+###  getAriaRole
+
+▸ **getAriaRole**(): *string*
+
+*Inherited from [Action](action.md).[getAriaRole](action.md#getariarole)*
+
+**Returns:** *string*
 
 ___
 
@@ -470,8 +419,6 @@ ___
 ▸ **getCustomProperty**(`name`: string): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
-
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
 
 **Parameters:**
 
@@ -489,8 +436,6 @@ ___
 
 *Inherited from [Action](action.md).[getHref](action.md#gethref)*
 
-*Defined in [card-elements.ts:3402](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3402)*
-
 **Returns:** *string | undefined*
 
 ___
@@ -500,8 +445,6 @@ ___
 ▸ **getJsonTypeName**(): *string*
 
 *Overrides [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
-
-*Defined in [card-elements.ts:3983](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3983)*
 
 **Returns:** *string*
 
@@ -513,8 +456,6 @@ ___
 
 *Inherited from [Action](action.md).[getReferencedInputs](action.md#getreferencedinputs)*
 
-*Defined in [card-elements.ts:3524](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3524)*
-
 **Returns:** *[Dictionary](../README.md#dictionary)‹[Input](input.md)› | undefined*
 
 ___
@@ -524,8 +465,6 @@ ___
 ▸ **getResourceInformation**(): *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
 *Overrides [Action](action.md).[getResourceInformation](action.md#getresourceinformation)*
-
-*Defined in [card-elements.ts:4011](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4011)*
 
 **Returns:** *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
@@ -537,8 +476,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getRootObject](cardobject.md#getrootobject)*
 
-*Defined in [card-object.ts:100](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L100)*
-
 **Returns:** *[CardObject](cardobject.md)*
 
 ___
@@ -548,8 +485,6 @@ ___
 ▸ **getSchema**(): *[SerializableObjectSchema](serializableobjectschema.md)*
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
-
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
 
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
@@ -563,8 +498,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-object.ts:45](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L45)*
-
 **Returns:** *string*
 
 ___
@@ -574,8 +507,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -593,8 +524,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -604,8 +533,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -623,8 +550,6 @@ ___
 
 *Inherited from [Action](action.md).[internalGetReferencedInputs](action.md#protected-internalgetreferencedinputs)*
 
-*Defined in [card-elements.ts:3372](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3372)*
-
 **Parameters:**
 
 Name | Type |
@@ -640,8 +565,6 @@ ___
 ▸ **internalParse**(`source`: any, `context`: [SerializationContext](serializationcontext.md)): *void*
 
 *Overrides [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
-
-*Defined in [card-elements.ts:3949](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3949)*
 
 **Parameters:**
 
@@ -660,8 +583,6 @@ ___
 
 *Inherited from [Action](action.md).[internalPrepareForExecution](action.md#protected-internalprepareforexecution)*
 
-*Defined in [card-elements.ts:3376](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3376)*
-
 **Parameters:**
 
 Name | Type |
@@ -677,8 +598,6 @@ ___
 ▸ **internalToJSON**(`target`: [PropertyBag](../README.md#propertybag), `context`: [SerializationContext](serializationcontext.md)): *void*
 
 *Overrides [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
-
-*Defined in [card-elements.ts:3965](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3965)*
 
 **Parameters:**
 
@@ -697,8 +616,6 @@ ___
 
 *Inherited from [Action](action.md).[internalValidateInputs](action.md#protected-internalvalidateinputs)*
 
-*Defined in [card-elements.ts:3380](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3380)*
-
 **Parameters:**
 
 Name | Type |
@@ -714,8 +631,6 @@ ___
 ▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
 
 *Overrides [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
-
-*Defined in [card-elements.ts:3987](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3987)*
 
 **Parameters:**
 
@@ -735,8 +650,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
 
-*Defined in [card-elements.ts:3410](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3410)*
-
 **Parameters:**
 
 Name | Type |
@@ -754,8 +667,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [serialization.ts:738](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L738)*
-
 **Parameters:**
 
 Name | Type |
@@ -771,8 +682,6 @@ ___
 ▸ **preProcessPropertyValue**(`property`: [PropertyDefinition](propertydefinition.md), `propertyValue?`: any): *any*
 
 *Inherited from [CardObject](cardobject.md).[preProcessPropertyValue](cardobject.md#preprocesspropertyvalue)*
-
-*Defined in [card-object.ts:70](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L70)*
 
 **Parameters:**
 
@@ -791,8 +700,6 @@ ___
 
 *Inherited from [Action](action.md).[prepareForExecution](action.md#prepareforexecution)*
 
-*Defined in [card-elements.ts:3492](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3492)*
-
 **Returns:** *boolean*
 
 ___
@@ -803,8 +710,6 @@ ___
 
 *Inherited from [Action](action.md).[remove](action.md#remove)*
 
-*Defined in [card-elements.ts:3504](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3504)*
-
 **Returns:** *boolean*
 
 ___
@@ -814,8 +719,6 @@ ___
 ▸ **render**(`baseCssClass`: string): *void*
 
 *Inherited from [Action](action.md).[render](action.md#render)*
-
-*Defined in [card-elements.ts:3418](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3418)*
 
 **Parameters:**
 
@@ -833,8 +736,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -844,8 +745,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -864,8 +763,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[setParent](cardobject.md#setparent)*
 
-*Defined in [card-elements.ts:4001](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4001)*
-
 **Parameters:**
 
 Name | Type |
@@ -882,8 +779,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setShouldFallback](cardobject.md#setshouldfallback)*
 
-*Defined in [card-object.ts:92](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L92)*
-
 **Parameters:**
 
 Name | Type |
@@ -899,8 +794,6 @@ ___
 ▸ **setValue**(`property`: [PropertyDefinition](propertydefinition.md), `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
-
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
 
 **Parameters:**
 
@@ -919,8 +812,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[shouldFallback](cardobject.md#shouldfallback)*
 
-*Defined in [card-object.ts:96](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L96)*
-
 **Returns:** *boolean*
 
 ___
@@ -932,8 +823,6 @@ ___
 *Inherited from [Action](action.md).[shouldSerialize](action.md#protected-shouldserialize)*
 
 *Overrides [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
-
-*Defined in [card-elements.ts:3396](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3396)*
 
 **Parameters:**
 
@@ -953,8 +842,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
 
-*Defined in [card-elements.ts:3414](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3414)*
-
 **Parameters:**
 
 Name | Type |
@@ -970,8 +857,6 @@ ___
 ▸ **updateActionButtonCssStyle**(`actionButtonElement`: HTMLElement): *void*
 
 *Overrides [Action](action.md).[updateActionButtonCssStyle](action.md#updateactionbuttoncssstyle)*
-
-*Defined in [card-elements.ts:3993](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3993)*
 
 **Parameters:**
 
@@ -989,8 +874,6 @@ ___
 
 *Inherited from [Action](action.md).[validateInputs](action.md#validateinputs)*
 
-*Defined in [card-elements.ts:3528](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3528)*
-
 **Returns:** *[Input](input.md)‹›[]*
 
 ___
@@ -1000,7 +883,5 @@ ___
 ▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
 
 *Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
-
-*Defined in [card-object.ts:128](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L128)*
 
 **Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/showcardactionconfig.md
+++ b/source/nodejs/adaptivecards/docs/classes/showcardactionconfig.md
@@ -28,8 +28,6 @@
 
 \+ **new ShowCardActionConfig**(`obj?`: any): *[ShowCardActionConfig](showcardactionconfig.md)*
 
-*Defined in [host-config.ts:171](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L171)*
-
 **Parameters:**
 
 Name | Type |
@@ -44,15 +42,11 @@ Name | Type |
 
 • **actionMode**: *[ShowCardActionMode](../enums/showcardactionmode.md)* = Enums.ShowCardActionMode.Inline
 
-*Defined in [host-config.ts:169](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L169)*
-
 ___
 
 ###  inlineTopMargin
 
 • **inlineTopMargin**: *number* = 16
-
-*Defined in [host-config.ts:170](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L170)*
 
 ___
 
@@ -60,15 +54,11 @@ ___
 
 • **style**? : *undefined | string* = Enums.ContainerStyle.Emphasis
 
-*Defined in [host-config.ts:171](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L171)*
-
 ## Methods
 
 ###  toJSON
 
 ▸ **toJSON**(): *object*
-
-*Defined in [host-config.ts:181](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L181)*
 
 **Returns:** *object*
 

--- a/source/nodejs/adaptivecards/docs/classes/sizeandunit.md
+++ b/source/nodejs/adaptivecards/docs/classes/sizeandunit.md
@@ -27,8 +27,6 @@
 
 \+ **new SizeAndUnit**(`physicalSize`: number, `unit`: [SizeUnit](../enums/sizeunit.md)): *[SizeAndUnit](sizeandunit.md)*
 
-*Defined in [shared.ts:177](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L177)*
-
 **Parameters:**
 
 Name | Type |
@@ -44,23 +42,17 @@ Name | Type |
 
 • **physicalSize**: *number*
 
-*Defined in [shared.ts:147](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L147)*
-
 ___
 
 ###  unit
 
 • **unit**: *[SizeUnit](../enums/sizeunit.md)*
 
-*Defined in [shared.ts:148](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L148)*
-
 ## Methods
 
 ### `Static` parse
 
 ▸ **parse**(`input`: string, `requireUnitSpecifier`: boolean): *[SizeAndUnit](sizeandunit.md)*
-
-*Defined in [shared.ts:150](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L150)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/docs/classes/spacingdefinition.md
+++ b/source/nodejs/adaptivecards/docs/classes/spacingdefinition.md
@@ -25,8 +25,6 @@
 
 \+ **new SpacingDefinition**(`top`: number, `right`: number, `bottom`: number, `left`: number): *[SpacingDefinition](spacingdefinition.md)*
 
-*Defined in [shared.ts:116](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L116)*
-
 **Parameters:**
 
 Name | Type | Default |
@@ -44,15 +42,11 @@ Name | Type | Default |
 
 • **bottom**: *number* = 0
 
-*Defined in [shared.ts:116](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L116)*
-
 ___
 
 ###  left
 
 • **left**: *number* = 0
-
-*Defined in [shared.ts:113](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L113)*
 
 ___
 
@@ -60,12 +54,8 @@ ___
 
 • **right**: *number* = 0
 
-*Defined in [shared.ts:115](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L115)*
-
 ___
 
 ###  top
 
 • **top**: *number* = 0
-
-*Defined in [shared.ts:114](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L114)*

--- a/source/nodejs/adaptivecards/docs/classes/stringproperty.md
+++ b/source/nodejs/adaptivecards/docs/classes/stringproperty.md
@@ -38,8 +38,6 @@
 
 *Overrides [PropertyDefinition](propertydefinition.md).[constructor](propertydefinition.md#constructor)*
 
-*Defined in [serialization.ts:298](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L298)*
-
 **Parameters:**
 
 Name | Type | Default |
@@ -61,8 +59,6 @@ Name | Type | Default |
 
 *Overrides [PropertyDefinition](propertydefinition.md).[defaultValue](propertydefinition.md#optional-defaultvalue)*
 
-*Defined in [serialization.ts:305](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L305)*
-
 ___
 
 ###  name
@@ -70,8 +66,6 @@ ___
 • **name**: *string*
 
 *Overrides [PropertyDefinition](propertydefinition.md).[name](propertydefinition.md#name)*
-
-*Defined in [serialization.ts:302](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L302)*
 
 ___
 
@@ -81,15 +75,11 @@ ___
 
 *Overrides [PropertyDefinition](propertydefinition.md).[onGetInitialValue](propertydefinition.md#optional-ongetinitialvalue)*
 
-*Defined in [serialization.ts:306](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L306)*
-
 ___
 
 ### `Optional` regEx
 
 • **regEx**? : *RegExp*
-
-*Defined in [serialization.ts:304](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L304)*
 
 ___
 
@@ -99,8 +89,6 @@ ___
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[sequentialNumber](propertydefinition.md#sequentialnumber)*
 
-*Defined in [serialization.ts:258](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L258)*
-
 ___
 
 ###  targetVersion
@@ -109,15 +97,11 @@ ___
 
 *Overrides [PropertyDefinition](propertydefinition.md).[targetVersion](propertydefinition.md#targetversion)*
 
-*Defined in [serialization.ts:301](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L301)*
-
 ___
 
 ###  treatEmptyAsUndefined
 
 • **treatEmptyAsUndefined**: *boolean*
-
-*Defined in [serialization.ts:303](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L303)*
 
 ## Methods
 
@@ -126,8 +110,6 @@ ___
 ▸ **getInternalName**(): *string*
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[getInternalName](propertydefinition.md#getinternalname)*
-
-*Defined in [serialization.ts:246](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L246)*
 
 **Returns:** *string*
 
@@ -138,8 +120,6 @@ ___
 ▸ **parse**(`sender`: [SerializableObject](serializableobject.md), `source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *string | undefined*
 
 *Overrides [PropertyDefinition](propertydefinition.md).[parse](propertydefinition.md#parse)*
-
-*Defined in [serialization.ts:272](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L272)*
 
 **Parameters:**
 
@@ -158,8 +138,6 @@ ___
 ▸ **toJSON**(`sender`: [SerializableObject](serializableobject.md), `target`: [PropertyBag](../README.md#propertybag), `value`: string | undefined, `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Overrides [PropertyDefinition](propertydefinition.md).[toJSON](propertydefinition.md#tojson)*
-
-*Defined in [serialization.ts:292](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L292)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/docs/classes/stringwithsubstitutions.md
+++ b/source/nodejs/adaptivecards/docs/classes/stringwithsubstitutions.md
@@ -22,8 +22,6 @@
 
 ▸ **get**(): *string | undefined*
 
-*Defined in [shared.ts:97](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L97)*
-
 **Returns:** *string | undefined*
 
 ___
@@ -32,8 +30,6 @@ ___
 
 ▸ **getOriginal**(): *string | undefined*
 
-*Defined in [shared.ts:93](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L93)*
-
 **Returns:** *string | undefined*
 
 ___
@@ -41,8 +37,6 @@ ___
 ###  getReferencedInputs
 
 ▸ **getReferencedInputs**(`inputs`: [IInput](../interfaces/iinput.md)[], `referencedInputs`: [Dictionary](../README.md#dictionary)‹[IInput](../interfaces/iinput.md)›): *void*
-
-*Defined in [shared.ts:42](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L42)*
 
 **Parameters:**
 
@@ -59,8 +53,6 @@ ___
 
 ▸ **set**(`value`: string | undefined): *void*
 
-*Defined in [shared.ts:106](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L106)*
-
 **Parameters:**
 
 Name | Type |
@@ -74,8 +66,6 @@ ___
 ###  substituteInputValues
 
 ▸ **substituteInputValues**(`inputs`: [Dictionary](../README.md#dictionary)‹[IInput](../interfaces/iinput.md)›, `contentType`: string): *void*
-
-*Defined in [shared.ts:56](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L56)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/docs/classes/stylablecardelementcontainer.md
+++ b/source/nodejs/adaptivecards/docs/classes/stylablecardelementcontainer.md
@@ -161,8 +161,6 @@
 
 *Inherited from [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 **Returns:** *[StylableCardElementContainer](stylablecardelementcontainer.md)*
 
 ## Properties
@@ -173,8 +171,6 @@
 
 *Inherited from [CardObject](cardobject.md).[_parent](cardobject.md#protected-optional-_parent)*
 
-*Defined in [card-object.ts:61](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L61)*
-
 ___
 
 ### `Protected` `Optional` _renderedElement
@@ -182,8 +178,6 @@ ___
 • **_renderedElement**? : *HTMLElement*
 
 *Inherited from [CardObject](cardobject.md).[_renderedElement](cardobject.md#protected-optional-_renderedelement)*
-
-*Defined in [card-object.ts:62](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L62)*
 
 ___
 
@@ -193,8 +187,6 @@ ___
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[_selectAction](cardelementcontainer.md#protected-optional-_selectaction)*
 
-*Defined in [card-elements.ts:1747](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1747)*
-
 ___
 
 ###  allowVerticalOverflow
@@ -202,8 +194,6 @@ ___
 • **allowVerticalOverflow**: *boolean* = false
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[allowVerticalOverflow](cardelementcontainer.md#allowverticaloverflow)*
-
-*Defined in [card-elements.ts:1787](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1787)*
 
 ___
 
@@ -213,8 +203,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#optional-customcssselector)*
 
-*Defined in [card-elements.ts:311](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L311)*
-
 ___
 
 ###  height
@@ -222,8 +210,6 @@ ___
 • **height**: *[CardElementHeight](../README.md#cardelementheight)*
 
 *Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
-
-*Defined in [card-elements.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L53)*
 
 ___
 
@@ -233,8 +219,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#horizontalalignment)*
 
-*Defined in [card-elements.ts:44](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L44)*
-
 ___
 
 ### `Optional` id
@@ -242,8 +226,6 @@ ___
 • **id**? : *undefined | string*
 
 *Inherited from [CardObject](cardobject.md).[id](cardobject.md#optional-id)*
-
-*Defined in [card-object.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L50)*
 
 ___
 
@@ -253,15 +235,11 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 ___
 
 ### `Optional` minPixelHeight
 
 • **minPixelHeight**? : *undefined | number*
-
-*Defined in [card-elements.ts:4621](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4621)*
 
 ___
 
@@ -271,8 +249,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[onPreProcessPropertyValue](cardobject.md#optional-onpreprocesspropertyvalue)*
 
-*Defined in [card-object.ts:64](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L64)*
-
 ___
 
 ###  separator
@@ -280,8 +256,6 @@ ___
 • **separator**: *boolean*
 
 *Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
-
-*Defined in [card-elements.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L50)*
 
 ___
 
@@ -291,15 +265,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
 
-*Defined in [card-elements.ts:47](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L47)*
-
 ___
 
 ### `Static` bleedProperty
 
 ▪ **bleedProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_2, "bleed", false)
-
-*Defined in [card-elements.ts:4597](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4597)*
 
 ___
 
@@ -316,8 +286,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[heightProperty](cardelement.md#static-heightproperty)*
 
-*Defined in [card-elements.ts:24](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L24)*
-
 ___
 
 ### `Static` horizontalAlignmentProperty
@@ -330,8 +298,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignmentProperty](cardelement.md#static-horizontalalignmentproperty)*
 
-*Defined in [card-elements.ts:32](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L32)*
-
 ___
 
 ### `Static` idProperty
@@ -339,8 +305,6 @@ ___
 ▪ **idProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "id")
 
 *Inherited from [CardObject](cardobject.md).[idProperty](cardobject.md#static-idproperty)*
-
-*Defined in [card-object.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L39)*
 
 ___
 
@@ -350,8 +314,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisibleProperty](cardelement.md#static-isvisibleproperty)*
 
-*Defined in [card-elements.ts:22](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L22)*
-
 ___
 
 ### `Static` langProperty
@@ -360,15 +322,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[langProperty](cardelement.md#static-langproperty)*
 
-*Defined in [card-elements.ts:21](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L21)*
-
 ___
 
 ### `Static` minHeightProperty
 
 ▪ **minHeightProperty**: *[PixelSizeProperty](pixelsizeproperty.md)‹›* = new PixelSizeProperty(Versions.v1_2, "minHeight")
-
-*Defined in [card-elements.ts:4598](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4598)*
 
 ___
 
@@ -377,8 +335,6 @@ ___
 ▪ **onRegisterCustomProperties**? : *undefined | function*
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
-
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
 
 ___
 
@@ -391,8 +347,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requiresProperty](cardobject.md#static-requiresproperty)*
 
-*Defined in [card-object.ts:40](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L40)*
-
 ___
 
 ### `Static` selectActionProperty
@@ -401,8 +355,6 @@ ___
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[selectActionProperty](cardelementcontainer.md#static-selectactionproperty)*
 
-*Defined in [card-elements.ts:1736](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1736)*
-
 ___
 
 ### `Static` separatorProperty
@@ -410,8 +362,6 @@ ___
 ▪ **separatorProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_0, "separator", false)
 
 *Inherited from [CardElement](cardelement.md).[separatorProperty](cardelement.md#static-separatorproperty)*
-
-*Defined in [card-elements.ts:23](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L23)*
 
 ___
 
@@ -424,8 +374,6 @@ ___
         Enums.Spacing.Default)
 
 *Inherited from [CardElement](cardelement.md).[spacingProperty](cardelement.md#static-spacingproperty)*
-
-*Defined in [card-elements.ts:37](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L37)*
 
 ___
 
@@ -443,8 +391,6 @@ ___
             { targetVersion: Versions.v1_2, value: Enums.ContainerStyle.Warning }
         ])
 
-*Defined in [card-elements.ts:4586](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4586)*
-
 ___
 
 ### `Static` typeNameProperty
@@ -461,8 +407,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[typeNameProperty](cardobject.md#static-typenameproperty)*
 
-*Defined in [card-object.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L30)*
-
 ## Accessors
 
 ### `Protected` allowCustomPadding
@@ -471,8 +415,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
 
-*Defined in [card-elements.ts:299](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L299)*
-
 **Returns:** *boolean*
 
 ___
@@ -480,8 +422,6 @@ ___
 ### `Protected` allowCustomStyle
 
 • **get allowCustomStyle**(): *boolean*
-
-*Defined in [card-elements.ts:4742](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4742)*
 
 **Returns:** *boolean*
 
@@ -493,8 +433,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
 
-*Defined in [card-elements.ts:307](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L307)*
-
 **Returns:** *string*
 
 ___
@@ -502,8 +440,6 @@ ___
 ### `Protected` hasExplicitStyle
 
 • **get hasExplicitStyle**(): *boolean*
-
-*Defined in [card-elements.ts:4738](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4738)*
 
 **Returns:** *boolean*
 
@@ -514,8 +450,6 @@ ___
 • **get hasVisibleSeparator**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
-
-*Defined in [card-elements.ts:580](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L580)*
 
 **Returns:** *boolean*
 
@@ -529,8 +463,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
 
-*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
-
 **Returns:** *[HostConfig](hostconfig.md)*
 
 • **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
@@ -538,8 +470,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
-
-*Defined in [card-elements.ts:555](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L555)*
 
 **Parameters:**
 
@@ -557,8 +487,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
 
-*Defined in [card-elements.ts:559](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L559)*
-
 **Returns:** *number*
 
 ___
@@ -568,8 +496,6 @@ ___
 • **get isInline**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
-
-*Defined in [card-elements.ts:576](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L576)*
 
 **Returns:** *boolean*
 
@@ -581,8 +507,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
 
-*Defined in [card-elements.ts:568](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L568)*
-
 **Returns:** *boolean*
 
 ___
@@ -592,8 +516,6 @@ ___
 • **get isSelectable**(): *boolean*
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[isSelectable](cardelementcontainer.md#protected-isselectable)*
-
-*Defined in [card-elements.ts:1777](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1777)*
 
 **Returns:** *boolean*
 
@@ -605,8 +527,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
 
-*Defined in [card-elements.ts:572](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L572)*
-
 **Returns:** *boolean*
 
 ___
@@ -617,15 +537,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
 
-*Defined in [card-elements.ts:77](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L77)*
-
 **Returns:** *boolean*
 
 • **set isVisible**(`value`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
-
-*Defined in [card-elements.ts:81](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L81)*
 
 **Parameters:**
 
@@ -643,15 +559,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
 
-*Defined in [card-elements.ts:56](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L56)*
-
 **Returns:** *string | undefined*
 
 • **set lang**(`value`: string | undefined): *void*
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
-
-*Defined in [card-elements.ts:72](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L72)*
 
 **Parameters:**
 
@@ -671,8 +583,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[parent](cardobject.md#parent)*
 
-*Defined in [card-elements.ts:593](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L593)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -680,8 +590,6 @@ ___
 ### `Protected` renderedActionCount
 
 • **get renderedActionCount**(): *number*
-
-*Defined in [card-elements.ts:4734](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4734)*
 
 **Returns:** *number*
 
@@ -693,8 +601,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[renderedElement](cardobject.md#renderedelement)*
 
-*Defined in [card-object.ts:140](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L140)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -704,8 +610,6 @@ ___
 • **get requires**(): *HostCapabilities*
 
 *Inherited from [CardObject](cardobject.md).[requires](cardobject.md#requires)*
-
-*Defined in [card-object.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L53)*
 
 **Returns:** *HostCapabilities*
 
@@ -717,8 +621,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
 
-*Defined in [card-elements.ts:589](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L589)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -729,8 +631,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
 
-*Defined in [card-elements.ts:303](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L303)*
-
 **Returns:** *[Orientation](../enums/orientation.md)*
 
 ___
@@ -739,13 +639,9 @@ ___
 
 • **get style**(): *string | undefined*
 
-*Defined in [card-elements.ts:4601](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4601)*
-
 **Returns:** *string | undefined*
 
 • **set style**(`value`: string | undefined): *void*
-
-*Defined in [card-elements.ts:4613](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4613)*
 
 **Parameters:**
 
@@ -763,8 +659,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
 
-*Defined in [card-elements.ts:295](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L295)*
-
 **Returns:** *boolean*
 
 ## Methods
@@ -774,8 +668,6 @@ ___
 ▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
 
 *Overrides [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
-
-*Defined in [card-elements.ts:4625](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4625)*
 
 **Parameters:**
 
@@ -791,8 +683,6 @@ ___
 
 ▸ **applyBackground**(): *void*
 
-*Defined in [card-elements.ts:4633](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4633)*
-
 **Returns:** *void*
 
 ___
@@ -802,8 +692,6 @@ ___
 ▸ **applyPadding**(): *void*
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[applyPadding](cardelementcontainer.md#protected-applypadding)*
-
-*Defined in [card-elements.ts:4643](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4643)*
 
 **Returns:** *void*
 
@@ -815,8 +703,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
 
-*Defined in [card-elements.ts:321](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L321)*
-
 **Returns:** *string | undefined*
 
 ___
@@ -827,8 +713,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
 
-*Defined in [card-elements.ts:205](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L205)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -838,8 +722,6 @@ ___
 ▸ **getActionAt**(`index`: number): *[Action](action.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
-
-*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
 
 **Parameters:**
 
@@ -857,8 +739,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
 
-*Defined in [card-elements.ts:531](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L531)*
-
 **Parameters:**
 
 Name | Type |
@@ -875,8 +755,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
 
-*Defined in [card-elements.ts:396](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L396)*
-
 **Returns:** *number*
 
 ___
@@ -889,8 +767,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
 
-*Defined in [card-elements.ts:1871](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1871)*
-
 **Returns:** *[Input](input.md)[]*
 
 ___
@@ -898,8 +774,6 @@ ___
 ### `Protected` getBleed
 
 ▸ **getBleed**(): *boolean*
-
-*Defined in [card-elements.ts:4726](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4726)*
 
 **Returns:** *boolean*
 
@@ -910,8 +784,6 @@ ___
 ▸ **getCustomProperty**(`name`: string): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
-
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
 
 **Parameters:**
 
@@ -929,8 +801,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
 
-*Defined in [card-elements.ts:4713](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4713)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
 ___
@@ -940,8 +810,6 @@ ___
 ▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
 
 *Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
-
-*Defined in [card-elements.ts:535](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L535)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
@@ -953,8 +821,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
 
-*Defined in [card-elements.ts:4777](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4777)*
-
 **Returns:** *string*
 
 ___
@@ -964,8 +830,6 @@ ___
 ▸ **getEffectiveStyleDefinition**(): *[ContainerStyleDefinition](containerstyledefinition.md)*
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyleDefinition](cardelement.md#geteffectivestyledefinition)*
-
-*Defined in [card-elements.ts:337](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L337)*
 
 **Returns:** *[ContainerStyleDefinition](containerstyledefinition.md)*
 
@@ -978,8 +842,6 @@ ___
 *Inherited from [CardElementContainer](cardelementcontainer.md).[getElementById](cardelementcontainer.md#getelementbyid)*
 
 *Overrides [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
-
-*Defined in [card-elements.ts:1891](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1891)*
 
 **Parameters:**
 
@@ -997,8 +859,6 @@ ___
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[getFirstVisibleRenderedItem](cardelementcontainer.md#abstract-getfirstvisiblerendereditem)*
 
-*Defined in [card-elements.ts:1783](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1783)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -1008,8 +868,6 @@ ___
 ▸ **getForbiddenActionTypes**(): *[ActionType](../README.md#actiontype)[]*
 
 *Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
-
-*Defined in [card-elements.ts:341](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L341)*
 
 **Returns:** *[ActionType](../README.md#actiontype)[]*
 
@@ -1021,8 +879,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
 
-*Defined in [card-elements.ts:4695](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4695)*
-
 **Returns:** *boolean*
 
 ___
@@ -1030,8 +886,6 @@ ___
 ### `Protected` getHasExpandedAction
 
 ▸ **getHasExpandedAction**(): *boolean*
-
-*Defined in [card-elements.ts:4722](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4722)*
 
 **Returns:** *boolean*
 
@@ -1042,8 +896,6 @@ ___
 ▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
-
-*Defined in [card-elements.ts:345](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L345)*
 
 **Parameters:**
 
@@ -1065,8 +917,6 @@ ___
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[getItemAt](cardelementcontainer.md#abstract-getitemat)*
 
-*Defined in [card-elements.ts:1782](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1782)*
-
 **Parameters:**
 
 Name | Type |
@@ -1083,8 +933,6 @@ ___
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[getItemCount](cardelementcontainer.md#abstract-getitemcount)*
 
-*Defined in [card-elements.ts:1781](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1781)*
-
 **Returns:** *number*
 
 ___
@@ -1094,8 +942,6 @@ ___
 ▸ **getJsonTypeName**(): *string*
 
 *Inherited from [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
-
-*Defined in [card-object.ts:66](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L66)*
 
 **Returns:** *string*
 
@@ -1107,8 +953,6 @@ ___
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[getLastVisibleRenderedItem](cardelementcontainer.md#abstract-getlastvisiblerendereditem)*
 
-*Defined in [card-elements.ts:1784](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1784)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -1119,8 +963,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
 
-*Defined in [card-elements.ts:283](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L283)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md) | undefined*
 
 ___
@@ -1130,8 +972,6 @@ ___
 ▸ **getParentContainer**(): *[Container](container.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
-
-*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
 
 **Returns:** *[Container](container.md) | undefined*
 
@@ -1145,8 +985,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
 
-*Defined in [card-elements.ts:1881](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1881)*
-
 **Returns:** *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
 ___
@@ -1156,8 +994,6 @@ ___
 ▸ **getRootElement**(): *[CardElement](cardelement.md)*
 
 *Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
-
-*Defined in [card-elements.ts:501](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L501)*
 
 **Returns:** *[CardElement](cardelement.md)*
 
@@ -1169,8 +1005,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getRootObject](cardobject.md#getrootobject)*
 
-*Defined in [card-object.ts:100](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L100)*
-
 **Returns:** *[CardObject](cardobject.md)*
 
 ___
@@ -1180,8 +1014,6 @@ ___
 ▸ **getSchema**(): *[SerializableObjectSchema](serializableobjectschema.md)*
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
-
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
 
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
@@ -1195,8 +1027,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-object.ts:45](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L45)*
-
 **Returns:** *string*
 
 ___
@@ -1206,8 +1036,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -1225,8 +1053,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -1236,8 +1062,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -1255,8 +1079,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
 
-*Defined in [card-elements.ts:439](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L439)*
-
 **Parameters:**
 
 Name | Type |
@@ -1272,8 +1094,6 @@ ___
 ▸ **internalParse**(`source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
-
-*Defined in [serialization.ts:789](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L789)*
 
 **Parameters:**
 
@@ -1292,8 +1112,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
 
-*Defined in [card-elements.ts:233](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L233)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1303,8 +1121,6 @@ ___
 ▸ **internalToJSON**(`target`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
-
-*Defined in [serialization.ts:821](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L821)*
 
 **Parameters:**
 
@@ -1323,8 +1139,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[internalValidateProperties](cardelementcontainer.md#internalvalidateproperties)*
 
-*Defined in [card-elements.ts:4750](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4750)*
-
 **Parameters:**
 
 Name | Type |
@@ -1341,8 +1155,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
 
-*Defined in [card-elements.ts:469](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L469)*
-
 **Returns:** *boolean*
 
 ___
@@ -1352,8 +1164,6 @@ ___
 ▸ **isAtTheVeryLeft**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
-
-*Defined in [card-elements.ts:457](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L457)*
 
 **Returns:** *boolean*
 
@@ -1365,8 +1175,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
 
-*Defined in [card-elements.ts:461](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L461)*
-
 **Returns:** *boolean*
 
 ___
@@ -1376,8 +1184,6 @@ ___
 ▸ **isAtTheVeryTop**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
-
-*Defined in [card-elements.ts:465](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L465)*
 
 **Returns:** *boolean*
 
@@ -1389,8 +1195,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
 
-*Defined in [card-elements.ts:4746](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4746)*
-
 **Returns:** *boolean*
 
 ___
@@ -1400,8 +1204,6 @@ ___
 ▸ **isBleedingAtBottom**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
-
-*Defined in [card-elements.ts:477](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L477)*
 
 **Returns:** *boolean*
 
@@ -1413,8 +1215,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
 
-*Defined in [card-elements.ts:473](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L473)*
-
 **Returns:** *boolean*
 
 ___
@@ -1424,8 +1224,6 @@ ___
 ▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
-
-*Defined in [card-elements.ts:493](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L493)*
 
 **Parameters:**
 
@@ -1443,8 +1241,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
 
-*Defined in [card-elements.ts:443](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L443)*
-
 **Returns:** *boolean*
 
 ___
@@ -1455,8 +1251,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDisplayed](cardelement.md#protected-isdisplayed)*
 
-*Defined in [card-elements.ts:229](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L229)*
-
 **Returns:** *boolean*
 
 ___
@@ -1466,8 +1260,6 @@ ___
 ▸ **isElementAllowed**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[isElementAllowed](cardelementcontainer.md#protected-iselementallowed)*
-
-*Defined in [card-elements.ts:1751](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1751)*
 
 **Parameters:**
 
@@ -1485,8 +1277,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
 
-*Defined in [card-elements.ts:449](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L449)*
-
 **Parameters:**
 
 Name | Type |
@@ -1503,8 +1293,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
 
-*Defined in [card-elements.ts:497](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L497)*
-
 **Returns:** *boolean*
 
 ___
@@ -1514,8 +1302,6 @@ ___
 ▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
-
-*Defined in [card-elements.ts:453](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L453)*
 
 **Parameters:**
 
@@ -1533,8 +1319,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
 
-*Defined in [card-elements.ts:481](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L481)*
-
 **Parameters:**
 
 Name | Type |
@@ -1550,8 +1334,6 @@ ___
 ▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
-
-*Defined in [card-elements.ts:485](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L485)*
 
 **Parameters:**
 
@@ -1569,8 +1351,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
 
-*Defined in [card-elements.ts:489](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L489)*
-
 **Parameters:**
 
 Name | Type |
@@ -1587,8 +1367,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
 
-*Defined in [card-elements.ts:235](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L235)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1600,8 +1378,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[parse](cardelement.md#parse)*
 
 *Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
-
-*Defined in [card-elements.ts:313](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L313)*
 
 **Parameters:**
 
@@ -1622,8 +1398,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [card-elements.ts:1738](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1738)*
-
 **Parameters:**
 
 Name | Type |
@@ -1639,8 +1413,6 @@ ___
 ▸ **preProcessPropertyValue**(`property`: [PropertyDefinition](propertydefinition.md), `propertyValue?`: any): *any*
 
 *Inherited from [CardObject](cardobject.md).[preProcessPropertyValue](cardobject.md#preprocesspropertyvalue)*
-
-*Defined in [card-object.ts:70](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L70)*
 
 **Parameters:**
 
@@ -1659,8 +1431,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
 
-*Defined in [card-elements.ts:404](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L404)*
-
 **Returns:** *boolean*
 
 ___
@@ -1670,8 +1440,6 @@ ___
 ▸ **removeItem**(`item`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElementContainer](cardelementcontainer.md).[removeItem](cardelementcontainer.md#abstract-removeitem)*
-
-*Defined in [card-elements.ts:1785](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1785)*
 
 **Parameters:**
 
@@ -1689,8 +1457,6 @@ ___
 
 *Overrides [CardElementContainer](cardelementcontainer.md).[render](cardelementcontainer.md#render)*
 
-*Defined in [card-elements.ts:4767](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4767)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1701,8 +1467,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -1710,8 +1474,6 @@ ___
 ### `Protected` setBleed
 
 ▸ **setBleed**(`value`: boolean): *void*
-
-*Defined in [card-elements.ts:4730](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L4730)*
 
 **Parameters:**
 
@@ -1728,8 +1490,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -1748,8 +1508,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
 
-*Defined in [card-elements.ts:287](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L287)*
-
 **Parameters:**
 
 Name | Type |
@@ -1765,8 +1523,6 @@ ___
 ▸ **setParent**(`value`: [CardObject](cardobject.md) | undefined): *void*
 
 *Inherited from [CardObject](cardobject.md).[setParent](cardobject.md#setparent)*
-
-*Defined in [card-object.ts:88](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L88)*
 
 **Parameters:**
 
@@ -1784,8 +1540,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setShouldFallback](cardobject.md#setshouldfallback)*
 
-*Defined in [card-object.ts:92](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L92)*
-
 **Parameters:**
 
 Name | Type |
@@ -1801,8 +1555,6 @@ ___
 ▸ **setValue**(`property`: [PropertyDefinition](propertydefinition.md), `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
-
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
 
 **Parameters:**
 
@@ -1821,8 +1573,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[shouldFallback](cardobject.md#shouldfallback)*
 
-*Defined in [card-object.ts:96](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L96)*
-
 **Returns:** *boolean*
 
 ___
@@ -1834,8 +1584,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[shouldSerialize](cardelement.md#protected-shouldserialize)*
 
 *Overrides [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
-
-*Defined in [card-elements.ts:291](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L291)*
 
 **Parameters:**
 
@@ -1855,8 +1603,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
 
-*Defined in [card-elements.ts:317](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L317)*
-
 **Parameters:**
 
 Name | Type |
@@ -1872,8 +1618,6 @@ ___
 ▸ **truncateOverflow**(`maxHeight`: number): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
-
-*Defined in [card-elements.ts:263](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L263)*
 
 **Parameters:**
 
@@ -1891,8 +1635,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
 
-*Defined in [card-elements.ts:273](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L273)*
-
 **Returns:** *void*
 
 ___
@@ -1904,8 +1646,6 @@ ___
 *Inherited from [CardElementContainer](cardelementcontainer.md).[updateLayout](cardelementcontainer.md#updatelayout)*
 
 *Overrides [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
-
-*Defined in [card-elements.ts:1861](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1861)*
 
 **Parameters:**
 
@@ -1922,7 +1662,5 @@ ___
 ▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
 
 *Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
-
-*Defined in [card-object.ts:128](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L128)*
 
 **Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/submitaction.md
+++ b/source/nodejs/adaptivecards/docs/classes/submitaction.md
@@ -52,6 +52,7 @@
 * [execute](submitaction.md#execute)
 * [getActionById](submitaction.md#getactionbyid)
 * [getAllInputs](submitaction.md#getallinputs)
+* [getAriaRole](submitaction.md#getariarole)
 * [getCustomProperty](submitaction.md#getcustomproperty)
 * [getHref](submitaction.md#gethref)
 * [getJsonTypeName](submitaction.md#getjsontypename)
@@ -95,8 +96,6 @@
 
 *Inherited from [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 **Returns:** *[SubmitAction](submitaction.md)*
 
 ## Properties
@@ -107,8 +106,6 @@
 
 *Inherited from [CardObject](cardobject.md).[_parent](cardobject.md#protected-optional-_parent)*
 
-*Defined in [card-object.ts:61](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L61)*
-
 ___
 
 ### `Protected` `Optional` _renderedElement
@@ -116,8 +113,6 @@ ___
 • **_renderedElement**? : *HTMLElement*
 
 *Inherited from [CardObject](cardobject.md).[_renderedElement](cardobject.md#protected-optional-_renderedelement)*
-
-*Defined in [card-object.ts:62](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L62)*
 
 ___
 
@@ -127,8 +122,6 @@ ___
 
 *Inherited from [Action](action.md).[iconUrl](action.md#optional-iconurl)*
 
-*Defined in [card-elements.ts:3359](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3359)*
-
 ___
 
 ### `Optional` id
@@ -136,8 +129,6 @@ ___
 • **id**? : *undefined | string*
 
 *Inherited from [CardObject](cardobject.md).[id](cardobject.md#optional-id)*
-
-*Defined in [card-object.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L50)*
 
 ___
 
@@ -147,8 +138,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 ___
 
 ###  onExecute
@@ -156,8 +145,6 @@ ___
 • **onExecute**: *function*
 
 *Inherited from [Action](action.md).[onExecute](action.md#onexecute)*
-
-*Defined in [card-elements.ts:3400](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3400)*
 
 #### Type declaration:
 
@@ -177,8 +164,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[onPreProcessPropertyValue](cardobject.md#optional-onpreprocesspropertyvalue)*
 
-*Defined in [card-object.ts:64](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L64)*
-
 ___
 
 ###  style
@@ -186,8 +171,6 @@ ___
 • **style**: *string* = Enums.ActionStyle.Default
 
 *Inherited from [Action](action.md).[style](action.md#style)*
-
-*Defined in [card-elements.ts:3362](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3362)*
 
 ___
 
@@ -197,23 +180,17 @@ ___
 
 *Inherited from [Action](action.md).[title](action.md#optional-title)*
 
-*Defined in [card-elements.ts:3356](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3356)*
-
 ___
 
 ### `Static` JsonTypeName
 
 ▪ **JsonTypeName**: *"Action.Submit"* = "Action.Submit"
 
-*Defined in [card-elements.ts:3575](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3575)*
-
 ___
 
 ### `Static` dataProperty
 
 ▪ **dataProperty**: *[PropertyDefinition](propertydefinition.md)‹›* = new PropertyDefinition(Versions.v1_0, "data")
-
-*Defined in [card-elements.ts:3563](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3563)*
 
 ___
 
@@ -223,8 +200,6 @@ ___
 
 *Inherited from [Action](action.md).[iconUrlProperty](action.md#static-iconurlproperty)*
 
-*Defined in [card-elements.ts:3342](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3342)*
-
 ___
 
 ### `Static` idProperty
@@ -232,8 +207,6 @@ ___
 ▪ **idProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "id")
 
 *Inherited from [CardObject](cardobject.md).[idProperty](cardobject.md#static-idproperty)*
-
-*Defined in [card-object.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L39)*
 
 ___
 
@@ -243,8 +216,6 @@ ___
 
 *Inherited from [Action](action.md).[ignoreInputValidationProperty](action.md#static-ignoreinputvalidationproperty)*
 
-*Defined in [card-elements.ts:3353](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3353)*
-
 ___
 
 ### `Static` `Optional` onRegisterCustomProperties
@@ -252,8 +223,6 @@ ___
 ▪ **onRegisterCustomProperties**? : *undefined | function*
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
-
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
 
 ___
 
@@ -265,8 +234,6 @@ ___
         HostCapabilities)
 
 *Inherited from [CardObject](cardobject.md).[requiresProperty](cardobject.md#static-requiresproperty)*
-
-*Defined in [card-object.ts:40](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L40)*
 
 ___
 
@@ -284,8 +251,6 @@ ___
 
 *Inherited from [Action](action.md).[styleProperty](action.md#static-styleproperty)*
 
-*Defined in [card-elements.ts:3343](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3343)*
-
 ___
 
 ### `Static` titleProperty
@@ -293,8 +258,6 @@ ___
 ▪ **titleProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "title")
 
 *Inherited from [Action](action.md).[titleProperty](action.md#static-titleproperty)*
-
-*Defined in [card-elements.ts:3341](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3341)*
 
 ___
 
@@ -312,21 +275,15 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[typeNameProperty](cardobject.md#static-typenameproperty)*
 
-*Defined in [card-object.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L30)*
-
 ## Accessors
 
 ###  data
 
 • **get data**(): *object | undefined*
 
-*Defined in [card-elements.ts:3625](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3625)*
-
 **Returns:** *object | undefined*
 
 • **set data**(`value`: object | undefined): *void*
-
-*Defined in [card-elements.ts:3629](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3629)*
 
 **Parameters:**
 
@@ -346,8 +303,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
 
-*Defined in [card-elements.ts:3551](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3551)*
-
 **Returns:** *[HostConfig](hostconfig.md)*
 
 ___
@@ -358,15 +313,11 @@ ___
 
 *Overrides [Action](action.md).[ignoreInputValidation](action.md#ignoreinputvalidation)*
 
-*Defined in [card-elements.ts:3617](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3617)*
-
 **Returns:** *boolean*
 
 • **set ignoreInputValidation**(`value`: boolean): *void*
 
 *Overrides [Action](action.md).[ignoreInputValidation](action.md#ignoreinputvalidation)*
-
-*Defined in [card-elements.ts:3621](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3621)*
 
 **Parameters:**
 
@@ -384,15 +335,11 @@ ___
 
 *Inherited from [Action](action.md).[isPrimary](action.md#isprimary)*
 
-*Defined in [card-elements.ts:3532](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3532)*
-
 **Returns:** *boolean*
 
 • **set isPrimary**(`value`: boolean): *void*
 
 *Inherited from [Action](action.md).[isPrimary](action.md#isprimary)*
-
-*Defined in [card-elements.ts:3536](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3536)*
 
 **Parameters:**
 
@@ -412,8 +359,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[parent](cardobject.md#parent)*
 
-*Defined in [card-elements.ts:3555](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3555)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -423,8 +368,6 @@ ___
 • **get renderedElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardObject](cardobject.md).[renderedElement](cardobject.md#renderedelement)*
-
-*Defined in [card-object.ts:140](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L140)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -436,8 +379,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requires](cardobject.md#requires)*
 
-*Defined in [card-object.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L53)*
-
 **Returns:** *HostCapabilities*
 
 ## Methods
@@ -447,8 +388,6 @@ ___
 ▸ **addCssClasses**(`element`: HTMLElement): *void*
 
 *Inherited from [Action](action.md).[addCssClasses](action.md#protected-addcssclasses)*
-
-*Defined in [card-elements.ts:3368](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3368)*
 
 **Parameters:**
 
@@ -466,8 +405,6 @@ ___
 
 *Inherited from [Action](action.md).[execute](action.md#execute)*
 
-*Defined in [card-elements.ts:3484](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3484)*
-
 **Returns:** *void*
 
 ___
@@ -477,8 +414,6 @@ ___
 ▸ **getActionById**(`id`: string): *[Action](action.md) | undefined*
 
 *Inherited from [Action](action.md).[getActionById](action.md#getactionbyid)*
-
-*Defined in [card-elements.ts:3520](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3520)*
 
 **Parameters:**
 
@@ -496,9 +431,17 @@ ___
 
 *Inherited from [Action](action.md).[getAllInputs](action.md#getallinputs)*
 
-*Defined in [card-elements.ts:3512](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3512)*
-
 **Returns:** *[Input](input.md)[]*
+
+___
+
+###  getAriaRole
+
+▸ **getAriaRole**(): *string*
+
+*Inherited from [Action](action.md).[getAriaRole](action.md#getariarole)*
+
+**Returns:** *string*
 
 ___
 
@@ -507,8 +450,6 @@ ___
 ▸ **getCustomProperty**(`name`: string): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
-
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
 
 **Parameters:**
 
@@ -526,8 +467,6 @@ ___
 
 *Inherited from [Action](action.md).[getHref](action.md#gethref)*
 
-*Defined in [card-elements.ts:3402](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3402)*
-
 **Returns:** *string | undefined*
 
 ___
@@ -537,8 +476,6 @@ ___
 ▸ **getJsonTypeName**(): *string*
 
 *Overrides [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
-
-*Defined in [card-elements.ts:3613](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3613)*
 
 **Returns:** *string*
 
@@ -550,8 +487,6 @@ ___
 
 *Inherited from [Action](action.md).[getReferencedInputs](action.md#getreferencedinputs)*
 
-*Defined in [card-elements.ts:3524](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3524)*
-
 **Returns:** *[Dictionary](../README.md#dictionary)‹[Input](input.md)› | undefined*
 
 ___
@@ -561,8 +496,6 @@ ___
 ▸ **getResourceInformation**(): *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
 *Inherited from [Action](action.md).[getResourceInformation](action.md#getresourceinformation)*
-
-*Defined in [card-elements.ts:3516](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3516)*
 
 **Returns:** *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
@@ -574,8 +507,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getRootObject](cardobject.md#getrootobject)*
 
-*Defined in [card-object.ts:100](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L100)*
-
 **Returns:** *[CardObject](cardobject.md)*
 
 ___
@@ -585,8 +516,6 @@ ___
 ▸ **getSchema**(): *[SerializableObjectSchema](serializableobjectschema.md)*
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
-
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
 
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
@@ -600,8 +529,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-object.ts:45](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L45)*
-
 **Returns:** *string*
 
 ___
@@ -611,8 +538,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -630,8 +555,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -641,8 +564,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -660,8 +581,6 @@ ___
 
 *Overrides [Action](action.md).[internalGetReferencedInputs](action.md#protected-internalgetreferencedinputs)*
 
-*Defined in [card-elements.ts:3580](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3580)*
-
 **Parameters:**
 
 Name | Type |
@@ -677,8 +596,6 @@ ___
 ▸ **internalParse**(`source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
-
-*Defined in [serialization.ts:789](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L789)*
 
 **Parameters:**
 
@@ -697,8 +614,6 @@ ___
 
 *Overrides [Action](action.md).[internalPrepareForExecution](action.md#protected-internalprepareforexecution)*
 
-*Defined in [card-elements.ts:3592](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3592)*
-
 **Parameters:**
 
 Name | Type |
@@ -714,8 +629,6 @@ ___
 ▸ **internalToJSON**(`target`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
-
-*Defined in [serialization.ts:821](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L821)*
 
 **Parameters:**
 
@@ -734,8 +647,6 @@ ___
 
 *Inherited from [Action](action.md).[internalValidateInputs](action.md#protected-internalvalidateinputs)*
 
-*Defined in [card-elements.ts:3380](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3380)*
-
 **Parameters:**
 
 Name | Type |
@@ -751,8 +662,6 @@ ___
 ▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
 
 *Inherited from [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
-
-*Defined in [card-object.ts:110](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L110)*
 
 **Parameters:**
 
@@ -772,8 +681,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
 
-*Defined in [card-elements.ts:3410](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3410)*
-
 **Parameters:**
 
 Name | Type |
@@ -791,8 +698,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [serialization.ts:738](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L738)*
-
 **Parameters:**
 
 Name | Type |
@@ -808,8 +713,6 @@ ___
 ▸ **preProcessPropertyValue**(`property`: [PropertyDefinition](propertydefinition.md), `propertyValue?`: any): *any*
 
 *Inherited from [CardObject](cardobject.md).[preProcessPropertyValue](cardobject.md#preprocesspropertyvalue)*
-
-*Defined in [card-object.ts:70](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L70)*
 
 **Parameters:**
 
@@ -828,8 +731,6 @@ ___
 
 *Inherited from [Action](action.md).[prepareForExecution](action.md#prepareforexecution)*
 
-*Defined in [card-elements.ts:3492](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3492)*
-
 **Returns:** *boolean*
 
 ___
@@ -840,8 +741,6 @@ ___
 
 *Inherited from [Action](action.md).[remove](action.md#remove)*
 
-*Defined in [card-elements.ts:3504](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3504)*
-
 **Returns:** *boolean*
 
 ___
@@ -851,8 +750,6 @@ ___
 ▸ **render**(`baseCssClass`: string): *void*
 
 *Inherited from [Action](action.md).[render](action.md#render)*
-
-*Defined in [card-elements.ts:3418](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3418)*
 
 **Parameters:**
 
@@ -870,8 +767,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -881,8 +776,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -901,8 +794,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setParent](cardobject.md#setparent)*
 
-*Defined in [card-object.ts:88](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L88)*
-
 **Parameters:**
 
 Name | Type |
@@ -919,8 +810,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setShouldFallback](cardobject.md#setshouldfallback)*
 
-*Defined in [card-object.ts:92](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L92)*
-
 **Parameters:**
 
 Name | Type |
@@ -936,8 +825,6 @@ ___
 ▸ **setValue**(`property`: [PropertyDefinition](propertydefinition.md), `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
-
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
 
 **Parameters:**
 
@@ -956,8 +843,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[shouldFallback](cardobject.md#shouldfallback)*
 
-*Defined in [card-object.ts:96](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L96)*
-
 **Returns:** *boolean*
 
 ___
@@ -969,8 +854,6 @@ ___
 *Inherited from [Action](action.md).[shouldSerialize](action.md#protected-shouldserialize)*
 
 *Overrides [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
-
-*Defined in [card-elements.ts:3396](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3396)*
 
 **Parameters:**
 
@@ -990,8 +873,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
 
-*Defined in [card-elements.ts:3414](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3414)*
-
 **Parameters:**
 
 Name | Type |
@@ -1007,8 +888,6 @@ ___
 ▸ **updateActionButtonCssStyle**(`actionButtonElement`: HTMLElement): *void*
 
 *Inherited from [Action](action.md).[updateActionButtonCssStyle](action.md#updateactionbuttoncssstyle)*
-
-*Defined in [card-elements.ts:3406](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3406)*
 
 **Parameters:**
 
@@ -1026,8 +905,6 @@ ___
 
 *Inherited from [Action](action.md).[validateInputs](action.md#validateinputs)*
 
-*Defined in [card-elements.ts:3528](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3528)*
-
 **Returns:** *[Input](input.md)‹›[]*
 
 ___
@@ -1037,7 +914,5 @@ ___
 ▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
 
 *Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
-
-*Defined in [card-object.ts:128](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L128)*
 
 **Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/textblock.md
+++ b/source/nodejs/adaptivecards/docs/classes/textblock.md
@@ -160,8 +160,6 @@
 
 *Inherited from [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 **Returns:** *[TextBlock](textblock.md)*
 
 ## Properties
@@ -172,8 +170,6 @@
 
 *Inherited from [CardObject](cardobject.md).[_parent](cardobject.md#protected-optional-_parent)*
 
-*Defined in [card-object.ts:61](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L61)*
-
 ___
 
 ### `Protected` `Optional` _renderedElement
@@ -181,8 +177,6 @@ ___
 • **_renderedElement**? : *HTMLElement*
 
 *Inherited from [CardObject](cardobject.md).[_renderedElement](cardobject.md#protected-optional-_renderedelement)*
-
-*Defined in [card-object.ts:62](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L62)*
 
 ___
 
@@ -192,8 +186,6 @@ ___
 
 *Inherited from [BaseTextBlock](basetextblock.md).[color](basetextblock.md#color)*
 
-*Defined in [card-elements.ts:668](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L668)*
-
 ___
 
 ### `Optional` customCssSelector
@@ -201,8 +193,6 @@ ___
 • **customCssSelector**? : *undefined | string*
 
 *Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#optional-customcssselector)*
-
-*Defined in [card-elements.ts:311](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L311)*
 
 ___
 
@@ -212,8 +202,6 @@ ___
 
 *Inherited from [BaseTextBlock](basetextblock.md).[fontType](basetextblock.md#optional-fonttype)*
 
-*Defined in [card-elements.ts:671](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L671)*
-
 ___
 
 ###  height
@@ -221,8 +209,6 @@ ___
 • **height**: *[CardElementHeight](../README.md#cardelementheight)*
 
 *Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
-
-*Defined in [card-elements.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L53)*
 
 ___
 
@@ -232,8 +218,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#horizontalalignment)*
 
-*Defined in [card-elements.ts:44](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L44)*
-
 ___
 
 ### `Optional` id
@@ -241,8 +225,6 @@ ___
 • **id**? : *undefined | string*
 
 *Inherited from [CardObject](cardobject.md).[id](cardobject.md#optional-id)*
-
-*Defined in [card-object.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L50)*
 
 ___
 
@@ -252,15 +234,11 @@ ___
 
 *Inherited from [BaseTextBlock](basetextblock.md).[isSubtle](basetextblock.md#issubtle)*
 
-*Defined in [card-elements.ts:674](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L674)*
-
 ___
 
 ### `Optional` maxLines
 
 • **maxLines**? : *undefined | number*
-
-*Defined in [card-elements.ts:797](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L797)*
 
 ___
 
@@ -270,8 +248,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 ___
 
 ### `Optional` onPreProcessPropertyValue
@@ -279,8 +255,6 @@ ___
 • **onPreProcessPropertyValue**? : *undefined | function*
 
 *Inherited from [CardObject](cardobject.md).[onPreProcessPropertyValue](cardobject.md#optional-onpreprocesspropertyvalue)*
-
-*Defined in [card-object.ts:64](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L64)*
 
 ___
 
@@ -290,8 +264,6 @@ ___
 
 *Inherited from [BaseTextBlock](basetextblock.md).[selectAction](basetextblock.md#optional-selectaction)*
 
-*Defined in [card-elements.ts:686](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L686)*
-
 ___
 
 ###  separator
@@ -299,8 +271,6 @@ ___
 • **separator**: *boolean*
 
 *Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
-
-*Defined in [card-elements.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L50)*
 
 ___
 
@@ -310,8 +280,6 @@ ___
 
 *Inherited from [BaseTextBlock](basetextblock.md).[size](basetextblock.md#size)*
 
-*Defined in [card-elements.ts:662](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L662)*
-
 ___
 
 ###  spacing
@@ -320,15 +288,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
 
-*Defined in [card-elements.ts:47](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L47)*
-
 ___
 
 ###  useMarkdown
 
 • **useMarkdown**: *boolean* = true
-
-*Defined in [card-elements.ts:1011](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1011)*
 
 ___
 
@@ -338,15 +302,11 @@ ___
 
 *Inherited from [BaseTextBlock](basetextblock.md).[weight](basetextblock.md#weight)*
 
-*Defined in [card-elements.ts:665](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L665)*
-
 ___
 
 ###  wrap
 
 • **wrap**: *boolean* = false
-
-*Defined in [card-elements.ts:794](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L794)*
 
 ___
 
@@ -360,8 +320,6 @@ ___
 
 *Inherited from [BaseTextBlock](basetextblock.md).[colorProperty](basetextblock.md#static-colorproperty)*
 
-*Defined in [card-elements.ts:638](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L638)*
-
 ___
 
 ### `Static` fontTypeProperty
@@ -372,8 +330,6 @@ ___
         Enums.FontType)
 
 *Inherited from [BaseTextBlock](basetextblock.md).[fontTypeProperty](basetextblock.md#static-fonttypeproperty)*
-
-*Defined in [card-elements.ts:647](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L647)*
 
 ___
 
@@ -390,8 +346,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[heightProperty](cardelement.md#static-heightproperty)*
 
-*Defined in [card-elements.ts:24](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L24)*
-
 ___
 
 ### `Static` horizontalAlignmentProperty
@@ -404,8 +358,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignmentProperty](cardelement.md#static-horizontalalignmentproperty)*
 
-*Defined in [card-elements.ts:32](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L32)*
-
 ___
 
 ### `Static` idProperty
@@ -413,8 +365,6 @@ ___
 ▪ **idProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "id")
 
 *Inherited from [CardObject](cardobject.md).[idProperty](cardobject.md#static-idproperty)*
-
-*Defined in [card-object.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L39)*
 
 ___
 
@@ -427,8 +377,6 @@ ___
 
 *Inherited from [BaseTextBlock](basetextblock.md).[isSubtleProperty](basetextblock.md#static-issubtleproperty)*
 
-*Defined in [card-elements.ts:643](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L643)*
-
 ___
 
 ### `Static` isVisibleProperty
@@ -436,8 +384,6 @@ ___
 ▪ **isVisibleProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_2, "isVisible", true)
 
 *Inherited from [CardElement](cardelement.md).[isVisibleProperty](cardelement.md#static-isvisibleproperty)*
-
-*Defined in [card-elements.ts:22](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L22)*
 
 ___
 
@@ -447,15 +393,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[langProperty](cardelement.md#static-langproperty)*
 
-*Defined in [card-elements.ts:21](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L21)*
-
 ___
 
 ### `Static` maxLinesProperty
 
 ▪ **maxLinesProperty**: *[NumProperty](numproperty.md)‹›* = new NumProperty(Versions.v1_0, "maxLines")
-
-*Defined in [card-elements.ts:791](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L791)*
 
 ___
 
@@ -464,8 +406,6 @@ ___
 ▪ **onRegisterCustomProperties**? : *undefined | function*
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
-
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
 
 ___
 
@@ -478,8 +418,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requiresProperty](cardobject.md#static-requiresproperty)*
 
-*Defined in [card-object.ts:40](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L40)*
-
 ___
 
 ### `Static` selectActionProperty
@@ -488,8 +426,6 @@ ___
 
 *Inherited from [BaseTextBlock](basetextblock.md).[selectActionProperty](basetextblock.md#static-selectactionproperty)*
 
-*Defined in [card-elements.ts:651](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L651)*
-
 ___
 
 ### `Static` separatorProperty
@@ -497,8 +433,6 @@ ___
 ▪ **separatorProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_0, "separator", false)
 
 *Inherited from [CardElement](cardelement.md).[separatorProperty](cardelement.md#static-separatorproperty)*
-
-*Defined in [card-elements.ts:23](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L23)*
 
 ___
 
@@ -512,8 +446,6 @@ ___
 
 *Inherited from [BaseTextBlock](basetextblock.md).[sizeProperty](basetextblock.md#static-sizeproperty)*
 
-*Defined in [card-elements.ts:628](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L628)*
-
 ___
 
 ### `Static` spacingProperty
@@ -526,8 +458,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[spacingProperty](cardelement.md#static-spacingproperty)*
 
-*Defined in [card-elements.ts:37](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L37)*
-
 ___
 
 ### `Static` textProperty
@@ -538,8 +468,6 @@ ___
         true)
 
 *Inherited from [BaseTextBlock](basetextblock.md).[textProperty](basetextblock.md#static-textproperty)*
-
-*Defined in [card-elements.ts:624](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L624)*
 
 ___
 
@@ -557,8 +485,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[typeNameProperty](cardobject.md#static-typenameproperty)*
 
-*Defined in [card-object.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L30)*
-
 ___
 
 ### `Static` weightProperty
@@ -571,15 +497,11 @@ ___
 
 *Inherited from [BaseTextBlock](basetextblock.md).[weightProperty](basetextblock.md#static-weightproperty)*
 
-*Defined in [card-elements.ts:633](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L633)*
-
 ___
 
 ### `Static` wrapProperty
 
 ▪ **wrapProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_0, "wrap", false)
-
-*Defined in [card-elements.ts:790](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L790)*
 
 ## Accessors
 
@@ -588,8 +510,6 @@ ___
 • **get allowCustomPadding**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
-
-*Defined in [card-elements.ts:299](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L299)*
 
 **Returns:** *boolean*
 
@@ -601,8 +521,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
 
-*Defined in [card-elements.ts:307](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L307)*
-
 **Returns:** *string*
 
 ___
@@ -613,8 +531,6 @@ ___
 
 *Inherited from [BaseTextBlock](basetextblock.md).[effectiveColor](basetextblock.md#effectivecolor)*
 
-*Defined in [card-elements.ts:782](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L782)*
-
 **Returns:** *[TextColor](../enums/textcolor.md)*
 
 ___
@@ -624,8 +540,6 @@ ___
 • **get hasVisibleSeparator**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
-
-*Defined in [card-elements.ts:580](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L580)*
 
 **Returns:** *boolean*
 
@@ -639,8 +553,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
 
-*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
-
 **Returns:** *[HostConfig](hostconfig.md)*
 
 • **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
@@ -648,8 +560,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
-
-*Defined in [card-elements.ts:555](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L555)*
 
 **Parameters:**
 
@@ -667,8 +577,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
 
-*Defined in [card-elements.ts:559](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L559)*
-
 **Returns:** *number*
 
 ___
@@ -678,8 +586,6 @@ ___
 • **get isInline**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
-
-*Defined in [card-elements.ts:576](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L576)*
 
 **Returns:** *boolean*
 
@@ -691,8 +597,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
 
-*Defined in [card-elements.ts:568](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L568)*
-
 **Returns:** *boolean*
 
 ___
@@ -702,8 +606,6 @@ ___
 • **get isStandalone**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
-
-*Defined in [card-elements.ts:572](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L572)*
 
 **Returns:** *boolean*
 
@@ -715,15 +617,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
 
-*Defined in [card-elements.ts:77](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L77)*
-
 **Returns:** *boolean*
 
 • **set isVisible**(`value`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
-
-*Defined in [card-elements.ts:81](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L81)*
 
 **Parameters:**
 
@@ -741,15 +639,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
 
-*Defined in [card-elements.ts:56](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L56)*
-
 **Returns:** *string | undefined*
 
 • **set lang**(`value`: string | undefined): *void*
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
-
-*Defined in [card-elements.ts:72](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L72)*
 
 **Parameters:**
 
@@ -769,8 +663,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[parent](cardobject.md#parent)*
 
-*Defined in [card-elements.ts:593](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L593)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -780,8 +672,6 @@ ___
 • **get renderedElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardObject](cardobject.md).[renderedElement](cardobject.md#renderedelement)*
-
-*Defined in [card-object.ts:140](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L140)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -793,8 +683,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requires](cardobject.md#requires)*
 
-*Defined in [card-object.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L53)*
-
 **Returns:** *HostCapabilities*
 
 ___
@@ -804,8 +692,6 @@ ___
 • **get separatorElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
-
-*Defined in [card-elements.ts:589](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L589)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -817,8 +703,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
 
-*Defined in [card-elements.ts:303](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L303)*
-
 **Returns:** *[Orientation](../enums/orientation.md)*
 
 ___
@@ -829,15 +713,11 @@ ___
 
 *Inherited from [BaseTextBlock](basetextblock.md).[text](basetextblock.md#text)*
 
-*Defined in [card-elements.ts:677](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L677)*
-
 **Returns:** *string | undefined*
 
 • **set text**(`value`: string | undefined): *void*
 
 *Inherited from [BaseTextBlock](basetextblock.md).[text](basetextblock.md#text)*
-
-*Defined in [card-elements.ts:681](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L681)*
 
 **Parameters:**
 
@@ -855,8 +735,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
 
-*Defined in [card-elements.ts:295](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L295)*
-
 **Returns:** *boolean*
 
 ## Methods
@@ -866,8 +744,6 @@ ___
 ▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
 
 *Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
-
-*Defined in [card-elements.ts:220](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L220)*
 
 **Parameters:**
 
@@ -885,8 +761,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
 
-*Defined in [card-elements.ts:239](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L239)*
-
 **Returns:** *void*
 
 ___
@@ -896,8 +770,6 @@ ___
 ▸ **applyStylesTo**(`targetElement`: HTMLElement): *void*
 
 *Overrides [BaseTextBlock](basetextblock.md).[applyStylesTo](basetextblock.md#applystylesto)*
-
-*Defined in [card-elements.ts:1013](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1013)*
 
 **Parameters:**
 
@@ -917,8 +789,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
 
-*Defined in [card-elements.ts:728](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L728)*
-
 **Returns:** *string | undefined*
 
 ___
@@ -929,8 +799,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
 
-*Defined in [card-elements.ts:205](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L205)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -940,8 +808,6 @@ ___
 ▸ **getActionAt**(`index`: number): *[Action](action.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
-
-*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
 
 **Parameters:**
 
@@ -959,8 +825,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
 
-*Defined in [card-elements.ts:531](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L531)*
-
 **Parameters:**
 
 Name | Type |
@@ -977,8 +841,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
 
-*Defined in [card-elements.ts:396](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L396)*
-
 **Returns:** *number*
 
 ___
@@ -989,8 +851,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
 
-*Defined in [card-elements.ts:519](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L519)*
-
 **Returns:** *[Input](input.md)[]*
 
 ___
@@ -1000,8 +860,6 @@ ___
 ▸ **getColorDefinition**(`colorSet`: [ColorSetDefinition](colorsetdefinition.md), `color`: [TextColor](../enums/textcolor.md)): *[TextColorDefinition](textcolordefinition.md)*
 
 *Inherited from [BaseTextBlock](basetextblock.md).[getColorDefinition](basetextblock.md#protected-getcolordefinition)*
-
-*Defined in [card-elements.ts:705](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L705)*
 
 **Parameters:**
 
@@ -1020,8 +878,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
 
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
-
 **Parameters:**
 
 Name | Type |
@@ -1038,8 +894,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
 
-*Defined in [card-elements.ts:275](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L275)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
 ___
@@ -1049,8 +903,6 @@ ___
 ▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
 
 *Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
-
-*Defined in [card-elements.ts:535](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L535)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
@@ -1062,8 +914,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
 
-*Defined in [card-elements.ts:329](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L329)*
-
 **Returns:** *string*
 
 ___
@@ -1074,8 +924,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyleDefinition](cardelement.md#geteffectivestyledefinition)*
 
-*Defined in [card-elements.ts:337](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L337)*
-
 **Returns:** *[ContainerStyleDefinition](containerstyledefinition.md)*
 
 ___
@@ -1085,8 +933,6 @@ ___
 ▸ **getElementById**(`id`: string): *[CardElement](cardelement.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
-
-*Defined in [card-elements.ts:527](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L527)*
 
 **Parameters:**
 
@@ -1104,8 +950,6 @@ ___
 
 *Inherited from [BaseTextBlock](basetextblock.md).[getFontSize](basetextblock.md#protected-getfontsize)*
 
-*Defined in [card-elements.ts:690](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L690)*
-
 **Parameters:**
 
 Name | Type |
@@ -1122,8 +966,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
 
-*Defined in [card-elements.ts:341](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L341)*
-
 **Returns:** *[ActionType](../README.md#actiontype)[]*
 
 ___
@@ -1134,8 +976,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
 
-*Defined in [card-elements.ts:279](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L279)*
-
 **Returns:** *boolean*
 
 ___
@@ -1145,8 +985,6 @@ ___
 ▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
-
-*Defined in [card-elements.ts:345](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L345)*
 
 **Parameters:**
 
@@ -1168,8 +1006,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
 
-*Defined in [card-elements.ts:1061](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1061)*
-
 **Returns:** *string*
 
 ___
@@ -1179,8 +1015,6 @@ ___
 ▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
-
-*Defined in [card-elements.ts:283](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L283)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md) | undefined*
 
@@ -1192,8 +1026,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
 
-*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
-
 **Returns:** *[Container](container.md) | undefined*
 
 ___
@@ -1201,8 +1033,6 @@ ___
 ### `Protected` getRenderedDomElementType
 
 ▸ **getRenderedDomElementType**(): *string*
-
-*Defined in [card-elements.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L843)*
 
 **Returns:** *string*
 
@@ -1214,8 +1044,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
 
-*Defined in [card-elements.ts:523](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L523)*
-
 **Returns:** *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
 ___
@@ -1225,8 +1053,6 @@ ___
 ▸ **getRootElement**(): *[CardElement](cardelement.md)*
 
 *Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
-
-*Defined in [card-elements.ts:501](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L501)*
 
 **Returns:** *[CardElement](cardelement.md)*
 
@@ -1238,8 +1064,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getRootObject](cardobject.md#getrootobject)*
 
-*Defined in [card-object.ts:100](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L100)*
-
 **Returns:** *[CardObject](cardobject.md)*
 
 ___
@@ -1249,8 +1073,6 @@ ___
 ▸ **getSchema**(): *[SerializableObjectSchema](serializableobjectschema.md)*
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
-
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
 
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
@@ -1264,8 +1086,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-object.ts:45](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L45)*
-
 **Returns:** *string*
 
 ___
@@ -1275,8 +1095,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -1294,8 +1112,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -1305,8 +1121,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -1324,8 +1138,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
 
-*Defined in [card-elements.ts:439](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L439)*
-
 **Parameters:**
 
 Name | Type |
@@ -1341,8 +1153,6 @@ ___
 ▸ **internalParse**(`source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
-
-*Defined in [serialization.ts:789](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L789)*
 
 **Parameters:**
 
@@ -1361,8 +1171,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
 
-*Defined in [card-elements.ts:847](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L847)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1372,8 +1180,6 @@ ___
 ▸ **internalToJSON**(`target`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
-
-*Defined in [serialization.ts:821](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L821)*
 
 **Parameters:**
 
@@ -1392,8 +1198,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
 
-*Defined in [card-object.ts:110](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L110)*
-
 **Parameters:**
 
 Name | Type |
@@ -1410,8 +1214,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
 
-*Defined in [card-elements.ts:469](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L469)*
-
 **Returns:** *boolean*
 
 ___
@@ -1421,8 +1223,6 @@ ___
 ▸ **isAtTheVeryLeft**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
-
-*Defined in [card-elements.ts:457](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L457)*
 
 **Returns:** *boolean*
 
@@ -1434,8 +1234,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
 
-*Defined in [card-elements.ts:461](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L461)*
-
 **Returns:** *boolean*
 
 ___
@@ -1445,8 +1243,6 @@ ___
 ▸ **isAtTheVeryTop**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
-
-*Defined in [card-elements.ts:465](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L465)*
 
 **Returns:** *boolean*
 
@@ -1458,8 +1254,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
 
-*Defined in [card-elements.ts:325](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L325)*
-
 **Returns:** *boolean*
 
 ___
@@ -1469,8 +1263,6 @@ ___
 ▸ **isBleedingAtBottom**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
-
-*Defined in [card-elements.ts:477](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L477)*
 
 **Returns:** *boolean*
 
@@ -1482,8 +1274,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
 
-*Defined in [card-elements.ts:473](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L473)*
-
 **Returns:** *boolean*
 
 ___
@@ -1493,8 +1283,6 @@ ___
 ▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
-
-*Defined in [card-elements.ts:493](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L493)*
 
 **Parameters:**
 
@@ -1512,8 +1300,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
 
-*Defined in [card-elements.ts:443](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L443)*
-
 **Returns:** *boolean*
 
 ___
@@ -1524,8 +1310,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDisplayed](cardelement.md#protected-isdisplayed)*
 
-*Defined in [card-elements.ts:229](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L229)*
-
 **Returns:** *boolean*
 
 ___
@@ -1535,8 +1319,6 @@ ___
 ▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
-
-*Defined in [card-elements.ts:449](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L449)*
 
 **Parameters:**
 
@@ -1554,8 +1336,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
 
-*Defined in [card-elements.ts:497](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L497)*
-
 **Returns:** *boolean*
 
 ___
@@ -1565,8 +1345,6 @@ ___
 ▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
-
-*Defined in [card-elements.ts:453](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L453)*
 
 **Parameters:**
 
@@ -1584,8 +1362,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
 
-*Defined in [card-elements.ts:481](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L481)*
-
 **Parameters:**
 
 Name | Type |
@@ -1601,8 +1377,6 @@ ___
 ▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
-
-*Defined in [card-elements.ts:485](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L485)*
 
 **Parameters:**
 
@@ -1620,8 +1394,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
 
-*Defined in [card-elements.ts:489](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L489)*
-
 **Parameters:**
 
 Name | Type |
@@ -1638,8 +1410,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
 
-*Defined in [card-elements.ts:235](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L235)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1651,8 +1421,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[parse](cardelement.md#parse)*
 
 *Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
-
-*Defined in [card-elements.ts:313](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L313)*
 
 **Parameters:**
 
@@ -1673,8 +1441,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [card-elements.ts:653](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L653)*
-
 **Parameters:**
 
 Name | Type |
@@ -1690,8 +1456,6 @@ ___
 ▸ **preProcessPropertyValue**(`property`: [PropertyDefinition](propertydefinition.md), `propertyValue?`: any): *any*
 
 *Inherited from [CardObject](cardobject.md).[preProcessPropertyValue](cardobject.md#preprocesspropertyvalue)*
-
-*Defined in [card-object.ts:70](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L70)*
 
 **Parameters:**
 
@@ -1710,8 +1474,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
 
-*Defined in [card-elements.ts:404](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L404)*
-
 **Returns:** *boolean*
 
 ___
@@ -1721,8 +1483,6 @@ ___
 ▸ **render**(): *HTMLElement | undefined*
 
 *Inherited from [CardElement](cardelement.md).[render](cardelement.md#render)*
-
-*Defined in [card-elements.ts:412](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L412)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -1734,8 +1494,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -1745,8 +1503,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -1765,8 +1521,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
 
-*Defined in [card-elements.ts:287](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L287)*
-
 **Parameters:**
 
 Name | Type |
@@ -1782,8 +1536,6 @@ ___
 ▸ **setParent**(`value`: [CardObject](cardobject.md) | undefined): *void*
 
 *Inherited from [CardObject](cardobject.md).[setParent](cardobject.md#setparent)*
-
-*Defined in [card-object.ts:88](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L88)*
 
 **Parameters:**
 
@@ -1801,8 +1553,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setShouldFallback](cardobject.md#setshouldfallback)*
 
-*Defined in [card-object.ts:92](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L92)*
-
 **Parameters:**
 
 Name | Type |
@@ -1819,8 +1569,6 @@ ___
 
 *Overrides [BaseTextBlock](basetextblock.md).[setText](basetextblock.md#protected-settext)*
 
-*Defined in [card-elements.ts:837](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L837)*
-
 **Parameters:**
 
 Name | Type |
@@ -1836,8 +1584,6 @@ ___
 ▸ **setValue**(`property`: [PropertyDefinition](propertydefinition.md), `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
-
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
 
 **Parameters:**
 
@@ -1856,8 +1602,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[shouldFallback](cardobject.md#shouldfallback)*
 
-*Defined in [card-object.ts:96](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L96)*
-
 **Returns:** *boolean*
 
 ___
@@ -1869,8 +1613,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[shouldSerialize](cardelement.md#protected-shouldserialize)*
 
 *Overrides [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
-
-*Defined in [card-elements.ts:291](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L291)*
 
 **Parameters:**
 
@@ -1890,8 +1632,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
 
-*Defined in [card-elements.ts:317](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L317)*
-
 **Parameters:**
 
 Name | Type |
@@ -1907,8 +1647,6 @@ ___
 ▸ **truncateOverflow**(`maxHeight`: number): *boolean*
 
 *Overrides [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
-
-*Defined in [card-elements.ts:993](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L993)*
 
 **Parameters:**
 
@@ -1926,8 +1664,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
 
-*Defined in [card-elements.ts:1001](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1001)*
-
 **Returns:** *void*
 
 ___
@@ -1937,8 +1673,6 @@ ___
 ▸ **updateLayout**(`processChildren`: boolean): *void*
 
 *Overrides [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
-
-*Defined in [card-elements.ts:1065](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1065)*
 
 **Parameters:**
 
@@ -1955,7 +1689,5 @@ ___
 ▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
 
 *Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
-
-*Defined in [card-object.ts:128](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L128)*
 
 **Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/textcolordefinition.md
+++ b/source/nodejs/adaptivecards/docs/classes/textcolordefinition.md
@@ -32,8 +32,6 @@
 
 *Inherited from [ColorDefinition](colordefinition.md).[constructor](colordefinition.md#constructor)*
 
-*Defined in [host-config.ts:24](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L24)*
-
 **Parameters:**
 
 Name | Type |
@@ -51,15 +49,11 @@ Name | Type |
 
 *Inherited from [ColorDefinition](colordefinition.md).[default](colordefinition.md#default)*
 
-*Defined in [host-config.ts:23](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L23)*
-
 ___
 
 ###  highlightColors
 
 • **highlightColors**: *[ColorDefinition](colordefinition.md)‹›* = new ColorDefinition("#22000000", "#11000000")
-
-*Defined in [host-config.ts:45](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L45)*
 
 ___
 
@@ -69,8 +63,6 @@ ___
 
 *Inherited from [ColorDefinition](colordefinition.md).[subtle](colordefinition.md#subtle)*
 
-*Defined in [host-config.ts:24](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L24)*
-
 ## Methods
 
 ###  parse
@@ -78,8 +70,6 @@ ___
 ▸ **parse**(`obj?`: any): *void*
 
 *Overrides [ColorDefinition](colordefinition.md).[parse](colordefinition.md#parse)*
-
-*Defined in [host-config.ts:47](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L47)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/docs/classes/textinput.md
+++ b/source/nodejs/adaptivecards/docs/classes/textinput.md
@@ -163,8 +163,6 @@
 
 *Inherited from [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 **Returns:** *[TextInput](textinput.md)*
 
 ## Properties
@@ -175,8 +173,6 @@
 
 *Inherited from [CardObject](cardobject.md).[_parent](cardobject.md#protected-optional-_parent)*
 
-*Defined in [card-object.ts:61](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L61)*
-
 ___
 
 ### `Protected` `Optional` _renderedElement
@@ -184,8 +180,6 @@ ___
 • **_renderedElement**? : *HTMLElement*
 
 *Inherited from [CardObject](cardobject.md).[_renderedElement](cardobject.md#protected-optional-_renderedelement)*
-
-*Defined in [card-object.ts:62](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L62)*
 
 ___
 
@@ -195,15 +189,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#optional-customcssselector)*
 
-*Defined in [card-elements.ts:311](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L311)*
-
 ___
 
 ### `Optional` defaultValue
 
 • **defaultValue**? : *undefined | string*
-
-*Defined in [card-elements.ts:2469](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2469)*
 
 ___
 
@@ -213,8 +203,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
 
-*Defined in [card-elements.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L53)*
-
 ___
 
 ###  horizontalAlignment
@@ -222,8 +210,6 @@ ___
 • **horizontalAlignment**: *[HorizontalAlignment](../enums/horizontalalignment.md)*
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#horizontalalignment)*
-
-*Defined in [card-elements.ts:44](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L44)*
 
 ___
 
@@ -235,15 +221,11 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[id](cardobject.md#optional-id)*
 
-*Defined in [card-object.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L50)*
-
 ___
 
 ### `Optional` inlineAction
 
 • **inlineAction**? : *[Action](action.md)*
-
-*Defined in [card-elements.ts:2484](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2484)*
 
 ___
 
@@ -251,15 +233,11 @@ ___
 
 • **isMultiline**: *boolean* = false
 
-*Defined in [card-elements.ts:2475](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2475)*
-
 ___
 
 ### `Optional` maxLength
 
 • **maxLength**? : *undefined | number*
-
-*Defined in [card-elements.ts:2472](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2472)*
 
 ___
 
@@ -269,8 +247,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 ___
 
 ### `Optional` onPreProcessPropertyValue
@@ -279,8 +255,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[onPreProcessPropertyValue](cardobject.md#optional-onpreprocesspropertyvalue)*
 
-*Defined in [card-object.ts:64](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L64)*
-
 ___
 
 ###  onValueChanged
@@ -288,8 +262,6 @@ ___
 • **onValueChanged**: *function*
 
 *Inherited from [Input](input.md).[onValueChanged](input.md#onvaluechanged)*
-
-*Defined in [card-elements.ts:2415](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2415)*
 
 #### Type declaration:
 
@@ -307,8 +279,6 @@ ___
 
 • **placeholder**? : *undefined | string*
 
-*Defined in [card-elements.ts:2478](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2478)*
-
 ___
 
 ###  separator
@@ -316,8 +286,6 @@ ___
 • **separator**: *boolean*
 
 *Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
-
-*Defined in [card-elements.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L50)*
 
 ___
 
@@ -327,15 +295,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
 
-*Defined in [card-elements.ts:47](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L47)*
-
 ___
 
 ###  style
 
 • **style**: *[InputTextStyle](../enums/inputtextstyle.md)* = Enums.InputTextStyle.Text
-
-*Defined in [card-elements.ts:2481](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2481)*
 
 ___
 
@@ -352,8 +316,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[heightProperty](cardelement.md#static-heightproperty)*
 
-*Defined in [card-elements.ts:24](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L24)*
-
 ___
 
 ### `Static` horizontalAlignmentProperty
@@ -366,8 +328,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignmentProperty](cardelement.md#static-horizontalalignmentproperty)*
 
-*Defined in [card-elements.ts:32](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L32)*
-
 ___
 
 ### `Static` idProperty
@@ -376,23 +336,17 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[idProperty](cardobject.md#static-idproperty)*
 
-*Defined in [card-object.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L39)*
-
 ___
 
 ### `Static` inlineActionProperty
 
 ▪ **inlineActionProperty**: *[ActionProperty](actionproperty.md)‹›* = new ActionProperty(Versions.v1_0, "inlineAction", [ "Action.ShowCard" ])
 
-*Defined in [card-elements.ts:2466](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2466)*
-
 ___
 
 ### `Static` isMultilineProperty
 
 ▪ **isMultilineProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_0, "isMultiline", false)
-
-*Defined in [card-elements.ts:2463](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2463)*
 
 ___
 
@@ -402,8 +356,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisibleProperty](cardelement.md#static-isvisibleproperty)*
 
-*Defined in [card-elements.ts:22](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L22)*
-
 ___
 
 ### `Static` langProperty
@@ -412,15 +364,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[langProperty](cardelement.md#static-langproperty)*
 
-*Defined in [card-elements.ts:21](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L21)*
-
 ___
 
 ### `Static` maxLengthProperty
 
 ▪ **maxLengthProperty**: *[NumProperty](numproperty.md)‹›* = new NumProperty(Versions.v1_0, "maxLength")
-
-*Defined in [card-elements.ts:2462](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2462)*
 
 ___
 
@@ -430,15 +378,11 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
 
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
-
 ___
 
 ### `Static` placeholderProperty
 
 ▪ **placeholderProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "placeholder")
-
-*Defined in [card-elements.ts:2464](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2464)*
 
 ___
 
@@ -451,8 +395,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requiresProperty](cardobject.md#static-requiresproperty)*
 
-*Defined in [card-object.ts:40](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L40)*
-
 ___
 
 ### `Static` separatorProperty
@@ -460,8 +402,6 @@ ___
 ▪ **separatorProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_0, "separator", false)
 
 *Inherited from [CardElement](cardelement.md).[separatorProperty](cardelement.md#static-separatorproperty)*
-
-*Defined in [card-elements.ts:23](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L23)*
 
 ___
 
@@ -475,15 +415,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[spacingProperty](cardelement.md#static-spacingproperty)*
 
-*Defined in [card-elements.ts:37](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L37)*
-
 ___
 
 ### `Static` styleProperty
 
 ▪ **styleProperty**: *[EnumProperty](enumproperty.md)‹[InputTextStyle](../enums/inputtextstyle.md)›* = new EnumProperty(Versions.v1_0, "style", Enums.InputTextStyle, Enums.InputTextStyle.Text)
-
-*Defined in [card-elements.ts:2465](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2465)*
 
 ___
 
@@ -501,8 +437,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[typeNameProperty](cardobject.md#static-typenameproperty)*
 
-*Defined in [card-object.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L30)*
-
 ___
 
 ### `Static` validationProperty
@@ -514,15 +448,11 @@ ___
 
 *Inherited from [Input](input.md).[validationProperty](input.md#static-validationproperty)*
 
-*Defined in [card-elements.ts:2313](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2313)*
-
 ___
 
 ### `Static` valueProperty
 
 ▪ **valueProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "value")
-
-*Defined in [card-elements.ts:2461](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2461)*
 
 ## Accessors
 
@@ -531,8 +461,6 @@ ___
 • **get allowCustomPadding**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
-
-*Defined in [card-elements.ts:299](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L299)*
 
 **Returns:** *boolean*
 
@@ -544,8 +472,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
 
-*Defined in [card-elements.ts:307](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L307)*
-
 **Returns:** *string*
 
 ___
@@ -555,8 +481,6 @@ ___
 • **get hasVisibleSeparator**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
-
-*Defined in [card-elements.ts:580](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L580)*
 
 **Returns:** *boolean*
 
@@ -570,8 +494,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
 
-*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
-
 **Returns:** *[HostConfig](hostconfig.md)*
 
 • **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
@@ -579,8 +501,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
-
-*Defined in [card-elements.ts:555](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L555)*
 
 **Parameters:**
 
@@ -598,8 +518,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
 
-*Defined in [card-elements.ts:559](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L559)*
-
 **Returns:** *number*
 
 ___
@@ -610,8 +528,6 @@ ___
 
 *Inherited from [Input](input.md).[inputControlContainerElement](input.md#protected-inputcontrolcontainerelement)*
 
-*Defined in [card-elements.ts:2346](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2346)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -621,8 +537,6 @@ ___
 • **get isInline**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
-
-*Defined in [card-elements.ts:576](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L576)*
 
 **Returns:** *boolean*
 
@@ -636,8 +550,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
 
-*Defined in [card-elements.ts:2453](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2453)*
-
 **Returns:** *boolean*
 
 ___
@@ -647,8 +559,6 @@ ___
 • **get isNullable**(): *boolean*
 
 *Inherited from [Input](input.md).[isNullable](input.md#protected-isnullable)*
-
-*Defined in [card-elements.ts:2338](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2338)*
 
 **Returns:** *boolean*
 
@@ -660,8 +570,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
 
-*Defined in [card-elements.ts:572](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L572)*
-
 **Returns:** *boolean*
 
 ___
@@ -672,15 +580,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
 
-*Defined in [card-elements.ts:77](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L77)*
-
 **Returns:** *boolean*
 
 • **set isVisible**(`value`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
-
-*Defined in [card-elements.ts:81](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L81)*
 
 **Parameters:**
 
@@ -698,15 +602,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
 
-*Defined in [card-elements.ts:56](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L56)*
-
 **Returns:** *string | undefined*
 
 • **set lang**(`value`: string | undefined): *void*
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
-
-*Defined in [card-elements.ts:72](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L72)*
 
 **Parameters:**
 
@@ -726,8 +626,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[parent](cardobject.md#parent)*
 
-*Defined in [card-elements.ts:593](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L593)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -737,8 +635,6 @@ ___
 • **get renderedElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardObject](cardobject.md).[renderedElement](cardobject.md#renderedelement)*
-
-*Defined in [card-object.ts:140](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L140)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -750,8 +646,6 @@ ___
 
 *Inherited from [Input](input.md).[renderedInputControlElement](input.md#protected-renderedinputcontrolelement)*
 
-*Defined in [card-elements.ts:2342](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2342)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -761,8 +655,6 @@ ___
 • **get requires**(): *HostCapabilities*
 
 *Inherited from [CardObject](cardobject.md).[requires](cardobject.md#requires)*
-
-*Defined in [card-object.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L53)*
 
 **Returns:** *HostCapabilities*
 
@@ -774,8 +666,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
 
-*Defined in [card-elements.ts:589](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L589)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -785,8 +675,6 @@ ___
 • **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
 
 *Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
-
-*Defined in [card-elements.ts:303](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L303)*
 
 **Returns:** *[Orientation](../enums/orientation.md)*
 
@@ -798,8 +686,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
 
-*Defined in [card-elements.ts:295](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L295)*
-
 **Returns:** *boolean*
 
 ___
@@ -809,8 +695,6 @@ ___
 • **get validation**(): *[InputValidationOptions](inputvalidationoptions.md)*
 
 *Inherited from [Input](input.md).[validation](input.md#validation)*
-
-*Defined in [card-elements.ts:2327](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2327)*
 
 **Returns:** *[InputValidationOptions](inputvalidationoptions.md)*
 
@@ -822,8 +706,6 @@ ___
 
 *Overrides [Input](input.md).[value](input.md#value)*
 
-*Defined in [card-elements.ts:2613](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2613)*
-
 **Returns:** *string | undefined*
 
 ## Methods
@@ -833,8 +715,6 @@ ___
 ▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
 
 *Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
-
-*Defined in [card-elements.ts:220](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L220)*
 
 **Parameters:**
 
@@ -852,8 +732,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
 
-*Defined in [card-elements.ts:239](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L239)*
-
 **Returns:** *void*
 
 ___
@@ -863,8 +741,6 @@ ___
 ▸ **asString**(): *string | undefined*
 
 *Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
-
-*Defined in [card-elements.ts:321](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L321)*
 
 **Returns:** *string | undefined*
 
@@ -876,8 +752,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
 
-*Defined in [card-elements.ts:205](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L205)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -887,8 +761,6 @@ ___
 ▸ **getActionAt**(`index`: number): *[Action](action.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
-
-*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
 
 **Parameters:**
 
@@ -906,8 +778,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
 
-*Defined in [card-elements.ts:2599](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2599)*
-
 **Parameters:**
 
 Name | Type |
@@ -924,8 +794,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
 
-*Defined in [card-elements.ts:396](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L396)*
-
 **Returns:** *number*
 
 ___
@@ -938,8 +806,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
 
-*Defined in [card-elements.ts:2449](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2449)*
-
 **Returns:** *[Input](input.md)[]*
 
 ___
@@ -949,8 +815,6 @@ ___
 ▸ **getCustomProperty**(`name`: string): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
-
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
 
 **Parameters:**
 
@@ -968,8 +832,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
 
-*Defined in [card-elements.ts:275](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L275)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
 ___
@@ -979,8 +841,6 @@ ___
 ▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
 
 *Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
-
-*Defined in [card-elements.ts:535](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L535)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
@@ -992,8 +852,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
 
-*Defined in [card-elements.ts:329](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L329)*
-
 **Returns:** *string*
 
 ___
@@ -1004,8 +862,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyleDefinition](cardelement.md#geteffectivestyledefinition)*
 
-*Defined in [card-elements.ts:337](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L337)*
-
 **Returns:** *[ContainerStyleDefinition](containerstyledefinition.md)*
 
 ___
@@ -1015,8 +871,6 @@ ___
 ▸ **getElementById**(`id`: string): *[CardElement](cardelement.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
-
-*Defined in [card-elements.ts:527](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L527)*
 
 **Parameters:**
 
@@ -1034,8 +888,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
 
-*Defined in [card-elements.ts:341](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L341)*
-
 **Returns:** *[ActionType](../README.md#actiontype)[]*
 
 ___
@@ -1046,8 +898,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
 
-*Defined in [card-elements.ts:279](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L279)*
-
 **Returns:** *boolean*
 
 ___
@@ -1057,8 +907,6 @@ ___
 ▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
-
-*Defined in [card-elements.ts:345](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L345)*
 
 **Parameters:**
 
@@ -1080,8 +928,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
 
-*Defined in [card-elements.ts:2595](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2595)*
-
 **Returns:** *string*
 
 ___
@@ -1091,8 +937,6 @@ ___
 ▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
-
-*Defined in [card-elements.ts:283](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L283)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md) | undefined*
 
@@ -1104,8 +948,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
 
-*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
-
 **Returns:** *[Container](container.md) | undefined*
 
 ___
@@ -1115,8 +957,6 @@ ___
 ▸ **getResourceInformation**(): *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
 *Inherited from [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
-
-*Defined in [card-elements.ts:523](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L523)*
 
 **Returns:** *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
@@ -1128,8 +968,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
 
-*Defined in [card-elements.ts:501](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L501)*
-
 **Returns:** *[CardElement](cardelement.md)*
 
 ___
@@ -1140,8 +978,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getRootObject](cardobject.md#getrootobject)*
 
-*Defined in [card-object.ts:100](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L100)*
-
 **Returns:** *[CardObject](cardobject.md)*
 
 ___
@@ -1151,8 +987,6 @@ ___
 ▸ **getSchema**(): *[SerializableObjectSchema](serializableobjectschema.md)*
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
-
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
 
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
@@ -1166,8 +1000,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-object.ts:45](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L45)*
-
 **Returns:** *string*
 
 ___
@@ -1177,8 +1009,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -1196,8 +1026,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -1207,8 +1035,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -1226,8 +1052,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
 
-*Defined in [card-elements.ts:439](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L439)*
-
 **Parameters:**
 
 Name | Type |
@@ -1243,8 +1067,6 @@ ___
 ▸ **internalParse**(`source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
-
-*Defined in [serialization.ts:789](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L789)*
 
 **Parameters:**
 
@@ -1263,8 +1085,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
 
-*Defined in [card-elements.ts:2514](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2514)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1274,8 +1094,6 @@ ___
 ▸ **internalToJSON**(`target`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
-
-*Defined in [serialization.ts:821](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L821)*
 
 **Parameters:**
 
@@ -1296,8 +1114,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
 
-*Defined in [card-elements.ts:2419](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2419)*
-
 **Parameters:**
 
 Name | Type |
@@ -1314,8 +1130,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
 
-*Defined in [card-elements.ts:469](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L469)*
-
 **Returns:** *boolean*
 
 ___
@@ -1325,8 +1139,6 @@ ___
 ▸ **isAtTheVeryLeft**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
-
-*Defined in [card-elements.ts:457](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L457)*
 
 **Returns:** *boolean*
 
@@ -1338,8 +1150,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
 
-*Defined in [card-elements.ts:461](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L461)*
-
 **Returns:** *boolean*
 
 ___
@@ -1349,8 +1159,6 @@ ___
 ▸ **isAtTheVeryTop**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
-
-*Defined in [card-elements.ts:465](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L465)*
 
 **Returns:** *boolean*
 
@@ -1362,8 +1170,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
 
-*Defined in [card-elements.ts:325](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L325)*
-
 **Returns:** *boolean*
 
 ___
@@ -1373,8 +1179,6 @@ ___
 ▸ **isBleedingAtBottom**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
-
-*Defined in [card-elements.ts:477](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L477)*
 
 **Returns:** *boolean*
 
@@ -1386,8 +1190,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
 
-*Defined in [card-elements.ts:473](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L473)*
-
 **Returns:** *boolean*
 
 ___
@@ -1397,8 +1199,6 @@ ___
 ▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
-
-*Defined in [card-elements.ts:493](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L493)*
 
 **Parameters:**
 
@@ -1416,8 +1216,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
 
-*Defined in [card-elements.ts:443](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L443)*
-
 **Returns:** *boolean*
 
 ___
@@ -1428,8 +1226,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDisplayed](cardelement.md#protected-isdisplayed)*
 
-*Defined in [card-elements.ts:229](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L229)*
-
 **Returns:** *boolean*
 
 ___
@@ -1439,8 +1235,6 @@ ___
 ▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
-
-*Defined in [card-elements.ts:449](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L449)*
 
 **Parameters:**
 
@@ -1458,8 +1252,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
 
-*Defined in [card-elements.ts:497](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L497)*
-
 **Returns:** *boolean*
 
 ___
@@ -1469,8 +1261,6 @@ ___
 ▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
-
-*Defined in [card-elements.ts:453](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L453)*
 
 **Parameters:**
 
@@ -1488,8 +1278,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
 
-*Defined in [card-elements.ts:481](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L481)*
-
 **Parameters:**
 
 Name | Type |
@@ -1505,8 +1293,6 @@ ___
 ▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
-
-*Defined in [card-elements.ts:485](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L485)*
 
 **Parameters:**
 
@@ -1524,8 +1310,6 @@ ___
 
 *Overrides [Input](input.md).[isSet](input.md#abstract-isset)*
 
-*Defined in [card-elements.ts:2609](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2609)*
-
 **Returns:** *boolean*
 
 ___
@@ -1535,8 +1319,6 @@ ___
 ▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
-
-*Defined in [card-elements.ts:489](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L489)*
 
 **Parameters:**
 
@@ -1554,8 +1336,6 @@ ___
 
 *Overrides [Input](input.md).[overrideInternalRender](input.md#protected-overrideinternalrender)*
 
-*Defined in [card-elements.ts:2532](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2532)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1567,8 +1347,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[parse](cardelement.md#parse)*
 
 *Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
-
-*Defined in [card-elements.ts:313](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L313)*
 
 **Parameters:**
 
@@ -1589,8 +1367,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [card-elements.ts:2318](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2318)*
-
 **Parameters:**
 
 Name | Type |
@@ -1606,8 +1382,6 @@ ___
 ▸ **preProcessPropertyValue**(`property`: [PropertyDefinition](propertydefinition.md), `propertyValue?`: any): *any*
 
 *Inherited from [CardObject](cardobject.md).[preProcessPropertyValue](cardobject.md#preprocesspropertyvalue)*
-
-*Defined in [card-object.ts:70](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L70)*
 
 **Parameters:**
 
@@ -1626,8 +1400,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
 
-*Defined in [card-elements.ts:404](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L404)*
-
 **Returns:** *boolean*
 
 ___
@@ -1637,8 +1409,6 @@ ___
 ▸ **render**(): *HTMLElement | undefined*
 
 *Inherited from [CardElement](cardelement.md).[render](cardelement.md#render)*
-
-*Defined in [card-elements.ts:412](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L412)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -1650,8 +1420,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -1662,8 +1430,6 @@ ___
 
 *Inherited from [Input](input.md).[resetValidationFailureCue](input.md#protected-resetvalidationfailurecue)*
 
-*Defined in [card-elements.ts:2391](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2391)*
-
 **Returns:** *void*
 
 ___
@@ -1673,8 +1439,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -1693,8 +1457,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
 
-*Defined in [card-elements.ts:287](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L287)*
-
 **Parameters:**
 
 Name | Type |
@@ -1710,8 +1472,6 @@ ___
 ▸ **setParent**(`value`: [CardObject](cardobject.md) | undefined): *void*
 
 *Inherited from [CardObject](cardobject.md).[setParent](cardobject.md#setparent)*
-
-*Defined in [card-object.ts:88](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L88)*
 
 **Parameters:**
 
@@ -1729,8 +1489,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setShouldFallback](cardobject.md#setshouldfallback)*
 
-*Defined in [card-object.ts:92](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L92)*
-
 **Parameters:**
 
 Name | Type |
@@ -1746,8 +1504,6 @@ ___
 ▸ **setValue**(`property`: [PropertyDefinition](propertydefinition.md), `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
-
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
 
 **Parameters:**
 
@@ -1766,8 +1522,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[shouldFallback](cardobject.md#shouldfallback)*
 
-*Defined in [card-object.ts:96](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L96)*
-
 **Returns:** *boolean*
 
 ___
@@ -1779,8 +1533,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[shouldSerialize](cardelement.md#protected-shouldserialize)*
 
 *Overrides [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
-
-*Defined in [card-elements.ts:291](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L291)*
 
 **Parameters:**
 
@@ -1798,8 +1550,6 @@ ___
 
 *Inherited from [Input](input.md).[showValidationErrorMessage](input.md#protected-showvalidationerrormessage)*
 
-*Defined in [card-elements.ts:2403](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2403)*
-
 **Returns:** *void*
 
 ___
@@ -1811,8 +1561,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[toJSON](cardelement.md#tojson)*
 
 *Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
-
-*Defined in [card-elements.ts:317](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L317)*
 
 **Parameters:**
 
@@ -1830,8 +1578,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
 
-*Defined in [card-elements.ts:263](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L263)*
-
 **Parameters:**
 
 Name | Type |
@@ -1848,8 +1594,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
 
-*Defined in [card-elements.ts:273](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L273)*
-
 **Returns:** *void*
 
 ___
@@ -1859,8 +1603,6 @@ ___
 ▸ **updateLayout**(`processChildren`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
-
-*Defined in [card-elements.ts:434](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L434)*
 
 **Parameters:**
 
@@ -1878,8 +1620,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
 
-*Defined in [card-object.ts:128](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L128)*
-
 **Returns:** *[ValidationResults](validationresults.md)*
 
 ___
@@ -1892,8 +1632,6 @@ ___
 
 *Inherited from [Input](input.md).[validateValue](input.md#validatevalue)*
 
-*Defined in [card-elements.ts:2430](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2430)*
-
 **Returns:** *boolean*
 
 ___
@@ -1903,7 +1641,5 @@ ___
 ▸ **valueChanged**(): *void*
 
 *Inherited from [Input](input.md).[valueChanged](input.md#protected-valuechanged)*
-
-*Defined in [card-elements.ts:2381](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2381)*
 
 **Returns:** *void*

--- a/source/nodejs/adaptivecards/docs/classes/textrun.md
+++ b/source/nodejs/adaptivecards/docs/classes/textrun.md
@@ -160,8 +160,6 @@
 
 *Inherited from [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 **Returns:** *[TextRun](textrun.md)*
 
 ## Properties
@@ -172,8 +170,6 @@
 
 *Inherited from [CardObject](cardobject.md).[_parent](cardobject.md#protected-optional-_parent)*
 
-*Defined in [card-object.ts:61](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L61)*
-
 ___
 
 ### `Protected` `Optional` _renderedElement
@@ -181,8 +177,6 @@ ___
 • **_renderedElement**? : *HTMLElement*
 
 *Inherited from [CardObject](cardobject.md).[_renderedElement](cardobject.md#protected-optional-_renderedelement)*
-
-*Defined in [card-object.ts:62](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L62)*
 
 ___
 
@@ -192,8 +186,6 @@ ___
 
 *Inherited from [BaseTextBlock](basetextblock.md).[color](basetextblock.md#color)*
 
-*Defined in [card-elements.ts:668](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L668)*
-
 ___
 
 ### `Optional` customCssSelector
@@ -201,8 +193,6 @@ ___
 • **customCssSelector**? : *undefined | string*
 
 *Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#optional-customcssselector)*
-
-*Defined in [card-elements.ts:311](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L311)*
 
 ___
 
@@ -212,8 +202,6 @@ ___
 
 *Inherited from [BaseTextBlock](basetextblock.md).[fontType](basetextblock.md#optional-fonttype)*
 
-*Defined in [card-elements.ts:671](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L671)*
-
 ___
 
 ###  height
@@ -222,15 +210,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
 
-*Defined in [card-elements.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L53)*
-
 ___
 
 ###  highlight
 
 • **highlight**: *boolean* = false
-
-*Defined in [card-elements.ts:1115](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1115)*
 
 ___
 
@@ -240,8 +224,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#horizontalalignment)*
 
-*Defined in [card-elements.ts:44](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L44)*
-
 ___
 
 ### `Optional` id
@@ -249,8 +231,6 @@ ___
 • **id**? : *undefined | string*
 
 *Inherited from [CardObject](cardobject.md).[id](cardobject.md#optional-id)*
-
-*Defined in [card-object.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L50)*
 
 ___
 
@@ -260,15 +240,11 @@ ___
 
 *Inherited from [BaseTextBlock](basetextblock.md).[isSubtle](basetextblock.md#issubtle)*
 
-*Defined in [card-elements.ts:674](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L674)*
-
 ___
 
 ###  italic
 
 • **italic**: *boolean* = false
-
-*Defined in [card-elements.ts:1109](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1109)*
 
 ___
 
@@ -278,8 +254,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 ___
 
 ### `Optional` onPreProcessPropertyValue
@@ -287,8 +261,6 @@ ___
 • **onPreProcessPropertyValue**? : *undefined | function*
 
 *Inherited from [CardObject](cardobject.md).[onPreProcessPropertyValue](cardobject.md#optional-onpreprocesspropertyvalue)*
-
-*Defined in [card-object.ts:64](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L64)*
 
 ___
 
@@ -298,8 +270,6 @@ ___
 
 *Inherited from [BaseTextBlock](basetextblock.md).[selectAction](basetextblock.md#optional-selectaction)*
 
-*Defined in [card-elements.ts:686](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L686)*
-
 ___
 
 ###  separator
@@ -307,8 +277,6 @@ ___
 • **separator**: *boolean*
 
 *Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
-
-*Defined in [card-elements.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L50)*
 
 ___
 
@@ -318,8 +286,6 @@ ___
 
 *Inherited from [BaseTextBlock](basetextblock.md).[size](basetextblock.md#size)*
 
-*Defined in [card-elements.ts:662](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L662)*
-
 ___
 
 ###  spacing
@@ -328,15 +294,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
 
-*Defined in [card-elements.ts:47](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L47)*
-
 ___
 
 ###  strikethrough
 
 • **strikethrough**: *boolean* = false
-
-*Defined in [card-elements.ts:1112](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1112)*
 
 ___
 
@@ -345,8 +307,6 @@ ___
 • **weight**: *[TextWeight](../enums/textweight.md)* = Enums.TextWeight.Default
 
 *Inherited from [BaseTextBlock](basetextblock.md).[weight](basetextblock.md#weight)*
-
-*Defined in [card-elements.ts:665](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L665)*
 
 ___
 
@@ -360,8 +320,6 @@ ___
 
 *Inherited from [BaseTextBlock](basetextblock.md).[colorProperty](basetextblock.md#static-colorproperty)*
 
-*Defined in [card-elements.ts:638](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L638)*
-
 ___
 
 ### `Static` fontTypeProperty
@@ -372,8 +330,6 @@ ___
         Enums.FontType)
 
 *Inherited from [BaseTextBlock](basetextblock.md).[fontTypeProperty](basetextblock.md#static-fonttypeproperty)*
-
-*Defined in [card-elements.ts:647](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L647)*
 
 ___
 
@@ -390,15 +346,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[heightProperty](cardelement.md#static-heightproperty)*
 
-*Defined in [card-elements.ts:24](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L24)*
-
 ___
 
 ### `Static` highlightProperty
 
 ▪ **highlightProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_2, "highlight", false)
-
-*Defined in [card-elements.ts:1100](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1100)*
 
 ___
 
@@ -412,8 +364,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignmentProperty](cardelement.md#static-horizontalalignmentproperty)*
 
-*Defined in [card-elements.ts:32](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L32)*
-
 ___
 
 ### `Static` idProperty
@@ -421,8 +371,6 @@ ___
 ▪ **idProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "id")
 
 *Inherited from [CardObject](cardobject.md).[idProperty](cardobject.md#static-idproperty)*
-
-*Defined in [card-object.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L39)*
 
 ___
 
@@ -435,8 +383,6 @@ ___
 
 *Inherited from [BaseTextBlock](basetextblock.md).[isSubtleProperty](basetextblock.md#static-issubtleproperty)*
 
-*Defined in [card-elements.ts:643](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L643)*
-
 ___
 
 ### `Static` isVisibleProperty
@@ -445,15 +391,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisibleProperty](cardelement.md#static-isvisibleproperty)*
 
-*Defined in [card-elements.ts:22](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L22)*
-
 ___
 
 ### `Static` italicProperty
 
 ▪ **italicProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_2, "italic", false)
-
-*Defined in [card-elements.ts:1098](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1098)*
 
 ___
 
@@ -463,8 +405,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[langProperty](cardelement.md#static-langproperty)*
 
-*Defined in [card-elements.ts:21](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L21)*
-
 ___
 
 ### `Static` `Optional` onRegisterCustomProperties
@@ -472,8 +412,6 @@ ___
 ▪ **onRegisterCustomProperties**? : *undefined | function*
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
-
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
 
 ___
 
@@ -486,8 +424,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requiresProperty](cardobject.md#static-requiresproperty)*
 
-*Defined in [card-object.ts:40](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L40)*
-
 ___
 
 ### `Static` selectActionProperty
@@ -496,8 +432,6 @@ ___
 
 *Inherited from [BaseTextBlock](basetextblock.md).[selectActionProperty](basetextblock.md#static-selectactionproperty)*
 
-*Defined in [card-elements.ts:651](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L651)*
-
 ___
 
 ### `Static` separatorProperty
@@ -505,8 +439,6 @@ ___
 ▪ **separatorProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_0, "separator", false)
 
 *Inherited from [CardElement](cardelement.md).[separatorProperty](cardelement.md#static-separatorproperty)*
-
-*Defined in [card-elements.ts:23](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L23)*
 
 ___
 
@@ -520,8 +452,6 @@ ___
 
 *Inherited from [BaseTextBlock](basetextblock.md).[sizeProperty](basetextblock.md#static-sizeproperty)*
 
-*Defined in [card-elements.ts:628](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L628)*
-
 ___
 
 ### `Static` spacingProperty
@@ -534,15 +464,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[spacingProperty](cardelement.md#static-spacingproperty)*
 
-*Defined in [card-elements.ts:37](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L37)*
-
 ___
 
 ### `Static` strikethroughProperty
 
 ▪ **strikethroughProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_2, "strikethrough", false)
-
-*Defined in [card-elements.ts:1099](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1099)*
 
 ___
 
@@ -554,8 +480,6 @@ ___
         true)
 
 *Inherited from [BaseTextBlock](basetextblock.md).[textProperty](basetextblock.md#static-textproperty)*
-
-*Defined in [card-elements.ts:624](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L624)*
 
 ___
 
@@ -573,8 +497,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[typeNameProperty](cardobject.md#static-typenameproperty)*
 
-*Defined in [card-object.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L30)*
-
 ___
 
 ### `Static` weightProperty
@@ -587,8 +509,6 @@ ___
 
 *Inherited from [BaseTextBlock](basetextblock.md).[weightProperty](basetextblock.md#static-weightproperty)*
 
-*Defined in [card-elements.ts:633](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L633)*
-
 ## Accessors
 
 ### `Protected` allowCustomPadding
@@ -596,8 +516,6 @@ ___
 • **get allowCustomPadding**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
-
-*Defined in [card-elements.ts:299](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L299)*
 
 **Returns:** *boolean*
 
@@ -609,8 +527,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
 
-*Defined in [card-elements.ts:307](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L307)*
-
 **Returns:** *string*
 
 ___
@@ -621,8 +537,6 @@ ___
 
 *Inherited from [BaseTextBlock](basetextblock.md).[effectiveColor](basetextblock.md#effectivecolor)*
 
-*Defined in [card-elements.ts:782](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L782)*
-
 **Returns:** *[TextColor](../enums/textcolor.md)*
 
 ___
@@ -632,8 +546,6 @@ ___
 • **get hasVisibleSeparator**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
-
-*Defined in [card-elements.ts:580](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L580)*
 
 **Returns:** *boolean*
 
@@ -647,8 +559,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
 
-*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
-
 **Returns:** *[HostConfig](hostconfig.md)*
 
 • **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
@@ -656,8 +566,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
-
-*Defined in [card-elements.ts:555](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L555)*
 
 **Parameters:**
 
@@ -675,8 +583,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
 
-*Defined in [card-elements.ts:559](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L559)*
-
 **Returns:** *number*
 
 ___
@@ -686,8 +592,6 @@ ___
 • **get isInline**(): *boolean*
 
 *Overrides [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
-
-*Defined in [card-elements.ts:1193](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1193)*
 
 **Returns:** *boolean*
 
@@ -699,8 +603,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
 
-*Defined in [card-elements.ts:568](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L568)*
-
 **Returns:** *boolean*
 
 ___
@@ -710,8 +612,6 @@ ___
 • **get isStandalone**(): *boolean*
 
 *Overrides [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
-
-*Defined in [card-elements.ts:1189](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1189)*
 
 **Returns:** *boolean*
 
@@ -723,15 +623,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
 
-*Defined in [card-elements.ts:77](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L77)*
-
 **Returns:** *boolean*
 
 • **set isVisible**(`value`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
-
-*Defined in [card-elements.ts:81](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L81)*
 
 **Parameters:**
 
@@ -749,15 +645,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
 
-*Defined in [card-elements.ts:56](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L56)*
-
 **Returns:** *string | undefined*
 
 • **set lang**(`value`: string | undefined): *void*
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
-
-*Defined in [card-elements.ts:72](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L72)*
 
 **Parameters:**
 
@@ -777,8 +669,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[parent](cardobject.md#parent)*
 
-*Defined in [card-elements.ts:593](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L593)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -788,8 +678,6 @@ ___
 • **get renderedElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardObject](cardobject.md).[renderedElement](cardobject.md#renderedelement)*
-
-*Defined in [card-object.ts:140](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L140)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -801,8 +689,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requires](cardobject.md#requires)*
 
-*Defined in [card-object.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L53)*
-
 **Returns:** *HostCapabilities*
 
 ___
@@ -812,8 +698,6 @@ ___
 • **get separatorElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
-
-*Defined in [card-elements.ts:589](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L589)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -825,8 +709,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
 
-*Defined in [card-elements.ts:303](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L303)*
-
 **Returns:** *[Orientation](../enums/orientation.md)*
 
 ___
@@ -837,15 +719,11 @@ ___
 
 *Inherited from [BaseTextBlock](basetextblock.md).[text](basetextblock.md#text)*
 
-*Defined in [card-elements.ts:677](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L677)*
-
 **Returns:** *string | undefined*
 
 • **set text**(`value`: string | undefined): *void*
 
 *Inherited from [BaseTextBlock](basetextblock.md).[text](basetextblock.md#text)*
-
-*Defined in [card-elements.ts:681](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L681)*
 
 **Parameters:**
 
@@ -863,8 +741,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
 
-*Defined in [card-elements.ts:295](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L295)*
-
 **Returns:** *boolean*
 
 ## Methods
@@ -874,8 +750,6 @@ ___
 ▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
 
 *Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
-
-*Defined in [card-elements.ts:220](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L220)*
 
 **Parameters:**
 
@@ -893,8 +767,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
 
-*Defined in [card-elements.ts:239](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L239)*
-
 **Returns:** *void*
 
 ___
@@ -904,8 +776,6 @@ ___
 ▸ **applyStylesTo**(`targetElement`: HTMLElement): *void*
 
 *Overrides [BaseTextBlock](basetextblock.md).[applyStylesTo](basetextblock.md#applystylesto)*
-
-*Defined in [card-elements.ts:1167](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1167)*
 
 **Parameters:**
 
@@ -925,8 +795,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
 
-*Defined in [card-elements.ts:728](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L728)*
-
 **Returns:** *string | undefined*
 
 ___
@@ -937,8 +805,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
 
-*Defined in [card-elements.ts:205](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L205)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -948,8 +814,6 @@ ___
 ▸ **getActionAt**(`index`: number): *[Action](action.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
-
-*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
 
 **Parameters:**
 
@@ -967,8 +831,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
 
-*Defined in [card-elements.ts:531](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L531)*
-
 **Parameters:**
 
 Name | Type |
@@ -985,8 +847,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
 
-*Defined in [card-elements.ts:396](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L396)*
-
 **Returns:** *number*
 
 ___
@@ -997,8 +857,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
 
-*Defined in [card-elements.ts:519](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L519)*
-
 **Returns:** *[Input](input.md)[]*
 
 ___
@@ -1008,8 +866,6 @@ ___
 ▸ **getColorDefinition**(`colorSet`: [ColorSetDefinition](colorsetdefinition.md), `color`: [TextColor](../enums/textcolor.md)): *[TextColorDefinition](textcolordefinition.md)*
 
 *Inherited from [BaseTextBlock](basetextblock.md).[getColorDefinition](basetextblock.md#protected-getcolordefinition)*
-
-*Defined in [card-elements.ts:705](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L705)*
 
 **Parameters:**
 
@@ -1028,8 +884,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
 
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
-
 **Parameters:**
 
 Name | Type |
@@ -1046,8 +900,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
 
-*Defined in [card-elements.ts:275](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L275)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
 ___
@@ -1057,8 +909,6 @@ ___
 ▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
 
 *Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
-
-*Defined in [card-elements.ts:535](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L535)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
@@ -1070,8 +920,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
 
-*Defined in [card-elements.ts:329](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L329)*
-
 **Returns:** *string*
 
 ___
@@ -1082,8 +930,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyleDefinition](cardelement.md#geteffectivestyledefinition)*
 
-*Defined in [card-elements.ts:337](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L337)*
-
 **Returns:** *[ContainerStyleDefinition](containerstyledefinition.md)*
 
 ___
@@ -1093,8 +939,6 @@ ___
 ▸ **getElementById**(`id`: string): *[CardElement](cardelement.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
-
-*Defined in [card-elements.ts:527](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L527)*
 
 **Parameters:**
 
@@ -1112,8 +956,6 @@ ___
 
 *Inherited from [BaseTextBlock](basetextblock.md).[getFontSize](basetextblock.md#protected-getfontsize)*
 
-*Defined in [card-elements.ts:690](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L690)*
-
 **Parameters:**
 
 Name | Type |
@@ -1130,8 +972,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
 
-*Defined in [card-elements.ts:341](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L341)*
-
 **Returns:** *[ActionType](../README.md#actiontype)[]*
 
 ___
@@ -1142,8 +982,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
 
-*Defined in [card-elements.ts:279](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L279)*
-
 **Returns:** *boolean*
 
 ___
@@ -1153,8 +991,6 @@ ___
 ▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
-
-*Defined in [card-elements.ts:345](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L345)*
 
 **Parameters:**
 
@@ -1176,8 +1012,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
 
-*Defined in [card-elements.ts:1185](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1185)*
-
 **Returns:** *string*
 
 ___
@@ -1187,8 +1021,6 @@ ___
 ▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
-
-*Defined in [card-elements.ts:283](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L283)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md) | undefined*
 
@@ -1200,8 +1032,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
 
-*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
-
 **Returns:** *[Container](container.md) | undefined*
 
 ___
@@ -1211,8 +1041,6 @@ ___
 ▸ **getResourceInformation**(): *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
 *Inherited from [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
-
-*Defined in [card-elements.ts:523](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L523)*
 
 **Returns:** *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
@@ -1224,8 +1052,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
 
-*Defined in [card-elements.ts:501](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L501)*
-
 **Returns:** *[CardElement](cardelement.md)*
 
 ___
@@ -1236,8 +1062,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getRootObject](cardobject.md#getrootobject)*
 
-*Defined in [card-object.ts:100](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L100)*
-
 **Returns:** *[CardObject](cardobject.md)*
 
 ___
@@ -1247,8 +1071,6 @@ ___
 ▸ **getSchema**(): *[SerializableObjectSchema](serializableobjectschema.md)*
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
-
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
 
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
@@ -1262,8 +1084,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-object.ts:45](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L45)*
-
 **Returns:** *string*
 
 ___
@@ -1273,8 +1093,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -1292,8 +1110,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -1303,8 +1119,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -1322,8 +1136,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
 
-*Defined in [card-elements.ts:439](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L439)*
-
 **Parameters:**
 
 Name | Type |
@@ -1339,8 +1151,6 @@ ___
 ▸ **internalParse**(`source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
-
-*Defined in [serialization.ts:789](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L789)*
 
 **Parameters:**
 
@@ -1359,8 +1169,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
 
-*Defined in [card-elements.ts:1119](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1119)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1370,8 +1178,6 @@ ___
 ▸ **internalToJSON**(`target`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
-
-*Defined in [serialization.ts:821](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L821)*
 
 **Parameters:**
 
@@ -1390,8 +1196,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
 
-*Defined in [card-object.ts:110](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L110)*
-
 **Parameters:**
 
 Name | Type |
@@ -1408,8 +1212,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
 
-*Defined in [card-elements.ts:469](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L469)*
-
 **Returns:** *boolean*
 
 ___
@@ -1419,8 +1221,6 @@ ___
 ▸ **isAtTheVeryLeft**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
-
-*Defined in [card-elements.ts:457](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L457)*
 
 **Returns:** *boolean*
 
@@ -1432,8 +1232,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
 
-*Defined in [card-elements.ts:461](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L461)*
-
 **Returns:** *boolean*
 
 ___
@@ -1443,8 +1241,6 @@ ___
 ▸ **isAtTheVeryTop**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
-
-*Defined in [card-elements.ts:465](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L465)*
 
 **Returns:** *boolean*
 
@@ -1456,8 +1252,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
 
-*Defined in [card-elements.ts:325](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L325)*
-
 **Returns:** *boolean*
 
 ___
@@ -1467,8 +1261,6 @@ ___
 ▸ **isBleedingAtBottom**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
-
-*Defined in [card-elements.ts:477](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L477)*
 
 **Returns:** *boolean*
 
@@ -1480,8 +1272,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
 
-*Defined in [card-elements.ts:473](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L473)*
-
 **Returns:** *boolean*
 
 ___
@@ -1491,8 +1281,6 @@ ___
 ▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
-
-*Defined in [card-elements.ts:493](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L493)*
 
 **Parameters:**
 
@@ -1510,8 +1298,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
 
-*Defined in [card-elements.ts:443](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L443)*
-
 **Returns:** *boolean*
 
 ___
@@ -1522,8 +1308,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDisplayed](cardelement.md#protected-isdisplayed)*
 
-*Defined in [card-elements.ts:229](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L229)*
-
 **Returns:** *boolean*
 
 ___
@@ -1533,8 +1317,6 @@ ___
 ▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
-
-*Defined in [card-elements.ts:449](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L449)*
 
 **Parameters:**
 
@@ -1552,8 +1334,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
 
-*Defined in [card-elements.ts:497](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L497)*
-
 **Returns:** *boolean*
 
 ___
@@ -1563,8 +1343,6 @@ ___
 ▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
-
-*Defined in [card-elements.ts:453](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L453)*
 
 **Parameters:**
 
@@ -1582,8 +1360,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
 
-*Defined in [card-elements.ts:481](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L481)*
-
 **Parameters:**
 
 Name | Type |
@@ -1599,8 +1375,6 @@ ___
 ▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
-
-*Defined in [card-elements.ts:485](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L485)*
 
 **Parameters:**
 
@@ -1618,8 +1392,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
 
-*Defined in [card-elements.ts:489](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L489)*
-
 **Parameters:**
 
 Name | Type |
@@ -1636,8 +1408,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
 
-*Defined in [card-elements.ts:235](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L235)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1649,8 +1419,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[parse](cardelement.md#parse)*
 
 *Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
-
-*Defined in [card-elements.ts:313](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L313)*
 
 **Parameters:**
 
@@ -1669,8 +1437,6 @@ ___
 
 *Overrides [BaseTextBlock](basetextblock.md).[populateSchema](basetextblock.md#protected-populateschema)*
 
-*Defined in [card-elements.ts:1102](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L1102)*
-
 **Parameters:**
 
 Name | Type |
@@ -1686,8 +1452,6 @@ ___
 ▸ **preProcessPropertyValue**(`property`: [PropertyDefinition](propertydefinition.md), `propertyValue?`: any): *any*
 
 *Inherited from [CardObject](cardobject.md).[preProcessPropertyValue](cardobject.md#preprocesspropertyvalue)*
-
-*Defined in [card-object.ts:70](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L70)*
 
 **Parameters:**
 
@@ -1706,8 +1470,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
 
-*Defined in [card-elements.ts:404](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L404)*
-
 **Returns:** *boolean*
 
 ___
@@ -1717,8 +1479,6 @@ ___
 ▸ **render**(): *HTMLElement | undefined*
 
 *Inherited from [CardElement](cardelement.md).[render](cardelement.md#render)*
-
-*Defined in [card-elements.ts:412](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L412)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -1730,8 +1490,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -1741,8 +1499,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -1761,8 +1517,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
 
-*Defined in [card-elements.ts:287](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L287)*
-
 **Parameters:**
 
 Name | Type |
@@ -1778,8 +1532,6 @@ ___
 ▸ **setParent**(`value`: [CardObject](cardobject.md) | undefined): *void*
 
 *Inherited from [CardObject](cardobject.md).[setParent](cardobject.md#setparent)*
-
-*Defined in [card-object.ts:88](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L88)*
 
 **Parameters:**
 
@@ -1797,8 +1549,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setShouldFallback](cardobject.md#setshouldfallback)*
 
-*Defined in [card-object.ts:92](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L92)*
-
 **Parameters:**
 
 Name | Type |
@@ -1815,8 +1565,6 @@ ___
 
 *Inherited from [BaseTextBlock](basetextblock.md).[setText](basetextblock.md#protected-settext)*
 
-*Defined in [card-elements.ts:724](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L724)*
-
 **Parameters:**
 
 Name | Type |
@@ -1832,8 +1580,6 @@ ___
 ▸ **setValue**(`property`: [PropertyDefinition](propertydefinition.md), `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
-
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
 
 **Parameters:**
 
@@ -1852,8 +1598,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[shouldFallback](cardobject.md#shouldfallback)*
 
-*Defined in [card-object.ts:96](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L96)*
-
 **Returns:** *boolean*
 
 ___
@@ -1865,8 +1609,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[shouldSerialize](cardelement.md#protected-shouldserialize)*
 
 *Overrides [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
-
-*Defined in [card-elements.ts:291](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L291)*
 
 **Parameters:**
 
@@ -1886,8 +1628,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
 
-*Defined in [card-elements.ts:317](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L317)*
-
 **Parameters:**
 
 Name | Type |
@@ -1903,8 +1643,6 @@ ___
 ▸ **truncateOverflow**(`maxHeight`: number): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
-
-*Defined in [card-elements.ts:263](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L263)*
 
 **Parameters:**
 
@@ -1922,8 +1660,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
 
-*Defined in [card-elements.ts:273](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L273)*
-
 **Returns:** *void*
 
 ___
@@ -1933,8 +1669,6 @@ ___
 ▸ **updateLayout**(`processChildren`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
-
-*Defined in [card-elements.ts:434](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L434)*
 
 **Parameters:**
 
@@ -1951,7 +1685,5 @@ ___
 ▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
 
 *Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
-
-*Defined in [card-object.ts:128](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L128)*
 
 **Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/timeinput.md
+++ b/source/nodejs/adaptivecards/docs/classes/timeinput.md
@@ -159,8 +159,6 @@
 
 *Inherited from [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 **Returns:** *[TimeInput](timeinput.md)*
 
 ## Properties
@@ -171,8 +169,6 @@
 
 *Inherited from [CardObject](cardobject.md).[_parent](cardobject.md#protected-optional-_parent)*
 
-*Defined in [card-object.ts:61](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L61)*
-
 ___
 
 ### `Protected` `Optional` _renderedElement
@@ -180,8 +176,6 @@ ___
 • **_renderedElement**? : *HTMLElement*
 
 *Inherited from [CardObject](cardobject.md).[_renderedElement](cardobject.md#protected-optional-_renderedelement)*
-
-*Defined in [card-object.ts:62](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L62)*
 
 ___
 
@@ -191,15 +185,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#optional-customcssselector)*
 
-*Defined in [card-elements.ts:311](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L311)*
-
 ___
 
 ### `Optional` defaultValue
 
 • **defaultValue**? : *undefined | string*
-
-*Defined in [card-elements.ts:3201](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3201)*
 
 ___
 
@@ -209,8 +199,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
 
-*Defined in [card-elements.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L53)*
-
 ___
 
 ###  horizontalAlignment
@@ -218,8 +206,6 @@ ___
 • **horizontalAlignment**: *[HorizontalAlignment](../enums/horizontalalignment.md)*
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#horizontalalignment)*
-
-*Defined in [card-elements.ts:44](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L44)*
 
 ___
 
@@ -231,15 +217,11 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[id](cardobject.md#optional-id)*
 
-*Defined in [card-object.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L50)*
-
 ___
 
 ### `Optional` max
 
 • **max**? : *undefined | string*
-
-*Defined in [card-elements.ts:3207](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3207)*
 
 ___
 
@@ -249,15 +231,11 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 ___
 
 ### `Optional` min
 
 • **min**? : *undefined | string*
-
-*Defined in [card-elements.ts:3204](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3204)*
 
 ___
 
@@ -267,8 +245,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[onPreProcessPropertyValue](cardobject.md#optional-onpreprocesspropertyvalue)*
 
-*Defined in [card-object.ts:64](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L64)*
-
 ___
 
 ###  onValueChanged
@@ -276,8 +252,6 @@ ___
 • **onValueChanged**: *function*
 
 *Inherited from [Input](input.md).[onValueChanged](input.md#onvaluechanged)*
-
-*Defined in [card-elements.ts:2415](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2415)*
 
 #### Type declaration:
 
@@ -295,8 +269,6 @@ ___
 
 • **placeholder**? : *undefined | string*
 
-*Defined in [card-elements.ts:3210](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3210)*
-
 ___
 
 ###  separator
@@ -305,8 +277,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
 
-*Defined in [card-elements.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L50)*
-
 ___
 
 ###  spacing
@@ -314,8 +284,6 @@ ___
 • **spacing**: *[Spacing](../enums/spacing.md)*
 
 *Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
-
-*Defined in [card-elements.ts:47](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L47)*
 
 ___
 
@@ -332,8 +300,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[heightProperty](cardelement.md#static-heightproperty)*
 
-*Defined in [card-elements.ts:24](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L24)*
-
 ___
 
 ### `Static` horizontalAlignmentProperty
@@ -346,8 +312,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignmentProperty](cardelement.md#static-horizontalalignmentproperty)*
 
-*Defined in [card-elements.ts:32](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L32)*
-
 ___
 
 ### `Static` idProperty
@@ -355,8 +319,6 @@ ___
 ▪ **idProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "id")
 
 *Inherited from [CardObject](cardobject.md).[idProperty](cardobject.md#static-idproperty)*
-
-*Defined in [card-object.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L39)*
 
 ___
 
@@ -366,8 +328,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisibleProperty](cardelement.md#static-isvisibleproperty)*
 
-*Defined in [card-elements.ts:22](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L22)*
-
 ___
 
 ### `Static` langProperty
@@ -376,23 +336,17 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[langProperty](cardelement.md#static-langproperty)*
 
-*Defined in [card-elements.ts:21](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L21)*
-
 ___
 
 ### `Static` maxProperty
 
 ▪ **maxProperty**: *[TimeProperty](timeproperty.md)‹›* = new TimeProperty(Versions.v1_0, "max")
 
-*Defined in [card-elements.ts:3198](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3198)*
-
 ___
 
 ### `Static` minProperty
 
 ▪ **minProperty**: *[TimeProperty](timeproperty.md)‹›* = new TimeProperty(Versions.v1_0, "min")
-
-*Defined in [card-elements.ts:3197](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3197)*
 
 ___
 
@@ -402,15 +356,11 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
 
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
-
 ___
 
 ### `Static` placeholderProperty
 
 ▪ **placeholderProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "placeholder")
-
-*Defined in [card-elements.ts:3196](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3196)*
 
 ___
 
@@ -423,8 +373,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requiresProperty](cardobject.md#static-requiresproperty)*
 
-*Defined in [card-object.ts:40](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L40)*
-
 ___
 
 ### `Static` separatorProperty
@@ -432,8 +380,6 @@ ___
 ▪ **separatorProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_0, "separator", false)
 
 *Inherited from [CardElement](cardelement.md).[separatorProperty](cardelement.md#static-separatorproperty)*
-
-*Defined in [card-elements.ts:23](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L23)*
 
 ___
 
@@ -446,8 +392,6 @@ ___
         Enums.Spacing.Default)
 
 *Inherited from [CardElement](cardelement.md).[spacingProperty](cardelement.md#static-spacingproperty)*
-
-*Defined in [card-elements.ts:37](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L37)*
 
 ___
 
@@ -465,8 +409,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[typeNameProperty](cardobject.md#static-typenameproperty)*
 
-*Defined in [card-object.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L30)*
-
 ___
 
 ### `Static` validationProperty
@@ -478,15 +420,11 @@ ___
 
 *Inherited from [Input](input.md).[validationProperty](input.md#static-validationproperty)*
 
-*Defined in [card-elements.ts:2313](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2313)*
-
 ___
 
 ### `Static` valueProperty
 
 ▪ **valueProperty**: *[TimeProperty](timeproperty.md)‹›* = new TimeProperty(Versions.v1_0, "value")
-
-*Defined in [card-elements.ts:3195](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3195)*
 
 ## Accessors
 
@@ -495,8 +433,6 @@ ___
 • **get allowCustomPadding**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
-
-*Defined in [card-elements.ts:299](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L299)*
 
 **Returns:** *boolean*
 
@@ -508,8 +444,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
 
-*Defined in [card-elements.ts:307](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L307)*
-
 **Returns:** *string*
 
 ___
@@ -519,8 +453,6 @@ ___
 • **get hasVisibleSeparator**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
-
-*Defined in [card-elements.ts:580](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L580)*
 
 **Returns:** *boolean*
 
@@ -534,8 +466,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
 
-*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
-
 **Returns:** *[HostConfig](hostconfig.md)*
 
 • **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
@@ -543,8 +473,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
-
-*Defined in [card-elements.ts:555](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L555)*
 
 **Parameters:**
 
@@ -562,8 +490,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
 
-*Defined in [card-elements.ts:559](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L559)*
-
 **Returns:** *number*
 
 ___
@@ -574,8 +500,6 @@ ___
 
 *Inherited from [Input](input.md).[inputControlContainerElement](input.md#protected-inputcontrolcontainerelement)*
 
-*Defined in [card-elements.ts:2346](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2346)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -585,8 +509,6 @@ ___
 • **get isInline**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
-
-*Defined in [card-elements.ts:576](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L576)*
 
 **Returns:** *boolean*
 
@@ -600,8 +522,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
 
-*Defined in [card-elements.ts:2453](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2453)*
-
 **Returns:** *boolean*
 
 ___
@@ -611,8 +531,6 @@ ___
 • **get isNullable**(): *boolean*
 
 *Inherited from [Input](input.md).[isNullable](input.md#protected-isnullable)*
-
-*Defined in [card-elements.ts:2338](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2338)*
 
 **Returns:** *boolean*
 
@@ -624,8 +542,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
 
-*Defined in [card-elements.ts:572](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L572)*
-
 **Returns:** *boolean*
 
 ___
@@ -636,15 +552,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
 
-*Defined in [card-elements.ts:77](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L77)*
-
 **Returns:** *boolean*
 
 • **set isVisible**(`value`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
-
-*Defined in [card-elements.ts:81](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L81)*
 
 **Parameters:**
 
@@ -662,15 +574,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
 
-*Defined in [card-elements.ts:56](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L56)*
-
 **Returns:** *string | undefined*
 
 • **set lang**(`value`: string | undefined): *void*
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
-
-*Defined in [card-elements.ts:72](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L72)*
 
 **Parameters:**
 
@@ -690,8 +598,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[parent](cardobject.md#parent)*
 
-*Defined in [card-elements.ts:593](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L593)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -701,8 +607,6 @@ ___
 • **get renderedElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardObject](cardobject.md).[renderedElement](cardobject.md#renderedelement)*
-
-*Defined in [card-object.ts:140](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L140)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -714,8 +618,6 @@ ___
 
 *Inherited from [Input](input.md).[renderedInputControlElement](input.md#protected-renderedinputcontrolelement)*
 
-*Defined in [card-elements.ts:2342](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2342)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -725,8 +627,6 @@ ___
 • **get requires**(): *HostCapabilities*
 
 *Inherited from [CardObject](cardobject.md).[requires](cardobject.md#requires)*
-
-*Defined in [card-object.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L53)*
 
 **Returns:** *HostCapabilities*
 
@@ -738,8 +638,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
 
-*Defined in [card-elements.ts:589](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L589)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -749,8 +647,6 @@ ___
 • **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
 
 *Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
-
-*Defined in [card-elements.ts:303](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L303)*
 
 **Returns:** *[Orientation](../enums/orientation.md)*
 
@@ -762,8 +658,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
 
-*Defined in [card-elements.ts:295](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L295)*
-
 **Returns:** *boolean*
 
 ___
@@ -773,8 +667,6 @@ ___
 • **get validation**(): *[InputValidationOptions](inputvalidationoptions.md)*
 
 *Inherited from [Input](input.md).[validation](input.md#validation)*
-
-*Defined in [card-elements.ts:2327](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2327)*
 
 **Returns:** *[InputValidationOptions](inputvalidationoptions.md)*
 
@@ -786,8 +678,6 @@ ___
 
 *Overrides [Input](input.md).[value](input.md#value)*
 
-*Defined in [card-elements.ts:3245](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3245)*
-
 **Returns:** *string | undefined*
 
 ## Methods
@@ -797,8 +687,6 @@ ___
 ▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
 
 *Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
-
-*Defined in [card-elements.ts:220](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L220)*
 
 **Parameters:**
 
@@ -816,8 +704,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
 
-*Defined in [card-elements.ts:239](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L239)*
-
 **Returns:** *void*
 
 ___
@@ -827,8 +713,6 @@ ___
 ▸ **asString**(): *string | undefined*
 
 *Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
-
-*Defined in [card-elements.ts:321](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L321)*
 
 **Returns:** *string | undefined*
 
@@ -840,8 +724,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
 
-*Defined in [card-elements.ts:205](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L205)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -851,8 +733,6 @@ ___
 ▸ **getActionAt**(`index`: number): *[Action](action.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
-
-*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
 
 **Parameters:**
 
@@ -870,8 +750,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
 
-*Defined in [card-elements.ts:531](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L531)*
-
 **Parameters:**
 
 Name | Type |
@@ -888,8 +766,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
 
-*Defined in [card-elements.ts:396](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L396)*
-
 **Returns:** *number*
 
 ___
@@ -902,8 +778,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
 
-*Defined in [card-elements.ts:2449](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2449)*
-
 **Returns:** *[Input](input.md)[]*
 
 ___
@@ -913,8 +787,6 @@ ___
 ▸ **getCustomProperty**(`name`: string): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
-
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
 
 **Parameters:**
 
@@ -932,8 +804,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
 
-*Defined in [card-elements.ts:275](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L275)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
 ___
@@ -943,8 +813,6 @@ ___
 ▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
 
 *Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
-
-*Defined in [card-elements.ts:535](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L535)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
@@ -956,8 +824,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
 
-*Defined in [card-elements.ts:329](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L329)*
-
 **Returns:** *string*
 
 ___
@@ -968,8 +834,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyleDefinition](cardelement.md#geteffectivestyledefinition)*
 
-*Defined in [card-elements.ts:337](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L337)*
-
 **Returns:** *[ContainerStyleDefinition](containerstyledefinition.md)*
 
 ___
@@ -979,8 +843,6 @@ ___
 ▸ **getElementById**(`id`: string): *[CardElement](cardelement.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
-
-*Defined in [card-elements.ts:527](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L527)*
 
 **Parameters:**
 
@@ -998,8 +860,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
 
-*Defined in [card-elements.ts:341](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L341)*
-
 **Returns:** *[ActionType](../README.md#actiontype)[]*
 
 ___
@@ -1010,8 +870,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
 
-*Defined in [card-elements.ts:279](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L279)*
-
 **Returns:** *boolean*
 
 ___
@@ -1021,8 +879,6 @@ ___
 ▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
-
-*Defined in [card-elements.ts:345](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L345)*
 
 **Parameters:**
 
@@ -1044,8 +900,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
 
-*Defined in [card-elements.ts:3237](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3237)*
-
 **Returns:** *string*
 
 ___
@@ -1055,8 +909,6 @@ ___
 ▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
-
-*Defined in [card-elements.ts:283](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L283)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md) | undefined*
 
@@ -1068,8 +920,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
 
-*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
-
 **Returns:** *[Container](container.md) | undefined*
 
 ___
@@ -1079,8 +929,6 @@ ___
 ▸ **getResourceInformation**(): *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
 *Inherited from [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
-
-*Defined in [card-elements.ts:523](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L523)*
 
 **Returns:** *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
@@ -1092,8 +940,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
 
-*Defined in [card-elements.ts:501](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L501)*
-
 **Returns:** *[CardElement](cardelement.md)*
 
 ___
@@ -1104,8 +950,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getRootObject](cardobject.md#getrootobject)*
 
-*Defined in [card-object.ts:100](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L100)*
-
 **Returns:** *[CardObject](cardobject.md)*
 
 ___
@@ -1115,8 +959,6 @@ ___
 ▸ **getSchema**(): *[SerializableObjectSchema](serializableobjectschema.md)*
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
-
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
 
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
@@ -1130,8 +972,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-object.ts:45](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L45)*
-
 **Returns:** *string*
 
 ___
@@ -1141,8 +981,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -1160,8 +998,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -1171,8 +1007,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -1190,8 +1024,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
 
-*Defined in [card-elements.ts:439](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L439)*
-
 **Parameters:**
 
 Name | Type |
@@ -1207,8 +1039,6 @@ ___
 ▸ **internalParse**(`source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
-
-*Defined in [serialization.ts:789](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L789)*
 
 **Parameters:**
 
@@ -1227,8 +1057,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
 
-*Defined in [card-elements.ts:3216](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3216)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1238,8 +1066,6 @@ ___
 ▸ **internalToJSON**(`target`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
-
-*Defined in [serialization.ts:821](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L821)*
 
 **Parameters:**
 
@@ -1260,8 +1086,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
 
-*Defined in [card-elements.ts:2419](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2419)*
-
 **Parameters:**
 
 Name | Type |
@@ -1278,8 +1102,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
 
-*Defined in [card-elements.ts:469](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L469)*
-
 **Returns:** *boolean*
 
 ___
@@ -1289,8 +1111,6 @@ ___
 ▸ **isAtTheVeryLeft**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
-
-*Defined in [card-elements.ts:457](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L457)*
 
 **Returns:** *boolean*
 
@@ -1302,8 +1122,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
 
-*Defined in [card-elements.ts:461](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L461)*
-
 **Returns:** *boolean*
 
 ___
@@ -1313,8 +1131,6 @@ ___
 ▸ **isAtTheVeryTop**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
-
-*Defined in [card-elements.ts:465](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L465)*
 
 **Returns:** *boolean*
 
@@ -1326,8 +1142,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
 
-*Defined in [card-elements.ts:325](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L325)*
-
 **Returns:** *boolean*
 
 ___
@@ -1337,8 +1151,6 @@ ___
 ▸ **isBleedingAtBottom**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
-
-*Defined in [card-elements.ts:477](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L477)*
 
 **Returns:** *boolean*
 
@@ -1350,8 +1162,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
 
-*Defined in [card-elements.ts:473](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L473)*
-
 **Returns:** *boolean*
 
 ___
@@ -1361,8 +1171,6 @@ ___
 ▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
-
-*Defined in [card-elements.ts:493](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L493)*
 
 **Parameters:**
 
@@ -1380,8 +1188,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
 
-*Defined in [card-elements.ts:443](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L443)*
-
 **Returns:** *boolean*
 
 ___
@@ -1392,8 +1198,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDisplayed](cardelement.md#protected-isdisplayed)*
 
-*Defined in [card-elements.ts:229](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L229)*
-
 **Returns:** *boolean*
 
 ___
@@ -1403,8 +1207,6 @@ ___
 ▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
-
-*Defined in [card-elements.ts:449](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L449)*
 
 **Parameters:**
 
@@ -1422,8 +1224,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
 
-*Defined in [card-elements.ts:497](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L497)*
-
 **Returns:** *boolean*
 
 ___
@@ -1433,8 +1233,6 @@ ___
 ▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
-
-*Defined in [card-elements.ts:453](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L453)*
 
 **Parameters:**
 
@@ -1452,8 +1250,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
 
-*Defined in [card-elements.ts:481](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L481)*
-
 **Parameters:**
 
 Name | Type |
@@ -1469,8 +1265,6 @@ ___
 ▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
-
-*Defined in [card-elements.ts:485](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L485)*
 
 **Parameters:**
 
@@ -1488,8 +1282,6 @@ ___
 
 *Overrides [Input](input.md).[isSet](input.md#abstract-isset)*
 
-*Defined in [card-elements.ts:3241](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3241)*
-
 **Returns:** *boolean*
 
 ___
@@ -1499,8 +1291,6 @@ ___
 ▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
-
-*Defined in [card-elements.ts:489](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L489)*
 
 **Parameters:**
 
@@ -1520,8 +1310,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
 
-*Defined in [card-elements.ts:2350](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2350)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1533,8 +1321,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[parse](cardelement.md#parse)*
 
 *Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
-
-*Defined in [card-elements.ts:313](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L313)*
 
 **Parameters:**
 
@@ -1555,8 +1341,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [card-elements.ts:2318](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2318)*
-
 **Parameters:**
 
 Name | Type |
@@ -1572,8 +1356,6 @@ ___
 ▸ **preProcessPropertyValue**(`property`: [PropertyDefinition](propertydefinition.md), `propertyValue?`: any): *any*
 
 *Inherited from [CardObject](cardobject.md).[preProcessPropertyValue](cardobject.md#preprocesspropertyvalue)*
-
-*Defined in [card-object.ts:70](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L70)*
 
 **Parameters:**
 
@@ -1592,8 +1374,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
 
-*Defined in [card-elements.ts:404](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L404)*
-
 **Returns:** *boolean*
 
 ___
@@ -1603,8 +1383,6 @@ ___
 ▸ **render**(): *HTMLElement | undefined*
 
 *Inherited from [CardElement](cardelement.md).[render](cardelement.md#render)*
-
-*Defined in [card-elements.ts:412](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L412)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -1616,8 +1394,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -1628,8 +1404,6 @@ ___
 
 *Inherited from [Input](input.md).[resetValidationFailureCue](input.md#protected-resetvalidationfailurecue)*
 
-*Defined in [card-elements.ts:2391](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2391)*
-
 **Returns:** *void*
 
 ___
@@ -1639,8 +1413,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -1659,8 +1431,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
 
-*Defined in [card-elements.ts:287](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L287)*
-
 **Parameters:**
 
 Name | Type |
@@ -1676,8 +1446,6 @@ ___
 ▸ **setParent**(`value`: [CardObject](cardobject.md) | undefined): *void*
 
 *Inherited from [CardObject](cardobject.md).[setParent](cardobject.md#setparent)*
-
-*Defined in [card-object.ts:88](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L88)*
 
 **Parameters:**
 
@@ -1695,8 +1463,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setShouldFallback](cardobject.md#setshouldfallback)*
 
-*Defined in [card-object.ts:92](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L92)*
-
 **Parameters:**
 
 Name | Type |
@@ -1712,8 +1478,6 @@ ___
 ▸ **setValue**(`property`: [PropertyDefinition](propertydefinition.md), `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
-
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
 
 **Parameters:**
 
@@ -1732,8 +1496,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[shouldFallback](cardobject.md#shouldfallback)*
 
-*Defined in [card-object.ts:96](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L96)*
-
 **Returns:** *boolean*
 
 ___
@@ -1745,8 +1507,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[shouldSerialize](cardelement.md#protected-shouldserialize)*
 
 *Overrides [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
-
-*Defined in [card-elements.ts:291](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L291)*
 
 **Parameters:**
 
@@ -1764,8 +1524,6 @@ ___
 
 *Inherited from [Input](input.md).[showValidationErrorMessage](input.md#protected-showvalidationerrormessage)*
 
-*Defined in [card-elements.ts:2403](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2403)*
-
 **Returns:** *void*
 
 ___
@@ -1777,8 +1535,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[toJSON](cardelement.md#tojson)*
 
 *Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
-
-*Defined in [card-elements.ts:317](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L317)*
 
 **Parameters:**
 
@@ -1796,8 +1552,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
 
-*Defined in [card-elements.ts:263](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L263)*
-
 **Parameters:**
 
 Name | Type |
@@ -1814,8 +1568,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
 
-*Defined in [card-elements.ts:273](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L273)*
-
 **Returns:** *void*
 
 ___
@@ -1825,8 +1577,6 @@ ___
 ▸ **updateLayout**(`processChildren`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
-
-*Defined in [card-elements.ts:434](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L434)*
 
 **Parameters:**
 
@@ -1844,8 +1594,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
 
-*Defined in [card-object.ts:128](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L128)*
-
 **Returns:** *[ValidationResults](validationresults.md)*
 
 ___
@@ -1858,8 +1606,6 @@ ___
 
 *Inherited from [Input](input.md).[validateValue](input.md#validatevalue)*
 
-*Defined in [card-elements.ts:2430](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2430)*
-
 **Returns:** *boolean*
 
 ___
@@ -1869,7 +1615,5 @@ ___
 ▸ **valueChanged**(): *void*
 
 *Inherited from [Input](input.md).[valueChanged](input.md#protected-valuechanged)*
-
-*Defined in [card-elements.ts:2381](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2381)*
 
 **Returns:** *void*

--- a/source/nodejs/adaptivecards/docs/classes/timeproperty.md
+++ b/source/nodejs/adaptivecards/docs/classes/timeproperty.md
@@ -38,8 +38,6 @@
 
 *Overrides [CustomProperty](customproperty.md).[constructor](customproperty.md#constructor)*
 
-*Defined in [card-elements.ts:3172](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3172)*
-
 **Parameters:**
 
 Name | Type |
@@ -59,8 +57,6 @@ Name | Type |
 
 *Overrides [PropertyDefinition](propertydefinition.md).[defaultValue](propertydefinition.md#optional-defaultvalue)*
 
-*Defined in [serialization.ts:652](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L652)*
-
 ___
 
 ###  name
@@ -68,8 +64,6 @@ ___
 • **name**: *string*
 
 *Overrides [CustomProperty](customproperty.md).[name](customproperty.md#name)*
-
-*Defined in [card-elements.ts:3173](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3173)*
 
 ___
 
@@ -81,8 +75,6 @@ ___
 
 *Overrides [PropertyDefinition](propertydefinition.md).[onGetInitialValue](propertydefinition.md#optional-ongetinitialvalue)*
 
-*Defined in [serialization.ts:653](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L653)*
-
 ___
 
 ###  onParse
@@ -90,8 +82,6 @@ ___
 • **onParse**: *function*
 
 *Inherited from [CustomProperty](customproperty.md).[onParse](customproperty.md#onparse)*
-
-*Defined in [serialization.ts:650](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L650)*
 
 #### Type declaration:
 
@@ -113,8 +103,6 @@ ___
 • **onToJSON**: *function*
 
 *Inherited from [CustomProperty](customproperty.md).[onToJSON](customproperty.md#ontojson)*
-
-*Defined in [serialization.ts:651](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L651)*
 
 #### Type declaration:
 
@@ -138,8 +126,6 @@ ___
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[sequentialNumber](propertydefinition.md#sequentialnumber)*
 
-*Defined in [serialization.ts:258](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L258)*
-
 ___
 
 ###  targetVersion
@@ -148,8 +134,6 @@ ___
 
 *Overrides [CustomProperty](customproperty.md).[targetVersion](customproperty.md#targetversion)*
 
-*Defined in [card-elements.ts:3173](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3173)*
-
 ## Methods
 
 ###  getInternalName
@@ -157,8 +141,6 @@ ___
 ▸ **getInternalName**(): *string*
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[getInternalName](propertydefinition.md#getinternalname)*
-
-*Defined in [serialization.ts:246](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L246)*
 
 **Returns:** *string*
 
@@ -171,8 +153,6 @@ ___
 *Inherited from [CustomProperty](customproperty.md).[parse](customproperty.md#parse)*
 
 *Overrides [PropertyDefinition](propertydefinition.md).[parse](propertydefinition.md#parse)*
-
-*Defined in [serialization.ts:639](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L639)*
 
 **Parameters:**
 
@@ -193,8 +173,6 @@ ___
 *Inherited from [CustomProperty](customproperty.md).[toJSON](customproperty.md#tojson)*
 
 *Overrides [PropertyDefinition](propertydefinition.md).[toJSON](propertydefinition.md#tojson)*
-
-*Defined in [serialization.ts:643](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L643)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/docs/classes/toggleinput.md
+++ b/source/nodejs/adaptivecards/docs/classes/toggleinput.md
@@ -161,8 +161,6 @@
 
 *Inherited from [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 **Returns:** *[ToggleInput](toggleinput.md)*
 
 ## Properties
@@ -173,8 +171,6 @@
 
 *Inherited from [CardObject](cardobject.md).[_parent](cardobject.md#protected-optional-_parent)*
 
-*Defined in [card-object.ts:61](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L61)*
-
 ___
 
 ### `Protected` `Optional` _renderedElement
@@ -182,8 +178,6 @@ ___
 • **_renderedElement**? : *HTMLElement*
 
 *Inherited from [CardObject](cardobject.md).[_renderedElement](cardobject.md#protected-optional-_renderedelement)*
-
-*Defined in [card-object.ts:62](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L62)*
 
 ___
 
@@ -193,15 +187,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[customCssSelector](cardelement.md#optional-customcssselector)*
 
-*Defined in [card-elements.ts:311](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L311)*
-
 ___
 
 ### `Optional` defaultValue
 
 • **defaultValue**? : *undefined | string*
-
-*Defined in [card-elements.ts:2638](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2638)*
 
 ___
 
@@ -211,8 +201,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[height](cardelement.md#height)*
 
-*Defined in [card-elements.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L53)*
-
 ___
 
 ###  horizontalAlignment
@@ -220,8 +208,6 @@ ___
 • **horizontalAlignment**: *[HorizontalAlignment](../enums/horizontalalignment.md)*
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignment](cardelement.md#horizontalalignment)*
-
-*Defined in [card-elements.ts:44](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L44)*
 
 ___
 
@@ -233,8 +219,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[id](cardobject.md#optional-id)*
 
-*Defined in [card-object.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L50)*
-
 ___
 
 ###  maxVersion
@@ -242,8 +226,6 @@ ___
 • **maxVersion**: *[Version](version.md)* = Versions.latest
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
-
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
 
 ___
 
@@ -253,8 +235,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[onPreProcessPropertyValue](cardobject.md#optional-onpreprocesspropertyvalue)*
 
-*Defined in [card-object.ts:64](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L64)*
-
 ___
 
 ###  onValueChanged
@@ -262,8 +242,6 @@ ___
 • **onValueChanged**: *function*
 
 *Inherited from [Input](input.md).[onValueChanged](input.md#onvaluechanged)*
-
-*Defined in [card-elements.ts:2415](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2415)*
 
 #### Type declaration:
 
@@ -283,8 +261,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separator](cardelement.md#separator)*
 
-*Defined in [card-elements.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L50)*
-
 ___
 
 ###  spacing
@@ -293,15 +269,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[spacing](cardelement.md#spacing)*
 
-*Defined in [card-elements.ts:47](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L47)*
-
 ___
 
 ### `Optional` title
 
 • **title**? : *undefined | string*
-
-*Defined in [card-elements.ts:2641](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2641)*
 
 ___
 
@@ -309,23 +281,17 @@ ___
 
 • **valueOff**: *string* = "false"
 
-*Defined in [card-elements.ts:2647](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2647)*
-
 ___
 
 ###  valueOn
 
 • **valueOn**: *string* = "true"
 
-*Defined in [card-elements.ts:2644](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2644)*
-
 ___
 
 ###  wrap
 
 • **wrap**: *boolean* = false
-
-*Defined in [card-elements.ts:2650](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2650)*
 
 ___
 
@@ -342,8 +308,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[heightProperty](cardelement.md#static-heightproperty)*
 
-*Defined in [card-elements.ts:24](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L24)*
-
 ___
 
 ### `Static` horizontalAlignmentProperty
@@ -356,8 +320,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[horizontalAlignmentProperty](cardelement.md#static-horizontalalignmentproperty)*
 
-*Defined in [card-elements.ts:32](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L32)*
-
 ___
 
 ### `Static` idProperty
@@ -365,8 +327,6 @@ ___
 ▪ **idProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "id")
 
 *Inherited from [CardObject](cardobject.md).[idProperty](cardobject.md#static-idproperty)*
-
-*Defined in [card-object.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L39)*
 
 ___
 
@@ -376,8 +336,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisibleProperty](cardelement.md#static-isvisibleproperty)*
 
-*Defined in [card-elements.ts:22](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L22)*
-
 ___
 
 ### `Static` langProperty
@@ -386,8 +344,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[langProperty](cardelement.md#static-langproperty)*
 
-*Defined in [card-elements.ts:21](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L21)*
-
 ___
 
 ### `Static` `Optional` onRegisterCustomProperties
@@ -395,8 +351,6 @@ ___
 ▪ **onRegisterCustomProperties**? : *undefined | function*
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
-
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
 
 ___
 
@@ -409,8 +363,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requiresProperty](cardobject.md#static-requiresproperty)*
 
-*Defined in [card-object.ts:40](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L40)*
-
 ___
 
 ### `Static` separatorProperty
@@ -418,8 +370,6 @@ ___
 ▪ **separatorProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_0, "separator", false)
 
 *Inherited from [CardElement](cardelement.md).[separatorProperty](cardelement.md#static-separatorproperty)*
-
-*Defined in [card-elements.ts:23](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L23)*
 
 ___
 
@@ -433,15 +383,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[spacingProperty](cardelement.md#static-spacingproperty)*
 
-*Defined in [card-elements.ts:37](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L37)*
-
 ___
 
 ### `Static` titleProperty
 
 ▪ **titleProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "title")
-
-*Defined in [card-elements.ts:2632](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2632)*
 
 ___
 
@@ -459,8 +405,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[typeNameProperty](cardobject.md#static-typenameproperty)*
 
-*Defined in [card-object.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L30)*
-
 ___
 
 ### `Static` validationProperty
@@ -472,15 +416,11 @@ ___
 
 *Inherited from [Input](input.md).[validationProperty](input.md#static-validationproperty)*
 
-*Defined in [card-elements.ts:2313](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2313)*
-
 ___
 
 ### `Static` valueOffProperty
 
 ▪ **valueOffProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "valueOff", true, undefined, "false", (sender: SerializableObject) => { return "false"; })
-
-*Defined in [card-elements.ts:2634](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2634)*
 
 ___
 
@@ -488,23 +428,17 @@ ___
 
 ▪ **valueOnProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "valueOn", true, undefined, "true", (sender: SerializableObject) => { return "true"; })
 
-*Defined in [card-elements.ts:2633](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2633)*
-
 ___
 
 ### `Static` valueProperty
 
 ▪ **valueProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "value")
 
-*Defined in [card-elements.ts:2631](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2631)*
-
 ___
 
 ### `Static` wrapProperty
 
 ▪ **wrapProperty**: *[BoolProperty](boolproperty.md)‹›* = new BoolProperty(Versions.v1_2, "wrap", false)
-
-*Defined in [card-elements.ts:2635](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2635)*
 
 ## Accessors
 
@@ -513,8 +447,6 @@ ___
 • **get allowCustomPadding**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[allowCustomPadding](cardelement.md#protected-allowcustompadding)*
-
-*Defined in [card-elements.ts:299](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L299)*
 
 **Returns:** *boolean*
 
@@ -526,8 +458,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[defaultStyle](cardelement.md#protected-defaultstyle)*
 
-*Defined in [card-elements.ts:307](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L307)*
-
 **Returns:** *string*
 
 ___
@@ -537,8 +467,6 @@ ___
 • **get hasVisibleSeparator**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[hasVisibleSeparator](cardelement.md#hasvisibleseparator)*
-
-*Defined in [card-elements.ts:580](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L580)*
 
 **Returns:** *boolean*
 
@@ -552,8 +480,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
 
-*Defined in [card-elements.ts:541](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L541)*
-
 **Returns:** *[HostConfig](hostconfig.md)*
 
 • **set hostConfig**(`value`: [HostConfig](hostconfig.md)): *void*
@@ -561,8 +487,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[hostConfig](cardelement.md#hostconfig)*
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
-
-*Defined in [card-elements.ts:555](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L555)*
 
 **Parameters:**
 
@@ -580,8 +504,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[index](cardelement.md#index)*
 
-*Defined in [card-elements.ts:559](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L559)*
-
 **Returns:** *number*
 
 ___
@@ -592,8 +514,6 @@ ___
 
 *Inherited from [Input](input.md).[inputControlContainerElement](input.md#protected-inputcontrolcontainerelement)*
 
-*Defined in [card-elements.ts:2346](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2346)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -603,8 +523,6 @@ ___
 • **get isInline**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isInline](cardelement.md#isinline)*
-
-*Defined in [card-elements.ts:576](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L576)*
 
 **Returns:** *boolean*
 
@@ -618,8 +536,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[isInteractive](cardelement.md#isinteractive)*
 
-*Defined in [card-elements.ts:2453](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2453)*
-
 **Returns:** *boolean*
 
 ___
@@ -629,8 +545,6 @@ ___
 • **get isNullable**(): *boolean*
 
 *Overrides [Input](input.md).[isNullable](input.md#protected-isnullable)*
-
-*Defined in [card-elements.ts:2713](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2713)*
 
 **Returns:** *boolean*
 
@@ -642,8 +556,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isStandalone](cardelement.md#isstandalone)*
 
-*Defined in [card-elements.ts:572](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L572)*
-
 **Returns:** *boolean*
 
 ___
@@ -654,15 +566,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
 
-*Defined in [card-elements.ts:77](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L77)*
-
 **Returns:** *boolean*
 
 • **set isVisible**(`value`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[isVisible](cardelement.md#isvisible)*
-
-*Defined in [card-elements.ts:81](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L81)*
 
 **Parameters:**
 
@@ -680,15 +588,11 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
 
-*Defined in [card-elements.ts:56](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L56)*
-
 **Returns:** *string | undefined*
 
 • **set lang**(`value`: string | undefined): *void*
 
 *Inherited from [CardElement](cardelement.md).[lang](cardelement.md#lang)*
-
-*Defined in [card-elements.ts:72](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L72)*
 
 **Parameters:**
 
@@ -708,8 +612,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[parent](cardobject.md#parent)*
 
-*Defined in [card-elements.ts:593](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L593)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -719,8 +621,6 @@ ___
 • **get renderedElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardObject](cardobject.md).[renderedElement](cardobject.md#renderedelement)*
-
-*Defined in [card-object.ts:140](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L140)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -732,8 +632,6 @@ ___
 
 *Inherited from [Input](input.md).[renderedInputControlElement](input.md#protected-renderedinputcontrolelement)*
 
-*Defined in [card-elements.ts:2342](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2342)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -743,8 +641,6 @@ ___
 • **get requires**(): *HostCapabilities*
 
 *Inherited from [CardObject](cardobject.md).[requires](cardobject.md#requires)*
-
-*Defined in [card-object.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L53)*
 
 **Returns:** *HostCapabilities*
 
@@ -756,8 +652,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[separatorElement](cardelement.md#separatorelement)*
 
-*Defined in [card-elements.ts:589](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L589)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -767,8 +661,6 @@ ___
 • **get separatorOrientation**(): *[Orientation](../enums/orientation.md)*
 
 *Inherited from [CardElement](cardelement.md).[separatorOrientation](cardelement.md#protected-separatororientation)*
-
-*Defined in [card-elements.ts:303](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L303)*
 
 **Returns:** *[Orientation](../enums/orientation.md)*
 
@@ -780,8 +672,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[useDefaultSizing](cardelement.md#protected-usedefaultsizing)*
 
-*Defined in [card-elements.ts:295](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L295)*
-
 **Returns:** *boolean*
 
 ___
@@ -791,8 +681,6 @@ ___
 • **get validation**(): *[InputValidationOptions](inputvalidationoptions.md)*
 
 *Inherited from [Input](input.md).[validation](input.md#validation)*
-
-*Defined in [card-elements.ts:2327](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2327)*
 
 **Returns:** *[InputValidationOptions](inputvalidationoptions.md)*
 
@@ -804,8 +692,6 @@ ___
 
 *Overrides [Input](input.md).[value](input.md#value)*
 
-*Defined in [card-elements.ts:2725](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2725)*
-
 **Returns:** *string | undefined*
 
 ## Methods
@@ -815,8 +701,6 @@ ___
 ▸ **adjustRenderedElementSize**(`renderedElement`: HTMLElement): *void*
 
 *Inherited from [CardElement](cardelement.md).[adjustRenderedElementSize](cardelement.md#protected-adjustrenderedelementsize)*
-
-*Defined in [card-elements.ts:220](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L220)*
 
 **Parameters:**
 
@@ -834,8 +718,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[applyPadding](cardelement.md#protected-applypadding)*
 
-*Defined in [card-elements.ts:239](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L239)*
-
 **Returns:** *void*
 
 ___
@@ -845,8 +727,6 @@ ___
 ▸ **asString**(): *string | undefined*
 
 *Inherited from [CardElement](cardelement.md).[asString](cardelement.md#asstring)*
-
-*Defined in [card-elements.ts:321](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L321)*
 
 **Returns:** *string | undefined*
 
@@ -858,8 +738,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[createPlaceholderElement](cardelement.md#protected-createplaceholderelement)*
 
-*Defined in [card-elements.ts:205](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L205)*
-
 **Returns:** *HTMLElement*
 
 ___
@@ -869,8 +747,6 @@ ___
 ▸ **getActionAt**(`index`: number): *[Action](action.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getActionAt](cardelement.md#getactionat)*
-
-*Defined in [card-elements.ts:400](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L400)*
 
 **Parameters:**
 
@@ -888,8 +764,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionById](cardelement.md#getactionbyid)*
 
-*Defined in [card-elements.ts:531](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L531)*
-
 **Parameters:**
 
 Name | Type |
@@ -906,8 +780,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getActionCount](cardelement.md#getactioncount)*
 
-*Defined in [card-elements.ts:396](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L396)*
-
 **Returns:** *number*
 
 ___
@@ -920,8 +792,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[getAllInputs](cardelement.md#getallinputs)*
 
-*Defined in [card-elements.ts:2449](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2449)*
-
 **Returns:** *[Input](input.md)[]*
 
 ___
@@ -931,8 +801,6 @@ ___
 ▸ **getCustomProperty**(`name`: string): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
-
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
 
 **Parameters:**
 
@@ -950,8 +818,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getDefaultPadding](cardelement.md#protected-getdefaultpadding)*
 
-*Defined in [card-elements.ts:275](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L275)*
-
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
 ___
@@ -961,8 +827,6 @@ ___
 ▸ **getEffectivePadding**(): *[PaddingDefinition](paddingdefinition.md)*
 
 *Inherited from [CardElement](cardelement.md).[getEffectivePadding](cardelement.md#geteffectivepadding)*
-
-*Defined in [card-elements.ts:535](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L535)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md)*
 
@@ -974,8 +838,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyle](cardelement.md#geteffectivestyle)*
 
-*Defined in [card-elements.ts:329](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L329)*
-
 **Returns:** *string*
 
 ___
@@ -986,8 +848,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getEffectiveStyleDefinition](cardelement.md#geteffectivestyledefinition)*
 
-*Defined in [card-elements.ts:337](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L337)*
-
 **Returns:** *[ContainerStyleDefinition](containerstyledefinition.md)*
 
 ___
@@ -997,8 +857,6 @@ ___
 ▸ **getElementById**(`id`: string): *[CardElement](cardelement.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getElementById](cardelement.md#getelementbyid)*
-
-*Defined in [card-elements.ts:527](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L527)*
 
 **Parameters:**
 
@@ -1016,8 +874,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getForbiddenActionTypes](cardelement.md#getforbiddenactiontypes)*
 
-*Defined in [card-elements.ts:341](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L341)*
-
 **Returns:** *[ActionType](../README.md#actiontype)[]*
 
 ___
@@ -1028,8 +884,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getHasBackground](cardelement.md#protected-gethasbackground)*
 
-*Defined in [card-elements.ts:279](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L279)*
-
 **Returns:** *boolean*
 
 ___
@@ -1039,8 +893,6 @@ ___
 ▸ **getImmediateSurroundingPadding**(`result`: [PaddingDefinition](paddingdefinition.md), `processTop`: boolean, `processRight`: boolean, `processBottom`: boolean, `processLeft`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[getImmediateSurroundingPadding](cardelement.md#getimmediatesurroundingpadding)*
-
-*Defined in [card-elements.ts:345](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L345)*
 
 **Parameters:**
 
@@ -1062,8 +914,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
 
-*Defined in [card-elements.ts:2717](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2717)*
-
 **Returns:** *string*
 
 ___
@@ -1073,8 +923,6 @@ ___
 ▸ **getPadding**(): *[PaddingDefinition](paddingdefinition.md) | undefined*
 
 *Inherited from [CardElement](cardelement.md).[getPadding](cardelement.md#protected-getpadding)*
-
-*Defined in [card-elements.ts:283](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L283)*
 
 **Returns:** *[PaddingDefinition](paddingdefinition.md) | undefined*
 
@@ -1086,8 +934,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getParentContainer](cardelement.md#getparentcontainer)*
 
-*Defined in [card-elements.ts:505](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L505)*
-
 **Returns:** *[Container](container.md) | undefined*
 
 ___
@@ -1097,8 +943,6 @@ ___
 ▸ **getResourceInformation**(): *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
 *Inherited from [CardElement](cardelement.md).[getResourceInformation](cardelement.md#getresourceinformation)*
-
-*Defined in [card-elements.ts:523](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L523)*
 
 **Returns:** *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
@@ -1110,8 +954,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[getRootElement](cardelement.md#getrootelement)*
 
-*Defined in [card-elements.ts:501](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L501)*
-
 **Returns:** *[CardElement](cardelement.md)*
 
 ___
@@ -1122,8 +964,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getRootObject](cardobject.md#getrootobject)*
 
-*Defined in [card-object.ts:100](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L100)*
-
 **Returns:** *[CardObject](cardobject.md)*
 
 ___
@@ -1133,8 +973,6 @@ ___
 ▸ **getSchema**(): *[SerializableObjectSchema](serializableobjectschema.md)*
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
-
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
 
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
@@ -1148,8 +986,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-object.ts:45](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L45)*
-
 **Returns:** *string*
 
 ___
@@ -1159,8 +995,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -1178,8 +1012,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -1189,8 +1021,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -1208,8 +1038,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[indexOf](cardelement.md#indexof)*
 
-*Defined in [card-elements.ts:439](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L439)*
-
 **Parameters:**
 
 Name | Type |
@@ -1225,8 +1053,6 @@ ___
 ▸ **internalParse**(`source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
-
-*Defined in [serialization.ts:789](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L789)*
 
 **Parameters:**
 
@@ -1245,8 +1071,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[internalRender](cardelement.md#protected-abstract-internalrender)*
 
-*Defined in [card-elements.ts:2656](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2656)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1256,8 +1080,6 @@ ___
 ▸ **internalToJSON**(`target`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
-
-*Defined in [serialization.ts:821](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L821)*
 
 **Parameters:**
 
@@ -1278,8 +1100,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
 
-*Defined in [card-elements.ts:2419](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2419)*
-
 **Parameters:**
 
 Name | Type |
@@ -1296,8 +1116,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryBottom](cardelement.md#isattheverybottom)*
 
-*Defined in [card-elements.ts:469](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L469)*
-
 **Returns:** *boolean*
 
 ___
@@ -1307,8 +1125,6 @@ ___
 ▸ **isAtTheVeryLeft**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryLeft](cardelement.md#isattheveryleft)*
-
-*Defined in [card-elements.ts:457](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L457)*
 
 **Returns:** *boolean*
 
@@ -1320,8 +1136,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryRight](cardelement.md#isattheveryright)*
 
-*Defined in [card-elements.ts:461](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L461)*
-
 **Returns:** *boolean*
 
 ___
@@ -1331,8 +1145,6 @@ ___
 ▸ **isAtTheVeryTop**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isAtTheVeryTop](cardelement.md#isattheverytop)*
-
-*Defined in [card-elements.ts:465](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L465)*
 
 **Returns:** *boolean*
 
@@ -1344,8 +1156,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleeding](cardelement.md#isbleeding)*
 
-*Defined in [card-elements.ts:325](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L325)*
-
 **Returns:** *boolean*
 
 ___
@@ -1355,8 +1165,6 @@ ___
 ▸ **isBleedingAtBottom**(): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtBottom](cardelement.md#isbleedingatbottom)*
-
-*Defined in [card-elements.ts:477](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L477)*
 
 **Returns:** *boolean*
 
@@ -1368,8 +1176,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isBleedingAtTop](cardelement.md#isbleedingattop)*
 
-*Defined in [card-elements.ts:473](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L473)*
-
 **Returns:** *boolean*
 
 ___
@@ -1379,8 +1185,6 @@ ___
 ▸ **isBottomElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isBottomElement](cardelement.md#isbottomelement)*
-
-*Defined in [card-elements.ts:493](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L493)*
 
 **Parameters:**
 
@@ -1398,8 +1202,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDesignMode](cardelement.md#isdesignmode)*
 
-*Defined in [card-elements.ts:443](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L443)*
-
 **Returns:** *boolean*
 
 ___
@@ -1410,8 +1212,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isDisplayed](cardelement.md#protected-isdisplayed)*
 
-*Defined in [card-elements.ts:229](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L229)*
-
 **Returns:** *boolean*
 
 ___
@@ -1421,8 +1221,6 @@ ___
 ▸ **isFirstElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isFirstElement](cardelement.md#isfirstelement)*
-
-*Defined in [card-elements.ts:449](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L449)*
 
 **Parameters:**
 
@@ -1440,8 +1238,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isHiddenDueToOverflow](cardelement.md#ishiddenduetooverflow)*
 
-*Defined in [card-elements.ts:497](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L497)*
-
 **Returns:** *boolean*
 
 ___
@@ -1451,8 +1247,6 @@ ___
 ▸ **isLastElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isLastElement](cardelement.md#islastelement)*
-
-*Defined in [card-elements.ts:453](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L453)*
 
 **Parameters:**
 
@@ -1470,8 +1264,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[isLeftMostElement](cardelement.md#isleftmostelement)*
 
-*Defined in [card-elements.ts:481](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L481)*
-
 **Parameters:**
 
 Name | Type |
@@ -1487,8 +1279,6 @@ ___
 ▸ **isRightMostElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isRightMostElement](cardelement.md#isrightmostelement)*
-
-*Defined in [card-elements.ts:485](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L485)*
 
 **Parameters:**
 
@@ -1506,8 +1296,6 @@ ___
 
 *Overrides [Input](input.md).[isSet](input.md#abstract-isset)*
 
-*Defined in [card-elements.ts:2721](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2721)*
-
 **Returns:** *boolean*
 
 ___
@@ -1517,8 +1305,6 @@ ___
 ▸ **isTopElement**(`element`: [CardElement](cardelement.md)): *boolean*
 
 *Inherited from [CardElement](cardelement.md).[isTopElement](cardelement.md#istopelement)*
-
-*Defined in [card-elements.ts:489](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L489)*
 
 **Parameters:**
 
@@ -1538,8 +1324,6 @@ ___
 
 *Overrides [CardElement](cardelement.md).[overrideInternalRender](cardelement.md#protected-overrideinternalrender)*
 
-*Defined in [card-elements.ts:2350](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2350)*
-
 **Returns:** *HTMLElement | undefined*
 
 ___
@@ -1551,8 +1335,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[parse](cardelement.md#parse)*
 
 *Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
-
-*Defined in [card-elements.ts:313](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L313)*
 
 **Parameters:**
 
@@ -1573,8 +1355,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [card-elements.ts:2318](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2318)*
-
 **Parameters:**
 
 Name | Type |
@@ -1590,8 +1370,6 @@ ___
 ▸ **preProcessPropertyValue**(`property`: [PropertyDefinition](propertydefinition.md), `propertyValue?`: any): *any*
 
 *Inherited from [CardObject](cardobject.md).[preProcessPropertyValue](cardobject.md#preprocesspropertyvalue)*
-
-*Defined in [card-object.ts:70](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L70)*
 
 **Parameters:**
 
@@ -1610,8 +1388,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[remove](cardelement.md#remove)*
 
-*Defined in [card-elements.ts:404](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L404)*
-
 **Returns:** *boolean*
 
 ___
@@ -1621,8 +1397,6 @@ ___
 ▸ **render**(): *HTMLElement | undefined*
 
 *Inherited from [CardElement](cardelement.md).[render](cardelement.md#render)*
-
-*Defined in [card-elements.ts:412](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L412)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -1634,8 +1408,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -1646,8 +1418,6 @@ ___
 
 *Inherited from [Input](input.md).[resetValidationFailureCue](input.md#protected-resetvalidationfailurecue)*
 
-*Defined in [card-elements.ts:2391](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2391)*
-
 **Returns:** *void*
 
 ___
@@ -1657,8 +1427,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -1677,8 +1445,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[setPadding](cardelement.md#protected-setpadding)*
 
-*Defined in [card-elements.ts:287](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L287)*
-
 **Parameters:**
 
 Name | Type |
@@ -1694,8 +1460,6 @@ ___
 ▸ **setParent**(`value`: [CardObject](cardobject.md) | undefined): *void*
 
 *Inherited from [CardObject](cardobject.md).[setParent](cardobject.md#setparent)*
-
-*Defined in [card-object.ts:88](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L88)*
 
 **Parameters:**
 
@@ -1713,8 +1477,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setShouldFallback](cardobject.md#setshouldfallback)*
 
-*Defined in [card-object.ts:92](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L92)*
-
 **Parameters:**
 
 Name | Type |
@@ -1730,8 +1492,6 @@ ___
 ▸ **setValue**(`property`: [PropertyDefinition](propertydefinition.md), `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
-
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
 
 **Parameters:**
 
@@ -1750,8 +1510,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[shouldFallback](cardobject.md#shouldfallback)*
 
-*Defined in [card-object.ts:96](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L96)*
-
 **Returns:** *boolean*
 
 ___
@@ -1763,8 +1521,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[shouldSerialize](cardelement.md#protected-shouldserialize)*
 
 *Overrides [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
-
-*Defined in [card-elements.ts:291](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L291)*
 
 **Parameters:**
 
@@ -1782,8 +1538,6 @@ ___
 
 *Inherited from [Input](input.md).[showValidationErrorMessage](input.md#protected-showvalidationerrormessage)*
 
-*Defined in [card-elements.ts:2403](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2403)*
-
 **Returns:** *void*
 
 ___
@@ -1795,8 +1549,6 @@ ___
 *Inherited from [CardElement](cardelement.md).[toJSON](cardelement.md#tojson)*
 
 *Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
-
-*Defined in [card-elements.ts:317](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L317)*
 
 **Parameters:**
 
@@ -1814,8 +1566,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[truncateOverflow](cardelement.md#protected-truncateoverflow)*
 
-*Defined in [card-elements.ts:263](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L263)*
-
 **Parameters:**
 
 Name | Type |
@@ -1832,8 +1582,6 @@ ___
 
 *Inherited from [CardElement](cardelement.md).[undoOverflowTruncation](cardelement.md#protected-undooverflowtruncation)*
 
-*Defined in [card-elements.ts:273](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L273)*
-
 **Returns:** *void*
 
 ___
@@ -1843,8 +1591,6 @@ ___
 ▸ **updateLayout**(`processChildren`: boolean): *void*
 
 *Inherited from [CardElement](cardelement.md).[updateLayout](cardelement.md#updatelayout)*
-
-*Defined in [card-elements.ts:434](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L434)*
 
 **Parameters:**
 
@@ -1862,8 +1608,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
 
-*Defined in [card-object.ts:128](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L128)*
-
 **Returns:** *[ValidationResults](validationresults.md)*
 
 ___
@@ -1876,8 +1620,6 @@ ___
 
 *Inherited from [Input](input.md).[validateValue](input.md#validatevalue)*
 
-*Defined in [card-elements.ts:2430](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2430)*
-
 **Returns:** *boolean*
 
 ___
@@ -1887,7 +1629,5 @@ ___
 ▸ **valueChanged**(): *void*
 
 *Inherited from [Input](input.md).[valueChanged](input.md#protected-valuechanged)*
-
-*Defined in [card-elements.ts:2381](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L2381)*
 
 **Returns:** *void*

--- a/source/nodejs/adaptivecards/docs/classes/togglevisibilityaction.md
+++ b/source/nodejs/adaptivecards/docs/classes/togglevisibilityaction.md
@@ -53,6 +53,7 @@
 * [execute](togglevisibilityaction.md#execute)
 * [getActionById](togglevisibilityaction.md#getactionbyid)
 * [getAllInputs](togglevisibilityaction.md#getallinputs)
+* [getAriaRole](togglevisibilityaction.md#getariarole)
 * [getCustomProperty](togglevisibilityaction.md#getcustomproperty)
 * [getHref](togglevisibilityaction.md#gethref)
 * [getJsonTypeName](togglevisibilityaction.md#getjsontypename)
@@ -97,8 +98,6 @@
 
 *Inherited from [SerializableObject](serializableobject.md).[constructor](serializableobject.md#constructor)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 **Returns:** *[ToggleVisibilityAction](togglevisibilityaction.md)*
 
 ## Properties
@@ -109,8 +108,6 @@
 
 *Inherited from [CardObject](cardobject.md).[_parent](cardobject.md#protected-optional-_parent)*
 
-*Defined in [card-object.ts:61](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L61)*
-
 ___
 
 ### `Protected` `Optional` _renderedElement
@@ -118,8 +115,6 @@ ___
 • **_renderedElement**? : *HTMLElement*
 
 *Inherited from [CardObject](cardobject.md).[_renderedElement](cardobject.md#protected-optional-_renderedelement)*
-
-*Defined in [card-object.ts:62](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L62)*
 
 ___
 
@@ -129,8 +124,6 @@ ___
 
 *Inherited from [Action](action.md).[iconUrl](action.md#optional-iconurl)*
 
-*Defined in [card-elements.ts:3359](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3359)*
-
 ___
 
 ### `Optional` id
@@ -138,8 +131,6 @@ ___
 • **id**? : *undefined | string*
 
 *Inherited from [CardObject](cardobject.md).[id](cardobject.md#optional-id)*
-
-*Defined in [card-object.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L50)*
 
 ___
 
@@ -149,8 +140,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[maxVersion](serializableobject.md#maxversion)*
 
-*Defined in [serialization.ts:843](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L843)*
-
 ___
 
 ###  onExecute
@@ -158,8 +147,6 @@ ___
 • **onExecute**: *function*
 
 *Inherited from [Action](action.md).[onExecute](action.md#onexecute)*
-
-*Defined in [card-elements.ts:3400](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3400)*
 
 #### Type declaration:
 
@@ -179,8 +166,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[onPreProcessPropertyValue](cardobject.md#optional-onpreprocesspropertyvalue)*
 
-*Defined in [card-object.ts:64](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L64)*
-
 ___
 
 ###  style
@@ -189,15 +174,11 @@ ___
 
 *Inherited from [Action](action.md).[style](action.md#style)*
 
-*Defined in [card-elements.ts:3362](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3362)*
-
 ___
 
 ###  targetElements
 
 • **targetElements**: *object*
-
-*Defined in [card-elements.ts:3727](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3727)*
 
 #### Type declaration:
 
@@ -211,15 +192,11 @@ ___
 
 *Inherited from [Action](action.md).[title](action.md#optional-title)*
 
-*Defined in [card-elements.ts:3356](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3356)*
-
 ___
 
 ### `Static` JsonTypeName
 
 ▪ **JsonTypeName**: *"Action.ToggleVisibility"* = "Action.ToggleVisibility"
-
-*Defined in [card-elements.ts:3733](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3733)*
 
 ___
 
@@ -229,8 +206,6 @@ ___
 
 *Inherited from [Action](action.md).[iconUrlProperty](action.md#static-iconurlproperty)*
 
-*Defined in [card-elements.ts:3342](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3342)*
-
 ___
 
 ### `Static` idProperty
@@ -238,8 +213,6 @@ ___
 ▪ **idProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "id")
 
 *Inherited from [CardObject](cardobject.md).[idProperty](cardobject.md#static-idproperty)*
-
-*Defined in [card-object.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L39)*
 
 ___
 
@@ -249,8 +222,6 @@ ___
 
 *Inherited from [Action](action.md).[ignoreInputValidationProperty](action.md#static-ignoreinputvalidationproperty)*
 
-*Defined in [card-elements.ts:3353](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3353)*
-
 ___
 
 ### `Static` `Optional` onRegisterCustomProperties
@@ -258,8 +229,6 @@ ___
 ▪ **onRegisterCustomProperties**? : *undefined | function*
 
 *Inherited from [SerializableObject](serializableobject.md).[onRegisterCustomProperties](serializableobject.md#static-optional-onregistercustomproperties)*
-
-*Defined in [serialization.ts:729](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L729)*
 
 ___
 
@@ -271,8 +240,6 @@ ___
         HostCapabilities)
 
 *Inherited from [CardObject](cardobject.md).[requiresProperty](cardobject.md#static-requiresproperty)*
-
-*Defined in [card-object.ts:40](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L40)*
 
 ___
 
@@ -289,8 +256,6 @@ ___
         Enums.ActionStyle.Default)
 
 *Inherited from [Action](action.md).[styleProperty](action.md#static-styleproperty)*
-
-*Defined in [card-elements.ts:3343](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3343)*
 
 ___
 
@@ -341,8 +306,6 @@ ___
         {},
         (sender: SerializableObject) => { return {}; })
 
-*Defined in [card-elements.ts:3681](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3681)*
-
 ___
 
 ### `Static` titleProperty
@@ -350,8 +313,6 @@ ___
 ▪ **titleProperty**: *[StringProperty](stringproperty.md)‹›* = new StringProperty(Versions.v1_0, "title")
 
 *Inherited from [Action](action.md).[titleProperty](action.md#static-titleproperty)*
-
-*Defined in [card-elements.ts:3341](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3341)*
 
 ___
 
@@ -369,8 +330,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[typeNameProperty](cardobject.md#static-typenameproperty)*
 
-*Defined in [card-object.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L30)*
-
 ## Accessors
 
 ###  hostConfig
@@ -380,8 +339,6 @@ ___
 *Inherited from [Action](action.md).[hostConfig](action.md#hostconfig)*
 
 *Overrides [CardObject](cardobject.md).[hostConfig](cardobject.md#hostconfig)*
-
-*Defined in [card-elements.ts:3551](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3551)*
 
 **Returns:** *[HostConfig](hostconfig.md)*
 
@@ -393,8 +350,6 @@ ___
 
 *Inherited from [Action](action.md).[ignoreInputValidation](action.md#ignoreinputvalidation)*
 
-*Defined in [card-elements.ts:3547](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3547)*
-
 **Returns:** *boolean*
 
 ___
@@ -405,15 +360,11 @@ ___
 
 *Inherited from [Action](action.md).[isPrimary](action.md#isprimary)*
 
-*Defined in [card-elements.ts:3532](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3532)*
-
 **Returns:** *boolean*
 
 • **set isPrimary**(`value`: boolean): *void*
 
 *Inherited from [Action](action.md).[isPrimary](action.md#isprimary)*
-
-*Defined in [card-elements.ts:3536](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3536)*
 
 **Parameters:**
 
@@ -433,8 +384,6 @@ ___
 
 *Overrides [CardObject](cardobject.md).[parent](cardobject.md#parent)*
 
-*Defined in [card-elements.ts:3555](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3555)*
-
 **Returns:** *[CardElement](cardelement.md) | undefined*
 
 ___
@@ -444,8 +393,6 @@ ___
 • **get renderedElement**(): *HTMLElement | undefined*
 
 *Inherited from [CardObject](cardobject.md).[renderedElement](cardobject.md#renderedelement)*
-
-*Defined in [card-object.ts:140](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L140)*
 
 **Returns:** *HTMLElement | undefined*
 
@@ -457,8 +404,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[requires](cardobject.md#requires)*
 
-*Defined in [card-object.ts:53](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L53)*
-
 **Returns:** *HostCapabilities*
 
 ## Methods
@@ -468,8 +413,6 @@ ___
 ▸ **addCssClasses**(`element`: HTMLElement): *void*
 
 *Inherited from [Action](action.md).[addCssClasses](action.md#protected-addcssclasses)*
-
-*Defined in [card-elements.ts:3368](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3368)*
 
 **Parameters:**
 
@@ -484,8 +427,6 @@ ___
 ###  addTargetElement
 
 ▸ **addTargetElement**(`elementId`: string, `isVisible`: boolean | undefined): *void*
-
-*Defined in [card-elements.ts:3756](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3756)*
 
 **Parameters:**
 
@@ -504,8 +445,6 @@ ___
 
 *Overrides [Action](action.md).[execute](action.md#execute)*
 
-*Defined in [card-elements.ts:3739](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3739)*
-
 **Returns:** *void*
 
 ___
@@ -515,8 +454,6 @@ ___
 ▸ **getActionById**(`id`: string): *[Action](action.md) | undefined*
 
 *Inherited from [Action](action.md).[getActionById](action.md#getactionbyid)*
-
-*Defined in [card-elements.ts:3520](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3520)*
 
 **Parameters:**
 
@@ -534,9 +471,17 @@ ___
 
 *Inherited from [Action](action.md).[getAllInputs](action.md#getallinputs)*
 
-*Defined in [card-elements.ts:3512](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3512)*
-
 **Returns:** *[Input](input.md)[]*
+
+___
+
+###  getAriaRole
+
+▸ **getAriaRole**(): *string*
+
+*Inherited from [Action](action.md).[getAriaRole](action.md#getariarole)*
+
+**Returns:** *string*
 
 ___
 
@@ -545,8 +490,6 @@ ___
 ▸ **getCustomProperty**(`name`: string): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getCustomProperty](serializableobject.md#getcustomproperty)*
-
-*Defined in [serialization.ts:922](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L922)*
 
 **Parameters:**
 
@@ -564,8 +507,6 @@ ___
 
 *Inherited from [Action](action.md).[getHref](action.md#gethref)*
 
-*Defined in [card-elements.ts:3402](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3402)*
-
 **Returns:** *string | undefined*
 
 ___
@@ -575,8 +516,6 @@ ___
 ▸ **getJsonTypeName**(): *string*
 
 *Overrides [CardObject](cardobject.md).[getJsonTypeName](cardobject.md#abstract-getjsontypename)*
-
-*Defined in [card-elements.ts:3735](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3735)*
 
 **Returns:** *string*
 
@@ -588,8 +527,6 @@ ___
 
 *Inherited from [Action](action.md).[getReferencedInputs](action.md#getreferencedinputs)*
 
-*Defined in [card-elements.ts:3524](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3524)*
-
 **Returns:** *[Dictionary](../README.md#dictionary)‹[Input](input.md)› | undefined*
 
 ___
@@ -599,8 +536,6 @@ ___
 ▸ **getResourceInformation**(): *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
 *Inherited from [Action](action.md).[getResourceInformation](action.md#getresourceinformation)*
-
-*Defined in [card-elements.ts:3516](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3516)*
 
 **Returns:** *[IResourceInformation](../interfaces/iresourceinformation.md)[]*
 
@@ -612,8 +547,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[getRootObject](cardobject.md#getrootobject)*
 
-*Defined in [card-object.ts:100](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L100)*
-
 **Returns:** *[CardObject](cardobject.md)*
 
 ___
@@ -623,8 +556,6 @@ ___
 ▸ **getSchema**(): *[SerializableObjectSchema](serializableobjectschema.md)*
 
 *Inherited from [SerializableObject](serializableobject.md).[getSchema](serializableobject.md#getschema)*
-
-*Defined in [serialization.ts:926](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L926)*
 
 **Returns:** *[SerializableObjectSchema](serializableobjectschema.md)*
 
@@ -638,8 +569,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[getSchemaKey](serializableobject.md#protected-abstract-getschemakey)*
 
-*Defined in [card-object.ts:45](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L45)*
-
 **Returns:** *string*
 
 ___
@@ -649,8 +578,6 @@ ___
 ▸ **getValue**(`property`: [PropertyDefinition](propertydefinition.md)): *any*
 
 *Inherited from [SerializableObject](serializableobject.md).[getValue](serializableobject.md#protected-getvalue)*
-
-*Defined in [serialization.ts:776](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L776)*
 
 **Parameters:**
 
@@ -668,8 +595,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[hasAllDefaultValues](serializableobject.md#hasalldefaultvalues)*
 
-*Defined in [serialization.ts:887](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L887)*
-
 **Returns:** *boolean*
 
 ___
@@ -679,8 +604,6 @@ ___
 ▸ **hasDefaultValue**(`property`: [PropertyDefinition](propertydefinition.md)): *boolean*
 
 *Inherited from [SerializableObject](serializableobject.md).[hasDefaultValue](serializableobject.md#hasdefaultvalue)*
-
-*Defined in [serialization.ts:883](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L883)*
 
 **Parameters:**
 
@@ -698,8 +621,6 @@ ___
 
 *Inherited from [Action](action.md).[internalGetReferencedInputs](action.md#protected-internalgetreferencedinputs)*
 
-*Defined in [card-elements.ts:3372](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3372)*
-
 **Parameters:**
 
 Name | Type |
@@ -715,8 +636,6 @@ ___
 ▸ **internalParse**(`source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalParse](serializableobject.md#protected-internalparse)*
-
-*Defined in [serialization.ts:789](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L789)*
 
 **Parameters:**
 
@@ -735,8 +654,6 @@ ___
 
 *Inherited from [Action](action.md).[internalPrepareForExecution](action.md#protected-internalprepareforexecution)*
 
-*Defined in [card-elements.ts:3376](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3376)*
-
 **Parameters:**
 
 Name | Type |
@@ -752,8 +669,6 @@ ___
 ▸ **internalToJSON**(`target`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[internalToJSON](serializableobject.md#protected-internaltojson)*
-
-*Defined in [serialization.ts:821](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L821)*
 
 **Parameters:**
 
@@ -772,8 +687,6 @@ ___
 
 *Inherited from [Action](action.md).[internalValidateInputs](action.md#protected-internalvalidateinputs)*
 
-*Defined in [card-elements.ts:3380](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3380)*
-
 **Parameters:**
 
 Name | Type |
@@ -789,8 +702,6 @@ ___
 ▸ **internalValidateProperties**(`context`: [ValidationResults](validationresults.md)): *void*
 
 *Inherited from [CardObject](cardobject.md).[internalValidateProperties](cardobject.md#internalvalidateproperties)*
-
-*Defined in [card-object.ts:110](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L110)*
 
 **Parameters:**
 
@@ -810,8 +721,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[parse](serializableobject.md#parse)*
 
-*Defined in [card-elements.ts:3410](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3410)*
-
 **Parameters:**
 
 Name | Type |
@@ -829,8 +738,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[populateSchema](serializableobject.md#protected-populateschema)*
 
-*Defined in [serialization.ts:738](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L738)*
-
 **Parameters:**
 
 Name | Type |
@@ -846,8 +753,6 @@ ___
 ▸ **preProcessPropertyValue**(`property`: [PropertyDefinition](propertydefinition.md), `propertyValue?`: any): *any*
 
 *Inherited from [CardObject](cardobject.md).[preProcessPropertyValue](cardobject.md#preprocesspropertyvalue)*
-
-*Defined in [card-object.ts:70](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L70)*
 
 **Parameters:**
 
@@ -866,8 +771,6 @@ ___
 
 *Inherited from [Action](action.md).[prepareForExecution](action.md#prepareforexecution)*
 
-*Defined in [card-elements.ts:3492](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3492)*
-
 **Returns:** *boolean*
 
 ___
@@ -878,8 +781,6 @@ ___
 
 *Inherited from [Action](action.md).[remove](action.md#remove)*
 
-*Defined in [card-elements.ts:3504](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3504)*
-
 **Returns:** *boolean*
 
 ___
@@ -887,8 +788,6 @@ ___
 ###  removeTargetElement
 
 ▸ **removeTargetElement**(`elementId`: string): *void*
-
-*Defined in [card-elements.ts:3760](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3760)*
 
 **Parameters:**
 
@@ -906,8 +805,6 @@ ___
 
 *Inherited from [Action](action.md).[render](action.md#render)*
 
-*Defined in [card-elements.ts:3418](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3418)*
-
 **Parameters:**
 
 Name | Type | Default |
@@ -924,8 +821,6 @@ ___
 
 *Inherited from [SerializableObject](serializableobject.md).[resetDefaultValues](serializableobject.md#resetdefaultvalues)*
 
-*Defined in [serialization.ts:901](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L901)*
-
 **Returns:** *void*
 
 ___
@@ -935,8 +830,6 @@ ___
 ▸ **setCustomProperty**(`name`: string, `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setCustomProperty](serializableobject.md#setcustomproperty)*
-
-*Defined in [serialization.ts:911](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L911)*
 
 **Parameters:**
 
@@ -955,8 +848,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setParent](cardobject.md#setparent)*
 
-*Defined in [card-object.ts:88](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L88)*
-
 **Parameters:**
 
 Name | Type |
@@ -973,8 +864,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[setShouldFallback](cardobject.md#setshouldfallback)*
 
-*Defined in [card-object.ts:92](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L92)*
-
 **Parameters:**
 
 Name | Type |
@@ -990,8 +879,6 @@ ___
 ▸ **setValue**(`property`: [PropertyDefinition](propertydefinition.md), `value`: any): *void*
 
 *Inherited from [SerializableObject](serializableobject.md).[setValue](serializableobject.md#protected-setvalue)*
-
-*Defined in [serialization.ts:780](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L780)*
 
 **Parameters:**
 
@@ -1010,8 +897,6 @@ ___
 
 *Inherited from [CardObject](cardobject.md).[shouldFallback](cardobject.md#shouldfallback)*
 
-*Defined in [card-object.ts:96](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L96)*
-
 **Returns:** *boolean*
 
 ___
@@ -1023,8 +908,6 @@ ___
 *Inherited from [Action](action.md).[shouldSerialize](action.md#protected-shouldserialize)*
 
 *Overrides [SerializableObject](serializableobject.md).[shouldSerialize](serializableobject.md#protected-shouldserialize)*
-
-*Defined in [card-elements.ts:3396](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3396)*
 
 **Parameters:**
 
@@ -1044,8 +927,6 @@ ___
 
 *Overrides [SerializableObject](serializableobject.md).[toJSON](serializableobject.md#tojson)*
 
-*Defined in [card-elements.ts:3414](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3414)*
-
 **Parameters:**
 
 Name | Type |
@@ -1061,8 +942,6 @@ ___
 ▸ **updateActionButtonCssStyle**(`actionButtonElement`: HTMLElement): *void*
 
 *Inherited from [Action](action.md).[updateActionButtonCssStyle](action.md#updateactionbuttoncssstyle)*
-
-*Defined in [card-elements.ts:3406](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3406)*
 
 **Parameters:**
 
@@ -1080,8 +959,6 @@ ___
 
 *Inherited from [Action](action.md).[validateInputs](action.md#validateinputs)*
 
-*Defined in [card-elements.ts:3528](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L3528)*
-
 **Returns:** *[Input](input.md)‹›[]*
 
 ___
@@ -1091,7 +968,5 @@ ___
 ▸ **validateProperties**(): *[ValidationResults](validationresults.md)*
 
 *Inherited from [CardObject](cardobject.md).[validateProperties](cardobject.md#validateproperties)*
-
-*Defined in [card-object.ts:128](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L128)*
 
 **Returns:** *[ValidationResults](validationresults.md)*

--- a/source/nodejs/adaptivecards/docs/classes/uuid.md
+++ b/source/nodejs/adaptivecards/docs/classes/uuid.md
@@ -27,8 +27,6 @@ Fast UUID generator, RFC4122 version 4 compliant.
 
 ▸ **generate**(): *string*
 
-*Defined in [shared.ts:199](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L199)*
-
 **Returns:** *string*
 
 ___
@@ -36,7 +34,5 @@ ___
 ### `Static` initialize
 
 ▸ **initialize**(): *void*
-
-*Defined in [shared.ts:211](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L211)*
 
 **Returns:** *void*

--- a/source/nodejs/adaptivecards/docs/classes/validationresults.md
+++ b/source/nodejs/adaptivecards/docs/classes/validationresults.md
@@ -23,23 +23,17 @@
 
 • **allIds**: *[Dictionary](../README.md#dictionary)‹number›*
 
-*Defined in [card-object.ts:10](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L10)*
-
 ___
 
 ###  validationEvents
 
 • **validationEvents**: *[IValidationEvent](../interfaces/ivalidationevent.md)[]* = []
 
-*Defined in [card-object.ts:11](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L11)*
-
 ## Methods
 
 ###  addFailure
 
 ▸ **addFailure**(`cardObject`: [CardObject](cardobject.md), `event`: [ValidationEvent](../enums/validationevent.md), `message`: string): *void*
-
-*Defined in [card-object.ts:13](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-object.ts#L13)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/docs/classes/valuesetproperty.md
+++ b/source/nodejs/adaptivecards/docs/classes/valuesetproperty.md
@@ -37,8 +37,6 @@
 
 *Overrides [PropertyDefinition](propertydefinition.md).[constructor](propertydefinition.md#constructor)*
 
-*Defined in [serialization.ts:447](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L447)*
-
 **Parameters:**
 
 Name | Type |
@@ -59,8 +57,6 @@ Name | Type |
 
 *Overrides [PropertyDefinition](propertydefinition.md).[defaultValue](propertydefinition.md#optional-defaultvalue)*
 
-*Defined in [serialization.ts:453](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L453)*
-
 ___
 
 ###  name
@@ -68,8 +64,6 @@ ___
 • **name**: *string*
 
 *Overrides [PropertyDefinition](propertydefinition.md).[name](propertydefinition.md#name)*
-
-*Defined in [serialization.ts:451](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L451)*
 
 ___
 
@@ -79,8 +73,6 @@ ___
 
 *Overrides [PropertyDefinition](propertydefinition.md).[onGetInitialValue](propertydefinition.md#optional-ongetinitialvalue)*
 
-*Defined in [serialization.ts:454](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L454)*
-
 ___
 
 ###  sequentialNumber
@@ -88,8 +80,6 @@ ___
 • **sequentialNumber**: *number*
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[sequentialNumber](propertydefinition.md#sequentialnumber)*
-
-*Defined in [serialization.ts:258](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L258)*
 
 ___
 
@@ -99,15 +89,11 @@ ___
 
 *Overrides [PropertyDefinition](propertydefinition.md).[targetVersion](propertydefinition.md#targetversion)*
 
-*Defined in [serialization.ts:450](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L450)*
-
 ___
 
 ###  values
 
 • **values**: *[IVersionedValue](../interfaces/iversionedvalue.md)‹string›[]*
-
-*Defined in [serialization.ts:452](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L452)*
 
 ## Methods
 
@@ -116,8 +102,6 @@ ___
 ▸ **getInternalName**(): *string*
 
 *Inherited from [PropertyDefinition](propertydefinition.md).[getInternalName](propertydefinition.md#getinternalname)*
-
-*Defined in [serialization.ts:246](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L246)*
 
 **Returns:** *string*
 
@@ -128,8 +112,6 @@ ___
 ▸ **parse**(`sender`: [SerializableObject](serializableobject.md), `source`: [PropertyBag](../README.md#propertybag), `context`: [BaseSerializationContext](baseserializationcontext.md)): *string | undefined*
 
 *Overrides [PropertyDefinition](propertydefinition.md).[parse](propertydefinition.md#parse)*
-
-*Defined in [serialization.ts:385](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L385)*
 
 **Parameters:**
 
@@ -148,8 +130,6 @@ ___
 ▸ **toJSON**(`sender`: [SerializableObject](serializableobject.md), `target`: [PropertyBag](../README.md#propertybag), `value`: string | undefined, `context`: [BaseSerializationContext](baseserializationcontext.md)): *void*
 
 *Overrides [PropertyDefinition](propertydefinition.md).[toJSON](propertydefinition.md#tojson)*
-
-*Defined in [serialization.ts:420](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L420)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/docs/classes/version.md
+++ b/source/nodejs/adaptivecards/docs/classes/version.md
@@ -32,8 +32,6 @@
 
 \+ **new Version**(`major`: number, `minor`: number, `label?`: undefined | string): *[Version](version.md)*
 
-*Defined in [serialization.ts:19](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L19)*
-
 **Parameters:**
 
 Name | Type | Default |
@@ -50,8 +48,6 @@ Name | Type | Default |
 
 • **get isValid**(): *boolean*
 
-*Defined in [serialization.ts:96](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L96)*
-
 **Returns:** *boolean*
 
 ___
@@ -59,8 +55,6 @@ ___
 ###  label
 
 • **get label**(): *string*
-
-*Defined in [serialization.ts:84](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L84)*
 
 **Returns:** *string*
 
@@ -70,8 +64,6 @@ ___
 
 • **get major**(): *number*
 
-*Defined in [serialization.ts:88](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L88)*
-
 **Returns:** *number*
 
 ___
@@ -80,8 +72,6 @@ ___
 
 • **get minor**(): *number*
 
-*Defined in [serialization.ts:92](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L92)*
-
 **Returns:** *number*
 
 ## Methods
@@ -89,8 +79,6 @@ ___
 ###  compareTo
 
 ▸ **compareTo**(`otherVersion`: [Version](version.md)): *number*
-
-*Defined in [serialization.ts:63](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L63)*
 
 **Parameters:**
 
@@ -106,8 +94,6 @@ ___
 
 ▸ **toJSON**(): *any*
 
-*Defined in [serialization.ts:59](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L59)*
-
 **Returns:** *any*
 
 ___
@@ -116,8 +102,6 @@ ___
 
 ▸ **toString**(): *string*
 
-*Defined in [serialization.ts:55](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L55)*
-
 **Returns:** *string*
 
 ___
@@ -125,8 +109,6 @@ ___
 ### `Static` parse
 
 ▸ **parse**(`versionString`: string, `context`: [BaseSerializationContext](baseserializationcontext.md)): *[Version](version.md) | undefined*
-
-*Defined in [serialization.ts:27](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L27)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/docs/classes/versions.md
+++ b/source/nodejs/adaptivecards/docs/classes/versions.md
@@ -22,15 +22,11 @@
 
 ▪ **latest**: *[Version](version.md)‹›* = Versions.v1_2
 
-*Defined in [serialization.ts:107](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L107)*
-
 ___
 
 ### `Static` v1_0
 
 ▪ **v1_0**: *[Version](version.md)‹›* = new Version(1, 0)
-
-*Defined in [serialization.ts:104](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L104)*
 
 ___
 
@@ -38,20 +34,14 @@ ___
 
 ▪ **v1_1**: *[Version](version.md)‹›* = new Version(1, 1)
 
-*Defined in [serialization.ts:105](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L105)*
-
 ___
 
 ### `Static` v1_2
 
 ▪ **v1_2**: *[Version](version.md)‹›* = new Version(1, 2)
 
-*Defined in [serialization.ts:106](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L106)*
-
 ___
 
 ### `Static` vNext
 
 ▪ **vNext**: *[Version](version.md)‹›* = new Version(1000, 0, "vNext")
-
-*Defined in [serialization.ts:108](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L108)*

--- a/source/nodejs/adaptivecards/docs/enums/actionalignment.md
+++ b/source/nodejs/adaptivecards/docs/enums/actionalignment.md
@@ -17,15 +17,11 @@
 
 • **Center**:
 
-*Defined in [enums.ts:79](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L79)*
-
 ___
 
 ###  Left
 
 • **Left**:
-
-*Defined in [enums.ts:78](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L78)*
 
 ___
 
@@ -33,12 +29,8 @@ ___
 
 • **Right**:
 
-*Defined in [enums.ts:80](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L80)*
-
 ___
 
 ###  Stretch
 
 • **Stretch**:
-
-*Defined in [enums.ts:81](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L81)*

--- a/source/nodejs/adaptivecards/docs/enums/actioniconplacement.md
+++ b/source/nodejs/adaptivecards/docs/enums/actioniconplacement.md
@@ -15,12 +15,8 @@
 
 • **AboveTitle**:
 
-*Defined in [enums.ts:108](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L108)*
-
 ___
 
 ###  LeftOfTitle
 
 • **LeftOfTitle**:
-
-*Defined in [enums.ts:107](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L107)*

--- a/source/nodejs/adaptivecards/docs/enums/containerfitstatus.md
+++ b/source/nodejs/adaptivecards/docs/enums/containerfitstatus.md
@@ -16,20 +16,14 @@
 
 • **FullyInContainer**:
 
-*Defined in [enums.ts:176](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L176)*
-
 ___
 
 ###  FullyOutOfContainer
 
 • **FullyOutOfContainer**:
 
-*Defined in [enums.ts:178](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L178)*
-
 ___
 
 ###  Overflowing
 
 • **Overflowing**:
-
-*Defined in [enums.ts:177](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L177)*

--- a/source/nodejs/adaptivecards/docs/enums/fillmode.md
+++ b/source/nodejs/adaptivecards/docs/enums/fillmode.md
@@ -17,15 +17,11 @@
 
 • **Cover**:
 
-*Defined in [enums.ts:100](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L100)*
-
 ___
 
 ###  Repeat
 
 • **Repeat**:
-
-*Defined in [enums.ts:103](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L103)*
 
 ___
 
@@ -33,12 +29,8 @@ ___
 
 • **RepeatHorizontally**:
 
-*Defined in [enums.ts:101](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L101)*
-
 ___
 
 ###  RepeatVertically
 
 • **RepeatVertically**:
-
-*Defined in [enums.ts:102](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L102)*

--- a/source/nodejs/adaptivecards/docs/enums/fonttype.md
+++ b/source/nodejs/adaptivecards/docs/enums/fonttype.md
@@ -15,12 +15,8 @@
 
 • **Default**:
 
-*Defined in [enums.ts:41](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L41)*
-
 ___
 
 ###  Monospace
 
 • **Monospace**:
-
-*Defined in [enums.ts:42](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L42)*

--- a/source/nodejs/adaptivecards/docs/enums/horizontalalignment.md
+++ b/source/nodejs/adaptivecards/docs/enums/horizontalalignment.md
@@ -16,20 +16,14 @@
 
 • **Center**:
 
-*Defined in [enums.ts:67](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L67)*
-
 ___
 
 ###  Left
 
 • **Left**:
 
-*Defined in [enums.ts:66](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L66)*
-
 ___
 
 ###  Right
 
 • **Right**:
-
-*Defined in [enums.ts:68](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L68)*

--- a/source/nodejs/adaptivecards/docs/enums/imagestyle.md
+++ b/source/nodejs/adaptivecards/docs/enums/imagestyle.md
@@ -15,12 +15,8 @@
 
 • **Default**:
 
-*Defined in [enums.ts:85](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L85)*
-
 ___
 
 ###  Person
 
 • **Person**:
-
-*Defined in [enums.ts:86](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L86)*

--- a/source/nodejs/adaptivecards/docs/enums/inputtextstyle.md
+++ b/source/nodejs/adaptivecards/docs/enums/inputtextstyle.md
@@ -17,15 +17,11 @@
 
 • **Email**:
 
-*Defined in [enums.ts:115](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L115)*
-
 ___
 
 ###  Tel
 
 • **Tel**:
-
-*Defined in [enums.ts:113](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L113)*
 
 ___
 
@@ -33,12 +29,8 @@ ___
 
 • **Text**:
 
-*Defined in [enums.ts:112](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L112)*
-
 ___
 
 ###  Url
 
 • **Url**:
-
-*Defined in [enums.ts:114](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L114)*

--- a/source/nodejs/adaptivecards/docs/enums/inputvalidationnecessity.md
+++ b/source/nodejs/adaptivecards/docs/enums/inputvalidationnecessity.md
@@ -16,20 +16,14 @@
 
 • **Optional**:
 
-*Defined in [enums.ts:119](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L119)*
-
 ___
 
 ###  Required
 
 • **Required**:
 
-*Defined in [enums.ts:120](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L120)*
-
 ___
 
 ###  RequiredWithVisualCue
 
 • **RequiredWithVisualCue**:
-
-*Defined in [enums.ts:121](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L121)*

--- a/source/nodejs/adaptivecards/docs/enums/orientation.md
+++ b/source/nodejs/adaptivecards/docs/enums/orientation.md
@@ -15,12 +15,8 @@
 
 • **Horizontal**:
 
-*Defined in [enums.ts:95](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L95)*
-
 ___
 
 ###  Vertical
 
 • **Vertical**:
-
-*Defined in [enums.ts:96](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L96)*

--- a/source/nodejs/adaptivecards/docs/enums/showcardactionmode.md
+++ b/source/nodejs/adaptivecards/docs/enums/showcardactionmode.md
@@ -15,12 +15,8 @@
 
 • **Inline**:
 
-*Defined in [enums.ts:90](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L90)*
-
 ___
 
 ###  Popup
 
 • **Popup**:
-
-*Defined in [enums.ts:91](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L91)*

--- a/source/nodejs/adaptivecards/docs/enums/size.md
+++ b/source/nodejs/adaptivecards/docs/enums/size.md
@@ -18,15 +18,11 @@
 
 • **Auto**:
 
-*Defined in [enums.ts:14](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L14)*
-
 ___
 
 ###  Large
 
 • **Large**:
-
-*Defined in [enums.ts:18](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L18)*
 
 ___
 
@@ -34,20 +30,14 @@ ___
 
 • **Medium**:
 
-*Defined in [enums.ts:17](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L17)*
-
 ___
 
 ###  Small
 
 • **Small**:
 
-*Defined in [enums.ts:16](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L16)*
-
 ___
 
 ###  Stretch
 
 • **Stretch**:
-
-*Defined in [enums.ts:15](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L15)*

--- a/source/nodejs/adaptivecards/docs/enums/sizeunit.md
+++ b/source/nodejs/adaptivecards/docs/enums/sizeunit.md
@@ -15,12 +15,8 @@
 
 • **Pixel**:
 
-*Defined in [enums.ts:23](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L23)*
-
 ___
 
 ###  Weight
 
 • **Weight**:
-
-*Defined in [enums.ts:22](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L22)*

--- a/source/nodejs/adaptivecards/docs/enums/spacing.md
+++ b/source/nodejs/adaptivecards/docs/enums/spacing.md
@@ -20,15 +20,11 @@
 
 • **Default**:
 
-*Defined in [enums.ts:48](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L48)*
-
 ___
 
 ###  ExtraLarge
 
 • **ExtraLarge**:
-
-*Defined in [enums.ts:51](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L51)*
 
 ___
 
@@ -36,15 +32,11 @@ ___
 
 • **Large**:
 
-*Defined in [enums.ts:50](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L50)*
-
 ___
 
 ###  Medium
 
 • **Medium**:
-
-*Defined in [enums.ts:49](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L49)*
 
 ___
 
@@ -52,20 +44,14 @@ ___
 
 • **None**:
 
-*Defined in [enums.ts:46](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L46)*
-
 ___
 
 ###  Padding
 
 • **Padding**:
 
-*Defined in [enums.ts:52](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L52)*
-
 ___
 
 ###  Small
 
 • **Small**:
-
-*Defined in [enums.ts:47](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L47)*

--- a/source/nodejs/adaptivecards/docs/enums/textcolor.md
+++ b/source/nodejs/adaptivecards/docs/enums/textcolor.md
@@ -20,15 +20,11 @@
 
 • **Accent**:
 
-*Defined in [enums.ts:59](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L59)*
-
 ___
 
 ###  Attention
 
 • **Attention**:
-
-*Defined in [enums.ts:62](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L62)*
 
 ___
 
@@ -36,15 +32,11 @@ ___
 
 • **Dark**:
 
-*Defined in [enums.ts:57](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L57)*
-
 ___
 
 ###  Default
 
 • **Default**:
-
-*Defined in [enums.ts:56](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L56)*
 
 ___
 
@@ -52,20 +44,14 @@ ___
 
 • **Good**:
 
-*Defined in [enums.ts:60](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L60)*
-
 ___
 
 ###  Light
 
 • **Light**:
 
-*Defined in [enums.ts:58](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L58)*
-
 ___
 
 ###  Warning
 
 • **Warning**:
-
-*Defined in [enums.ts:61](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L61)*

--- a/source/nodejs/adaptivecards/docs/enums/textsize.md
+++ b/source/nodejs/adaptivecards/docs/enums/textsize.md
@@ -18,15 +18,11 @@
 
 • **Default**:
 
-*Defined in [enums.ts:28](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L28)*
-
 ___
 
 ###  ExtraLarge
 
 • **ExtraLarge**:
-
-*Defined in [enums.ts:31](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L31)*
 
 ___
 
@@ -34,20 +30,14 @@ ___
 
 • **Large**:
 
-*Defined in [enums.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L30)*
-
 ___
 
 ###  Medium
 
 • **Medium**:
 
-*Defined in [enums.ts:29](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L29)*
-
 ___
 
 ###  Small
 
 • **Small**:
-
-*Defined in [enums.ts:27](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L27)*

--- a/source/nodejs/adaptivecards/docs/enums/textweight.md
+++ b/source/nodejs/adaptivecards/docs/enums/textweight.md
@@ -16,20 +16,14 @@
 
 • **Bolder**:
 
-*Defined in [enums.ts:37](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L37)*
-
 ___
 
 ###  Default
 
 • **Default**:
 
-*Defined in [enums.ts:36](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L36)*
-
 ___
 
 ###  Lighter
 
 • **Lighter**:
-
-*Defined in [enums.ts:35](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L35)*

--- a/source/nodejs/adaptivecards/docs/enums/validationevent.md
+++ b/source/nodejs/adaptivecards/docs/enums/validationevent.md
@@ -29,15 +29,11 @@
 
 • **ActionTypeNotAllowed**:
 
-*Defined in [enums.ts:158](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L158)*
-
 ___
 
 ###  CollectionCantBeEmpty
 
 • **CollectionCantBeEmpty**:
-
-*Defined in [enums.ts:159](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L159)*
 
 ___
 
@@ -45,15 +41,11 @@ ___
 
 • **Deprecated**:
 
-*Defined in [enums.ts:160](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L160)*
-
 ___
 
 ###  DuplicateId
 
 • **DuplicateId**:
-
-*Defined in [enums.ts:170](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L170)*
 
 ___
 
@@ -61,15 +53,11 @@ ___
 
 • **ElementTypeNotAllowed**:
 
-*Defined in [enums.ts:161](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L161)*
-
 ___
 
 ###  Hint
 
 • **Hint**:
-
-*Defined in [enums.ts:157](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L157)*
 
 ___
 
@@ -77,15 +65,11 @@ ___
 
 • **InteractivityNotAllowed**:
 
-*Defined in [enums.ts:162](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L162)*
-
 ___
 
 ###  InvalidPropertyValue
 
 • **InvalidPropertyValue**:
-
-*Defined in [enums.ts:163](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L163)*
 
 ___
 
@@ -93,15 +77,11 @@ ___
 
 • **MissingCardType**:
 
-*Defined in [enums.ts:164](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L164)*
-
 ___
 
 ###  Other
 
 • **Other**:
-
-*Defined in [enums.ts:172](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L172)*
 
 ___
 
@@ -109,15 +89,11 @@ ___
 
 • **PropertyCantBeNull**:
 
-*Defined in [enums.ts:165](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L165)*
-
 ___
 
 ###  TooManyActions
 
 • **TooManyActions**:
-
-*Defined in [enums.ts:166](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L166)*
 
 ___
 
@@ -125,15 +101,11 @@ ___
 
 • **UnknownActionType**:
 
-*Defined in [enums.ts:167](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L167)*
-
 ___
 
 ###  UnknownElementType
 
 • **UnknownElementType**:
-
-*Defined in [enums.ts:168](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L168)*
 
 ___
 
@@ -141,12 +113,8 @@ ___
 
 • **UnsupportedCardVersion**:
 
-*Defined in [enums.ts:169](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L169)*
-
 ___
 
 ###  UnsupportedProperty
 
 • **UnsupportedProperty**:
-
-*Defined in [enums.ts:171](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L171)*

--- a/source/nodejs/adaptivecards/docs/enums/validationphase.md
+++ b/source/nodejs/adaptivecards/docs/enums/validationphase.md
@@ -16,20 +16,14 @@
 
 • **Parse**:
 
-*Defined in [enums.ts:151](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L151)*
-
 ___
 
 ###  ToJSON
 
 • **ToJSON**:
 
-*Defined in [enums.ts:152](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L152)*
-
 ___
 
 ###  Validation
 
 • **Validation**:
-
-*Defined in [enums.ts:153](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L153)*

--- a/source/nodejs/adaptivecards/docs/enums/verticalalignment.md
+++ b/source/nodejs/adaptivecards/docs/enums/verticalalignment.md
@@ -16,20 +16,14 @@
 
 • **Bottom**:
 
-*Defined in [enums.ts:74](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L74)*
-
 ___
 
 ###  Center
 
 • **Center**:
 
-*Defined in [enums.ts:73](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L73)*
-
 ___
 
 ###  Top
 
 • **Top**:
-
-*Defined in [enums.ts:72](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/enums.ts#L72)*

--- a/source/nodejs/adaptivecards/docs/interfaces/iadaptivecard.md
+++ b/source/nodejs/adaptivecards/docs/interfaces/iadaptivecard.md
@@ -34,23 +34,17 @@
 
 • **actions**? : *ISubmitAction | IOpenUrlAction | IShowCardAction[]*
 
-*Defined in [schema.ts:170](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/schema.ts#L170)*
-
 ___
 
 ### `Optional` backgroundImage
 
 • **backgroundImage**? : *IBackgroundImage | string*
 
-*Defined in [schema.ts:168](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/schema.ts#L168)*
-
 ___
 
 ### `Optional` body
 
 • **body**? : *ITextBlock | IImage | IImageSet | IFactSet | IColumnSet | IContainer[]*
-
-*Defined in [schema.ts:169](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/schema.ts#L169)*
 
 ___
 
@@ -60,8 +54,6 @@ ___
 
 *Inherited from [IAdaptiveCard](iadaptivecard.md).[height](iadaptivecard.md#optional-height)*
 
-*Defined in [schema.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/schema.ts#L39)*
-
 ___
 
 ### `Optional` horizontalAlignment
@@ -69,8 +61,6 @@ ___
 • **horizontalAlignment**? : *[HorizontalAlignment](../enums/horizontalalignment.md)*
 
 *Inherited from [IAdaptiveCard](iadaptivecard.md).[horizontalAlignment](iadaptivecard.md#optional-horizontalalignment)*
-
-*Defined in [schema.ts:36](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/schema.ts#L36)*
 
 ___
 
@@ -80,8 +70,6 @@ ___
 
 *Inherited from [IAdaptiveCard](iadaptivecard.md).[id](iadaptivecard.md#optional-id)*
 
-*Defined in [schema.ts:34](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/schema.ts#L34)*
-
 ___
 
 ### `Optional` separator
@@ -89,8 +77,6 @@ ___
 • **separator**? : *undefined | false | true*
 
 *Inherited from [IAdaptiveCard](iadaptivecard.md).[separator](iadaptivecard.md#optional-separator)*
-
-*Defined in [schema.ts:38](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/schema.ts#L38)*
 
 ___
 
@@ -100,8 +86,6 @@ ___
 
 *Inherited from [IAdaptiveCard](iadaptivecard.md).[spacing](iadaptivecard.md#optional-spacing)*
 
-*Defined in [schema.ts:37](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/schema.ts#L37)*
-
 ___
 
 ### `Optional` speak
@@ -110,20 +94,14 @@ ___
 
 *Overrides [ICardElement](icardelement.md).[speak](icardelement.md#optional-speak)*
 
-*Defined in [schema.ts:171](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/schema.ts#L171)*
-
 ___
 
 ###  type
 
 • **type**: *"AdaptiveCard"*
 
-*Defined in [schema.ts:166](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/schema.ts#L166)*
-
 ___
 
 ### `Optional` version
 
 • **version**? : *IVersion | string*
-
-*Defined in [schema.ts:167](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/schema.ts#L167)*

--- a/source/nodejs/adaptivecards/docs/interfaces/icardelement.md
+++ b/source/nodejs/adaptivecards/docs/interfaces/icardelement.md
@@ -29,15 +29,11 @@
 
 • **height**? : *"auto" | "stretch"*
 
-*Defined in [schema.ts:39](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/schema.ts#L39)*
-
 ___
 
 ### `Optional` horizontalAlignment
 
 • **horizontalAlignment**? : *[HorizontalAlignment](../enums/horizontalalignment.md)*
-
-*Defined in [schema.ts:36](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/schema.ts#L36)*
 
 ___
 
@@ -45,15 +41,11 @@ ___
 
 • **id**? : *undefined | string*
 
-*Defined in [schema.ts:34](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/schema.ts#L34)*
-
 ___
 
 ### `Optional` separator
 
 • **separator**? : *undefined | false | true*
-
-*Defined in [schema.ts:38](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/schema.ts#L38)*
 
 ___
 
@@ -61,12 +53,8 @@ ___
 
 • **spacing**? : *[Spacing](../enums/spacing.md)*
 
-*Defined in [schema.ts:37](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/schema.ts#L37)*
-
 ___
 
 ### `Optional` speak
 
 • **speak**? : *undefined | string*
-
-*Defined in [schema.ts:35](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/schema.ts#L35)*

--- a/source/nodejs/adaptivecards/docs/interfaces/ifontsizedefinitions.md
+++ b/source/nodejs/adaptivecards/docs/interfaces/ifontsizedefinitions.md
@@ -22,15 +22,11 @@
 
 • **default**: *number*
 
-*Defined in [host-config.ts:409](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L409)*
-
 ___
 
 ###  extraLarge
 
 • **extraLarge**: *number*
-
-*Defined in [host-config.ts:412](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L412)*
 
 ___
 
@@ -38,20 +34,14 @@ ___
 
 • **large**: *number*
 
-*Defined in [host-config.ts:411](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L411)*
-
 ___
 
 ###  medium
 
 • **medium**: *number*
 
-*Defined in [host-config.ts:410](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L410)*
-
 ___
 
 ###  small
 
 • **small**: *number*
-
-*Defined in [host-config.ts:408](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L408)*

--- a/source/nodejs/adaptivecards/docs/interfaces/ifontweightdefinitions.md
+++ b/source/nodejs/adaptivecards/docs/interfaces/ifontweightdefinitions.md
@@ -20,20 +20,14 @@
 
 • **bolder**: *number*
 
-*Defined in [host-config.ts:418](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L418)*
-
 ___
 
 ###  default
 
 • **default**: *number*
 
-*Defined in [host-config.ts:417](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L417)*
-
 ___
 
 ###  lighter
 
 • **lighter**: *number*
-
-*Defined in [host-config.ts:416](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L416)*

--- a/source/nodejs/adaptivecards/docs/interfaces/iinput.md
+++ b/source/nodejs/adaptivecards/docs/interfaces/iinput.md
@@ -33,22 +33,16 @@
 
 • **id**? : *undefined | string*
 
-*Defined in [shared.ts:30](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L30)*
-
 ___
 
 ### `Optional` value
 
 • **value**? : *undefined | string*
 
-*Defined in [shared.ts:31](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L31)*
-
 ## Methods
 
 ###  validateValue
 
 ▸ **validateValue**(): *boolean*
-
-*Defined in [shared.ts:32](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L32)*
 
 **Returns:** *boolean*

--- a/source/nodejs/adaptivecards/docs/interfaces/ilineheightdefinitions.md
+++ b/source/nodejs/adaptivecards/docs/interfaces/ilineheightdefinitions.md
@@ -22,15 +22,11 @@
 
 • **default**: *number*
 
-*Defined in [host-config.ts:319](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L319)*
-
 ___
 
 ###  extraLarge
 
 • **extraLarge**: *number*
-
-*Defined in [host-config.ts:321](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L321)*
 
 ___
 
@@ -38,20 +34,14 @@ ___
 
 • **large**: *number*
 
-*Defined in [host-config.ts:320](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L320)*
-
 ___
 
 ###  medium
 
 • **medium**: *number*
 
-*Defined in [host-config.ts:318](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L318)*
-
 ___
 
 ###  small
 
 • **small**: *number*
-
-*Defined in [host-config.ts:317](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/host-config.ts#L317)*

--- a/source/nodejs/adaptivecards/docs/interfaces/imarkdownprocessingresult.md
+++ b/source/nodejs/adaptivecards/docs/interfaces/imarkdownprocessingresult.md
@@ -19,12 +19,8 @@
 
 • **didProcess**: *boolean*
 
-*Defined in [card-elements.ts:5912](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5912)*
-
 ___
 
 ### `Optional` outputHtml
 
 • **outputHtml**? : *any*
-
-*Defined in [card-elements.ts:5913](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/card-elements.ts#L5913)*

--- a/source/nodejs/adaptivecards/docs/interfaces/iresourceinformation.md
+++ b/source/nodejs/adaptivecards/docs/interfaces/iresourceinformation.md
@@ -19,12 +19,8 @@
 
 • **mimeType**: *string*
 
-*Defined in [shared.ts:187](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L187)*
-
 ___
 
 ###  url
 
 • **url**: *string*
-
-*Defined in [shared.ts:186](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L186)*

--- a/source/nodejs/adaptivecards/docs/interfaces/iseparationdefinition.md
+++ b/source/nodejs/adaptivecards/docs/interfaces/iseparationdefinition.md
@@ -20,20 +20,14 @@
 
 • **lineColor**? : *undefined | string*
 
-*Defined in [shared.ts:26](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L26)*
-
 ___
 
 ### `Optional` lineThickness
 
 • **lineThickness**? : *undefined | number*
 
-*Defined in [shared.ts:25](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L25)*
-
 ___
 
 ###  spacing
 
 • **spacing**: *number*
-
-*Defined in [shared.ts:24](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/shared.ts#L24)*

--- a/source/nodejs/adaptivecards/docs/interfaces/ityperegistration.md
+++ b/source/nodejs/adaptivecards/docs/interfaces/ityperegistration.md
@@ -24,8 +24,6 @@
 
 • **objectType**: *object*
 
-*Defined in [registry.ts:7](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/registry.ts#L7)*
-
 #### Type declaration:
 
 * **new __type**(): *T*
@@ -36,12 +34,8 @@ ___
 
 • **schemaVersion**: *[Version](../classes/version.md)*
 
-*Defined in [registry.ts:8](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/registry.ts#L8)*
-
 ___
 
 ###  typeName
 
 • **typeName**: *string*
-
-*Defined in [registry.ts:6](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/registry.ts#L6)*

--- a/source/nodejs/adaptivecards/docs/interfaces/ivalidationevent.md
+++ b/source/nodejs/adaptivecards/docs/interfaces/ivalidationevent.md
@@ -21,15 +21,11 @@
 
 • **event**: *[ValidationEvent](../enums/validationevent.md)*
 
-*Defined in [serialization.ts:10](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L10)*
-
 ___
 
 ###  message
 
 • **message**: *string*
-
-*Defined in [serialization.ts:11](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L11)*
 
 ___
 
@@ -37,12 +33,8 @@ ___
 
 • **phase**: *[ValidationPhase](../enums/validationphase.md)*
 
-*Defined in [serialization.ts:9](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L9)*
-
 ___
 
 ### `Optional` source
 
 • **source**? : *[SerializableObject](../classes/serializableobject.md)*
-
-*Defined in [serialization.ts:8](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L8)*

--- a/source/nodejs/adaptivecards/docs/interfaces/iversionedvalue.md
+++ b/source/nodejs/adaptivecards/docs/interfaces/iversionedvalue.md
@@ -23,12 +23,8 @@
 
 • **targetVersion**? : *[Version](../classes/version.md)*
 
-*Defined in [serialization.ts:381](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L381)*
-
 ___
 
 ###  value
 
 • **value**: *TValue*
-
-*Defined in [serialization.ts:380](https://github.com/microsoft/AdaptiveCards/blob/899191664/source/nodejs/adaptivecards/src/serialization.ts#L380)*

--- a/source/nodejs/adaptivecards/typedoc.json
+++ b/source/nodejs/adaptivecards/typedoc.json
@@ -13,5 +13,6 @@
 		"typedoc-plugin-markdown"
 	],
 	"theme": "markdown",
-	"stripInternal": true
+	"stripInternal": true,
+	"hideSources": true
 }


### PR DESCRIPTION
## Description
Remove source links from our javascript docs. They currently point to a specific commit, which will change pretty much every time the tools runs. We'd rather have the tool running on every build to ensure the docs are up-to-date, but this would cause problems if the links are edited all the time.

## How Verified
Built and diffed

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4079)