### PR TITLE
Fixing .NET CI tests for feature/inputEvolution

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveContainerRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveContainerRenderer.cs
@@ -359,7 +359,7 @@ namespace AdaptiveCards.Rendering.Wpf
                     }
                 }
 
-                AutomationProperties.SetIsRequiredForForm(GetVisualElementForAccessibility(context, inputElement), inputElement.IsRequired);
+                AutomationProperties.SetIsRequiredForForm(GetVisualElementForAccessibility(context, inputElement)?? elementForAccessibility, inputElement.IsRequired);
 
                 if ((!String.IsNullOrEmpty(inputElement.Label)) || (!String.IsNullOrEmpty(inputElement.ErrorMessage)))
                 {
@@ -474,7 +474,7 @@ namespace AdaptiveCards.Rendering.Wpf
             }
 
             // For Input.Text we render inline actions inside of a Grid, so we set the property
-            AutomationProperties.SetLabeledBy(GetVisualElementForAccessibility(context, input), uiTextBlock);
+            AutomationProperties.SetLabeledBy(GetVisualElementForAccessibility(context, input) ?? renderedInput, uiTextBlock);
 
             return uiTextBlock;
         }
@@ -505,7 +505,7 @@ namespace AdaptiveCards.Rendering.Wpf
 
         public static UIElement GetVisualElementForAccessibility(AdaptiveRenderContext context, AdaptiveInput input)
         {
-            return context.InputValues[input.Id].VisualElementForAccessibility;
+            return context.InputValues[input.Id]?.VisualElementForAccessibility;
         }
     }
 }

--- a/source/dotnet/Library/AdaptiveCards/Rendering/LabelConfig.cs
+++ b/source/dotnet/Library/AdaptiveCards/Rendering/LabelConfig.cs
@@ -18,8 +18,9 @@ namespace AdaptiveCards.Rendering
         public InputLabelConfig OptionalInputs { get; set; } = new InputLabelConfig();
 
         /// <summary>
-        /// Specifies the spacing bewteen the label and the input
+        /// Specifies the spacing between the label and the input
         /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public AdaptiveSpacing InputSpacing { get; set; }
     }
 }

--- a/source/dotnet/Library/AdaptiveCards/docs/AdaptiveCards.md
+++ b/source/dotnet/Library/AdaptiveCards/docs/AdaptiveCards.md
@@ -2673,7 +2673,7 @@ Properties which control rendering of input labels
 
 ##### Summary
 
-Specifies the spacing bewteen the label and the input
+Specifies the spacing between the label and the input
 
 <a name='T-AdaptiveCards-Rendering-MediaConfig'></a>
 ## MediaConfig `type`

--- a/source/dotnet/Samples/AdaptiveCards.Sample.ImageRender/AdaptiveCards.Sample.ImageRender.csproj
+++ b/source/dotnet/Samples/AdaptiveCards.Sample.ImageRender/AdaptiveCards.Sample.ImageRender.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/source/dotnet/Samples/AdaptiveCards.Sample.ImageRender/Properties/launchSettings.json
+++ b/source/dotnet/Samples/AdaptiveCards.Sample.ImageRender/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "AdaptiveCards.Sample.ImageRender": {
       "commandName": "Project",
-      "commandLineArgs": "-r  -o ./out"
+      "commandLineArgs": "\" C:\\AdaptiveCards\\samples\\v1.0\\Scenarios\" -r  -o ./out"
     }
   }
 }

--- a/source/dotnet/Samples/AdaptiveCards.Sample.ImageRender/Properties/launchSettings.json
+++ b/source/dotnet/Samples/AdaptiveCards.Sample.ImageRender/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "AdaptiveCards.Sample.ImageRender": {
       "commandName": "Project",
-      "commandLineArgs": "\" C:\\AdaptiveCards\\samples\\v1.0\\Scenarios\" -r  -o ./out"
+      "commandLineArgs": "-r  -o ./out"
     }
   }
 }


### PR DESCRIPTION
## Related Issue
Not being tracked (CI failure in .NET)

## Description
1. Updating the serialization behavior for the newly introduced LabelConfig.InputSpacing property to ignore default values from being written out while serializing to allow the current HTML renderer that doesn't yet support Labels to continue to work.
2. In AdaptiveContainerRenderer, fallback to working with the earlier elementForAccessibility element for inputs with null values _(appears at least the v1.0 samples fell into this category)._
3. Fixing a typo in the XML comments for the API doc
4. Including the regenerated API doc 

## How Verified
1. Ran RunAllTests.ps1 with defaults (samples\v1.0\scenarios) 
2. Manually ran the ImageRenderer sample for WPF, the WPF visualizer as well as the HTML Test suite, with the problem scenario files and verified they now successfully render as expected.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4462)