### PR TITLE
[Samples] Update FlightDetails sample to have more logical reading order

### DIFF
--- a/samples/Templates/Scenarios/FlightDetails.template.json
+++ b/samples/Templates/Scenarios/FlightDetails.template.json
@@ -128,9 +128,25 @@
                                             "type": "Column",
                                             "items": [
                                                 {
-                                                    "type": "TextBlock",
-                                                    "size": "Medium",
-                                                    "text": "{{TIME(${string(reservationFor.departureTime)})}}"
+                                                    "type": "RichTextBlock",
+													"inlines": [
+														{
+															"type": "TextRun",
+															"size": "medium",
+															"text": "{{TIME(${string(reservationFor.departureTime)})}}\r"
+														},
+														{
+															"type": "TextRun",
+															"text": "{{DATE(${string(reservationFor.departureTime)}, SHORT)}}\r",
+															"isSubtle": true,
+															"wrap": true
+														},
+														{
+															"type": "TextRun",
+														    "text": "${reservationFor.departureAirport.city}",
+															"isSubtle": true
+														}
+													]
                                                 }
                                             ],
                                             "width": 1
@@ -139,77 +155,32 @@
                                             "type": "Column",
                                             "items": [
                                                 {
-                                                    "type": "TextBlock",
-                                                    "horizontalAlignment": "Right",
-                                                    "size": "Medium",
-                                                    "text": "{{TIME(${string(reservationFor.arrivalTime)})}}"
+                                                    "type": "RichTextBlock",
+                                                    "horizontalAlignment": "right",
+													"inlines": [
+														{
+															"type": "TextRun",
+															"size": "medium",
+															"text": "{{TIME(${string(reservationFor.arrivalTime)})}}\r"
+														},
+														{
+															"type": "TextRun",
+															"text": "{{DATE(${string(reservationFor.arrivalTime)}, SHORT)}}\r",
+															"isSubtle": true,
+															"wrap": true
+														},
+														{
+															"type": "TextRun",
+														    "text": "${reservationFor.arrivalAirport.city}",
+															"isSubtle": true
+														}
+													]
                                                 }
                                             ],
                                             "width": 1
                                         }
-                                    ]
-                                },
-                                {
-                                    "type": "ColumnSet",
-                                    "spacing": "None",
-                                    "columns": [
-                                        {
-                                            "type": "Column",
-                                            "items": [
-                                                {
-                                                    "type": "TextBlock",
-                                                    "text": "{{DATE(${string(reservationFor.departureTime)}, SHORT)}}",
-                                                    "isSubtle": true,
-                                                    "wrap": true
-                                                }
-                                            ],
-                                            "width": 1
-                                        },
-                                        {
-                                            "type": "Column",
-                                            "items": [
-                                                {
-                                                    "type": "TextBlock",
-                                                    "horizontalAlignment": "Right",
-                                                    "text": "{{DATE(${string(reservationFor.departureTime)}, SHORT)}}",
-                                                    "isSubtle": true,
-                                                    "wrap": true
-                                                }
-                                            ],
-                                            "width": 1
-                                        }
-                                    ]
-                                },
-                                {
-                                    "type": "ColumnSet",
-                                    "spacing": "None",
-                                    "columns": [
-                                        {
-                                            "type": "Column",
-                                            "items": [
-                                                {
-                                                    "type": "TextBlock",
-                                                    "text": "${reservationFor.departureAirport.city}",
-                                                    "isSubtle": true
-                                                }
-                                            ],
-                                            "width": 1
-                                        },
-                                        {
-                                            "type": "Column",
-                                            "items": [
-                                                {
-                                                    "type": "TextBlock",
-                                                    "horizontalAlignment": "Right",
-                                                    "text": "${reservationFor.arrivalAirport.city}",
-                                                    "isSubtle": true
-                                                }
-                                            ],
-                                            "width": 1
-                                        }
-                                    ],
-                                    "height": "stretch"
-                                },
+									]
+								}
                                 {
                                     "type": "ActionSet",
                                     "separator": true,

--- a/samples/v1.2/Scenarios/FlightDetails.json
+++ b/samples/v1.2/Scenarios/FlightDetails.json
@@ -27,7 +27,7 @@
 							"items": [
 								{
 									"type": "TextBlock",
-									"size": "ExtraLarge",
+									"size": "extraLarge",
 									"weight": "lighter",
 									"color": "accent",
 									"text": "Flight to JFK",
@@ -74,7 +74,7 @@
 											"items": [
 												{
 													"type": "TextBlock",
-													"size": "ExtraLarge",
+													"size": "extraLarge",
 													"weight": "lighter",
 													"text": "SFO"
 												}
@@ -96,7 +96,7 @@
 										},
 										{
 											"type": "Column",
-											"spacing": "Small",
+											"spacing": "small",
 											"verticalContentAlignment": "center",
 											"items": [
 												{
@@ -114,7 +114,7 @@
 												{
 													"type": "TextBlock",
 													"horizontalAlignment": "right",
-													"size": "ExtraLarge",
+													"size": "extraLarge",
 													"weight": "lighter",
 													"text": "JFK"
 												}
@@ -135,11 +135,11 @@
 														{
 															"type": "TextRun",
 															"size": "medium",
-															"text": "8:15 PM\r"
+															"text": "8:15 PM\n"
 														},
 														{
 															"type": "TextRun",
-															"text": "Sat, Mar 4, 2017\r",
+															"text": "Sat, Mar 4, 2017\n",
 															"isSubtle": true,
 															"wrap": true
 														},
@@ -163,11 +163,11 @@
 														{
 															"type": "TextRun",
 															"size": "medium",
-															"text": "3:30 AM\r"
+															"text": "3:30 AM\n"
 														},
 														{
 															"type": "TextRun",
-															"text": "Sat, Mar 4, 2017\r",
+															"text": "Sat, Mar 4, 2017\n",
 															"isSubtle": true,
 															"wrap": true
 														},

--- a/samples/v1.2/Scenarios/FlightDetails.json
+++ b/samples/v1.2/Scenarios/FlightDetails.json
@@ -13,7 +13,7 @@
 							"items": [
 								{
 									"type": "Image",
-									"horizontalAlignment": "Center",
+									"horizontalAlignment": "center",
 									"url": "https://messagecardplayground.azurewebsites.net/assets/TxP_Flight.png",
 									"altText": "Departing airplane"
 								}
@@ -28,26 +28,26 @@
 								{
 									"type": "TextBlock",
 									"size": "ExtraLarge",
-									"weight": "Lighter",
-									"color": "Accent",
+									"weight": "lighter",
+									"color": "accent",
 									"text": "Flight to JFK",
 									"wrap": true
 								},
 								{
 									"type": "TextBlock",
-									"spacing": "Small",
+									"spacing": "small",
 									"text": "Continental Air Lines flight UA110",
 									"wrap": true
 								},
 								{
 									"type": "TextBlock",
-									"spacing": "None",
+									"spacing": "none",
 									"text": "Confirmation code: RXJ34P",
 									"wrap": true
 								},
 								{
 									"type": "TextBlock",
-									"spacing": "None",
+									"spacing": "none",
 									"text": "4 hours 15 minutes",
 									"wrap": true
 								}
@@ -75,7 +75,7 @@
 												{
 													"type": "TextBlock",
 													"size": "ExtraLarge",
-													"weight": "Lighter",
+													"weight": "lighter",
 													"text": "SFO"
 												}
 											],
@@ -83,7 +83,7 @@
 										},
 										{
 											"type": "Column",
-											"verticalContentAlignment": "Center",
+											"verticalContentAlignment": "center",
 											"items": [
 												{
 													"type": "Image",
@@ -97,7 +97,7 @@
 										{
 											"type": "Column",
 											"spacing": "Small",
-											"verticalContentAlignment": "Center",
+											"verticalContentAlignment": "center",
 											"items": [
 												{
 													"type": "Image",
@@ -113,9 +113,9 @@
 											"items": [
 												{
 													"type": "TextBlock",
-													"horizontalAlignment": "Right",
+													"horizontalAlignment": "right",
 													"size": "ExtraLarge",
-													"weight": "Lighter",
+													"weight": "lighter",
 													"text": "JFK"
 												}
 											],
@@ -130,9 +130,25 @@
 											"type": "Column",
 											"items": [
 												{
-													"type": "TextBlock",
-													"size": "Medium",
-													"text": "8:15 PM"
+													"type": "RichTextBlock",
+													"inlines": [
+														{
+															"type": "TextRun",
+															"size": "medium",
+															"text": "8:15 PM\r"
+														},
+														{
+															"type": "TextRun",
+															"text": "Sat, Mar 4, 2017\r",
+															"isSubtle": true,
+															"wrap": true
+														},
+														{
+															"type": "TextRun",
+															"text": "San Francisco",
+															"isSubtle": true
+														}
+													]
 												}
 											],
 											"width": 1
@@ -141,76 +157,31 @@
 											"type": "Column",
 											"items": [
 												{
-													"type": "TextBlock",
-													"horizontalAlignment": "Right",
-													"size": "Medium",
-													"text": "3:30 AM"
+													"type": "RichTextBlock",
+													"horizontalAlignment": "right",
+													"inlines": [
+														{
+															"type": "TextRun",
+															"size": "medium",
+															"text": "3:30 AM\r"
+														},
+														{
+															"type": "TextRun",
+															"text": "Sat, Mar 4, 2017\r",
+															"isSubtle": true,
+															"wrap": true
+														},
+														{
+															"type": "TextRun",
+															"text": "New York",
+															"isSubtle": true
+														}
+													]
 												}
 											],
 											"width": 1
 										}
 									]
-								},
-								{
-									"type": "ColumnSet",
-									"spacing": "None",
-									"columns": [
-										{
-											"type": "Column",
-											"items": [
-												{
-													"type": "TextBlock",
-													"text": "Sat, Mar 4, 2017",
-													"isSubtle": true,
-													"wrap": true
-												}
-											],
-											"width": 1
-										},
-										{
-											"type": "Column",
-											"items": [
-												{
-													"type": "TextBlock",
-													"horizontalAlignment": "Right",
-													"text": "Sat, Mar 4, 2017",
-													"isSubtle": true,
-													"wrap": true
-												}
-											],
-											"width": 1
-										}
-									]
-								},
-								{
-									"type": "ColumnSet",
-									"spacing": "None",
-									"columns": [
-										{
-											"type": "Column",
-											"items": [
-												{
-													"type": "TextBlock",
-													"text": "San Francisco",
-													"isSubtle": true
-												}
-											],
-											"width": 1
-										},
-										{
-											"type": "Column",
-											"items": [
-												{
-													"type": "TextBlock",
-													"horizontalAlignment": "Right",
-													"text": "New York",
-													"isSubtle": true
-												}
-											],
-											"width": 1
-										}
-									],
-									"height": "stretch"
 								},
 								{
 									"type": "ActionSet",
@@ -222,7 +193,7 @@
 											"style": "positive"
 										}
 									],
-									"spacing": "Medium"
+									"spacing": "medium"
 								},
 								{
 									"type": "ActionSet",
@@ -232,7 +203,7 @@
 											"title": "View in calendar"
 										}
 									],
-									"spacing": "Medium"
+									"spacing": "medium"
 								}
 							]
 						}


### PR DESCRIPTION
## Related Issue
Fixes VSO 24096000

## Description
Update the FlightDetails sample to use a `RichTextBlock` in a single set of `ColumnSet`s so that screenreaders can give a more reasonable reading experience. Prior to this, rather than reading down a column, Narrator would read left to right and top to bottom (i.e. it would read SFO's time then JFK's time, then SFO's date, then JFK's date etc.)

## How Verified
* local build and narrator

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4736)