### PR TITLE
[pic2card] Path filter for github actions

### DIFF
--- a/.github/workflows/pic2card_build.yml
+++ b/.github/workflows/pic2card_build.yml
@@ -4,8 +4,12 @@ name: pic2card-build
 on:
   push:
     branches: [ master, main, pic2card-backend ]
+    paths:
+    - 'source/pic2card/**'
   pull_request:
     branches: [ master, main, pic2card-backend ]
+    paths:
+    - 'source/pic2card/**'
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
Helps to avoid unnecessary builds, build happens only when some changes happens under `source/pic2card`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4187)