### PR TITLE
Add developers info

### DIFF
--- a/source/android/adaptivecards/build.gradle
+++ b/source/android/adaptivecards/build.gradle
@@ -59,6 +59,13 @@ def projectInfo = {
         }
     }
 
+    developers {
+        developer {
+            id = "microsoft"
+            name = "adaptivecards"
+        }
+    }
+
     organization {
         name = 'Microsoft'
         url = 'https://microsoft.com/'


### PR DESCRIPTION
## Issue
Generated pom didn't have developers section, added that part

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4718)