### PR TITLE
Changed Textview to Update Its Text Color Correctly According to Theme

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextView.mm
@@ -144,7 +144,7 @@
     if (_placeholderText && [textView.text isEqualToString:_placeholderText]) {
         textView.text = @"";
         if (@available(iOS 13.0, *)) {
-            textView.textColor = UIColor.labelColor;
+            textView.textColor = [UIColor labelColor];
         } else {
             // Fallback on earlier versions
             textView.textColor = [UIColor blackColor];
@@ -157,7 +157,7 @@
     if (![textView.text length]) {
         textView.text = _placeholderText;
         if (@available(iOS 13.0, *)) {
-            textView.textColor = UIColor.placeholderTextColor;
+            textView.textColor = [UIColor placeholderTextColor];
         } else {
             // Fallback on earlier versions
             textView.textColor = [UIColor lightGrayColor];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextView.mm
@@ -33,6 +33,7 @@
         self.text = _placeholderText;
         self.textColor = [UIColor lightGrayColor];
     }
+
     self.isRequired = inputBlck->GetIsRequired();
     self.delegate = self;
     self.id = [NSString stringWithCString:inputBlck->GetId().c_str()
@@ -142,7 +143,12 @@
 {
     if (_placeholderText && [textView.text isEqualToString:_placeholderText]) {
         textView.text = @"";
-        textView.textColor = [UIColor blackColor];
+        if (@available(iOS 13.0, *)) {
+            textView.textColor = UIColor.labelColor;
+        } else {
+            // Fallback on earlier versions
+            textView.textColor = [UIColor blackColor];
+        }
     }
     [textView becomeFirstResponder];
 }
@@ -150,7 +156,12 @@
 {
     if (![textView.text length]) {
         textView.text = _placeholderText;
-        textView.textColor = [UIColor lightGrayColor];
+        if (@available(iOS 13.0, *)) {
+            textView.textColor = UIColor.placeholderTextColor;
+        } else {
+            // Fallback on earlier versions
+            textView.textColor = [UIColor lightGrayColor];
+        }
     }
     [textView resignFirstResponder];
 }


### PR DESCRIPTION
With iOS 13, Apple introduced a dark theme.
Changed Textview to update its text color according to the theme

## Related Issue
Fixed #4216
 
## How Verified
How you verified the fix, including one or all of the following:  
1. regression tests were run.
2. tested and visually confirmed that the change is good by changing system theme to dark mode, and ran the repro step.
![IMG_D7DFFCC676F4-1](https://user-images.githubusercontent.com/4112696/86418637-a4379600-bc85-11ea-80a8-15d682995f9b.jpeg)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4291)