### PR TITLE
[Designer] Add aria attributes to dropdown controls

### DIFF
--- a/source/nodejs/adaptivecards-controls/src/dropdown.ts
+++ b/source/nodejs/adaptivecards-controls/src/dropdown.ts
@@ -32,7 +32,15 @@ export class DropDownItem {
             this._element = document.createElement("span");
             this._element.className = "ms-ctrl ms-ctrl-dropdown-item";
             this._element.innerText = this.value;
+            this._element.setAttribute("role", "option");
+            this._element.setAttribute("aria-selected", "false");
             this._element.onmouseup = (e) => { this.click(); };
+            this._element.onkeydown = (e) => {
+                if (e.keyCode === Constants.KEY_ENTER) {
+                    this.click();
+                    e.cancelBubble = true;
+                }
+            };
         }
 
         return this._element;
@@ -65,6 +73,7 @@ export class DropDownPopupControl extends PopupControl {
     protected renderContent(): HTMLElement {
         var element = document.createElement("div");
         element.className = "ms-ctrl ms-popup";
+        element.setAttribute("role", "listbox");
 
         var selectedIndex = this._owner.selectedIndex;
 
@@ -85,7 +94,7 @@ export class DropDownPopupControl extends PopupControl {
     }
 
     keyDown(e: KeyboardEvent) {
-        super.keyDown(e);
+        super.keyDown(e); // handles ESC
 
         var selectedItemIndex = this._selectedIndex;
 
@@ -154,7 +163,14 @@ export class DropDownPopupControl extends PopupControl {
 
     set selectedIndex(index: number) {
         if (index >= 0 && index < this._renderedItems.length) {
+            // deselect previous item (if one was selected)
+            if (this._selectedIndex >= 0 && this._selectedIndex < this._renderedItems.length) {
+                this._renderedItems[this._selectedIndex].setAttribute("aria-selected", "false");
+            }
+
+            // select new item
             this._renderedItems[index].focus();
+            this._renderedItems[index].setAttribute("aria-selected", "true");
 
             this._selectedIndex = index;
         }
@@ -163,6 +179,7 @@ export class DropDownPopupControl extends PopupControl {
 
 export class DropDown extends InputWithPopup<DropDownPopupControl, DropDownItem> {
     private _items: Collection<DropDownItem>;
+    private _parentLabelId: string; // tracks the id of the parent control's label
 
     private itemClicked(item: DropDownItem) {
         this.selectedItem = item;
@@ -207,6 +224,21 @@ export class DropDown extends InputWithPopup<DropDownPopupControl, DropDownItem>
                 this._items.add(item);
             }
         }
+
+        // add aria-labelledby tag with all pertinent label ids
+        let ariaLabelledByIds: Array<string> = [];
+
+        if (this.parentLabelId) {
+            ariaLabelledByIds.push(this.parentLabelId);
+        }
+
+        if (this.labelId) {
+            ariaLabelledByIds.push(this.labelId);
+        }
+
+        if (ariaLabelledByIds.length > 0) {
+            this.rootElement.setAttribute("aria-labelledby", ariaLabelledByIds.join(" "));
+        }
     }
 
     popup() {
@@ -235,5 +267,13 @@ export class DropDown extends InputWithPopup<DropDownPopupControl, DropDownItem>
         if (index >= 0 && this.items.length > index) {
             this.selectedItem = this.items.get(index);
         }
+    }
+
+    get parentLabelId() : string {
+        return this._parentLabelId;
+    }
+
+    set parentLabelId(newParentLabelId: string) {
+        this._parentLabelId = newParentLabelId;
     }
 }

--- a/source/nodejs/adaptivecards-controls/src/dropdown.ts
+++ b/source/nodejs/adaptivecards-controls/src/dropdown.ts
@@ -273,7 +273,7 @@ export class DropDown extends InputWithPopup<DropDownPopupControl, DropDownItem>
         return this._parentLabelId;
     }
 
-    set parentLabelId(newParentLabelId: string) {
-        this._parentLabelId = newParentLabelId;
+    set parentLabelId(value: string) {
+        this._parentLabelId = value;
     }
 }

--- a/source/nodejs/adaptivecards-controls/src/inputwithpopup.ts
+++ b/source/nodejs/adaptivecards-controls/src/inputwithpopup.ts
@@ -3,6 +3,7 @@
 import * as Constants from "./constants";
 import * as Utils from "./utils";
 import { InputControl } from "./inputcontrol";
+import { v4 as uuidv4 } from "uuid";
 
 export abstract class PopupControl {
     private _isOpen: boolean = false;
@@ -26,6 +27,8 @@ export abstract class PopupControl {
         let element = document.createElement("div");
         element.tabIndex = 0;
         element.className = "ms-ctrl ms-ctrl-popup-container";
+        element.setAttribute("role", "dialog");
+        element.setAttribute("aria-modal", "true");
         element.onkeydown = (e) => {
             this.keyDown(e);
 
@@ -63,6 +66,13 @@ export abstract class PopupControl {
                 "ms-ctrl-slideRightToLeft",
                 "ms-ctrl-slideTopToBottom",
                 "ms-ctrl-slideRightToLeft");
+
+            window.addEventListener("resize", (e) => { this.closePopup(true); });
+
+            const rootElementLabel = rootElement.getAttribute("aria-label");
+            if (rootElementLabel) {
+                this._popupElement.setAttribute("aria-label", rootElementLabel);
+            }
 
             this._overlayElement.appendChild(this._popupElement);
 
@@ -237,6 +247,7 @@ export abstract class InputWithPopup<TPopupControl extends PopupControl, TValue>
 
         this._labelElement = document.createElement("span");
         this._labelElement.className = "ms-ctrl ms-dropdown-label";
+        this._labelElement.id = uuidv4(); // generate unique id for our label element
 
         this._dropDownButtonElement = document.createElement("i");
         this._dropDownButtonElement.className = "ms-icon ms-ctrl-dropdown-button " + this.getButtonIconCssClassName();
@@ -248,7 +259,6 @@ export abstract class InputWithPopup<TPopupControl extends PopupControl, TValue>
     }
 
     popup() {
-        this._popupControl = this.createPopupControl();
         this._popupControl = this.createPopupControl();
         this._popupControl.onClose = (sender, wasCancelled) => {
             this.closePopup(wasCancelled);
@@ -263,6 +273,13 @@ export abstract class InputWithPopup<TPopupControl extends PopupControl, TValue>
         if (this.popupControl) {
             this.popupControl.closePopup(wasCancelled);
         }
+    }
+
+    get labelId(): string {
+        if (this._labelElement) {
+            return this._labelElement.id;
+        }
+        return undefined;
     }
 
     get isOpen(): boolean {

--- a/source/nodejs/adaptivecards-controls/src/inputwithpopup.ts
+++ b/source/nodejs/adaptivecards-controls/src/inputwithpopup.ts
@@ -277,8 +277,10 @@ export abstract class InputWithPopup<TPopupControl extends PopupControl, TValue>
 
     get labelId(): string {
         if (this._labelElement) {
+
             return this._labelElement.id;
         }
+
         return undefined;
     }
 

--- a/source/nodejs/adaptivecards-controls/src/popupmenu.ts
+++ b/source/nodejs/adaptivecards-controls/src/popupmenu.ts
@@ -17,6 +17,7 @@ export class PopupMenu extends PopupControl {
     protected renderContent(): HTMLElement {
         var element = document.createElement("div");
         element.className = "ms-ctrl ms-popup";
+        element.setAttribute("role", "listbox");
 
         for (var i = 0; i < this._items.length; i++) {
             var renderedItem = this._items.get(i).render();

--- a/source/nodejs/adaptivecards-designer/src/toolbar.ts
+++ b/source/nodejs/adaptivecards-designer/src/toolbar.ts
@@ -76,6 +76,7 @@ export class ToolbarButton extends ToolbarElement {
         else {
             this.renderedElement.classList.remove("acd-toolbar-button-toggled");
         }
+
         this.renderedElement.setAttribute("aria-pressed", this.isToggled.toString());
 
         if (this.iconClass) {

--- a/source/nodejs/adaptivecards-designer/src/toolbar.ts
+++ b/source/nodejs/adaptivecards-designer/src/toolbar.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { DropDown, DropDownItem } from "adaptivecards-controls";
+import { v4 as uuidv4 } from "uuid";
 
 export enum ToolbarElementAlignment {
     Left,
@@ -75,6 +76,7 @@ export class ToolbarButton extends ToolbarElement {
         else {
             this.renderedElement.classList.remove("acd-toolbar-button-toggled");
         }
+        this.renderedElement.setAttribute("aria-pressed", this.isToggled.toString());
 
         if (this.iconClass) {
             this.renderedElement.classList.add(this.iconClass);
@@ -199,6 +201,7 @@ export interface IChoicePickerItem {
 
 export class ToolbarChoicePicker extends ToolbarElement {
     private _dropDown: DropDown;
+    private _labelledById: string; // id to use for our label element
 
     protected internalRender(): HTMLElement {
         this._dropDown = new DropDown();
@@ -222,6 +225,12 @@ export class ToolbarChoicePicker extends ToolbarElement {
             pickerElement.style.width = this.width + "px";
         }
 
+        // update label ids so we can generate correct aria
+        if (this.label && !this._labelledById) {
+            this._labelledById = uuidv4();
+            this._dropDown.parentLabelId = this._labelledById;
+        }
+
         this._dropDown.attach(pickerElement);
 
         let pickerContainerElement = document.createElement("div");
@@ -233,6 +242,7 @@ export class ToolbarChoicePicker extends ToolbarElement {
             let labelElement = document.createElement("span");
             labelElement.className = "acd-toolbar-label";
             labelElement.innerText = this.label;
+            labelElement.id = this._labelledById;
 
             pickerContainerElement.appendChild(labelElement);
         }


### PR DESCRIPTION
## Related Issue
Fixes VSO #24095594
Fixes VSO #24113643
Fixes VSO #24081494

## Description
A few fixes:
* The "Preview Mode" toolbar button now gets the `aria-pressed` property set appropriately set
* The toolbar dropdown menus are now marked up correctly for accessibility
* Keyboard access to peer comboboxes now works

## How Verified
* local build, narrator, dev tools, keyboard


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4171)