### PR TITLE
[pic2card] Stabilizing columns grouping

### DIFF
--- a/source/pic2card/mystique/config.py
+++ b/source/pic2card/mystique/config.py
@@ -86,3 +86,9 @@ LAST_COLUMN_THRESHOLD = {
         (1.0, 3.68): "stretch",
         (1.0, 22.40): "auto"
 }
+# COLUMNSET GROUPING THRESHOLDS
+COLUMNSET_GROUPING = {
+        "ymin_difference": 10.0,
+        "ymax-ymin_difference": 3,
+        "xmax-xmin_difference": 100
+}

--- a/source/pic2card/mystique/debug.py
+++ b/source/pic2card/mystique/debug.py
@@ -161,7 +161,7 @@ class Debug:
         # {"image": self.plot_debug_images(image_np, image_copy)}
         debug_output = {"image": image_model_base64_string}
         # generate card from existing workflow
-        predict_json = predict_card.main(
-            image=pil_image, card_format=card_format)
+        predict_json = predict_card.generate_card(output_dict, pil_image,
+                                                  image_np, card_format)
         debug_output.update(predict_json)
         return debug_output


### PR DESCRIPTION
- **Reduced the number of thresholds** used for column-set and columns grouping.
- **Used horizontal and vertical inclusive logic** to group the objects into a column-set or column.
- **Changes in noise removal** : along with the IOU based removal , the smaller objects [ in overlapping scenarios] which covers more than 50% of the intersection area will also be removed.
- Changed the columns and column-set alignment logic of **doing max of count of the alignments** to **choose from a** **predefined order - Left, Center, Right** in cases where the **alignments of the objects are unique**.
    - for example:  if a column as 2 elements with ["Right", "Left"] as alignments, on doing max of count will pick different alignment each time, instead changed the logic  to choose in the predefined order in case of unique alignments.
   - So if the  alignments of the objects are ["Right", "Center"] in a column , then the column's alignment will be Center.
- Removed the redundant call made to get_objects method in debug API to one.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4656)