### PR TITLE
[WPF] Fix InputForm json card behaviour

### DIFF
--- a/source/dotnet/Library/AdaptiveCards/Rendering/AdaptiveRenderArgs.cs
+++ b/source/dotnet/Library/AdaptiveCards/Rendering/AdaptiveRenderArgs.cs
@@ -29,6 +29,7 @@ namespace AdaptiveCards.Rendering
             ForegroundColors = previousRenderArgs.ForegroundColors;
             BleedDirection = previousRenderArgs.BleedDirection;
             HasParentWithPadding = previousRenderArgs.HasParentWithPadding;
+            ContainerCardId = previousRenderArgs.ContainerCardId;
         }
 
         // Default value for the container style of the first adaptiveCard


### PR DESCRIPTION
## Related Issue
Fixes #4861

## Description
The issue was that the Container Id was not being saved when duplicating the RenderArgs object, this fix had been previously made but at some point this regression happened

## How Verified
The fix was verified manually
![image](https://user-images.githubusercontent.com/35784165/94747218-2db53d80-0333-11eb-9d29-d60a6c94c676.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4864)