### PR TITLE
Updated accessiblity for Inputs

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSource.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSource.mm
@@ -27,6 +27,7 @@ NSString *uncheckedRadioButtonReuseID = @"unchecked-radiobutton";
     BOOL _shouldWrap;
     std::shared_ptr<HostConfig> _config;
     CGSize _contentSize;
+    NSString *_accessibilityString;
 }
 
 - (instancetype)initWithInputChoiceSet:(std::shared_ptr<AdaptiveCards::ChoiceSetInput> const &)choiceSet WithHostConfig:(std::shared_ptr<AdaptiveCards::HostConfig> const &)hostConfig;
@@ -105,7 +106,12 @@ NSString *uncheckedRadioButtonReuseID = @"unchecked-radiobutton";
     cell.textLabel.text = title;
     cell.textLabel.numberOfLines = _choiceSetDataSource->GetWrap() ? 0 : 1;
     cell.textLabel.textColor = getForegroundUIColorFromAdaptiveAttribute(_config, _parentStyle);
+    if (!_accessibilityString) {
+        _accessibilityString = tableView.accessibilityLabel;
+        tableView.accessibilityLabel = nil;
+    }
     cell.accessibilityTraits = cell.accessibilityTraits | UIAccessibilityTraitButton;
+    cell.accessibilityLabel = [NSString stringWithFormat:@"%@, %@", _accessibilityString, title];
 
     return cell;
 }
@@ -230,7 +236,10 @@ NSString *uncheckedRadioButtonReuseID = @"unchecked-radiobutton";
 
 - (void)setFocus:(BOOL)shouldBecomeFirstResponder view:(UIView *)view
 {
-    [ACRInputLabelView commonSetFocus:shouldBecomeFirstResponder view:view];
+    if (shouldBecomeFirstResponder) {
+        UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, view);
+        [ACRInputLabelView commonSetFocus:shouldBecomeFirstResponder view:view];
+    }        
 }
 
 - (NSString *)getTitlesOfChoices

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSourceCompactStyle.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSourceCompactStyle.mm
@@ -24,11 +24,14 @@ static NSString *pickerCell = @"pickerCell";
     NSMutableDictionary<NSString *, NSString *> *_titlesMap;
     NSString *_defaultString;
     NSString *_userSelectedTitle;
+    NSString *_inputLabel;
+    NSString *_errorLabel;
     NSInteger _userSelectedRow;
     BOOL _showPickerView;
     CGFloat _pickerViewHeight;
     NSString *_textInCompactView;
     CGFloat _compactViewHeight;
+    BOOL _isValid;
 }
 
 - (instancetype)initWithInputChoiceSet:(std::shared_ptr<AdaptiveCards::ChoiceSetInput> const &)choiceSet
@@ -44,6 +47,7 @@ static NSString *pickerCell = @"pickerCell";
         _delegate = (NSObject<UITableViewDelegate> *)_dataSource;
         _showPickerView = NO;
         _defaultString = [NSString stringWithCString:choiceSet->GetPlaceholder().c_str() encoding:NSUTF8StringEncoding];
+        _isValid = YES;
 
         NSBundle *bundle = [NSBundle bundleWithIdentifier:@"MSFT.AdaptiveCards"];
         [bundle loadNibNamed:@"ACRPickerView" owner:rootView options:nil];
@@ -54,6 +58,16 @@ static NSString *pickerCell = @"pickerCell";
                                                     encoding:NSUTF8StringEncoding];
         NSMutableArray *mutableArrayStrings = [[NSMutableArray alloc] init];
         NSInteger index = 0;
+        auto inputLabel = _choiceSetInput->GetLabel();
+        if (!inputLabel.empty()) {
+            _inputLabel = [NSString stringWithCString:inputLabel.c_str() encoding:NSUTF8StringEncoding];
+        }
+        
+        auto errorLabel = _choiceSetInput->GetErrorMessage();
+        if (!errorLabel.empty()) {
+            _errorLabel = [NSString stringWithCString:errorLabel.c_str() encoding:NSUTF8StringEncoding];
+        }
+        
         for (auto choice : _choiceSetInput->GetChoices()) {
             NSString *title = [NSString stringWithCString:choice->GetTitle().c_str() encoding:NSUTF8StringEncoding];
             NSString *value = [NSString stringWithCString:choice->GetValue().c_str() encoding:NSUTF8StringEncoding];
@@ -106,8 +120,7 @@ static NSString *pickerCell = @"pickerCell";
         } else {
             cell.textLabel.text = _defaultString;
         }
-
-        tableView.accessibilityHint = cell.textLabel.text;
+        
         _textInCompactView = cell.textLabel.text;
         cell.textLabel.numberOfLines = 0;
         cell.textLabel.adjustsFontSizeToFitWidth = NO;
@@ -115,6 +128,16 @@ static NSString *pickerCell = @"pickerCell";
         cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
         [cell setSelectionStyle:UITableViewCellSelectionStyleNone];
         cell.backgroundColor = UIColor.clearColor;
+        // validate and set appropriate error message
+        if (_errorLabel) {
+            if (!_isValid) {
+                cell.accessibilityLabel = [NSString stringWithFormat:@"%@, %@", _inputLabel, _errorLabel];
+            } else {
+                cell.accessibilityLabel = _inputLabel;
+            }
+        } else {
+            cell.accessibilityLabel = _inputLabel;
+        }
     } else {
         cell = [tableView dequeueReusableCellWithIdentifier:pickerCell];
         UIPickerView *pickerView = nil;
@@ -126,11 +149,14 @@ static NSString *pickerCell = @"pickerCell";
         } else {
             pickerView = [cell viewWithTag:pickerViewId];
         }
+        cell.accessibilityLabel = nil;
         pickerView.dataSource = self;
         pickerView.delegate = self;
         pickerView.hidden = NO;
         [pickerView selectRow:_userSelectedRow inComponent:0 animated:NO];
     }
+    
+    cell.accessibilityTraits = UIAccessibilityTraitStaticText;
     return cell;
 }
 
@@ -186,7 +212,6 @@ static NSString *pickerCell = @"pickerCell";
                     }
                 }
                 completion:^(BOOL finished) {
-                    ;
                     [tableView reloadData];
                     pickerView.hidden = YES;
                 }];
@@ -220,11 +245,12 @@ static NSString *pickerCell = @"pickerCell";
 - (BOOL)validate:(NSError **)error
 {
     if (self.isRequired) {
-        BOOL result = !(!_userSelectedTitle || [_userSelectedTitle isEqualToString:_defaultString]);
-        return result;
+        _isValid = !(!_userSelectedTitle || [_userSelectedTitle isEqualToString:_defaultString]);
+        return _isValid;
     }
+    _isValid = YES;
     // no need to validate
-    return YES;
+    return _isValid;
 }
 
 - (void)getInput:(NSMutableDictionary *)dictionary
@@ -235,8 +261,8 @@ static NSString *pickerCell = @"pickerCell";
 - (void)setFocus:(BOOL)shouldBecomeFirstResponder view:(UITableView *)tableView
 {
     if (shouldBecomeFirstResponder) {
+        UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, tableView);
         [tableView becomeFirstResponder];
-        [self tableView:tableView didSelectRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0]];
     } else {
         [tableView resignFirstResponder];
     }
@@ -261,6 +287,7 @@ static NSString *pickerCell = @"pickerCell";
 {
     return [_titles objectAtIndex:row];
 }
+
 @synthesize isRequired;
 @synthesize hasValidationProperties;
 @synthesize hasVisibilityChanged;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSourceCompactStyle.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSourceCompactStyle.mm
@@ -106,6 +106,8 @@ static NSString *pickerCell = @"pickerCell";
         } else {
             cell.textLabel.text = _defaultString;
         }
+
+        tableView.accessibilityHint = cell.textLabel.text;
         _textInCompactView = cell.textLabel.text;
         cell.textLabel.numberOfLines = 0;
         cell.textLabel.adjustsFontSizeToFitWidth = NO;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSourceCompactStyle.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSourceCompactStyle.mm
@@ -248,8 +248,8 @@ static NSString *pickerCell = @"pickerCell";
         _isValid = !(!_userSelectedTitle || [_userSelectedTitle isEqualToString:_defaultString]);
         return _isValid;
     }
-    _isValid = YES;
     // no need to validate
+    _isValid = YES;    
     return _isValid;
 }
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputChoiceSetRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputChoiceSetRenderer.mm
@@ -60,12 +60,10 @@
 
     choiceSetView.delegate = dataSource;
     choiceSetView.dataSource = dataSource;
-
-    ACRInputLabelView *inputLabelView = [[ACRInputLabelView alloc] initInputLabelView:rootView acoConfig:acoConfig adptiveInputElement:choiceSet inputView:choiceSetView viewGroup:viewGroup dataSource:dataSource];
-
-    choiceSetView.isAccessibilityElement = YES;
-    choiceSetView.accessibilityLabel = [inputLabelView.labelText string];
-
+    
+    ACRInputLabelView *inputLabelView = [[ACRInputLabelView alloc] initInputLabelView:rootView acoConfig:acoConfig adptiveInputElement:choiceSet inputView:choiceSetView accessibilityItem:choiceSetView viewGroup:viewGroup dataSource:dataSource];
+    choiceSetView.isAccessibilityElement = NO;
+    choiceSetView.shouldGroupAccessibilityChildren = YES;
     [inputs addObject:inputLabelView];
 
     if (elem->GetHeight() == HeightType::Stretch) {

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputChoiceSetRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputChoiceSetRenderer.mm
@@ -62,6 +62,10 @@
     choiceSetView.dataSource = dataSource;
 
     ACRInputLabelView *inputLabelView = [[ACRInputLabelView alloc] initInputLabelView:rootView acoConfig:acoConfig adptiveInputElement:choiceSet inputView:choiceSetView viewGroup:viewGroup dataSource:dataSource];
+
+    choiceSetView.isAccessibilityElement = YES;
+    choiceSetView.accessibilityLabel = [inputLabelView.labelText string];
+
     [inputs addObject:inputLabelView];
 
     if (elem->GetHeight() == HeightType::Stretch) {

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputDateRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputDateRenderer.mm
@@ -39,6 +39,9 @@
 
     ACRInputLabelView *inputLabelView = [[ACRInputLabelView alloc] initInputLabelView:rootView acoConfig:acoConfig adptiveInputElement:dateInput inputView:dateField viewGroup:viewGroup dataSource:nil];
 
+    dateField.isAccessibilityElement = YES;
+    dateField.accessibilityLabel = [inputLabelView.labelText string];
+
     if (elem->GetHeight() == HeightType::Stretch) {
         ACRColumnView *inputContainer = [[ACRColumnView alloc] init];
         [inputContainer addArrangedSubview:inputLabelView];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputDateRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputDateRenderer.mm
@@ -37,11 +37,9 @@
     std::shared_ptr<BaseInputElement> dateInput = std::dynamic_pointer_cast<BaseInputElement>(elem);
     ACRDateTextField *dateField = [[ACRDateTextField alloc] initWithTimeDateInput:dateInput dateStyle:NSDateFormatterShortStyle];
 
-    ACRInputLabelView *inputLabelView = [[ACRInputLabelView alloc] initInputLabelView:rootView acoConfig:acoConfig adptiveInputElement:dateInput inputView:dateField viewGroup:viewGroup dataSource:nil];
-
-    dateField.isAccessibilityElement = YES;
-    dateField.accessibilityLabel = [inputLabelView.labelText string];
-
+    ACRInputLabelView *inputLabelView = [[ACRInputLabelView alloc] initInputLabelView:rootView acoConfig:acoConfig adptiveInputElement:dateInput inputView:dateField accessibilityItem:dateField.inputView viewGroup:viewGroup dataSource:nil];
+    dateField.accessibilityTraits = UIAccessibilityTraitButton | UIAccessibilityTraitStaticText;
+    
     if (elem->GetHeight() == HeightType::Stretch) {
         ACRColumnView *inputContainer = [[ACRColumnView alloc] init];
         [inputContainer addArrangedSubview:inputLabelView];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.h
@@ -11,7 +11,8 @@
 @interface ACRInputLabelView : UIView <ACRIBaseInputHandler>
 @property (weak, nonatomic) IBOutlet UILabel *errorMessage;
 @property (weak, nonatomic) IBOutlet UILabel *label;
-@property NSMutableAttributedString *labelText;
+@property NSString *labelText;
+@property (weak, nonatomic) UIView *inputAccessibilityItem;
 @property (strong, nonatomic) IBOutlet UIStackView *stack;
 @property (strong, nonatomic) NSObject <ACRIBaseInputHandler> *dataSource;
 @property BOOL isRequired;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.h
@@ -11,6 +11,7 @@
 @interface ACRInputLabelView : UIView <ACRIBaseInputHandler>
 @property (weak, nonatomic) IBOutlet UILabel *errorMessage;
 @property (weak, nonatomic) IBOutlet UILabel *label;
+@property NSMutableAttributedString *labelText;
 @property (strong, nonatomic) IBOutlet UIStackView *stack;
 @property (strong, nonatomic) NSObject <ACRIBaseInputHandler> *dataSource;
 @property BOOL isRequired;
@@ -19,7 +20,6 @@
 @property IBInspectable CGFloat validationFailBorderRadius;
 @property IBInspectable CGFloat validationFailBorderWidth;
 @property IBInspectable CGFloat validationSuccessBorderWidth;
-
 
 + (void)commonSetFocus:(BOOL)shouldBecomeFirstResponder view:(UIView *)view;
 + (BOOL)commonTextUIValidate:(BOOL)isRequired hasText:(BOOL)hasText predicate:(NSPredicate *)predicate text:(NSString *)text error:(NSError *__autoreleasing *)error;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.mm
@@ -87,6 +87,7 @@
         }
 
         self.label.attributedText = attributedLabel;
+        self.labelText = attributedLabel;
 
         std::string errorMessage = inputBlck->GetErrorMessage();
         if (!errorMessage.empty()) {
@@ -101,13 +102,15 @@
         self.errorMessage.hidden = YES;
 
         [self.stack insertArrangedSubview:inputView atIndex:1];
+        self.label.isAccessibilityElement = NO;
+        self.shouldGroupAccessibilityChildren = YES;
         NSObject<ACRIBaseInputHandler> *inputHandler = [self getInputHandler];
         inputHandler.isRequired = self.isRequired;
         inputHandler.hasValidationProperties |= inputHandler.isRequired;
         if (inputHandler.hasValidationProperties && errorMessage.empty()) {
             [rootView addWarnings:ACRMissingInputErrorMessage mesage:@"The input has validation, but there is no associated error message, consider adding error message to the input"];
         }
-        
+
         if (self.isRequired && (!self.label || !self.label.text.length)) {
             [rootView addWarnings:ACRMissingInputErrorMessage mesage:@"There exist required input, but there is no associated label with it, consider adding label to the input"];
         }
@@ -149,14 +152,13 @@
     NSObject<ACRIBaseInputHandler> *inputHandler = nil;
     if (self.dataSource && [self.dataSource conformsToProtocol:@protocol(ACRIBaseInputHandler)]) {
         inputHandler = self.dataSource;
-    }
-    else {
+    } else {
         UIView *inputView = [self getInputView];
         if ([inputView conformsToProtocol:@protocol(ACRIBaseInputHandler)]) {
             inputHandler = (NSObject<ACRIBaseInputHandler> *)inputView;
         }
     }
-    
+
     return inputHandler;
 }
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.xib
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.xib
@@ -5,6 +5,7 @@
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -34,13 +35,13 @@
             <rect key="frame" x="0.0" y="0.0" width="110" height="200"/>
             <subviews>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="My Text" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1Ch-uc-lfs">
-                    <rect key="frame" x="0.0" y="0.0" width="110" height="18"/>
+                    <rect key="frame" x="0.0" y="0.0" width="110" height="200"/>
                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="My Error Massage" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UhI-YL-bG4">
-                    <rect key="frame" x="0.0" y="164" width="110" height="36"/>
+                <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="My Error Massage" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UhI-YL-bG4">
+                    <rect key="frame" x="0.0" y="0.0" width="110" height="36"/>
                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelViewPrivate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelViewPrivate.h
@@ -15,6 +15,6 @@ using namespace AdaptiveCards;
 
 @interface ACRInputLabelView()
 
-- (instancetype)initInputLabelView:(ACRView *)rootView acoConfig:(ACOHostConfig *)acoConfig adptiveInputElement:(const std::shared_ptr<BaseInputElement> &)inputBlck inputView:(UIView *)inputView viewGroup:(UIView<ACRIContentHoldingView> *)viewGroup dataSource:(NSObject<ACRIBaseInputHandler> *)dataSource;
+- (instancetype)initInputLabelView:(ACRView *)rootView acoConfig:(ACOHostConfig *)acoConfig adptiveInputElement:(const std::shared_ptr<BaseInputElement> &)inputBlck inputView:(UIView *)inputView accessibilityItem:(UIView *)accessibilityItem viewGroup:(UIView<ACRIContentHoldingView> *)viewGroup dataSource:(NSObject<ACRIBaseInputHandler> *)dataSource;
 
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputNumberRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputNumberRenderer.mm
@@ -11,9 +11,9 @@
 #import "ACRContentHoldingUIView.h"
 #import "ACRInputLabelViewPrivate.h"
 #import "ACRNumericTextField.h"
+#import "ACRTextInputHandler.h"
 #import "NumberInput.h"
 #import "UtiliOS.h"
-#import "ACRTextInputHandler.h"
 
 @implementation ACRInputNumberRenderer
 
@@ -40,13 +40,16 @@
     NSBundle *bundle = [NSBundle bundleWithIdentifier:@"MSFT.AdaptiveCards"];
     ACRNumericTextField *numInput = [bundle loadNibNamed:@"ACRTextNumberField" owner:rootView options:nil][0];
     numInput.placeholder = [NSString stringWithCString:numInputBlck->GetPlaceholder().c_str() encoding:NSUTF8StringEncoding];
-    
+
     ACRNumberInputHandler *numberInputHandler = [[ACRNumberInputHandler alloc] init:acoElem];
-    
+
     numInput.delegate = numberInputHandler;
     numInput.text = numberInputHandler.text;
-    
+
     ACRInputLabelView *inputLabelView = [[ACRInputLabelView alloc] initInputLabelView:rootView acoConfig:acoConfig adptiveInputElement:numInputBlck inputView:numInput viewGroup:viewGroup dataSource:numberInputHandler];
+
+    numInput.isAccessibilityElement = YES;
+    numInput.accessibilityLabel = [inputLabelView.labelText string];
 
     if (elem->GetHeight() == HeightType::Stretch) {
         ACRColumnView *inputContainer = [[ACRColumnView alloc] init];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputNumberRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputNumberRenderer.mm
@@ -46,10 +46,7 @@
     numInput.delegate = numberInputHandler;
     numInput.text = numberInputHandler.text;
 
-    ACRInputLabelView *inputLabelView = [[ACRInputLabelView alloc] initInputLabelView:rootView acoConfig:acoConfig adptiveInputElement:numInputBlck inputView:numInput viewGroup:viewGroup dataSource:numberInputHandler];
-
-    numInput.isAccessibilityElement = YES;
-    numInput.accessibilityLabel = [inputLabelView.labelText string];
+    ACRInputLabelView *inputLabelView = [[ACRInputLabelView alloc] initInputLabelView:rootView acoConfig:acoConfig adptiveInputElement:numInputBlck inputView:numInput accessibilityItem:numInput viewGroup:viewGroup dataSource:numberInputHandler];
 
     if (elem->GetHeight() == HeightType::Stretch) {
         ACRColumnView *inputContainer = [[ACRColumnView alloc] init];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputRenderer.mm
@@ -142,6 +142,9 @@
             inputview = txtview;
         }
         ACRInputLabelView *inputLabelView = [[ACRInputLabelView alloc] initInputLabelView:rootView acoConfig:acoConfig adptiveInputElement:inputBlck inputView:inputview viewGroup:viewGroup dataSource:nil];
+
+        inputview.isAccessibilityElement = YES;
+        inputview.accessibilityLabel = [inputLabelView.labelText string];
         inputview = inputLabelView;
     } else {
         if (renderAction) {
@@ -149,13 +152,17 @@
             quickReplyView = [[ACRQuickReplyView alloc] initWithFrame:CGRectMake(0, 0, viewGroup.frame.size.width, 0)];
             button = quickReplyView.button;
             txtInput = [ACRInputRenderer configTextFiled:inputBlck renderAction:renderAction rootView:rootView viewGroup:viewGroup];
-            [quickReplyView addTextField:txtInput];            
+            [quickReplyView addTextField:txtInput];
             ACRInputLabelView *inputLabelView = [[ACRInputLabelView alloc] initInputLabelView:rootView acoConfig:acoConfig adptiveInputElement:inputBlck inputView:quickReplyView viewGroup:viewGroup dataSource:textInputHandler];
+            quickReplyView.isAccessibilityElement = YES;
+            quickReplyView.accessibilityLabel = [inputLabelView.labelText string];
             inputview = inputLabelView;
 
         } else {
             txtInput = [ACRInputRenderer configTextFiled:inputBlck renderAction:renderAction rootView:rootView viewGroup:viewGroup];
             ACRInputLabelView *inputLabelView = [[ACRInputLabelView alloc] initInputLabelView:rootView acoConfig:acoConfig adptiveInputElement:inputBlck inputView:txtInput viewGroup:viewGroup dataSource:textInputHandler];
+            txtInput.isAccessibilityElement = YES;
+            txtInput.accessibilityLabel = [inputLabelView.labelText string];
             inputview = inputLabelView;
         }
         txtInput.delegate = textInputHandler;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputRenderer.mm
@@ -141,10 +141,7 @@
             [txtview.layer setCornerRadius:5.0f];
             inputview = txtview;
         }
-        ACRInputLabelView *inputLabelView = [[ACRInputLabelView alloc] initInputLabelView:rootView acoConfig:acoConfig adptiveInputElement:inputBlck inputView:inputview viewGroup:viewGroup dataSource:nil];
-
-        inputview.isAccessibilityElement = YES;
-        inputview.accessibilityLabel = [inputLabelView.labelText string];
+        ACRInputLabelView *inputLabelView = [[ACRInputLabelView alloc] initInputLabelView:rootView acoConfig:acoConfig adptiveInputElement:inputBlck inputView:inputview accessibilityItem:inputview viewGroup:viewGroup dataSource:nil];
         inputview = inputLabelView;
     } else {
         if (renderAction) {
@@ -153,16 +150,12 @@
             button = quickReplyView.button;
             txtInput = [ACRInputRenderer configTextFiled:inputBlck renderAction:renderAction rootView:rootView viewGroup:viewGroup];
             [quickReplyView addTextField:txtInput];
-            ACRInputLabelView *inputLabelView = [[ACRInputLabelView alloc] initInputLabelView:rootView acoConfig:acoConfig adptiveInputElement:inputBlck inputView:quickReplyView viewGroup:viewGroup dataSource:textInputHandler];
-            quickReplyView.isAccessibilityElement = YES;
-            quickReplyView.accessibilityLabel = [inputLabelView.labelText string];
+            ACRInputLabelView *inputLabelView = [[ACRInputLabelView alloc] initInputLabelView:rootView acoConfig:acoConfig adptiveInputElement:inputBlck inputView:quickReplyView accessibilityItem:quickReplyView viewGroup:viewGroup dataSource:textInputHandler];
             inputview = inputLabelView;
 
         } else {
             txtInput = [ACRInputRenderer configTextFiled:inputBlck renderAction:renderAction rootView:rootView viewGroup:viewGroup];
-            ACRInputLabelView *inputLabelView = [[ACRInputLabelView alloc] initInputLabelView:rootView acoConfig:acoConfig adptiveInputElement:inputBlck inputView:txtInput viewGroup:viewGroup dataSource:textInputHandler];
-            txtInput.isAccessibilityElement = YES;
-            txtInput.accessibilityLabel = [inputLabelView.labelText string];
+            ACRInputLabelView *inputLabelView = [[ACRInputLabelView alloc] initInputLabelView:rootView acoConfig:acoConfig adptiveInputElement:inputBlck inputView:txtInput accessibilityItem:txtInput viewGroup:viewGroup dataSource:textInputHandler];
             inputview = inputLabelView;
         }
         txtInput.delegate = textInputHandler;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputTimeRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputTimeRenderer.mm
@@ -37,6 +37,10 @@
     ACRDateTextField *field = [[ACRDateTextField alloc] initWithTimeDateInput:timeInput dateStyle:NSDateFormatterNoStyle];
 
     ACRInputLabelView *inputLabelView = [[ACRInputLabelView alloc] initInputLabelView:rootView acoConfig:acoConfig adptiveInputElement:timeInput inputView:field viewGroup:viewGroup dataSource:nil];
+
+    field.isAccessibilityElement = YES;
+    field.accessibilityLabel = [inputLabelView.labelText string];
+
     UIView *renderedview = inputLabelView;
 
     if (viewGroup) {

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputTimeRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputTimeRenderer.mm
@@ -36,11 +36,8 @@
     std::shared_ptr<BaseInputElement> timeInput = std::dynamic_pointer_cast<BaseInputElement>(elem);
     ACRDateTextField *field = [[ACRDateTextField alloc] initWithTimeDateInput:timeInput dateStyle:NSDateFormatterNoStyle];
 
-    ACRInputLabelView *inputLabelView = [[ACRInputLabelView alloc] initInputLabelView:rootView acoConfig:acoConfig adptiveInputElement:timeInput inputView:field viewGroup:viewGroup dataSource:nil];
-
-    field.isAccessibilityElement = YES;
-    field.accessibilityLabel = [inputLabelView.labelText string];
-
+    ACRInputLabelView *inputLabelView = [[ACRInputLabelView alloc] initInputLabelView:rootView acoConfig:acoConfig adptiveInputElement:timeInput inputView:field accessibilityItem:field.inputView viewGroup:viewGroup dataSource:nil];
+    field.accessibilityTraits = UIAccessibilityTraitButton | UIAccessibilityTraitStaticText;    
     UIView *renderedview = inputLabelView;
 
     if (viewGroup) {

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputToggleRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputToggleRenderer.mm
@@ -51,6 +51,8 @@
     toggleView.title.text = [NSString stringWithCString:adaptiveToggleInput->GetTitle().c_str() encoding:NSUTF8StringEncoding];
     toggleView.title.textColor = getForegroundUIColorFromAdaptiveAttribute(config, viewGroup.style);
     toggleView.title.adjustsFontSizeToFitWidth = NO;
+    toggleView.title.isAccessibilityElement = NO;
+
     if (!adaptiveToggleInput->GetWrap()) {
         toggleView.title.numberOfLines = 1;
         toggleView.title.lineBreakMode = NSLineBreakByTruncatingTail;
@@ -64,6 +66,10 @@
     dataSource.toggleSwitch = toggleView.toggle;
 
     ACRInputLabelView *inputLabelView = [[ACRInputLabelView alloc] initInputLabelView:rootView acoConfig:acoConfig adptiveInputElement:adaptiveToggleInput inputView:toggleView viewGroup:viewGroup dataSource:dataSource];
+
+    toggleView.toggle.isAccessibilityElement = YES;
+    toggleView.toggle.accessibilityLabel = [inputLabelView.labelText string];
+    toggleView.toggle.accessibilityHint = toggleView.title.text;
 
     [inputs addObject:inputLabelView];
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputToggleRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputToggleRenderer.mm
@@ -65,11 +65,12 @@
     ACRToggleInputDataSource *dataSource = [[ACRToggleInputDataSource alloc] initWithInputToggle:adaptiveToggleInput WithHostConfig:config];
     dataSource.toggleSwitch = toggleView.toggle;
 
-    ACRInputLabelView *inputLabelView = [[ACRInputLabelView alloc] initInputLabelView:rootView acoConfig:acoConfig adptiveInputElement:adaptiveToggleInput inputView:toggleView viewGroup:viewGroup dataSource:dataSource];
-
-    toggleView.toggle.isAccessibilityElement = YES;
-    toggleView.toggle.accessibilityLabel = [inputLabelView.labelText string];
-    toggleView.toggle.accessibilityHint = toggleView.title.text;
+    ACRInputLabelView *inputLabelView = [[ACRInputLabelView alloc] initInputLabelView:rootView acoConfig:acoConfig adptiveInputElement:adaptiveToggleInput inputView:toggleView accessibilityItem:toggleView.toggle viewGroup:viewGroup dataSource:dataSource];
+    
+    toggleView.isAccessibilityElement = NO;
+    if (toggleView.title.text) {
+        toggleView.toggle.accessibilityLabel = [NSString stringWithFormat:@"%@, %@,", toggleView.toggle.accessibilityLabel, toggleView.title.text];
+    }
 
     [inputs addObject:inputLabelView];
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextView.mm
@@ -111,7 +111,6 @@
     [ACRInputLabelView commonSetFocus:shouldBecomeFirstResponder view:view];
 }
 
-
 - (BOOL)textFieldShouldReturn:(UITextField *)textField
 {
     [self resignFirstResponder];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRToggleInputDataSource.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRToggleInputDataSource.mm
@@ -47,7 +47,8 @@ using namespace AdaptiveCards;
 
 - (void)setFocus:(BOOL)shouldBecomeFirstResponder view:(UIView *)view
 {
-    [ACRInputLabelView commonSetFocus:shouldBecomeFirstResponder view:view];
+    [ACRInputLabelView commonSetFocus:shouldBecomeFirstResponder view:_toggleSwitch];
+    UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, _toggleSwitch);
 }
 
 @synthesize isRequired;


### PR DESCRIPTION
## Related Issue
reference #4898 

## Description
Fixed the VoiceOver issue for iOS. Input's label and input field were treated as disparate units during the VoiceOver, and the input field did not provide the information contained in the input label. 

## How Verified
How you verified the fix, including one or all of the following: 
1. All Input cards in 1.3 were tested and verified.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4951)