### PR TITLE
Fixed the crash when image is not available

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRImageRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRImageRenderer.mm
@@ -103,6 +103,7 @@
     ACRContentHoldingUIView *wrappingview = [[ACRContentHoldingUIView alloc] initWithFrame:view.frame];
 
     if (!view) {
+        [viewGroup addSubview:wrappingview];
         return wrappingview;
     }
     wrappingview.desiredContentSize = intrinsicContentSize;


### PR DESCRIPTION
## Related Issue
Fixed #4105 

## Description
When image is not available, Image renderer does not add the empty view to the super view. This will lead to an exception when two consecutive items with stretch are present because for those two items, layout constraint is set, and both items are needed to have a common ancestor.

## How Verified
1. JSON sample card was ran. this card was not added to our sample cards since this scenario is only relevant to iOS.   

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4196)