### PR TITLE
Remove control validation

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf.Xceed/XceedNumberInput.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf.Xceed/XceedNumberInput.cs
@@ -19,12 +19,6 @@ namespace AdaptiveCards.Rendering.Wpf
                 if (!Double.IsNaN(input.Value))
                     numberPicker.Value = Convert.ToInt32(input.Value);
 
-                if (!Double.IsNaN(input.Min))
-                    numberPicker.Minimum = Convert.ToInt32(input.Min);
-
-                if (!Double.IsNaN(input.Max))
-                    numberPicker.Maximum = Convert.ToInt32(input.Max);
-
                 numberPicker.Watermark = input.Placeholder;
                 numberPicker.Style = context.GetStyle("Adaptive.Input.Number");
                 numberPicker.DataContext = input;


### PR DESCRIPTION
## Related Issue
Fixes #4276 

## Description
The issue was that we were using the built-in Minimum and Maximum validation that the control provided, that made the control behavior to remove any "extra" characters whenever the input was greater or smaller than the min/max values and the control lost focus. This made the user experience being odd as an user could have inputted an out of bounds number, the control would have "fixed" the input clipping it to be in bounds and then successfully submitted the issue with a value the user didn't intended to use.

## How Verified
The fix was verified manually by checking that the min/max validation was actually triggered on submit

![WPFInputNumberValidation](https://user-images.githubusercontent.com/35784165/87477174-8bf83d00-c5dc-11ea-9590-89d761bc35c5.gif)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4379)