### PR TITLE
[Site] Fix sticky sidebar math

### DIFF
--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/source/js/script.js
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/source/js/script.js
@@ -543,6 +543,9 @@ $(function () {
 		$(document).scroll(function () {
 			updateSidebarTopOffset();
 		});
+		$(document).resize(function () {
+			updateSidebarTopOffset();
+		});
 	}
 
 	function updateSidebarTopOffset() {
@@ -555,11 +558,9 @@ $(function () {
 
 		var topPadding = 24;
 
-		var calculatedTop = headerHeight - scrollOffset + topPadding;
-		if (calculatedTop < topPadding) {
-			calculatedTop = topPadding;
-		}
+		var calculatedTop = Math.max(headerHeight - scrollOffset + topPadding, topPadding);
+		var calculatedBottom = Math.max(footerHeight - hiddenAfter, 0);
 
-		sidebar.css("top", calculatedTop).css("bottom", footerHeight - hiddenAfter);
+		sidebar.css("top", calculatedTop).css("bottom", calculatedBottom);
 	}
 });


### PR DESCRIPTION
## Related Issue
Fixes #4086
Fixes VSO #23940370

## Description
The problem here shows up when the window height and scroll position are such that:
* the footer isn't visible
* the window is too short to display the entire sidebar

In this scenario, the user isn't able to access the bottom elements in the sidebar without scrolling to the bottom of the current page, which is kind of a pain. This is somewhat related to the VSO issue I mention above where the tester was `shift-tab`ing from the `Copy` button, which placed focus on the last item in the sidebar. However, since the item is stuck offscreen due to css, there's no visual indication of where the focus has gone. The actual bug is just that we weren't accounting for the case where `hiddenAfter > footerHeight` in our sidebar calculations, leading to the sidebar's `bottom` property being set to a negative number.

## How Verified
* local build, devtools, keyboard

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4173)