### PR TITLE
Trigger inlineAction with CTRL+Enter

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -2702,7 +2702,7 @@ export class TextInput extends Input {
         input.oninput = () => { this.valueChanged(); }
         input.onkeypress = (e: KeyboardEvent) => {
             // Ctrl+Enter pressed
-            if (e.keyCode == 10 && this.inlineAction) {
+            if (e.ctrlKey && e.code === "Enter" && this.inlineAction) {
                 this.inlineAction.execute();
             }
         }


### PR DESCRIPTION
## Related Issue
Fixes #4575

## Description
This ensures that the keyboard shortcut of `Ctrl+Enter` works when an inlineAction is assigned to a `Text.Input`.

## How Verified
Verified manually in adaptivecards-designer-app

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4840)