### PR TITLE
Jwoo/input error ui update

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.h
@@ -15,6 +15,11 @@
 @property (strong, nonatomic) NSObject <ACRIBaseInputHandler> *dataSource;
 @property BOOL isRequired;
 @property BOOL hasErrorMessage;
+@property IBInspectable UIColor *validationFailBorderColor;
+@property IBInspectable CGFloat validationFailBorderRadius;
+@property IBInspectable CGFloat validationFailBorderWidth;
+@property IBInspectable CGFloat validationSuccessBorderWidth;
+
 
 + (void)commonSetFocus:(BOOL)shouldBecomeFirstResponder view:(UIView *)view;
 + (BOOL)commonTextUIValidate:(BOOL)isRequired hasText:(BOOL)hasText predicate:(NSPredicate *)predicate text:(NSString *)text error:(NSError *__autoreleasing *)error;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.mm
@@ -126,19 +126,21 @@
         NSError *error = nil;
         if (NO == [inputHandler validate:&error]) {
             if (self.hasErrorMessage) {
+                inputHandler.hasVisibilityChanged = self.errorMessage.hidden != NO;
                 self.errorMessage.hidden = NO;
             }
         } else {
             if (self.hasErrorMessage) {
+                inputHandler.hasVisibilityChanged = self.errorMessage.hidden != YES;
                 self.errorMessage.hidden = YES;
             }
-            self.stack.arrangedSubviews[1].layer.borderWidth = 0;
+            self.stack.arrangedSubviews[1].layer.borderWidth = self.validationSuccessBorderWidth;
             return YES;
         }
     }
-    self.stack.arrangedSubviews[1].layer.borderWidth = 1;
-    self.stack.arrangedSubviews[1].layer.cornerRadius = 6.0f;
-    self.stack.arrangedSubviews[1].layer.borderColor = UIColor.systemRedColor.CGColor;
+    self.stack.arrangedSubviews[1].layer.borderWidth = self.validationFailBorderWidth;
+    self.stack.arrangedSubviews[1].layer.cornerRadius = self.validationFailBorderRadius;
+    self.stack.arrangedSubviews[1].layer.borderColor = self.validationFailBorderColor.CGColor;
     return NO;
 }
 
@@ -210,5 +212,7 @@
 @synthesize hasValidationProperties;
 
 @synthesize id;
+
+@synthesize hasVisibilityChanged;
 
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.mm
@@ -126,12 +126,10 @@
         NSError *error = nil;
         if (NO == [inputHandler validate:&error]) {
             if (self.hasErrorMessage) {
-                inputHandler.hasVisibilityChanged = self.errorMessage.hidden != NO;
                 self.errorMessage.hidden = NO;
             }
         } else {
             if (self.hasErrorMessage) {
-                inputHandler.hasVisibilityChanged = self.errorMessage.hidden != YES;
                 self.errorMessage.hidden = YES;
             }
             self.stack.arrangedSubviews[1].layer.borderWidth = self.validationSuccessBorderWidth;
@@ -212,7 +210,5 @@
 @synthesize hasValidationProperties;
 
 @synthesize id;
-
-@synthesize hasVisibilityChanged;
 
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.xib
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.xib
@@ -1,14 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ACRInputLabelView">
+            <userDefinedRuntimeAttributes>
+                <userDefinedRuntimeAttribute type="number" keyPath="validationFailBorderRadius">
+                    <real key="value" value="5"/>
+                </userDefinedRuntimeAttribute>
+                <userDefinedRuntimeAttribute type="color" keyPath="validationFailBorderColor">
+                    <color key="value" systemColor="systemIndigoColor"/>
+                </userDefinedRuntimeAttribute>
+                <userDefinedRuntimeAttribute type="number" keyPath="validationSuccessBorderWidth">
+                    <real key="value" value="0.0"/>
+                </userDefinedRuntimeAttribute>
+                <userDefinedRuntimeAttribute type="number" keyPath="validationFailBorderWidth">
+                    <real key="value" value="1"/>
+                </userDefinedRuntimeAttribute>
+            </userDefinedRuntimeAttributes>
             <connections>
                 <outlet property="errorMessage" destination="UhI-YL-bG4" id="mY3-fQ-LVc"/>
                 <outlet property="label" destination="1Ch-uc-lfs" id="BEl-KZ-Pwn"/>
@@ -36,4 +50,9 @@
             <point key="canvasLocation" x="132" y="132"/>
         </stackView>
     </objects>
+    <resources>
+        <systemColor name="systemIndigoColor">
+            <color red="0.34509803921568627" green="0.33725490196078434" blue="0.83921568627450982" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
 </document>


### PR DESCRIPTION
## Related Issue
Fixes #4839 

## Description
Added customizable attributes to ACRInputLableView.xib.
<img width="534" alt="Screen Shot 2020-09-29 at 6 28 29 PM" src="https://user-images.githubusercontent.com/4112696/94633301-bbd0eb80-0281-11eb-9ed8-6cf56794f33a.png">

<img width="334" alt="Screen Shot 2020-09-29 at 6 28 43 PM" src="https://user-images.githubusercontent.com/4112696/94633318-c4292680-0281-11eb-8c2c-f16b9831785d.png">
Updating the values can change the visual error cue

## How Verified
How you verified the fix, including one or all of the following: 
1. Tested with existing Input cards to validate that the changes are in effect.
2. Ran the regression Test.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4852)