### PR TITLE
[UWP] Fix null AV when rendering a media element

### DIFF
--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -4444,8 +4444,14 @@ namespace AdaptiveNamespace
             return;
         }
 
-        ABI::AdaptiveNamespace::ActionType actionType;
-        action->get_ActionType(&actionType);
+        // We only care about action type for creating the button below. If an action wasn't supplied (this can happen
+        // e.g. when using WrapInTouchTarget to build a media element), just default to a non-OpenUrl action type so
+        // that a generic button is used.
+        ABI::AdaptiveNamespace::ActionType actionType = ABI::AdaptiveNamespace::ActionType::Submit;
+        if (action != nullptr)
+        {
+            action->get_ActionType(&actionType);
+        }
 
         ComPtr<IButton> button;
         CreateAppropriateButton(actionType, button);


### PR DESCRIPTION
## Related Issue
Fixes #4489

## Description
Simple issue -- rendering certain cards would NULL AV in `XamlBuilder::WrapInTouchTarget()`. Analysis is in #4489, but suffice it to say that this is one of the easy NULL AV fixes. We just need a `nullptr` check and a reasonable default.

## How Verified
* local build, debug, and test payload verification


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4503)