### PR TITLE
Update the default card payload on the Designer

### DIFF
--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/designer.ejs
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/designer.ejs
@@ -185,31 +185,7 @@
 			} else {
 				designer.setCard({
 					"type": "AdaptiveCard",
-					"body": [
-						{
-							"type": "Container",
-							"items": [
-								{
-									"type": "TextBlock",
-									"text": "This example uses [Adaptive Card Templating](https://docs.microsoft.com/en-us/adaptive-cards/templating/)",
-									"size": "Medium",
-									"wrap": true
-								},
-								{
-									"type": "TextBlock",
-									"text": "Click the **Preview mode** toolbar button to see the card bound to the **Sample Data** in the lower-right. Sample Data helps design your card by simulating the real data.",
-									"wrap": true
-								},
-								{
-									"type": "TextBlock",
-									"text": "When you're ready to populate it with real data, use the Adaptive Card [templating SDKs](https://docs.microsoft.com/en-us/adaptive-cards/templating/sdk).",
-									"wrap": true
-								}
-							],
-							"style": "good",
-							"bleed": true
-						},
-						{
+					"body": [{
 							"type": "TextBlock",
 							"size": "Medium",
 							"weight": "Bolder",


### PR DESCRIPTION
Removed the somewhat ugly "This card uses Templating" callout, now that it's out of Preview and we've got a "Templating docs" button on the toolbar

## How Verified

- Tested website


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4625)