### PR TITLE
[JS] Add aria-expanded state to showcard action button

### DIFF
--- a/source/nodejs/adaptivecards/docs/classes/action.md
+++ b/source/nodejs/adaptivecards/docs/classes/action.md
@@ -790,13 +790,14 @@ ___
 
 ###  updateActionButtonCssStyle
 
-▸ **updateActionButtonCssStyle**(`actionButtonElement`: HTMLElement): *void*
+▸ **updateActionButtonCssStyle**(`actionButtonElement`: HTMLElement, `buttonState`: ActionButtonState): *void*
 
 **Parameters:**
 
-Name | Type |
------- | ------ |
-`actionButtonElement` | HTMLElement |
+Name | Type | Default |
+------ | ------ | ------ |
+`actionButtonElement` | HTMLElement | - |
+`buttonState` | ActionButtonState | ActionButtonState.Normal |
 
 **Returns:** *void*
 

--- a/source/nodejs/adaptivecards/docs/classes/httpaction.md
+++ b/source/nodejs/adaptivecards/docs/classes/httpaction.md
@@ -939,15 +939,16 @@ ___
 
 ###  updateActionButtonCssStyle
 
-▸ **updateActionButtonCssStyle**(`actionButtonElement`: HTMLElement): *void*
+▸ **updateActionButtonCssStyle**(`actionButtonElement`: HTMLElement, `buttonState`: ActionButtonState): *void*
 
 *Inherited from [Action](action.md).[updateActionButtonCssStyle](action.md#updateactionbuttoncssstyle)*
 
 **Parameters:**
 
-Name | Type |
------- | ------ |
-`actionButtonElement` | HTMLElement |
+Name | Type | Default |
+------ | ------ | ------ |
+`actionButtonElement` | HTMLElement | - |
+`buttonState` | ActionButtonState | ActionButtonState.Normal |
 
 **Returns:** *void*
 

--- a/source/nodejs/adaptivecards/docs/classes/openurlaction.md
+++ b/source/nodejs/adaptivecards/docs/classes/openurlaction.md
@@ -861,15 +861,16 @@ ___
 
 ###  updateActionButtonCssStyle
 
-▸ **updateActionButtonCssStyle**(`actionButtonElement`: HTMLElement): *void*
+▸ **updateActionButtonCssStyle**(`actionButtonElement`: HTMLElement, `buttonState`: ActionButtonState): *void*
 
 *Inherited from [Action](action.md).[updateActionButtonCssStyle](action.md#updateactionbuttoncssstyle)*
 
 **Parameters:**
 
-Name | Type |
------- | ------ |
-`actionButtonElement` | HTMLElement |
+Name | Type | Default |
+------ | ------ | ------ |
+`actionButtonElement` | HTMLElement | - |
+`buttonState` | ActionButtonState | ActionButtonState.Normal |
 
 **Returns:** *void*
 

--- a/source/nodejs/adaptivecards/docs/classes/showcardaction.md
+++ b/source/nodejs/adaptivecards/docs/classes/showcardaction.md
@@ -854,15 +854,16 @@ ___
 
 ###  updateActionButtonCssStyle
 
-▸ **updateActionButtonCssStyle**(`actionButtonElement`: HTMLElement): *void*
+▸ **updateActionButtonCssStyle**(`actionButtonElement`: HTMLElement, `buttonState`: ActionButtonState): *void*
 
 *Overrides [Action](action.md).[updateActionButtonCssStyle](action.md#updateactionbuttoncssstyle)*
 
 **Parameters:**
 
-Name | Type |
------- | ------ |
-`actionButtonElement` | HTMLElement |
+Name | Type | Default |
+------ | ------ | ------ |
+`actionButtonElement` | HTMLElement | - |
+`buttonState` | ActionButtonState | ActionButtonState.Normal |
 
 **Returns:** *void*
 

--- a/source/nodejs/adaptivecards/docs/classes/submitaction.md
+++ b/source/nodejs/adaptivecards/docs/classes/submitaction.md
@@ -885,15 +885,16 @@ ___
 
 ###  updateActionButtonCssStyle
 
-▸ **updateActionButtonCssStyle**(`actionButtonElement`: HTMLElement): *void*
+▸ **updateActionButtonCssStyle**(`actionButtonElement`: HTMLElement, `buttonState`: ActionButtonState): *void*
 
 *Inherited from [Action](action.md).[updateActionButtonCssStyle](action.md#updateactionbuttoncssstyle)*
 
 **Parameters:**
 
-Name | Type |
------- | ------ |
-`actionButtonElement` | HTMLElement |
+Name | Type | Default |
+------ | ------ | ------ |
+`actionButtonElement` | HTMLElement | - |
+`buttonState` | ActionButtonState | ActionButtonState.Normal |
 
 **Returns:** *void*
 

--- a/source/nodejs/adaptivecards/docs/classes/togglevisibilityaction.md
+++ b/source/nodejs/adaptivecards/docs/classes/togglevisibilityaction.md
@@ -939,15 +939,16 @@ ___
 
 ###  updateActionButtonCssStyle
 
-▸ **updateActionButtonCssStyle**(`actionButtonElement`: HTMLElement): *void*
+▸ **updateActionButtonCssStyle**(`actionButtonElement`: HTMLElement, `buttonState`: ActionButtonState): *void*
 
 *Inherited from [Action](action.md).[updateActionButtonCssStyle](action.md#updateactionbuttoncssstyle)*
 
 **Parameters:**
 
-Name | Type |
------- | ------ |
-`actionButtonElement` | HTMLElement |
+Name | Type | Default |
+------ | ------ | ------ |
+`actionButtonElement` | HTMLElement | - |
+`buttonState` | ActionButtonState | ActionButtonState.Normal |
 
 **Returns:** *void*
 

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -3290,6 +3290,20 @@ class ActionButton {
                     this.action.renderedElement.classList.add(...hostConfig.makeCssClassNames("style-" + this.action.style.toLowerCase()));
                 }
             }
+
+            this.updateAriaExpandedState();
+        }
+    }
+
+    private updateAriaExpandedState() {
+        // update aria-expanded property
+        if (this.action.renderedElement && this.action.renderedElement.classList.contains("expandable")) {
+            if (this.state === ActionButtonState.Expanded) {
+                this.action.renderedElement.setAttribute("aria-expanded", "true");
+            }
+            else {
+                this.action.renderedElement.setAttribute("aria-expanded", "false");
+            }
         }
     }
 

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -3268,7 +3268,7 @@ class ActionButton {
                 this.action.renderedElement.classList.add("style-" + this._parentContainerStyle);
             }
 
-            this.action.updateActionButtonCssStyle(this.action.renderedElement);
+            this.action.updateActionButtonCssStyle(this.action.renderedElement, this._state);
 
             this.action.renderedElement.classList.remove(hostConfig.makeCssClassName("expanded"));
             this.action.renderedElement.classList.remove(hostConfig.makeCssClassName("subdued"));
@@ -3289,20 +3289,6 @@ class ActionButton {
                 else {
                     this.action.renderedElement.classList.add(...hostConfig.makeCssClassNames("style-" + this.action.style.toLowerCase()));
                 }
-            }
-
-            this.updateAriaExpandedState();
-        }
-    }
-
-    private updateAriaExpandedState() {
-        // update aria-expanded property
-        if (this.action.renderedElement && this.action.renderedElement.classList.contains("expandable")) {
-            if (this.state === ActionButtonState.Expanded) {
-                this.action.renderedElement.setAttribute("aria-expanded", "true");
-            }
-            else {
-                this.action.renderedElement.setAttribute("aria-expanded", "false");
             }
         }
     }
@@ -3422,7 +3408,7 @@ export abstract class Action extends CardObject {
         return "button";
     }
 
-    updateActionButtonCssStyle(actionButtonElement: HTMLElement): void {
+    updateActionButtonCssStyle(actionButtonElement: HTMLElement, buttonState: ActionButtonState = ActionButtonState.Normal): void {
         // Do nothing in base implementation
     }
 
@@ -4006,11 +3992,12 @@ export class ShowCardAction extends Action {
         this.card.internalValidateProperties(context);
     }
 
-    updateActionButtonCssStyle(actionButtonElement: HTMLElement): void {
+    updateActionButtonCssStyle(actionButtonElement: HTMLElement, buttonState: ActionButtonState = ActionButtonState.Normal): void {
         super.updateActionButtonCssStyle(actionButtonElement);
 
         if (this.parent) {
             actionButtonElement.classList.add(this.parent.hostConfig.makeCssClassName("expandable"));
+            actionButtonElement.setAttribute("aria-expanded", (buttonState === ActionButtonState.Expanded).toString());
         }
     }
 


### PR DESCRIPTION
## Related Issue
Fixes VSO #23940376

## Description
Expandable showcard actions lack the `aria-expanded` attribute, which is helpful for screenreaders.

![image](https://user-images.githubusercontent.com/16614499/84185878-84c19a80-aa44-11ea-8a25-7885965875ea.png)

## How Verified
* local build and devtools testing

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4157)