### PR TITLE
[.NET] Don't set number input text box value to NaN.

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveNumberInputRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveNumberInputRenderer.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+using System;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -10,7 +11,12 @@ namespace AdaptiveCards.Rendering.Wpf
     {
         public static FrameworkElement Render(AdaptiveNumberInput input, AdaptiveRenderContext context)
         {
-            var textBox = new TextBox() { Text = input.Value.ToString() };
+            var textBox = new TextBox();
+
+            if (!Double.IsNaN(input.Value))
+            {
+                textBox.Text = input.Value.ToString();
+            }
             textBox.SetPlaceholder(input.Placeholder);
             textBox.Style = context.GetStyle($"Adaptive.Input.Text.Number");
             textBox.SetContext(input);


### PR DESCRIPTION
## Related Issue
Fixes #4882

## Description
Per linked bug, the non-xceed number renderer was explicitly putting "NaN" into the input box for number inputs that don't have a value set. Updated the code to not set the text if the value is not set.

## How Verified
Validated in the visualizer using the [Input.Number.Label.json](https://github.com/microsoft/AdaptiveCards/blob/main/samples/v1.3/Elements/Input.Number.Label.json) sample.
