### PR TITLE
[Designer] Accessibility updates for designer new sample dialog

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/dialog.ts
+++ b/source/nodejs/adaptivecards-designer/src/dialog.ts
@@ -59,6 +59,7 @@ export abstract class Dialog {
             dialogFrameElement.style.height = this.height;
             dialogFrameElement.style.justifyContent = "space-between";
             dialogFrameElement.setAttribute("role", "dialog");
+            dialogFrameElement.setAttribute("aria-modal", "true");
             dialogFrameElement.setAttribute("aria-labelledby", "acd-dialog-title-element");
             dialogFrameElement.tabIndex = -1;
 

--- a/source/nodejs/adaptivecards-designer/src/dialog.ts
+++ b/source/nodejs/adaptivecards-designer/src/dialog.ts
@@ -67,6 +67,7 @@ export abstract class Dialog {
                 // disable click bubbling from the frame element -- otherwise it'll get to the overlay, closing the
                 // dialog unexpectedly
                 e.cancelBubble = true;
+
                 return false;
             }
 

--- a/source/nodejs/adaptivecards-designer/src/dialog.ts
+++ b/source/nodejs/adaptivecards-designer/src/dialog.ts
@@ -1,3 +1,5 @@
+import * as Controls from "adaptivecards-controls";
+
 export class DialogButton {
     onClick: (sender: DialogButton) => void;
 
@@ -46,12 +48,39 @@ export abstract class Dialog {
         if (!this._isOpen) {
             this._overlayElement = document.createElement("div");
             this._overlayElement.className = "acd-dialog-overlay";
+            this._overlayElement.onclick = (e) => {
+                // clicks on the overlay window should dismiss the dialog
+                this.close();
+            }
 
             let dialogFrameElement = document.createElement("div");
             dialogFrameElement.className = "acd-dialog-frame";
             dialogFrameElement.style.width = this.width;
             dialogFrameElement.style.height = this.height;
             dialogFrameElement.style.justifyContent = "space-between";
+            dialogFrameElement.setAttribute("role", "dialog");
+            dialogFrameElement.setAttribute("aria-labelledby", "acd-dialog-title-element");
+            dialogFrameElement.tabIndex = -1;
+
+            dialogFrameElement.onclick = (e) => {
+                // disable click bubbling from the frame element -- otherwise it'll get to the overlay, closing the
+                // dialog unexpectedly
+                e.cancelBubble = true;
+                return false;
+            }
+
+            // keyboard navigation support
+            dialogFrameElement.onkeydown = (e) => {
+                switch (e.keyCode) {
+                    case Controls.KEY_ESCAPE:
+                        this.close();
+                        e.preventDefault();
+                        e.cancelBubble = true;
+                        break;
+                }
+
+                return !e.cancelBubble;
+            };
 
             let titleBarElement = document.createElement("div");
             titleBarElement.style.display = "flex";
@@ -61,6 +90,7 @@ export abstract class Dialog {
 
             let titleElement = document.createElement("div");
             titleElement.className = "acd-dialog-title";
+            titleElement.id = "acd-dialog-title-element";
             titleElement.innerText = this.title;
             titleElement.style.flex = "1 1 auto";
 
@@ -87,6 +117,7 @@ export abstract class Dialog {
             this._overlayElement.appendChild(dialogFrameElement);
 
             document.body.appendChild(this._overlayElement);
+            dialogFrameElement.focus();
 
             this._isOpen = true;
         }

--- a/source/nodejs/adaptivecards-designer/src/open-sample-dialog.ts
+++ b/source/nodejs/adaptivecards-designer/src/open-sample-dialog.ts
@@ -9,9 +9,20 @@ class CatalogueItem {
 
     constructor(readonly entry: CatalogueEntry) { }
 
+    private static _id = 0;
+    private static _getNewItemId(prefix: string): string {
+        let newId = prefix + "-" + CatalogueItem._id;
+        CatalogueItem._id++;
+        return newId;
+    }
+
     render(): HTMLElement {
+        const newItemId = CatalogueItem._getNewItemId("acd-open-sample-item-title");
         let element = document.createElement("div");
         element.className = "acd-open-sample-item";
+        element.tabIndex = 0;
+        element.setAttribute("aria-labelledBy", newItemId);
+        element.setAttribute("role", "listitem");
         element.onclick = (e) => {
             if (this.onClick) {
                 this.onClick(this);
@@ -30,6 +41,7 @@ class CatalogueItem {
 
         let displayNameElement = document.createElement("div");
         displayNameElement.className = "acd-open-sample-item-title";
+        displayNameElement.id = newItemId;
         displayNameElement.innerText = this.entry.displayName;
 
         element.append(thumbnailHost, displayNameElement);
@@ -115,7 +127,7 @@ export class OpenSampleDialog extends Dialog {
     private renderCatalogue(): HTMLElement {
         let renderedElement = document.createElement("div");
         renderedElement.className = "acd-open-sample-item-container";
-
+        renderedElement.setAttribute("role", "list");
         for (let entry of this.catalogue.entries) {
             let item = new CatalogueItem(entry);
             item.onClick = (sender: CatalogueItem) => {

--- a/source/nodejs/adaptivecards-designer/src/open-sample-dialog.ts
+++ b/source/nodejs/adaptivecards-designer/src/open-sample-dialog.ts
@@ -10,14 +10,17 @@ class CatalogueItem {
     constructor(readonly entry: CatalogueEntry) { }
 
     private static _id = 0;
-    private static _getNewItemId(prefix: string): string {
+    private static getNewItemId(prefix: string): string {
         let newId = prefix + "-" + CatalogueItem._id;
+
         CatalogueItem._id++;
+
         return newId;
     }
 
     render(): HTMLElement {
-        const newItemId = CatalogueItem._getNewItemId("acd-open-sample-item-title");
+        const newItemId = CatalogueItem.getNewItemId("acd-open-sample-item-title");
+
         let element = document.createElement("div");
         element.className = "acd-open-sample-item";
         element.tabIndex = 0;
@@ -128,6 +131,7 @@ export class OpenSampleDialog extends Dialog {
         let renderedElement = document.createElement("div");
         renderedElement.className = "acd-open-sample-item-container";
         renderedElement.setAttribute("role", "list");
+
         for (let entry of this.catalogue.entries) {
             let item = new CatalogueItem(entry);
             item.onClick = (sender: CatalogueItem) => {


### PR DESCRIPTION
## Related Issue
VSO #24068357

## Description
The open samples dialog has multiple accessibility issues. The one noted in the bug is that keyboard focus doesn't go to the dialog when it is shown. Additional fixes:
* Dialog marked up to be accessible as a dialog
* Dialog is dismissable with ESC
* Clicks outside the dialog also close the dialog
* Cards are presented as listitems in a list

## How Verified
* local build
* narrator
* developer tools

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4133)