### PR TITLE
[Designer] Set focus on first card in card catalog when it loads

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/open-sample-dialog.ts
+++ b/source/nodejs/adaptivecards-designer/src/open-sample-dialog.ts
@@ -165,7 +165,12 @@ export class OpenSampleDialog extends Dialog {
 
         this.catalogue.onDownloaded = (sender: SampleCatalogue) => {
             if (sender.isDownloaded) {
-                this.setContent(this.renderCatalogue());
+                let catalogue = this.renderCatalogue();
+                this.setContent(catalogue);
+
+                // now set focus on the first card in the catalog (usually the Blank Card)
+                let firstChild = catalogue.firstElementChild as HTMLElement;
+                firstChild.focus();
             }
             else {
                 this.setContent(this.renderMessage("The catalogue couldn't be loaded. Please try again later.", false));


### PR DESCRIPTION
## Related Issue
Fixes VSO #24068357

## Description
I previously fixed a bunch of accessibility issues around the "New card" dialog, but missed setting keyboard focus on the first card in the catalog.

## How Verified
* local build/validation

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4562)