### PR TITLE
[Android][Build] Change publication job to include pom

### DIFF
--- a/source/android/adaptivecards/build.gradle
+++ b/source/android/adaptivecards/build.gradle
@@ -80,9 +80,53 @@ publishing {
     publications {
         adaptivecards(MavenPublication) {
             groupId 'io.adaptivecards'
-            version System.getenv('ACSDKVERSION') + '-' + System.getenv('BUILD_BUILDNUMBER')
+            version System.getenv('XES_PACKAGEVERSIONNUMBER') ?: '0.0.0'
             artifact(sourceJar)
             artifact("$buildDir/outputs/aar/adaptivecards-release.aar")
+            artifactId 'adaptivecards-android'
+
+            pom.withXml {
+                // Appends the nodes corresponding to general information
+                asNode().appendNode('name', 'Android Adaptive Cards Library')
+                asNode().appendNode('description', 'Android Adaptive Cards Lib')
+                asNode().appendNode('url', 'https://github.com/Microsoft/AdaptiveCards')
+
+                // Appends the nodes corresponding to the licenses
+                def licensesNode = asNode().appendNode('licenses')
+                def licenseNode = licensesNode.appendNode('license')
+                licenseNode.appendNode('name', 'MIT')
+                licenseNode.appendNode('url', 'https://github.com/Microsoft/AdaptiveCards/blob/main/LICENSE')
+                licenseNode.appendNode('distribution', 'repo')
+
+                // Appends the nodes corresponding with the developers
+                def developersNode = asNode().appendNode('developers')
+                def developerNode = developersNode.appendNode('developer')
+                developerNode.appendNode('id', 'microsoft')
+                developerNode.appendNode('name', 'adaptivecards')
+
+                // Appends the node corresponding to scm
+                def scmNode = asNode().appendNode('scm')
+                scmNode.appendNode('url', 'https://github.com/Microsoft/AdaptiveCards')
+
+                // for dependencies and exclusions
+                def dependenciesNode = asNode().appendNode('dependencies')
+                configurations.implementation.allDependencies.withType(ModuleDependency) { ModuleDependency dp ->
+                    def dependencyNode = dependenciesNode.appendNode('dependency')
+                    dependencyNode.appendNode('groupId', dp.group)
+                    dependencyNode.appendNode('artifactId', dp.name)
+                    dependencyNode.appendNode('version', dp.version)
+
+                    // for exclusions
+                    if (dp.excludeRules.size() > 0) {
+                        def exclusions = dependencyNode.appendNode('exclusions')
+                        dp.excludeRules.each { ExcludeRule ex ->
+                            def exclusion = exclusions.appendNode('exclusion')
+                            exclusion.appendNode('groupId', ex.group)
+                            exclusion.appendNode('artifactId', ex.module)
+                        }
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Related Issue

## Description
This change allows us to change the way POM files are created in our project, the biggest pro of this change is that it allows us to include dependencies into the generated file.

```xml
<?xml version="1.0" encoding="UTF-8"?>
<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0">
<modelVersion>4.0.0</modelVersion>
<groupId>io.adaptivecards</groupId>
<artifactId>adaptivecards-android</artifactId>
<version>0.0.0</version>
<packaging>aar</packaging>
<name>Android Adaptive Cards Library</name>
<description>Android Adaptive Cards Lib</description>
<url>https://github.com/Microsoft/AdaptiveCards</url>
<licenses>
<license>
<name>MIT</name>
<url>https://github.com/Microsoft/AdaptiveCards/blob/main/LICENSE</url>
<distribution>repo</distribution>
</license>
</licenses>
<developers>
<developer>
<id>microsoft</id>
<name>adaptivecards</name>
</developer>
</developers>
<scm>
<url>https://github.com/Microsoft/AdaptiveCards</url>
</scm>
<dependencies>
<dependency>
<groupId>com.android.support</groupId>
<artifactId>appcompat-v7</artifactId>
<version>26.1.0</version>
</dependency>
</dependencies>
</project>
```

As can be seen above the dependencies are now generated. 

## Work to do
To be able to deploy this solution some work is required
* Verify that the version is generated correctly (currently it's generated as 0.0.0)
* Modify the build pipeline to execute the ```generatePomFileForAdaptiveCardsPublication``` and move the generated pom file to the correct spot

## How Verified



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4538)