### PR TITLE
[Cherry Pick][Android] Fix ChoiceSet wrapping

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/ChoiceSetInputRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/ChoiceSetInputRenderer.java
@@ -143,7 +143,7 @@ public class ChoiceSetInputRenderer extends BaseCardElementRenderer
 
             if(!choiceSetInput.GetWrap())
             {
-                radioButton.setLines(1);
+                radioButton.setMaxLines(1);
                 radioButton.setEllipsize(TextUtils.TruncateAt.END);
             }
 


### PR DESCRIPTION
## Related Issue
Fixes #4016 

## Description
Consistent spacing behavior for both wrapped and non-wrapped choiceset's.

## How Verified
Manual verification, screenshot below for payload attached in the linked issue.

![image](https://user-images.githubusercontent.com/4442788/85898828-f9c5fb80-b7ca-11ea-91a3-a6d563106913.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4234)