### PR TITLE
[Android] Auto sized images scale to dp

### DIFF
--- a/samples/v1.2/Tests/Image.Size.Auto.json
+++ b/samples/v1.2/Tests/Image.Size.Auto.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "type": "AdaptiveCard",
+    "version": "1.2",
+    "body": [
+        {
+            "type": "Image",
+            "url": "https://picsum.photos/300?image=882",
+            "size": "auto",
+            "altText": "Seated guest drinking a cup of coffee"
+        },
+        {
+            "type": "Image",
+            "url": "https://picsum.photos/300?image=882",
+            "size": "auto",
+            "altText": "Seated guest drinking a cup of coffee",
+            "width": "300",
+            "height": "300"
+        }
+    ]
+}

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/BackgroundImageLoaderAsync.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/BackgroundImageLoaderAsync.java
@@ -10,6 +10,7 @@ import android.graphics.Matrix;
 import android.graphics.Paint;
 import android.graphics.Rect;
 import android.graphics.drawable.BitmapDrawable;
+import android.util.DisplayMetrics;
 import android.view.ViewGroup;
 
 import io.adaptivecards.objectmodel.BackgroundImage;
@@ -56,7 +57,7 @@ public class BackgroundImageLoaderAsync extends GenericImageLoaderAsync
             // A 1x1 bitmap is created to avoid the container to have a minimum width/height defined by the actual image
             // When the background is set with setBackground, the layout may grow if the original image is larger than the layout
             super(resources, Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888));
-            m_bitmap = bitmap;
+            m_bitmap = Bitmap.createScaledBitmap(bitmap, Util.dpToPixels(m_context, bitmap.getWidth()), Util.dpToPixels(m_context, bitmap.getHeight()), true);
             m_backgroundImageProperties = backgroundImageProperties;
         }
 

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/GenericImageLoaderAsync.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/GenericImageLoaderAsync.java
@@ -8,6 +8,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.util.DisplayMetrics;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -254,7 +255,9 @@ public abstract class GenericImageLoaderAsync extends AsyncTask<String, Void, Ht
     {
         if (result.isSuccessful())
         {
-            onSuccessfulPostExecute(result.getResult());
+            Bitmap image = result.getResult();
+            image.setDensity(DisplayMetrics.DENSITY_DEFAULT);
+            onSuccessfulPostExecute(image);
         }
         else
         {

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/Util.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/Util.java
@@ -35,6 +35,12 @@ import io.adaptivecards.renderer.inputhandler.BaseInputHandler;
 
 public final class Util {
 
+    /**
+     * Convert dp to px
+     * @param context
+     * @param dp The number of Android dips (display-independent pixels)
+     * @return The number of equivalent physical pixels
+     */
     public static int dpToPixels(Context context, long dp)
     {
         DisplayMetrics metrics = context.getResources().getDisplayMetrics();
@@ -42,6 +48,12 @@ public final class Util {
         return returnVal;
     }
 
+    /**
+     * Convert px to dp
+     * @param context
+     * @param pixels The number of physical pixels
+     * @return The number of equivalent Android dips (display-independent pixels)
+     */
     public static double pixelsToDp(Context context, double pixels)
     {
         return pixels / dpToPixels(context, 1);

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/Util.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/Util.java
@@ -42,6 +42,11 @@ public final class Util {
         return returnVal;
     }
 
+    public static double pixelsToDp(Context context, double pixels)
+    {
+        return pixels / dpToPixels(context, 1);
+    }
+
     public static byte[] getBytes(CharVector charVector)
     {
         long vectorSize = charVector.size();

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/action/ActionElementRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/action/ActionElementRenderer.java
@@ -14,6 +14,7 @@ import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
 import android.support.v4.app.FragmentManager;
+import android.util.DisplayMetrics;
 import android.util.TypedValue;
 import android.view.ContextThemeWrapper;
 import android.view.View;
@@ -99,7 +100,7 @@ public class ActionElementRenderer extends BaseActionElementRenderer
             else
             {
                 // Otherwise, the height of the image should be the height of the action's text
-                imageHeight = button.getTextSize();
+                imageHeight = Util.pixelsToDp(m_context, button.getTextSize());
             }
 
             double scaleRatio = imageHeight / originalDrawableIcon.getIntrinsicHeight();

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/action/ActionElementRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/action/ActionElementRenderer.java
@@ -2,32 +2,23 @@
 // Licensed under the MIT License.
 package io.adaptivecards.renderer.action;
 
-import android.app.Activity;
 import android.content.Context;
-import android.content.ContextWrapper;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
-import android.graphics.Paint;
 import android.graphics.PorterDuff;
-import android.graphics.Rect;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
 import android.support.v4.app.FragmentManager;
-import android.util.DisplayMetrics;
 import android.util.TypedValue;
 import android.view.ContextThemeWrapper;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
-import android.widget.HorizontalScrollView;
 import android.widget.LinearLayout;
-
-import java.util.HashMap;
 
 import io.adaptivecards.R;
 import io.adaptivecards.objectmodel.ActionAlignment;
-import io.adaptivecards.objectmodel.ActionMode;
 import io.adaptivecards.objectmodel.ActionType;
 import io.adaptivecards.objectmodel.ActionsOrientation;
 import io.adaptivecards.objectmodel.BaseActionElement;
@@ -35,20 +26,11 @@ import io.adaptivecards.objectmodel.ContainerStyle;
 import io.adaptivecards.objectmodel.ForegroundColor;
 import io.adaptivecards.objectmodel.HostConfig;
 import io.adaptivecards.objectmodel.IconPlacement;
-import io.adaptivecards.objectmodel.IsVisible;
-import io.adaptivecards.objectmodel.ShowCardAction;
 import io.adaptivecards.objectmodel.SubmitAction;
-import io.adaptivecards.objectmodel.ToggleInput;
-import io.adaptivecards.objectmodel.ToggleVisibilityAction;
-import io.adaptivecards.objectmodel.ToggleVisibilityTarget;
-import io.adaptivecards.objectmodel.ToggleVisibilityTargetVector;
-import io.adaptivecards.renderer.AdaptiveCardRenderer;
 import io.adaptivecards.renderer.BaseActionElementRenderer;
-import io.adaptivecards.renderer.IBaseActionElementRenderer;
 import io.adaptivecards.renderer.InnerImageLoaderAsync;
 import io.adaptivecards.renderer.RenderArgs;
 import io.adaptivecards.renderer.RenderedAdaptiveCard;
-import io.adaptivecards.renderer.TagContent;
 import io.adaptivecards.renderer.Util;
 import io.adaptivecards.renderer.actionhandler.ICardActionHandler;
 


### PR DESCRIPTION
## Related Issue
Fixes #4687 

## Description
A 100px x 150px image, when used in an Image Element (size auto) or a backgroundImage property (w/ tiling enabled), the image now takes up 100dp x 150dp (device-independent pixels) instead of 100px x 150px (physical pixels).

## How Verified
Manually checked `v1.2/Elements/Container.BackgroundImage.json`:

![image](https://user-images.githubusercontent.com/4442788/96905474-7bbaee00-1466-11eb-97e2-881cdf88a2ec.png)

Also added the following test card:

```
{
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
    "type": "AdaptiveCard",
    "version": "1.3",
    "body": [
        {
            "type": "Image",
            "url": "https://picsum.photos/300?image=882",
            "size": "auto",
            "altText": "Seated guest drinking a cup of coffee"
        },
        {
            "type": "Image",
            "url": "https://picsum.photos/300?image=882",
            "size": "auto",
            "altText": "Seated guest drinking a cup of coffee",
            "width": "300",
            "height": "300"
        }
    ]
}
```

The two images have the same size, as expected:

![image](https://user-images.githubusercontent.com/4442788/96905968-29c69800-1467-11eb-8526-ad4b2e71fd52.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4956)