### PR TITLE
[Designer] Improve show/hide accessibility and labels

### DIFF
--- a/source/nodejs/adaptivecards-controls/src/constants.ts
+++ b/source/nodejs/adaptivecards-controls/src/constants.ts
@@ -3,6 +3,7 @@
 export const KEY_TAB = 9;
 export const KEY_ENTER = 13;
 export const KEY_ESCAPE = 27;
+export const KEY_SPACE = 32;
 export const KEY_UP = 38;
 export const KEY_DOWN = 40;
 export const KEY_DELETE = 46;

--- a/source/nodejs/adaptivecards-designer/src/base-tree-item.ts
+++ b/source/nodejs/adaptivecards-designer/src/base-tree-item.ts
@@ -1,4 +1,5 @@
 import { DraggableElement } from "./draggable-element";
+import { KEY_ENTER, KEY_SPACE } from "adaptivecards-controls";
 
 export abstract class BaseTreeItem extends DraggableElement {
     private static collapsedIconClass = "acd-icon-chevronRight";
@@ -77,6 +78,10 @@ export abstract class BaseTreeItem extends DraggableElement {
         this._expandCollapseElement.classList.add("acd-tree-item-expandCollapseButton");
         this._expandCollapseElement.style.flex = "0 0 auto";
         this._expandCollapseElement.style.visibility = this.getChildCount() > 0 ? "visible" : "hidden";
+        this._expandCollapseElement.tabIndex = 0;
+        this._expandCollapseElement.setAttribute("role", "button");
+        this._expandCollapseElement.setAttribute("aria-expanded", this._isExpanded.toString());
+
         this._expandCollapseElement.onclick = (e: MouseEvent) => {
             this._isExpanded = !this._isExpanded;
 
@@ -84,6 +89,16 @@ export abstract class BaseTreeItem extends DraggableElement {
 
             e.cancelBubble = true;
             e.preventDefault();
+        }
+
+        this._expandCollapseElement.onkeydown = (e: KeyboardEvent) => {
+            if (e.keyCode === KEY_ENTER || e.keyCode === KEY_SPACE) {
+                this._isExpanded = !this._isExpanded;
+
+                this.updateLayout();
+                this._expandCollapseElement.focus();
+                e.preventDefault();
+            }
         }
 
         this._treeItemElement.appendChild(this._expandCollapseElement);
@@ -151,6 +166,8 @@ export abstract class BaseTreeItem extends DraggableElement {
     abstract getChildAt(index: number): BaseTreeItem;
 
     updateLayout() {
+        this._expandCollapseElement.setAttribute("aria-expanded", this._isExpanded.toString());
+
         if (this._isExpanded) {
             this._childContainerElement.classList.remove("acd-hidden");
             this._expandCollapseElement.classList.remove(BaseTreeItem.collapsedIconClass);

--- a/source/nodejs/adaptivecards-designer/src/tool-box.ts
+++ b/source/nodejs/adaptivecards-designer/src/tool-box.ts
@@ -1,4 +1,5 @@
 import { SettingsManager } from "./settings-manager";
+import { KEY_ENTER, KEY_SPACE } from "adaptivecards-controls";
 
 export interface IToolboxCommand {
     title: string;
@@ -108,17 +109,23 @@ export class Toolbox {
 
         this._expandCollapseButtonElement = document.createElement("span");
         this._expandCollapseButtonElement.className = "acd-toolbox-header-commandButton";
-        this._expandCollapseButtonElement.title = "Hide";
+        this._expandCollapseButtonElement.title = "Hide " + this.title;
+        this._expandCollapseButtonElement.tabIndex = 0;
+        this._expandCollapseButtonElement.setAttribute("role", "button");
+        this._expandCollapseButtonElement.setAttribute("aria-expanded", "true");
 
         this._headerIconElement = document.createElement("span")
         this._headerIconElement.classList.add("acd-icon", "acd-icon-header-expanded");
 
         this._expandCollapseButtonElement.appendChild(this._headerIconElement);
 
-        this._expandCollapseButtonElement.onmousedown = (e) => {
-            e.preventDefault();
+        this._expandCollapseButtonElement.onkeydown = (e) => {
+            if (e.keyCode === KEY_ENTER || e.keyCode === KEY_SPACE) {
+                this.toggle();
 
-            return true;
+                e.preventDefault();
+                this._expandCollapseButtonElement.focus();
+            }
         }
 
         this._expandCollapseButtonElement.onclick = (e) => {
@@ -154,7 +161,8 @@ export class Toolbox {
                 this._collapsedTabContainer.appendChild(this._headerRootElement);
             }
 
-            this._expandCollapseButtonElement.title = "Show";
+            this._expandCollapseButtonElement.title = "Show " + this.title;
+            this._expandCollapseButtonElement.setAttribute("aria-expanded", "false");
 
             this._isExpanded = false;
 
@@ -173,7 +181,8 @@ export class Toolbox {
                 this._renderedElement.insertBefore(this._headerRootElement, this._renderedElement.firstChild);
             }
 
-            this._expandCollapseButtonElement.title = "Hide";
+            this._expandCollapseButtonElement.title = "Hide " + this.title;
+            this._expandCollapseButtonElement.setAttribute("aria-expanded", "true");
 
             this._isExpanded = true;
 

--- a/source/nodejs/adaptivecards-designer/src/tree-view.ts
+++ b/source/nodejs/adaptivecards-designer/src/tree-view.ts
@@ -24,7 +24,6 @@ export class TreeView {
     render(): HTMLElement {
         let treeRoot = document.createElement("div");
         treeRoot.className = "acd-treeView";
-        treeRoot.tabIndex = 0;
         treeRoot.appendChild(this.rootItem.render());
 
         this.setupTreeItemEvents(this.rootItem);


### PR DESCRIPTION
## Related Issue
Partially fixes VSO #24096574

## Description
A few things missing:
* Hide/show controls were not keyboard focusable/interactable
* Hide/show controls weren't marked up as `aria-expanded`
* Hide/show control aria labels didn't indicate what toolbox was being expanded/collapsed when invoked

## How Verified
* local build, keyboard, narrator, and devtools

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4179)