### PR TITLE
[WPF] Fix cards with no inputs crashing when submitting

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveRenderContext.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveRenderContext.cs
@@ -534,7 +534,10 @@ namespace AdaptiveCards.Rendering.Wpf
             while (!submitActionCardId.Equals(new AdaptiveInternalID()))
             {
                 // Copy the inputs into the result
-                inputList.InsertRange(0, InputsInCard[submitActionCardId]);
+                if (InputsInCard.ContainsKey(submitActionCardId))
+                {
+                    inputList.InsertRange(0, InputsInCard[submitActionCardId]);
+                }
 
                 // Move to the parent card
                 submitActionCardId = ParentCards[submitActionCardId];


### PR DESCRIPTION
## Related Issue
Fixes #4270 

## Description
The issue was that trying to retrieve a value with a key that didn't exist in the dictionary threw an exception, that's why the app crashed

## How Verified
1. The fix was verified manually as can be seen in the gif below 

![WPFNoInputsFix](https://user-images.githubusercontent.com/35784165/86826028-ff320a00-c044-11ea-8021-b7c9d3a69bf0.gif)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4316)