### PR TITLE
[UWP] Implement focus lost validation behavior controlled by host config

### DIFF
--- a/source/shared/cpp/ObjectModel/Enums.cpp
+++ b/source/shared/cpp/ObjectModel/Enums.cpp
@@ -80,6 +80,7 @@ namespace AdaptiveSharedNamespace
             {AdaptiveCardSchemaKey::ImageSize, "imageSize"},
             {AdaptiveCardSchemaKey::ImageSizes, "imageSizes"},
             {AdaptiveCardSchemaKey::Images, "images"},
+            {AdaptiveCardSchemaKey::InitialValidation, "initialValidation"},
             {AdaptiveCardSchemaKey::InlineAction, "inlineAction"},
             {AdaptiveCardSchemaKey::Inlines, "inlines"},
             {AdaptiveCardSchemaKey::InlineTopMargin, "inlineTopMargin"},
@@ -334,4 +335,9 @@ namespace AdaptiveSharedNamespace
             {InputNecessityIndicators::None, "None"},
             {InputNecessityIndicators::RequiredInputs, "RequiredInputs"},
             {InputNecessityIndicators::OptionalInputs, "OptionalInputs"}});
+
+    DEFINE_ADAPTIVECARD_ENUM_DEFAULT(InitialValidation, InitialValidation::OnFocusLost, {
+            {InitialValidation::OnFocusLost, "OnFocusLost"},
+            {InitialValidation::OnFocusLostWithInput, "OnFocusLostWithInput"},
+            {InitialValidation::OnSubmit, "OnSubmit"}});
 }

--- a/source/shared/cpp/ObjectModel/Enums.h
+++ b/source/shared/cpp/ObjectModel/Enums.h
@@ -82,6 +82,7 @@ namespace AdaptiveSharedNamespace
         ImageSize,
         ImageSizes,
         Images,
+        InitialValidation,
         InlineAction,
         Inlines,
         InlineTopMargin,
@@ -495,4 +496,12 @@ namespace AdaptiveSharedNamespace
         OptionalInputs
     };
     DECLARE_ADAPTIVECARD_ENUM(InputNecessityIndicators);
+
+    enum class InitialValidation
+    {
+        OnFocusLost,
+        OnFocusLostWithInput,
+        OnSubmit
+    };
+    DECLARE_ADAPTIVECARD_ENUM(InitialValidation);
 }

--- a/source/shared/cpp/ObjectModel/HostConfig.cpp
+++ b/source/shared/cpp/ObjectModel/HostConfig.cpp
@@ -200,7 +200,8 @@ TextConfig TextConfig::Deserialize(const Json::Value& json, const TextConfig& de
 
     result.size = ParseUtil::GetEnumValue<TextSize>(json, AdaptiveCardSchemaKey::Size, defaultValue.size, TextSizeFromString);
 
-    result.fontType = ParseUtil::GetEnumValue<FontType>(json, AdaptiveCardSchemaKey::FontType, defaultValue.fontType, FontTypeFromString);
+    result.fontType =
+        ParseUtil::GetEnumValue<FontType>(json, AdaptiveCardSchemaKey::FontType, defaultValue.fontType, FontTypeFromString);
 
     result.color = ParseUtil::GetEnumValue<ForegroundColor>(json, AdaptiveCardSchemaKey::Color, defaultValue.color, ForegroundColorFromString);
 
@@ -314,7 +315,7 @@ InputLabelConfig InputLabelConfig::Deserialize(const Json::Value& json, const In
     result.size = ParseUtil::GetEnumValue<TextSize>(json, AdaptiveCardSchemaKey::Size, defaultValue.size, TextSizeFromString);
 
     result.suffix = ParseUtil::GetString(json, AdaptiveCardSchemaKey::Suffix, defaultValue.suffix);
-    
+
     result.weight = ParseUtil::GetEnumValue<TextWeight>(json, AdaptiveCardSchemaKey::Weight, defaultValue.weight, TextWeightFromString);
 
     return result;
@@ -324,17 +325,14 @@ LabelConfig LabelConfig::Deserialize(const Json::Value& json, const LabelConfig&
 {
     LabelConfig result;
 
-    result.inputSpacing = ParseUtil::GetEnumValue<Spacing>(json, AdaptiveCardSchemaKey::InputSpacing, defaultValue.inputSpacing, SpacingFromString);
+    result.inputSpacing =
+        ParseUtil::GetEnumValue<Spacing>(json, AdaptiveCardSchemaKey::InputSpacing, defaultValue.inputSpacing, SpacingFromString);
 
-    result.requiredInputs = ParseUtil::ExtractJsonValueAndMergeWithDefault<InputLabelConfig>(json,
-                                                                                             AdaptiveCardSchemaKey::RequiredInputs,
-                                                                                             defaultValue.requiredInputs,
-                                                                                             InputLabelConfig::Deserialize);
+    result.requiredInputs = ParseUtil::ExtractJsonValueAndMergeWithDefault<InputLabelConfig>(
+        json, AdaptiveCardSchemaKey::RequiredInputs, defaultValue.requiredInputs, InputLabelConfig::Deserialize);
 
-    result.optionalInputs = ParseUtil::ExtractJsonValueAndMergeWithDefault<InputLabelConfig>(json,
-                                                                                             AdaptiveCardSchemaKey::OptionalInputs,
-                                                                                             defaultValue.optionalInputs,
-                                                                                             InputLabelConfig::Deserialize);
+    result.optionalInputs = ParseUtil::ExtractJsonValueAndMergeWithDefault<InputLabelConfig>(
+        json, AdaptiveCardSchemaKey::OptionalInputs, defaultValue.optionalInputs, InputLabelConfig::Deserialize);
 
     return result;
 }
@@ -356,19 +354,21 @@ InputsConfig InputsConfig::Deserialize(const Json::Value& json, const InputsConf
 {
     InputsConfig result;
 
-    result.errorMessage = ParseUtil::ExtractJsonValueAndMergeWithDefault<ErrorMessageConfig>(json,
-                                                                                             AdaptiveCardSchemaKey::ErrorMessage,
-                                                                                             defaultValue.errorMessage,
-                                                                                             ErrorMessageConfig::Deserialize);
+    result.errorMessage = ParseUtil::ExtractJsonValueAndMergeWithDefault<ErrorMessageConfig>(
+        json, AdaptiveCardSchemaKey::ErrorMessage, defaultValue.errorMessage, ErrorMessageConfig::Deserialize);
 
     result.label = ParseUtil::ExtractJsonValueAndMergeWithDefault<LabelConfig>(json,
                                                                                AdaptiveCardSchemaKey::Label,
                                                                                defaultValue.label,
                                                                                LabelConfig::Deserialize);
 
+    result.initialValidation = ParseUtil::GetEnumValue<InitialValidation>(json,
+                                                                          AdaptiveCardSchemaKey::InitialValidation,
+                                                                          defaultValue.initialValidation,
+                                                                          InitialValidationFromString);
+
     return result;
 }
-
 
 SpacingConfig SpacingConfig::Deserialize(const Json::Value& json, const SpacingConfig& defaultValue)
 {

--- a/source/shared/cpp/ObjectModel/HostConfig.h
+++ b/source/shared/cpp/ObjectModel/HostConfig.h
@@ -330,6 +330,7 @@ namespace AdaptiveSharedNamespace
     {
         LabelConfig label;
         ErrorMessageConfig errorMessage;
+        InitialValidation initialValidation = InitialValidation::OnFocusLost;
 
         static InputsConfig Deserialize(const Json::Value& json, const InputsConfig& defaultValue);
     };

--- a/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
+++ b/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
@@ -398,6 +398,16 @@ AdaptiveNamespaceStart
         OptionalInputs
     } InputNecessityIndicators;
 
+    [version(NTDDI_WIN10_RS1), flags]
+#ifdef ADAPTIVE_CARDS_WINDOWS
+    [contract(InternalContract, 1)][internal]
+#endif
+    typedef[v1_enum] enum InitialValidation {
+        OnFocusLost = 0,
+        OnFocusLostWithInput,
+        OnSubmit
+    } InitialValidation;
+
     declare
     {
         interface Windows.Foundation.Collections.IVector<IAdaptiveCardElement*>;
@@ -1415,6 +1425,7 @@ AdaptiveNamespaceStart
 
         AdaptiveErrorMessageConfig ErrorMessage;
         AdaptiveLabelConfig Label;
+        InitialValidation InitialValidation;
     };
 
     [

--- a/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.cpp
@@ -106,7 +106,6 @@ namespace AdaptiveNamespace
         ComPtr<IComboBox> comboBox =
             XamlHelpers::CreateXamlClass<IComboBox>(HStringReference(RuntimeClass_Windows_UI_Xaml_Controls_ComboBox));
 
-        
         // Set HorizontalAlignment to Stretch (defaults to Left for combo boxes)
         ComPtr<IFrameworkElement> comboBoxAsFrameworkElement;
         RETURN_IF_FAILED(comboBox.As(&comboBoxAsFrameworkElement));
@@ -172,17 +171,13 @@ namespace AdaptiveNamespace
 
         ComPtr<IUIElement> inputLayout;
         ComPtr<IBorder> validationBorder;
-        RETURN_IF_FAILED(XamlHelpers::HandleInputLayoutAndValidation(adaptiveChoiceSetInputAsAdaptiveInput.Get(),
-                                                    comboBoxAsUIElement.Get(),
-                                                    false,
-                                                    renderContext,
-                                                    &inputLayout,
-                                                    &validationBorder));
+        RETURN_IF_FAILED(XamlHelpers::HandleInputLayoutAndValidation(
+            adaptiveChoiceSetInputAsAdaptiveInput.Get(), comboBoxAsUIElement.Get(), false, renderContext, &inputLayout, &validationBorder));
 
         // Create the InputValue and add it to the context
         ComPtr<ChoiceSetInputValue> input;
         RETURN_IF_FAILED(MakeAndInitialize<ChoiceSetInputValue>(
-            &input, adaptiveChoiceSetInput, comboBoxAsUIElement.Get(), validationBorder.Get()));
+            &input, adaptiveChoiceSetInput, renderContext, comboBoxAsUIElement.Get(), validationBorder.Get()));
         RETURN_IF_FAILED(renderContext->AddInputValue(input.Get(), renderArgs));
 
         return inputLayout.CopyTo(choiceInputSet);
@@ -270,17 +265,13 @@ namespace AdaptiveNamespace
         RETURN_IF_FAILED(stackPanel.As(&choiceSetAsUIElement));
 
         ComPtr<IUIElement> inputLayout;
-        RETURN_IF_FAILED(XamlHelpers::HandleInputLayoutAndValidation(adaptiveChoiceSetInputAsAdaptiveInput.Get(),
-                                                    choiceSetAsUIElement.Get(),
-                                                    false,
-                                                    renderContext,
-                                                    &inputLayout,
-                                                    nullptr));
+        RETURN_IF_FAILED(XamlHelpers::HandleInputLayoutAndValidation(
+            adaptiveChoiceSetInputAsAdaptiveInput.Get(), choiceSetAsUIElement.Get(), false, renderContext, &inputLayout, nullptr));
 
         // Create the InputValue and add it to the context
         ComPtr<ChoiceSetInputValue> input;
-        RETURN_IF_FAILED(MakeAndInitialize<ChoiceSetInputValue>(
-            &input, adaptiveChoiceSetInput, choiceSetAsUIElement.Get(), nullptr);
+        RETURN_IF_FAILED(
+            MakeAndInitialize<ChoiceSetInputValue>(&input, adaptiveChoiceSetInput, renderContext, choiceSetAsUIElement.Get(), nullptr);
         RETURN_IF_FAILED(renderContext->AddInputValue(input.Get(), renderArgs)));
 
         return inputLayout.CopyTo(choiceInputSet);

--- a/source/uwp/Renderer/lib/AdaptiveDateInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveDateInputRenderer.cpp
@@ -130,7 +130,7 @@ namespace AdaptiveNamespace
         // Create the InputValue and add it to the context
         ComPtr<DateInputValue> input;
         RETURN_IF_FAILED(MakeAndInitialize<DateInputValue>(
-            &input, adaptiveDateInput.Get(), datePicker.Get(), validationBorder.Get()));
+            &input, adaptiveDateInput.Get(), renderContext, datePicker.Get(), validationBorder.Get()));
         RETURN_IF_FAILED(renderContext->AddInputValue(input.Get(), renderArgs));
 
         RETURN_IF_FAILED(inputLayout.CopyTo(dateInputControl));

--- a/source/uwp/Renderer/lib/AdaptiveInputsConfig.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveInputsConfig.cpp
@@ -21,7 +21,8 @@ namespace AdaptiveNamespace
     {
         RETURN_IF_FAILED(MakeAndInitialize<AdaptiveErrorMessageConfig>(m_errorMessage.GetAddressOf(), inputsConfig.errorMessage));
         RETURN_IF_FAILED(MakeAndInitialize<AdaptiveLabelConfig>(m_label.GetAddressOf(), inputsConfig.label));
-       
+        m_initialValidation = static_cast<ABI::AdaptiveNamespace::InitialValidation>(inputsConfig.initialValidation);
+
         return S_OK;
     }
 
@@ -44,6 +45,17 @@ namespace AdaptiveNamespace
     HRESULT AdaptiveInputsConfig::put_Label(_In_ ABI::AdaptiveNamespace::IAdaptiveLabelConfig* inputLabels)
     {
         m_label = inputLabels;
+        return S_OK;
+    }
+    HRESULT AdaptiveInputsConfig::get_InitialValidation(ABI::AdaptiveNamespace::InitialValidation* initialValidation)
+    {
+        *initialValidation = m_initialValidation;
+        return S_OK;
+    }
+
+    HRESULT AdaptiveInputsConfig::put_InitialValidation(ABI::AdaptiveNamespace::InitialValidation initialValidation)
+    {
+        m_initialValidation = initialValidation;
         return S_OK;
     }
 }

--- a/source/uwp/Renderer/lib/AdaptiveInputsConfig.h
+++ b/source/uwp/Renderer/lib/AdaptiveInputsConfig.h
@@ -22,9 +22,13 @@ namespace AdaptiveNamespace
         IFACEMETHODIMP get_Label(_Outptr_ ABI::AdaptiveNamespace::IAdaptiveLabelConfig** inputLabels);
         IFACEMETHODIMP put_Label(_In_ ABI::AdaptiveNamespace::IAdaptiveLabelConfig* inputLabels);
 
+        IFACEMETHODIMP get_InitialValidation(_Outptr_ ABI::AdaptiveNamespace::InitialValidation* initialValidation);
+        IFACEMETHODIMP put_InitialValidation(_In_ ABI::AdaptiveNamespace::InitialValidation initialValidation);
+
     private:
         Microsoft::WRL::ComPtr<ABI::AdaptiveNamespace::IAdaptiveLabelConfig> m_label;
         Microsoft::WRL::ComPtr<ABI::AdaptiveNamespace::IAdaptiveErrorMessageConfig> m_errorMessage;
+        ABI::AdaptiveNamespace::InitialValidation m_initialValidation;
     };
     ActivatableClass(AdaptiveInputsConfig);
 }

--- a/source/uwp/Renderer/lib/AdaptiveNumberInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveNumberInputRenderer.cpp
@@ -102,7 +102,7 @@ namespace AdaptiveNamespace
         // Create the InputValue and add it to the context
         ComPtr<NumberInputValue> input;
         RETURN_IF_FAILED(
-            MakeAndInitialize<NumberInputValue>(&input, adaptiveNumberInput.Get(), textBox.Get(), validationBorder.Get()));
+            MakeAndInitialize<NumberInputValue>(&input, adaptiveNumberInput.Get(), renderContext, textBox.Get(), validationBorder.Get()));
         RETURN_IF_FAILED(renderContext->AddInputValue(input.Get(), renderArgs));
 
         RETURN_IF_FAILED(inputLayout.CopyTo(numberInputControl));

--- a/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.cpp
@@ -90,7 +90,7 @@ namespace AdaptiveNamespace
         // Create the InputValue and add it to the context
         ComPtr<TextInputValue> input;
         RETURN_IF_FAILED(MakeAndInitialize<TextInputValue>(
-            &input, adaptiveTextInput, textBox, validationBorder.Get()));
+            &input, adaptiveTextInput, renderContext, textBox, validationBorder.Get()));
         RETURN_IF_FAILED(renderContext->AddInputValue(input.Get(), renderArgs));
 
         RETURN_IF_FAILED(inputLayout.CopyTo(textInputLayout));

--- a/source/uwp/Renderer/lib/AdaptiveTimeInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTimeInputRenderer.cpp
@@ -86,9 +86,9 @@ namespace AdaptiveNamespace
 
         // Create the InputValue and add it to the context
         ComPtr<TimeInputValue> input;
-        RETURN_IF_FAILED(
-            MakeAndInitialize<TimeInputValue>(&input, adaptiveTimeInput.Get(), timePicker.Get(), validationBorder.Get());
-            RETURN_IF_FAILED(renderContext->AddInputValue(input.Get(), renderArgs)));
+        RETURN_IF_FAILED(MakeAndInitialize<TimeInputValue>(
+                             &input, adaptiveTimeInput.Get(), renderContext, timePicker.Get(), validationBorder.Get());
+        RETURN_IF_FAILED(renderContext->AddInputValue(input.Get(), renderArgs)));
 
         RETURN_IF_FAILED(inputLayout.CopyTo(timeInputControl));
 

--- a/source/uwp/Renderer/lib/AdaptiveToggleInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveToggleInputRenderer.cpp
@@ -85,8 +85,7 @@ namespace AdaptiveNamespace
             adapitveToggleInputAsAdaptiveInput.Get(), checkboxAsUIElement.Get(), false, renderContext, &inputLayout, nullptr));
 
         ComPtr<ToggleInputValue> input;
-        RETURN_IF_FAILED(MakeAndInitialize<ToggleInputValue>(
-            &input, adaptiveToggleInput.Get(), checkBox.Get(), nullptr));
+        RETURN_IF_FAILED(MakeAndInitialize<ToggleInputValue>(&input, adaptiveToggleInput.Get(), renderContext, checkBox.Get(), nullptr));
         RETURN_IF_FAILED(renderContext->AddInputValue(input.Get(), renderArgs));
 
         RETURN_IF_FAILED(inputLayout.CopyTo(toggleInputControl));

--- a/source/uwp/Renderer/lib/InputValue.h
+++ b/source/uwp/Renderer/lib/InputValue.h
@@ -12,7 +12,10 @@ namespace AdaptiveNamespace
                                               ABI::AdaptiveNamespace::IAdaptiveInputValue>
     {
     public:
+        InputValue() : m_isFocusLostValidationEnabled(false) {}
+
         HRESULT RuntimeClassInitialize(_In_ ABI::AdaptiveNamespace::IAdaptiveInputElement* adaptiveInputElement,
+                                       _In_ ABI::AdaptiveNamespace::IAdaptiveRenderContext* renderContext,
                                        _In_ ABI::Windows::UI::Xaml::IUIElement* uiInputElement,
                                        _In_ ABI::Windows::UI::Xaml::Controls::IBorder* validationBorder);
 
@@ -29,26 +32,38 @@ namespace AdaptiveNamespace
         virtual HRESULT IsValueValid(_Out_ boolean* isInputValid);
         virtual HRESULT SetValidation(boolean isValid);
 
+        virtual HRESULT EnableFocusLostValidation();
+        virtual HRESULT EnableFocusLostOnInput() { return S_OK; };
+        virtual HRESULT EnableValueChangedValidation() = 0;
+
         Microsoft::WRL::ComPtr<ABI::AdaptiveNamespace::IAdaptiveInputElement> m_adaptiveInputElement;
         Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IUIElement> m_uiInputElement;
         Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::Controls::IBorder> m_validationBorder;
         Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IUIElement> m_validationError;
+        ABI::AdaptiveNamespace::InitialValidation m_initialValidation;
+        bool m_isFocusLostValidationEnabled;
     };
 
     // Base class for input value types that use ITextBox (Input.Text and Input.Number)
     class TextInputBase : public InputValue
     {
     public:
-        TextInputBase() {}
+        TextInputBase() : m_isTextChangedValidationEnabled(false) {}
+
 
         HRESULT RuntimeClassInitialize(_In_ ABI::AdaptiveNamespace::IAdaptiveInputElement* adaptiveInputElement,
+                                       _In_ ABI::AdaptiveNamespace::IAdaptiveRenderContext* renderContext,
                                        _In_ ABI::Windows::UI::Xaml::Controls::ITextBox* uiTextBoxElement,
                                        _In_ ABI::Windows::UI::Xaml::Controls::IBorder* validationBorder);
 
         IFACEMETHODIMP get_CurrentValue(_Outptr_ HSTRING* serializedUserInput) override;
 
     protected:
+        virtual HRESULT EnableFocusLostOnInput() override;
+        virtual HRESULT EnableValueChangedValidation() override;
+
         Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::Controls::ITextBox> m_textBoxElement;
+        bool m_isTextChangedValidationEnabled;
     };
 
     // Input value for Input.Text
@@ -56,6 +71,7 @@ namespace AdaptiveNamespace
     {
     public:
         HRESULT RuntimeClassInitialize(_In_ ABI::AdaptiveNamespace::IAdaptiveTextInput* adaptiveTextInput,
+                                       _In_ ABI::AdaptiveNamespace::IAdaptiveRenderContext* renderContext,
                                        _In_ ABI::Windows::UI::Xaml::Controls::ITextBox* uiTextBoxElement,
                                        _In_ ABI::Windows::UI::Xaml::Controls::IBorder* validationBorder);
 
@@ -70,6 +86,7 @@ namespace AdaptiveNamespace
     {
     public:
         HRESULT RuntimeClassInitialize(_In_ ABI::AdaptiveNamespace::IAdaptiveNumberInput* adaptiveNumberInput,
+                                       _In_ ABI::AdaptiveNamespace::IAdaptiveRenderContext* renderContext,
                                        _In_ ABI::Windows::UI::Xaml::Controls::ITextBox* uiTextBoxElement,
                                        _In_ ABI::Windows::UI::Xaml::Controls::IBorder* validationBorder);
 
@@ -83,26 +100,32 @@ namespace AdaptiveNamespace
     class DateInputValue : public InputValue
     {
     public:
-        DateInputValue() {}
+        DateInputValue() : m_isDateChangedValidationEnabled(false) {}
 
         HRESULT RuntimeClassInitialize(_In_ ABI::AdaptiveNamespace::IAdaptiveDateInput* adaptiveDateInput,
+                                       _In_ ABI::AdaptiveNamespace::IAdaptiveRenderContext* renderContext,
                                        _In_ ABI::Windows::UI::Xaml::Controls::ICalendarDatePicker* uiDatePickerElement,
                                        _In_ ABI::Windows::UI::Xaml::Controls::IBorder* validationBorder);
 
         IFACEMETHODIMP get_CurrentValue(_Outptr_ HSTRING* serializedUserInput) override;
 
     private:
+        virtual HRESULT EnableFocusLostOnInput() override;
+        virtual HRESULT EnableValueChangedValidation() override;
+
         Microsoft::WRL::ComPtr<ABI::AdaptiveNamespace::IAdaptiveDateInput> m_adaptiveDateInput;
         Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::Controls::ICalendarDatePicker> m_datePickerElement;
+        bool m_isDateChangedValidationEnabled;
     };
 
     // Input value for Input.Time
     class TimeInputValue : public InputValue
     {
     public:
-        TimeInputValue() {}
+        TimeInputValue() : m_isTimeChangedValidationEnabled(false) {}
 
         HRESULT RuntimeClassInitialize(_In_ ABI::AdaptiveNamespace::IAdaptiveTimeInput* adaptiveTimeInput,
+                                       _In_ ABI::AdaptiveNamespace::IAdaptiveRenderContext* renderContext,
                                        _In_ ABI::Windows::UI::Xaml::Controls::ITimePicker* uiTimePickerElement,
                                        _In_ ABI::Windows::UI::Xaml::Controls::IBorder* validationBorder);
 
@@ -110,18 +133,23 @@ namespace AdaptiveNamespace
 
     private:
         virtual HRESULT IsValueValid(_Out_ boolean* isInputValid) override;
+        virtual HRESULT EnableFocusLostOnInput() override;
+        virtual HRESULT EnableValueChangedValidation() override;
+        virtual HRESULT EnableFocusLostValidation() override;
 
         Microsoft::WRL::ComPtr<ABI::AdaptiveNamespace::IAdaptiveTimeInput> m_adaptiveTimeInput;
         Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::Controls::ITimePicker> m_timePickerElement;
+        bool m_isTimeChangedValidationEnabled;
     };
 
     // Input value for Input.Toggle
     class ToggleInputValue : public InputValue
     {
     public:
-        ToggleInputValue() {}
+        ToggleInputValue() : m_isToggleChangedValidationEnabled(false) {}
 
         HRESULT RuntimeClassInitialize(_In_ ABI::AdaptiveNamespace::IAdaptiveToggleInput* adaptiveTimeInput,
+                                       _In_ ABI::AdaptiveNamespace::IAdaptiveRenderContext* renderContext,
                                        _In_ ABI::Windows::UI::Xaml::Controls::ICheckBox* uiCheckBoxElement,
                                        _In_ ABI::Windows::UI::Xaml::Controls::IBorder* validationBorder);
 
@@ -129,18 +157,22 @@ namespace AdaptiveNamespace
 
     private:
         virtual HRESULT IsValueValid(_Out_ boolean* isInputValid) override;
+        virtual HRESULT EnableFocusLostOnInput() override;
+        virtual HRESULT EnableValueChangedValidation() override;
 
         Microsoft::WRL::ComPtr<ABI::AdaptiveNamespace::IAdaptiveToggleInput> m_adaptiveToggleInput;
         Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::Controls::ICheckBox> m_checkBoxElement;
+        bool m_isToggleChangedValidationEnabled;
     };
 
     // Input value for Input.ChoiceSet
     class ChoiceSetInputValue : public InputValue
     {
     public:
-        ChoiceSetInputValue() {}
+        ChoiceSetInputValue() : m_isChoiceSetChangedValidationEnabled(false) {}
 
         HRESULT RuntimeClassInitialize(_In_ ABI::AdaptiveNamespace::IAdaptiveChoiceSetInput* adaptiveChoiceSetInput,
+                                       _In_ ABI::AdaptiveNamespace::IAdaptiveRenderContext* renderContext,
                                        _In_ ABI::Windows::UI::Xaml::IUIElement* uiChoiceSetElement,
                                        _In_ ABI::Windows::UI::Xaml::Controls::IBorder* validationBorder);
 
@@ -149,8 +181,16 @@ namespace AdaptiveNamespace
     private:
         IFACEMETHODIMP SetFocus() override;
 
+        virtual HRESULT EnableFocusLostValidation() override;
+        virtual HRESULT EnableFocusLostOnInput() override;
+        virtual HRESULT EnableValueChangedValidation() override;
+
+        HRESULT IsCompactChoiceSet(bool* isExpandedChoiceSet);
+        HRESULT SetExpandedClickHandlers(ABI::Windows::UI::Xaml::IRoutedEventHandler* clickHandler);
+
         std::string GetChoiceValue(_In_ ABI::AdaptiveNamespace::IAdaptiveChoiceSetInput* choiceInput, INT32 selectedIndex) const;
 
         Microsoft::WRL::ComPtr<ABI::AdaptiveNamespace::IAdaptiveChoiceSetInput> m_adaptiveChoiceSetInput;
+        bool m_isChoiceSetChangedValidationEnabled;
     };
 }


### PR DESCRIPTION
## Related Issue
UWP implementation of #4602 

## Description
Added support for focusLost and focusLostWithInput to UWP as spec'd in #4603. Change includes:
 - Add `InitialiValidation` property to host config for shared model and UWP
 - Wire renderContext to the InputValue classes to allow access to HostConfig
 - Add support for focusLost and focusLostWithInput validation to the InputValue classes.
 - Add support for keystroke validation once an input has failed initial validation.

## How Verified
Validated expected behavior in visualizer using existing v1.3 input cards.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4647)