### PR TITLE
[UWP] Fix CustomActionWrapper's title handling

### DIFF
--- a/source/uwp/Renderer/lib/CustomActionWrapper.cpp
+++ b/source/uwp/Renderer/lib/CustomActionWrapper.cpp
@@ -82,8 +82,14 @@ namespace AdaptiveNamespace
     std::string CustomActionWrapper::GetActionElementTitle() const
     {
         Wrappers::HString title;
-        THROW_IF_FAILED(m_actionElement->get_Title(title.GetAddressOf()));
-        return HStringToUTF8(title.Get());
+        if (SUCCEEDED(m_actionElement->get_Title(title.GetAddressOf())) && title.IsValid())
+        {
+            return HStringToUTF8(title.Get());
+        }
+        else
+        {
+            return "";
+        }
     }
 
     void CustomActionWrapper::SetActionElementTitle(const std::string& value)


### PR DESCRIPTION
## Description
While working on something unrelated, I noticed that some of the UWP unit tests were failing. This is the root cause (the thrown exception bubbled all the way up to the unit test, causing a failure.

## How Verified
* local build and tests

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4440)