### PR TITLE
Update Package Version to 1.2.10

### DIFF
--- a/custom.props
+++ b/custom.props
@@ -4,7 +4,7 @@
     <VersionMajor>1</VersionMajor>
     <VersionMinor>2</VersionMinor>
     <!-- The nuget package version should be incremented when we produce QFEs -->
-    <NuGetPackVersion>1.2.9</NuGetPackVersion>
+    <NuGetPackVersion>1.2.10</NuGetPackVersion>
     <VersionInfoProductName>AdaptiveCards</VersionInfoProductName>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Related Issue
Updating the package version number for AdaptiveCards renderer ahead of v1.2.10 release.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4315)