### PR TITLE
[UWP] Update renderer package license expression

### DIFF
--- a/source/uwp/NuGet/AdaptiveCards.Rendering.Uwp.nuspec
+++ b/source/uwp/NuGet/AdaptiveCards.Rendering.Uwp.nuspec
@@ -10,7 +10,7 @@
         <tags>adaptivecards;adaptive-cards</tags>
         <projectUrl>https://adaptivecards.io</projectUrl>
         <iconUrl>https://adaptivecards.io/content/icons_blue/blue-48.png</iconUrl>
-        <licenseUrl>https://raw.githubusercontent.com/Microsoft/AdaptiveCards/main/LICENSE</licenseUrl>
+        <license type="expression">MIT</license>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     </metadata>
     <files>


### PR DESCRIPTION
## Description
The `licenseUrl` metadata item in `.nuspec` files is [deprecated](https://docs.microsoft.com/en-us/nuget/reference/nuspec#licenseurl), and our internal tooling doesn't seem to respect it anyways. This change moves us to using the `license` directive, which *is* recognized (and already in use for our .NET packages).

## How Verified
* local build

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4874)