### PR TITLE
[Samples] Update ExpenseReport and WeatherLarge samples

### DIFF
--- a/samples/v1.0/Scenarios/WeatherLarge.json
+++ b/samples/v1.0/Scenarios/WeatherLarge.json
@@ -3,7 +3,7 @@
 	"type": "AdaptiveCard",
 	"version": "1.0",
 	"speak": "<s>Weather forecast for Monday is high of 62 and low of 42 degrees with a 20% chance of rain</s><s>Winds will be 5 mph from the northeast</s>",
-	"backgroundImage": "https://messagecardplayground.azurewebsites.net/assets/Mostly%20Cloudy-Background-Dark.jpg",
+	"backgroundImage": "https://messagecardplayground.azurewebsites.net/assets/Mostly%20Cloudy-Background.jpg",
 	"body": [
 		{
 			"type": "ColumnSet",
@@ -28,8 +28,7 @@
 							"type": "TextBlock",
 							"text": "Monday April 1",
 							"weight": "bolder",
-							"size": "large",
-							"color": "light"
+							"size": "large"
 						},
 						{
 							"type": "TextBlock",
@@ -39,13 +38,11 @@
 						},
 						{
 							"type": "TextBlock",
-							"isSubtle": true,
 							"text": "20% chance of rain",
 							"spacing": "none"
 						},
 						{
 							"type": "TextBlock",
-							"isSubtle": true,
 							"text": "Winds 5 mph NE",
 							"spacing": "none"
 						}
@@ -73,18 +70,18 @@
 							"altText": "Mostly cloudy weather"
 						},
 						{
-							"type": "TextBlock",
-							"horizontalAlignment": "center",
-							"wrap": false,
-							"text": "62"
-						},
-						{
-							"type": "TextBlock",
-							"horizontalAlignment": "center",
-							"isSubtle": true,
-							"wrap": false,
-							"text": "52",
-							"spacing": "none"
+							"type": "FactSet",
+							"horizontalAlignment": "right",
+							"facts": [
+								{
+									"title": "High",
+									"value": "62"
+								},
+								{
+									"title": "Low",
+									"value": "52"
+								}
+							]
 						}
 					],
 					"selectAction": {
@@ -110,18 +107,17 @@
 							"altText": "Drizzly weather"
 						},
 						{
-							"type": "TextBlock",
-							"horizontalAlignment": "center",
-							"wrap": false,
-							"text": "60"
-						},
-						{
-							"type": "TextBlock",
-							"horizontalAlignment": "center",
-							"isSubtle": true,
-							"wrap": false,
-							"text": "48",
-							"spacing": "none"
+							"type": "FactSet",
+							"facts": [
+								{
+									"title": "High",
+									"value": "60"
+								},
+								{
+									"title": "Low",
+									"value": "48"
+								}
+							]
 						}
 					],
 					"selectAction": {
@@ -147,18 +143,17 @@
 							"altText": "Mostly cloudy weather"
 						},
 						{
-							"type": "TextBlock",
-							"horizontalAlignment": "center",
-							"wrap": false,
-							"text": "59"
-						},
-						{
-							"type": "TextBlock",
-							"horizontalAlignment": "center",
-							"isSubtle": true,
-							"wrap": false,
-							"text": "49",
-							"spacing": "none"
+							"type": "FactSet",
+							"facts": [
+								{
+									"title": "High",
+									"value": "59"
+								},
+								{
+									"title": "Low",
+									"value": "49"
+								}
+							]
 						}
 					],
 					"selectAction": {
@@ -184,18 +179,17 @@
 							"altText": "Mostly cloudy weather"
 						},
 						{
-							"type": "TextBlock",
-							"horizontalAlignment": "center",
-							"wrap": false,
-							"text": "64"
-						},
-						{
-							"type": "TextBlock",
-							"horizontalAlignment": "center",
-							"isSubtle": true,
-							"wrap": false,
-							"text": "51",
-							"spacing": "none"
+							"type": "FactSet",
+							"facts": [
+								{
+									"title": "High",
+									"value": "64"
+								},
+								{
+									"title": "Low",
+									"value": "51"
+								}
+							]
 						}
 					],
 					"selectAction": {

--- a/samples/v1.2/Scenarios/ExpenseReport.json
+++ b/samples/v1.2/Scenarios/ExpenseReport.json
@@ -51,14 +51,6 @@
 									"size": "ExtraLarge",
 									"text": "Trip to UAE",
 									"wrap": true
-								},
-								{
-									"type": "TextBlock",
-									"spacing": "Small",
-									"size": "Small",
-									"weight": "Bolder",
-									"color": "Accent",
-									"text": "[ER-13052](https://adaptivecards.io)"
 								}
 							],
 							"width": "stretch"
@@ -80,6 +72,14 @@
 							"width": "auto"
 						}
 					]
+				},
+				{
+					"type": "TextBlock",
+					"spacing": "Small",
+					"size": "Small",
+					"weight": "Bolder",
+					"color": "Accent",
+					"text": "[ER-13052](https://adaptivecards.io)"
 				},
 				{
 					"type": "FactSet",
@@ -107,7 +107,7 @@
 						},
 						{
 							"title": "Submitted to",
-							"value": "**David**   david@contoso.com"
+							"value": "**David**  david@contoso.com"
 						}
 					]
 				}


### PR DESCRIPTION
## Related Issue
Fixes VSO #23713559
Fixes VSO #23703249

## Description
A couple of card sample updates:

* WeatherLarge.json was called out for bad contrast
  * Switched to lighter background
  * Removed `"isSubtle": true` on multiple elements
  * Move High/Low temps to use `FactSet`

|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/16614499/87587861-890e5280-c697-11ea-86e6-718e5324121b.png)|![image](https://user-images.githubusercontent.com/16614499/87587893-99bec880-c697-11ea-823d-81f030e92160.png)

* ExpenseReport.json was reported for an odd tabbing order (specifically the `ER-13052` link under `Trip to UAE` precedes the `Export as PDF` button in the tab order)
  * Moved `ER-13052` link outside of the columnset

|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/16614499/87588128-f9b56f00-c697-11ea-8d01-4df45da77186.png)|![image](https://user-images.githubusercontent.com/16614499/87588163-0afe7b80-c698-11ea-994c-20bfb62c8ea5.png)|
|Tab order: `ER-13052` link→`Export as PDF` button|Tab order: `Export as PDF` button→`ER-13052` link|

## How Verified
* local build, color contrast checking tools, manual test


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4383)