### PR TITLE
[Site] Remove visualizer link in Designer

### DIFF
--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/designer.ejs
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/designer.ejs
@@ -96,19 +96,6 @@
 
 			designer.toolbar.getElementById(ACDesigner.CardDesigner.ToolbarCommands.HostAppPicker).width = "auto";
 
-
-			let visualizerButton = new ACDesigner.ToolbarButton(
-				"visualizerButton",
-				"Classic Visualizer",
-				null,
-				function () {
-					window.open("<%- config.root %>visualizer")
-				}
-			);
-			visualizerButton.separator = true;
-			visualizerButton.alignment = ACDesigner.ToolbarElementAlignment.Right;
-			designer.toolbar.addElement(visualizerButton);
-
 			let feedbackButton = new ACDesigner.ToolbarButton(
 				"feedbackButton",
 				"Feedback",


### PR DESCRIPTION
## Related Issue
Fixes VSO #24081771

## Description
Per advice in VSO item, removing the visualizer link from the Designer. The visualizer itself will remain up, but should have some work done per conversation (see #4180).

## How Verified
* local build and testing

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4177)