### PR TITLE
[Designer] Place keyboard focus back on "New card" button after dialog close

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/card-designer.ts
+++ b/source/nodejs/adaptivecards-designer/src/card-designer.ts
@@ -638,6 +638,12 @@ export class CardDesigner extends Designer.DesignContext {
                         };
                         dialog.selectedSample.download();
                     }
+
+                    const newCardButton = document.getElementById(CardDesigner.ToolbarCommands.NewCard);
+
+                    if (newCardButton) {
+                        newCardButton.focus();
+                    }
                 };
                 dialog.open();
             });

--- a/source/nodejs/adaptivecards-designer/src/toolbar.ts
+++ b/source/nodejs/adaptivecards-designer/src/toolbar.ts
@@ -94,6 +94,7 @@ export class ToolbarButton extends ToolbarElement {
     protected internalRender(): HTMLElement {
         let element = document.createElement("button");
 
+        element.id = this.id;
         element.onclick = (e) => {
             if (this.allowToggle) {
                 this.isToggled = !this.isToggled;


### PR DESCRIPTION
## Related Issue
Fixes VSO #24068381

## Description
Per accessibility rules, when a button shows a dialog, focus should be returned to the button after the dialog is closed. This does that for the designer's "New card" button.

## How Verified
* local build, keyboard