### PR TITLE
[JS] Prevent factsets from presenting as tables for accessibility

### DIFF
--- a/source/nodejs/ac-typed-schema/package-lock.json
+++ b/source/nodejs/ac-typed-schema/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "ac-typed-schema",
-	"version": "0.5.4",
+	"version": "0.5.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/source/nodejs/aclint/package-lock.json
+++ b/source/nodejs/aclint/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aclint",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/source/nodejs/adaptivecards-controls/package-lock.json
+++ b/source/nodejs/adaptivecards-controls/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "adaptivecards-controls",
-	"version": "0.3.5",
+	"version": "0.3.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/source/nodejs/adaptivecards-designer-app/package-lock.json
+++ b/source/nodejs/adaptivecards-designer-app/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "adaptivecards-designer-app",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/source/nodejs/adaptivecards-designer/package-lock.json
+++ b/source/nodejs/adaptivecards-designer/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "adaptivecards-designer",
-	"version": "0.8.0-rc.2",
+	"version": "1.0.0-rc.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/source/nodejs/adaptivecards-site/package-lock.json
+++ b/source/nodejs/adaptivecards-site/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "adaptivecards-site",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/package-lock.json
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "hexo-theme-adaptivecards",
-	"version": "0.1.4",
+	"version": "0.1.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/source/nodejs/adaptivecards-templating/package-lock.json
+++ b/source/nodejs/adaptivecards-templating/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "adaptivecards-templating",
-	"version": "0.1.2-alpha.0",
+	"version": "1.0.0-rc.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/source/nodejs/adaptivecards-visualizer/package-lock.json
+++ b/source/nodejs/adaptivecards-visualizer/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "adaptivecards-visualizer",
-	"version": "1.2.6",
+	"version": "1.2.7",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -1395,6 +1395,7 @@ export class FactSet extends CardElement {
             element.style.display = "block";
             element.style.overflow = "hidden";
             element.classList.add(hostConfig.makeCssClassName("ac-factset"));
+            element.setAttribute("role", "presentation");
 
             for (let i = 0; i < this.facts.length; i++) {
                 let trElement = document.createElement("tr");

--- a/source/nodejs/package-lock.json
+++ b/source/nodejs/package-lock.json
@@ -3338,7 +3338,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -3375,7 +3375,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -4388,7 +4388,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -4401,7 +4401,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -4500,7 +4500,7 @@
     },
     "css-select": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "dev": true,
       "requires": {
@@ -4867,7 +4867,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -5045,7 +5045,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
@@ -7675,7 +7675,7 @@
     },
     "http-proxy-middleware": {
       "version": "0.19.1",
-      "resolved": "http://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
       "integrity": "sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==",
       "dev": true,
       "requires": {
@@ -8350,7 +8350,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -11120,7 +11120,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -12581,7 +12581,7 @@
     },
     "pretty-hrtime": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true
     },
@@ -13512,7 +13512,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -14649,7 +14649,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -14870,7 +14870,7 @@
     },
     "tty-browserify": {
       "version": "0.0.0",
-      "resolved": "http://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },

--- a/source/nodejs/spec-generator/package-lock.json
+++ b/source/nodejs/spec-generator/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "spec-generator",
-	"version": "0.5.5",
+	"version": "0.5.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
## Related Issue
VSO #23950960

## Description
We build factsets in JS using a `<table>`. However, this has semantic meaning for screenreaders, which causes factsets to be read awkwardly. The fix (as recommended) is to set `role="presentation"` on the `<table>` element. This does not cause the screenreader to skip the content (as the child elements have no `role` set), but does cause it to treat the content normally.

## How Verified
* Local build
* Local inspection
* Narrator

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4124)