### PR TITLE
[UWP] Expand custom input test case to handle validation

### DIFF
--- a/samples/v1.3/Tests/customInput.json
+++ b/samples/v1.3/Tests/customInput.json
@@ -1,17 +1,26 @@
 {
-    "type": "AdaptiveCard",
-    "version": "1.2",
-    "body": [
-        {
-            "type": "customInput",
-            "id": "id1",
-            "label": "A label"
-        }
-    ],
-    "actions": [
-        {
-            "type": "Action.Submit",
-            "title": "Submit"
-        }
-    ]
+	"type": "AdaptiveCard",
+	"version": "1.2",
+	"body": [
+		{
+			"type": "CSharpKeywordInput",
+			"id": "id1",
+			"label": "Please enter a csharp keyword",
+			"isRequired": true,
+			"errorMessage": "This has to be a csharp keyword!"
+		},
+		{
+			"type": "Input.Text",
+			"id": "id2",
+			"label": "Please enter some text",
+			"isRequired": true,
+			"errorMessage": "This input is required."
+		}
+	],
+	"actions": [
+		{
+			"type": "Action.Submit",
+			"title": "Submit"
+		}
+	]
 }

--- a/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.cpp
@@ -80,7 +80,7 @@ namespace AdaptiveNamespace
             RETURN_IF_FAILED(textBoxFrameworkElement->put_VerticalAlignment(ABI::Windows::UI::Xaml::VerticalAlignment_Top));
         }
 
-        // Call XamlHelpers::HandleInputLayoutAndValidation to handle label and error message. Pass nullptr for
+        // Call XamlHelpers::HandleInputLayoutAndValidation to handle accessibility properties. Pass nullptr for
         // validationBorder as we've already handled that above.
         ComPtr<IUIElement> inputLayout;
         ComPtr<IUIElement> validationError;

--- a/source/uwp/Renderer/lib/XamlHelpers.cpp
+++ b/source/uwp/Renderer/lib/XamlHelpers.cpp
@@ -1019,9 +1019,11 @@ namespace AdaptiveNamespace::XamlHelpers
             auto separator = XamlHelpers::CreateSeparator(renderContext, spacing, 0, ABI::Windows::UI::Color());
 
             ComPtr<IAdaptiveInputValue> inputValue;
-            renderContext->GetInputValue(adaptiveInput, inputValue.GetAddressOf());
-            RETURN_IF_FAILED(inputValue->put_ErrorMessage(errorMessageControl.Get()));
-
+            RETURN_IF_FAILED(renderContext->GetInputValue(adaptiveInput, inputValue.GetAddressOf()));
+            if (inputValue)
+            {
+                RETURN_IF_FAILED(inputValue->put_ErrorMessage(errorMessageControl.Get()));
+            }
             XamlHelpers::AppendXamlElementToPanel(separator.Get(), stackPanelAsPanel.Get());
 
             // Add the rendered error message

--- a/source/uwp/Visualizer/ViewModel/DocumentViewModel.cs
+++ b/source/uwp/Visualizer/ViewModel/DocumentViewModel.cs
@@ -87,11 +87,11 @@ namespace AdaptiveCardVisualizer.ViewModel
                 if (JsonObject.TryParse(payload, out jsonObject))
                 {
                     AdaptiveElementParserRegistration reg = new AdaptiveElementParserRegistration();
-                    reg.Set(CustomInput.customInputType, new CustomInputParser());
+                    reg.Set(CSharpKeywordInput.customInputType, new CustomInputParser());
 
                     AdaptiveCardParseResult parseResult = AdaptiveCard.FromJson(jsonObject, reg, new AdaptiveActionParserRegistration());
 
-                    _renderer.ElementRenderers.Set(CustomInput.customInputType, new CustomInputRenderer());
+                    _renderer.ElementRenderers.Set(CSharpKeywordInput.customInputType, new CustomInputRenderer());
                     _renderedAdaptiveCard = _renderer.RenderAdaptiveCard(parseResult.AdaptiveCard);
                     if (_renderedAdaptiveCard.FrameworkElement != null)
                     {


### PR DESCRIPTION
## Related Issue
Fixes #4812

## Description
The custom input renderer at [CustomInput.cs](https://github.com/microsoft/AdaptiveCards/blob/main/source/uwp/Visualizer/CustomElements/CustomInput.cs) wasn't handling marking the input as invalid. Updated that code to handle that functionality.

## How Verified
Confirmed custom element file [customInput.json](https://github.com/microsoft/AdaptiveCards/blob/main/samples/v1.3/Tests/customInput.json) now handles validation scenarios.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4813)