### PR TITLE
[WPF] Add label for hostconfig combo box

### DIFF
--- a/source/dotnet/Samples/WPFVisualizer/MainWindow.xaml
+++ b/source/dotnet/Samples/WPFVisualizer/MainWindow.xaml
@@ -48,10 +48,10 @@
             <TextBlock Name="xceedLabel" Margin="0,4,-1,4" HorizontalAlignment="Center" VerticalAlignment="Center">Use Xceed Renderers</TextBlock>
         </StackPanel>
         <StackPanel Orientation="Horizontal" Grid.ColumnSpan="5" HorizontalAlignment="Right">
-            <Label HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Padding="4">HostConfig:</Label>
-            <Button Name="loadConfig" Content="Load" Margin="4" Click="loadConfig_Click" HorizontalAlignment="Right" Padding="4"/>
+            <Label Name="hostConfigLabel"  HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Padding="4">Select a HostConfig:</Label>
+            <ComboBox Name="hostConfigs" IsEditable="False" Width="149" SelectionChanged="hostConfigs_Selected" HorizontalAlignment="Right" Padding="6,9,5,3" Margin="0,4" AutomationProperties.LabeledBy="{Binding ElementName=hostConfigLabel}"/>
+            <Button Name="loadConfig" Content="Load HostConfig" Margin="4" Click="loadConfig_Click" HorizontalAlignment="Right" Padding="4"/>
             <Button Name="saveConfig" Content="Save" Margin="4" Click="saveConfig_Click" HorizontalAlignment="Right" Padding="4"/>
-            <ComboBox Name="hostConfigs" IsEditable="False" Width="149" SelectionChanged="hostConfigs_Selected" HorizontalAlignment="Right" Padding="6,9,5,3" Margin="0,4"/>
             <Button Name="toggleOptions" Content="Edit" Margin="4" Click="toggleOptions_Click" HorizontalAlignment="Right" Padding="4"/>
         </StackPanel>
 


### PR DESCRIPTION
## Related Issue
ADO 24112801

## Description
Adds a label for the combo box to allow screen readers to get a name for the control. 

## How Verified
Fix was verified using narrator and the live properties visualizer of visual studio

![image](https://user-images.githubusercontent.com/35784165/93816551-89cde280-fc0c-11ea-8407-7f602ff9da61.png)




###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4792)