### PR TITLE
[Designer] Change icon and error background colors for contrast

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/adaptivecards-designer.css
+++ b/source/nodejs/adaptivecards-designer/src/adaptivecards-designer.css
@@ -107,7 +107,7 @@
 .acd-error-pane {
     flex: 0 0 65px;
     color: white;
-    background-color: #3a96dd;
+    background-color: #2D7BB7;
     border-top: 1px solid #D2D2D2;
     overflow-x: hidden;
     overflow-y: auto;
@@ -281,11 +281,11 @@
 }
 
 .acd-toolPalette-icon {
-    color: #3a96dd;
+    color: #2D7BB7;
 }
 
 .acd-treeView-icon {
-    color: #3a96dd;
+    color: #2D7BB7;
 }
 
 .acd-icon-bolt::before {
@@ -727,7 +727,7 @@
 }
 
 .acd-data-tree-item-additionalText {
-    color: #3a96dd;
+    color: #2D7BB7;
     margin-left: 8px;
 }
 
@@ -978,6 +978,6 @@ a.default-ac-anchor:visited:active {
 }
 
 .default-ac-textBlock.default-ac-selectable:hover {
-    color: #3A96DD !important;
+    color: #2D7BB7 !important;
     cursor: pointer;
 }


### PR DESCRIPTION
## Related Issue
Fixes VSO #24094745

## Description
The blue color we use for icons (and the error background) is a bit too light to contrast well with a white background (or white text on the blue color's background in the case of the error banner). Fix is to use a darker blue in CSS.

### Before (icons)
![image](https://user-images.githubusercontent.com/16614499/85345452-611c3c80-b4a7-11ea-87fa-0501598d3aa2.png)

### After (icons)
![image](https://user-images.githubusercontent.com/16614499/85345465-65e0f080-b4a7-11ea-9889-0206f006eecb.png)

### Before (error banner)
![image](https://user-images.githubusercontent.com/16614499/85347167-a727cf00-b4ac-11ea-9137-955ca49dd98c.png)

### After (error banner)
![image](https://user-images.githubusercontent.com/16614499/85347142-970fef80-b4ac-11ea-95f8-4fc58e9555d0.png)

## How Verified
* local build, devtools color tooling

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4207)