### PR TITLE
Fix Column missing type in schema explorer

### DIFF
--- a/schemas/src/AdaptiveCard.json
+++ b/schemas/src/AdaptiveCard.json
@@ -30,7 +30,7 @@
     },
     "backgroundImage": {
       "type": "BackgroundImage",
-      "description": "Specifies the background image of the card.",
+      "description": "Specifies the background image of the card. Acceptable formats are PNG, JPEG, and GIF",
       "version": "1.2",
       "shorthands": [
         {

--- a/schemas/src/elements/ActionSet.json
+++ b/schemas/src/elements/ActionSet.json
@@ -5,7 +5,7 @@
   "properties": {
     "actions": {
       "type": "Action[]",
-      "description": "The array of `Image` elements to show.",
+      "description": "The array of `Action` elements to show.",
       "required": true
     }
   },

--- a/schemas/src/elements/Column.json
+++ b/schemas/src/elements/Column.json
@@ -9,7 +9,7 @@
     },
     "backgroundImage": {
       "type": "BackgroundImage",
-      "description": "Specifies the background image.",
+      "description": "Specifies the background image. Acceptable formats are PNG, JPEG, and GIF",
       "version": "1.2",
       "shorthands": [
         {

--- a/schemas/src/elements/Column.json
+++ b/schemas/src/elements/Column.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/AdaptiveCards/6f39aedce45864ae1067ed44a5551dc973790bb5/source/nodejs/typed-schema/schema/lib/Type.json",
-  "extends": "ToggleableItem",
   "description": "Defines a container that is part of a ColumnSet.",
   "properties": {
     "items": {

--- a/schemas/src/elements/Container.json
+++ b/schemas/src/elements/Container.json
@@ -33,7 +33,7 @@
     },
     "backgroundImage": {
       "type": "BackgroundImage",
-      "description": "Specifies the background image.",
+      "description": "Specifies the background image. Acceptable formats are PNG, JPEG, and GIF",
       "version": "1.2",
       "shorthands": [
         {

--- a/schemas/src/elements/Image.json
+++ b/schemas/src/elements/Image.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/AdaptiveCards/6f39aedce45864ae1067ed44a5551dc973790bb5/source/nodejs/typed-schema/schema/lib/Type.json",
   "extends": "Element",
-  "description": "Displays an image.",
+  "description": "Displays an image. Acceptable formats are PNG, JPEG, and GIF",
   "properties": {
     "url": {
       "type": "uri-reference",

--- a/schemas/src/elements/ImageSet.json
+++ b/schemas/src/elements/ImageSet.json
@@ -1,16 +1,16 @@
 {
 	"$schema": "https://raw.githubusercontent.com/microsoft/AdaptiveCards/6f39aedce45864ae1067ed44a5551dc973790bb5/source/nodejs/typed-schema/schema/lib/Type.json",
 	"extends": "Element",
-	"description": "The ImageSet displays a collection of Images similar to a gallery.",
+	"description": "The ImageSet displays a collection of Images similar to a gallery. Acceptable formats are PNG, JPEG, and GIF",
 	"properties": {
 		"images": {
 			"type": "Image[]",
-      "description": "The array of `Image` elements to show.",
-      "required": true
-    },
-    "imageSize": {
+			"description": "The array of `Image` elements to show.",
+			"required": true
+		},
+		"imageSize": {
 			"type": "ImageSize",
 			"description": "Controls the approximate size of each image. The physical dimensions will vary per host."
-    }
+		}
 	}
 }

--- a/schemas/src/shared/BackgroundImage.json
+++ b/schemas/src/shared/BackgroundImage.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/AdaptiveCards/6f39aedce45864ae1067ed44a5551dc973790bb5/source/nodejs/typed-schema/schema/lib/Type.json",
-  "description": "Specifies a background image.",
+  "description": "Specifies a background image. Acceptable formats are PNG, JPEG, and GIF",
   "properties": {
     "url": {
       "type": "uri-reference",
-      "description": "The URL (or data url) of the image.",
+      "description": "The URL (or data url) of the image. Acceptable formats are PNG, JPEG, and GIF",
       "required": true
     },
     "fillMode": {


### PR DESCRIPTION
## Related Issue

Fixes #4156 

## Description

The schema had an incorrect base element defined and was hiding it's `type` property from the schema docs

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4259)