### PR TITLE
added '*' as a list marker

### DIFF
--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/MarkDownUnitTest.cpp
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/MarkDownUnitTest.cpp
@@ -43,13 +43,6 @@ namespace AdaptiveCardsSharedModelUnitTest
             Assert::AreEqual<std::string>("<p><em>foo bar</em></p>", parser.TransformToHtml());
         }
 
-        TEST_METHOD(EmphasisLeftDelimiterTest_LeftDelimiterFalseCaseWithSpaceTest)
-        {
-            MarkDownParser parser("* foo bar*");
-            Assert::AreEqual<std::string>("<p>* foo bar*</p>", parser.TransformToHtml());
-            Assert::AreEqual<bool>(false, parser.HasHtmlTags());
-        }
-
         TEST_METHOD(EmphasisLeftDelimiterTest_UnderscoreLeftDelimiterFalseCaseWithSpaceTest)
         {
             MarkDownParser parser("_ foo bar_");
@@ -493,36 +486,50 @@ namespace AdaptiveCardsSharedModelUnitTest
         {
             MarkDownParser parser("- hello");
             Assert::AreEqual<std::string>("<ul><li>hello</li></ul>", parser.TransformToHtml());
+            MarkDownParser parser2("* hello");
+            Assert::AreEqual<std::string>("<ul><li>hello</li></ul>", parser2.TransformToHtml());
         }
 
         TEST_METHOD(ListTest_MultipleSimpleValidListTest)
         {
-            MarkDownParser parser("- hello\n- Hi");
-            Assert::AreEqual<std::string>("<ul><li>hello</li><li>Hi</li></ul>", parser.TransformToHtml());
+            MarkDownParser parser("- hello\n- world\n- hi");
+            Assert::AreEqual<std::string>("<ul><li>hello</li><li>world</li><li>hi</li></ul>", parser.TransformToHtml());
+            MarkDownParser parser2("* hello\n* world\n* hi");
+            Assert::AreEqual<std::string>("<ul><li>hello</li><li>world</li><li>hi</li></ul>", parser2.TransformToHtml());
+            MarkDownParser parser3("* hello\n- Hi");
+            Assert::AreEqual<std::string>("<ul><li>hello</li><li>Hi</li></ul>", parser3.TransformToHtml());
         }
 
         TEST_METHOD(ListTest_ListTestsWithInterHyphen)
         {
             MarkDownParser parser("- hello world - hello hello");
             Assert::AreEqual<std::string>("<ul><li>hello world - hello hello</li></ul>", parser.TransformToHtml());
+            MarkDownParser parser2("* hello world - hello hello");
+            Assert::AreEqual<std::string>("<ul><li>hello world - hello hello</li></ul>", parser2.TransformToHtml());
         }
 
         TEST_METHOD(ListTest_MultipleListWithHyphenTests)
         {
             MarkDownParser parser("- hello world - hello hello\r- winner winner chicken dinner");
             Assert::AreEqual<std::string>("<ul><li>hello world - hello hello</li><li>winner winner chicken dinner</li></ul>", parser.TransformToHtml());
+            MarkDownParser parser2("* hello world * hello hello\r* winner winner chicken dinner");
+            Assert::AreEqual<std::string>("<ul><li>hello world * hello hello</li><li>winner winner chicken dinner</li></ul>", parser2.TransformToHtml());
         }
 
         TEST_METHOD(ListTest_MultipleListWithHyphenAndEmphasisTests)
         {
             MarkDownParser parser("- hello world - hello hello\r- ***winner* winner** chicken dinner");
             Assert::AreEqual<std::string>("<ul><li>hello world - hello hello</li><li><strong><em>winner</em> winner</strong> chicken dinner</li></ul>", parser.TransformToHtml());
+            MarkDownParser parser2("* hello world * hello hello\r* ***winner* winner** chicken dinner");
+            Assert::AreEqual<std::string>("<ul><li>hello world * hello hello</li><li><strong><em>winner</em> winner</strong> chicken dinner</li></ul>", parser2.TransformToHtml());
         }
 
         TEST_METHOD(ListTest_MultipleListWithLinkTest)
         {
             MarkDownParser parser("- hello world\r- hello hello\r- new site = [adaptive card](www.adaptivecards.io)");
             Assert::AreEqual<std::string>("<ul><li>hello world</li><li>hello hello</li><li>new site = <a href=\"www.adaptivecards.io\">adaptive card</a></li></ul>", parser.TransformToHtml());
+            MarkDownParser parser2("* hello world\r* hello hello\r* new site = [adaptive card](www.adaptivecards.io)");
+            Assert::AreEqual<std::string>("<ul><li>hello world</li><li>hello hello</li><li>new site = <a href=\"www.adaptivecards.io\">adaptive card</a></li></ul>", parser2.TransformToHtml());
         }
 
         TEST_METHOD(ListTest_PtagedBlockElementFollowedByListTest)
@@ -530,18 +537,25 @@ namespace AdaptiveCardsSharedModelUnitTest
             MarkDownParser parser("Hello\r- my list");
             Assert::AreEqual<std::string>("<p>Hello</p><ul><li>my list</li></ul>", parser.TransformToHtml());
             Assert::AreEqual<bool>(true, parser.HasHtmlTags());
+            MarkDownParser parser2("Hello\r* my list");
+            Assert::AreEqual<std::string>("<p>Hello</p><ul><li>my list</li></ul>", parser2.TransformToHtml());
+            Assert::AreEqual<bool>(true, parser2.HasHtmlTags());
         }
 
         TEST_METHOD(ListTest_ListFollowedByPtagedBlockElementTest)
         {
             MarkDownParser parser("- my list\r\rHello");
             Assert::AreEqual<std::string>("<ul><li>my list</li></ul><p>Hello</p>", parser.TransformToHtml());
+            MarkDownParser parser2("* my list\r\rHello");
+            Assert::AreEqual<std::string>("<ul><li>my list</li></ul><p>Hello</p>", parser2.TransformToHtml());
         }
 
         TEST_METHOD(ListTest_ListFollowedWithNewLineCharTest)
         {
             MarkDownParser parser("- my list\rHello");
             Assert::AreEqual<std::string>("<ul><li>my list\rHello</li></ul>", parser.TransformToHtml());
+            MarkDownParser parser2("* my list\rHello");
+            Assert::AreEqual<std::string>("<ul><li>my list\rHello</li></ul>", parser2.TransformToHtml());
         }
 
         TEST_METHOD(ListTest_InvalidListStringReturnedUnchangedTest)
@@ -549,6 +563,13 @@ namespace AdaptiveCardsSharedModelUnitTest
             MarkDownParser parser("023-34-567");
             Assert::AreEqual<std::string>("<p>023-34-567</p>", parser.TransformToHtml());
             Assert::AreEqual<bool>(false, parser.HasHtmlTags());
+        }
+
+        TEST_METHOD(ListTest_LeftDelimiterFalseCaseWithSpaceTest)
+        {
+            MarkDownParser parser("* foo bar*");
+            Assert::AreEqual<std::string>("<ul><li>foo bar*</li></ul>", parser.TransformToHtml());
+            Assert::AreEqual<bool>(true, parser.HasHtmlTags());
         }
 
         TEST_METHOD(OrderedListTest_SimpleValidListTest)

--- a/source/shared/cpp/ObjectModel/MarkDownBlockParser.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownBlockParser.cpp
@@ -51,6 +51,18 @@ void MarkDownBlockParser::ParseBlock(std::stringstream& stream)
         m_parsedResult.AppendParseResult(listParser.GetParsedResult());
         break;
     }
+
+    // handles list block
+    case '*':
+    {
+        ListParser listParser;
+        // do syntax check of list
+        listParser.Match(stream);
+        // append list result to the rest
+        m_parsedResult.AppendParseResult(listParser.GetParsedResult());
+        break;
+    }
+
     case '0':
     case '1':
     case '2':
@@ -71,12 +83,17 @@ void MarkDownBlockParser::ParseBlock(std::stringstream& stream)
     }
     // everything else is treated as normal text + emphasis
     default:
-        EmphasisParser emphasisParser;
-        // do syntax check of normal text + emphasis
-        emphasisParser.Match(stream);
-        // append result to the rest
-        m_parsedResult.AppendParseResult(emphasisParser.GetParsedResult());
+        ParseTextAndEmphasis(stream);
     }
+}
+
+void MarkDownBlockParser::ParseTextAndEmphasis(std::stringstream& stream)
+{
+    EmphasisParser emphasisParser;
+    // do syntax check of normal text + emphasis
+    emphasisParser.Match(stream);
+    // append result to the rest
+    m_parsedResult.AppendParseResult(emphasisParser.GetParsedResult());
 }
 
 // Emphasis Match's syntax is complete when it's Captured
@@ -464,7 +481,9 @@ bool LinkParser::MatchAtLinkDestinationStart(std::stringstream& lookahead)
 // link is in form of [txt](url), this method matches ')'
 bool LinkParser::MatchAtLinkDestinationRun(std::stringstream& lookahead)
 {
-    if (lookahead.peek() > 0 && (MarkDownBlockParser::IsSpace(static_cast<char>(lookahead.peek())) || MarkDownBlockParser::IsCntrl(static_cast<char>(lookahead.peek()))))
+    if (lookahead.peek() > 0 &&
+        (MarkDownBlockParser::IsSpace(static_cast<char>(lookahead.peek())) ||
+         MarkDownBlockParser::IsCntrl(static_cast<char>(lookahead.peek()))))
     {
         m_parsedResult.AppendParseResult(m_linkTextParsedResult);
         return false;
@@ -524,7 +543,8 @@ void LinkParser::CaptureLinkToken()
 // this method matches -\s
 bool ListParser::MatchNewListItem(std::stringstream& stream)
 {
-    if (IsHyphen(static_cast<char>(stream.peek())))
+    const char ch = static_cast<char>(stream.peek());
+    if (IsHyphen(ch) || IsAsterisk(ch))
     {
         stream.get();
         if (stream.peek() == ' ')
@@ -640,7 +660,8 @@ bool ListParser::CompleteListParsing(std::stringstream& stream)
 void ListParser::Match(std::stringstream& stream)
 {
     // check for - of -\s+ list marker
-    if (IsHyphen(static_cast<char>(stream.peek())))
+    const char ch = static_cast<char>(stream.peek());
+    if (IsHyphen(ch) || IsAsterisk(ch))
     {
         stream.get();
         if (CompleteListParsing(stream))
@@ -649,8 +670,18 @@ void ListParser::Match(std::stringstream& stream)
         }
         else
         {
-            // if incorrect syntax, capture what was thrown as a new token.
-            m_parsedResult.AddNewTokenToParsedResult('-');
+            // if it was asterisk, put the char back and start emphasis parsing
+            if (IsAsterisk(ch))
+            {
+                stream.putback(ch);
+
+                ParseTextAndEmphasis(stream);
+            }
+            else
+            {
+                // if incorrect syntax, capture what was thrown as a new token.
+                m_parsedResult.AddNewTokenToParsedResult(ch);
+            }
         }
     }
 }

--- a/source/shared/cpp/ObjectModel/MarkDownBlockParser.h
+++ b/source/shared/cpp/ObjectModel/MarkDownBlockParser.h
@@ -46,6 +46,8 @@ namespace AdaptiveSharedNamespace
             return (ch > 0) && isdigit(ch);
         }
 
+        void ParseTextAndEmphasis(std::stringstream& stream);
+
         // Holds parsed results
         MarkDownParsedResult m_parsedResult;
     };
@@ -166,6 +168,7 @@ namespace AdaptiveSharedNamespace
         bool MatchNewBlock(std::stringstream&);
         bool MatchNewOrderedListItem(std::stringstream&, std::string&);
         static constexpr bool IsHyphen(const char ch) { return ch == '-'; };
+        static constexpr bool IsAsterisk(const char ch) { return ch == '*'; };
         static constexpr bool IsDot(const char ch) { return ch == '.'; };
         static constexpr bool IsNewLine(const char ch) { return (ch == '\r') || (ch == '\n'); };
 


### PR DESCRIPTION
## Related Issue
Fixes #4117 

## Description
Added '*' as list marker to MarkDown parser

## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added
2. Existing unit tests were performed.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4175)