### PR TITLE
[TS][Renderer] Add TextRun.underline

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/shared.ts
+++ b/source/nodejs/adaptivecards-designer/src/shared.ts
@@ -13,5 +13,6 @@ export var SupportedTargetVersions: Adaptive.Version[] = [
     Adaptive.Versions.v1_0,
     Adaptive.Versions.v1_1,
     Adaptive.Versions.v1_2,
+    Adaptive.Versions.v1_3,
     Adaptive.Versions.vNext
 ];

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -1098,6 +1098,7 @@ export class TextRun extends BaseTextBlock {
     static readonly italicProperty = new BoolProperty(Versions.v1_2, "italic", false);
     static readonly strikethroughProperty = new BoolProperty(Versions.v1_2, "strikethrough", false);
     static readonly highlightProperty = new BoolProperty(Versions.v1_2, "highlight", false);
+    static readonly underlineProperty = new BoolProperty(Versions.v1_3, "underline", false);
 
     protected populateSchema(schema: SerializableObjectSchema) {
         super.populateSchema(schema);
@@ -1113,6 +1114,9 @@ export class TextRun extends BaseTextBlock {
 
     @property(TextRun.highlightProperty)
     highlight: boolean = false;
+
+    @property(TextRun.underlineProperty)
+    underline: boolean = false;
 
     //#endregion
 
@@ -1179,6 +1183,10 @@ export class TextRun extends BaseTextBlock {
             let colorDefinition = this.getColorDefinition(this.getEffectiveStyleDefinition().foregroundColors, this.effectiveColor);
 
             targetElement.style.backgroundColor = <string>Utils.stringToCssColor(this.isSubtle ? colorDefinition.highlightColors.subtle : colorDefinition.highlightColors.default);
+        }
+
+        if (this.underline) {
+            targetElement.style.textDecoration = "underline";
         }
     }
 

--- a/source/nodejs/adaptivecards/src/serialization.ts
+++ b/source/nodejs/adaptivecards/src/serialization.ts
@@ -104,7 +104,8 @@ export class Versions {
     static readonly v1_0 = new Version(1, 0);
     static readonly v1_1 = new Version(1, 1);
     static readonly v1_2 = new Version(1, 2);
-    static readonly latest = Versions.v1_2;
+    static readonly v1_3 = new Version(1, 3);
+    static readonly latest = Versions.v1_3;
     static readonly vNext = new Version(1000, 0, "vNext");
 }
 


### PR DESCRIPTION
## Related Issue
Fixes https://github.com/microsoft/AdaptiveCards/issues/3051
Fixes https://github.com/microsoft/AdaptiveCards/issues/3218
Fixes https://github.com/microsoft/AdaptiveCards/issues/3221

## Description
Adds the `underline` property to TextRun

## How Verified
Verified manually in adaptivecards-designer-app

Test payload:
```json
{
    "type": "AdaptiveCard",
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
    "version": "1.3",
    "body": [
        {
            "type": "RichTextBlock",
            "inlines": [
                {
                    "type": "TextRun",
                    "text": "Now you can have "
                },
                {
                    "type": "TextRun",
                    "text": "underlined text",
                    "underline": true
                },
                {
                    "type": "TextRun",
                    "text": " within a RichTextBLock"
                }
            ]
        }
    ]
}
```

As rendered:
![image](https://user-images.githubusercontent.com/1334689/85338658-8ef98500-b497-11ea-8af2-b2ee68e09445.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4205)