### PR TITLE
[CherryPick] Revert "[Android] Use ConstraintLayout for Image sizing (#4461)" (#4520)

### DIFF
--- a/samples/v1.2/Tests/ImageSizing.json
+++ b/samples/v1.2/Tests/ImageSizing.json
@@ -1,285 +1,153 @@
 {
-	"type": "AdaptiveCard",
-	"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
-	"version": "1.2",
-	"body": [
-		{
-			"type": "TextBlock",
-			"text": "(default)"
-		},
-		{
-			"type": "Image",
-			"url": "https://picsum.photos/id/133/300/200"
-		},
-		{
-			"type": "TextBlock",
-			"text": "Size: Small"
-		},
-		{
-			"type": "Image",
-			"url": "https://picsum.photos/id/133/300/200",
-			"size": "Small"
-		},
-		{
-			"type": "TextBlock",
-			"text": "Size: Small, Align: Center"
-		},
-		{
-			"type": "Image",
-			"url": "https://picsum.photos/id/133/300/200",
-			"size": "Small",
-			"horizontalAlignment": "Center"
-		},
-		{
-			"type": "TextBlock",
-			"text": "Size: Small, Align: Right"
-		},
-		{
-			"type": "Image",
-			"url": "https://picsum.photos/id/133/300/200",
-			"size": "Small",
-			"horizontalAlignment": "Right"
-		},
-		{
-		  "type": "TextBlock",
-		  "text": "Size: Medium"
-		},
-		{
-			"type": "Image",
-			"url": "https://picsum.photos/id/133/300/200",
-			"size": "Medium"
-		},
-		{
-		  "type": "TextBlock",
-		  "text": "Size: Large"
-		},
-		{
-			"type": "Image",
-			"url": "https://picsum.photos/id/133/300/200",
-			"size": "Large"
-		},
-		{
-		  "type": "TextBlock",
-		  "text": "Size: Auto"
-		},
-		{
-			"type": "Image",
-			"url": "https://picsum.photos/id/133/300/200",
-			"size": "Auto"
-		},
-		{
-		  "type": "TextBlock",
-		  "text": "Size: Stretch"
-		},
-		{
-			"type": "Image",
-			"url": "https://picsum.photos/id/133/300/200",
-			"size": "Stretch"
-		},
-		{
-		  "type": "TextBlock",
-		  "text": "Width: 250px"
-		},
-		{
-			"type": "Image",
-			"url": "https://picsum.photos/id/133/300/200",
-			"width": "250px"
-		},
-		{
-		  "type": "TextBlock",
-		  "text": "Height: 100px"
-		},
-		{
-			"type": "Image",
-			"url": "https://picsum.photos/id/133/300/200",
-			"height": "100px"
-		},
-		{
-		  "type": "TextBlock",
-		  "text": "Width: 250px, Height: 100px"
-		},
-		{
-			"type": "Image",
-			"url": "https://picsum.photos/id/133/300/200",
-			"height": "100px",
-			"width": "250px"
-		},
-		{
-			"type": "ColumnSet",
-			"columns": [
-			{
-				"type": "Column",
-				"width": "50px",
-				"items": [
-				{
-					  "type": "TextBlock",
-					  "text": "Col 1 (50px)",
-					  "wrap": true
-				},
-				{
-					"type": "TextBlock",
-					"text": "Width: 10px",
-					"wrap": true
-				},
-				{
-					"type": "Image",
-					"url": "https://picsum.photos/id/133/300/200",
-					"width": "10px"
-				},
-				{
-					"type": "TextBlock",
-					"text": "Size: Large",
-					"wrap": true
-				},
-				{
-					"type": "Image",
-					"url": "https://picsum.photos/id/133/300/200",
-					"size": "Large"
-				},
-				{
-					"type": "TextBlock",
-					"text": "Height: Stretch",
-					"wrap": true
-				},
-				{
-					"type": "Image",
-					"url": "https://picsum.photos/id/133/300/200",
-					"height": "stretch"
-				},
-				{
-					"type": "TextBlock",
-					"text": "Size: Stretch",
-					"wrap": true
-				},
-				{
-					"type": "Image",
-					"url": "https://picsum.photos/id/133/300/200",
-					"size": "Stretch"
-				}
-				]
-			},
-			{
-				"type": "Column",
-				"width": "stretch",
-				"items": [
-				{
-					"type": "TextBlock",
-					"text": "Column 2 (Stretch)",
-					"wrap": true
-				},
-				{
-					"type": "TextBlock",
-					"text": "Size: Small"
-				},
-				{
-					"type": "Image",
-					"url": "https://picsum.photos/id/133/300/200",
-					"size": "Small"
-				},
-				{
-					"type": "TextBlock",
-					"text": "Size: Large"
-				},
-				{
-					"type": "Image",
-					"url": "https://picsum.photos/id/133/300/200",
-					"size": "Large"
-				},
-				{
-					"type": "TextBlock",
-					"text": "(default)"
-				},
-				{
-					"type": "Image",
-					"url": "https://picsum.photos/id/133/300/200"
-				},
-				{
-					"type": "TextBlock",
-					"text": "Size: Stretch"
-				},
-				{
-					"type": "Image",
-					"url": "https://picsum.photos/id/133/300/200",
-					"size": "Stretch"
-				}
-				]
-			}
-			]
-		},
-		{
-			"type": "TextBlock",
-			"text": "ImageSet[1] - ImageSize: Small"
-		},
-		{
-			"type": "ImageSet",
-			"imageSize": "Small",
-			"images": [
-			{
-				"type": "Image",
-				"url": "https://picsum.photos/id/133/300/200"
-			}
-			]
-		},
-		{
-			"type": "TextBlock",
-			"text": "ImageSet[1] - (default)"
-		},
-		{
-			"type": "ImageSet",
-			"images": [
-			{
-				"type": "Image",
-				"url": "https://picsum.photos/id/133/300/200"
-			}
-			]
-		},
-		{
-			"type": "TextBlock",
-			"text": "ImageSet[1] - ImageSize: Large"
-		},
-		{
-			"type": "ImageSet",
-			"imageSize": "Large",
-			"images": [
-			{
-				"type": "Image",
-				"url": "https://picsum.photos/id/133/300/200"
-			}
-			]
-		},
-		{
-			"type": "TextBlock",
-			"text": "ImageSet[6] - ImageSize: Medium"
-		},
-		{
-			"type": "ImageSet",
-			"imageSize": "Medium",
-			"images": [
-			{
-				"type": "Image",
-				"url": "https://picsum.photos/id/133/300/200"
-			},
-			{
-				"type": "Image",
-				"url": "https://picsum.photos/id/133/300/200"
-			},
-			{
-				"type": "Image",
-				"url": "https://picsum.photos/id/133/300/200"
-			},
-			{
-				"type": "Image",
-				"url": "https://picsum.photos/id/133/300/200"
-			},
-			{
-				"type": "Image",
-				"url": "https://picsum.photos/id/133/300/200"
-			},
-			{
-				"type": "Image",
-				"url": "https://picsum.photos/id/133/300/200"
-			}
-			]
-		}
-	]
+    "type": "AdaptiveCard",
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.2",
+    "body": [
+        {
+            "type": "Image",
+            "url": "https://picsum.photos/id/133/300/200"
+        },
+        {
+            "type": "Image",
+            "url": "https://picsum.photos/id/133/300/200",
+            "size": "Small"
+        },
+        {
+            "type": "Image",
+            "url": "https://picsum.photos/id/133/300/200",
+            "size": "Medium"
+        },
+        {
+            "type": "Image",
+            "url": "https://picsum.photos/id/133/300/200",
+            "size": "Large"
+        },
+        {
+            "type": "Image",
+            "url": "https://picsum.photos/id/133/300/200"
+        },
+        {
+            "type": "Image",
+            "url": "https://picsum.photos/id/133/300/200",
+            "size": "Stretch"
+        },
+        {
+            "type": "Image",
+            "url": "https://picsum.photos/id/133/300/200",
+            "width": "250px"
+        },
+        {
+            "type": "Image",
+            "url": "https://picsum.photos/id/133/300/200",
+            "height": "100px"
+        },
+        {
+            "type": "Image",
+            "url": "https://picsum.photos/id/133/300/200",
+            "height": "100px",
+            "width": "250px"
+        },
+        {
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "width": "50px",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Col 1"
+                        },
+                        {
+                            "type": "Image",
+                            "url": "https://picsum.photos/id/133/300/200",
+                            "size": "Small"
+                        },
+                        {
+                            "type": "Image",
+                            "url": "https://picsum.photos/id/133/300/200",
+                            "size": "Large"
+                        },
+                        {
+                            "type": "Image",
+                            "url": "https://picsum.photos/id/133/300/200"
+                        },
+                        {
+                            "type": "Image",
+                            "url": "https://picsum.photos/id/133/300/200",
+                            "size": "Stretch"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Column 2"
+                        },
+                        {
+                            "type": "Image",
+                            "url": "https://picsum.photos/id/133/300/200",
+                            "size": "Small"
+                        },
+                        {
+                            "type": "Image",
+                            "url": "https://picsum.photos/id/133/300/200",
+                            "size": "Large"
+                        },
+                        {
+                            "type": "Image",
+                            "url": "https://picsum.photos/id/133/300/200"
+                        },
+                        {
+                            "type": "Image",
+                            "url": "https://picsum.photos/id/133/300/200",
+                            "size": "Stretch"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "ImageSet",
+            "images": [
+                {
+                    "type": "Image",
+                    "url": "https://picsum.photos/id/133/300/200"
+                }
+            ]
+        },
+        {
+            "type": "ImageSet",
+            "imageSize": "Small",
+            "images": [
+                {
+                    "type": "Image",
+                    "url": "https://picsum.photos/id/133/300/200"
+                }
+            ]
+        },
+        {
+            "type": "ImageSet",
+            "imageSize": "Medium",
+            "images": [
+                {
+                    "type": "Image",
+                    "url": "https://picsum.photos/id/133/300/200"
+                }
+            ]
+        },
+        {
+            "type": "ImageSet",
+            "imageSize": "Large",
+            "images": [
+                {
+                    "type": "Image",
+                    "url": "https://picsum.photos/id/133/300/200"
+                }
+            ]
+        }
+    ]
 }

--- a/source/android/adaptivecards/build.gradle
+++ b/source/android/adaptivecards/build.gradle
@@ -146,6 +146,5 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     implementation 'com.android.support:appcompat-v7:26.1.0'
-    implementation "com.android.support.constraint:constraint-layout:1.1.3"
     testImplementation 'junit:junit:4.12'
 }

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ImageRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ImageRenderer.java
@@ -9,16 +9,18 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Shader;
-import android.os.AsyncTask;
-import android.support.constraint.ConstraintLayout;
-import android.support.constraint.ConstraintSet;
 import android.support.v4.app.FragmentManager;
 import android.text.TextUtils;
+import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
+import android.os.AsyncTask;
+import android.widget.RelativeLayout;
 
+import io.adaptivecards.objectmodel.CardElementType;
+import io.adaptivecards.objectmodel.ContainerStyle;
 import io.adaptivecards.objectmodel.HeightType;
 import io.adaptivecards.renderer.BaseActionElementRenderer;
 import io.adaptivecards.renderer.IOnlineImageLoader;
@@ -27,6 +29,7 @@ import io.adaptivecards.renderer.RenderArgs;
 import io.adaptivecards.renderer.RenderedAdaptiveCard;
 import io.adaptivecards.renderer.TagContent;
 import io.adaptivecards.renderer.Util;
+import io.adaptivecards.renderer.action.ActionElementRenderer;
 import io.adaptivecards.renderer.actionhandler.ICardActionHandler;
 import io.adaptivecards.objectmodel.BaseCardElement;
 import io.adaptivecards.objectmodel.HorizontalAlignment;
@@ -140,123 +143,68 @@ public class ImageRenderer extends BaseCardElementRenderer
     }
 
     /**
-     * Set ImageView size. Only for use in ImageSet.
+     * Set ImageView size according to 'height', 'width', and 'size' attributes of the given Image
      * @param context
      * @param imageView the view to resize
      * @param image the parsed Image
      * @param hostConfig the HostConfig that configures semantic 'size' values
+     * @param isInImageSet true if the Image was declared in an ImageSet
      */
-    private static void sizeImageForImageSet(Context context, ImageView imageView, Image image, HostConfig hostConfig)
-    {
-        int semanticWidth = getImageSizePixels(context, image.GetImageSize(), hostConfig.GetImageSizes());
-
-        imageView.setAdjustViewBounds(true);
-        imageView.setScaleType(ImageView.ScaleType.FIT_START);
-        imageView.setLayoutParams(new LinearLayout.LayoutParams(semanticWidth, LinearLayout.LayoutParams.WRAP_CONTENT));
-    }
-
-    /**
-     * Calculate horizontal bias for ConstraintLayout
-     * @param image the parsed Image
-     * @return horizontal bias
-     */
-    private static float getHorizontalBias(Image image) {
-        if (image.GetHorizontalAlignment() == HorizontalAlignment.Center)
-        {
-            return 0.5f;
-        }
-        if (image.GetHorizontalAlignment() == HorizontalAlignment.Right)
-        {
-            return 1;
-        }
-        return 0;
-    }
-
-    /**
-     * Calculate constraints for placing/sizing this ImageView in a ConstraintLayout
-     * For sizing Images in ImageSets, use {@link #sizeImageForImageSet}
-     * @param context
-     * @param imageView the view to constrain
-     * @param image the parsed Image
-     * @param hostConfig the HostConfig that configures semantic 'size' values
-     * @return
-     */
-    private static ConstraintSet getConstraints(Context context, ImageView imageView, Image image, HostConfig hostConfig)
+    private static void setImageSize(Context context, ImageView imageView, Image image, HostConfig hostConfig, boolean isInImageSet)
     {
         long explicitWidth = image.GetPixelWidth();
         long explicitHeight = image.GetPixelHeight();
         ImageSize imageSize = image.GetImageSize();
-        ConstraintSet constraints = new ConstraintSet();
 
-        // ConstraintSet requires unique id
-        if(imageView.getId() == View.NO_ID) {
-            imageView.setId(View.generateViewId());
-        }
-        int id = imageView.getId();
-
-        // Set horizontal alignment
-        constraints.setHorizontalBias(id, getHorizontalBias(image));
-
-        // By default, scale image and maintain aspect ratio
         imageView.setAdjustViewBounds(true);
         imageView.setScaleType(ImageView.ScaleType.FIT_START);
 
-        // By default, constrain view to top of parent, and expand width to parent
-        constraints.connect(id, ConstraintSet.START, ConstraintSet.PARENT_ID, ConstraintSet.START);
-        constraints.connect(id, ConstraintSet.END, ConstraintSet.PARENT_ID, ConstraintSet.END);
-        constraints.connect(id, ConstraintSet.TOP, ConstraintSet.PARENT_ID, ConstraintSet.TOP);
-        constraints.constrainWidth(id, ConstraintSet.MATCH_CONSTRAINT);
-        constraints.constrainHeight(id, ConstraintSet.WRAP_CONTENT);
+        int viewWidth = ViewGroup.LayoutParams.WRAP_CONTENT;
+        int viewHeight = ViewGroup.LayoutParams.WRAP_CONTENT;
 
-        // Explicit height and/or width given
+        // explicit height and/or width given
         if (explicitWidth != 0 || explicitHeight != 0)
         {
             if (explicitWidth != 0 && explicitHeight != 0)
             {
-                // If both are set, ignore aspect ratio
                 imageView.setScaleType(ImageView.ScaleType.FIT_XY);
             }
             if (explicitWidth != 0)
             {
-                // Limit width expansion to the given width (this approach ensures width never exceeds parent)
-                constraints.constrainMaxWidth(id, Util.dpToPixels(context, explicitWidth));
+                viewWidth = Util.dpToPixels(context, explicitWidth);
             }
             if (explicitHeight != 0)
             {
-                // Exact height
-                constraints.constrainHeight(id, Util.dpToPixels(context, explicitHeight));
+                viewHeight = Util.dpToPixels(context, explicitHeight);
             }
         }
-        // Semantic size from host config
-        else if (imageSize == ImageSize.Small || imageSize == ImageSize.Medium || imageSize == ImageSize.Large)
+        // stretch
+        else if (imageSize == ImageSize.Stretch)
         {
-            // Limit width expansion to the given width (this approach ensures width never exceeds parent)
-            constraints.constrainMaxWidth(id, getImageSizePixels(context, imageSize, hostConfig.GetImageSizes()));
+            viewWidth = ViewGroup.LayoutParams.MATCH_PARENT;
         }
-        // Don't scale image
-        else if (imageSize != ImageSize.Stretch)
+        // semantic size from host config
+        else if ((imageSize == ImageSize.Small) || (imageSize == ImageSize.Medium) || (imageSize == ImageSize.Large))
         {
-            // Disable width expansion
-            constraints.constrainWidth(id, ConstraintSet.WRAP_CONTENT);
+            viewWidth = getImageSizePixels(context, imageSize, hostConfig.GetImageSizes());
         }
-        return constraints;
-    }
+        else if (imageSize != ImageSize.Auto && imageSize != ImageSize.None) {
+            // TODO: Instead of failing, proceed to render w/ default size "auto"
+            throw new IllegalArgumentException("Unknown image size: " + imageSize.toString());
+        }
 
-    /**
-     * Create container for this image (with stretch height if needed)
-     * @param context
-     * @param image the parsed Image
-     * @return the container
-     */
-    private static ConstraintLayout getContainer(Context context, Image image)
-    {
-        ConstraintLayout container = new ConstraintLayout(context);
-
-        // Grow container layout if height is stretch (assumes the parent is a vertical LinearLayout)
-        int weight = (image.GetHeight() == HeightType.Stretch) ? 1 : 0;
-        container.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT, weight));
-
-        return container;
+        LinearLayout.LayoutParams params = (LinearLayout.LayoutParams) imageView.getLayoutParams();
+        if (params == null)
+        {
+            params = new LinearLayout.LayoutParams(viewWidth, viewHeight);
+        }
+        else
+        {
+            params.width = viewWidth;
+            params.height = viewHeight;
+        }
+        
+        imageView.setLayoutParams(params);
     }
 
     private int getBackgroundColorFromHexCode(String hexColorCode)
@@ -287,6 +235,70 @@ public class ImageRenderer extends BaseCardElementRenderer
         return backgroundColor;
     }
 
+    private int getImageHorizontalAlignment(Image image)
+    {
+        HorizontalAlignment horizontalAlignment = image.GetHorizontalAlignment();
+        int gravity = Gravity.LEFT;
+
+        if (horizontalAlignment == HorizontalAlignment.Center)
+        {
+            gravity = Gravity.CENTER_HORIZONTAL;
+        }
+        else if (horizontalAlignment == HorizontalAlignment.Right)
+        {
+            gravity = Gravity.RIGHT;
+        }
+
+        return gravity;
+    }
+
+    private View setImageHeightAndHorizontalAlignment(Context context, boolean isInImageSet, ImageView imageView, Image image, TagContent tagContent)
+    {
+        int height = LinearLayout.LayoutParams.WRAP_CONTENT, width = LinearLayout.LayoutParams.WRAP_CONTENT, weight = 0;
+
+        // The expected behavior for the image must be:
+        // If the image has stretch size:
+        //      width grows as big as the parent but only uses as much vertical space as needed
+        // If the image has stretch size and also stretches in height:
+        //      width grows as big as the parent and uses as much leftover vertical space as there is
+        // If the image has a fixed or auto size:
+        //      width is limited to image size or defined size and only uses as much vertical space as needed
+        // If the image has a fixed or auto size and also stretched in height:
+        //      width is limited to image size or defined size and uses as much leftover vertical space as there is
+        if (image.GetImageSize() == ImageSize.Stretch)
+        {
+            width = LinearLayout.LayoutParams.MATCH_PARENT;
+        }
+
+        if (image.GetHeight() == HeightType.Stretch)
+        {
+            height = LinearLayout.LayoutParams.MATCH_PARENT;
+            weight = 1;
+        }
+
+        LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(width, height, weight);
+
+        // Set horizontal alignment for the image
+        layoutParams.gravity = getImageHorizontalAlignment(image);
+
+        // If the image is part of an imageSet or has height auto, we set the layout parameter to
+        // it and return just the view, otherwise we have to create a layout to grow in height and
+        // contain the image avoiding it to grow larger and making the background color to stretch
+        if (isInImageSet || image.GetHeight() != HeightType.Stretch)
+        {
+            imageView.setLayoutParams(layoutParams);
+            return imageView;
+        }
+        else
+        {
+            LinearLayout stretchLayout = new LinearLayout(context);
+            stretchLayout.setLayoutParams(layoutParams);
+            stretchLayout.addView(imageView);
+            tagContent.SetStretchContainer(stretchLayout);
+            return stretchLayout;
+        }
+    }
+
     @Override
     public View render(
             RenderedAdaptiveCard renderedCard,
@@ -296,15 +308,15 @@ public class ImageRenderer extends BaseCardElementRenderer
             BaseCardElement baseCardElement,
             ICardActionHandler cardActionHandler,
             HostConfig hostConfig,
-            RenderArgs renderArgs) throws Exception
+            RenderArgs renderArgs)
     {
         Image image = Util.castTo(baseCardElement, Image.class);
 
-        View separator = null;
         boolean isInImageSet = viewGroup instanceof HorizontalFlowLayout;
+        View separator = null;
         if (isInImageSet)
         {
-            separator = setSpacingAndSeparator(context, viewGroup, image.GetSpacing(), image.GetSeparator(), hostConfig, false /* horizontal line */, isInImageSet);
+            separator = setSpacingAndSeparator(context, viewGroup, image.GetSpacing(), image.GetSeparator(), hostConfig, !isInImageSet /* horizontal line */, isInImageSet);
         }
 
         ImageView imageView = new ImageView(context);
@@ -335,22 +347,10 @@ public class ImageRenderer extends BaseCardElementRenderer
 
         TagContent tagContent = new TagContent(image, separator, viewGroup);
 
-        // No container needed for image in ImageSet
-        if(isInImageSet)
-        {
-            sizeImageForImageSet(context, imageView, image, hostConfig);
-            viewGroup.addView(imageView);
-        }
-        // ConstraintLayout container for first-class images
-        else
-        {
-            ConstraintLayout container = getContainer(context, image);
-            tagContent.SetStretchContainer(container);
-            container.addView(imageView);
-            getConstraints(context, imageView, image, hostConfig).applyTo(container);
-            viewGroup.addView(container);
-        }
+        View imageContainer = setImageHeightAndHorizontalAlignment(context, isInImageSet, imageView, image, tagContent);
+        setImageSize(context, imageView, image, hostConfig, isInImageSet);
 
+        viewGroup.addView(imageContainer);
         imageView.setTag(tagContent);
         setVisibility(baseCardElement.GetIsVisible(), imageView);
 


### PR DESCRIPTION
* Revert "[Android] Use ConstraintLayout for Image sizing (#4461)"

This reverts commit 805c51e0d28fc2ca8ff49ae311e0f9e85bea6f7d.

* Make media work again

* Reset imageview gravity

## Related Issue
Fixes #4518 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4533)