### PR TITLE
Templating and renderer fixes

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/designer-peers.ts
+++ b/source/nodejs/adaptivecards-designer/src/designer-peers.ts
@@ -1860,7 +1860,7 @@ export class ColumnSetPeer extends TypedCardElementPeer<Adaptive.ColumnSet> {
 }
 
 export class ContainerPeer extends TypedCardElementPeer<Adaptive.Container> {
-    static readonly selectActionProperty = new ActionPropertyEditor(Adaptive.Versions.v1_0, "selectAction", "Action type", [ Adaptive.ShowCardAction.JsonTypeName ], true);
+    static readonly selectActionProperty = new ActionPropertyEditor(Adaptive.Versions.v1_1, "selectAction", "Action type", [ Adaptive.ShowCardAction.JsonTypeName ], true);
     static readonly minHeightProperty = new NumberPropertyEditor(Adaptive.Versions.v1_2, "minPixelHeight", "Minimum height in pixels");
     static readonly verticalContentAlignmentProperty = new EnumPropertyEditor(Adaptive.Versions.v1_1, "verticalContentAlignment", "Vertical content alignment", Adaptive.VerticalAlignment);
     static readonly styleProperty = new ContainerStylePropertyEditor(Adaptive.Versions.v1_0, "style", "Style");

--- a/source/nodejs/adaptivecards-templating/src/template-engine.ts
+++ b/source/nodejs/adaptivecards-templating/src/template-engine.ts
@@ -3,7 +3,7 @@
 import * as AEL from "adaptive-expressions";
 
 class EvaluationContext {
-    private static readonly _reservedFields = ["$data", "$root", "$index"];
+    private static readonly _reservedFields = ["$data", "$when", "$root", "$index"];
 
     private _stateStack: Array<{ $data: any, $index: any }> = [];
     private _$data: any;

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -656,7 +656,7 @@ export abstract class BaseTextBlock extends CardElement {
         Versions.v1_2,
         "fontType",
         Enums.FontType);
-    static readonly selectActionProperty = new ActionProperty(Versions.v1_0, "selectAction", [ "Action.ShowCard" ]);
+    static readonly selectActionProperty = new ActionProperty(Versions.v1_1, "selectAction", [ "Action.ShowCard" ]);
 
     protected populateSchema(schema: SerializableObjectSchema) {
         super.populateSchema(schema);
@@ -1589,7 +1589,7 @@ export class Image extends CardElement {
         Enums.Size.Auto);
     static readonly pixelWidthProperty = new ImageDimensionProperty(Versions.v1_1, "width", "pixelWidth");
     static readonly pixelHeightProperty = new ImageDimensionProperty(Versions.v1_1, "height", "pixelHeight", CardElement.heightProperty);
-    static readonly selectActionProperty = new ActionProperty(Versions.v1_0, "selectAction", [ "Action.ShowCard" ]);
+    static readonly selectActionProperty = new ActionProperty(Versions.v1_1, "selectAction", [ "Action.ShowCard" ]);
 
     protected populateSchema(schema: SerializableObjectSchema) {
         super.populateSchema(schema);
@@ -1810,7 +1810,7 @@ export class Image extends CardElement {
 export abstract class CardElementContainer extends CardElement {
     //#region Schema
 
-    static readonly selectActionProperty = new ActionProperty(Versions.v1_0, "selectAction", [ "Action.ShowCard" ]);
+    static readonly selectActionProperty = new ActionProperty(Versions.v1_1, "selectAction", [ "Action.ShowCard" ]);
 
     protected populateSchema(schema: SerializableObjectSchema) {
         super.populateSchema(schema);
@@ -6535,6 +6535,10 @@ export class AdaptiveCard extends ContainerWithActions {
         }
 
         return renderedCard;
+    }
+
+    toJSON(context?: SerializationContext): PropertyBag | undefined {
+        return super.toJSON(context ? context : new SerializationContext(this.version));
     }
 
     updateLayout(processChildren: boolean = true) {

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -909,6 +909,7 @@ export class TextBlock extends BaseTextBlock {
 
                     if (this.selectAction.title) {
                         element.setAttribute("aria-label", this.selectAction.title);
+                        element.title = this.selectAction.title;
                     }
 
                     element.classList.add(hostConfig.makeCssClassName("ac-selectable"));
@@ -1170,6 +1171,10 @@ export class TextRun extends BaseTextBlock {
                     if (this.selectAction) {
                         this.selectAction.execute();
                     }
+                }
+
+                if (this.selectAction.title) {
+                    anchor.title = this.selectAction.title;
                 }
 
                 anchor.innerText = formattedText;
@@ -1759,6 +1764,7 @@ export class Image extends CardElement {
 
                 if (this.selectAction.title) {
                     imageElement.setAttribute("aria-label", <string>this.selectAction.title);
+                    imageElement.title = this.selectAction.title;
                 }
 
                 imageElement.classList.add(hostConfig.makeCssClassName("ac-selectable"));
@@ -1909,6 +1915,7 @@ export abstract class CardElementContainer extends CardElement {
 
                 if (this._selectAction.title) {
                     element.setAttribute("aria-label", this._selectAction.title);
+                    element.title = this._selectAction.title;
                 }
 
                 element.onclick = (e) => {


### PR DESCRIPTION
## Related Issue
- Fixes https://github.com/microsoft/AdaptiveCards/issues/4620
- Fixes https://github.com/microsoft/AdaptiveCards/issues/4595
- Fixes https://github.com/microsoft/AdaptiveCards/issues/4692
- Fixes https://github.com/microsoft/AdaptiveCards/issues/4699

## Description
- `toJSON` now serializes to the version specified at the card level unless an explicit SerializationContext is specified
- The `$when` property isn't emitted anymore in an expanded template
- The `selectAction` property is now tied to schema version  1.1 and later (instead of 1.0)
- `selectAction.title` is now used as a tooltip

## How Verified
Verified manually in adaptivecards-designer-app

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4693)