### PR TITLE
[JS] Reconcile Action.OpenUrl rendering with getAriaRole()

### DIFF
--- a/source/nodejs/adaptivecards/docs/classes/openurlaction.md
+++ b/source/nodejs/adaptivecards/docs/classes/openurlaction.md
@@ -725,7 +725,7 @@ ___
 
 ▸ **render**(`baseCssClass`: string): *void*
 
-*Overrides [Action](action.md).[render](action.md#render)*
+*Inherited from [Action](action.md).[render](action.md#render)*
 
 **Parameters:**
 

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -3436,6 +3436,8 @@ export abstract class Action extends CardObject {
         buttonElement.style.alignItems = "center";
         buttonElement.style.justifyContent = "center";
 
+        buttonElement.setAttribute("role", this.getAriaRole());
+
         let titleElement = document.createElement("div");
         titleElement.style.overflow = "hidden";
         titleElement.style.textOverflow = "ellipsis";
@@ -3666,15 +3668,6 @@ export class OpenUrlAction extends Action {
                 this,
                 Enums.ValidationEvent.PropertyCantBeNull,
                 "An Action.OpenUrl must have its url property set.");
-        }
-    }
-
-    render(baseCssClass: string = "ac-pushButton") {
-        super.render(baseCssClass);
-
-        // OpenUrl actions behave like a hyperlink. Make sure screenreaders treat them that way.
-        if (this.renderedElement) {
-            this.renderedElement.setAttribute("role", "link");
         }
     }
 


### PR DESCRIPTION
## Related Issue
Unifies fixes for #3914 and #2240 

## Description
Now that we have `getAriaRole()`, it removes the need for `OpenUrlAction` to override `Action.render()`.

## How Verified
* Local build, verified link role continues to get applied correctly

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4080)