### PR TITLE
Detr cpp binding for model inference 

### DIFF
--- a/source/pic2card/mystique/config.py
+++ b/source/pic2card/mystique/config.py
@@ -59,7 +59,8 @@ MODEL_REGISTRY = {
     "tf_faster_rcnn": "mystique.detect_objects.ObjectDetection",
     "tfs_faster_rcnn": "mystique.detect_objects.TfsObjectDetection",
     "pth_faster_rcnn": "mystique.obj_detect.PtObjectDetection",
-    "pth_detr": "mystique.obj_detect.DetrOD"
+    "pth_detr": "mystique.obj_detect.DetrOD",
+    "pth_detr_cpp": "mystique.obj_detect.DetrCppOD"
 }
 
 ACTIVE_MODEL_NAME = os.environ.get("ACTIVE_MODEL_NAME", "tf_faster_rcnn")

--- a/source/pic2card/mystique/models/pth/detr_cpp/CMakeLists.txt
+++ b/source/pic2card/mystique/models/pth/detr_cpp/CMakeLists.txt
@@ -1,26 +1,37 @@
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-project(detr_inference)
+project(detr)
 
-# add_subdirectory(libs/pybind11)
-
+add_subdirectory(pybind11)
+find_package (Python COMPONENTS Development)
 find_package(OpenCV REQUIRED)
 find_package(Torch REQUIRED)
-find_package(Python3 REQUIRED)
 
 message(STATUS "Pytorch status: ")
 message(STATUS " libraries: ${TORCH_LIBRARIES}")
 message(STATUS "    include path: ${TORCH_INCLUDE_DIRS}")
+
+message(STATUS "Python status: ")
+message(STATUS "    libraries: ${Python_LIBRARIES}")
+message(STATUS "    include path: ${Python_INCLUDE_DIRS}")
+
 message(STATUS "OpenCV library status:")
 message(STATUS "    version: ${OpenCV_VERSION}")
 message(STATUS "    libraries: ${OpenCV_LIBS}")
 message(STATUS "    include path: ${OpenCV_INCLUDE_DIRS}")
 
+
 #SET (CMAKE_EXE_LINKER_FLAGS "-static")
 
 include_directories(${OpenCV_INCLUDE_DIRS})
 include_directories(${TORCH_INCLUDE_DIRS})
-add_executable(detr_inference detr_infer.cpp)
-#
-target_link_libraries(detr_inference ${OpenCV_LIBS})
-target_link_libraries(detr_inference ${TORCH_LIBRARIES})
-set_property(TARGET detr_inference PROPERTY CXX_STANDARD 14)
+include_directories(${Python_INCLUDE_DIRS})
+
+# add_executable(detr detr_infer.cpp)
+pybind11_add_module(detr detr_infer.cpp)
+
+# add_library(deter_inference detr_infer.cpp)
+
+target_link_libraries(detr PRIVATE ${OpenCV_LIBS})
+target_link_libraries(detr PRIVATE ${TORCH_LIBRARIES})
+target_link_libraries(detr PRIVATE ${Python_LIBRARIES})
+set_property(TARGET detr PROPERTY CXX_STANDARD 14)

--- a/source/pic2card/mystique/models/pth/detr_cpp/CMakeLists.txt
+++ b/source/pic2card/mystique/models/pth/detr_cpp/CMakeLists.txt
@@ -27,7 +27,7 @@ include_directories(${TORCH_INCLUDE_DIRS})
 include_directories(${Python_INCLUDE_DIRS})
 
 # add_executable(detr detr_infer.cpp)
-pybind11_add_module(detr detr_infer.cpp)
+pybind11_add_module(detr detr.cpp)
 
 # add_library(deter_inference detr_infer.cpp)
 

--- a/source/pic2card/mystique/models/pth/detr_cpp/CMakeLists.txt
+++ b/source/pic2card/mystique/models/pth/detr_cpp/CMakeLists.txt
@@ -26,10 +26,8 @@ include_directories(${OpenCV_INCLUDE_DIRS})
 include_directories(${TORCH_INCLUDE_DIRS})
 include_directories(${Python_INCLUDE_DIRS})
 
-# add_executable(detr detr_infer.cpp)
-pybind11_add_module(detr detr.cpp)
-
-# add_library(deter_inference detr_infer.cpp)
+add_executable(detr detr_infer.cpp)
+# pybind11_add_module(detr detr.cpp)
 
 target_link_libraries(detr PRIVATE ${OpenCV_LIBS})
 target_link_libraries(detr PRIVATE ${TORCH_LIBRARIES})

--- a/source/pic2card/mystique/models/pth/detr_cpp/README.md
+++ b/source/pic2card/mystique/models/pth/detr_cpp/README.md
@@ -1,16 +1,15 @@
 ## Torchscript based Inference
 
 Here we are trying to evaluate the benefits of using libtorch to handle the
-model core functionality.
-
+model inference part.
 
 
 ## Dependencies
 
-1. Opencv 4.3.0
-2. libtorch nightly build.
-2. DETR github implementation.
-
+1. Opencv 3.2+
+2. torch 1.6+
+3. Detr Model trace file.
+4. g++7 and above.
 
 
 You need to download the C++-11 ABI compatible libtorch, and latest opencv to
@@ -21,34 +20,56 @@ link our library. As mentioned libtorch is already build one, only thing need to
 be take care is the ABI compatibility.
 
 
-## Build and test the libtorch
-
-```bash
-# Build opencv first
-cd opencv-4.3.0
-mkdir build
-cmake -DCMAKE_INSTALL_PREFIX=`pwd`/../release ..
-make install
-
-
-# Build the detr_inference
-mkdir build
-cd build
-cmake -DCMAKE_PREFIX_PATH="<path-to>/libtorch;<path-to>/opencv-4.3.0/release"
-cmake --build . --config Release --verbose
-
-# The model path and image path are supplied via variables now.
-./deter_infer
-..
-```
 
 
 ## Integration with pic2card
 
 Model inference is the first stage of the pic2card pipeline and all the pic2card
-implementation are in python based, we have to expose the c++ inference model to
+implementation are in python, we have to expose the c++ inference model to
 python ecosystem back, in this case we are skipping all other requirements of
 the python torch library.
 
 This can be done multiple ways, looking into ways to expose the model interface
 as a python module.
+
+
+## Build the detr cpp inference python binding
+
+To build this cpp extension you requires the torch python package, after
+building you can remove that dependency except for those dynamic linked
+libraries comes with the torch package. Initially we will keep both, eventually
+for the production pipeline we can remove the dependency on the pytorch
+dependency instead using the libtorch.
+
+
+```bash
+    pip install torch torchvision
+    apt-get install libopencv-core-dev libopencv-imgproc-dev
+
+    # Install the detr package into your python environment.
+    python setup.py install
+```
+
+## To run the Pic2card with this new inference pipeline
+
+```bash
+# From the root dir of pic2card
+ACTIVE_MODEL_NAME=pth_detr_cpp python -m app.main
+```
+
+## Debug Build and testing
+
+Building a executable able testing without attaching to the python would be
+required to debug problems at the c++ world in much easier fashion, for that use
+this camke based build and corresponding executable.
+
+```bash
+mkdir build
+cd build
+cmake -DCMAKE_PREFIX_PATH="<path-to>/libtorch"
+cmake --build . --config Release --verbose
+
+# The model path and image path are supplied via variables now.
+./deter
+..
+```

--- a/source/pic2card/mystique/models/pth/detr_cpp/detr.cpp
+++ b/source/pic2card/mystique/models/pth/detr_cpp/detr.cpp
@@ -1,0 +1,118 @@
+#include <vector>
+#include <torch/extension.h>
+#include <torch/script.h>
+#include <torch/python.h>
+#include <torch/torch.h>
+#include <torch/csrc/utils/tensor_numpy.h>
+#include <torch/csrc/python_headers.h>
+
+#include "detr.hpp"
+
+cv::Mat addmat(cv::Mat &lhs, cv::Mat &rhs)
+{
+    return lhs + rhs;
+}
+
+struct Detr
+{
+
+    std::string model_path;
+    torch::jit::script::Module model;
+
+    Detr(const std::string &model_path) : model_path(model_path) {}
+
+    const std::string &getModelPath()
+    {
+        return model_path;
+    }
+
+    void loadModel()
+    {
+        model = torch::jit::load(model_path);
+    }
+
+    //c10::IValue predict(cv::Mat &image)
+    const std::vector<cv::Mat> predict(cv::Mat &image)
+    {
+        cv::cvtColor(image, image, cv::COLOR_BGR2RGB);
+        image.convertTo(image, CV_32FC3, 1.0f / 255.0f);
+        cv::Size imsize = image.size();
+        std::cout << "Width: " << imsize.width << std::endl;
+        torch::Tensor imTensor = torch::from_blob(image.data, { 1, imsize.width, imsize.height, 3 });
+        imTensor = imTensor.permute({ 0, 3, 1, 2 });
+        imTensor[0][0] = imTensor[0][0].sub_(0.485).div_(0.229);
+        imTensor[0][1] = imTensor[0][1].sub_(0.456).div_(0.224);
+        imTensor[0][2] = imTensor[0][2].sub_(0.406).div_(0.225);
+
+        std::vector<torch::jit::IValue> inputs;
+        inputs.push_back(imTensor);
+        auto outDict = model.forward(inputs).toGenericDict();
+
+        torch::Tensor predLogits = outDict.at("pred_logits").toTensor();
+        torch::Tensor predBoxes = outDict.at("pred_boxes").toTensor();
+        //return predLogits;
+        std::cout << "PredLogits Size: " << predLogits.size(1) << " " << predLogits.size(2) << std::endl;
+        std::cout << "predBoxes Size: " << predBoxes.size(1) << " " << predBoxes.size(2) << std::endl;
+
+        // return torch::utils::tensor_to_numpy(predLogits.detach().cpu());
+        // return predLogits.detach().cpu();
+        //std::cout << predLogits.size(0) << std::endl;
+        predLogits = predLogits.to(torch::kCPU);
+        cv::Mat cvMatLogits(predLogits.size(1), predLogits.size(2), CV_32F);
+        std::memcpy((void*)cvMatLogits.data, predLogits.data_ptr(), sizeof(torch::kF32)*predLogits.numel());
+
+        predBoxes = predBoxes.to(torch::kCPU);
+        cv::Mat cvMatBoxes(predBoxes.size(1), predBoxes.size(2), CV_32F);
+        std::memcpy((void*)cvMatBoxes.data, predBoxes.data_ptr(), sizeof(torch::kF32)*predBoxes.numel());
+
+        return { cvMatLogits, cvMatBoxes };
+    }
+};
+
+struct MatrixMultiplier
+{
+    MatrixMultiplier(int A, int B)
+    {
+        tensor_ =
+            torch::ones({ A, B }, torch::dtype(torch::kFloat64).requires_grad(true));
+    }
+    torch::Tensor forward(torch::Tensor weights)
+    {
+        return tensor_.mm(weights);
+    }
+    torch::Tensor get() const
+    {
+        return tensor_;
+    }
+
+private:
+    torch::Tensor tensor_;
+};
+
+bool function_taking_optional(c10::optional<torch::Tensor> tensor)
+{
+    return tensor.has_value();
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
+{
+    m.def("addmat", &addmat, "add two matrix");
+
+    py::class_<Detr>(m, "Detr")
+        .def(py::init<const std::string &>())
+        .def("get_model_path", &Detr::getModelPath)
+        .def_readonly("model_path", &Detr::model_path)
+        .def("load", &Detr::loadModel)
+        .def("predict", &Detr::predict)
+        .def_readonly("model", &Detr::model);
+
+    m.def(
+        "function_taking_optional",
+        &function_taking_optional,
+        "function_taking_optional");
+
+    py::class_<MatrixMultiplier>(m, "MatrixMultiplier")
+        .def(py::init<int, int>())
+        .def("forward", &MatrixMultiplier::forward)
+        .def("get", &MatrixMultiplier::get);
+}

--- a/source/pic2card/mystique/models/pth/detr_cpp/detr.hpp
+++ b/source/pic2card/mystique/models/pth/detr_cpp/detr.hpp
@@ -1,0 +1,119 @@
+// Reusing the type conversion from https://github.com/ausk/keras-unet-deploy/tree/master
+#pragma once
+
+#include <opencv2/core/core.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+
+#include <pybind11/stl.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+
+namespace py = pybind11;
+
+namespace pybind11
+{
+    namespace detail
+    {
+        template <>
+        struct type_caster<cv::Mat>
+        {
+        public:
+            PYBIND11_TYPE_CASTER(cv::Mat, _("numpy.ndarray"));
+
+            //! 1. cast numpy.ndarray to cv::Mat
+            bool load(handle obj, bool)
+            {
+                array b = reinterpret_borrow<array>(obj);
+                buffer_info info = b.request();
+
+                int nh = 1;
+                int nw = 1;
+                int nc = 1;
+                int ndims = info.ndim;
+                if (ndims == 2)
+                {
+                    nh = info.shape[0];
+                    nw = info.shape[1];
+                }
+                else if (ndims == 3)
+                {
+                    nh = info.shape[0];
+                    nw = info.shape[1];
+                    nc = info.shape[2];
+                }
+                else
+                {
+                    throw std::logic_error("Only support 2d, 2d matrix");
+                    return false;
+                }
+
+                int dtype;
+                if (info.format == format_descriptor<unsigned char>::format())
+                {
+                    dtype = CV_8UC(nc);
+                }
+                else if (info.format == format_descriptor<int>::format())
+                {
+                    dtype = CV_32SC(nc);
+                }
+                else if (info.format == format_descriptor<float>::format())
+                {
+                    dtype = CV_32FC(nc);
+                }
+                else
+                {
+                    throw std::logic_error("Unsupported type, only support uchar, int32, float");
+                    return false;
+                }
+                value = cv::Mat(nh, nw, dtype, info.ptr);
+                return true;
+            }
+
+            //! 2. cast cv::Mat to numpy.ndarray
+            static handle cast(const cv::Mat &mat, return_value_policy, handle defval)
+            {
+                std::string format = format_descriptor<unsigned char>::format();
+                size_t elemsize = sizeof(unsigned char);
+                int nw = mat.cols;
+                int nh = mat.rows;
+                int nc = mat.channels();
+                int depth = mat.depth();
+                int type = mat.type();
+                int dim = (depth == type) ? 2 : 3;
+                if (depth == CV_8U)
+                {
+                    format = format_descriptor<unsigned char>::format();
+                    elemsize = sizeof(unsigned char);
+                }
+                else if (depth == CV_32S)
+                {
+                    format = format_descriptor<int>::format();
+                    elemsize = sizeof(int);
+                }
+                else if (depth == CV_32F)
+                {
+                    format = format_descriptor<float>::format();
+                    elemsize = sizeof(float);
+                }
+                else
+                {
+                    throw std::logic_error("Unsupport type, only support uchar, int32, float");
+                }
+
+                std::vector<size_t> bufferdim;
+                std::vector<size_t> strides;
+                if (dim == 2)
+                {
+                    bufferdim = {(size_t)nh, (size_t)nw};
+                    strides = {elemsize * (size_t)nw, elemsize};
+                }
+                else if (dim == 3)
+                {
+                    bufferdim = {(size_t)nh, (size_t)nw, (size_t)nc};
+                    strides = {(size_t)elemsize * nw * nc, (size_t)elemsize * nc, (size_t)elemsize};
+                }
+                return array(buffer_info(mat.data, elemsize, format, dim, bufferdim, strides)).release();
+            }
+        };
+    } // namespace detail
+} // namespace pybind11

--- a/source/pic2card/mystique/models/pth/detr_cpp/detr_infer.cpp
+++ b/source/pic2card/mystique/models/pth/detr_cpp/detr_infer.cpp
@@ -4,61 +4,90 @@
 
 #include <opencv2/opencv.hpp>
 #include <torch/script.h> // One-stop header.
-// #include <pybind11/pybind11.h>
+#include <pybind11/pybind11.h>
 
 using namespace cv;
 using namespace std;
 
-vector<int> random_scale(Mat image)
-{}
+namespace py = pybind11;
 
-// Scale sizes
-int main(int argc, const char *argv[])
+// // Scale sizes
+// int main(int argc, const char *argv[])
+// {
+//   string model_path = "/mnt1/haridas/projects/pic2card-models/pytorch/detr_trace.pt";
+//   string image_path = "/mnt1/haridas/projects/mystique/data/templates_test_data/1.png";
+
+//   // if (argc != 3)
+//   // {
+//   //   std::cerr << "usage: detr-app <path-to-exported-script-module> <image-path> \n";
+//   //   return -1;
+//   // }
+
+//   try
+//   {
+//     // Deserialize image_pathiptModule from a file using torch::jit::load().
+//     Mat image = cv::imread(image_path, 1);
+//     cv::cvtColor(image, image, cv::COLOR_BGR2RGB);
+//     cv::Size scale(500, 600);
+//     cv::resize(image, image, scale);
+//     image.convertTo(image, CV_32FC3, 1.0f / 255.0f);
+//     std::cout << "Image: " << image.size();
+
+//     auto input_tensor = torch::from_blob(image.data, {1, 500, 600, 3});
+//     input_tensor = input_tensor.permute({0, 3, 1, 2});
+//     std::cout << "Tensor: " << input_tensor[0][0].sizes();
+//     // Apply normalization based on imagenet data.
+//     input_tensor[0][0] = input_tensor[0][0].sub_(0.485).div_(0.229);
+//     input_tensor[0][1] = input_tensor[0][1].sub_(0.456).div_(0.224);
+//     input_tensor[0][2] = input_tensor[0][2].sub_(0.406).div_(0.225);
+
+//     torch::jit::script::Module module;
+//     module = torch::jit::load(model_path);
+//     // Create a vector of inputs.
+//     std::vector<torch::jit::IValue> inputs;
+//     //inputs.push_back(torch::ones({1, 3, 500, 600}));
+//     inputs.push_back(input_tensor);
+
+//     // Execute the model and turn its output into a tensor.
+//     c10::IValue output = module.forward(inputs);
+//     std::cout << output;
+//   }
+//   catch (const c10::Error &e)
+//   {
+//     std::cerr << "error loading the model\n";
+//     std::cout << e.what() << "\n";
+//     return -1;
+//   }
+
+//   std::cout << "ok\n";
+// }
+
+//int add(int i, int j)
+//{
+//  return i + j;
+//}
+//
+//PYBIND11_MODULE(example, m)
+//{
+//  m.doc() = "pybind11 example plugin"; // optional module docstring
+//  m.def("add", &add, "A function which adds two numbers");
+//}
+
+struct TensorWrapper
 {
-  string model_path = "/mnt1/haridas/projects/pic2card-models/pytorch/detr_trace.pt";
-  string image_path = "/mnt1/haridas/projects/mystique/data/templates_test_data/1.png";
-
-  // if (argc != 3)
-  // {
-  //   std::cerr << "usage: detr-app <path-to-exported-script-module> <image-path> \n";
-  //   return -1;
-  // }
-
-  try
+  TensorWrapper()
   {
-    // Deserialize image_pathiptModule from a file using torch::jit::load().
-    Mat image = cv::imread(image_path, 1);
-    cv::cvtColor(image, image, cv::COLOR_BGR2RGB);
-    cv::Size scale(500, 600);
-    cv::resize(image, image, scale);
-    image.convertTo(image, CV_32FC3, 1.0f / 255.0f);
-    std::cout << "Image: " << image.size();
-
-    auto input_tensor = torch::from_blob(image.data, {1, 500, 600, 3});
-    input_tensor = input_tensor.permute({0, 3, 1, 2});
-    std::cout << "Tensor: " << input_tensor[0][0].sizes();
-    // Apply normalization based on imagenet data.
-    input_tensor[0][0] = input_tensor[0][0].sub_(0.485).div_(0.229);
-    input_tensor[0][1] = input_tensor[0][1].sub_(0.456).div_(0.224);
-    input_tensor[0][2] = input_tensor[0][2].sub_(0.406).div_(0.225);
-
-    torch::jit::script::Module module;
-    module = torch::jit::load(model_path);
-    // Create a vector of inputs.
-    std::vector<torch::jit::IValue> inputs;
-    //inputs.push_back(torch::ones({1, 3, 500, 600}));
-    inputs.push_back(input_tensor);
-
-    // Execute the model and turn its output into a tensor.
-    c10::IValue output = module.forward(inputs);
-    std::cout << output;
-  }
-  catch (const c10::Error &e)
-  {
-    std::cerr << "error loading the model\n";
-    std::cout << e.what() << "\n";
-    return -1;
+    tensor = torch::ones({3, 3}, torch::kInt32);
   }
 
-  std::cout << "ok\n";
+  int size;
+  torch::Tensor tensor;
+};
+
+PYBIND11_MODULE(detr, m)
+{
+  py::class_<TensorWrapper>(m, "TensorWrapper")
+      .def(py::init<>())
+      .def_readwrite("tensor", &TensorWrapper::tensor)
+      .def_readwrite("size", &TensorWrapper::size);
 }

--- a/source/pic2card/mystique/models/pth/detr_cpp/detr_infer.cpp
+++ b/source/pic2card/mystique/models/pth/detr_cpp/detr_infer.cpp
@@ -1,147 +1,69 @@
+#include <iostream>
+
+#include <opencv2/opencv.hpp>
+
 #include <torch/extension.h>
+#include <torch/script.h>
 
-// // Scale sizes
-// int
-// main(int argc, const char *argv[])
-// {
-//   string model_path = "/mnt1/haridas/projects/pic2card-models/pytorch/detr_trace.pt";
-//   string image_path = "/mnt1/haridas/projects/mystique/data/templates_test_data/1.png";
+using namespace std;
+using namespace cv;
 
-//   // if (argc != 3)
-//   // {
-//   //   std::cerr << "usage: detr-app <path-to-exported-script-module> <image-path> \n";
-//   //   return -1;
-//   // }
-
-//   try
-//   {
-//     // Deserialize image_pathiptModule from a file using torch::jit::load().
-//     Mat image = cv::imread(image_path, 1);
-//     cv::cvtColor(image, image, cv::COLOR_BGR2RGB);
-//     cv::Size scale(500, 600);
-//     cv::resize(image, image, scale);
-//     image.convertTo(image, CV_32FC3, 1.0f / 255.0f);
-//     std::cout << "Image: " << image.size();
-
-//     auto input_tensor = torch::from_blob(image.data, {1, 500, 600, 3});
-//     input_tensor = input_tensor.permute({0, 3, 1, 2});
-//     std::cout << "Tensor: " << input_tensor[0][0].sizes();
-//     // Apply normalization based on imagenet data.
-//     input_tensor[0][0] = input_tensor[0][0].sub_(0.485).div_(0.229);
-//     input_tensor[0][1] = input_tensor[0][1].sub_(0.456).div_(0.224);
-//     input_tensor[0][2] = input_tensor[0][2].sub_(0.406).div_(0.225);
-
-//     torch::jit::script::Module module;
-//     module = torch::jit::load(model_path);
-//     // Create a vector of inputs.
-//     std::vector<torch::jit::IValue> inputs;
-//     //inputs.push_back(torch::ones({1, 3, 500, 600}));
-//     inputs.push_back(input_tensor);
-
-//     // Execute the model and turn its output into a tensor.
-//     c10::IValue output = module.forward(inputs);
-//     std::cout << output;
-//   }
-//   catch (const c10::Error &e)
-//   {
-//     std::cerr << "error loading the model\n";
-//     std::cout << e.what() << "\n";
-//     return -1;
-//   }
-
-//   std::cout << "ok\n";
-// }
-
-// struct TensorWrapper
-// {
-//   TensorWrapper()
-//   {
-//     tensor = torch::ones({3, 3}, torch::kInt32);
-//     cvmat = cv::Mat::zeros(10, 10, CV_32F);
-//   }
-
-//   int size;
-//   torch::Tensor tensor;
-//   cv::Mat cvmat;
-
-//   int myfunc()
-//   {
-//     return 0;
-//   }
-// };
-
-// cv::Mat cvMatrix()
-// {
-//   cv::Mat cvmat = cv::Mat::zeros(10, 10, CV_32F);
-//   std::cout << "--> " << CV_8UC3 << std::endl;
-//   return cvmat;
-// }
-
-torch::Tensor testTensor()
+// Scale sizes
+int main(int argc, const char *argv[])
 {
-    torch::Tensor tensor = torch::ones({3, 3}, torch::kInt32);
-    return tensor;
-}
+    string model_path = "/mnt1/haridas/projects/pic2card-models/pytorch/detr_trace.pt";
+    string image_path = "/mnt1/haridas/projects/mystique/data/templates_test_data/1.png";
 
-torch::Tensor d_sigmoid(torch::Tensor z)
-{
-    auto s = torch::sigmoid(z);
-    return (1 - s) * s;
-}
+    // if (argc != 3)
+    // {
+    //   std::cerr << "usage: detr-app <path-to-exported-script-module> <image-path> \n";
+    //   return -1;
+    // }
 
-cv::Mat addmat(cv::Mat &lhs, cv::Mat &rhs)
-{
-    return lhs + rhs;
-}
+    try
+    {
+        // Deserialize image_pathiptModule from a file using torch::jit::load().
+        Mat image = cv::imread(image_path, 1);
+        cv::cvtColor(image, image, cv::COLOR_BGR2RGB);
+        //cv::Size scale(500, 600);
+        //cv::resize(image, image, scale);
+        cv::Size imsize = image.size();
+        image.convertTo(image, CV_32FC3, 1.0f / 255.0f);
+        //std::cout << "Image: " << image.size();
 
-// torch::Tensor numpy_uint8_3c_to_cv_mat(py::array input)
-// {
-//   cv::Mat cvmat = cv::Mat::zeros(10, 10, CV_32F);
-//   if (input.ndim() != 3)
-//     throw std::runtime_error("3-channel image must be 3 dims ");
+        //auto input_tensor = torch::from_blob(image.data, {1, 500, 600, 3});
+        torch::Tensor input_tensor = torch::from_blob(image.data, { 1, imsize.width, imsize.height, 3 });
+        input_tensor = input_tensor.permute({ 0, 3, 1, 2 });
+        //std::cout << "Tensor: " << input_tensor[0][0].sizes();
+        // Apply normalization based on imagenet data.
+        input_tensor[0][0] = input_tensor[0][0].sub_(0.485).div_(0.229);
+        input_tensor[0][1] = input_tensor[0][1].sub_(0.456).div_(0.224);
+        input_tensor[0][2] = input_tensor[0][2].sub_(0.406).div_(0.225);
 
-//   py::buffer_info buf = input.request();
-//   std::cout << "Buff shape: " << buf.shape[0] << " " << buf.shape[1] << " --- " << buf.ptr << " -> " << CV_32F << std::endl;
-//   cv::Mat mat(buf.shape[0], buf.shape[1], CV_8UC3, (unsigned char *)buf.ptr);
-//   // cv::Mat mat(buf.shape[0], buf.shape[1], 16, (unsigned char *)buf.ptr);
+        torch::jit::script::Module module;
+        module = torch::jit::load(model_path);
+        // Create a vector of inputs.
+        std::vector<torch::jit::IValue> inputs;
+        //inputs.push_back(torch::ones({1, 3, 500, 600}));
+        inputs.push_back(input_tensor);
 
-//   torch::Tensor tmat = torch::from_blob(cvmat.data, {10, 10});
-//   return tmat;
-// }
+        // Execute the model and turn its output into a tensor.
+        auto outDict = module.forward(inputs).toGenericDict();
+        // auto outDict = output.toGenericDict();
 
-// cv::Mat numpy_uint8_3c_to_cv_mat(py::array_t<unsigned char> &input)
-// {
+        //std::cout << "PredLogits: " << outDict.at("pred_logits") << " pred Boxes: " << outDict.at("pred_boxes") << std::endl;
 
-//   if (input.ndim() != 3)
-//     throw std::runtime_error("3-channel image must be 3 dims ");
+        auto predLogits = outDict.at("pred_logits").toTensor();
+        auto predBoxes = outDict.at("pred_boxes").toTensor();
+        //std::vector<torch::Tensor> test = predLogits.toTensor();
+        std::cout << predBoxes;
+    }
+    catch (const c10::Error &e)
+    {
+        std::cerr << "error loading the model\n";
+        std::cout << e.what() << "\n";
+        return -1;
+    }
 
-//   py::buffer_info buf = input.request();
-
-//   cv::Mat mat(buf.shape[0], buf.shape[1], CV_8UC3, (unsigned char *)buf.ptr);
-
-//   return mat;
-// }
-
-PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
-{
-    m.def("get_tensor", &testTensor, "Get a sample tensor.");
-    m.def("sigmoid", &d_sigmoid, "Sigmoid activation");
-    // m.def("cvMatrix", &cvMatrix, "Sigmoid activation");
-    m.def("addmat", &addmat, "add two point");
-    // m.def("np_to_mat", &numpy_uint8_3c_to_cv_mat, "numpy_unit8 to 3 channel cv::Mat");
-    // py::class_<TensorWrapper>(m, "TensorWrapper")
-    //     .def(py::init<>())
-    //     .def_readwrite("tensor", &TensorWrapper::tensor)
-    //     .def_readwrite("size", &TensorWrapper::size)
-    //     .def_readwrite("cvmat", &TensorWrapper::cvmat);
-
-    // m.def("base64_fn",
-    //       [](const std::string &s) {
-    //         std::cout << "utf-8 is icing on the cake.\n";
-    //         //std::cout << s << std::endl;
-
-    //         std::string out;
-    //         macaron::Base64::Decode(s, &&out);
-    //         std::cout << out.length() << std::endl;
-    //       });
+    std::cout << "ok\n";
 }

--- a/source/pic2card/mystique/models/pth/detr_cpp/detr_infer.cpp
+++ b/source/pic2card/mystique/models/pth/detr_cpp/detr_infer.cpp
@@ -1,11 +1,11 @@
-// // #include <iostream>
-// // #include <memory>
-// // #include <stdio.h>
+// #include <iostream>
+// #include <memory>
+// #include <stdio.h>
 
-// // #include <opencv2/opencv.hpp>
+#include <opencv2/opencv.hpp>
 #include <torch/extension.h>
 
-// using namespace cv;
+using namespace cv;
 // using namespace std;
 
 // namespace py = pybind11;
@@ -62,38 +62,29 @@
 //   std::cout << "ok\n";
 // }
 
-// // struct TensorWrapper
-// // {
-// //   TensorWrapper()
-// //   {
-// //     tensor = torch::ones({3, 3}, torch::kInt32);
-// //     cvmat = cv::Mat::zeros(10, 10, CV_32F);
-// //   }
+struct TensorWrapper
+{
+  TensorWrapper()
+  {
+    tensor = torch::ones({3, 3}, torch::kInt32);
+    cvmat = cv::Mat::zeros(10, 10, CV_32F);
+  }
 
-// //   int size;
-// //   torch::Tensor tensor;
-// //   cv::Mat cvmat;
+  int size;
+  torch::Tensor tensor;
+  cv::Mat cvmat;
 
-// //   int myfunc()
-// //   {
-// //     return 0;
-// //   }
-// // };
+  int myfunc()
+  {
+    return 0;
+  }
+};
 
-// // PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
-// // {
-// //   py::class_<TensorWrapper>(m, "TensorWrapper")
-// //       .def(py::init<>())
-// //       .def_readwrite("tensor", &TensorWrapper::tensor)
-// //       .def_readwrite("size", &TensorWrapper::size)
-// //       .def_readwrite("cvmat", &TensorWrapper::cvmat);
-// // }
-
-// cv::Mat cvMatrix()
-// {
-//   cv::Mat cvmat = cv::Mat::zeros(10, 10, CV_32F);
-//   return cvmat;
-// }
+cv::Mat cvMatrix()
+{
+  cv::Mat cvmat = cv::Mat::zeros(10, 10, CV_32F);
+  return cvmat;
+}
 
 torch::Tensor testTensor()
 {
@@ -111,4 +102,10 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
 {
   m.def("get_tensor", &testTensor, "Get a sample tensor.");
   m.def("sigmoid", &d_sigmoid, "Sigmoid activation");
+  m.def("cvMatrix", &cvMatrix, "Sigmoid activation");
+  py::class_<TensorWrapper>(m, "TensorWrapper")
+      .def(py::init<>())
+      .def_readwrite("tensor", &TensorWrapper::tensor)
+      .def_readwrite("size", &TensorWrapper::size)
+      .def_readwrite("cvmat", &TensorWrapper::cvmat);
 }

--- a/source/pic2card/mystique/models/pth/detr_cpp/detr_infer.cpp
+++ b/source/pic2card/mystique/models/pth/detr_cpp/detr_infer.cpp
@@ -1,18 +1,18 @@
-#include <iostream>
-#include <memory>
-#include <stdio.h>
+// // #include <iostream>
+// // #include <memory>
+// // #include <stdio.h>
 
-#include <opencv2/opencv.hpp>
-#include <torch/script.h> // One-stop header.
-#include <pybind11/pybind11.h>
+// // #include <opencv2/opencv.hpp>
+#include <torch/extension.h>
 
-using namespace cv;
-using namespace std;
+// using namespace cv;
+// using namespace std;
 
-namespace py = pybind11;
+// namespace py = pybind11;
 
 // // Scale sizes
-// int main(int argc, const char *argv[])
+// int
+// main(int argc, const char *argv[])
 // {
 //   string model_path = "/mnt1/haridas/projects/pic2card-models/pytorch/detr_trace.pt";
 //   string image_path = "/mnt1/haridas/projects/mystique/data/templates_test_data/1.png";
@@ -62,32 +62,53 @@ namespace py = pybind11;
 //   std::cout << "ok\n";
 // }
 
-//int add(int i, int j)
-//{
-//  return i + j;
-//}
-//
-//PYBIND11_MODULE(example, m)
-//{
-//  m.doc() = "pybind11 example plugin"; // optional module docstring
-//  m.def("add", &add, "A function which adds two numbers");
-//}
+// // struct TensorWrapper
+// // {
+// //   TensorWrapper()
+// //   {
+// //     tensor = torch::ones({3, 3}, torch::kInt32);
+// //     cvmat = cv::Mat::zeros(10, 10, CV_32F);
+// //   }
 
-struct TensorWrapper
+// //   int size;
+// //   torch::Tensor tensor;
+// //   cv::Mat cvmat;
+
+// //   int myfunc()
+// //   {
+// //     return 0;
+// //   }
+// // };
+
+// // PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
+// // {
+// //   py::class_<TensorWrapper>(m, "TensorWrapper")
+// //       .def(py::init<>())
+// //       .def_readwrite("tensor", &TensorWrapper::tensor)
+// //       .def_readwrite("size", &TensorWrapper::size)
+// //       .def_readwrite("cvmat", &TensorWrapper::cvmat);
+// // }
+
+// cv::Mat cvMatrix()
+// {
+//   cv::Mat cvmat = cv::Mat::zeros(10, 10, CV_32F);
+//   return cvmat;
+// }
+
+torch::Tensor testTensor()
 {
-  TensorWrapper()
-  {
-    tensor = torch::ones({3, 3}, torch::kInt32);
-  }
+  torch::Tensor tensor = torch::ones({3, 3}, torch::kInt32);
+  return tensor;
+}
 
-  int size;
-  torch::Tensor tensor;
-};
-
-PYBIND11_MODULE(detr, m)
+torch::Tensor d_sigmoid(torch::Tensor z)
 {
-  py::class_<TensorWrapper>(m, "TensorWrapper")
-      .def(py::init<>())
-      .def_readwrite("tensor", &TensorWrapper::tensor)
-      .def_readwrite("size", &TensorWrapper::size);
+  auto s = torch::sigmoid(z);
+  return (1 - s) * s;
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
+{
+  m.def("get_tensor", &testTensor, "Get a sample tensor.");
+  m.def("sigmoid", &d_sigmoid, "Sigmoid activation");
 }

--- a/source/pic2card/mystique/models/pth/detr_cpp/detr_infer.cpp
+++ b/source/pic2card/mystique/models/pth/detr_cpp/detr_infer.cpp
@@ -1,14 +1,4 @@
-// #include <iostream>
-// #include <memory>
-#include <stdio.h>
-#include <pybind11/pybind11.h>
-#include <pybind11/numpy.h>
-#include <opencv2/opencv.hpp>
 #include <torch/extension.h>
-
-using namespace cv;
-// using namespace std;
-namespace py = pybind11;
 
 // // Scale sizes
 // int
@@ -62,52 +52,62 @@ namespace py = pybind11;
 //   std::cout << "ok\n";
 // }
 
-struct TensorWrapper
-{
-  TensorWrapper()
-  {
-    tensor = torch::ones({3, 3}, torch::kInt32);
-    cvmat = cv::Mat::zeros(10, 10, CV_32F);
-  }
+// struct TensorWrapper
+// {
+//   TensorWrapper()
+//   {
+//     tensor = torch::ones({3, 3}, torch::kInt32);
+//     cvmat = cv::Mat::zeros(10, 10, CV_32F);
+//   }
 
-  int size;
-  torch::Tensor tensor;
-  cv::Mat cvmat;
+//   int size;
+//   torch::Tensor tensor;
+//   cv::Mat cvmat;
 
-  int myfunc()
-  {
-    return 0;
-  }
-};
+//   int myfunc()
+//   {
+//     return 0;
+//   }
+// };
 
-cv::Mat cvMatrix(cv::Mat const &img)
-{
-  cv::Mat cvmat = cv::Mat::zeros(10, 10, CV_32F);
-  return cvmat;
-}
+// cv::Mat cvMatrix()
+// {
+//   cv::Mat cvmat = cv::Mat::zeros(10, 10, CV_32F);
+//   std::cout << "--> " << CV_8UC3 << std::endl;
+//   return cvmat;
+// }
 
 torch::Tensor testTensor()
 {
-  torch::Tensor tensor = torch::ones({3, 3}, torch::kInt32);
-  return tensor;
+    torch::Tensor tensor = torch::ones({3, 3}, torch::kInt32);
+    return tensor;
 }
 
 torch::Tensor d_sigmoid(torch::Tensor z)
 {
-  std::cout << CV_8UC3;
-  auto s = torch::sigmoid(z);
-  return (1 - s) * s;
+    auto s = torch::sigmoid(z);
+    return (1 - s) * s;
 }
 
-torch::Tensor numpy_uint8_3c_to_cv_mat(py::array_t<unsigned char> &input)
+cv::Mat addmat(cv::Mat &lhs, cv::Mat &rhs)
 {
-  cv::Mat cvmat = cv::Mat::zeros(10, 10, CV_32F);
-  if (input.ndim() != 3)
-    throw std::runtime_error("3-channel image must be 3 dims ");
-
-  torch::Tensor tmat = torch::from_blob(cvmat.data, {10, 10});
-  return tmat;
+    return lhs + rhs;
 }
+
+// torch::Tensor numpy_uint8_3c_to_cv_mat(py::array input)
+// {
+//   cv::Mat cvmat = cv::Mat::zeros(10, 10, CV_32F);
+//   if (input.ndim() != 3)
+//     throw std::runtime_error("3-channel image must be 3 dims ");
+
+//   py::buffer_info buf = input.request();
+//   std::cout << "Buff shape: " << buf.shape[0] << " " << buf.shape[1] << " --- " << buf.ptr << " -> " << CV_32F << std::endl;
+//   cv::Mat mat(buf.shape[0], buf.shape[1], CV_8UC3, (unsigned char *)buf.ptr);
+//   // cv::Mat mat(buf.shape[0], buf.shape[1], 16, (unsigned char *)buf.ptr);
+
+//   torch::Tensor tmat = torch::from_blob(cvmat.data, {10, 10});
+//   return tmat;
+// }
 
 // cv::Mat numpy_uint8_3c_to_cv_mat(py::array_t<unsigned char> &input)
 // {
@@ -124,13 +124,24 @@ torch::Tensor numpy_uint8_3c_to_cv_mat(py::array_t<unsigned char> &input)
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
 {
-  m.def("get_tensor", &testTensor, "Get a sample tensor.");
-  m.def("sigmoid", &d_sigmoid, "Sigmoid activation");
-  m.def("cvMatrix", &cvMatrix, "Sigmoid activation");
-  m.def("np_to_mat", &numpy_uint8_3c_to_cv_mat, "numpy_unit8 to 3 channel cv::Mat");
-  py::class_<TensorWrapper>(m, "TensorWrapper")
-      .def(py::init<>())
-      .def_readwrite("tensor", &TensorWrapper::tensor)
-      .def_readwrite("size", &TensorWrapper::size)
-      .def_readwrite("cvmat", &TensorWrapper::cvmat);
+    m.def("get_tensor", &testTensor, "Get a sample tensor.");
+    m.def("sigmoid", &d_sigmoid, "Sigmoid activation");
+    // m.def("cvMatrix", &cvMatrix, "Sigmoid activation");
+    m.def("addmat", &addmat, "add two point");
+    // m.def("np_to_mat", &numpy_uint8_3c_to_cv_mat, "numpy_unit8 to 3 channel cv::Mat");
+    // py::class_<TensorWrapper>(m, "TensorWrapper")
+    //     .def(py::init<>())
+    //     .def_readwrite("tensor", &TensorWrapper::tensor)
+    //     .def_readwrite("size", &TensorWrapper::size)
+    //     .def_readwrite("cvmat", &TensorWrapper::cvmat);
+
+    // m.def("base64_fn",
+    //       [](const std::string &s) {
+    //         std::cout << "utf-8 is icing on the cake.\n";
+    //         //std::cout << s << std::endl;
+
+    //         std::string out;
+    //         macaron::Base64::Decode(s, &&out);
+    //         std::cout << out.length() << std::endl;
+    //       });
 }

--- a/source/pic2card/mystique/models/pth/detr_cpp/setup.py
+++ b/source/pic2card/mystique/models/pth/detr_cpp/setup.py
@@ -5,14 +5,15 @@ from torch.utils import cpp_extension
 os.environ["CXX"] = "g++-8"
 os.environ["CC"] = "g++-8"
 
+
+curr_dir = os.path.dirname(__file__)
+
 # Required libopencv-3.2-dev and libopencv-3.2
 setup(name="detr",
-    ext_modules=[cpp_extension.CppExtension(
+      ext_modules=[cpp_extension.CppExtension(
         name='detr',
-        sources=['detr.cpp'],
+        sources=[os.path.join(curr_dir, "detr.cpp")],
         libraries=["opencv_core", "opencv_imgproc"],
         extra_compile_args=["-fno-inline"]
-        )
-    ],
-    cmdclass={'build_ext': cpp_extension.BuildExtension}
-)
+        )],
+      cmdclass={'build_ext': cpp_extension.BuildExtension})

--- a/source/pic2card/mystique/models/pth/detr_cpp/setup.py
+++ b/source/pic2card/mystique/models/pth/detr_cpp/setup.py
@@ -1,18 +1,18 @@
 from setuptools import setup, Extension
 from torch.utils import cpp_extension
 
-opencv_inc_dir = "/home/haridas/projects/opensource/detr/libs/opencv-4.3.0/build/release/include/opencv4/"
-opencv_lib_dir = "/home/haridas/projects/opensource/detr/libs/opencv-4.3.0/build/release/lib"
+#opencv_inc_dir = "/home/haridas/projects/opensource/detr/libs/opencv-4.3.0/build/release/include/opencv4/"
+#opencv_lib_dir = "/home/haridas/projects/opensource/detr/libs/opencv-4.3.0/build/release/lib"
 
 
-setup(name="detr_infer",
+setup(name="detr",
     ext_modules=[cpp_extension.CppExtension(
-        name='detr_infer',
-        sources=['detr_infer.cpp'],
+        name='detr',
+        sources=['detr.cpp'],
         libraries=["opencv_core"],
-        include_dirs=[opencv_inc_dir],
-        library_dirs=[opencv_lib_dir]
-        #extra_compile_args=["-D_GLIBCXX_USE_CXX11_ABI=1"]
+        #include_dirs=[opencv_inc_dir],
+        #library_dirs=[opencv_lib_dir],
+        extra_compile_args=["-fno-inline"]
         )
     ],
     cmdclass={'build_ext': cpp_extension.BuildExtension}

--- a/source/pic2card/mystique/models/pth/detr_cpp/setup.py
+++ b/source/pic2card/mystique/models/pth/detr_cpp/setup.py
@@ -9,9 +9,9 @@ setup(name="detr_infer",
     ext_modules=[cpp_extension.CppExtension(
         name='detr_infer',
         sources=['detr_infer.cpp'],
-        # libraries=["opencv_core"],
-        # include_dirs=[opencv_inc_dir],
-        # library_dirs=[opencv_lib_dir]
+        libraries=["opencv_core"],
+        include_dirs=[opencv_inc_dir],
+        library_dirs=[opencv_lib_dir]
         #extra_compile_args=["-D_GLIBCXX_USE_CXX11_ABI=1"]
         )
     ],

--- a/source/pic2card/mystique/models/pth/detr_cpp/setup.py
+++ b/source/pic2card/mystique/models/pth/detr_cpp/setup.py
@@ -1,17 +1,16 @@
+import os
 from setuptools import setup, Extension
 from torch.utils import cpp_extension
 
-#opencv_inc_dir = "/home/haridas/projects/opensource/detr/libs/opencv-4.3.0/build/release/include/opencv4/"
-#opencv_lib_dir = "/home/haridas/projects/opensource/detr/libs/opencv-4.3.0/build/release/lib"
+os.environ["CXX"] = "g++-8"
+os.environ["CC"] = "g++-8"
 
-
+# Required libopencv-3.2-dev and libopencv-3.2
 setup(name="detr",
     ext_modules=[cpp_extension.CppExtension(
         name='detr',
         sources=['detr.cpp'],
-        libraries=["opencv_core"],
-        #include_dirs=[opencv_inc_dir],
-        #library_dirs=[opencv_lib_dir],
+        libraries=["opencv_core", "opencv_imgproc"],
         extra_compile_args=["-fno-inline"]
         )
     ],

--- a/source/pic2card/mystique/models/pth/detr_cpp/setup.py
+++ b/source/pic2card/mystique/models/pth/detr_cpp/setup.py
@@ -1,0 +1,19 @@
+from setuptools import setup, Extension
+from torch.utils import cpp_extension
+
+opencv_inc_dir = "/home/haridas/projects/opensource/detr/libs/opencv-4.3.0/build/release/include/opencv4/"
+opencv_lib_dir = "/home/haridas/projects/opensource/detr/libs/opencv-4.3.0/build/release/lib"
+
+
+setup(name="detr_infer",
+    ext_modules=[cpp_extension.CppExtension(
+        name='detr_infer',
+        sources=['detr_infer.cpp'],
+        # libraries=["opencv_core"],
+        # include_dirs=[opencv_inc_dir],
+        # library_dirs=[opencv_lib_dir]
+        #extra_compile_args=["-D_GLIBCXX_USE_CXX11_ABI=1"]
+        )
+    ],
+    cmdclass={'build_ext': cpp_extension.BuildExtension}
+)

--- a/source/pic2card/mystique/models/pth/detr_cpp/test.py
+++ b/source/pic2card/mystique/models/pth/detr_cpp/test.py
@@ -1,19 +1,6 @@
-import detr_infer
-import torch
+import detr
 import numpy as np
 
-t = torch.Tensor([1, 2, 3])
-print(detr_infer.sigmoid(t))
-print(detr_infer.get_tensor())
+arr1 = np.array([[1, 2, 3], [2, 3, 4], [3, 4, 5]], dtype=np.uint8)
 
-
-tw = detr_infer.TensorWrapper()
-print(tw.tensor)
-
-
-#arr = np.array([1, 2, 3, 4], dtype=np.uint8)
-arr = np.random.normal(loc=255, size=(10, 10, 3))
-
-print(detr_infer.np_to_mat(arr))
-
-#print(detr_infer.cvMatrix())
+print(detr.addmat(arr1, arr1))

--- a/source/pic2card/mystique/models/pth/detr_cpp/test.py
+++ b/source/pic2card/mystique/models/pth/detr_cpp/test.py
@@ -1,5 +1,7 @@
 import detr_infer
 import torch
+import numpy as np
+
 t = torch.Tensor([1, 2, 3])
 print(detr_infer.sigmoid(t))
 print(detr_infer.get_tensor())
@@ -7,3 +9,11 @@ print(detr_infer.get_tensor())
 
 tw = detr_infer.TensorWrapper()
 print(tw.tensor)
+
+
+#arr = np.array([1, 2, 3, 4], dtype=np.uint8)
+arr = np.random.normal(loc=255, size=(10, 10, 3))
+
+print(detr_infer.np_to_mat(arr))
+
+#print(detr_infer.cvMatrix())

--- a/source/pic2card/mystique/models/pth/detr_cpp/test.py
+++ b/source/pic2card/mystique/models/pth/detr_cpp/test.py
@@ -1,6 +1,0 @@
-import detr
-import numpy as np
-
-arr1 = np.array([[1, 2, 3], [2, 3, 4], [3, 4, 5]], dtype=np.uint8)
-
-print(detr.addmat(arr1, arr1))

--- a/source/pic2card/mystique/models/pth/detr_cpp/test.py
+++ b/source/pic2card/mystique/models/pth/detr_cpp/test.py
@@ -4,3 +4,6 @@ t = torch.Tensor([1, 2, 3])
 print(detr_infer.sigmoid(t))
 print(detr_infer.get_tensor())
 
+
+tw = detr_infer.TensorWrapper()
+print(tw.tensor)

--- a/source/pic2card/mystique/models/pth/detr_cpp/test.py
+++ b/source/pic2card/mystique/models/pth/detr_cpp/test.py
@@ -1,0 +1,6 @@
+import detr_infer
+import torch
+t = torch.Tensor([1, 2, 3])
+print(detr_infer.sigmoid(t))
+print(detr_infer.get_tensor())
+

--- a/source/pic2card/mystique/models/pth/detr_cpp/tests.py
+++ b/source/pic2card/mystique/models/pth/detr_cpp/tests.py
@@ -1,0 +1,18 @@
+import detr
+import numpy as np
+import unittest
+
+
+class TestDetrLib(unittest.TestCase):
+    def setUp(self):
+        pass
+    def test_add_np_array(self):
+        arr1 = np.array([[1, 2, 3], [2, 3, 4], [3, 4, 5]], dtype=np.uint8)
+        res = detr.addmat(arr1, arr1)
+        exp_res = np.array([[2, 4, 6], [4, 6, 8], [6, 8, 10]], dtype=np.uint8)
+        self.assertTrue(np.all(res == exp_res))
+
+    
+
+
+

--- a/source/pic2card/mystique/models/pth/detr_cpp/tests.py
+++ b/source/pic2card/mystique/models/pth/detr_cpp/tests.py
@@ -1,18 +1,42 @@
 import detr
 import numpy as np
+from PIL import Image
 import unittest
+#import torch
 
 
 class TestDetrLib(unittest.TestCase):
     def setUp(self):
-        pass
+        self.model_path = "/mnt1/haridas/projects/pic2card-models/pytorch/detr_trace.pt"
+        image = "/home/haridas/projects/mystique/data/templates_test_data/1.png"
+        img = Image.open(image)
+        self.img_np = np.asarray(img)
+
     def test_add_np_array(self):
         arr1 = np.array([[1, 2, 3], [2, 3, 4], [3, 4, 5]], dtype=np.uint8)
         res = detr.addmat(arr1, arr1)
         exp_res = np.array([[2, 4, 6], [4, 6, 8], [6, 8, 10]], dtype=np.uint8)
         self.assertTrue(np.all(res == exp_res))
 
-    
+    def test_detr_constructor(self):
+        detr1 = detr.Detr(self.model_path)
+        self.assertEqual(self.model_path, detr1.model_path)
+        self.assertEqual(self.model_path, detr1.get_model_path())
+
+    def test_model_loading(self):
+        model = detr.Detr(self.model_path)
+        model.load()
+        #import pdb; pdb.set_trace()
+        print(model.predict(self.img_np))
+
+    #     #import pdb; pdb.set_trace()
+
+    def test_matrix_mal(self):
+        mm = detr.MatrixMultiplier(3, 4)
+        #print(mm.getstr())
+        #print(mm.getvector())
+        #print(mm.randomTensor())
+            
 
 
 

--- a/source/pic2card/mystique/models/pth/detr_cpp/tests.py
+++ b/source/pic2card/mystique/models/pth/detr_cpp/tests.py
@@ -7,8 +7,8 @@ import unittest
 class TestDetrLib(unittest.TestCase):
     def setUp(self):
         self.model_path = "/mnt1/haridas/projects/pic2card-models/pytorch/detr_trace.pt"
-        image = "/home/haridas/projects/mystique/data/templates_test_data/1.png"
-        img = Image.open(image)
+        self.image_path = "/home/haridas/projects/mystique/data/templates_test_data/1.png"
+        img = Image.open(self.image_path)
         self.img_np = np.asarray(img)
 
     def test_add_np_array(self):
@@ -28,6 +28,6 @@ class TestDetrLib(unittest.TestCase):
         model.load()
         pred_logits, pred_boxes = model.predict(self.img_np)
 
+        print(pred_logits.shape)
         self.assertEqual(pred_logits.shape, (60, 7))
         self.assertEqual(pred_boxes.shape, (60, 4))
-        #print(pred_logits.shape, pred_boxes.shape)

--- a/source/pic2card/mystique/models/pth/detr_cpp/tests.py
+++ b/source/pic2card/mystique/models/pth/detr_cpp/tests.py
@@ -2,7 +2,6 @@ import detr
 import numpy as np
 from PIL import Image
 import unittest
-#import torch
 
 
 class TestDetrLib(unittest.TestCase):
@@ -13,6 +12,7 @@ class TestDetrLib(unittest.TestCase):
         self.img_np = np.asarray(img)
 
     def test_add_np_array(self):
+        "Check numpy Type conversion works"
         arr1 = np.array([[1, 2, 3], [2, 3, 4], [3, 4, 5]], dtype=np.uint8)
         res = detr.addmat(arr1, arr1)
         exp_res = np.array([[2, 4, 6], [4, 6, 8], [6, 8, 10]], dtype=np.uint8)
@@ -26,17 +26,8 @@ class TestDetrLib(unittest.TestCase):
     def test_model_loading(self):
         model = detr.Detr(self.model_path)
         model.load()
-        #import pdb; pdb.set_trace()
-        print(model.predict(self.img_np))
+        pred_logits, pred_boxes = model.predict(self.img_np)
 
-    #     #import pdb; pdb.set_trace()
-
-    def test_matrix_mal(self):
-        mm = detr.MatrixMultiplier(3, 4)
-        #print(mm.getstr())
-        #print(mm.getvector())
-        #print(mm.randomTensor())
-            
-
-
-
+        self.assertEqual(pred_logits.shape, (60, 7))
+        self.assertEqual(pred_boxes.shape, (60, 4))
+        #print(pred_logits.shape, pred_boxes.shape)

--- a/source/pic2card/mystique/obj_detect/__init__.py
+++ b/source/pic2card/mystique/obj_detect/__init__.py
@@ -1,5 +1,6 @@
 from .detect_objects_pth import PtObjectDetection
 from .detr_objects import DetrOD
+from .detr_cpp_objects import DetrCppOD
 
 
-__all__ = [PtObjectDetection, DetrOD]
+__all__ = [PtObjectDetection, DetrOD, DetrCppOD]

--- a/source/pic2card/mystique/predict_card.py
+++ b/source/pic2card/mystique/predict_card.py
@@ -17,6 +17,7 @@ from mystique.image_extraction import ImageExtraction
 from mystique.card_template import DataBinding
 from mystique import config
 from mystique.extract_properties import CollectProperties
+from mystique.utils import timeit
 
 
 class PredictCard:
@@ -105,9 +106,10 @@ class PredictCard:
         image_np = np.asarray(image)
         image_np = cv2.cvtColor(image_np, cv2.COLOR_RGB2BGR)
         # Extract the design objects from faster rcnn model
-        output_dict, _ = self.od_model.get_objects(
-            image_np=image_np, image=image
-        )
+        with timeit("Model inference"):
+            output_dict, _ = self.od_model.get_objects(
+                image_np=image_np, image=image
+            )
         return self.generate_card(output_dict, image, image_np, card_format)
 
     def tf_serving_main(self, bs64_img: str, tf_server: str, model_name: str,


### PR DESCRIPTION
Detr cpp binding for python, it does the actual inference at cpp side using the torchscript trace file.

We are seeing more than  3x relative speed improvement on the model inference side.



Use this inference method by passing the environment variable to enable this inference method with pic2card pipeline.
```bash
$ ACTIVE_MODEL_NAME=pth_detr_cpp python -m app.main
```

**NOTE**: This PR doesn't include options for the production packaging like docker and all.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4549)