### PR TITLE
[JavaScript][Accessibility] presentational img and layout separator

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -2244,6 +2244,7 @@ export class Media extends CardElement {
             let posterImageElement = document.createElement("img");
             posterImageElement.style.width = "100%";
             posterImageElement.style.height = "100%";
+            posterImageElement.setAttribute("role", "presentation");
 
             posterImageElement.onerror = (e: Event) => {
                 if (posterImageElement.parentNode) {

--- a/source/nodejs/adaptivecards/src/utils.ts
+++ b/source/nodejs/adaptivecards/src/utils.ts
@@ -79,6 +79,7 @@ export function renderSeparation(hostConfig: HostConfig, separationDefinition: S
     if (separationDefinition.spacing > 0 || (separationDefinition.lineThickness && separationDefinition.lineThickness > 0)) {
         let separator = document.createElement("div");
         separator.className = hostConfig.makeCssClassName("ac-" + (orientation == Enums.Orientation.Horizontal ? "horizontal" : "vertical") + "-separator");
+        separator.setAttribute("aria-hidden", "true");
 
         let color = separationDefinition.lineColor ? stringToCssColor(separationDefinition.lineColor) : "";
 


### PR DESCRIPTION
## Related Issue
ADO 24129943 

## Description
img in Media is presentational, and layout separators should be entirely hidden. Marking them with the appropriate aria attributes.

## How Verified
Manual verification

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4823)