### PR TITLE
Allows a background image to be set for Containers and derivitives

### DIFF
--- a/source/nodejs/adaptivecards/src/__tests__/components/column.spec.ts
+++ b/source/nodejs/adaptivecards/src/__tests__/components/column.spec.ts
@@ -1,8 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Column } from "../../card-elements";
+import { BackgroundImage, Column } from "../../card-elements";
 
 test('Column should be instantiated', () => {
     const column = new Column();
     expect(column).toEqual(expect.anything());
+})
+
+test('Column can have a backgroundImage set', () =>{
+    const column = new Column();
+    const background = new BackgroundImage();
+    background.url = 'https://adaptivecards.io/content/outlook-logo.png'
+    column.backgroundImage = background;
+
+    expect(column.backgroundImage).not.toBeNull()
 })

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -5286,6 +5286,10 @@ export class Container extends StylableCardElementContainer {
         return this.getValue(Container.backgroundImageProperty);
     }
 
+    set backgroundImage(value: BackgroundImage){
+        this.setValue(Container.backgroundImageProperty, value);
+    }
+
     @property(Container.verticalContentAlignmentProperty)
     verticalContentAlignment: Enums.VerticalAlignment = Enums.VerticalAlignment.Top;
 


### PR DESCRIPTION
## Related Issue
Fixes #4741 

## Description
This fix allows the `backgroundImage` property on Containers and everything that extends it. Currently this was set to be a getter only. 

## How Verified
Have added a test to `column.spec.ts`


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4779)