### PR TITLE
[UWP] Fix inline actions not getting inputs

### DIFF
--- a/source/uwp/Renderer/lib/ActionHelpers.cpp
+++ b/source/uwp/Renderer/lib/ActionHelpers.cpp
@@ -443,6 +443,13 @@ namespace AdaptiveNamespace::ActionHelpers
             return;
         }
 
+        if (actionType == ABI::AdaptiveNamespace::ActionType::Submit)
+        {
+            ComPtr<IAdaptiveSubmitAction> submitAction;
+            THROW_IF_FAILED(localInlineAction.As(&submitAction));
+            THROW_IF_FAILED(renderContext->LinkSubmitActionToCard(submitAction.Get(), renderArgs));
+        }
+
         // Create a grid to hold the text box and the action button
         ComPtr<IGridStatics> gridStatics;
         THROW_IF_FAILED(GetActivationFactory(HStringReference(RuntimeClass_Windows_UI_Xaml_Controls_Grid).Get(), &gridStatics));

--- a/specs/elements/AdaptiveCard.md
+++ b/specs/elements/AdaptiveCard.md
@@ -10,11 +10,10 @@
 | **actions** | `Action[]` | No | The Actions to show in the card's action bar. | 1.0 |
 | **selectAction** | `ISelectAction` | No | An Action that will be invoked when the card is tapped or selected. `Action.ShowCard` is not supported. | 1.1 |
 | **fallbackText** | `string` | No | Text shown when the client doesn't support the version specified (may contain markdown). | 1.0 |
-| **backgroundImage** | `BackgroundImage`, `uri` | No | Specifies the background image of the card. Acceptable formats are PNG, JPEG, and GIF | 1.2, 1.0 |
+| **backgroundImage** | `BackgroundImage`, `uri` | No | Specifies the background image of the card. | 1.2, 1.0 |
 | **minHeight** | `string` | No | Specifies the minimum height of the card. | 1.2 |
 | **speak** | `string` | No | Specifies what should be spoken for this entire card. This is simple text or SSML fragment. | 1.0 |
 | **lang** | `string` | No | The 2-letter ISO-639-1 language used in the card. Used to localize any date/time functions. | 1.0 |
-| **showRequiredInputHints** | `boolean` | No, default: `true` | True if required fields should be visually indicated | 1.3 |
 | **verticalContentAlignment** | `VerticalContentAlignment` | No | Defines how the content should be aligned vertically within the container. Only relevant for fixed-height cards, or cards with a `minHeight` specified. | 1.1 |
 | **$schema** | `uri` | No | The Adaptive Card schema. | 1.0 |
 
@@ -71,7 +70,7 @@ An Action that will be invoked when the card is tapped or selected. `Action.Show
 
 ## backgroundImage
 
-Specifies the background image of the card. Acceptable formats are PNG, JPEG, and GIF
+Specifies the background image of the card.
 
 * **Type**: `BackgroundImage`, `uri`
 * **Version** : 1.2, 1.0

--- a/specs/elements/Input.Text.md
+++ b/specs/elements/Input.Text.md
@@ -10,7 +10,7 @@
 | **maxLength** | `number` | No | Hint of maximum length characters to collect (may be ignored by some clients). | 1.0 |
 | **placeholder** | `string` | No | Description of the input desired. Displayed when no text has been input. | 1.0 |
 | **regex** | `string` | No | Regular expression indicating the required format of this text input. | 1.0 |
-| **style** | `TextInputStyle` | No |  | 1.0 |
+| **style** | `TextInputStyle` | No | Style hint for text input. | 1.0 |
 | **inlineAction** | `ISelectAction` | No | The inline action for the input. Typically displayed to the right of the input. It is strongly recommended to provide an icon on the action (which will be displayed instead of the title of the action). | 1.2 |
 | **value** | `string` | No | The initial value for this field. | 1.0 |
 


### PR DESCRIPTION
## Related Issue
Fixes #4241 

## Description
Adds a call to LinkSubmitActionToCard during inline action creation. This was an oversight as inline actions are rendered differently than regular actions

## How Verified
The "Input.Text.InlineAction.Label.json" was used for rendering a card that would have the behaviour to test. As can be seen in the gif below, the inputs are now validating and, though out a little bit out of the screen, a pop up dialog shows up with the retrieved inputs

![inlineActionValidation](https://user-images.githubusercontent.com/35784165/86191374-c1d8f400-bafb-11ea-88a4-52aa71867dda.gif)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4266)