### PR TITLE
[Samples] Add altText to Action.ToggleVisibility card

### DIFF
--- a/samples/v1.2/Elements/Action.ToggleVisibility.json
+++ b/samples/v1.2/Elements/Action.ToggleVisibility.json
@@ -1,1 +1,144 @@
-{	"type": "AdaptiveCard",	"version": "1.2",	"body": [		{			"type": "TextBlock",			"text": "Press the buttons to toggle the images!",			"wrap": true		},		{			"type": "TextBlock",			"text": "Here are some images:",			"isVisible": false,			"id": "textToToggle"		},		{			"type": "ColumnSet",			"columns": [				{					"type": "Column",					"items": [						{							"style": "person",							"type": "Image",							"url": "https://picsum.photos/100/100?image=112",							"isVisible": false,							"id": "imageToToggle",							"size": "medium"						}					]				},				{					"type": "Column",					"items": [						{							"type": "Image",							"url": "https://picsum.photos/100/100?image=123",							"isVisible": false,							"id": "imageToToggle2",							"size": "medium"						}					]				}			]		}	],	"actions": [		{			"type": "Action.ToggleVisibility",			"title": "Toggle!",			"targetElements": [ "textToToggle", "imageToToggle", "imageToToggle2" ]		},		{			"type": "Action.ToggleVisibility",			"title": "Also Toggle!",			"targetElements": [				{					"elementId": "textToToggle"				},				{					"elementId": "imageToToggle"				},				{					"elementId": "imageToToggle2"				}			]		},		{			"type": "Action.ToggleVisibility",			"title": "Show!",			"targetElements": [				{					"elementId": "textToToggle",					"isVisible": true				},				{					"elementId": "imageToToggle",					"isVisible": true				},				{					"elementId": "imageToToggle2",					"isVisible": true				}			]		},		{			"type": "Action.ToggleVisibility",			"title": "Hide!",			"targetElements": [				{					"elementId": "textToToggle",					"isVisible": false				},				{					"elementId": "imageToToggle",					"isVisible": false				},				{					"elementId": "imageToToggle2",					"isVisible": false				}			]		},		{			"type": "Action.ToggleVisibility",			"title": "Grain!",			"targetElements": [				{					"elementId": "textToToggle",					"isVisible": true				},				{					"elementId": "imageToToggle",					"isVisible": true				},				{					"elementId": "imageToToggle2",					"isVisible": false				}			]		},		{			"type": "Action.ToggleVisibility",			"title": "Water!",			"targetElements": [				{					"elementId": "textToToggle",					"isVisible": true				},				{					"elementId": "imageToToggle",					"isVisible": false				},				{					"elementId": "imageToToggle2",					"isVisible": true				}			]		}	]}
+{
+	"type": "AdaptiveCard",
+	"version": "1.2",
+	"body": [
+		{
+			"type": "TextBlock",
+			"text": "Press the buttons to toggle the images!",
+			"wrap": true
+		},
+		{
+			"type": "TextBlock",
+			"text": "Here are some images:",
+			"isVisible": false,
+			"id": "textToToggle"
+		},
+		{
+			"type": "ColumnSet",
+			"columns": [
+				{
+					"type": "Column",
+					"items": [
+						{
+							"style": "person",
+							"type": "Image",
+							"url": "https://picsum.photos/100/100?image=112",
+							"isVisible": false,
+							"id": "imageToToggle",
+							"altText": "sample image 1",
+							"size": "medium"
+						}
+					]
+				},
+				{
+					"type": "Column",
+					"items": [
+
+						{
+							"type": "Image",
+							"url": "https://picsum.photos/100/100?image=123",
+							"isVisible": false,
+							"id": "imageToToggle2",
+							"altText": "sample image 2",
+							"size": "medium"
+						}
+					]
+				}
+			]
+		}
+	],
+	"actions": [
+		{
+			"type": "Action.ToggleVisibility",
+			"title": "Toggle!",
+			"targetElements": [ "textToToggle", "imageToToggle", "imageToToggle2" ]
+		},
+		{
+			"type": "Action.ToggleVisibility",
+			"title": "Also Toggle!",
+			"targetElements": [
+				{
+					"elementId": "textToToggle"
+				},
+				{
+					"elementId": "imageToToggle"
+				},
+				{
+					"elementId": "imageToToggle2"
+				}
+			]
+		},
+		{
+			"type": "Action.ToggleVisibility",
+			"title": "Show!",
+			"targetElements": [
+				{
+					"elementId": "textToToggle",
+					"isVisible": true
+				},
+				{
+					"elementId": "imageToToggle",
+					"isVisible": true
+				},
+				{
+					"elementId": "imageToToggle2",
+					"isVisible": true
+				}
+			]
+		},
+		{
+			"type": "Action.ToggleVisibility",
+			"title": "Hide!",
+			"targetElements": [
+				{
+					"elementId": "textToToggle",
+					"isVisible": false
+				},
+				{
+					"elementId": "imageToToggle",
+					"isVisible": false
+				},
+				{
+					"elementId": "imageToToggle2",
+					"isVisible": false
+				}
+			]
+		},
+		{
+			"type": "Action.ToggleVisibility",
+			"title": "Grain!",
+			"targetElements": [
+				{
+					"elementId": "textToToggle",
+					"isVisible": true
+				},
+				{
+					"elementId": "imageToToggle",
+					"isVisible": true
+				},
+				{
+					"elementId": "imageToToggle2",
+					"isVisible": false
+				}
+			]
+		},
+		{
+			"type": "Action.ToggleVisibility",
+			"title": "Water!",
+			"targetElements": [
+				{
+					"elementId": "textToToggle",
+					"isVisible": true
+				},
+				{
+					"elementId": "imageToToggle",
+					"isVisible": false
+				},
+				{
+					"elementId": "imageToToggle2",
+					"isVisible": true
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
## Related Issue
VSO #24019922

## Description
Missing `altText` on sample images in `Action.ToggleVisibility` card. Also, align newline format with the rest of the repo.

## How Verified
* local build and browser dev tools

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4154)