### PR TITLE
Updated text block to treat empty text string as invalid

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRenderer.mm
@@ -179,7 +179,7 @@ using namespace AdaptiveCards;
     auto prevElem = elems.empty() ? nullptr : *firstelem;
 
     for (const auto &elem : elems) {
-        if (*firstelem != elem) {
+        if (*firstelem != elem && prevStretchableElem) {
             ACRSeparator *separator = [ACRSeparator renderSeparation:elem
                                                         forSuperview:view
                                                       withHostConfig:[config getHostConfig]];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextBlockRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextBlockRenderer.mm
@@ -41,6 +41,11 @@
     std::shared_ptr<HostConfig> config = [acoConfig getHostConfig];
     std::shared_ptr<BaseCardElement> elem = [acoElem element];
     std::shared_ptr<TextBlock> txtBlck = std::dynamic_pointer_cast<TextBlock>(elem);
+
+    if (txtBlck->GetText().empty()) {
+        return nil;
+    }
+
     ACRUILabel *lab = [[ACRUILabel alloc] initWithFrame:CGRectMake(0, 0, 0, 0)];
     lab.backgroundColor = [UIColor clearColor];
 


### PR DESCRIPTION
## Related Issue
Fixes #3702 for iOS. 

## Description
Empty string is treated as invalid, and TextBlock won't get rendered. 

## How Verified
How you verified the fix, including one or all of the following: 
1. Existing relevant unit/regression tests that you ran
2. Test Payload is tested.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4248)