### PR TITLE
[Designer] Allow add/remove properties to/from property sheet

### DIFF
--- a/source/nodejs/adaptivecards-designer-app/src/app.ts
+++ b/source/nodejs/adaptivecards-designer-app/src/app.ts
@@ -36,7 +36,16 @@ window.onload = function() {
 
 	if (!ACDesigner.SettingsManager.isLocalStorageAvailable) {
 		console.log("Local storage is not available.");
-	}
+    }
+    
+    // Uncomment to add/remove properties to/from the designer's property sheet
+    /*
+    ACDesigner.DesignerPeer.onPopulatePropertySheet = (sender: ACDesigner.DesignerPeer, propertySheet: ACDesigner.PropertySheet) => {
+        if (sender instanceof ACDesigner.TextBlockPeer) {
+            propertySheet.remove(ACDesigner.TextBlockPeer.maxLinesProperty);
+        }
+    }
+    */
 
 	let designer = new ACDesigner.CardDesigner(ACDesigner.defaultMicrosoftHosts);
 	designer.sampleCatalogueUrl = window.location.origin + "/sample-catalogue.json";

--- a/source/nodejs/adaptivecards-designer/src/designer-peers.ts
+++ b/source/nodejs/adaptivecards-designer/src/designer-peers.ts
@@ -770,6 +770,8 @@ class NameValuePairPropertyEditor extends PropertySheetEntry {
 export abstract class DesignerPeer extends DraggableElement {
     static readonly idProperty = new StringPropertyEditor(Adaptive.Versions.v1_0, "id", "Id");
 
+    static onPopulatePropertySheet?: (sender: DesignerPeer, propertySheet: PropertySheet) => void;
+
     private _parent: DesignerPeer;
     private _cardObject: Adaptive.CardObject;
     private _children: Array<DesignerPeer> = [];
@@ -1094,6 +1096,10 @@ export abstract class DesignerPeer extends DraggableElement {
         let propertySheet = new PropertySheet();
 
         this.populatePropertySheet(propertySheet);
+
+        if (DesignerPeer.onPopulatePropertySheet) {
+            DesignerPeer.onPopulatePropertySheet(this, propertySheet);
+        }
 
         propertySheet.render(
             card,


### PR DESCRIPTION
## Related Issue
Fixes https://github.com/microsoft/AdaptiveCards/issues/4348

## Description
This change makes it possible to dynamically add or remove properties to/from the designer's property sheet. For instance, here's how to remove the "Maximum lines" property for **TextBlock** elements:

```typescript
ACDesigner.DesignerPeer.onPopulatePropertySheet = (sender: ACDesigner.DesignerPeer, propertySheet: ACDesigner.PropertySheet) => {
	if (sender instanceof ACDesigner.TextBlockPeer) {
		propertySheet.remove(ACDesigner.TextBlockPeer.maxLinesProperty);
	}
}
```

## How Verified
Verified manually in adaptivecards-designer-app

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4365)