### PR TITLE
[JS] Fix aria accessibility for media element

### DIFF
--- a/samples/v1.1/Scenarios/ProductVideo.json
+++ b/samples/v1.1/Scenarios/ProductVideo.json
@@ -3,23 +3,24 @@
 	"type": "AdaptiveCard",
 	"version": "1.1",
 	"fallbackText": "This card requires Media to be viewed. Ask your platform to update to Adaptive Cards v1.1 for this and more!",
-    "body": [
-        {
-            "type": "Media",
-            "poster": "https://adaptivecards.io/content/poster-video.png",
-            "sources": [
-                {
-                    "mimeType": "video/mp4",
-                    "url": "https://adaptivecardsblob.blob.core.windows.net/assets/AdaptiveCardsOverviewVideo.mp4"
-                }
-            ]
-        }
-    ],
-    "actions": [
-        {
-            "type": "Action.OpenUrl",
-            "title": "Learn more",
-            "url": "https://adaptivecards.io"
-        }
-    ]
+	"body": [
+		{
+			"type": "Media",
+			"poster": "https://adaptivecards.io/content/poster-video.png",
+			"altText": "Adaptive Cards overview video",
+			"sources": [
+				{
+					"mimeType": "video/mp4",
+					"url": "https://adaptivecardsblob.blob.core.windows.net/assets/AdaptiveCardsOverviewVideo.mp4"
+				}
+			]
+		}
+	],
+	"actions": [
+		{
+			"type": "Action.OpenUrl",
+			"title": "Learn more",
+			"url": "https://adaptivecards.io"
+		}
+	]
 }

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -2138,6 +2138,7 @@ export class Media extends CardElement {
 
         if (this.hostConfig.supportsInteractivity && this._selectedSources.length > 0) {
             let playButtonOuterElement = document.createElement("div");
+            playButtonOuterElement.tabIndex = 0;
             playButtonOuterElement.setAttribute("role", "button");
             playButtonOuterElement.setAttribute("aria-label", "Play media");
             playButtonOuterElement.className = this.hostConfig.makeCssClassName("ac-media-playButton");


### PR DESCRIPTION
## Related Issue
Fixes VSO #24110397

## Description
* Missing `altText` in ProductVideo.json (fixed up tabs while I was there)
* Play button was missing `tabIndex=0`, so it wasn't possible to trigger media playback using only keyboard.

## How Verified
* local build, narrator, keyboard, devtools

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4182)