### PR TITLE
[Schema] Add version to new regex property

### DIFF
--- a/schemas/1.3.0/adaptive-card.json
+++ b/schemas/1.3.0/adaptive-card.json
@@ -1039,7 +1039,8 @@
         },
         "regex": {
           "type": "string",
-          "description": "Regular expression indicating the required format of this text input."
+          "description": "Regular expression indicating the required format of this text input.",
+          "version": "1.3"
         },
         "style": {
           "$ref": "#/definitions/TextInputStyle",

--- a/schemas/src/elements/inputs/Input.Text.json
+++ b/schemas/src/elements/inputs/Input.Text.json
@@ -18,7 +18,8 @@
 		},
 		"regex": {
 			"type": "string",
-			"description": "Regular expression indicating the required format of this text input."
+			"description": "Regular expression indicating the required format of this text input.",
+			"version": "1.3"
 		},
 		"style": {
 			"type": "TextInputStyle",
@@ -30,7 +31,7 @@
 			"version": "1.2"
 		},
 		"value": {
-			"type": "string", 
+			"type": "string",
 			"description": "The initial value for this field."
 		}
 	}

--- a/specs/elements/Input.Text.md
+++ b/specs/elements/Input.Text.md
@@ -9,7 +9,7 @@
 | **isMultiline** | `boolean` | No | If `true`, allow multiple lines of input. | 1.0 |
 | **maxLength** | `number` | No | Hint of maximum length characters to collect (may be ignored by some clients). | 1.0 |
 | **placeholder** | `string` | No | Description of the input desired. Displayed when no text has been input. | 1.0 |
-| **regex** | `string` | No | Regular expression indicating the required format of this text input. | 1.0 |
+| **regex** | `string` | No | Regular expression indicating the required format of this text input. | 1.3 |
 | **style** | `TextInputStyle` | No | Style hint for text input. | 1.0 |
 | **inlineAction** | `ISelectAction` | No | The inline action for the input. Typically displayed to the right of the input. It is strongly recommended to provide an icon on the action (which will be displayed instead of the title of the action). | 1.2 |
 | **value** | `string` | No | The initial value for this field. | 1.0 |


### PR DESCRIPTION
## Related Issue
Fixes #4728

## Description
Simple missing of the `version` property when `regex` was introduced on `Input.Text`.

## How Verified
* local build


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4729)