### PR TITLE
[JS] Express action sets as collections

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -4276,6 +4276,7 @@ class ActionCollection {
             let buttonStrip = document.createElement("div");
             buttonStrip.className = hostConfig.makeCssClassName("ac-actionSet");
             buttonStrip.style.display = "flex";
+            buttonStrip.setAttribute("role", "group");
 
             if (orientation == Enums.Orientation.Horizontal) {
                 buttonStrip.style.flexDirection = "row";
@@ -4346,47 +4347,51 @@ class ActionCollection {
             if (parentContainer) {
                 let parentContainerStyle = parentContainer.getEffectiveStyle();
 
-                for (let i = 0; i < this.items.length; i++) {
-                    if (this.isActionAllowed(this.items[i])) {
-                        let actionButton = this.findActionButton(this.items[i]);
+                const allowedActions = this.items.filter(this.isActionAllowed.bind(this));
 
-                        if (!actionButton) {
-                            actionButton = new ActionButton(this.items[i], parentContainerStyle);
-                            actionButton.onClick = (ab) => { this.actionClicked(ab); };
+                for (let i = 0; i < allowedActions.length; i++) {
+                    let actionButton = this.findActionButton(allowedActions[i]);
 
-                            this.buttons.push(actionButton);
+                    if (!actionButton) {
+                        actionButton = new ActionButton(allowedActions[i], parentContainerStyle);
+                        actionButton.onClick = (ab) => { this.actionClicked(ab); };
+
+                        this.buttons.push(actionButton);
+                    }
+
+                    actionButton.render();
+
+                    if (actionButton.action.renderedElement) {
+                        actionButton.action.renderedElement.setAttribute("aria-posinset", (i + 1).toString());
+                        actionButton.action.renderedElement.setAttribute("aria-setsize", allowedActions.length.toString());
+                        actionButton.action.renderedElement.setAttribute("role", "listitem");
+
+                        if (hostConfig.actions.actionsOrientation == Enums.Orientation.Horizontal && hostConfig.actions.actionAlignment == Enums.ActionAlignment.Stretch) {
+                            actionButton.action.renderedElement.style.flex = "0 1 100%";
+                        }
+                        else {
+                            actionButton.action.renderedElement.style.flex = "0 1 auto";
                         }
 
-                        actionButton.render();
+                        buttonStrip.appendChild(actionButton.action.renderedElement);
 
-                        if (actionButton.action.renderedElement) {
-                            if (hostConfig.actions.actionsOrientation == Enums.Orientation.Horizontal && hostConfig.actions.actionAlignment == Enums.ActionAlignment.Stretch) {
-                                actionButton.action.renderedElement.style.flex = "0 1 100%";
+                        this._renderedActionCount++;
+
+                        if (this._renderedActionCount >= hostConfig.actions.maxActions || i == this.items.length - 1) {
+                            break;
+                        }
+                        else if (hostConfig.actions.buttonSpacing > 0) {
+                            let spacer = document.createElement("div");
+
+                            if (orientation === Enums.Orientation.Horizontal) {
+                                spacer.style.flex = "0 0 auto";
+                                spacer.style.width = hostConfig.actions.buttonSpacing + "px";
                             }
                             else {
-                                actionButton.action.renderedElement.style.flex = "0 1 auto";
+                                spacer.style.height = hostConfig.actions.buttonSpacing + "px";
                             }
 
-                            buttonStrip.appendChild(actionButton.action.renderedElement);
-
-                            this._renderedActionCount++;
-
-                            if (this._renderedActionCount >= hostConfig.actions.maxActions || i == this.items.length - 1) {
-                                break;
-                            }
-                            else if (hostConfig.actions.buttonSpacing > 0) {
-                                let spacer = document.createElement("div");
-
-                                if (orientation === Enums.Orientation.Horizontal) {
-                                    spacer.style.flex = "0 0 auto";
-                                    spacer.style.width = hostConfig.actions.buttonSpacing + "px";
-                                }
-                                else {
-                                    spacer.style.height = hostConfig.actions.buttonSpacing + "px";
-                                }
-
-                                Utils.appendChild(buttonStrip, spacer);
-                            }
+                            Utils.appendChild(buttonStrip, spacer);
                         }
                     }
                 }


### PR DESCRIPTION
## Related Issue
Fixes VSO #24019554

## Description
Before this change, each `Action` in an `ActionSet` was considered in isolation by accessibility. There was no way of knowing how many actions were on card without tabbing through all of them. With this change, screenreaders can surface count information to the user (Narrator does this).

## How Verified
* local build, devtools, narrator


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4184)