### PR TITLE
[UWP] Don't render TextBlocks with empty strings

### DIFF
--- a/source/uwp/Renderer/lib/AdaptiveTextBlockRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTextBlockRenderer.cpp
@@ -35,6 +35,18 @@ namespace AdaptiveNamespace
         ComPtr<IAdaptiveTextBlock> adaptiveTextBlock;
         RETURN_IF_FAILED(cardElement.As(&adaptiveTextBlock));
 
+        ComPtr<IAdaptiveTextElement> textBlockAsTextElement;
+        RETURN_IF_FAILED(adaptiveTextBlock.As(&textBlockAsTextElement));
+        HString text;
+        RETURN_IF_FAILED(textBlockAsTextElement->get_Text(text.ReleaseAndGetAddressOf()));
+
+        // If the text is null, return immediately without constructing a text block
+        if (text.Get() == nullptr)
+        {
+            *textBlockControl = nullptr;
+            return S_OK;
+        }
+
         ComPtr<ITextBlock> xamlTextBlock =
             XamlHelpers::CreateXamlClass<ITextBlock>(HStringReference(RuntimeClass_Windows_UI_Xaml_Controls_TextBlock));
 


### PR DESCRIPTION
## Related Issue
UWP change for #3702

## Description
Updated the TextBlock renderer return early rather than constructing an empty Xaml element that takes up space in the card.

## How Verified
Confirmed expected behavior in the visualizer using [EmptyTextBlock.json](https://github.com/microsoft/AdaptiveCards/blob/main/samples/v1.2/Tests/EmptyTextBlock.json) 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4303)