### PR TITLE
[Android] Concurrent image load

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/AdaptiveCardRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/AdaptiveCardRenderer.java
@@ -4,6 +4,7 @@ package io.adaptivecards.renderer;
 
 import android.content.Context;
 import android.graphics.Color;
+import android.os.AsyncTask;
 import android.support.v4.app.FragmentManager;
 import android.view.Gravity;
 import android.view.View;
@@ -206,7 +207,7 @@ public class AdaptiveCardRenderer
                 loaderAsync.registerCustomOnlineImageLoader(onlineImageLoader);
             }
 
-            loaderAsync.execute(backgroundImageProperties.GetUrl());
+            loaderAsync.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, backgroundImageProperties.GetUrl());
         }
 
         BaseActionElement selectAction = renderedCard.getAdaptiveCard().GetSelectAction();

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/action/ActionElementRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/action/ActionElementRenderer.java
@@ -12,6 +12,7 @@ import android.graphics.PorterDuff;
 import android.graphics.Rect;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
+import android.os.AsyncTask;
 import android.support.v4.app.FragmentManager;
 import android.util.TypedValue;
 import android.view.ContextThemeWrapper;
@@ -225,7 +226,7 @@ public class ActionElementRenderer extends BaseActionElementRenderer
                     hostConfig.GetSpacing().getDefaultSpacing(),
                     context
             );
-            imageLoader.execute(baseActionElement.GetIconUrl());
+            imageLoader.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, baseActionElement.GetIconUrl());
         }
 
         viewGroup.addView(button);

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/TextInputRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/TextInputRenderer.java
@@ -8,6 +8,7 @@ import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
+import android.os.AsyncTask;
 import android.support.v4.app.FragmentManager;
 import android.text.Editable;
 import android.text.InputFilter;
@@ -242,7 +243,7 @@ public class TextInputRenderer extends BaseCardElementRenderer
                                         url,
                                         editText);
 
-                        imageLoader.execute(url);
+                        imageLoader.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, url);
                         textInputViewGroup.addView(inlineButton, new LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT, 0));
                     }
                     else

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ImageRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ImageRenderer.java
@@ -9,6 +9,7 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Shader;
+import android.os.AsyncTask;
 import android.support.v4.app.FragmentManager;
 import android.text.TextUtils;
 import android.view.Gravity;
@@ -220,7 +221,7 @@ public class ImageRenderer extends BaseCardElementRenderer
             imageLoaderAsync.registerCustomOnlineImageLoader(onlineImageLoader);
         }
 
-        imageLoaderAsync.execute(image.GetUrl());
+        imageLoaderAsync.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, image.GetUrl());
 
         LinearLayout.LayoutParams layoutParams;
         if (image.GetImageSize() == ImageSize.Stretch)


### PR DESCRIPTION
## Related Issue
Untracked issue

## Description
The issue was that we were using the method "execute" when running the download image async tasks, quoting the [official documentation](https://developer.android.com/reference/android/os/AsyncTask#execute(Params...)), this api has suffered some changes across different android api versions

> Note: this function schedules the task on a queue for a single background thread or pool of threads depending on the platform version. When first introduced, AsyncTasks were executed serially on a single background thread. Starting with Build.VERSION_CODES.DONUT, this was changed to a pool of threads allowing multiple tasks to operate in parallel. Starting Build.VERSION_CODES.HONEYCOMB, tasks are back to being executed on a single thread to avoid common application errors caused by parallel execution. If you truly want parallel execution, you can use the executeOnExecutor(Executor, Params...) version of this method with THREAD_POOL_EXECUTOR; however, see commentary there for warnings on its use.

Because of this, all calls to the method ```execute``` were changed to ```executeOnExecutor```

## How Verified
The fix was verified using a modified version of the ImageGallery card, by bumping the number of images loaded we can see how images are not being downloaded sequentially

![AndroidMultiDownload](https://user-images.githubusercontent.com/35784165/87109704-386fa300-c21a-11ea-9867-5be2ad9d6e25.gif)
 


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4346)