### PR TITLE
resets selected state of button

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRShowCardTarget.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRShowCardTarget.mm
@@ -87,10 +87,12 @@
 
 - (IBAction)toggleVisibilityOfShowCard
 {
-    _button.selected = !_button.selected;
+
+    BOOL isSelected = _button.selected;
     BOOL hidden = _adcView.hidden;
     [_superview hideAllShowCards];
     _adcView.hidden = (hidden == YES) ? NO : YES;
+    _button.selected = !isSelected;
 
     if ([_rootView.acrActionDelegate respondsToSelector:@selector(didChangeVisibility:isVisible:)]) {
         [_rootView.acrActionDelegate didChangeVisibility:_button isVisible:(!_adcView.hidden)];
@@ -102,7 +104,6 @@
         CGRect oldFrame = showCardFrame;
         oldFrame.size.height = 0;
         showCardFrame.size.height += [_config getHostConfig] -> GetActions().showCard.inlineTopMargin;
-        ;
         [_rootView.acrActionDelegate didChangeViewLayout:oldFrame newFrame:showCardFrame];
     }
     [_rootView.acrActionDelegate didFetchUserResponses:[_rootView card] action:_actionElement];
@@ -116,6 +117,7 @@
 - (void)hideShowCard
 {
     _adcView.hidden = YES;
+    _button.selected = NO;
 
     if ([_rootView.acrActionDelegate respondsToSelector:@selector(didChangeVisibility:isVisible:)]) {
         [_rootView.acrActionDelegate didChangeVisibility:_button isVisible:(!_adcView.hidden)];


### PR DESCRIPTION
## Related Issue

Fixed #4548 for iOS

## Description
Updates selected state for Buttons. Followed the logic of showing/hiding cards when the show card button is pressed.

## How Verified
How you verified the fix, including one or all of the following: 
1. Existing relevant unit/regression tests that you ran
2. ShowCardStyle.json was ran and verified the functionality.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4674)