### PR TITLE
Emit warning for required inputs without label

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -2570,6 +2570,13 @@ export abstract class Input extends CardElement implements IInput {
                 Enums.ValidationEvent.PropertyCantBeNull,
                 "All inputs must have a unique Id");
         }
+
+        if (this.isRequired && !this.label) {
+            context.addFailure(
+                this,
+                Enums.ValidationEvent.RequiredInputsShouldHaveLabel,
+                "Required inputs should have a label");
+        }
     }
 
     validateValue(): boolean {

--- a/source/nodejs/adaptivecards/src/enums.ts
+++ b/source/nodejs/adaptivecards/src/enums.ts
@@ -169,6 +169,7 @@ export enum ValidationEvent {
     UnsupportedCardVersion,
     DuplicateId,
     UnsupportedProperty,
+    RequiredInputsShouldHaveLabel,
     Other
 }
 


### PR DESCRIPTION
## Related Issue
Fixes https://github.com/microsoft/AdaptiveCards/issues/4389

## Description
Renderer now emits a warning for required inputs that do not have a label. The warning is displayed in the designer.

## How Verified
Verified manually in adaptivecards-designer-app

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4435)