### PR TITLE
Generate indexer for properties with special chars

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/data.ts
+++ b/source/nodejs/adaptivecards-designer/src/data.ts
@@ -1,5 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+function getAccessor(name: string): string {
+    let regEx = /[a-zA-Z0-9_$]*/;
+    let matches = regEx.exec(name);
+
+    // If name doesn't only contain letters/digits/_
+    // the accessor must use the indexer syntax
+    if (matches && matches[0] === name) {
+        return name;
+    }
+
+    return "[\"" + name + "\"]";
+}   
+
 export type ValueType = "String" | "Boolean" | "Number" | "Array" | "Object";
 
 export interface IStringData {
@@ -278,11 +291,18 @@ export class FieldDefinition {
     }
 
     getPath(asLeaf: boolean = true): string {
-        let result: string = this.qualifiedName(asLeaf);
+        let result: string = getAccessor(this.qualifiedName(asLeaf));
         let currentField = this.parent;
 
         while (currentField) {
-            result = currentField.qualifiedName(false) + "." + result;
+            let qualifiedName = getAccessor(currentField.qualifiedName(false));
+
+            if (result[0] === "[") {
+                result = qualifiedName + result;
+            }
+            else {
+                result = qualifiedName + "." + result;
+            }
 
             currentField = currentField.parent;
         }


### PR DESCRIPTION
## Related Issue
Fixes https://github.com/microsoft/AdaptiveCards/issues/4375

## Description
Currently, the designer's field picker always generated bindings using the "dot" syntax (e.g. `${myObj.a.b}`). But JSON property names can be any string. When non alpha-numerical characters are used in property names, AEL (just like JS) requires the use of the indexer syntax (e.g. `${myObj["a.b"]}`) and that's what this PR implements.

## How Verified
Verified manually in adaptivecards-designer-app

Test data payload:
```json
{
  "fields": {
    "System.AreaPath": "MyAgilePrj2",
    "System.TeamProject": "MyAgilePrj2"
}
```

In a simple card with just a **TextBlock**, binding the text property to "System.AreaPath" should result in this:
```json
{
    "type": "AdaptiveCard",
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
    "version": "1.2",
    "body": [
        {
            "type": "TextBlock",
            "text": "${$root.fields['System.AreaPath']}"
        }
    ]
}
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4376)