### PR TITLE
[pic2card] Detr cpp binding for model inference

### DIFF
--- a/source/pic2card/mystique/config.py
+++ b/source/pic2card/mystique/config.py
@@ -59,7 +59,8 @@ MODEL_REGISTRY = {
     "tf_faster_rcnn": "mystique.detect_objects.ObjectDetection",
     "tfs_faster_rcnn": "mystique.detect_objects.TfsObjectDetection",
     "pth_faster_rcnn": "mystique.obj_detect.PtObjectDetection",
-    "pth_detr": "mystique.obj_detect.DetrOD"
+    "pth_detr": "mystique.obj_detect.DetrOD",
+    "pth_detr_cpp": "mystique.obj_detect.DetrCppOD"
 }
 
 ACTIVE_MODEL_NAME = os.environ.get("ACTIVE_MODEL_NAME", "tf_faster_rcnn")

--- a/source/pic2card/mystique/models/pth/detr_cpp/CMakeLists.txt
+++ b/source/pic2card/mystique/models/pth/detr_cpp/CMakeLists.txt
@@ -1,26 +1,35 @@
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-project(detr_inference)
+project(detr)
 
-# add_subdirectory(libs/pybind11)
-
+add_subdirectory(pybind11)
+find_package (Python COMPONENTS Development)
 find_package(OpenCV REQUIRED)
 find_package(Torch REQUIRED)
-find_package(Python3 REQUIRED)
 
 message(STATUS "Pytorch status: ")
 message(STATUS " libraries: ${TORCH_LIBRARIES}")
 message(STATUS "    include path: ${TORCH_INCLUDE_DIRS}")
+
+message(STATUS "Python status: ")
+message(STATUS "    libraries: ${Python_LIBRARIES}")
+message(STATUS "    include path: ${Python_INCLUDE_DIRS}")
+
 message(STATUS "OpenCV library status:")
 message(STATUS "    version: ${OpenCV_VERSION}")
 message(STATUS "    libraries: ${OpenCV_LIBS}")
 message(STATUS "    include path: ${OpenCV_INCLUDE_DIRS}")
 
+
 #SET (CMAKE_EXE_LINKER_FLAGS "-static")
 
 include_directories(${OpenCV_INCLUDE_DIRS})
 include_directories(${TORCH_INCLUDE_DIRS})
-add_executable(detr_inference detr_infer.cpp)
-#
-target_link_libraries(detr_inference ${OpenCV_LIBS})
-target_link_libraries(detr_inference ${TORCH_LIBRARIES})
-set_property(TARGET detr_inference PROPERTY CXX_STANDARD 14)
+include_directories(${Python_INCLUDE_DIRS})
+
+add_executable(detr detr_infer.cpp)
+# pybind11_add_module(detr detr.cpp)
+
+target_link_libraries(detr PRIVATE ${OpenCV_LIBS})
+target_link_libraries(detr PRIVATE ${TORCH_LIBRARIES})
+target_link_libraries(detr PRIVATE ${Python_LIBRARIES})
+set_property(TARGET detr PROPERTY CXX_STANDARD 14)

--- a/source/pic2card/mystique/models/pth/detr_cpp/README.md
+++ b/source/pic2card/mystique/models/pth/detr_cpp/README.md
@@ -1,16 +1,15 @@
 ## Torchscript based Inference
 
 Here we are trying to evaluate the benefits of using libtorch to handle the
-model core functionality.
-
+model inference part.
 
 
 ## Dependencies
 
-1. Opencv 4.3.0
-2. libtorch nightly build.
-2. DETR github implementation.
-
+1. Opencv 3.2+
+2. torch 1.6+
+3. Detr Model trace file.
+4. g++7 and above.
 
 
 You need to download the C++-11 ABI compatible libtorch, and latest opencv to
@@ -21,34 +20,56 @@ link our library. As mentioned libtorch is already build one, only thing need to
 be take care is the ABI compatibility.
 
 
-## Build and test the libtorch
-
-```bash
-# Build opencv first
-cd opencv-4.3.0
-mkdir build
-cmake -DCMAKE_INSTALL_PREFIX=`pwd`/../release ..
-make install
-
-
-# Build the detr_inference
-mkdir build
-cd build
-cmake -DCMAKE_PREFIX_PATH="<path-to>/libtorch;<path-to>/opencv-4.3.0/release"
-cmake --build . --config Release --verbose
-
-# The model path and image path are supplied via variables now.
-./deter_infer
-..
-```
 
 
 ## Integration with pic2card
 
 Model inference is the first stage of the pic2card pipeline and all the pic2card
-implementation are in python based, we have to expose the c++ inference model to
+implementation are in python, we have to expose the c++ inference model to
 python ecosystem back, in this case we are skipping all other requirements of
 the python torch library.
 
 This can be done multiple ways, looking into ways to expose the model interface
 as a python module.
+
+
+## Build the detr cpp inference python binding
+
+To build this cpp extension you requires the torch python package, after
+building you can remove that dependency except for those dynamic linked
+libraries comes with the torch package. Initially we will keep both, eventually
+for the production pipeline we can remove the dependency on the pytorch
+dependency instead using the libtorch.
+
+
+```bash
+    pip install torch torchvision
+    apt-get install libopencv-core-dev libopencv-imgproc-dev
+
+    # Install the detr package into your python environment.
+    python setup.py install
+```
+
+## To run the Pic2card with this new inference pipeline
+
+```bash
+# From the root dir of pic2card
+ACTIVE_MODEL_NAME=pth_detr_cpp python -m app.main
+```
+
+## Debug Build and testing
+
+Building a executable able testing without attaching to the python would be
+required to debug problems at the c++ world in much easier fashion, for that use
+this camke based build and corresponding executable.
+
+```bash
+mkdir build
+cd build
+cmake -DCMAKE_PREFIX_PATH="<path-to>/libtorch"
+cmake --build . --config Release --verbose
+
+# The model path and image path are supplied via variables now.
+./deter
+..
+```

--- a/source/pic2card/mystique/models/pth/detr_cpp/detr.cpp
+++ b/source/pic2card/mystique/models/pth/detr_cpp/detr.cpp
@@ -1,0 +1,90 @@
+#include <torch/extension.h>
+#include <torch/script.h>
+
+#include "detr.hpp"
+
+cv::Mat addmat(cv::Mat &lhs, cv::Mat &rhs)
+{
+    return lhs + rhs;
+}
+
+struct Detr
+{
+
+    std::string model_path;
+    torch::jit::script::Module model;
+
+    Detr(const std::string &model_path) : model_path(model_path) {}
+
+    const std::string &getModelPath()
+    {
+        return model_path;
+    }
+
+    void loadModel()
+    {
+        model = torch::jit::load(model_path);
+    }
+
+    const std::vector<cv::Mat> predict(cv::Mat &image)
+    {
+        cv::cvtColor(image, image, cv::COLOR_BGR2RGB);
+        image.convertTo(image, CV_32FC3, 1.0f / 255.0f);
+        // cv::Size imsize = image.size();
+        // std::cout << "Width: " << imsize.width << std::endl;
+
+        torch::Tensor imTensor = torch::from_blob(
+            image.data,
+            { 1, image.rows, image.cols, 3 }
+        );
+        imTensor = imTensor.permute({ 0, 3, 1, 2 });
+
+        imTensor[0][0] = imTensor[0][0].sub_(0.485).div_(0.229);
+        imTensor[0][1] = imTensor[0][1].sub_(0.456).div_(0.224);
+        imTensor[0][2] = imTensor[0][2].sub_(0.406).div_(0.225);
+
+        // std::cout << "Image size: " << imTensor.size(0) << " " << imTensor.size(1) 
+        //     << " " << imTensor.size(2) << " " <<imTensor.size(3) << std::endl;
+
+        std::vector<torch::jit::IValue> inputs;
+        inputs.push_back(imTensor);
+        auto outDict = model.forward(inputs).toGenericDict();
+
+        torch::Tensor predLogits = outDict.at("pred_logits")
+            .toTensor()
+            .squeeze()
+            .softmax(-1);
+
+        // predLogits = predLogits.narrow(1, 0, predLogits.size(1) - 1);
+        torch::Tensor predBoxes = outDict.at("pred_boxes").toTensor().squeeze();
+
+        // //return predLogits;
+        // std::cout << "PredLogits Size: " << predLogits.size(0) << " " << predLogits.size(1) << std::endl;
+        // std::cout << "predBoxes Size: " << predBoxes.size(0) << " " << predBoxes.size(1) << std::endl;
+
+        // // Map the torch::Tensor to cv::Mat, helps to avoid torch package dependency at python side.
+        predLogits = predLogits.to(torch::kCPU).to(torch::kF32);
+        cv::Mat cvMatLogits(predLogits.size(0), predLogits.size(1), CV_32F);
+        std::memcpy((void*)cvMatLogits.data, predLogits.data_ptr(), sizeof(float)*predLogits.numel());
+
+        predBoxes = predBoxes.to(torch::kCPU).to(torch::kF32);
+        cv::Mat cvMatBoxes(predBoxes.size(0), predBoxes.size(1), CV_32F);
+        std::memcpy((void*)cvMatBoxes.data, predBoxes.data_ptr(), sizeof(float)*predBoxes.numel());
+
+        return { cvMatLogits, cvMatBoxes };
+    }
+};
+
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
+{
+    m.def("addmat", &addmat, "add two matrix");
+
+    py::class_<Detr>(m, "Detr")
+        .def(py::init<const std::string &>())
+        .def("get_model_path", &Detr::getModelPath)
+        .def_readonly("model_path", &Detr::model_path)
+        .def("load", &Detr::loadModel)
+        .def("predict", &Detr::predict)
+        .def_readonly("model", &Detr::model);
+}

--- a/source/pic2card/mystique/models/pth/detr_cpp/detr.hpp
+++ b/source/pic2card/mystique/models/pth/detr_cpp/detr.hpp
@@ -1,0 +1,119 @@
+// Reusing the type conversion from https://github.com/ausk/keras-unet-deploy/tree/master
+#pragma once
+
+#include <opencv2/core/core.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+
+#include <pybind11/stl.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+
+namespace py = pybind11;
+
+namespace pybind11
+{
+    namespace detail
+    {
+        template <>
+        struct type_caster<cv::Mat>
+        {
+        public:
+            PYBIND11_TYPE_CASTER(cv::Mat, _("numpy.ndarray"));
+
+            //! 1. cast numpy.ndarray to cv::Mat
+            bool load(handle obj, bool)
+            {
+                array b = reinterpret_borrow<array>(obj);
+                buffer_info info = b.request();
+
+                int nh = 1;
+                int nw = 1;
+                int nc = 1;
+                int ndims = info.ndim;
+                if (ndims == 2)
+                {
+                    nh = info.shape[0];
+                    nw = info.shape[1];
+                }
+                else if (ndims == 3)
+                {
+                    nh = info.shape[0];
+                    nw = info.shape[1];
+                    nc = info.shape[2];
+                }
+                else
+                {
+                    throw std::logic_error("Only support 2d, 2d matrix");
+                    return false;
+                }
+
+                int dtype;
+                if (info.format == format_descriptor<unsigned char>::format())
+                {
+                    dtype = CV_8UC(nc);
+                }
+                else if (info.format == format_descriptor<int>::format())
+                {
+                    dtype = CV_32SC(nc);
+                }
+                else if (info.format == format_descriptor<float>::format())
+                {
+                    dtype = CV_32FC(nc);
+                }
+                else
+                {
+                    throw std::logic_error("Unsupported type, only support uchar, int32, float");
+                    return false;
+                }
+                value = cv::Mat(nh, nw, dtype, info.ptr);
+                return true;
+            }
+
+            //! 2. cast cv::Mat to numpy.ndarray
+            static handle cast(const cv::Mat &mat, return_value_policy, handle defval)
+            {
+                std::string format = format_descriptor<unsigned char>::format();
+                size_t elemsize = sizeof(unsigned char);
+                int nw = mat.cols;
+                int nh = mat.rows;
+                int nc = mat.channels();
+                int depth = mat.depth();
+                int type = mat.type();
+                int dim = (depth == type) ? 2 : 3;
+                if (depth == CV_8U)
+                {
+                    format = format_descriptor<unsigned char>::format();
+                    elemsize = sizeof(unsigned char);
+                }
+                else if (depth == CV_32S)
+                {
+                    format = format_descriptor<int>::format();
+                    elemsize = sizeof(int);
+                }
+                else if (depth == CV_32F)
+                {
+                    format = format_descriptor<float>::format();
+                    elemsize = sizeof(float);
+                }
+                else
+                {
+                    throw std::logic_error("Unsupport type, only support uchar, int32, float");
+                }
+
+                std::vector<size_t> bufferdim;
+                std::vector<size_t> strides;
+                if (dim == 2)
+                {
+                    bufferdim = {(size_t)nh, (size_t)nw};
+                    strides = {elemsize * (size_t)nw, elemsize};
+                }
+                else if (dim == 3)
+                {
+                    bufferdim = {(size_t)nh, (size_t)nw, (size_t)nc};
+                    strides = {(size_t)elemsize * nw * nc, (size_t)elemsize * nc, (size_t)elemsize};
+                }
+                return array(buffer_info(mat.data, elemsize, format, dim, bufferdim, strides)).release();
+            }
+        };
+    } // namespace detail
+} // namespace pybind11

--- a/source/pic2card/mystique/models/pth/detr_cpp/detr_infer.cpp
+++ b/source/pic2card/mystique/models/pth/detr_cpp/detr_infer.cpp
@@ -1,64 +1,85 @@
 #include <iostream>
-#include <memory>
-#include <stdio.h>
+#include <string>
+#include <tuple>
 
 #include <opencv2/opencv.hpp>
-#include <torch/script.h> // One-stop header.
-// #include <pybind11/pybind11.h>
+#include <torch/extension.h>
+#include <torch/script.h>
+#include <torch/torch.h>
 
-using namespace cv;
-using namespace std;
 
-vector<int> random_scale(Mat image)
-{}
+// using namespace std;
+// using namespace cv;
 
 // Scale sizes
 int main(int argc, const char *argv[])
 {
-  string model_path = "/mnt1/haridas/projects/pic2card-models/pytorch/detr_trace.pt";
-  string image_path = "/mnt1/haridas/projects/mystique/data/templates_test_data/1.png";
+    std::string model_path = "/mnt1/haridas/projects/pic2card-models/pytorch/detr_trace.pt";
+    std::string image_path = "/mnt1/haridas/projects/mystique/data/templates_test_data/1.png";
 
-  // if (argc != 3)
-  // {
-  //   std::cerr << "usage: detr-app <path-to-exported-script-module> <image-path> \n";
-  //   return -1;
-  // }
+    // if (argc != 3)
+    // {
+    //   std::cerr << "usage: detr-app <path-to-exported-script-module> <image-path> \n";
+    //   return -1;
+    // }
+    try
+    {
+        // Deserialize image_pathiptModule from a file using torch::jit::load().
+        cv::Mat image = cv::imread(image_path, 1);
+        cv::cvtColor(image, image, cv::COLOR_BGR2RGB);
+        //cv::Size scale(500, 600);
+        //cv::resize(image, image, scale);
+        cv::Size imsize = image.size();
+        image.convertTo(image, CV_32FC3, 1.0f / 255.0f);
+        //std::cout << "Image: " << image.size();
 
-  try
-  {
-    // Deserialize image_pathiptModule from a file using torch::jit::load().
-    Mat image = cv::imread(image_path, 1);
-    cv::cvtColor(image, image, cv::COLOR_BGR2RGB);
-    cv::Size scale(500, 600);
-    cv::resize(image, image, scale);
-    image.convertTo(image, CV_32FC3, 1.0f / 255.0f);
-    std::cout << "Image: " << image.size();
+        //auto input_tensor = torch::from_blob(image.data, {1, 500, 600, 3});
+        torch::Tensor input_tensor = torch::from_blob(image.data, { 1, imsize.width, imsize.height, 3 });
+        input_tensor = input_tensor.permute({ 0, 3, 1, 2 });
+        //std::cout << "Tensor: " << input_tensor[0][0].sizes();
+        // Apply normalization based on imagenet data.
+        input_tensor[0][0] = input_tensor[0][0].sub_(0.485).div_(0.229);
+        input_tensor[0][1] = input_tensor[0][1].sub_(0.456).div_(0.224);
+        input_tensor[0][2] = input_tensor[0][2].sub_(0.406).div_(0.225);
 
-    auto input_tensor = torch::from_blob(image.data, {1, 500, 600, 3});
-    input_tensor = input_tensor.permute({0, 3, 1, 2});
-    std::cout << "Tensor: " << input_tensor[0][0].sizes();
-    // Apply normalization based on imagenet data.
-    input_tensor[0][0] = input_tensor[0][0].sub_(0.485).div_(0.229);
-    input_tensor[0][1] = input_tensor[0][1].sub_(0.456).div_(0.224);
-    input_tensor[0][2] = input_tensor[0][2].sub_(0.406).div_(0.225);
+        torch::jit::script::Module module;
+        module = torch::jit::load(model_path);
+        // Create a vector of inputs.
+        std::vector<torch::jit::IValue> inputs;
+        //inputs.push_back(torch::ones({1, 3, 500, 600}));
+        inputs.push_back(input_tensor);
 
-    torch::jit::script::Module module;
-    module = torch::jit::load(model_path);
-    // Create a vector of inputs.
-    std::vector<torch::jit::IValue> inputs;
-    //inputs.push_back(torch::ones({1, 3, 500, 600}));
-    inputs.push_back(input_tensor);
+        // Execute the model and turn its output into a tensor.
+        auto outDict = module.forward(inputs).toGenericDict();
+        // auto outDict = output.toGenericDict();
 
-    // Execute the model and turn its output into a tensor.
-    c10::IValue output = module.forward(inputs);
-    std::cout << output;
-  }
-  catch (const c10::Error &e)
-  {
-    std::cerr << "error loading the model\n";
-    std::cout << e.what() << "\n";
-    return -1;
-  }
+        //std::cout << "PredLogits: " << outDict.at("pred_logits") << " pred Boxes: " << outDict.at("pred_boxes") << std::endl;
+        torch::Tensor predLogits = outDict.at("pred_logits")
+            .toTensor()
+            .squeeze()
+            .softmax(-1);
+        predLogits = predLogits.narrow(1, 0, predLogits.size(1) - 1);
 
-  std::cout << "ok\n";
+        torch::Tensor predBoxes = outDict.at("pred_boxes").toTensor().squeeze();
+
+        auto keep = predLogits.max(-1);
+        auto keep1 = std::get<0>(keep); // apply threshold mask.
+        torch::Tensor mask = keep1.ge_(0.8);
+
+        mask = mask.to(torch::kBool);
+        std::cout << mask << std::endl;
+        //predBoxes = predBoxes.masked_select(mask);
+        predLogits = predLogits.index_select(0, mask);
+        // auto keep = predBoxes.max(-1) > 0.8;
+        //std::vector<torch::Tensor> test = predLogits.toTensor();
+    std::cout << predLogits;
+    }
+    catch (const c10::Error &e)
+    {
+        std::cerr << "error loading the model\n";
+        std::cout << e.what() << "\n";
+        return -1;
+    }
+
+    std::cout << "ok\n";
 }

--- a/source/pic2card/mystique/models/pth/detr_cpp/setup.py
+++ b/source/pic2card/mystique/models/pth/detr_cpp/setup.py
@@ -1,0 +1,19 @@
+import os
+from setuptools import setup
+from torch.utils import cpp_extension
+
+os.environ["CXX"] = "g++-8"
+os.environ["CC"] = "g++-8"
+
+
+curr_dir = os.path.dirname(__file__)
+
+# Required libopencv-3.2-dev and libopencv-3.2
+setup(name="detr",
+      ext_modules=[cpp_extension.CppExtension(
+        name='detr',
+        sources=[os.path.join(curr_dir, "detr.cpp")],
+        libraries=["opencv_core", "opencv_imgproc"],
+        extra_compile_args=["-fno-inline"]
+        )],
+      cmdclass={'build_ext': cpp_extension.BuildExtension})

--- a/source/pic2card/mystique/models/pth/detr_cpp/tests.py
+++ b/source/pic2card/mystique/models/pth/detr_cpp/tests.py
@@ -1,0 +1,38 @@
+import os
+import detr
+import numpy as np
+from PIL import Image
+import unittest
+
+curr_dir = os.path.dirname(__file__)
+
+
+class TestDetrLib(unittest.TestCase):
+    def setUp(self):
+        self.model_path = os.path.join(
+            curr_dir, "../../../../model/pth_models/detr_trace.pt")
+        self.image_path = os.path.join(
+            curr_dir, "../../../../tests/test_images/test01.png")
+        img = Image.open(self.image_path)
+        self.img_np = np.asarray(img)
+
+    def test_add_np_array(self):
+        "Check numpy Type conversion works"
+        arr1 = np.array([[1, 2, 3], [2, 3, 4], [3, 4, 5]], dtype=np.uint8)
+        res = detr.addmat(arr1, arr1)
+        exp_res = np.array([[2, 4, 6], [4, 6, 8], [6, 8, 10]], dtype=np.uint8)
+        self.assertTrue(np.all(res == exp_res))
+
+    def test_detr_constructor(self):
+        detr1 = detr.Detr(self.model_path)
+        self.assertEqual(self.model_path, detr1.model_path)
+        self.assertEqual(self.model_path, detr1.get_model_path())
+
+    def test_model_loading(self):
+        model = detr.Detr(self.model_path)
+        model.load()
+        pred_logits, pred_boxes = model.predict(self.img_np)
+
+        print(pred_logits.shape)
+        self.assertEqual(pred_logits.shape, (60, 7))
+        self.assertEqual(pred_boxes.shape, (60, 4))

--- a/source/pic2card/mystique/obj_detect/__init__.py
+++ b/source/pic2card/mystique/obj_detect/__init__.py
@@ -1,5 +1,6 @@
 from .detect_objects_pth import PtObjectDetection
 from .detr_objects import DetrOD
+from .detr_cpp_objects import DetrCppOD
 
 
-__all__ = [PtObjectDetection, DetrOD]
+__all__ = [PtObjectDetection, DetrOD, DetrCppOD]

--- a/source/pic2card/mystique/obj_detect/detr_cpp_objects.py
+++ b/source/pic2card/mystique/obj_detect/detr_cpp_objects.py
@@ -1,0 +1,73 @@
+"""
+Doing Detr inference using c++ binding, quick checks shows >3x improvements
+with the inference time.
+"""
+import detr
+import numpy as np
+from typing import Dict, Tuple
+from PIL import Image
+
+from .od_base import AbstractObjectDetection
+from mystique import config
+
+
+# for output bounding box post-processing
+# TODO: Move these tensor works too into c++ side, as this comes in
+# inference path.
+def box_cxcywh_to_xyxy(x: np.ndarray):
+    x_c, y_c, w, h = [i[:, 0] for i in np.split(x, [1, 2, 3], axis=1)]
+    b = [(x_c - 0.5 * w), (y_c - 0.5 * h),
+         (x_c + 0.5 * w), (y_c + 0.5 * h)]
+    return np.stack(b, axis=1)
+
+
+def rescale_bboxes(out_bbox: np.ndarray, size: Tuple[int, int]):
+    img_w, img_h = size
+    b = box_cxcywh_to_xyxy(out_bbox)
+    b = b * [img_w, img_h, img_w, img_h]
+    return b
+
+
+class DetrCppOD(AbstractObjectDetection):
+    """
+    Do the inference in c++ code and return the result. This class wraps uses
+    detr cpp python extension to do the inference.
+    """
+    def __init__(self, pt_path="./detr_trace.pt", threshold=0.8):
+        self.model = detr.Detr(self.model_path)
+        self.model.load()
+        self.threshold = threshold
+
+    @property
+    def model_path(self):
+        return config.DETR_MODEL_PATH
+
+    def get_objects(self, image_np: np.array, image: Image) -> Dict:
+        """
+        Do model inference using `od_model` and return standard response.
+
+        This function gets both image tensor or PIL image, The implementation
+        can pick the one which suits. Helps to avoid further transformations.
+
+        Response:
+            {
+            "detection_classes": [],
+             "detection_scores": [],
+             "detection_boxes": []
+             },
+        """
+        pred_logits, pred_boxes = self.model.predict(image_np)
+        pred_logits = pred_logits[:, :-1]
+        # TODO: Use the threshold from config
+        mask = pred_logits.max(-1) > 0.8
+
+        scores = pred_logits[mask]
+        boxes = rescale_bboxes(pred_boxes[mask], image.size)
+        return {
+            "detection_classes": scores.argmax(-1),
+            "detection_scores": scores.max(-1),
+            "detection_boxes": boxes
+        }, None
+
+    def get_bboxes(self):
+        pass


### PR DESCRIPTION
Detr cpp binding for python, it does the actual inference at cpp side using the torchscript trace file.

We are seeing more than  3x relative speed improvement on the model inference side.



Use this inference method by passing the environment variable to enable this inference method with pic2card pipeline.
```bash
$ ACTIVE_MODEL_NAME=pth_detr_cpp python -m app.main
```

**NOTE**: This PR doesn't include options for the production packaging like docker and all.

**Commits:-**

* creating python binding using pybind11

* Numpy to cv::Mat conversion via pybind11

* opencv cv::Mat to numpy ndarray type conversion.

* Testcase to validate the detr library

* cpp detr binding tested.

It doesn't require python torch library, instead it will be dynamically
linked to the libtorch library.

* CMakeLists updates, required for standard binary

* Integration of c++ inference binding.

* Readme update.

* Fixing the hard coded paths in test.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4550)