### PR TITLE
[Android] Fix stretch textblock claiming all visible space

### DIFF
--- a/samples/v1.3/Tests/Input.Text.Label.Stretch.json
+++ b/samples/v1.3/Tests/Input.Text.Label.Stretch.json
@@ -1,0 +1,73 @@
+{
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "type": "AdaptiveCard",
+    "version": "1.0",
+    "body": [
+        {
+            "type": "Container",
+            "minHeight": "200px",
+            "items": [
+                {
+                    "type": "Input.Text",
+                    "id": "input1",
+                    "style": "text",
+                    "label": "Required Input.Text label",
+                    "isRequired": true,
+                    "errorMessage": "Required input",
+                    "height": "stretch"
+                },
+                {
+                    "type": "TextBlock",
+                    "text": "Bottom text"
+                }
+            ]
+        },
+        {
+            "type": "Container",
+            "minHeight": "200px",
+            "style": "emphasis",
+            "bleed": true,
+            "verticalContentAlignment": "center",
+            "items": [
+                {
+                    "type": "Input.Text",
+                    "id": "input2",
+                    "style": "text",
+			        "label": "Required Input.Text label",
+			        "isRequired": true,
+                    "errorMessage": "Required input"
+                },
+                {
+                    "type": "TextBlock",
+                    "text": "Bottom text"
+                }
+            ]
+        },
+        {
+            "type": "Container",
+            "minHeight": "200px",
+            "bleed": true,
+            "verticalContentAlignment": "bottom",
+            "items": [
+		        {
+			        "type": "Input.Text",
+                    "id": "input3",
+                    "style": "text",
+			        "label": "Required Input.Text label",
+			        "isRequired": true,
+                    "errorMessage": "Required input"
+                },
+                {
+                    "type": "TextBlock",
+                    "text": "Bottom text"
+                }
+            ]
+        }
+	],
+	"actions": [
+		{
+			"type": "Action.Submit",
+			"title": "Submit"
+		}
+	]
+}

--- a/samples/v1.3/Tests/StretchForm.json
+++ b/samples/v1.3/Tests/StretchForm.json
@@ -1,0 +1,28 @@
+{
+    "type": "AdaptiveCard",
+    "version": "1.2",
+    "minHeight": "300px",
+    "body": [
+        {
+            "type": "TextBlock",
+            "text": "This is a stretched textblock",
+            "wrap": true,
+            "height": "stretch"
+        },
+        {
+            "type": "Input.Text",
+            "id": "input1",
+            "height": "stretch"
+        },
+        {
+            "type": "TextBlock",
+            "text": "This is a non-stretched textblock",
+            "wrap": true
+        },
+        {
+            "type": "Input.Text",
+            "id": "input2",
+            "height": "stretch"
+        }
+    ]
+}

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/TextBlockRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/TextBlockRenderer.java
@@ -157,7 +157,7 @@ public class TextBlockRenderer extends BaseCardElementRenderer
         }
 
         TextView textView = new TextView(context);
-        textView.setLayoutParams(new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT));
+        textView.setLayoutParams(new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT));
 
         textView.setTag(new TagContent(textBlock));
 


### PR DESCRIPTION
## Related Issue
Fixes #4433 

## Description
Changes the TextBlock sizing to avoid them taking all the space due to setting the height to match parent

## How Verified
The fix was verified by testing manually the card as well as adding it to the cards folder for v1.3

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/35784165/87996342-b5b2d780-caa6-11ea-873d-f2ee2f2be196.png) | ![image](https://user-images.githubusercontent.com/35784165/87996373-d418d300-caa6-11ea-93c9-99157896d571.png) |




###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4452)