### PR TITLE
[Site] Remove superfluous link on article subtitles

### DIFF
--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/archive.ejs
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/archive.ejs
@@ -29,7 +29,7 @@ layout: layout
 
 			<h2><a class="article-title" href="<%- config.root %><%- post.path %>"><%- post.title %></a></h2>
 
-			<h3><a class="article-subtitle" href="<%- config.root %><%- post.path %>"><%- post.subtitle %></a></h3>
+			<h3 class="article-subtitle"><%- post.subtitle %></h3>
 
 			<div class="w3-margin-top">
 				<div class="w3-cell w3-cell-middle">

--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/source/css/style.css
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/source/css/style.css
@@ -423,8 +423,7 @@ dir {
   text-decoration: none;
 }
 
-.blog .article-subtitle:link,
-.blog .article-subtitle:visited {
+.blog .article-subtitle {
   color: rgba(0, 0, 0, 0.54);
   font-size: 17px;
   line-height: 22px;


### PR DESCRIPTION
## Related Issue
Fixes VSO #24095883

## Description
Blog post subtitles were being emitted as links, which is unnecessary (and adds extra tabstops for screenreader users).

![image](https://user-images.githubusercontent.com/16614499/84689923-91d40300-aef6-11ea-94c0-2369ac3a8cb8.png)

## How Verified
* local build and test

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4178)