### PR TITLE
[WPF] Add warning for empty labels

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveContainerRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveContainerRenderer.cs
@@ -372,6 +372,10 @@ namespace AdaptiveCards.Rendering.Wpf
                         panel.Children.Add(RenderLabel(context, inputElement, elementForAccessibility));
                         AddSpacing(context, context.Config.Inputs.Label.InputSpacing, panel);
                     }
+                    else if (inputElement.IsRequired)
+                    {
+                        context.Warnings.Add(new AdaptiveWarning((int)AdaptiveWarning.WarningStatusCode.EmptyLabelInRequiredInput, "Input is required but there's no label for required hint rendering"));
+                    }
 
                     panel.Children.Add(enclosingElement);
                     enclosingElement = panel;

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveWarning.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveWarning.cs
@@ -6,7 +6,7 @@ namespace AdaptiveCards
     public class AdaptiveWarning
     {
         // TODO #2749: temporary warning code for fallback card. Remove when common set of error codes created and integrated.
-        public enum WarningStatusCode { UnsupportedSchemaVersion = 7, InvalidLanguage = 12, MaxActionsExceeded = 13 };
+        public enum WarningStatusCode { UnsupportedSchemaVersion = 7, InvalidLanguage = 12, MaxActionsExceeded = 13, EmptyLabelInRequiredInput = 14 };
 
         public AdaptiveWarning(int code, string message)
         {


### PR DESCRIPTION
## Related Issue
Fixes #4388

## Description
Adds a warning when an input element is required but no label was assigned so the required hint is not rendered which would provide a confusing story for card users.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4454)