### PR TITLE
[Android] Fix submit inline actions to retrieve inputs

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/TextInputRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/TextInputRenderer.java
@@ -34,6 +34,7 @@ import io.adaptivecards.objectmodel.BaseInputElement;
 
 import io.adaptivecards.objectmodel.ContainerStyle;
 import io.adaptivecards.objectmodel.ForegroundColor;
+import io.adaptivecards.objectmodel.SubmitAction;
 import io.adaptivecards.renderer.AdaptiveWarning;
 import io.adaptivecards.renderer.InnerImageLoaderAsync;
 import io.adaptivecards.renderer.RenderArgs;
@@ -366,6 +367,11 @@ public class TextInputRenderer extends BaseCardElementRenderer
         setVisibility(baseCardElement.GetIsVisible(), editText);
 
         BaseActionElement action = textInput.GetInlineAction();
+
+        if (Util.isOfType(action, SubmitAction.class))
+        {
+            renderedCard.setCardForSubmitAction(action.GetInternalId(), renderArgs.getContainerCardId());
+        }
 
         if (textInput.GetIsMultiline())
         {


### PR DESCRIPTION
## Related Issue
Fixes #4438

## Description
As with other platforms, inline submit actions in Android are rendered differently to regular actions so we have to manually register the inline action to the rendered card so it knows in what card it's located so it can retrieve inputs.

## How Verified

The fix was verified manually as can be seen below

![androidInlineAction](https://user-images.githubusercontent.com/35784165/87998615-47bdde80-caad-11ea-8c40-3d8fd2b4c62a.gif)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4453)