### PR TITLE
A couple of site updates for accessibility

### DIFF
--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/index.ejs
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/index.ejs
@@ -19,7 +19,7 @@
 			<h1 class="w3-xxxlarge">A whole new way to deliver UI</h1>
 			<h3>Adaptive Cards are platform-agnostic snippets of UI, authored in JSON, that apps and services can openly exchange. When delivered to a specific app, the JSON is transformed into native UI that automatically adapts to its surroundings. It helps design and integrate light-weight UI for all major platforms and frameworks.</h3>
 			<div class="w3-padding-16">
-				<button onclick="window.location.href='https://docs.microsoft.com/en-us/adaptive-cards/'"
+				<button role="link" onclick="window.location.href='https://docs.microsoft.com/en-us/adaptive-cards/'"
 					style="width:150px" class="w3-button w3-round-xxlarge ac-blue">
 					Get Started
 				</button>

--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/sample.ejs
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/sample.ejs
@@ -40,10 +40,9 @@
 
 			<div class="w3-col m6 w3-margin-top">
 				<div class="w3-cell-row2">
-					<div class="w3-cell" style="width: 70px">
-						<label class="switch">
-							<input type="checkbox" checked id="enableTemplating">
-							<span class="slider round"></span>
+					<div class="w3-cell" style="width: 50px;">
+						<label>
+							<input type="checkbox" checked id="enableTemplating" class="bigbox" />
 						</label>
 					</div>
 					<div class="w3-cell w3-cell-middle">

--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/source/css/style.css
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/source/css/style.css
@@ -676,65 +676,7 @@ dir {
   font-size: 1em;
 }
 
-/* The switch - the box around the slider */
-.switch {
-  position: relative;
-  display: inline-block;
-  width: 55px;
-  height: 30px;
-}
-
-/* Hide default HTML checkbox */
-.switch input {
-  opacity: 0;
-  width: 0;
-  height: 0;
-}
-
-/* The slider */
-.slider {
-  position: absolute;
-  cursor: pointer;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: #ccc;
-  -webkit-transition: 0.4s;
-  transition: 0.4s;
-}
-
-.slider:before {
-  position: absolute;
-  content: "";
-  height: 21px;
-  width: 21px;
-  left: 4px;
-  bottom: 4px;
-  background-color: white;
-  -webkit-transition: 0.4s;
-  transition: 0.4s;
-}
-
-input:checked + .slider {
-  background-color: #2196f3;
-}
-
-input:focus + .slider {
-  box-shadow: 0 0 1px #2196f3;
-}
-
-input:checked + .slider:before {
-  -webkit-transform: translateX(26px);
-  -ms-transform: translateX(26px);
-  transform: translateX(26px);
-}
-
-/* Rounded sliders */
-.slider.round {
-  border-radius: 30px;
-}
-
-.slider.round:before {
-  border-radius: 50%;
+input.bigbox {
+  transform: scale(2.5);
+  transform-origin: left;
 }


### PR DESCRIPTION
## Related Issue
VSO #24112626
VSO #24113398

## Description
Two small changes:
* Change "Get Started" button role to `link` since it navigates the page
* Replace slider control on the "samples" page since it doesn't play nice with high contrast modes (invisible in HC White, and only partially visible in HC Black). Now we have a big checkbox instead:
![image](https://user-images.githubusercontent.com/16614499/84092373-fd284d00-a9ab-11ea-8a03-09fa7a2137b8.png)
(alt: screenshot of webpage updated to use a checkbox)


## How Verified
* local build and inspection with browser devtools


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4155)