### PR TITLE
[JS] Emit "invisible" borders for containers

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -5010,7 +5010,9 @@ export abstract class StylableCardElementContainer extends CardElementContainer 
             let styleDefinition = this.hostConfig.containerStyles.getStyleByName(this.style, this.hostConfig.containerStyles.getStyleByName(this.defaultStyle));
 
             if (styleDefinition.backgroundColor) {
-                this.renderedElement.style.backgroundColor = <string>Utils.stringToCssColor(styleDefinition.backgroundColor);
+                const bgColor = <string>Utils.stringToCssColor(styleDefinition.backgroundColor);
+                this.renderedElement.style.backgroundColor = bgColor;
+                this.renderedElement.style.border = "1px solid " + bgColor;
             }
         }
     }


### PR DESCRIPTION
## Related Issue
Fixes VSO 24095690

## Description
When a user puts their system in high contrast mode, their user agent will override CSS properties in order to display content in the same high contrast mode. There's no way for us (the website) to know if this is happening. The user will of course lose some of our styling cues (e.g. `TextBlock`'s `color` property). This is expected, but we are losing one critical bit of useful visual state -- container borders.

Here's what our `Container` sample card looks like:

|Normal|High Contrast Black|
|--|--|
|![image](https://user-images.githubusercontent.com/16614499/92037015-fb112880-ed25-11ea-97a4-a48a67277db3.png)|![image](https://user-images.githubusercontent.com/16614499/92036919-d0bf6b00-ed25-11ea-9104-0d630dc16414.png)|

The fix on our end is to emit an "invisible" border on containers (specifically, we emit a 1px solid border that is the same color as the container's `backgroundColor`). Here's how it looks with our fix:

|Normal|High Contrast Black|
|--|--|
|![image](https://user-images.githubusercontent.com/16614499/92037304-6c50db80-ed26-11ea-861e-22c7d808a104.png)|![image](https://user-images.githubusercontent.com/16614499/92037221-50e5d080-ed26-11ea-933f-b574d168fae3.png)|


## How Verified
* local build


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4727)