### PR TITLE
Reactnative: Label support for all the Input elements.

### DIFF
--- a/source/community/reactnative/src/components/inputs/choice-set/choice-set-input.js
+++ b/source/community/reactnative/src/components/inputs/choice-set/choice-set-input.js
@@ -23,6 +23,7 @@ import * as Constants from '../../../utils/constants';
 import * as Enums from '../../../utils/enums';
 import { StyleManager } from '../../../styles/style-config';
 import { HostConfigManager } from '../../../utils/host-config';
+import InputLabel from "../input-label";
 
 const DropDownImage = './assets/dropdown.png';
 const CompactStyle = "compact";
@@ -41,6 +42,7 @@ export class ChoiceSetInput extends React.Component {
 		this.value = props.json.value;
 		this.choices = [];
 		this.payload = props.json;
+		this.label = Constants.EmptyString;
 
 		this.isValidationRequired = !!this.payload.validation &&
 			(Enums.ValidationNecessity.Required == this.payload.validation.necessity ||
@@ -71,6 +73,7 @@ export class ChoiceSetInput extends React.Component {
 		this.style = this.payload.style;
 		this.choices = this.payload.choices;
 		this.wrapText = this.payload.wrap || false
+		this.label = this.payload.label;
 	}
 
 	validate = () => {
@@ -283,9 +286,10 @@ export class ChoiceSetInput extends React.Component {
 
 		this.parseHostConfig();
 
-		let {
+		const {
 			isMultiSelect,
 			style,
+			label
 		} = this
 
 		onPress = () => {
@@ -298,6 +302,7 @@ export class ChoiceSetInput extends React.Component {
 			<InputContextConsumer>
 				{({ addInputItem, showErrors }) => (
 					<ElementWrapper json={this.payload} style={styles.containerView} isError={this.state.isError} isFirst={this.props.isFirst}>
+						<InputLabel label={label} />
 						<View style={this.getComputedStyles(showErrors)}>
 							{!isMultiSelect ?
 								((style == CompactStyle || style == undefined) ?
@@ -316,7 +321,7 @@ export class ChoiceSetInput extends React.Component {
 	 * @param showErrors show errors based on this flag.
 	 */
 	getComputedStyles = (showErrors) => {
-		let computedStyles = [];
+		let computedStyles = [styles.choiceSetView];
 		if (this.state.isError && (showErrors || this.validationRequiredWithVisualCue)) {
 			computedStyles.push(this.styleConfig.borderAttention);
 			computedStyles.push({ borderWidth: 1 });
@@ -328,6 +333,10 @@ export class ChoiceSetInput extends React.Component {
 const styles = StyleSheet.create({
 	containerView: {
 		alignSelf: Constants.AlignStretch,
+		marginVertical: 3,
+	},
+	choiceSetView: {
+		marginTop: 3
 	},
 	pickerContainer: {
 		backgroundColor: Constants.EmphasisColor,

--- a/source/community/reactnative/src/components/inputs/input-label.js
+++ b/source/community/reactnative/src/components/inputs/input-label.js
@@ -1,0 +1,43 @@
+import React from "react";
+import { Label } from '../elements';
+import { Registry } from '../registration/registry';
+import { StyleManager } from '../../styles/style-config';
+import * as Constants from '../../utils/constants';
+import * as Utils from '../../utils/util';
+
+export default class InputLabel extends React.Component {
+
+	styleConfig = StyleManager.getManager().styles;
+
+	constructor(props) {
+		super(props);
+		this.label = props.label || Constants.EmptyString;
+		this.wrap = props.wrap || false;
+		this.style = props.style || {};
+	}
+
+	render() {
+		const { label, wrap, style } = this;
+		if (label == Constants.EmptyString) return null;
+		else {
+			if (typeof label == Constants.TypeString) {
+				return (
+					<Label
+						text={label}
+						style={[this.styleConfig.defaultFontConfig, style]}
+						wrap={wrap} />
+				);
+			} else if (typeof label == Constants.TypeObject && this.isValidLabelType(label.type)) {
+				let children = [];
+				if (!Utils.isNullOrEmpty(label)) {
+					children = Registry.getManager().parseRegistryComponents([label], this.context.onParseError);
+				}
+				return children.map((ChildElement, index) => React.cloneElement(ChildElement));
+			} else return null;
+		}
+	}
+
+	isValidLabelType = type => {
+		return !Utils.isNullOrEmpty(type) && (type == Constants.TypeTextBlock || type == Constants.TypeRichTextBlock);
+	}
+}

--- a/source/community/reactnative/src/components/inputs/input.js
+++ b/source/community/reactnative/src/components/inputs/input.js
@@ -21,7 +21,7 @@ import * as Constants from '../../utils/constants';
 import { HostConfigManager } from '../../utils/host-config';
 import * as Utils from '../../utils/util';
 import * as Enums from '../../utils/enums';
-import { Label } from '../elements'
+import InputLabel from "./input-label";
 
 export class Input extends React.Component {
 
@@ -64,7 +64,8 @@ export class Input extends React.Component {
 			type,
 			isMultiline,
 			placeholder,
-			maxLength
+			maxLength,
+			label
 		} = this;
 
 		if (!id || !type) {
@@ -81,8 +82,8 @@ export class Input extends React.Component {
 						if (!inputArray[this.id])
 							addInputItem(this.id, { value: this.props.value, errorState: this.props.isError });
 						return (
-							<ElementWrapper json={this.payload} isError={this.props.isError} isFirst={this.props.isFirst}>
-								{this.renderLabel()}
+							<ElementWrapper style={styles.elementWrapper} json={this.payload} isError={this.props.isError} isFirst={this.props.isFirst}>
+								<InputLabel label={label}/>
 								<TextInput
 									style={this.getComputedStyles(showErrors)}
 									autoCapitalize={Constants.NoneString}
@@ -140,6 +141,7 @@ export class Input extends React.Component {
 		this.textStyle = Utils.getEffectiveInputStyle(this.props.styleValue);
 		this.keyboardType = Utils.getKeyboardType(this.props.styleValue);
 		this.inlineAction = this.payload.inlineAction;
+		this.label = this.payload.label;
 	}
 
     /**
@@ -179,6 +181,7 @@ export class Input extends React.Component {
 			textStyle,
 			keyboardType,
 			inlineAction,
+			label,
 		} = this;
 
 		if (!id || !type) {
@@ -205,7 +208,9 @@ export class Input extends React.Component {
 			return (
 				<View>
 					<ElementWrapper json={payload} style={wrapperStyle} isError={this.props.isError} isFirst={this.props.isFirst}>
-						<TextInput
+						<View style={styles.elementWrapper}>
+							<InputLabel label={label}/>
+							<TextInput
 							style={[styles.inlineActionTextInput, this.getComputedStyles(this.state.showInlineActionErrors)]}
 							autoCapitalize={Constants.NoneString}
 							autoCorrect={false}
@@ -228,6 +233,7 @@ export class Input extends React.Component {
 							}}
 							value={this.props.value}
 						/>
+						</View>
 						<TouchableOpacity onPress={() => { this.onClickHandle(onExecuteAction, 'inline-action') }}>
 							{Utils.isNullOrEmpty(inlineAction.iconUrl) ?
 								<Text style={styles.inlineActionText}>{inlineAction.title}</Text> :
@@ -290,27 +296,6 @@ export class Input extends React.Component {
 			}
 		}
 	}
-
-	renderLabel = () => {
-		let text = Constants.EmptyString;
-		let wrap = false;
-		if(this.label == Constants.EmptyString) return null;
-		
-		else{
-			if(typeof this.label == "string" ){
-				text = this.label;
-			}else if (typeof this.label == "object"){
-				
-			}
-			return (
-				label ? <Label
-					text={label}
-					style={[this.styleConfig.choiceSetTitle, this.styleConfig.defaultFontConfig]}
-					wrap={wrap} />
-					: null
-			)
-		}
-	}
 }
 
 const styles = StyleSheet.create({
@@ -325,10 +310,14 @@ const styles = StyleSheet.create({
 	singleLineHeight: {
 		height: 44,
 	},
+	elementWrapper: {
+		flex: 1,
+		marginVertical : 3
+	},
 	input: {
 		width: Constants.FullWidth,
 		padding: 5,
-		marginTop: 15,
+		marginTop: 3,
 	},
 	inlineActionWrapper: {
 		flexDirection: 'row',
@@ -347,7 +336,6 @@ const styles = StyleSheet.create({
 		marginLeft: 10,
 		width: 40,
 		height: 40,
-		marginTop: 15,
 		backgroundColor: 'transparent',
 		flexShrink: 0,
 	},

--- a/source/community/reactnative/src/components/inputs/input.js
+++ b/source/community/reactnative/src/components/inputs/input.js
@@ -21,6 +21,7 @@ import * as Constants from '../../utils/constants';
 import { HostConfigManager } from '../../utils/host-config';
 import * as Utils from '../../utils/util';
 import * as Enums from '../../utils/enums';
+import { Label } from '../elements'
 
 export class Input extends React.Component {
 
@@ -37,6 +38,7 @@ export class Input extends React.Component {
 		this.type = Constants.EmptyString;
 		this.keyboardType = Constants.EmptyString;
 		this.textStyle = Constants.EmptyString;
+		this.label = Constants.EmptyString;
 
 		this.validationRequiredWithVisualCue = (!this.payload.validation ||
 			Enums.ValidationNecessity.RequiredWithVisualCue == this.payload.validation.necessity);
@@ -80,6 +82,7 @@ export class Input extends React.Component {
 							addInputItem(this.id, { value: this.props.value, errorState: this.props.isError });
 						return (
 							<ElementWrapper json={this.payload} isError={this.props.isError} isFirst={this.props.isFirst}>
+								{this.renderLabel()}
 								<TextInput
 									style={this.getComputedStyles(showErrors)}
 									autoCapitalize={Constants.NoneString}
@@ -285,6 +288,27 @@ export class Input extends React.Component {
 				};
 				onExecuteAction(actionObject, true);
 			}
+		}
+	}
+
+	renderLabel = () => {
+		let text = Constants.EmptyString;
+		let wrap = false;
+		if(this.label == Constants.EmptyString) return null;
+		
+		else{
+			if(typeof this.label == "string" ){
+				text = this.label;
+			}else if (typeof this.label == "object"){
+				
+			}
+			return (
+				label ? <Label
+					text={label}
+					style={[this.styleConfig.choiceSetTitle, this.styleConfig.defaultFontConfig]}
+					wrap={wrap} />
+					: null
+			)
 		}
 	}
 }

--- a/source/community/reactnative/src/components/inputs/picker-input.js
+++ b/source/community/reactnative/src/components/inputs/picker-input.js
@@ -22,6 +22,7 @@ import * as Constants from '../../utils/constants';
 import * as Enums from '../../utils/enums';
 import { StyleManager } from '../../styles/style-config';
 import { HostConfigManager } from '../../utils/host-config';
+import InputLabel from "./input-label";
 
 export class PickerInput extends React.Component {
 
@@ -35,6 +36,7 @@ export class PickerInput extends React.Component {
 		this.placeHolder = Constants.EmptyString;
 		this.type = Constants.EmptyString;
 		this.modalButtonText = Constants.DoneString;
+		this.label = Constants.EmptyString;
 		this.parseHostConfig();
 
 		this.isValidationRequired = !!this.payload.validation &&
@@ -56,6 +58,7 @@ export class PickerInput extends React.Component {
 		this.id = this.payload.id;
 		this.type = this.payload.type;
 		this.placeholder = this.payload.placeholder;
+		this.label = this.payload.label;
 	}
 
 	componentWillReceiveProps(newProps) {
@@ -71,7 +74,8 @@ export class PickerInput extends React.Component {
 			id,
 			type,
 			placeholder,
-			modalButtonText
+			modalButtonText,
+			label
 		} = this;
 
 		if (!id || !type) {
@@ -86,7 +90,8 @@ export class PickerInput extends React.Component {
 		return (
 			<InputContextConsumer>
 				{({ addInputItem, showErrors }) => (
-					<ElementWrapper json={this.payload} isError={this.state.isError} isFirst={this.props.isFirst}>
+					<ElementWrapper style={styles.elementWrapper} json={this.payload} isError={this.state.isError} isFirst={this.props.isFirst}>
+						<InputLabel label={label}/>
 						<TouchableOpacity style={styles.inputWrapper} onPress={this.props.showPicker}>
 							{/* added extra view to fix touch event in ios . */}
 							<View pointerEvents='none' style={this.getComputedStyles(showErrors)}>
@@ -149,7 +154,10 @@ export class PickerInput extends React.Component {
 const styles = StyleSheet.create({
 	inputWrapper: {
 		width: Constants.FullWidth,
-		marginTop: 15,
+		marginTop: 3,
+	},
+	elementWrapper: {
+		marginVertical : 3
 	},
 	overlay: {
 		flex: 1,

--- a/source/community/reactnative/src/components/inputs/toggle-input.js
+++ b/source/community/reactnative/src/components/inputs/toggle-input.js
@@ -19,6 +19,7 @@ import { Label } from '../elements';
 import ElementWrapper from '../elements/element-wrapper';
 import * as Constants from '../../utils/constants';
 import * as Enums from '../../utils/enums';
+import InputLabel from "./input-label";
 
 export class ToggleInput extends React.Component {
 
@@ -32,6 +33,7 @@ export class ToggleInput extends React.Component {
 		this.valueOff = props.json.valueOff || Constants.FalseString;
 		this.value = props.json.value || this.valueOff;
 		this.id = props.json.id || Constants.ToggleValueOn
+		this.label = props.json.label;
 
 		this.isValidationRequired = !!props.json.validation &&
 			(Enums.ValidationNecessity.Required == props.json.validation.necessity ||
@@ -77,6 +79,7 @@ export class ToggleInput extends React.Component {
 						}
 						return (
 							<View>
+								<InputLabel label={this.label}/>
 								<View style={this.getComputedStyles(showErrors)}>
 									<Label text={this.title} wrap={this.wrapText} style={styles.title} />
 									<Switch

--- a/source/community/reactnative/src/models/input-model.js
+++ b/source/community/reactnative/src/models/input-model.js
@@ -1,13 +1,14 @@
-import {BaseModel} from './base-model'
+import { BaseModel } from './base-model'
 import { ElementType } from '../utils/enums'
 
-export class BaseInputModel extends BaseModel{
+export class BaseInputModel extends BaseModel {
     constructor(payload, parent) {
         super(payload, parent);
         this.placeholder = payload.placeholder;
         this.value = payload.value;
         this.inlineAction = payload.inlineAction;
         this.validation = payload.validation;
+        this.label = payload.label;
     }
 }
 
@@ -27,7 +28,7 @@ export class NumberInputModel extends BaseInputModel {
     type = ElementType.NumberInput;
 
     constructor(payload, parent) {
-        super(payload, parent);            
+        super(payload, parent);
         this.max = payload.max;
         this.min = payload.min;
     }

--- a/source/community/reactnative/src/utils/constants.js
+++ b/source/community/reactnative/src/utils/constants.js
@@ -56,3 +56,8 @@ export const ErrorMessage = "Required";
 
 export const TypeColumnSet = "ColumnSet";
 export const TypeAdaptiveCard = "AdaptiveCard";
+export const TypeTextBlock = "TextBlock";
+export const TypeRichTextBlock = "RichTextBlock";
+
+export const TypeString = "string";
+export const TypeObject = "object"

--- a/source/community/reactnative/src/visualizer/payloads/payloads/Input.Label.json
+++ b/source/community/reactnative/src/visualizer/payloads/payloads/Input.Label.json
@@ -1,0 +1,173 @@
+{
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "type": "AdaptiveCard",
+    "version": "1.0",
+    "body": [
+      {
+        "type": "TextBlock",
+        "size": "medium",
+        "weight": "bolder",
+        "text": "Input with Label",
+        "horizontalAlignment": "center"
+      },
+      {
+        "type": "Input.Text",
+        "style": "text",
+        "label": "Name",
+        "maxLength": 0,
+        "id": "SimpleVal",
+        "validation": {
+          "necessity": "Required",
+          "errorMessage": "Required"
+          }
+      },
+      {
+        "type": "Input.Number",
+        "id": "Phone",
+        "label": {
+          "type": "TextBlock",
+          "spacing": "none",
+          "color" : "warning",
+          "text": "Phone - **TextBlock**",
+          "wrap": true
+        },
+        "validation": {
+          "necessity": "Optional",
+          "errorMessage": " "
+          },
+        "inlineAction": {
+          "type": "Action.Submit",
+          "title": "Reply"
+        }
+      },
+      {
+        "type": "Input.Date",
+        "id": "DateVal",
+        "label": {
+          "type": "RichTextBlock",
+          "wrap": true,
+          "maxLines": 5,
+          "paragraphs": [
+              {
+                  "inlines": [
+                      {
+                          "type": "TextRun",
+                          "text": "Due Date",
+                          "color": "good",
+                          "selectAction": {
+                              "type": "Action.Submit",
+                              "title": "cool link"
+                          }
+                      },
+                      {
+                          "type": "TextRun",
+                          "text": " - **RichTextBlock**",
+                          "color": "good",
+                          "selectAction": {
+                              "type": "Action.Submit",
+                              "title": "cool link"
+                          }
+                      }
+                  ]
+              }
+          ]
+        },
+        "maxLength": 0
+      },
+      {
+        "type": "Input.Time",
+        "label": "Start time",
+        "id": "TimeVal",
+        "value": "16:59"
+      },
+      {
+        "type": "Input.ChoiceSet",
+        "id": "SingleSelectVal",
+        "style": "expanded",
+        "value" : "incorrect value",
+        "label": "What color do you want? (expanded)",
+        "choices": [
+          {
+            "title": "Red",
+            "value": "1"
+          },
+          {
+            "title": "Green",
+            "value": "2"
+          },
+          {
+            "title": "Blue",
+            "value": "3"
+          }
+        ]
+      },
+      {
+        "type": "Input.ChoiceSet",
+        "id": "MultiSelectVal",
+        "isMultiSelect": true,
+        "value": "1,2",
+        "label": {
+          "type": "TextBlock",
+          "text": "What colors do you want? (multi select)"
+        },
+        "choices": [
+          {
+            "title": "Red",
+            "value": "1"
+          },
+          {
+            "title": "Green",
+            "value": "2"
+          },
+          {
+            "title": "Blue",
+            "value": "3"
+          }
+        ]
+      },
+      {
+        "type": "Input.Toggle",
+        "label": "If you agree please enable",
+        "title": "Red cars are better than other cars",
+        "valueOn": "RedCars",
+        "valueOff": "NotRedCars",
+        "id": "ColorPreference",
+        "validation": {
+          "necessity": "Required",
+          "errorMessage": "Required"
+          }
+      }
+    ],
+    "actions": [
+      {
+        "type": "Action.Submit",
+        "title": "Submit",
+        "ignoreInputValidation": false,
+        "data": {
+          "id": "1234567890"
+        }
+      },
+      {
+        "type": "Action.ShowCard",
+        "title": "Show Card",
+        "card": {
+          "type": "AdaptiveCard",
+          "body": [
+            {
+              "type": "Input.Text",
+              "placeholder": "enter comment",
+              "style": "text",
+              "maxLength": 0,
+              "id": "CommentVal"
+            }
+          ],
+          "actions": [
+            {
+              "type": "Action.Submit",
+              "title": "OK"
+            }
+          ]
+        }
+      }
+    ]
+  }

--- a/source/community/reactnative/src/visualizer/payloads/payloads/index.js
+++ b/source/community/reactnative/src/visualizer/payloads/payloads/index.js
@@ -248,6 +248,10 @@ export default payloads = [
     "json": require('./Image.Style.json')
   },
   {
+    "title": "Input.Label.json",
+    "json": require('./Input.Label.json')
+  },
+  {
     "title": "Input.ChoiceSet.json",
     "json": require('./Input.ChoiceSet.json')
   },


### PR DESCRIPTION
## Description

Handled `label` property for all the Input elements. As per the schema `label` can be either **`string, TextBlock, RichTextBlock`**, and will be inside the input root-level object.

### Sample Payload

`{
        "type": "Input.Number",
        "id": "Phone",
        "label": {
          "type": "TextBlock",
          "spacing": "none",
          "color" : "warning",
          "text": "Phone",
          "wrap": true
        }
},`







###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4252)