### PR TITLE
[Designer] Trap keyboard for modal dialogs

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/adaptivecards-designer.css
+++ b/source/nodejs/adaptivecards-designer/src/adaptivecards-designer.css
@@ -161,7 +161,7 @@
     top: 0;
     width: 100%;
     height: 100%;
-    background-color: rgba(0, 0, 0, 0.1);
+    background-color: rgba(0, 0, 0, 0.4);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/source/nodejs/adaptivecards-designer/src/dialog.ts
+++ b/source/nodejs/adaptivecards-designer/src/dialog.ts
@@ -55,7 +55,6 @@ export abstract class Dialog {
 
             this._overlayElement = document.createElement("div");
             this._overlayElement.className = "acd-dialog-overlay";
-            this._overlayElement.style.backgroundColor = "rgba(0, 0, 0, 0.4)";
             this._overlayElement.onclick = (e) => {
                 // clicks on the overlay window should dismiss the dialog
                 this.close();

--- a/source/nodejs/adaptivecards-designer/src/dialog.ts
+++ b/source/nodejs/adaptivecards-designer/src/dialog.ts
@@ -28,6 +28,9 @@ export class DialogButton {
 export abstract class Dialog {
     private _overlayElement: HTMLElement;
     private _isOpen: boolean = false;
+    private _originalFocusedElement: HTMLElement;
+    private _firstFocusableElement: HTMLElement;
+    private _lastFocusableElement: HTMLElement;
 
     protected abstract renderContent(): HTMLElement;
 
@@ -48,19 +51,21 @@ export abstract class Dialog {
 
     open() {
         if (!this._isOpen) {
+            this._originalFocusedElement = document.activeElement as HTMLElement;
+
             this._overlayElement = document.createElement("div");
             this._overlayElement.className = "acd-dialog-overlay";
+            this._overlayElement.style.backgroundColor = "rgba(0, 0, 0, 0.4)";
             this._overlayElement.onclick = (e) => {
                 // clicks on the overlay window should dismiss the dialog
                 this.close();
             }
 
-            let dialogFrameElement = document.createElement("div");
+            let dialogFrameElement = document.createElement("dialog");
             dialogFrameElement.className = "acd-dialog-frame";
             dialogFrameElement.style.width = this.width;
             dialogFrameElement.style.height = this.height;
             dialogFrameElement.style.justifyContent = "space-between";
-            dialogFrameElement.setAttribute("role", "dialog");
             dialogFrameElement.setAttribute("aria-modal", "true");
             dialogFrameElement.setAttribute("aria-labelledby", "acd-dialog-title-element");
             dialogFrameElement.tabIndex = -1;
@@ -76,6 +81,19 @@ export abstract class Dialog {
             // keyboard navigation support
             dialogFrameElement.onkeydown = (e) => {
                 switch (e.key) {
+                    case Constants.keys.tab:
+                        if (e.shiftKey && document.activeElement === this._firstFocusableElement) {
+                            // backwards tab on first element. set focus on last
+                            e.preventDefault();
+                            this._lastFocusableElement.focus();
+                        }
+                        else if (!e.shiftKey && document.activeElement === this._lastFocusableElement) {
+                            // forward tab on last element
+                            e.preventDefault();
+                            this._firstFocusableElement.focus();
+                        }
+                        break;
+
                     case Constants.keys.escape:
                         this.close();
                         e.preventDefault();
@@ -121,7 +139,12 @@ export abstract class Dialog {
             this._overlayElement.appendChild(dialogFrameElement);
 
             document.body.appendChild(this._overlayElement);
-            dialogFrameElement.focus();
+
+            let focusableElements = dialogFrameElement.querySelectorAll('a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex="0"]');
+            this._firstFocusableElement = focusableElements[0] as HTMLElement;
+            this._lastFocusableElement = focusableElements[focusableElements.length-1] as HTMLElement;
+
+            this._firstFocusableElement.focus();
 
             this._isOpen = true;
         }
@@ -136,6 +159,9 @@ export abstract class Dialog {
             if (this.onClose) {
                 this.onClose(this);
             }
+
+            this._originalFocusedElement.focus();
+            this._originalFocusedElement = null;
         }
     }
 }


### PR DESCRIPTION
## Description
@golddove and I noticed a couple of issues with modal dialogs in the Designer:
* Keyboard focus wasn't returning to point of invocation when the dialog was dismissed
* Keyboard focus wasn't restricted to the dialog as it should be
* Modal dialog difficult to distinguish visually

This fixes that. Here's what modals look like now:
![image](https://user-images.githubusercontent.com/16614499/94614455-0db24b00-025b-11eb-8824-d2f5efcc5bb4.png)

## How Verified
* local build, devtools, narrator


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4850)