### PR TITLE
[UWP][Android] Add warning for empty labels

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/AdaptiveWarning.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/AdaptiveWarning.java
@@ -10,6 +10,7 @@ public class AdaptiveWarning {
     public static final int TOGGLE_MISSING_VALUE = 5;
     public static final int SELECT_SHOW_CARD_ACTION = 6;
     public static final int INVALID_COLUMN_WIDTH_VALUE = 7;
+    public static final int EMPTY_LABEL_IN_REQUIRED_INPUT = 8;
 
     private int code;
     private String message;

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/registration/CardRendererRegistration.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/registration/CardRendererRegistration.java
@@ -459,7 +459,7 @@ public class CardRendererRegistration
             if (baseInputElement != null)
             {
                 // put the element in a Stretchable input layout and
-                HandleLabelAndValidation(mockLayout, viewGroup, baseInputElement, context, hostConfig, renderArgs, tagContent);
+                HandleLabelAndValidation(renderedCard, mockLayout, viewGroup, baseInputElement, context, hostConfig, renderArgs, tagContent);
             }
             else
             {
@@ -505,7 +505,8 @@ public class CardRendererRegistration
         BaseCardElementRenderer.setVisibility(element.GetIsVisible(), renderedElementView);
     }
 
-    private static void HandleLabelAndValidation(ViewGroup mockLayout,
+    private static void HandleLabelAndValidation(RenderedAdaptiveCard renderedCard,
+                                                ViewGroup mockLayout,
                                                 ViewGroup container,
                                                 BaseInputElement element,
                                                 Context context,
@@ -543,6 +544,10 @@ public class CardRendererRegistration
                     true /* horizontalLine */);
 
                 inputLabel.setLabelFor(actualInput.getId());
+            }
+            else if (element.GetIsRequired())
+            {
+                renderedCard.addWarning(new AdaptiveWarning(AdaptiveWarning.EMPTY_LABEL_IN_REQUIRED_INPUT, "Input is required but there's no label for required hint rendering"));
             }
 
             tagContent.SetStretchContainer(inputLayout);

--- a/source/shared/cpp/ObjectModel/Enums.h
+++ b/source/shared/cpp/ObjectModel/Enums.h
@@ -400,6 +400,7 @@ namespace AdaptiveSharedNamespace
         InvalidLanguage,
         InvalidValue,
         CustomWarning,
+        EmptyLabelInRequiredInput,
     };
     // No mapping to string needed
 

--- a/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
+++ b/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
@@ -317,6 +317,7 @@ AdaptiveNamespaceStart
         UnsupportedValue,
         PerformingFallback,
         CustomWarning,
+        EmptyLabelInRequiredInput,
     } WarningStatusCode;
 
     [version(NTDDI_WIN10_RS1)]

--- a/source/uwp/Renderer/lib/XamlHelpers.cpp
+++ b/source/uwp/Renderer/lib/XamlHelpers.cpp
@@ -727,6 +727,10 @@ namespace AdaptiveNamespace::XamlHelpers
         HString inputLabel;
         RETURN_IF_FAILED(adaptiveInputElement->get_Label(inputLabel.GetAddressOf()));
 
+        // Retrieve if the input is required so we can file a warning if the label is empty
+        boolean isRequired;
+        RETURN_IF_FAILED(adaptiveInputElement->get_IsRequired(&isRequired));
+
         if (inputLabel != nullptr)
         {
             // Create a rich text block for the label
@@ -757,11 +761,8 @@ namespace AdaptiveNamespace::XamlHelpers
             RETURN_IF_FAILED(labelRun.As(&labelRunAsInline));
 
             RETURN_IF_FAILED(xamlInlines->Append(labelRunAsInline.Get()));
-
-            // If the input is required, add a * or other suffix if specified
-            boolean isRequired;
-            RETURN_IF_FAILED(adaptiveInputElement->get_IsRequired(&isRequired));
-
+           
+            // Get the label config depending if the input is required
             ComPtr<IAdaptiveHostConfig> hostConfig;
             RETURN_IF_FAILED(renderContext->get_HostConfig(&hostConfig));
 
@@ -792,6 +793,13 @@ namespace AdaptiveNamespace::XamlHelpers
             RETURN_IF_FAILED(xamlRichTextBlock->put_TextWrapping(TextWrapping_Wrap));
 
             RETURN_IF_FAILED(xamlRichTextBlock.CopyTo(labelControl));
+        }
+        else if (isRequired)
+        {
+            // if there was no label but the input is required file a warning for the card author
+            RETURN_IF_FAILED(
+                renderContext->AddWarning(ABI::AdaptiveNamespace::WarningStatusCode::EmptyLabelInRequiredInput,
+                                          HStringReference(L"Input is required but there's no label for required hint rendering").Get()));
         }
 
         return S_OK;


### PR DESCRIPTION
## Related Issue
Fixes #4385
Fixes #4386

## Description
Adds a warning when an input element is required but no label was assigned so the required hint is not rendered which would provide a confusing story for card users.

## How Verified



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4409)