### PR TITLE
[JS] Fix arrow keys and actionset aria

### DIFF
--- a/source/nodejs/adaptivecards-controls/src/constants.ts
+++ b/source/nodejs/adaptivecards-controls/src/constants.ts
@@ -35,8 +35,8 @@ export class Constants {
         enter: "Enter",
         escape: "Escape",
         space: " ",
-        up: "Up",
-        down: "Down",
+        up: "ArrowUp",
+        down: "ArrowDown",
         delete: "Delete"
     } as const;
 }

--- a/source/nodejs/adaptivecards-controls/src/dropdown.ts
+++ b/source/nodejs/adaptivecards-controls/src/dropdown.ts
@@ -32,7 +32,7 @@ export class DropDownItem {
             this._element = document.createElement("span");
             this._element.className = "ms-ctrl ms-ctrl-dropdown-item";
             this._element.innerText = this.value;
-            this._element.setAttribute("role", "option");
+            this._element.setAttribute("role", "menuitem");
             this._element.setAttribute("aria-selected", "false");
             this._element.onmouseup = (e) => { this.click(); };
             this._element.onkeydown = (e) => {
@@ -73,7 +73,7 @@ export class DropDownPopupControl extends PopupControl {
     protected renderContent(): HTMLElement {
         var element = document.createElement("div");
         element.className = "ms-ctrl ms-popup";
-        element.setAttribute("role", "listbox");
+        element.setAttribute("role", "menu");
 
         var selectedIndex = this._owner.selectedIndex;
 
@@ -238,6 +238,8 @@ export class DropDown extends InputWithPopup<DropDownPopupControl, DropDownItem>
         if (ariaLabelledByIds.length > 0) {
             this.rootElement.setAttribute("aria-labelledby", ariaLabelledByIds.join(" "));
         }
+
+        this.rootElement.setAttribute("role", "menu");
     }
 
     popup() {

--- a/source/nodejs/adaptivecards/package-lock.json
+++ b/source/nodejs/adaptivecards/package-lock.json
@@ -6657,9 +6657,9 @@
 			}
 		},
 		"lunr": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.8.tgz",
-			"integrity": "sha512-oxMeX/Y35PNFuZoHp+jUj5OSEmLCaIH4KTFJh7a93cHBoFmpw2IoPs22VIz7vyO2YUnx2Tn9dzIwO2P/4quIRg==",
+			"version": "2.3.9",
+			"resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+			"integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
 			"dev": true
 		},
 		"make-dir": {
@@ -9557,9 +9557,9 @@
 			"optional": true
 		},
 		"underscore": {
-			"version": "1.10.2",
-			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
-			"integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.11.0.tgz",
+			"integrity": "sha512-xY96SsN3NA461qIRKZ/+qox37YXPtSBswMGfiNptr+wrt6ds4HaMw23TP612fEyGekRE6LNRiLYr/aqbHXNedw==",
 			"dev": true
 		},
 		"union-value": {

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -4667,7 +4667,7 @@ class ActionCollection {
             let buttonStrip = document.createElement("div");
             buttonStrip.className = hostConfig.makeCssClassName("ac-actionSet");
             buttonStrip.style.display = "flex";
-            buttonStrip.setAttribute("role", "group");
+            buttonStrip.setAttribute("role", "menubar");
 
             if (orientation == Enums.Orientation.Horizontal) {
                 buttonStrip.style.flexDirection = "row";
@@ -4755,7 +4755,7 @@ class ActionCollection {
                     if (actionButton.action.renderedElement) {
                         actionButton.action.renderedElement.setAttribute("aria-posinset", (i + 1).toString());
                         actionButton.action.renderedElement.setAttribute("aria-setsize", allowedActions.length.toString());
-                        actionButton.action.renderedElement.setAttribute("role", "listitem");
+                        actionButton.action.renderedElement.setAttribute("role", "menuitem");
 
                         if (hostConfig.actions.actionsOrientation == Enums.Orientation.Horizontal && hostConfig.actions.actionAlignment == Enums.ActionAlignment.Stretch) {
                             actionButton.action.renderedElement.style.flex = "0 1 100%";


### PR DESCRIPTION
## Related Issue
Fixes VSO 23940376

## Description
Two, two, two fixes in one! #4828 regressed arrow keys in key handlers since the keys are referred to as `Arrow[Up|Down]`, not `[Up|Down]`. This broke keyboard accessibility in the Designer's toolbar pickers, since you couldn't arrow through the list of options. We also fix up the aria around `ActionSet`s as well as the dropdown list. Narrator now correctly reads both the expanded/collapsed state of `Action.ShowCard` buttons as well as their positions in the list of actions.

## How Verified
* local build, narrator, dev tools, NVDA

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4859)