### PR TITLE
[Android][InputEvolution] Fix number input default behaviour

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/NumberInputRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/NumberInputRenderer.java
@@ -64,13 +64,13 @@ public class NumberInputRenderer extends TextInputRenderer
                 context,
                 viewGroup,
                 numberInput,
-                String.valueOf(numberInput.GetValue()),
+                numberInput.GetValue() != null ? String.valueOf(numberInput.GetValue()) : "",
                 String.valueOf(numberInput.GetPlaceholder()),
                 numberInputHandler,
                 hostConfig,
                 tagContent,
                 renderArgs,
-                ((numberInput.GetMin() != Integer.MIN_VALUE) || (numberInput.GetMax() != Integer.MAX_VALUE)));
+                ((numberInput.GetMin() != null) || (numberInput.GetMax() != null)));
 
         editText.setInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_DECIMAL | InputType.TYPE_NUMBER_FLAG_SIGNED);
 

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/NumberInputHandler.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/NumberInputHandler.java
@@ -54,7 +54,18 @@ public class NumberInputHandler extends TextInputHandler
             return false;
         }
 
-        return (numberInput.GetMin() <= inputValue) && (inputValue <= numberInput.GetMax());
+        boolean isValid = true;
+        if (numberInput.GetMin() != null)
+        {
+            isValid = (numberInput.GetMin() <= inputValue);
+        }
+
+        if (numberInput.GetMax() != null)
+        {
+            isValid = isValid && (inputValue <= numberInput.GetMax());
+        }
+
+        return isValid;
     }
 
 }


### PR DESCRIPTION
## Related Issue
Fixes #4522 

## Description
This fix changes the comparisson behaviours to match the new use of nullable properties for value, min and max in Input.Number. Now there are null checks instead of comparissons against Integer.MIN_VALUE or Integer.MAX_VALUE constants.

## How Verified
The fix was verified manually and the results can be seen below:

Value set, Min/Max null/unset
![image](https://user-images.githubusercontent.com/35784165/89217334-da1bb300-d580-11ea-89ae-8d7ae6e85f77.png)

Value null/unset
![image](https://user-images.githubusercontent.com/35784165/89217272-be181180-d580-11ea-9401-da6a93adf8d2.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4523)