### PR TITLE
[Site] Fix markdown for version label on properties

### DIFF
--- a/source/nodejs/ac-typed-schema/src/markdown/generate-markdown.ts
+++ b/source/nodejs/ac-typed-schema/src/markdown/generate-markdown.ts
@@ -21,7 +21,7 @@ export function createPropertiesSummary(classDefinition: SchemaClass, knownTypes
 		properties = sortProperties(properties);
 
 		if (includeVersion && defined(elementVersion) && elementVersion != "1.0") {
-			md += "#### Introduced in version " + elementVersion + "\n\n";
+			md += "**Introduced in version " + elementVersion + "**\n\n";
 		}
 
 		var formattedProperties = [];


### PR DESCRIPTION
## Related Issue
Fixes VSO #24094341

## Description
Elements introduced after 1.0 have that fact called out on the schema explorer page. However, it's done via a heading element, which is incorrect from an accessibility standpoint:

![image](https://user-images.githubusercontent.com/16614499/84814736-be575000-afc6-11ea-8166-f14b3548268d.png)

Fix is to emit it in bold instead.

## How Verified
* local build, devtools


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4189)