### PR TITLE
[JS][Renderer] Use TextRun.selectAction.title as aria-label

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -1182,6 +1182,7 @@ export class TextRun extends BaseTextBlock {
                 }
 
                 if (this.selectAction.title) {
+                    anchor.setAttribute("aria-label", this.selectAction.title);
                     anchor.title = this.selectAction.title;
                 }
 


### PR DESCRIPTION
## Related Issue
References https://github.com/microsoft/AdaptiveCards/issues/4856

## Description
When a TextRun in a RichTextBlock has its `selectAction` set, the aria-label of the generated anchor DOM element is now set to the action's `title` property, if specified.

## How Verified
Verified manually in adaptivecards-designer-app

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4857)