### PR TITLE
[WPF] Change TextBlock to render only when text is not empty

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveTextBlockRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveTextBlockRenderer.cs
@@ -17,6 +17,11 @@ namespace AdaptiveCards.Rendering.Wpf
     {
         public static FrameworkElement Render(AdaptiveTextBlock textBlock, AdaptiveRenderContext context)
         {
+            if (String.IsNullOrEmpty(textBlock.Text))
+            {
+                return null;
+            }
+
             var uiTextBlock = CreateControl(textBlock, context);
 
             uiTextBlock.SetColor(textBlock.Color, textBlock.IsSubtle, context);

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveTextBlock.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveTextBlock.cs
@@ -99,7 +99,7 @@ namespace AdaptiveCards
 #if !NETSTANDARD1_3
         [XmlText]
 #endif
-        public string Text { get; set; } = " ";
+        public string Text { get; set; } = "";
 
         /// <summary>
         ///     Horizontal alignment for element

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveTypedElement.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveTypedElement.cs
@@ -46,6 +46,10 @@ namespace AdaptiveCards
         public AdaptiveFallbackElement Fallback { get; set; }
 
         [JsonIgnore]
+#if !NETSTANDARD1_3
+        // don't serialize type with xml, because we use element name or attribute for type
+        [XmlIgnore]
+#endif
         public AdaptiveInternalID InternalID { get; set; }
 
         /// <summary>


### PR DESCRIPTION
## Related Issue
references #4478

## Description
Updated WPF renderer to render a textblock only when text is given

## How Verified
The fix was verified manually, as in WPF we don't raise parsing errors, then it's a rendering only fix

![image](https://user-images.githubusercontent.com/35784165/93925780-7afa3500-fccb-11ea-8edf-e7b36244df47.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4799)