### PR TITLE
Remove try-catch from ParseUtil::GetBackgroundImage and other small fixes

### DIFF
--- a/source/shared/cpp/ObjectModel/BaseActionElement.h
+++ b/source/shared/cpp/ObjectModel/BaseActionElement.h
@@ -42,10 +42,9 @@ namespace AdaptiveSharedNamespace
 
         static void ParseJsonObject(AdaptiveSharedNamespace::ParseContext& context, const Json::Value& json, std::shared_ptr<BaseElement>& element);
 
-    protected:
+    private:
         void PopulateKnownPropertiesSet();
 
-    private:
         std::string m_title;
         std::string m_iconUrl;
         std::string m_style;

--- a/source/shared/cpp/ObjectModel/BaseCardElement.h
+++ b/source/shared/cpp/ObjectModel/BaseCardElement.h
@@ -48,9 +48,10 @@ namespace AdaptiveSharedNamespace
 
     protected:
         static Json::Value SerializeSelectAction(const std::shared_ptr<BaseActionElement> selectAction);
-        void PopulateKnownPropertiesSet();
 
     private:
+        void PopulateKnownPropertiesSet();
+
         CardElementType m_type;
         Spacing m_spacing;
         HeightType m_height;

--- a/source/shared/cpp/ObjectModel/BaseElement.cpp
+++ b/source/shared/cpp/ObjectModel/BaseElement.cpp
@@ -51,7 +51,7 @@ namespace AdaptiveSharedNamespace
                                   AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Type)});
     }
 
-    Json::Value BaseElement::GetAdditionalProperties() const { return m_additionalProperties; }
+    const Json::Value& BaseElement::GetAdditionalProperties() const { return m_additionalProperties; }
 
     void BaseElement::SetAdditionalProperties(Json::Value const& value) { m_additionalProperties = value; }
 
@@ -91,7 +91,7 @@ namespace AdaptiveSharedNamespace
 
     Json::Value BaseElement::SerializeToJsonValue() const
     {
-        Json::Value root = GetAdditionalProperties();
+        Json::Value root = GetAdditionalProperties(); // Create a copy of the additional properties by assigning the return value to a value, rather than reference, type
 
         // Important -- we're explicitly getting the type as a string here because that's where we store the type that
         // was specified by the card author.

--- a/source/shared/cpp/ObjectModel/BaseElement.h
+++ b/source/shared/cpp/ObjectModel/BaseElement.h
@@ -71,7 +71,7 @@ namespace AdaptiveSharedNamespace
 
         virtual std::string Serialize() const;
         virtual Json::Value SerializeToJsonValue() const;
-        Json::Value GetAdditionalProperties() const;
+        const Json::Value& GetAdditionalProperties() const;
         void SetAdditionalProperties(const Json::Value& additionalProperties);
 
         // Fallback and Requires support

--- a/source/shared/cpp/ObjectModel/BaseInputElement.h
+++ b/source/shared/cpp/ObjectModel/BaseInputElement.h
@@ -24,10 +24,9 @@ namespace AdaptiveSharedNamespace
 
         Json::Value SerializeToJsonValue() const override;
 
-    protected:
+    private:
         void PopulateKnownPropertiesSet();
 
-    private:
         bool m_isRequired;
         std::string m_errorMessage;
     };

--- a/source/shared/cpp/ObjectModel/Inline.cpp
+++ b/source/shared/cpp/ObjectModel/Inline.cpp
@@ -30,9 +30,14 @@ std::string Inline::GetInlineTypeString() const
     return InlineElementTypeToString(m_type);
 }
 
-Json::Value Inline::GetAdditionalProperties() const
+const Json::Value& Inline::GetAdditionalProperties() const
 {
     return m_additionalProperties;
+}
+
+void Inline::SetAdditionalProperties(Json::Value&& value)
+{
+    m_additionalProperties = std::move(value);
 }
 
 void Inline::SetAdditionalProperties(Json::Value const& value)

--- a/source/shared/cpp/ObjectModel/Inline.h
+++ b/source/shared/cpp/ObjectModel/Inline.h
@@ -33,11 +33,12 @@ namespace AdaptiveSharedNamespace
         void SetAdditionalProperties(const Json::Value& additionalProperties);
 
     protected:
-        void PopulateKnownPropertiesSet();
         std::unordered_set<std::string> m_knownProperties;
         Json::Value m_additionalProperties;
 
     private:
+        void PopulateKnownPropertiesSet();
+
         InlineElementType m_type;
     };
 }

--- a/source/shared/cpp/ObjectModel/Inline.h
+++ b/source/shared/cpp/ObjectModel/Inline.h
@@ -28,7 +28,8 @@ namespace AdaptiveSharedNamespace
 
         static std::shared_ptr<Inline> Deserialize(ParseContext& context, const Json::Value& root);
 
-        Json::Value GetAdditionalProperties() const;
+        const Json::Value& GetAdditionalProperties() const;
+        void SetAdditionalProperties(Json::Value&& additionalProperties);
         void SetAdditionalProperties(const Json::Value& additionalProperties);
 
     protected:

--- a/source/shared/cpp/ObjectModel/ParseUtil.cpp
+++ b/source/shared/cpp/ObjectModel/ParseUtil.cpp
@@ -150,29 +150,34 @@ namespace AdaptiveSharedNamespace
 
     std::shared_ptr<BackgroundImage> ParseUtil::GetBackgroundImage(const Json::Value& json)
     {
-        try
-        {
-            // handle "backgroundImage": <string>
-            std::string backgroundImageUrl = ParseUtil::GetString(json, AdaptiveCardSchemaKey::BackgroundImage, false);
-            if (backgroundImageUrl != "")
-            {
-                return std::make_shared<BackgroundImage>(backgroundImageUrl);
-            }
+        // handle "backgroundImage": <string>
+        const std::string& backgroundImagePropertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::BackgroundImage);
+        Json::Value propertyValue = json.get(backgroundImagePropertyName, Json::Value());
 
+        if (propertyValue.empty())
+        {
             // handle "backgroundImageUrl": <string>
-            backgroundImageUrl = ParseUtil::GetString(json, AdaptiveCardSchemaKey::BackgroundImageUrl, false);
+            const std::string& backgroundImageUrlPropertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::BackgroundImageUrl);
+            propertyValue = json.get(backgroundImageUrlPropertyName, Json::Value());
+        }
+
+        if (propertyValue.isString())
+        {
+            const std::string backgroundImageUrl = propertyValue.asString();
+
             if (backgroundImageUrl != "")
             {
                 return std::make_shared<BackgroundImage>(backgroundImageUrl);
             }
-            return nullptr;
         }
-        catch (AdaptiveCardParseException)
+        else if (!propertyValue.empty())
         {
             // handle "backgroundImage": { <content> }
             auto jsonValue = ParseUtil::ExtractJsonValue(json, AdaptiveCardSchemaKey::BackgroundImage, false);
             return BackgroundImage::Deserialize(jsonValue);
         }
+
+        return nullptr;
     }
 
     bool ParseUtil::GetBool(const Json::Value& json, AdaptiveCardSchemaKey key, bool defaultValue, bool isRequired)

--- a/source/shared/cpp/ObjectModel/ParseUtil.h
+++ b/source/shared/cpp/ObjectModel/ParseUtil.h
@@ -55,11 +55,11 @@ namespace AdaptiveSharedNamespace
 
         Json::Value ExtractJsonValue(const Json::Value& jsonRoot, AdaptiveCardSchemaKey key, bool isRequired = false);
 
-        template<typename T>
+        template<typename T, typename Fn>
         T GetEnumValue(const Json::Value& json,
                        AdaptiveCardSchemaKey key,
                        T defaultEnumValue,
-                       std::function<T(const std::string& name)> enumConverter,
+                       Fn enumConverter,
                        bool isRequired = false);
 
         template<typename T>
@@ -103,11 +103,11 @@ namespace AdaptiveSharedNamespace
         std::string ToLowercase(const std::string& value);
     };
 
-    template<typename T>
+    template<typename T, typename Fn>
     T ParseUtil::GetEnumValue(const Json::Value& json,
                               AdaptiveCardSchemaKey key,
                               T defaultEnumValue,
-                              std::function<T(const std::string& name)> enumConverter,
+                              Fn enumConverter,
                               bool isRequired)
     {
         std::string propertyValueStr = "";

--- a/source/shared/cpp/ObjectModel/TextRun.h
+++ b/source/shared/cpp/ObjectModel/TextRun.h
@@ -62,8 +62,10 @@ namespace AdaptiveSharedNamespace
 
     protected:
         std::shared_ptr<RichTextElementProperties> m_textElementProperties;
-        void PopulateKnownPropertiesSet();
         std::shared_ptr<BaseActionElement> m_selectAction;
         bool m_highlight;
+
+    private:
+        void PopulateKnownPropertiesSet();
     };
 }

--- a/source/uwp/Renderer/lib/Util.cpp
+++ b/source/uwp/Renderer/lib/Util.cpp
@@ -1420,8 +1420,7 @@ HRESULT JsonObjectToJsonCpp(_In_ ABI::Windows::Data::Json::IJsonObject* jsonObje
     std::string jsonString;
     RETURN_IF_FAILED(JsonObjectToString(jsonObject, jsonString));
 
-    Json::Value value = ParseUtil::GetJsonValueFromString(jsonString);
-    *jsonCppValue = value;
+    *jsonCppValue = ParseUtil::GetJsonValueFromString(jsonString);
 
     return S_OK;
 }


### PR DESCRIPTION
## Related Issue
Resolves #4217 

## Description
The ParseUtil::GetBackgroundImage throws and catches exception during 'good path' execution. This is confusing for new users of the library and goes against good programming practices. This PR replaces the try-catch with an if-else statement. There are also a number of other small fixes included in this PR:

- Ensure all PopulateKnownPropertiesSet functions are private, not protected.
- Update BaseElement::GetAdditionalProperties and Inline::GetAdditionalProperties to return a const reference instead of a value type.
- Update GetEnumValue function to use a template type parameter rather than std::function.
- Avoid use of unnecessary local variable in JsonObjectToJsonCpp for performance reasons.

## How Verified
Ran the existing unit tests and manually tested various cards with background images.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4218)