### PR TITLE
Added Event Handler Registration

### DIFF
--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer.xcodeproj/project.pbxproj
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		6B150A40230354F200046B3A /* Image.json in Resources */ = {isa = PBXBuildFile; fileRef = 6B150A35230354F200046B3A /* Image.json */; };
 		6B22426621E92AF9000ACDA1 /* CustomActionNewType.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6B22426521E92AF9000ACDA1 /* CustomActionNewType.mm */; };
 		6B22426A21FFA76D000ACDA1 /* ADCIOSVisualizerUITests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6B22426921FFA76D000ACDA1 /* ADCIOSVisualizerUITests.mm */; };
+		6B250FC9253FB0CE007FFCFB /* ACRCustomSubmitTargetBuilder.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6B250FC8253FB0CC007FFCFB /* ACRCustomSubmitTargetBuilder.mm */; };
 		6B268FE320CEF19400D99C1B /* (null) in Resources */ = {isa = PBXBuildFile; };
 		6B268FE520CEF89100D99C1B /* (null) in Resources */ = {isa = PBXBuildFile; };
 		6B2D8605211143BD008DD972 /* AdaptiveCards.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B2D8604211143BD008DD972 /* AdaptiveCards.framework */; };
@@ -143,6 +144,8 @@
 		6B22426421E92AF9000ACDA1 /* CustomActionNewType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CustomActionNewType.h; sourceTree = "<group>"; };
 		6B22426521E92AF9000ACDA1 /* CustomActionNewType.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CustomActionNewType.mm; sourceTree = "<group>"; };
 		6B22426921FFA76D000ACDA1 /* ADCIOSVisualizerUITests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ADCIOSVisualizerUITests.mm; sourceTree = "<group>"; };
+		6B250FC7253FB0CC007FFCFB /* ACRCustomSubmitTargetBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ACRCustomSubmitTargetBuilder.h; sourceTree = "<group>"; };
+		6B250FC8253FB0CC007FFCFB /* ACRCustomSubmitTargetBuilder.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ACRCustomSubmitTargetBuilder.mm; sourceTree = "<group>"; };
 		6B2D8604211143BD008DD972 /* AdaptiveCards.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AdaptiveCards.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6B5E9CBC24B663CA00757882 /* Adaptive1.0.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = Adaptive1.0.png; path = ../../../../../assets/Adaptive1.0.png; sourceTree = "<group>"; };
 		6B980930215AE4310024B79B /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -311,21 +314,23 @@
 		F423C0741EE1FB6100905679 /* ADCIOSVisualizer */ = {
 			isa = PBXGroup;
 			children = (
-				6B5E9CBC24B663CA00757882 /* Adaptive1.0.png */,
+				6B250FC7253FB0CC007FFCFB /* ACRCustomSubmitTargetBuilder.h */,
+				6B250FC8253FB0CC007FFCFB /* ACRCustomSubmitTargetBuilder.mm */,
 				F4D33E841F04705800941E44 /* ACVTableViewController.h */,
 				F4D33E851F04705800941E44 /* ACVTableViewController.m */,
+				6B5E9CBC24B663CA00757882 /* Adaptive1.0.png */,
+				6B150A0122FCE4BA00046B3A /* AdaptiveFileBrowserSource.h */,
+				6B1509FF22FCE49600046B3A /* AdaptiveFileBrowserSource.mm */,
 				F423C0811EE1FB6100905679 /* ADCIOSVisualizer.xcdatamodeld */,
 				6B9BDFCD20F6D16E00F13155 /* ADCResolver.h */,
 				6B9BDFCB20F6D11F00F13155 /* ADCResolver.m */,
 				F423C0781EE1FB6100905679 /* AppDelegate.h */,
 				F423C0791EE1FB6100905679 /* AppDelegate.m */,
 				F423C0841EE1FB6100905679 /* Assets.xcassets */,
-				F4F255731F9946B200A80D39 /* CustomActionOpenURLRenderer.h */,
-				F4F255711F993CD200A80D39 /* CustomActionOpenURLRenderer.mm */,
 				6B22426421E92AF9000ACDA1 /* CustomActionNewType.h */,
 				6B22426521E92AF9000ACDA1 /* CustomActionNewType.mm */,
-				6B1509FF22FCE49600046B3A /* AdaptiveFileBrowserSource.mm */,
-				6B150A0122FCE4BA00046B3A /* AdaptiveFileBrowserSource.h */,
+				F4F255731F9946B200A80D39 /* CustomActionOpenURLRenderer.h */,
+				F4F255711F993CD200A80D39 /* CustomActionOpenURLRenderer.mm */,
 				6B9BDF6E20E18E5B00F13155 /* CustomImageRenderer.h */,
 				6B9BDF6F20E18E5B00F13155 /* CustomImageRenderer.mm */,
 				F4F44B74203FE73D00A2F24C /* CustomInputNumberRenderer.h */,
@@ -335,12 +340,12 @@
 				6BF339D520A665E600DA5973 /* CustomTextBlockRenderer.h */,
 				6BF339D420A665E600DA5973 /* CustomTextBlockRenderer.mm */,
 				F423C0891EE1FB6100905679 /* Info.plist */,
-				6BA9091A23985CB5009421CA /* Adaptive1.0.png */,
 				F423C0861EE1FB6100905679 /* LaunchScreen.storyboard */,
 				F423C07E1EE1FB6100905679 /* Main.storyboard */,
 				F423C0751EE1FB6100905679 /* Supporting Files */,
 				F423C07B1EE1FB6100905679 /* ViewController.h */,
 				F423C07C1EE1FB6100905679 /* ViewController.m */,
+				6BA9091A23985CB5009421CA /* Adaptive1.0.png */,
 			);
 			path = ADCIOSVisualizer;
 			sourceTree = "<group>";
@@ -560,6 +565,7 @@
 				6B150A0022FCE49600046B3A /* AdaptiveFileBrowserSource.mm in Sources */,
 				F423C0831EE1FB6100905679 /* ADCIOSVisualizer.xcdatamodeld in Sources */,
 				F423C0771EE1FB6100905679 /* main.m in Sources */,
+				6B250FC9253FB0CE007FFCFB /* ACRCustomSubmitTargetBuilder.mm in Sources */,
 				F4F44B75203FE73D00A2F24C /* CustomInputNumberRenderer.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ACRCustomSubmitTargetBuilder.h
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ACRCustomSubmitTargetBuilder.h
@@ -1,0 +1,17 @@
+//
+//  ACRCustomSubmitTargetBuilder.h
+//  AdaptiveCards
+//
+//  Copyright © 2020 Microsoft. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <AdaptiveCards/ACFramework.h>
+
+// build target for submit and openUrl actions
+@interface ACRCustomSubmitTargetBuilder : ACRAggregateTargetBuilder
+@end
+
+
+
+

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ACRCustomSubmitTargetBuilder.mm
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ACRCustomSubmitTargetBuilder.mm
@@ -23,7 +23,17 @@
 
 - (void)doIfValidationFailed:(ACOInputResults *)results button:(UIButton *)button
 {
-    [super doIfValidationFailed:results button:button];
+    if (results) {
+        if ([self.view.acrActionDelegate respondsToSelector:@selector(didChangeViewLayout:newFrame:properties:)]) {
+            UIView *viewToFocus = (UIView *)results.firstFailedInput;
+            NSDictionary *prop = @{@"actiontype" : @"submit", @"firstResponder" : results.firstFailedInput};
+            if (viewToFocus) {
+                [self.view.acrActionDelegate didChangeViewLayout:CGRectNull newFrame:viewToFocus.frame properties:prop];
+            } else {
+                [self.view.acrActionDelegate didChangeViewLayout:CGRectNull newFrame:CGRectNull properties:prop];
+            }
+        }
+    }
     button.backgroundColor = UIColor.redColor;
 }
 

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ACRCustomSubmitTargetBuilder.mm
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ACRCustomSubmitTargetBuilder.mm
@@ -5,8 +5,8 @@
 //  Copyright © 2020 Microsoft. All rights reserved.
 
 #import "ACRCustomSubmitTargetBuilder.h"
-#import <AdaptiveCards/ACRTargetBuilderDirector.h>
 #import <AdaptiveCards/ACRAggregateTarget.h>
+#import <AdaptiveCards/ACRTargetBuilderDirector.h>
 #import <AdaptiveCards/ACRViewPrivate.h>
 
 @interface ACRCustomSubmitTarget : ACRAggregateTarget
@@ -15,36 +15,6 @@
 @implementation ACRCustomSubmitTarget
 - (IBAction)send:(UIButton *)sender
 {
-    BOOL hasValidationPassed = YES;
-    BOOL hasViewChangedForAnyViews = NO;
-    NSError *error = nil;
-    NSMutableArray<ACRIBaseInputHandler> *gatheredInputs = [[NSMutableArray<ACRIBaseInputHandler> alloc] init];
-
-    ACRColumnView *parent = self.currentShowcard;
-
-    while (parent) {
-        NSMutableArray<ACRIBaseInputHandler> *inputs = parent.inputHandlers;
-        for (id<ACRIBaseInputHandler> input in inputs) {
-            BOOL validationResult = [input validate:&error];
-            [gatheredInputs addObject:input];
-            if (hasValidationPassed && !validationResult) {
-                [input setFocus:YES view:nil];
-            } else {
-                [input setFocus:NO view:nil];
-            }
-            hasValidationPassed &= validationResult;
-            hasViewChangedForAnyViews |= input.hasVisibilityChanged;
-        }
-        parent = [self.view getParent:parent];
-    }
-
-    if (hasValidationPassed) {
-        sender.backgroundColor = UIColor.greenColor;
-        [[self.view card] setInputs:gatheredInputs];
-        [self.view.acrActionDelegate didFetchUserResponses:[self.view card] action:self.actionElement];
-    } else if (hasViewChangedForAnyViews && [self.view.acrActionDelegate respondsToSelector:@selector(didChangeViewLayout:newFrame:)]) {
-        [self.view.acrActionDelegate didChangeViewLayout:CGRectNull newFrame:CGRectNull];
-    }
 }
 @end
 

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ACRCustomSubmitTargetBuilder.mm
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ACRCustomSubmitTargetBuilder.mm
@@ -1,0 +1,78 @@
+//
+//  ACRCustomSubmitTargetBuilder.mm
+//  AdaptiveCards
+//
+//  Copyright © 2020 Microsoft. All rights reserved.
+
+#import "ACRCustomSubmitTargetBuilder.h"
+#import <AdaptiveCards/ACRTargetBuilderDirector.h>
+#import <AdaptiveCards/ACRAggregateTarget.h>
+#import <AdaptiveCards/ACRViewPrivate.h>
+
+@interface ACRCustomSubmitTarget : ACRAggregateTarget
+@end
+
+@implementation ACRCustomSubmitTarget
+- (IBAction)send:(UIButton *)sender
+{
+    BOOL hasValidationPassed = YES;
+    BOOL hasViewChangedForAnyViews = NO;
+    NSError *error = nil;
+    NSMutableArray<ACRIBaseInputHandler> *gatheredInputs = [[NSMutableArray<ACRIBaseInputHandler> alloc] init];
+
+    ACRColumnView *parent = self.currentShowcard;
+
+    while (parent) {
+        NSMutableArray<ACRIBaseInputHandler> *inputs = parent.inputHandlers;
+        for (id<ACRIBaseInputHandler> input in inputs) {
+            BOOL validationResult = [input validate:&error];
+            [gatheredInputs addObject:input];
+            if (hasValidationPassed && !validationResult) {
+                [input setFocus:YES view:nil];
+            } else {
+                [input setFocus:NO view:nil];
+            }
+            hasValidationPassed &= validationResult;
+            hasViewChangedForAnyViews |= input.hasVisibilityChanged;
+        }
+        parent = [self.view getParent:parent];
+    }
+
+    if (hasValidationPassed) {
+        sender.backgroundColor = UIColor.greenColor;
+        [[self.view card] setInputs:gatheredInputs];
+        [self.view.acrActionDelegate didFetchUserResponses:[self.view card] action:self.actionElement];
+    } else if (hasViewChangedForAnyViews && [self.view.acrActionDelegate respondsToSelector:@selector(didChangeViewLayout:newFrame:)]) {
+        [self.view.acrActionDelegate didChangeViewLayout:CGRectNull newFrame:CGRectNull];
+    }
+}
+@end
+
+@implementation ACRCustomSubmitTargetBuilder
+
++ (ACRCustomSubmitTargetBuilder *)getInstance
+{
+    static ACRCustomSubmitTargetBuilder *singletonInstance = [[self alloc] init];
+    return singletonInstance;
+}
+
+- (NSObject *)build:(ACOBaseActionElement *)action
+           director:(ACRTargetBuilderDirector *)director
+{
+    return [[ACRCustomSubmitTarget alloc] initWithActionElement:action rootView:director.rootView];
+}
+
+- (NSObject *)build:(ACOBaseActionElement *)action
+           director:(ACRTargetBuilderDirector *)director
+          ForButton:(UIButton *)button
+{
+    NSObject *target = [self build:action director:director];
+    if (target) {
+        [button addTarget:target
+                      action:@selector(send:)
+            forControlEvents:UIControlEventTouchUpInside];
+    }
+    return target;
+}
+
+@end

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ACRCustomSubmitTargetBuilder.mm
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ACRCustomSubmitTargetBuilder.mm
@@ -13,9 +13,22 @@
 @end
 
 @implementation ACRCustomSubmitTarget
-- (IBAction)send:(UIButton *)sender
+
+- (void)doIfValidationPassed:(ACOInputResults *)results button:(UIButton *)button
 {
+    [super doIfValidationPassed:results button:button];
+    button.backgroundColor = UIColor.grayColor;
 }
+
+- (void)doIfValidationFailed:(ACOInputResults *)result button:(UIButton *)button
+{
+    if (result) {
+        if (result.hasViewChangedForAnyViews && [super.view.acrActionDelegate respondsToSelector:@selector(didChangeViewLayout:newFrame:)]) {
+            [super.view.acrActionDelegate didChangeViewLayout:CGRectNull newFrame:CGRectNull];
+        }
+    }
+}
+
 @end
 
 @implementation ACRCustomSubmitTargetBuilder

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ACRCustomSubmitTargetBuilder.mm
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ACRCustomSubmitTargetBuilder.mm
@@ -20,13 +20,10 @@
     button.backgroundColor = UIColor.grayColor;
 }
 
-- (void)doIfValidationFailed:(ACOInputResults *)result button:(UIButton *)button
+- (void)doIfValidationFailed:(ACOInputResults *)results button:(UIButton *)button
 {
-    if (result) {
-        if (result.hasViewChangedForAnyViews && [super.view.acrActionDelegate respondsToSelector:@selector(didChangeViewLayout:newFrame:)]) {
-            [super.view.acrActionDelegate didChangeViewLayout:CGRectNull newFrame:CGRectNull];
-        }
-    }
+    [super doIfValidationFailed:results button:button];
+    button.backgroundColor = UIColor.redColor;
 }
 
 @end

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ACRCustomSubmitTargetBuilder.mm
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ACRCustomSubmitTargetBuilder.mm
@@ -6,6 +6,7 @@
 
 #import "ACRCustomSubmitTargetBuilder.h"
 #import <AdaptiveCards/ACRAggregateTarget.h>
+#import <AdaptiveCards/ACRInputLabelView.h>
 #import <AdaptiveCards/ACRTargetBuilderDirector.h>
 #import <AdaptiveCards/ACRViewPrivate.h>
 
@@ -24,6 +25,26 @@
 {
     [super doIfValidationFailed:results button:button];
     button.backgroundColor = UIColor.redColor;
+}
+
+- (void)updateInputUI:(ACOInputResults *)result button:(UIButton *)button;
+{
+    [super updateInputUI:result button:button];
+
+    for (id<ACRIBaseInputHandler> input in result.gatheredInputs) {
+        ACRInputLabelView *inputLabelView = (ACRInputLabelView *)input;
+        if ([inputLabelView isKindOfClass:[ACRInputLabelView class]]) {
+            if (![result isInputValid:input]) {
+                inputLabelView.inputView.layer.borderWidth = 5.0f;
+                inputLabelView.inputView.layer.cornerRadius = 2.0f;
+                inputLabelView.inputView.layer.borderColor = UIColor.purpleColor.CGColor;
+            } else {
+                inputLabelView.inputView.layer.borderWidth = 0.0f;
+                inputLabelView.inputView.layer.cornerRadius = 0.0f;
+                inputLabelView.inputView.layer.borderColor = nil;
+            }
+        }
+    }
 }
 
 @end

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ViewController.m
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ViewController.m
@@ -6,6 +6,7 @@
 //
 
 #import "ViewController.h"
+#import "ACRCustomSubmitTargetBuilder.h"
 #import "ADCResolver.h"
 #import "AdaptiveCards/ACRButton.h"
 #import "AdaptiveFileBrowserSource.h"
@@ -125,6 +126,7 @@ const CGFloat kAdaptiveCardsWidth = 330;
         [registration setBaseCardElementRenderer:[CustomImageRenderer getInstance]
                                  cardElementType:ACRImage];
 
+        [[ACRTargetBuilderRegistration getInstance] setTargetBuilder:[ACRCustomSubmitTargetBuilder getInstance] actionElementType:ACRSubmit capability:ACRAction];
         _enableCustomRendererButton.backgroundColor = UIColor.redColor;
         _defaultRenderer = [registration getActionSetRenderer];
         [registration setActionSetRenderer:self];

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ViewController.m
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ViewController.m
@@ -8,6 +8,7 @@
 #import "ViewController.h"
 #import "ACRCustomSubmitTargetBuilder.h"
 #import "ADCResolver.h"
+#import "AdaptiveCards/ACRAggregateTarget.h"
 #import "AdaptiveCards/ACRButton.h"
 #import "AdaptiveFileBrowserSource.h"
 #import "CustomActionNewType.h"
@@ -465,6 +466,19 @@ const CGFloat kAdaptiveCardsWidth = 330;
 - (void)didChangeViewLayout:(CGRect)oldFrame newFrame:(CGRect)newFrame
 {
     [self.scrView scrollRectToVisible:newFrame animated:YES];
+}
+
+- (void)didChangeViewLayout:(CGRect)oldFrame newFrame:(CGRect)newFrame properties:(NSDictionary *)properties
+{
+    NSString *actiontype = (NSString *)properties[ACRAggregateTargetActionType];
+    if ([actiontype isEqualToString:ACRAggregateTargetSubmitAction]) {
+        UIView *focusedView = properties[ACRAggregateTargetFirstResponder];
+        if (focusedView && [focusedView isKindOfClass:[UIView class]]) {
+            [self.scrView setContentOffset:focusedView.frame.origin animated:YES];
+        }
+    } else {
+        [self.scrView scrollRectToVisible:newFrame animated:YES];
+    }
 }
 
 - (void)didChangeVisibility:(UIButton *)button isVisible:(BOOL)isVisible

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards.xcodeproj/project.pbxproj
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards.xcodeproj/project.pbxproj
@@ -120,6 +120,8 @@
 		6BCE4B252108FA7D00021A62 /* ACRMediaRenderer.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6BCE4B242108FA7C00021A62 /* ACRMediaRenderer.mm */; };
 		6BCE4B272108FA9300021A62 /* ACRLongPressGestureRecognizerFactory.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6BCE4B262108FA9300021A62 /* ACRLongPressGestureRecognizerFactory.mm */; };
 		6BCE4B292108FBD800021A62 /* ACRLongPressGestureRecognizerFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BCE4B282108FBD800021A62 /* ACRLongPressGestureRecognizerFactory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6BD025ED254784670009B019 /* ACOInputResults.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BD025EB254784660009B019 /* ACOInputResults.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6BD025EE254784670009B019 /* ACOInputResults.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6BD025EC254784670009B019 /* ACOInputResults.mm */; };
 		6BD90D8E24C37D5900B040FB /* ACRInputLabelViewPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BD90D8D24C37D5900B040FB /* ACRInputLabelViewPrivate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6BD90D9024C64EBE00B040FB /* ACRInputLabelView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6BD90D8F24C64EBE00B040FB /* ACRInputLabelView.xib */; };
 		6BE8DFD2249C45C9005EFE66 /* ACRToggleInputView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6BE8DFD1249C45C9005EFE66 /* ACRToggleInputView.xib */; };
@@ -469,6 +471,8 @@
 		6BCE4B242108FA7C00021A62 /* ACRMediaRenderer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ACRMediaRenderer.mm; sourceTree = "<group>"; };
 		6BCE4B262108FA9300021A62 /* ACRLongPressGestureRecognizerFactory.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ACRLongPressGestureRecognizerFactory.mm; sourceTree = "<group>"; };
 		6BCE4B282108FBD800021A62 /* ACRLongPressGestureRecognizerFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ACRLongPressGestureRecognizerFactory.h; sourceTree = "<group>"; };
+		6BD025EB254784660009B019 /* ACOInputResults.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ACOInputResults.h; sourceTree = "<group>"; };
+		6BD025EC254784670009B019 /* ACOInputResults.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ACOInputResults.mm; sourceTree = "<group>"; };
 		6BD90D8D24C37D5900B040FB /* ACRInputLabelViewPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ACRInputLabelViewPrivate.h; sourceTree = "<group>"; };
 		6BD90D8F24C64EBE00B040FB /* ACRInputLabelView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ACRInputLabelView.xib; sourceTree = "<group>"; };
 		6BE8DFD1249C45C9005EFE66 /* ACRToggleInputView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ACRToggleInputView.xib; sourceTree = "<group>"; };
@@ -981,6 +985,8 @@
 		F42979321F30074900E89914 /* Inputs */ = {
 			isa = PBXGroup;
 			children = (
+				6BD025EB254784660009B019 /* ACOInputResults.h */,
+				6BD025EC254784670009B019 /* ACOInputResults.mm */,
 				F495FC092022A18F0093D4DE /* ACRChoiceSetViewDataSource.h */,
 				F495FC082022A18F0093D4DE /* ACRChoiceSetViewDataSource.mm */,
 				F495FC0D2022AC920093D4DE /* ACRChoiceSetViewDataSourceCompactStyle.h */,
@@ -1326,6 +1332,7 @@
 				F423C0C61EE1FBAA00905679 /* ACFramework.h in Headers */,
 				6BD90D8E24C37D5900B040FB /* ACRInputLabelViewPrivate.h in Headers */,
 				6B94F2DD24C7997D00E2B310 /* ACRTextInputHandler.h in Headers */,
+				6BD025ED254784670009B019 /* ACOInputResults.h in Headers */,
 				6B250FB2253F5F8F007FFCFB /* ACRTargetBuilder.h in Headers */,
 				6B5E9CBB24B644B100757882 /* ACRToggleInputView.h in Headers */,
 			);
@@ -1552,6 +1559,7 @@
 				6B94F2DE24C7997D00E2B310 /* ACRTextInputHandler.mm in Sources */,
 				F448730B1EE2261F00FCAFAE /* Fact.cpp in Sources */,
 				6BCE4B272108FA9300021A62 /* ACRLongPressGestureRecognizerFactory.mm in Sources */,
+				6BD025EE254784670009B019 /* ACOInputResults.mm in Sources */,
 				F495FC0E2022AC920093D4DE /* ACRChoiceSetViewDataSourceCompactStyle.mm in Sources */,
 				F4F44B7D20478C5C00A2F24C /* DateTimePreparser.cpp in Sources */,
 				F4F44BA0204CED2400A2F24C /* ACRCustomRenderer.mm in Sources */,

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards.xcodeproj/project.pbxproj
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		6B2242AF22334452000ACDA1 /* TextRun.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6B2242AA22334451000ACDA1 /* TextRun.cpp */; };
 		6B2242B022334452000ACDA1 /* Inline.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B2242AB22334451000ACDA1 /* Inline.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6B2242B422334492000ACDA1 /* Inline.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6B2242B322334492000ACDA1 /* Inline.cpp */; };
+		6B250FB2253F5F8F007FFCFB /* ACRTargetBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B250FB1253F5F8E007FFCFB /* ACRTargetBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6B268FE720CF19E200D99C1B /* RemoteResourceInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B268FE620CF19E100D99C1B /* RemoteResourceInformation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6B27CD6324BD343C00C0F90F /* ACRInputTableView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6B27CD6224BD343C00C0F90F /* ACRInputTableView.xib */; };
 		6B27CD6624BD52D600C0F90F /* ACRInputLabelView.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B27CD6424BD52D500C0F90F /* ACRInputLabelView.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -399,6 +400,7 @@
 		6B2242AA22334451000ACDA1 /* TextRun.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TextRun.cpp; path = ../../../../shared/cpp/ObjectModel/TextRun.cpp; sourceTree = "<group>"; };
 		6B2242AB22334451000ACDA1 /* Inline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Inline.h; path = ../../../../shared/cpp/ObjectModel/Inline.h; sourceTree = "<group>"; };
 		6B2242B322334492000ACDA1 /* Inline.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Inline.cpp; path = ../../../../shared/cpp/ObjectModel/Inline.cpp; sourceTree = "<group>"; };
+		6B250FB1253F5F8E007FFCFB /* ACRTargetBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ACRTargetBuilder.h; sourceTree = "<group>"; };
 		6B268FE620CF19E100D99C1B /* RemoteResourceInformation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RemoteResourceInformation.h; path = ../../../../shared/cpp/ObjectModel/RemoteResourceInformation.h; sourceTree = "<group>"; };
 		6B27CD6224BD343C00C0F90F /* ACRInputTableView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ACRInputTableView.xib; sourceTree = "<group>"; };
 		6B27CD6424BD52D500C0F90F /* ACRInputLabelView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ACRInputLabelView.h; sourceTree = "<group>"; };
@@ -821,8 +823,6 @@
 				F4CAE7851F75B25C00545555 /* ACRRendererPrivate.h */,
 				F49683501F6CA24600DF0D3A /* ACRRenderResult.h */,
 				F49683511F6CA24600DF0D3A /* ACRRenderResult.mm */,
-				6B696CD823202B1A00E1D607 /* ACRTargetBuilderDirector.h */,
-				6B696CD723202B1A00E1D607 /* ACRTargetBuilderDirector.mm */,
 				F4960C022051FE8000780566 /* ACRView.h */,
 				F4960C032051FE8100780566 /* ACRView.mm */,
 				F4D06948205B27E9003645E4 /* ACRViewController.h */,
@@ -1028,6 +1028,9 @@
 		F42979331F30079D00E89914 /* Actions */ = {
 			isa = PBXGroup;
 			children = (
+				6B250FB1253F5F8E007FFCFB /* ACRTargetBuilder.h */,
+				6B696CD823202B1A00E1D607 /* ACRTargetBuilderDirector.h */,
+				6B696CD723202B1A00E1D607 /* ACRTargetBuilderDirector.mm */,
 				6B616C4121CB20D1003E29CE /* ACRActionToggleVisibilityRenderer.h */,
 				6B22425B21E80647000ACDA1 /* ACOParseContext.h */,
 				6B22425C21E80647000ACDA1 /* ACOParseContext.mm */,
@@ -1323,6 +1326,7 @@
 				F423C0C61EE1FBAA00905679 /* ACFramework.h in Headers */,
 				6BD90D8E24C37D5900B040FB /* ACRInputLabelViewPrivate.h in Headers */,
 				6B94F2DD24C7997D00E2B310 /* ACRTextInputHandler.h in Headers */,
+				6B250FB2253F5F8F007FFCFB /* ACRTargetBuilder.h in Headers */,
 				6B5E9CBB24B644B100757882 /* ACRToggleInputView.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACFramework.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACFramework.h
@@ -42,6 +42,7 @@ FOUNDATION_EXPORT const unsigned char AdaptiveCarsFrameworkVersionString[];
 #import <AdaptiveCards/ACRImageSetRenderer.h>
 #import <AdaptiveCards/ACRInputChoiceSetRenderer.h>
 #import <AdaptiveCards/ACRInputDateRenderer.h>
+#import <AdaptiveCards/ACRInputLabelView.h>
 #import <AdaptiveCards/ACRInputNumberRenderer.h>
 #import <AdaptiveCards/ACRInputRenderer.h>
 #import <AdaptiveCards/ACRInputTimeRenderer.h>
@@ -54,8 +55,7 @@ FOUNDATION_EXPORT const unsigned char AdaptiveCarsFrameworkVersionString[];
 #import <AdaptiveCards/ACRRenderer.h>
 #import <AdaptiveCards/ACRRichTextBlockRenderer.h>
 #import <AdaptiveCards/ACRTextBlockRenderer.h>
+#import <AdaptiveCards/ACRTextInputHandler.h>
 #import <AdaptiveCards/ACRTextView.h>
 #import <AdaptiveCards/ACRToggleInputView.h>
 #import <AdaptiveCards/ACRView.h>
-#import <AdaptiveCards/ACRInputLabelView.h>
-#import <AdaptiveCards/ACRTextInputHandler.h>

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACFramework.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACFramework.h
@@ -18,6 +18,7 @@ FOUNDATION_EXPORT const unsigned char AdaptiveCarsFrameworkVersionString[];
 #import <AdaptiveCards/ACOHostConfig.h>
 #import <AdaptiveCards/ACOHostConfigParseResult.h>
 #import <AdaptiveCards/ACOIResourceResolver.h>
+#import <AdaptiveCards/ACOInputResults.h>
 #import <AdaptiveCards/ACOMediaEvent.h>
 #import <AdaptiveCards/ACORemoteResourceInformation.h>
 #import <AdaptiveCards/ACOResourceResolvers.h>

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOBaseActionElement.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOBaseActionElement.h
@@ -37,6 +37,8 @@ typedef NS_ENUM(NSInteger, ACRIconPlacement) {
 
 - (BOOL)meetsRequirements:(ACOFeatureRegistration *)featureReg;
 
++ (NSNumber *)getKey:(ACRActionType)actionType;
+
 @end
 
 @protocol ACOIBaseActionElementParser

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOBaseActionElement.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOBaseActionElement.mm
@@ -54,7 +54,8 @@ using namespace AdaptiveCards;
         std::stringstream sstream;
         writer->write(blob, &sstream);
         NSString *jsonString =
-        [[NSString alloc] initWithCString:sstream.str().c_str() encoding:NSUTF8StringEncoding];
+            [[NSString alloc] initWithCString:sstream.str().c_str()
+                                     encoding:NSUTF8StringEncoding];
         return (jsonString.length > 0) ? [jsonString dataUsingEncoding:NSUTF8StringEncoding] : nil;
     }
     return nil;
@@ -101,6 +102,26 @@ using namespace AdaptiveCards;
         return _elem->MeetsRequirements(*sharedFReg.get());
     }
     return false;
+}
+
++ (NSNumber *)getKey:(ACRActionType)actionType
+{
+    NSNumber *key = nil;
+    switch (actionType) {
+        case ACRShowCard:
+            key = [NSNumber numberWithInt:static_cast<int>(ActionType::ShowCard)];
+        case ACRSubmit:
+            key = [NSNumber numberWithInt:static_cast<int>(ActionType::Submit)];
+        case ACROpenUrl:
+            key = [NSNumber numberWithInt:static_cast<int>(ActionType::OpenUrl)];
+        case ACRToggleVisibility:
+            key = [NSNumber numberWithInt:static_cast<int>(ActionType::ToggleVisibility)];
+        case ACRUnknownAction:
+        default:
+            key = [NSNumber numberWithInt:static_cast<int>(ActionType::UnknownAction)];
+    }
+
+    return key;
 }
 
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOBaseActionElement.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOBaseActionElement.mm
@@ -110,12 +110,16 @@ using namespace AdaptiveCards;
     switch (actionType) {
         case ACRShowCard:
             key = [NSNumber numberWithInt:static_cast<int>(ActionType::ShowCard)];
+            break;
         case ACRSubmit:
             key = [NSNumber numberWithInt:static_cast<int>(ActionType::Submit)];
+            break;
         case ACROpenUrl:
             key = [NSNumber numberWithInt:static_cast<int>(ActionType::OpenUrl)];
+            break;
         case ACRToggleVisibility:
             key = [NSNumber numberWithInt:static_cast<int>(ActionType::ToggleVisibility)];
+            break;
         case ACRUnknownAction:
         default:
             key = [NSNumber numberWithInt:static_cast<int>(ActionType::UnknownAction)];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOInputResults.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOInputResults.h
@@ -1,0 +1,25 @@
+//
+//  ACOInputResults.h
+//  ACOInputResults
+//
+//  Copyright © 2020 Microsoft. All rights reserved.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import "ACRIBaseInputHandler.h"
+#import "ACRView.h"
+#import <UIKit/UIKit.h>
+
+@interface ACOInputResults : NSObject
+
+@property NSObject<ACRIBaseInputHandler> *firstFailedInput;
+@property NSMutableArray<ACRIBaseInputHandler> *gatheredInputs;
+@property BOOL hasValidationPassed;
+@property BOOL hasViewChangedForAnyViews;
+
+- (instancetype)init:(ACRView *)rootView parent:(ACRColumnView *)parent;
+- (void)validateInput;
+//- (UIView *)getInputView:(NSObject<ACRIBaseInputHandler> *)input;
+
+@end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOInputResults.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOInputResults.h
@@ -13,13 +13,13 @@
 
 @interface ACOInputResults : NSObject
 
-@property NSObject<ACRIBaseInputHandler> *firstFailedInput;
+@property (weak) id<ACRIBaseInputHandler> firstFailedInput;
 @property NSMutableArray<ACRIBaseInputHandler> *gatheredInputs;
 @property BOOL hasValidationPassed;
 @property BOOL hasViewChangedForAnyViews;
 
 - (instancetype)init:(ACRView *)rootView parent:(ACRColumnView *)parent;
 - (void)validateInput;
-//- (UIView *)getInputView:(NSObject<ACRIBaseInputHandler> *)input;
+- (BOOL)isInputValid:(id<ACRIBaseInputHandler>)input;
 
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOInputResults.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOInputResults.mm
@@ -1,0 +1,53 @@
+//
+//  ACOInputResults.mm
+//  ACOInputResults
+//
+//  Copyright © 2020 Microsoft. All rights reserved.
+//
+//
+
+#import "ACOInputResults.h"
+#import "ACRViewPrivate.h"
+
+@implementation ACOInputResults {
+    __weak ACRView *_view;
+    __weak ACRColumnView *_currentShowcard;
+}
+
+- (instancetype)init:(ACRView *)rootView parent:(ACRColumnView *)parent
+{
+    self = [super init];
+    if (self) {
+        _view = rootView;
+        _currentShowcard = parent;
+        _gatheredInputs = [[NSMutableArray<ACRIBaseInputHandler> alloc] init];
+    }
+    return self;
+}
+
+- (void)validateInput
+{
+    self.hasValidationPassed = YES;
+    self.hasViewChangedForAnyViews = NO;
+    NSError *error = nil;
+
+    ACRColumnView *parent = _currentShowcard;
+
+    while (parent) {
+        NSMutableArray<ACRIBaseInputHandler> *inputs = parent.inputHandlers;
+        for (id<ACRIBaseInputHandler> input in inputs) {
+            BOOL validationResult = [input validate:&error];
+            [_gatheredInputs addObject:input];
+            if (self.hasValidationPassed && !validationResult) {
+                [input setFocus:YES view:nil];
+            } else {
+                [input setFocus:NO view:nil];
+            }
+            self.hasValidationPassed &= validationResult;
+            self.hasViewChangedForAnyViews |= input.hasVisibilityChanged;
+        }
+        parent = [_view getParent:parent];
+    }
+}
+
+@end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOInputResults.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOInputResults.mm
@@ -12,6 +12,7 @@
 @implementation ACOInputResults {
     __weak ACRView *_view;
     __weak ACRColumnView *_currentShowcard;
+    NSHashTable *_set;
 }
 
 - (instancetype)init:(ACRView *)rootView parent:(ACRColumnView *)parent
@@ -21,6 +22,7 @@
         _view = rootView;
         _currentShowcard = parent;
         _gatheredInputs = [[NSMutableArray<ACRIBaseInputHandler> alloc] init];
+        _set = [[NSHashTable alloc] initWithOptions:NSHashTableWeakMemory capacity:5];
     }
     return self;
 }
@@ -39,15 +41,23 @@
             BOOL validationResult = [input validate:&error];
             [_gatheredInputs addObject:input];
             if (self.hasValidationPassed && !validationResult) {
-                [input setFocus:YES view:nil];
+                self.firstFailedInput = input;
             } else {
                 [input setFocus:NO view:nil];
+            }
+            if (validationResult) {
+                [_set addObject:input];
             }
             self.hasValidationPassed &= validationResult;
             self.hasViewChangedForAnyViews |= input.hasVisibilityChanged;
         }
         parent = [_view getParent:parent];
     }
+}
+
+- (BOOL)isInputValid:(id<ACRIBaseInputHandler>)input
+{
+    return [_set containsObject:input];
 }
 
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionDelegate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionDelegate.h
@@ -17,5 +17,6 @@
 - (void)didLoadElements;
 - (void)didChangeVisibility:(UIButton *)button isVisible:(BOOL)isVisible;
 - (void)didChangeViewLayout:(CGRect)oldFrame newFrame:(CGRect)newFrame;
+- (void)didChangeViewLayout:(CGRect)oldFrame newFrame:(CGRect)newFrame properties:(NSDictionary *)properties;
 
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRAggregateTarget.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRAggregateTarget.h
@@ -23,7 +23,7 @@
 
 - (void)doIfValidationPassed:(ACOInputResults *)results button:(UIButton *)button;
 
-- (void)doIfValidationFailed:(ACOInputResults *)result button:(UIButton *)button;
+- (void)doIfValidationFailed:(ACOInputResults *)results button:(UIButton *)button;
 
 - (void)doSelectAction;
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRAggregateTarget.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRAggregateTarget.h
@@ -7,6 +7,7 @@
 
 #import "ACRIContentHoldingView.h"
 #import "ACRLongPressGestureRecognizerEventHandler.h"
+#import "ACOInputResults.h"
 #import "ACRView.h"
 #import <UIKit/UIKit.h>
 
@@ -15,9 +16,14 @@
 @property ACOBaseActionElement *actionElement;
 @property (weak) ACRView *view;
 @property (weak) ACRColumnView *currentShowcard;
+
 - (instancetype)initWithActionElement:(ACOBaseActionElement *)actionElement rootView:(ACRView *)rootView;
 
 - (IBAction)send:(UIButton *)sender;
+
+- (void)doIfValidationPassed:(ACOInputResults *)results button:(UIButton *)button;
+
+- (void)doIfValidationFailed:(ACOInputResults *)result button:(UIButton *)button;
 
 - (void)doSelectAction;
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRAggregateTarget.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRAggregateTarget.h
@@ -25,6 +25,8 @@
 
 - (void)doIfValidationFailed:(ACOInputResults *)results button:(UIButton *)button;
 
+- (void)updateInputUI:(ACOInputResults *)result button:(UIButton *)button;
+
 - (void)doSelectAction;
 
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRAggregateTarget.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRAggregateTarget.h
@@ -12,7 +12,9 @@
 
 // AggregateTraget is used to relay the signal back to host
 @interface ACRAggregateTarget : NSObject <ACRSelectActionDelegate>
-
+@property ACOBaseActionElement *actionElement;
+@property (weak) ACRView *view;
+@property (weak) ACRColumnView *currentShowcard;
 - (instancetype)initWithActionElement:(ACOBaseActionElement *)actionElement rootView:(ACRView *)rootView;
 
 - (IBAction)send:(UIButton *)sender;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRAggregateTarget.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRAggregateTarget.h
@@ -11,7 +11,18 @@
 #import "ACRView.h"
 #import <UIKit/UIKit.h>
 
+// keys used in retrieving values from properties that are dispatced by
+// didChangeViewLayout: newFrame: properties:
+// possible values contained in the properties
+// a key that retreives an ActionType
+extern NSString *const ACRAggregateTargetActionType;
+// a possible value of ActionType key, SubmitAction
+extern NSString *const ACRAggregateTargetSubmitAction;
+// a key that retreives a view that is a FirstResponder in AdaptiveCards as a result of a submit action on the card
+extern NSString *const ACRAggregateTargetFirstResponder;
+
 // AggregateTraget is used to relay the signal back to host
+// It's associated with Action.Submit
 @interface ACRAggregateTarget : NSObject <ACRSelectActionDelegate>
 @property ACOBaseActionElement *actionElement;
 @property (weak) ACRView *view;
@@ -19,12 +30,13 @@
 
 - (instancetype)initWithActionElement:(ACOBaseActionElement *)actionElement rootView:(ACRView *)rootView;
 
+// It's the event handler when the button referenced by sender is activated
 - (IBAction)send:(UIButton *)sender;
-
+// it's the method called when input validation succeed
 - (void)doIfValidationPassed:(ACOInputResults *)results button:(UIButton *)button;
-
+// it's the method called when input validation failed
 - (void)doIfValidationFailed:(ACOInputResults *)results button:(UIButton *)button;
-
+// it's called after input gathering is done, and does UI updates for inputs UI
 - (void)updateInputUI:(ACOInputResults *)result button:(UIButton *)button;
 
 - (void)doSelectAction;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRAggregateTarget.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRAggregateTarget.mm
@@ -13,11 +13,7 @@
 #import "ACRViewPrivate.h"
 #import <UIKit/UIKit.h>
 
-@implementation ACRAggregateTarget {
-    ACOBaseActionElement *_actionElement;
-    __weak ACRView *_view;
-    __weak ACRColumnView *_currentShowcard;
-}
+@implementation ACRAggregateTarget
 
 - (instancetype)initWithActionElement:(ACOBaseActionElement *)actionElement rootView:(ACRView *)rootView;
 {

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRAggregateTarget.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRAggregateTarget.mm
@@ -30,6 +30,9 @@
 - (IBAction)send:(UIButton *)sender
 {
     ACOInputResults *result = [_view dispatchAndValidateInput:_currentShowcard];
+
+    [self updateInputUI:result button:sender];
+
     if (result.hasValidationPassed) {
         [self doIfValidationPassed:result button:sender];
     } else {
@@ -51,6 +54,13 @@
         if (result.hasViewChangedForAnyViews && [_view.acrActionDelegate respondsToSelector:@selector(didChangeViewLayout:newFrame:)]) {
             [_view.acrActionDelegate didChangeViewLayout:CGRectNull newFrame:CGRectNull];
         }
+    }
+}
+
+- (void)updateInputUI:(ACOInputResults *)result button:(UIButton *)button
+{
+    if (result && !result.hasValidationPassed) {
+        [result.firstFailedInput setFocus:YES view:nil];
     }
 }
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRAggregateTarget.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRAggregateTarget.mm
@@ -28,6 +28,14 @@
 
 - (IBAction)send:(UIButton *)sender
 {
+    [self validateInput];
+    [self updateUI];
+    [self dispatchUserInput];
+    [self dispatchUserInput];
+}
+
+- (NSMutableArray *)validateInput
+{
     BOOL hasValidationPassed = YES;
     BOOL hasViewChangedForAnyViews = NO;
     NSError *error = nil;
@@ -50,11 +58,29 @@
         }
         parent = [_view getParent:parent];
     }
+    return gatheredInputs;
+}
 
-    if (hasValidationPassed) {
-        [[_view card] setInputs:gatheredInputs];
-        [_view.acrActionDelegate didFetchUserResponses:[_view card] action:_actionElement];
-    } else if (hasViewChangedForAnyViews && [_view.acrActionDelegate respondsToSelector:@selector(didChangeViewLayout:newFrame:)]) {
+//    if (hasValidationPassed) {
+//        [[_view card] setInputs:gatheredInputs];
+//        [_view.acrActionDelegate didFetchUserResponses:[_view card] action:_actionElement];
+//    } else if (hasViewChangedForAnyViews && [_view.acrActionDelegate respondsToSelector:@selector(didChangeViewLayout:newFrame:)]) {
+//        [_view.acrActionDelegate didChangeViewLayout:CGRectNull newFrame:CGRectNull];
+//    }
+
+- (void)updateUI
+{
+}
+
+- (void)dispatchUserInput
+{
+    [[_view card] setInputs:gatheredInputs];
+    [_view.acrActionDelegate didFetchUserResponses:[_view card] action:_actionElement];
+}
+
+- (void)notifyLayoutChage
+{
+    if (hasViewChangedForAnyViews && [_view.acrActionDelegate respondsToSelector:@selector(didChangeViewLayout:newFrame:)]) {
         [_view.acrActionDelegate didChangeViewLayout:CGRectNull newFrame:CGRectNull];
     }
 }

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.h
@@ -12,6 +12,7 @@
 @property (weak, nonatomic) IBOutlet UILabel *errorMessage;
 @property (weak, nonatomic) IBOutlet UILabel *label;
 @property (strong, nonatomic) IBOutlet UIStackView *stack;
+@property (weak, nonatomic) UIView *inputView;
 @property (strong, nonatomic) NSObject <ACRIBaseInputHandler> *dataSource;
 @property BOOL isRequired;
 @property BOOL hasErrorMessage;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.mm
@@ -101,6 +101,7 @@
         self.errorMessage.hidden = YES;
 
         [self.stack insertArrangedSubview:inputView atIndex:1];
+        self.inputView = inputView;
         NSObject<ACRIBaseInputHandler> *inputHandler = [self getInputHandler];
         inputHandler.isRequired = self.isRequired;
         inputHandler.hasValidationProperties |= inputHandler.isRequired;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRegistration.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRegistration.h
@@ -9,7 +9,7 @@
 
 #import "ACOBaseCardElement.h"
 #import "ACRBaseActionElementRenderer.h"
-#import "ACRTargetBuilderDirector.h"
+#import "ACRTargetBuilder.h"
 
 @interface ACRRegistration : NSObject
 
@@ -54,8 +54,8 @@
 - (nonnull NSString *)getFeatureVersion:(nullable NSString *)featureName;
 @end
 
-@interface ACOTargetBuilderRegistration: NSObject
-+ (ACOTargetBuilderRegistration *_Nonnull)getInstance;
+@interface ACRTargetBuilderRegistration: NSObject
++ (ACRTargetBuilderRegistration *_Nonnull)getInstance;
 - (ACRTargetBuilder *_Nullable)getTargetBuilder:(ACRActionType)actionElementType capability:(ACRTargetCapability)capability;
 - (void)setTargetBuilder:(ACRTargetBuilder*_Nullable)targetBuilder actionElementType:(ACRActionType)actionElementType capability:(ACRTargetCapability)capability;
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRegistration.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRegistration.h
@@ -9,6 +9,7 @@
 
 #import "ACOBaseCardElement.h"
 #import "ACRBaseActionElementRenderer.h"
+#import "ACRTargetBuilderDirector.h"
 
 @interface ACRRegistration : NSObject
 
@@ -27,7 +28,6 @@
 - (void)setActionSetRenderer:(id<ACRIBaseActionSetRenderer>_Nullable)actionsetRenderer;
 
 - (void)setCustomElementParser:(NSObject<ACOIBaseCardElementParser> *_Nonnull)customElementPars_Nonnuller key:(NSString *_Nonnull)key;
-;
 
 - (NSObject<ACOIBaseCardElementParser> *_Nullable)getCustomElementParser:(NSString *_Nonnull)key;
 
@@ -52,4 +52,10 @@
 - (void)addFeature:(nullable NSString *)featureName featureVersion:(nullable NSString *)version;
 - (void)removeFeature:(nullable NSString *)featureName;
 - (nonnull NSString *)getFeatureVersion:(nullable NSString *)featureName;
+@end
+
+@interface ACOTargetBuilderRegistration: NSObject
++ (ACOTargetBuilderRegistration *_Nonnull)getInstance;
+- (ACRTargetBuilder *_Nullable)getTargetBuilder:(ACRActionType)actionElementType capability:(ACRTargetCapability)capability;
+- (void)setTargetBuilder:(ACRTargetBuilder*_Nullable)targetBuilder actionElementType:(ACRActionType)actionElementType capability:(ACRTargetCapability)capability;
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRegistration.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRegistration.mm
@@ -282,6 +282,7 @@ using namespace AdaptiveCards;
 }
 @end
 
+
 @interface ACRActionTargetBuildersList : NSObject
 
 @property ACRTargetCapability capability;
@@ -356,7 +357,7 @@ using namespace AdaptiveCards;
 @end
 
 @implementation
-    ACOTargetBuilderRegistration : NSObject {
+    ACRTargetBuilderRegistration {
     ACRActionTargetBuildersList *_actionsTargetBuildersList;
     ACRActionTargetBuildersList *_selectActionsTargetBuildersList;
     ACRActionTargetBuildersList *_quickReplyTargetBuildersList;
@@ -373,9 +374,9 @@ using namespace AdaptiveCards;
     return self;
 }
 
-+ (ACOTargetBuilderRegistration *_Nonnull)getInstance
++ (ACRTargetBuilderRegistration *_Nonnull)getInstance
 {
-    static ACOTargetBuilderRegistration *singletonInstance = [[self alloc] init];
+    static ACRTargetBuilderRegistration *singletonInstance = [[self alloc] init];
     return singletonInstance;
 }
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTargetBuilder.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTargetBuilder.h
@@ -1,0 +1,50 @@
+//
+//  ACRTargetBuilder.h
+//  AdaptiveCards
+//
+//  Copyright © 2020 Microsoft. All rights reserved.
+//
+
+#import "ACRView.h"
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSInteger, ACRTargetCapability) {
+    ACRAction = 0,
+    ACRSelectAction,
+    ACRQuickReply,
+};
+
+@class ACRTargetBuilderDirector;
+
+@protocol ACRITargetBuilder
+
+- (NSObject *)build:(ACOBaseActionElement *)action
+           director:(ACRTargetBuilderDirector *)director;
+- (NSObject *)build:(ACOBaseActionElement *)action
+           director:(ACRTargetBuilderDirector *)director
+          ForButton:(UIButton *)button;
+
+@end
+
+// provides singleton interface
+@interface ACRTargetBuilder : NSObject <ACRITargetBuilder>
+
++ (ACRTargetBuilder *)getInstance;
+
+@end
+
+// build target for submit and openUrl actions
+@interface ACRAggregateTargetBuilder : ACRTargetBuilder
+@end
+
+@interface ACRShowCardTargetBuilder : ACRTargetBuilder
+@end
+
+@interface ACRToggleVisibilityTargetBuilder : ACRTargetBuilder
+@end
+
+// build target for unknown actions
+@interface ACRUnknownActionTargetBuilder : ACRTargetBuilder
+@end
+
+

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTargetBuilderDirector.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTargetBuilderDirector.h
@@ -8,54 +8,17 @@
 #import "ACOBaseActionElementPrivate.h"
 #import "ACRView.h"
 #import <Foundation/Foundation.h>
+#import "ACRTargetBuilder.h"
 
 // protocol all TargetBuild should implement
 @interface ACRTargetBuilderDirector : NSObject
 // indicates types of target director is allowed to build
 @property __weak ACRView *rootView;
 @property __weak ACOHostConfig *adaptiveHostConfig;
-
-typedef NS_ENUM(NSInteger, ACRTargetCapability) {
-    ACRAction = 0,
-    ACRSelectAction,
-    ACRQuickReply,
-};
+@property (readonly) ACRTargetCapability capability;
 
 - (instancetype)init:(ACRView *)rootView capability:(ACRTargetCapability)capability adaptiveHostConfig:(ACOHostConfig *)adaptiveHostConfig;
 - (NSObject *)build:(std::shared_ptr<BaseActionElement> const &)action;
 - (NSObject *)build:(std::shared_ptr<BaseActionElement> const &)action forButton:(UIButton *)button;
 
 @end
-
-@protocol ACRITargetBuilder
-
-- (NSObject *)build:(std::shared_ptr<BaseActionElement> const &)action
-           director:(ACRTargetBuilderDirector *)director;
-- (NSObject *)build:(std::shared_ptr<BaseActionElement> const &)action
-           director:(ACRTargetBuilderDirector *)director
-          ForButton:(UIButton *)button;
-
-@end
-
-// provides singleton interface
-@interface ACRTargetBuilder : NSObject <ACRITargetBuilder>
-
-+ (ACRTargetBuilder *)getInstance;
-
-@end
-
-// build target for submit and openUrl actions
-@interface ACRAggregateTargetBuilder : ACRTargetBuilder
-@end
-
-@interface ACRShowCardTargetBuilder : ACRTargetBuilder
-@end
-
-@interface ACRToggleVisibilityTargetBuilder : ACRTargetBuilder
-@end
-
-// build target for unknown actions
-@interface ACRUnknownActionTargetBuilder : ACRTargetBuilder
-@end
-
-

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTargetBuilderDirector.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTargetBuilderDirector.h
@@ -9,6 +9,7 @@
 #import "ACRView.h"
 #import <Foundation/Foundation.h>
 
+// protocol all TargetBuild should implement
 @interface ACRTargetBuilderDirector : NSObject
 // indicates types of target director is allowed to build
 @property __weak ACRView *rootView;
@@ -25,3 +26,36 @@ typedef NS_ENUM(NSInteger, ACRTargetCapability) {
 - (NSObject *)build:(std::shared_ptr<BaseActionElement> const &)action forButton:(UIButton *)button;
 
 @end
+
+@protocol ACRITargetBuilder
+
+- (NSObject *)build:(std::shared_ptr<BaseActionElement> const &)action
+           director:(ACRTargetBuilderDirector *)director;
+- (NSObject *)build:(std::shared_ptr<BaseActionElement> const &)action
+           director:(ACRTargetBuilderDirector *)director
+          ForButton:(UIButton *)button;
+
+@end
+
+// provides singleton interface
+@interface ACRTargetBuilder : NSObject <ACRITargetBuilder>
+
++ (ACRTargetBuilder *)getInstance;
+
+@end
+
+// build target for submit and openUrl actions
+@interface ACRAggregateTargetBuilder : ACRTargetBuilder
+@end
+
+@interface ACRShowCardTargetBuilder : ACRTargetBuilder
+@end
+
+@interface ACRToggleVisibilityTargetBuilder : ACRTargetBuilder
+@end
+
+// build target for unknown actions
+@interface ACRUnknownActionTargetBuilder : ACRTargetBuilder
+@end
+
+

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTargetBuilderDirector.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTargetBuilderDirector.mm
@@ -30,29 +30,12 @@
 //  in UtiliOS.h, buildTarget and buildTargetForButton
 
 #import "ACRTargetBuilderDirector.h"
+#import "ACOBaseActionElement.h"
 #import "ACRAggregateTarget.h"
 #import "ACRErrors.h"
 #import "ACRShowCardTarget.h"
 #import "ACRToggleVisibilityTarget.h"
 #import "UtiliOS.h"
-
-// protocol all TargetBuild should implement
-@protocol ACRITargetBuilder
-
-- (NSObject *)build:(std::shared_ptr<BaseActionElement> const &)action
-           director:(ACRTargetBuilderDirector *)director;
-- (NSObject *)build:(std::shared_ptr<BaseActionElement> const &)action
-           director:(ACRTargetBuilderDirector *)director
-          ForButton:(UIButton *)button;
-
-@end
-
-// provides singleton interface
-@interface ACRTargetBuilder : NSObject <ACRITargetBuilder>
-
-+ (ACRTargetBuilder *)getInstance;
-
-@end
 
 @implementation ACRTargetBuilder
 
@@ -83,10 +66,6 @@
 
 @end
 
-// build target for submit and openUrl actions
-@interface ACRAggregateTargetBuilder : ACRTargetBuilder
-@end
-
 @implementation ACRAggregateTargetBuilder
 
 + (ACRAggregateTargetBuilder *)getInstance
@@ -103,9 +82,6 @@
     return [[ACRAggregateTarget alloc] initWithActionElement:acoElem rootView:director.rootView];
 }
 
-@end
-
-@interface ACRShowCardTargetBuilder : ACRTargetBuilder
 @end
 
 @implementation ACRShowCardTargetBuilder
@@ -137,9 +113,6 @@
     return nil;
 }
 
-@end
-
-@interface ACRToggleVisibilityTargetBuilder : ACRTargetBuilder
 @end
 
 @implementation ACRToggleVisibilityTargetBuilder
@@ -177,10 +150,6 @@
     return target;
 }
 
-@end
-
-// build target for unknown actions
-@interface ACRUnknownActionTargetBuilder : ACRTargetBuilder
 @end
 
 @implementation ACRUnknownActionTargetBuilder
@@ -223,38 +192,6 @@
     if (self) {
         self.rootView = rootView;
         self.adaptiveHostConfig = adaptiveHostConfig;
-        NSNumber *openUrl = [NSNumber numberWithInt:static_cast<int>(ActionType::OpenUrl)];
-        NSNumber *submit = [NSNumber numberWithInt:static_cast<int>(ActionType::Submit)];
-        NSNumber *showcard = [NSNumber numberWithInt:static_cast<int>(ActionType::ShowCard)];
-        NSNumber *toggle = [NSNumber numberWithInt:static_cast<int>(ActionType::ToggleVisibility)];
-        NSNumber *unknown = [NSNumber numberWithInt:static_cast<int>(ActionType::UnknownAction)];
-
-        // target capability lists supported events and corresponding target builders
-        switch (capability) {
-            case ACRAction:
-                _builders = @{
-                    openUrl : [ACRAggregateTargetBuilder getInstance],
-                    submit : [ACRAggregateTargetBuilder getInstance],
-                    showcard : [ACRShowCardTargetBuilder getInstance],
-                    toggle : [ACRToggleVisibilityTargetBuilder getInstance]
-                };
-                break;
-            case ACRSelectAction:
-                _builders = @{
-                    openUrl : [ACRAggregateTargetBuilder getInstance],
-                    submit : [ACRAggregateTargetBuilder getInstance],
-                    toggle : [ACRToggleVisibilityTargetBuilder getInstance],
-                    unknown : [ACRUnknownActionTargetBuilder getInstance]
-                };
-                break;
-            case ACRQuickReply:
-                _builders = @{
-                    openUrl : [ACRAggregateTargetBuilder getInstance],
-                    submit : [ACRAggregateTargetBuilder getInstance],
-                    toggle : [ACRToggleVisibilityTargetBuilder getInstance]
-                };
-                break;
-        }
     }
     return self;
 }
@@ -291,7 +228,7 @@
 - (ACRTargetBuilder *)getBuilder:(std::shared_ptr<BaseActionElement> const &)action
 {
     NSNumber *key = [NSNumber numberWithInt:static_cast<int>(action->GetElementType())];
-    return _builders[key];
+     return _builders[key];
 }
 
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm
@@ -776,4 +776,11 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
     return showcard;
 }
 
+- (ACOInputResults *)dispatchAndValidateInput:(ACRColumnView *)parent
+{
+    ACOInputResults *result = [[ACOInputResults alloc] init:self parent:parent];
+    [result validateInput];
+    return result;
+}
+
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRViewPrivate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRViewPrivate.h
@@ -7,6 +7,7 @@
 //
 
 #import "ACRErrors.h"
+#import "ACOInputResults.h"
 #import "ACRTargetBuilderDirector.h"
 #import "ACRView.h"
 #import "ActionParserRegistration.h"
@@ -69,4 +70,6 @@ typedef void (^ObserverActionBlockForBaseAction)(NSObject<ACOIResourceResolver> 
 - (void)popCurrentShowcard;
 
 - (ACRColumnView *)peekCurrentShowCard;
+
+- (ACOInputResults *)dispatchAndValidateInput:(ACRColumnView *)parent;
 @end


### PR DESCRIPTION
## Related Issue
Fixed #4888

## Description
#4888 asked for sending a ref to a button, so it can be configured on input submission. Our team's general consensus is that we need to take a long term view and review other renderers for us to change the behaviors of the existing action delegates that are common to other renderers. This PR adds a registration for event handlers aka targets in iOS builders. Users can register event handler builders as they would with the renderer.  When implemented the builder interface, the builder builds the event handler and can attach the handler to the associated button. This change also includes sample code for demonstration purposes. The demo code will turn the submit action button to green when clicked when custom rendering is enabled in the sample app.
## How Verified
How you verified the fix, including one or all of the following: 
1. Unit tests are run.
2. Cards with actions were ran
3. Added sample code to the sample app to verify that users can register a target builder.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4943)