### PR TITLE
[UWP] Convert to nuget version of cppwinrt

### DIFF
--- a/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj
+++ b/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.200630.5\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200630.5\build\native\Microsoft.Windows.CppWinRT.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">
       <Configuration>Debug</Configuration>
@@ -95,10 +96,6 @@
       </AdditionalDependencies>
       <AdditionalOptions>/profile %(AdditionalOptions)</AdditionalOptions>
     </Link>
-    <CustomBuildStep>
-      <Command>mdmerge -partial -i "$(OutDir)$(TargetName).winmd" -o "$(OutDir)Output" -metadata_dir "$(WindowsSDK_MetadataFoundationPath)" -metadata_dir "$(WindowsSDK_MetadataPathVersioned)\Windows.Foundation.UniversalApiContract\8.0.0.0" &amp;&amp; copy /y "$(OutDir)Output\*" "$(OutDir)"</Command>
-      <Outputs>$(OutDir)%(TargetName).winmd</Outputs>
-    </CustomBuildStep>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
@@ -371,9 +368,25 @@
   <ItemGroup>
     <Midl Include="idl\AdaptiveCards.Rendering.Uwp.idl">
       <HeaderFileName>%(Filename).h</HeaderFileName>
+      <!-- Enable Windows Runtime ABI header files. when /reference is passed to midl.exe, the ABI head includes headers
+           like Windows.AI.MachineLearning.MachineLearningContract.h which doesn't exist actually in SDK. To workaround
+           the problem, DisableReferences is enabled to disable /reference. -->
+      <DisableReferences>true</DisableReferences>
       <AdditionalIncludeDirectories>$(WindowsSDK_IncludePath)</AdditionalIncludeDirectories>
     </Midl>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <ImportGroup Label="ExtensionTargets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.200630.5\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200630.5\build\native\Microsoft.Windows.CppWinRT.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200630.5\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.200630.5\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200630.5\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.200630.5\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+  </Target>
 </Project>

--- a/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj.filters
+++ b/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj.filters
@@ -240,4 +240,7 @@
   <ItemGroup>
     <Midl Include="idl\AdaptiveCards.Rendering.Uwp.idl" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
+++ b/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
@@ -1820,6 +1820,7 @@ AdaptiveNamespaceStart
     };
 
     [
+        default_interface,
 #ifdef ADAPTIVE_CARDS_WINDOWS
         contract(InternalContract, 1),
         internal
@@ -1831,6 +1832,7 @@ AdaptiveNamespaceStart
     };
 
     [
+        default_interface,
 #ifdef ADAPTIVE_CARDS_WINDOWS
         contract(InternalContract, 1),
         internal
@@ -1842,6 +1844,7 @@ AdaptiveNamespaceStart
     };
 
     [
+        default_interface,
 #ifdef ADAPTIVE_CARDS_WINDOWS
         contract(InternalContract, 1),
         internal
@@ -1853,6 +1856,7 @@ AdaptiveNamespaceStart
     };
 
     [
+        default_interface,
 #ifdef ADAPTIVE_CARDS_WINDOWS
         contract(InternalContract, 1),
         internal
@@ -1864,6 +1868,7 @@ AdaptiveNamespaceStart
     };
 
     [
+        default_interface,
 #ifdef ADAPTIVE_CARDS_WINDOWS
         contract(InternalContract, 1),
         internal
@@ -1875,6 +1880,7 @@ AdaptiveNamespaceStart
     };
 
     [
+        default_interface,
 #ifdef ADAPTIVE_CARDS_WINDOWS
         contract(InternalContract, 1),
         internal
@@ -1886,6 +1892,7 @@ AdaptiveNamespaceStart
     };
 
     [
+        default_interface,
 #ifdef ADAPTIVE_CARDS_WINDOWS
         contract(InternalContract, 1),
         internal
@@ -1897,6 +1904,7 @@ AdaptiveNamespaceStart
     };
 
     [
+        default_interface,
 #ifdef ADAPTIVE_CARDS_WINDOWS
         contract(InternalContract, 1),
         internal
@@ -1908,6 +1916,7 @@ AdaptiveNamespaceStart
     };
 
     [
+        default_interface,
 #ifdef ADAPTIVE_CARDS_WINDOWS
         contract(InternalContract, 1),
         internal
@@ -1919,6 +1928,7 @@ AdaptiveNamespaceStart
     };
 
     [
+        default_interface,
 #ifdef ADAPTIVE_CARDS_WINDOWS
         contract(InternalContract, 1),
         internal
@@ -1930,6 +1940,7 @@ AdaptiveNamespaceStart
     };
 
     [
+        default_interface,
 #ifdef ADAPTIVE_CARDS_WINDOWS
         contract(InternalContract, 1),
         internal
@@ -1941,6 +1952,7 @@ AdaptiveNamespaceStart
     };
 
     [
+        default_interface,
 #ifdef ADAPTIVE_CARDS_WINDOWS
         contract(InternalContract, 1),
         internal
@@ -1952,6 +1964,7 @@ AdaptiveNamespaceStart
     };
 
     [
+        default_interface,
 #ifdef ADAPTIVE_CARDS_WINDOWS
         contract(InternalContract, 1),
         internal
@@ -1963,6 +1976,7 @@ AdaptiveNamespaceStart
     };
 
     [
+        default_interface,
 #ifdef ADAPTIVE_CARDS_WINDOWS
         contract(InternalContract, 1),
         internal
@@ -1974,6 +1988,7 @@ AdaptiveNamespaceStart
     };
 
     [
+        default_interface,
 #ifdef ADAPTIVE_CARDS_WINDOWS
         contract(InternalContract, 1),
         internal
@@ -1985,6 +2000,7 @@ AdaptiveNamespaceStart
     };
 
     [
+        default_interface,
 #ifdef ADAPTIVE_CARDS_WINDOWS
         contract(InternalContract, 1),
         internal
@@ -1996,6 +2012,7 @@ AdaptiveNamespaceStart
     };
 
     [
+        default_interface,
 #ifdef ADAPTIVE_CARDS_WINDOWS
         contract(InternalContract, 1),
         internal
@@ -2007,6 +2024,7 @@ AdaptiveNamespaceStart
     };
 
     [
+        default_interface,
 #ifdef ADAPTIVE_CARDS_WINDOWS
         contract(InternalContract, 1),
         internal
@@ -2018,6 +2036,7 @@ AdaptiveNamespaceStart
     };
 
     [
+        default_interface,
 #ifdef ADAPTIVE_CARDS_WINDOWS
         contract(InternalContract, 1),
         internal
@@ -2029,6 +2048,7 @@ AdaptiveNamespaceStart
     };
 
     [
+        default_interface,
 #ifdef ADAPTIVE_CARDS_WINDOWS
         contract(InternalContract, 1),
         internal
@@ -2040,6 +2060,7 @@ AdaptiveNamespaceStart
     };
 
     [
+        default_interface,
 #ifdef ADAPTIVE_CARDS_WINDOWS
         contract(InternalContract, 1),
         internal

--- a/source/uwp/Renderer/lib/pch.h
+++ b/source/uwp/Renderer/lib/pch.h
@@ -16,6 +16,7 @@
 #define AdaptivePointerCast dynamic_pointer_cast
 #endif
 
+#define DISABLE_NS_PREFIX_CHECKS 1
 #include <wrl.h>
 #include <wrl\wrappers\corewrappers.h>
 #include <unordered_map>

--- a/source/uwp/Renderer/packages.config
+++ b/source/uwp/Renderer/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.200630.5" targetFramework="native" />
+</packages>


### PR DESCRIPTION
## Description
Needed in order to continue using C++/WinRT on more recent Windows SDKs.

Changes required:
* Add `Microsoft.Windows.CppWinRT` nuget package
* Remove manual calls to `mdmerge` (this is handled by cppwinrt now)
* Add missing `default_interface` directives to various renderer runtimeclasses

Some decent benefits here (apart from having access to newer cppwinrt functionality):
* When we target a new Windows SDK, we will no longer have to maintain our custom `mdmerge` build step
* Since `mdmerge` is handled automatigically, build/debug is more seamless -- the custom step is no longer run every single time

## How Verified
* tested converting a small piece of code over to cppwinrt style then building/testing


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4319)