### PR TITLE
[Android] Support native styling for Action.ShowCard

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/BaseActionElementRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/BaseActionElementRenderer.java
@@ -246,7 +246,7 @@ public abstract class BaseActionElementRenderer implements IBaseActionElementRen
                 }
             }
 
-            v.setPressed(m_invisibleCard.getVisibility() != View.VISIBLE);
+            v.setSelected(m_invisibleCard.getVisibility() != View.VISIBLE);
             for (int i = 0; i < m_hiddenCardsLayout.getChildCount(); ++i)
             {
                 View child = m_hiddenCardsLayout.getChildAt(i);

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/action/ActionElementRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/action/ActionElementRenderer.java
@@ -178,6 +178,11 @@ public class ActionElementRenderer extends BaseActionElementRenderer
         RenderedAdaptiveCard renderedCard,
         RenderArgs renderArgs)
     {
+        TypedValue buttonStyle = new TypedValue();
+        if (baseActionElement.GetElementType() == ActionType.ShowCard && context.getTheme().resolveAttribute(R.attr.adaptiveShowCardAction, buttonStyle, true)) {
+            context = new ContextThemeWrapper(context, buttonStyle.data);
+        }
+
         Button button = getButtonForStyle(context, baseActionElement.GetStyle(), hostConfig);
 
         button.setText(baseActionElement.GetTitle());

--- a/source/android/adaptivecards/src/main/res/values/attrs.xml
+++ b/source/android/adaptivecards/src/main/res/values/attrs.xml
@@ -4,6 +4,7 @@
     <attr name="adaptiveActionDestructive" format="reference" />
     <attr name="adaptiveInlineAction" format="reference" />
     <attr name="adaptiveInlineActionImage" format="reference" />
+    <attr name="adaptiveShowCardAction" format="reference" />
     <style name="adaptiveInlineAction" format="reference" />
     <style name="adaptiveInlineActionImage" format="reference" />
 </resources>

--- a/source/android/mobile/src/main/res/drawable/show_card_arrow.xml
+++ b/source/android/mobile/src/main/res/drawable/show_card_arrow.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+</selector>

--- a/source/android/mobile/src/main/res/drawable/show_card_arrow.xml
+++ b/source/android/mobile/src/main/res/drawable/show_card_arrow.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-
+    <item android:drawable="@android:drawable/arrow_up_float"
+        android:state_selected="true" />
+    <item android:drawable="@android:drawable/arrow_down_float" />
 </selector>

--- a/source/android/mobile/src/main/res/values-v21/styles.xml
+++ b/source/android/mobile/src/main/res/values-v21/styles.xml
@@ -1,5 +1,10 @@
 <resources>
 
+    <!-- Sample style definitions -->
+    <style name="adaptiveShowCardAction" parent="@style/Widget.AppCompat.Button.Colored">
+        <item name="android:drawableEnd">@drawable/show_card_arrow</item>
+    </style>
+
     <style name="adaptiveActionPositive" parent="@style/Widget.AppCompat.Button.Colored">
         <item name="android:colorAccent">@color/actionPositive</item>
     </style>
@@ -29,13 +34,15 @@
         <item name="editTextBackground">@drawable/border</item>
         <item name="android:buttonStyle">@style/Widget.AppCompat.Button.Colored</item>
 
-        <!-- Example on how to define your own style for Positive and Destructive Actions -->
-        <!--
+        <!-- Add your custom styles (samples defined above) for use by the AdaptiveCards SDK
+
         <item name="adaptiveActionDestructive">@style/adaptiveActionDestructive</item>
         <item name="adaptiveActionPositive">@style/adaptiveActionPositive</item>
         <item name="adaptiveInlineAction">@style/adaptiveInlineAction</item>
-        <item name="adaptiveInlineActionImage">@style/adaptiveInlineActionImage</item> -->
+        <item name="adaptiveInlineActionImage">@style/adaptiveInlineActionImage</item>
+        <item name="adaptiveShowCardAction">@style/adaptiveShowCardAction</item>
 
+        -->
 
     </style>
 

--- a/source/android/mobile/src/main/res/values/styles.xml
+++ b/source/android/mobile/src/main/res/values/styles.xml
@@ -1,5 +1,10 @@
 <resources>
 
+    <!-- Sample style definitions -->
+    <style name="adaptiveShowCardAction" parent="@style/Widget.AppCompat.Button.Colored">
+        <item name="android:drawableEnd">@drawable/show_card_arrow</item>
+    </style>
+
     <style name="adaptiveActionPositive" parent="@style/Widget.AppCompat.Button.Colored">
         <item name="colorAccent">@color/actionPositive</item>
     </style>
@@ -29,12 +34,14 @@
         <item name="editTextBackground">@drawable/border</item>
         <!--<item name="android:buttonStyle">@style/Widget.AppCompat.Button.Colored</item> -->
 
-        <!-- Example on how to define your own style for Positive and Destructive Actions -->
-        <!--
+        <!-- Add your custom styles (samples defined above) for use by the AdaptiveCards SDK
+
         <item name="adaptiveActionDestructive">@style/adaptiveActionDestructive</item>
         <item name="adaptiveActionPositive">@style/adaptiveActionPositive</item>
         <item name="adaptiveInlineAction">@style/adaptiveInlineAction</item>
-        <item name="adaptiveInlineActionImage">@style/adaptiveInlineActionImage</item> -->
+        <item name="adaptiveInlineActionImage">@style/adaptiveInlineActionImage</item>
+
+        -->
 
     </style>
 


### PR DESCRIPTION
## Related Issue
Fixes #4167 

## Description
Allow apps to apply native styles to any Action.ShowCard by assigning a style definition to the app theme's `R.attr.adaptiveShowCardAction` attribute. Example usage (e.g. add a chevron that visually indicates a closed or open ShowCard) added to visualizer app's `styles.xml` and `v21/styles.xml`.

## How Verified
Manual vertification - uncommented the example usage in visualizer `styles`. Checked compatibility w/ existing styling support (e.g. positive action, as shown below).

![4167](https://user-images.githubusercontent.com/4442788/86613061-11e20b80-bf7f-11ea-9495-2dd039f4492a.gif)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4299)