### PR TITLE
[JS] Paint ToggleVisibility actions with `aria-controls` attribute

### DIFF
--- a/source/nodejs/adaptivecards/README.md
+++ b/source/nodejs/adaptivecards/README.md
@@ -59,6 +59,7 @@ Please be aware of the following **breaking changes** in particular versions.
 || The `CardElement.validate()` and `Action.validate()` methods have been **REMOVED**, replaced with `CardObject.validateProperties()` and `CardObject.internalValidateProperties(context: ValidationContext)`. Custom elements and actions now must override `internalValidateProperties` and add validation failures as appropriate to the `context` object passed as a parameter using its `addFailure` method. Be sure to always call `super.internalValidateProperties(context)` in your override.|
 | **1.1** | Due to a security concern, the `processMarkdown` event handler has been **REMOVED**. Setting it will throw an exception that will halt your code. Please change your code to set the `onProcessMarkdown(text, result)` event handler instead (see example below.) |
 | **1.0** | The standalone `renderCard()` helper function was removed as it was redundant with the class methods. Please use `adaptiveCard.render()` as described below. |
+| **2.4.0** | When a card element is rendered, its `id` property is used as the `id` of the resulting HTML element. |
 
 ## Install
 

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -95,6 +95,8 @@ export abstract class CardElement extends CardObject {
                 raiseElementVisibilityChangedEvent(this);
             }
         }
+
+        this._renderedElement?.setAttribute("aria-expanded", value.toString());
     }
 
     //#endregion
@@ -4098,8 +4100,27 @@ export class ToggleVisibilityAction extends Action {
     // change introduced in TS 3.1 wrt d.ts generation. DO NOT CHANGE
     static readonly JsonTypeName: "Action.ToggleVisibility" = "Action.ToggleVisibility";
 
+    private updateAriaControlsAttribute() {
+        // apply aria labels to make it clear which elements this action will toggle
+        if (this.targetElements) {
+            const elementIds = Object.keys(this.targetElements);
+
+            if (elementIds.length > 0) {
+                this._renderedElement?.setAttribute("aria-controls", elementIds.join(" "));
+            }
+            else {
+                this._renderedElement?.removeAttribute("aria-controls");
+            }
+        }
+    }
+
     getJsonTypeName(): string {
         return ToggleVisibilityAction.JsonTypeName;
+    }
+
+    render(baseCssClass: string = "ac-pushButton") {
+        super.render(baseCssClass);
+        this.updateAriaControlsAttribute();
     }
 
     execute() {
@@ -4121,10 +4142,12 @@ export class ToggleVisibilityAction extends Action {
 
     addTargetElement(elementId: string, isVisible: boolean | undefined = undefined) {
         this.targetElements[elementId] = isVisible;
+        this.updateAriaControlsAttribute();
     }
 
     removeTargetElement(elementId: string) {
         delete this.targetElements[elementId];
+        this.updateAriaControlsAttribute();
     }
 }
 

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -96,7 +96,9 @@ export abstract class CardElement extends CardObject {
             }
         }
 
-        this._renderedElement?.setAttribute("aria-expanded", value.toString());
+        if (this._renderedElement) {
+            this._renderedElement.setAttribute("aria-expanded", value.toString());
+        }
     }
 
     //#endregion
@@ -424,6 +426,10 @@ export abstract class CardElement extends CardObject {
         this._separatorElement = this.internalRenderSeparator();
 
         if (this._renderedElement) {
+            if (this.id) {
+                this._renderedElement.id = this.id;
+            }
+
             if (this.customCssSelector) {
                 this._renderedElement.classList.add(this.customCssSelector);
             }
@@ -4105,11 +4111,13 @@ export class ToggleVisibilityAction extends Action {
         if (this.targetElements) {
             const elementIds = Object.keys(this.targetElements);
 
-            if (elementIds.length > 0) {
-                this._renderedElement?.setAttribute("aria-controls", elementIds.join(" "));
-            }
-            else {
-                this._renderedElement?.removeAttribute("aria-controls");
+            if (this._renderedElement) {
+                if (elementIds.length > 0) {
+                    this._renderedElement.setAttribute("aria-controls", elementIds.join(" "));
+                }
+                else {
+                    this._renderedElement.removeAttribute("aria-controls");
+                }
             }
         }
     }


### PR DESCRIPTION
## Related Issue
Fixes VSO 23940376

## Description
The `aria-controls` attribute lets screenreaders know when one element controls the visibility of another element. This change adds `aria-controls` to `ToggleVisibility` actions and reflects the `aria-expanded` property on the elements that are toggled.

## How Verified
* local build, devtools, narrator

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4735)