### PR TITLE
fixed weak reference to copy property

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOBaseActionElement.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOBaseActionElement.mm
@@ -49,10 +49,12 @@ using namespace AdaptiveCards;
 {
     if (_elem) {
         Json::Value blob = _elem->GetAdditionalProperties();
-        Json::FastWriter fastWriter;
+        Json::StreamWriterBuilder streamWriterBuilder;
+        auto writer = streamWriterBuilder.newStreamWriter();
+        std::stringstream sstream;
+        writer->write(blob, &sstream);
         NSString *jsonString =
-            [[NSString alloc] initWithCString:fastWriter.write(blob).c_str()
-                                     encoding:NSUTF8StringEncoding];
+        [[NSString alloc] initWithCString:sstream.str().c_str() encoding:NSUTF8StringEncoding];
         return (jsonString.length > 0) ? [jsonString dataUsingEncoding:NSUTF8StringEncoding] : nil;
     }
     return nil;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOBaseCardElement.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOBaseCardElement.mm
@@ -45,10 +45,12 @@ using namespace AdaptiveCards;
 {
     if (_elem) {
         Json::Value blob = _elem->GetAdditionalProperties();
-        Json::FastWriter fastWriter;
+        Json::StreamWriterBuilder streamWriterBuilder;
+        auto writer = streamWriterBuilder.newStreamWriter();
+        std::stringstream sstream;
+        writer->write(blob, &sstream);
         NSString *jsonString =
-            [[NSString alloc] initWithCString:fastWriter.write(blob).c_str()
-                                     encoding:NSUTF8StringEncoding];
+        [[NSString alloc] initWithCString:sstream.str().c_str() encoding:NSUTF8StringEncoding];
         return (jsonString.length > 0) ? [jsonString dataUsingEncoding:NSUTF8StringEncoding] : nil;
     }
     return nil;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetCellChecked.xib
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetCellChecked.xib
@@ -9,22 +9,21 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="xfE-mE-JQp" imageView="Kcv-2T-W8W" style="IBUITableViewCellStyleDefault" id="0JF-PI-bTn">
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="xfE-mE-JQp" imageView="Kcv-2T-W8W" style="IBUITableViewCellStyleDefault" translatesAutoresizingMaskIntoConstraints="NO" id="0JF-PI-bTn">
             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
-            <autoresizingMask key="autoresizingMask"/>
-            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="0JF-PI-bTn" id="j2h-ft-4LW">
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="0JF-PI-bTn" translatesAutoresizingMaskIntoConstraints="NO" id="j2h-ft-4LW">
                 <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="xfE-mE-JQp">
-                        <rect key="frame" x="59" y="0.0" width="335" height="44"/>
+                    <label opaque="NO" multipleTouchEnabled="YES" userInteractionEnabled="NO" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xfE-mE-JQp">
+                        <rect key="frame" x="53" y="0.0" width="341" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                         <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
+                        <color key="highlightedColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </label>
-                    <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" image="checkmark.square" catalog="system" id="Kcv-2T-W8W">
-                        <rect key="frame" x="20" y="11" width="24" height="22"/>
+                    <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" userInteractionEnabled="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" image="checked-checkbox-24.png" translatesAutoresizingMaskIntoConstraints="NO" id="Kcv-2T-W8W">
+                        <rect key="frame" x="20" y="13" width="18" height="18"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </imageView>
                 </subviews>
@@ -34,6 +33,6 @@
         </tableViewCell>
     </objects>
     <resources>
-        <image name="checkmark.square" catalog="system" width="128" height="114"/>
+        <image name="checked-checkbox-24.png" width="18" height="18"/>
     </resources>
 </document>

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetCellCompactChecked.xib
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetCellCompactChecked.xib
@@ -9,22 +9,21 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ACRChoiceSetViewDataSourceCompactStyle"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="axm-gY-tdP" imageView="vKx-yn-Tze" style="IBUITableViewCellStyleDefault" id="OUc-2r-ktk">
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="492-kR-Cfr" imageView="ank-01-hjD" style="IBUITableViewCellStyleDefault" translatesAutoresizingMaskIntoConstraints="NO" id="OUc-2r-ktk">
             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
-            <autoresizingMask key="autoresizingMask"/>
-            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="OUc-2r-ktk" id="ikC-xw-bp0">
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="OUc-2r-ktk" translatesAutoresizingMaskIntoConstraints="NO" id="ikC-xw-bp0">
                 <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="axm-gY-tdP">
-                        <rect key="frame" x="59.5" y="0.0" width="334.5" height="44"/>
+                    <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="492-kR-Cfr">
+                        <rect key="frame" x="47" y="0.0" width="347" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" image="smallcircle.fill.circle" catalog="system" id="vKx-yn-Tze">
-                        <rect key="frame" x="19.5" y="10" width="25" height="24"/>
+                    <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" image="checked.png" id="ank-01-hjD">
+                        <rect key="frame" x="20" y="16" width="12" height="12"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </imageView>
                 </subviews>
@@ -35,6 +34,6 @@
         </tableViewCell>
     </objects>
     <resources>
-        <image name="smallcircle.fill.circle" catalog="system" width="128" height="121"/>
+        <image name="checked.png" width="12" height="12"/>
     </resources>
 </document>

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetCellCompactUnchecked.xib
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetCellCompactUnchecked.xib
@@ -9,23 +9,23 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="EfR-YS-Qdm" imageView="xbQ-X4-0gJ" style="IBUITableViewCellStyleDefault" id="5PL-8L-Mhg">
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="EfR-YS-Qdm" imageView="xbQ-X4-0gJ" style="IBUITableViewCellStyleDefault" translatesAutoresizingMaskIntoConstraints="NO" id="5PL-8L-Mhg">
             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
-            <autoresizingMask key="autoresizingMask"/>
-            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="5PL-8L-Mhg" id="4GY-3W-p3l">
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="5PL-8L-Mhg" translatesAutoresizingMaskIntoConstraints="NO" id="4GY-3W-p3l">
                 <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="EfR-YS-Qdm">
-                        <rect key="frame" x="59.5" y="0.0" width="334.5" height="44"/>
+                    <label opaque="NO" multipleTouchEnabled="YES" userInteractionEnabled="NO" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EfR-YS-Qdm">
+                        <rect key="frame" x="47" y="0.0" width="347" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                         <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
+                        <color key="highlightedColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </label>
-                    <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" image="circle" catalog="system" id="xbQ-X4-0gJ">
-                        <rect key="frame" x="19.5" y="10" width="25" height="24"/>
+                    <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" userInteractionEnabled="NO" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" image="unchecked.png" translatesAutoresizingMaskIntoConstraints="NO" id="xbQ-X4-0gJ">
+                        <rect key="frame" x="20" y="16" width="12" height="12"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="small"/>
                     </imageView>
                 </subviews>
             </tableViewCellContentView>
@@ -34,6 +34,6 @@
         </tableViewCell>
     </objects>
     <resources>
-        <image name="circle" catalog="system" width="128" height="121"/>
+        <image name="unchecked.png" width="12" height="12"/>
     </resources>
 </document>

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetCellUnchecked.xib
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetCellUnchecked.xib
@@ -9,23 +9,23 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="a6d-Cm-AWo" imageView="k57-vY-wY2" style="IBUITableViewCellStyleDefault" id="du8-bQ-J2V">
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="a6d-Cm-AWo" imageView="k57-vY-wY2" style="IBUITableViewCellStyleDefault" translatesAutoresizingMaskIntoConstraints="NO" id="du8-bQ-J2V">
             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
-            <autoresizingMask key="autoresizingMask"/>
-            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="du8-bQ-J2V" id="EaU-Q3-4IS">
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="du8-bQ-J2V" translatesAutoresizingMaskIntoConstraints="NO" id="EaU-Q3-4IS">
                 <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="a6d-Cm-AWo">
-                        <rect key="frame" x="59" y="0.0" width="335" height="44"/>
+                    <label opaque="NO" multipleTouchEnabled="YES" userInteractionEnabled="NO" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a6d-Cm-AWo">
+                        <rect key="frame" x="53" y="0.0" width="341" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                         <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
+                        <color key="highlightedColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </label>
-                    <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" image="square" catalog="system" id="k57-vY-wY2">
-                        <rect key="frame" x="20" y="11" width="24" height="22"/>
+                    <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" userInteractionEnabled="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" image="unchecked-checkbox-24.png" translatesAutoresizingMaskIntoConstraints="NO" id="k57-vY-wY2">
+                        <rect key="frame" x="20" y="13" width="18" height="18"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="small"/>
                     </imageView>
                 </subviews>
             </tableViewCellContentView>
@@ -34,6 +34,6 @@
         </tableViewCell>
     </objects>
     <resources>
-        <image name="square" catalog="system" width="128" height="114"/>
+        <image name="unchecked-checkbox-24.png" width="18" height="18"/>
     </resources>
 </document>

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSource.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSource.mm
@@ -99,13 +99,14 @@ NSString *uncheckedRadioButtonReuseID = @"unchecked-radiobutton";
         }
         cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
     }
-
+    
     NSString *title = [NSString stringWithCString:_choiceSetDataSource->GetChoices()[indexPath.row]->GetTitle().c_str()
                                          encoding:NSUTF8StringEncoding];
     cell.textLabel.text = title;
+    cell.textLabel.numberOfLines = _choiceSetDataSource->GetWrap() ? 0 : 1;
     cell.textLabel.textColor = getForegroundUIColorFromAdaptiveAttribute(_config, _parentStyle);
     cell.accessibilityTraits = cell.accessibilityTraits | UIAccessibilityTraitButton;
-
+    
     return cell;
 }
 
@@ -147,9 +148,10 @@ NSString *uncheckedRadioButtonReuseID = @"unchecked-radiobutton";
             _userSelections[[NSNumber numberWithInteger:indexPath.row]] = [NSNumber numberWithBool:YES];
         }
     }
-
-    [tableView reloadRowsAtIndexPaths:indexPathsToUpdate withRowAnimation:UITableViewRowAnimationAutomatic];
+    
+    [tableView reloadData];
     _currentSelectedIndexPath = indexPath;
+
 }
 
 - (void)tableView:(UITableView *)tableView didDeselectRowAtIndexPath:(nonnull NSIndexPath *)indexPath
@@ -251,7 +253,7 @@ NSString *uncheckedRadioButtonReuseID = @"unchecked-radiobutton";
 
 - (float)getNonInputWidth:(UITableViewCell *)cell
 {
-    return _spacing * 3 + cell.imageView.image.size.width;
+    return cell.separatorInset.left + cell.indentationWidth + cell.accessoryView.frame.size.width + cell.imageView.image.size.width;
 }
 
 @synthesize isRequired;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRCustomRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRCustomRenderer.mm
@@ -40,8 +40,12 @@
     if (reg) {
         NSString *type = [NSString stringWithCString:customElem->GetElementTypeString().c_str() encoding:NSUTF8StringEncoding];
         Json::Value blob = customElem->GetAdditionalProperties();
-        Json::FastWriter fastWriter;
-        NSString *jsonString = [[NSString alloc] initWithCString:fastWriter.write(blob).c_str() encoding:NSUTF8StringEncoding];
+        Json::StreamWriterBuilder streamWriterBuilder;
+        auto writer = streamWriterBuilder.newStreamWriter();
+        std::stringstream sstream;
+        writer->write(blob, &sstream);
+        NSString *jsonString =
+        [[NSString alloc] initWithCString:sstream.str().c_str() encoding:NSUTF8StringEncoding];
 
         if (jsonString.length > 0) {
             NSData *jsonPayload = [jsonString dataUsingEncoding:NSUTF8StringEncoding];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.mm
@@ -149,9 +149,9 @@
         inputHandler = self.dataSource;
     }
     else {
-        id inputView = [self getInputView];
+        UIView *inputView = [self getInputView];
         if ([inputView conformsToProtocol:@protocol(ACRIBaseInputHandler)]) {
-            inputHandler = inputView;
+            inputHandler = (NSObject<ACRIBaseInputHandler> *)inputView;
         }
     }
     
@@ -168,7 +168,7 @@
 
 - (void)setFocus:(BOOL)shouldBecomeFirstResponder view:(UIView *)view
 {
-    id inputHandler = [self getInputHandler];
+    NSObject<ACRIBaseInputHandler> *inputHandler = [self getInputHandler];
     UIView *viewToFocus = [self getInputView];
     if (!inputHandler || !viewToFocus) {
         return;
@@ -179,7 +179,7 @@
 
 - (void)getInput:(NSMutableDictionary *)dictionary
 {
-    id<ACRIBaseInputHandler> inputHandler = [self getInputHandler];
+    NSObject<ACRIBaseInputHandler> *inputHandler = [self getInputHandler];
     if (inputHandler) {
         [inputHandler getInput:dictionary];
     }
@@ -208,5 +208,7 @@
 }
 
 @synthesize hasValidationProperties;
+
+@synthesize id;
 
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputRenderer.mm
@@ -40,8 +40,9 @@
     return ACRTextInput;
 }
 
-+ (ACRTextField *)configTextFiled:(std::shared_ptr<TextInput> const &)inputBlock renderAction:(BOOL)renderAction rootView:(ACRView *)rootView txtInput:(ACRTextField *)txtInput viewGroup:(UIView<ACRIContentHoldingView> *)viewGroup
++ (ACRTextField *)configTextFiled:(std::shared_ptr<TextInput> const &)inputBlock renderAction:(BOOL)renderAction rootView:(ACRView *)rootView viewGroup:(UIView<ACRIContentHoldingView> *)viewGroup
 {
+    ACRTextField *txtInput = nil;
     switch (inputBlock->GetTextInputStyle()) {
         case TextInputStyle::Email: {
             NSBundle *bundle = [NSBundle bundleWithIdentifier:@"MSFT.AdaptiveCards"];
@@ -147,13 +148,13 @@
             // if action is defined, load ACRQuickReplyView nib for customizable UI
             quickReplyView = [[ACRQuickReplyView alloc] initWithFrame:CGRectMake(0, 0, viewGroup.frame.size.width, 0)];
             button = quickReplyView.button;
-            txtInput = [ACRInputRenderer configTextFiled:inputBlck renderAction:renderAction rootView:rootView txtInput:txtInput viewGroup:viewGroup];
+            txtInput = [ACRInputRenderer configTextFiled:inputBlck renderAction:renderAction rootView:rootView viewGroup:viewGroup];
             [quickReplyView addTextField:txtInput];            
             ACRInputLabelView *inputLabelView = [[ACRInputLabelView alloc] initInputLabelView:rootView acoConfig:acoConfig adptiveInputElement:inputBlck inputView:quickReplyView viewGroup:viewGroup dataSource:textInputHandler];
             inputview = inputLabelView;
 
         } else {
-            txtInput = [ACRInputRenderer configTextFiled:inputBlck renderAction:renderAction rootView:rootView txtInput:txtInput viewGroup:viewGroup];
+            txtInput = [ACRInputRenderer configTextFiled:inputBlck renderAction:renderAction rootView:rootView viewGroup:viewGroup];
             ACRInputLabelView *inputLabelView = [[ACRInputLabelView alloc] initInputLabelView:rootView acoConfig:acoConfig adptiveInputElement:inputBlck inputView:txtInput viewGroup:viewGroup dataSource:textInputHandler];
             inputview = inputLabelView;
         }

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputTableView.xib
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputTableView.xib
@@ -9,9 +9,8 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableView clipsSubviews="YES" contentMode="center" bounces="NO" alwaysBounceVertical="YES" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" sectionFooterHeight="-1" id="AeY-op-ug9" customClass="ACRInputTableView">
+        <tableView clipsSubviews="YES" contentMode="center" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="AeY-op-ug9" customClass="ACRInputTableView">
             <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
-            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>
@@ -21,7 +20,7 @@
             <color key="sectionIndexTrackingBackgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <userDefinedRuntimeAttributes>
                 <userDefinedRuntimeAttribute type="number" keyPath="inputTableViewSpacing">
-                    <real key="value" value="8"/>
+                    <real key="value" value="10"/>
                 </userDefinedRuntimeAttribute>
             </userDefinedRuntimeAttributes>
             <point key="canvasLocation" x="-337" y="-185"/>

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextInputHandler.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextInputHandler.h
@@ -13,7 +13,7 @@
 
 @property NSPredicate *regexPredicate;
 @property NSUInteger maxLength;
-@property __weak NSString *text;
+@property NSString *text;
 @property BOOL hasText;
 
 - (instancetype)init:(ACOBaseCardElement *)acoElem;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextInputHandler.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextInputHandler.mm
@@ -99,6 +99,8 @@
     if (self) {
         self.isRequired = numberInputBlock->GetIsRequired();
         self.text = [NSString stringWithFormat:@"%d", numberInputBlock->GetValue()];
+        self.id = [NSString stringWithCString:numberInputBlock->GetId().c_str()
+        encoding:NSUTF8StringEncoding];
         if (self.text && self.text.length) {
             self.hasText = YES;
         }

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
@@ -630,8 +630,12 @@ ACOBaseActionElement *deserializeUnknownActionToCustomAction(const std::shared_p
             @throw [ACOFallbackException fallbackException];
         }
         Json::Value blob = unknownAction->GetAdditionalProperties();
-        Json::FastWriter fastWriter;
-        NSString *jsonString = [[NSString alloc] initWithCString:fastWriter.write(blob).c_str() encoding:NSUTF8StringEncoding];
+        Json::StreamWriterBuilder streamWriterBuilder;
+        auto writer = streamWriterBuilder.newStreamWriter();
+        std::stringstream sstream;
+        writer->write(blob, &sstream);
+        NSString *jsonString =
+        [[NSString alloc] initWithCString:sstream.str().c_str() encoding:NSUTF8StringEncoding];        
         if (jsonString.length > 0) {
             NSData *jsonPayload = [jsonString dataUsingEncoding:NSUTF8StringEncoding];
             ACOParseContext *context = [reg getParseContext];

--- a/source/shared/cpp/ObjectModel/MarkDownBlockParser.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownBlockParser.cpp
@@ -51,15 +51,6 @@ void MarkDownBlockParser::ParseBlock(std::stringstream& stream)
         m_parsedResult.AppendParseResult(listParser.GetParsedResult());
         break;
     }
-    {
-        ListParser listParser;
-        // do syntax check of list
-        listParser.Match(stream);
-        // append list result to the rest
-        m_parsedResult.AppendParseResult(listParser.GetParsedResult());
-        break;
-    }
-
     // handles list block
     case '*':
     {


### PR DESCRIPTION
## Related Issue
Fixed #4465 

## Description
Text in the input handler had a weak reference to the text propertyUITextField. But this leads to problem since the text field has a copy property set.
## How Verified
Verified with relevant cards.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4473)