### PR TITLE
Updated layout notification to include properties

### DIFF
--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ACRCustomSubmitTargetBuilder.mm
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ACRCustomSubmitTargetBuilder.mm
@@ -23,7 +23,17 @@
 
 - (void)doIfValidationFailed:(ACOInputResults *)results button:(UIButton *)button
 {
-    [super doIfValidationFailed:results button:button];
+    if (results) {
+        if ([self.view.acrActionDelegate respondsToSelector:@selector(didChangeViewLayout:newFrame:properties:)]) {
+            UIView *viewToFocus = (UIView *)results.firstFailedInput;
+            NSDictionary *prop = @{@"actiontype" : @"submit", @"firstResponder" : results.firstFailedInput};
+            if (viewToFocus) {
+                [self.view.acrActionDelegate didChangeViewLayout:CGRectNull newFrame:viewToFocus.frame properties:prop];
+            } else {
+                [self.view.acrActionDelegate didChangeViewLayout:CGRectNull newFrame:CGRectNull properties:prop];
+            }
+        }
+    }
     button.backgroundColor = UIColor.redColor;
 }
 

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ViewController.m
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ViewController.m
@@ -462,6 +462,16 @@ const CGFloat kAdaptiveCardsWidth = 330;
     [self.scrView scrollRectToVisible:newFrame animated:YES];
 }
 
+- (void)didChangeViewLayout:(CGRect)oldFrame newFrame:(CGRect)newFrame properties:(NSDictionary *)properties
+{
+    NSString *actiontype = (NSString *)properties[@"actiontype"];
+    if ([actiontype isEqualToString:@"submit"]) {
+        [self.scrView setContentOffset:newFrame.origin animated:YES];
+    } else {
+    [self.scrView scrollRectToVisible:newFrame animated:YES];
+    }
+}
+
 - (void)didChangeVisibility:(UIButton *)button isVisible:(BOOL)isVisible
 {
     if (isVisible) {

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ViewController.m
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ViewController.m
@@ -8,6 +8,7 @@
 #import "ViewController.h"
 #import "ACRCustomSubmitTargetBuilder.h"
 #import "ADCResolver.h"
+#import "AdaptiveCards/ACRAggregateTarget.h"
 #import "AdaptiveCards/ACRButton.h"
 #import "AdaptiveFileBrowserSource.h"
 #import "CustomActionNewType.h"
@@ -464,11 +465,14 @@ const CGFloat kAdaptiveCardsWidth = 330;
 
 - (void)didChangeViewLayout:(CGRect)oldFrame newFrame:(CGRect)newFrame properties:(NSDictionary *)properties
 {
-    NSString *actiontype = (NSString *)properties[@"actiontype"];
-    if ([actiontype isEqualToString:@"submit"]) {
-        [self.scrView setContentOffset:newFrame.origin animated:YES];
+    NSString *actiontype = (NSString *)properties[ACRAggregateTargetActionType];
+    if ([actiontype isEqualToString:ACRAggregateTargetSubmitAction]) {
+        UIView *focusedView = properties[ACRAggregateTargetFirstResponder];
+        if (focusedView && [focusedView isKindOfClass:[UIView class]]) {
+            [self.scrView setContentOffset:focusedView.frame.origin animated:YES];
+        }
     } else {
-    [self.scrView scrollRectToVisible:newFrame animated:YES];
+        [self.scrView scrollRectToVisible:newFrame animated:YES];
     }
 }
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionDelegate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionDelegate.h
@@ -17,5 +17,6 @@
 - (void)didLoadElements;
 - (void)didChangeVisibility:(UIButton *)button isVisible:(BOOL)isVisible;
 - (void)didChangeViewLayout:(CGRect)oldFrame newFrame:(CGRect)newFrame;
+- (void)didChangeViewLayout:(CGRect)oldFrame newFrame:(CGRect)newFrame properties:(NSDictionary *)properties;
 
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRAggregateTarget.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRAggregateTarget.h
@@ -11,7 +11,18 @@
 #import "ACRView.h"
 #import <UIKit/UIKit.h>
 
+// keys used in retrieving values from properties that are dispatced by
+// didChangeViewLayout: newFrame: properties:
+// possible values contained in the properties
+// a key that retreives an ActionType
+extern NSString *const ACRAggregateTargetActionType;
+// a possible value of ActionType key, SubmitAction
+extern NSString *const ACRAggregateTargetSubmitAction;
+// a key that retreives a view that is a FirstResponder in AdaptiveCards as a result of a submit action on the card
+extern NSString *const ACRAggregateTargetFirstResponder;
+
 // AggregateTraget is used to relay the signal back to host
+// It's associated with Action.Submit
 @interface ACRAggregateTarget : NSObject <ACRSelectActionDelegate>
 @property ACOBaseActionElement *actionElement;
 @property (weak) ACRView *view;
@@ -19,12 +30,13 @@
 
 - (instancetype)initWithActionElement:(ACOBaseActionElement *)actionElement rootView:(ACRView *)rootView;
 
+// It's the event handler when the button referenced by sender is activated
 - (IBAction)send:(UIButton *)sender;
-
+// it's the method called when input validation succeed
 - (void)doIfValidationPassed:(ACOInputResults *)results button:(UIButton *)button;
-
+// it's the method called when input validation failed
 - (void)doIfValidationFailed:(ACOInputResults *)results button:(UIButton *)button;
-
+// it's called after input gathering is done, and does UI updates for inputs UI
 - (void)updateInputUI:(ACOInputResults *)result button:(UIButton *)button;
 
 - (void)doSelectAction;


### PR DESCRIPTION
## Related Issue
Fixed #4890 
## Description
Added layout update notification to include custom properties, so the user of this delegate include custom properties to enable them to do things like setting an input view or a label to be focused. The sample app can scroll to the correct input view with additional param passed from the notification.

## How Verified
How you verified the fix, including one or all of the following: 
1. Tested with sample cards for regression check
2. Updated sample app to demonstrate the new feature 



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4944)