### PR TITLE
[Site] Emit header tag in docs for "Inherited Properties"

### DIFF
--- a/source/nodejs/ac-typed-schema/src/markdown/generate-markdown.ts
+++ b/source/nodejs/ac-typed-schema/src/markdown/generate-markdown.ts
@@ -104,7 +104,7 @@ export function createPropertiesSummary(classDefinition: SchemaClass, knownTypes
 		}
 
 		if (inheritedFormattedProperties.length > 0) {
-			md += "\n**Inherited properties**\n\n";
+			md += "\n### Inherited properties\n\n";
 			md += createTable(inheritedFormattedProperties);
 			md += "\n";
 		}


### PR DESCRIPTION
## Related Issue
Fixes VSO 24043594

## Description
Instead of emitting "Inherited Properties" as a bold statement, we should be emitting it as a header, for accessibility purposes.

Before:
![image](https://user-images.githubusercontent.com/16614499/92033657-dfefea00-ed20-11ea-8aea-829bc5370548.png)

After:
![image](https://user-images.githubusercontent.com/16614499/92033682-eb431580-ed20-11ea-96c9-cf29882893f6.png)

## How Verified
* local build, devtools

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4726)