### PR TITLE
Updates ctrl+enter checks for TextInput

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -2668,7 +2668,7 @@ export class TextInput extends Input {
         input.oninput = () => { this.valueChanged(); }
         input.onkeypress = (e: KeyboardEvent) => {
             // Ctrl+Enter pressed
-            if (e.keyCode == 10 && this.inlineAction) {
+            if (e.ctrlKey && e.charCode == 13 && this.inlineAction) {
                 this.inlineAction.execute();
             }
         }


### PR DESCRIPTION
## Related Issue
Fixes #4575

## Description
This ensures that the keyboard shortcut of `Ctrl+Enter` works when an inlineAction is assigned to a `Text.Input`.

## Notes
In my own project, I had to use `e.ctrlKey && e.charCode === 13 && this.inlineAction` as my condition. This PR contains the fix for this, but I'm unsure whether it is OK because apparently `charCode` is deprecated and `code `should be used, but that doesn't appear in my types as an available option 🤷‍♂️

## How Verified
I have been writing my own control to display in adaptive code and it works there, so figured I'd bring across the change to here too.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4576)