### PR TITLE
[TS] Renderer and designer fixes

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/data.ts
+++ b/source/nodejs/adaptivecards-designer/src/data.ts
@@ -172,15 +172,17 @@ export class ArrayData extends DataType {
     generateSampleData(): any {
         let result = [];
 
-        for (let i = 1; i <= 3; i++) {
-            result.push(this.dataType.generateSampleData());
+        if (this.dataType) {
+            for (let i = 1; i <= 3; i++) {
+                result.push(this.dataType.generateSampleData());
+            }
         }
 
         return result;
     }
 
     getChildFields(): FieldDefinition[] {
-        return this.dataType.getChildFields();
+        return this.dataType ? this.dataType.getChildFields() : [];
     }
 
     qualifyFieldName(fieldName: string, fieldIsLeaf: boolean) {

--- a/source/nodejs/adaptivecards-designer/src/designer-peers.ts
+++ b/source/nodejs/adaptivecards-designer/src/designer-peers.ts
@@ -2533,6 +2533,8 @@ export class TextBlockPeer extends TypedCardElementPeer<Adaptive.TextBlock> {
         if (!this.cardElement.text || this.cardElement.text == "") {
             this.cardElement.text = "New TextBlock";
         }
+
+        this.cardElement.wrap = true;
     }
 }
 

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -214,6 +214,10 @@ export abstract class CardElement extends CardObject {
         return sizeChanged;
     }
 
+    protected getDefaultSerializationContext(): BaseSerializationContext {
+        return new SerializationContext();
+    }
+
     protected createPlaceholderElement(): HTMLElement {
         let styleDefinition = this.getEffectiveStyleDefinition();
         let foregroundCssColor = Utils.stringToCssColor(styleDefinition.foregroundColors.default.subtle);
@@ -324,10 +328,6 @@ export abstract class CardElement extends CardObject {
 
     parse(source: any, context?: SerializationContext) {
         super.parse(source, context ? context : new SerializationContext());
-    }
-
-    toJSON(context?: SerializationContext): PropertyBag | undefined {
-        return super.toJSON(context ? context : new SerializationContext());
     }
 
     asString(): string | undefined {
@@ -3722,6 +3722,10 @@ export abstract class Action extends CardObject {
 
     private _actionCollection?: ActionCollection; // hold the reference to its action collection
 
+    protected getDefaultSerializationContext(): BaseSerializationContext {
+        return new SerializationContext();
+    }
+
     protected addCssClasses(element: HTMLElement) {
         // Do nothing in base implementation
     }
@@ -3770,10 +3774,6 @@ export abstract class Action extends CardObject {
 
     parse(source: any, context?: SerializationContext) {
         return super.parse(source, context ? context : new SerializationContext());
-    }
-
-    toJSON(context?: SerializationContext): PropertyBag | undefined {
-        return super.toJSON(context ? context : new SerializationContext());
     }
 
     render(baseCssClass: string = "ac-pushButton") {
@@ -6434,6 +6434,10 @@ export class AdaptiveCard extends ContainerWithActions {
         }
     }
 
+    protected getDefaultSerializationContext(): BaseSerializationContext {
+        return new SerializationContext(this.version);
+    }
+
     protected getItemsCollectionPropertyName(): string {
         return "body";
     }
@@ -6575,10 +6579,6 @@ export class AdaptiveCard extends ContainerWithActions {
         }
 
         return renderedCard;
-    }
-
-    toJSON(context?: SerializationContext): PropertyBag | undefined {
-        return super.toJSON(context ? context : new SerializationContext(this.version));
     }
 
     updateLayout(processChildren: boolean = true) {

--- a/source/nodejs/adaptivecards/src/serialization.ts
+++ b/source/nodejs/adaptivecards/src/serialization.ts
@@ -129,6 +129,8 @@ export function isVersionLessOrEqual(version: TargetVersion, targetVersion: Targ
 export abstract class BaseSerializationContext {
     private _validationEvents: IValidationEvent[] = [];
 
+    toJSONOriginalParam: any;
+
     serializeValue(target: { [key: string]: any }, propertyName: string, propertyValue: any, defaultValue: any = undefined) {
         if (propertyValue === null || propertyValue === undefined || propertyValue === defaultValue) {
             if (!GlobalSettings.enableFullJsonRoundTrip) {
@@ -769,6 +771,10 @@ export abstract class SerializableObject {
 
     protected abstract getSchemaKey(): string;
 
+    protected getDefaultSerializationContext(): BaseSerializationContext {
+        return new SimpleSerializationContext();
+    }
+
     protected populateSchema(schema: SerializableObjectSchema) {
         let ctor = <any>this.constructor;
         let properties: PropertyDefinition[] = [];
@@ -898,7 +904,15 @@ export abstract class SerializableObject {
     }
 
     toJSON(context?: BaseSerializationContext): PropertyBag | undefined {
-        let effectiveContext = context ? context : new SimpleSerializationContext();
+        let effectiveContext: BaseSerializationContext;
+        
+        if (context && context instanceof BaseSerializationContext) {
+            effectiveContext = context;
+        }
+        else {
+            effectiveContext = this.getDefaultSerializationContext();
+            effectiveContext.toJSONOriginalParam = context;
+        }
 
         if (this.shouldSerialize(effectiveContext)) {
             let result: PropertyBag;


### PR DESCRIPTION
## Related Issue
Fixes https://github.com/microsoft/AdaptiveCards/issues/4767
Fixes https://github.com/microsoft/AdaptiveCards/issues/4734
References https://github.com/microsoft/AdaptiveCards/issues/4483

## Description
- When `toJSON()` is automatically invoked via `JSON.stringify()`, it gets a parameter of type `string`. The AC renderer's implementation of `toJSON()` takes an optional parameter of type `BaseSerializationContext`. When the value of this parameter is not `undefined`, the code assumes it is of type `BaseSerializationContext` which is not the case when `toJSON()` is invoked via `JSON.stringify()`, and thus generates an exception. This PR fixes that by checking the type of the parameter `toJSON()` receives.
- The data structure generated from JSON would cause an exception when the JSON contained an empty array. The code now properly handles that case.
- New TextBlock elements created in the designer via drag/drop now have their `wrap` property set to `true` by default


## How Verified
Verified manually in adaptivecards-designer-app and [test site](https://adaptivecardsci.z5.web.core.windows.net/pr/4791)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4791)