### PR TITLE
[Android][Accessibility] Announce label, errorMessage with inputs

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/BaseActionElementRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/BaseActionElementRenderer.java
@@ -264,7 +264,6 @@ public abstract class BaseActionElementRenderer implements IBaseActionElementRen
             if (m_invisibleCard.getVisibility() == View.VISIBLE)
             {
                 mainCardView.setPadding(padding, padding, padding, 0);
-                m_invisibleCard.requestFocus();
             }
             else
             {
@@ -332,6 +331,10 @@ public abstract class BaseActionElementRenderer implements IBaseActionElementRen
                 if (m_action.GetElementType() == ActionType.Submit)
                 {
                     SubmitAction submitAction = Util.castTo(m_action, SubmitAction.class);
+
+                    // If an input is in focus before submit, and the same input is focused on error,
+                    // the input would not be scrolled into view. Instead, clearing focus first ensures scroll.
+                    Util.clearFocus(v);
 
                     if (!m_renderedAdaptiveCard.areInputsValid(submitAction))
                     {

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/Util.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/Util.java
@@ -54,6 +54,24 @@ public final class Util {
         return byteArray;
     }
 
+    /**
+     * Clear any existing focus by temporarily adding then removing focus to a given helper View.
+     * @param v The helper View that will temporarily grab and release focus.
+     */
+    public static void clearFocus(View v) {
+        boolean focusable = v.isFocusable();
+        boolean focusableInTouchMode = v.isFocusableInTouchMode();
+
+        v.setFocusable(true);
+        v.setFocusableInTouchMode(true);
+
+        v.requestFocusFromTouch();
+        v.clearFocus();
+
+        v.setFocusable(focusable);
+        v.setFocusableInTouchMode(focusableInTouchMode);
+    }
+
     public static void MoveChildrenViews(ViewGroup origin, ViewGroup destination)
     {
         final int childCount = origin.getChildCount();

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/InputUtil.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/InputUtil.java
@@ -5,28 +5,19 @@ import android.text.SpannableStringBuilder;
 import android.view.View;
 import android.widget.TextView;
 
-import io.adaptivecards.objectmodel.BaseCardElement;
-import io.adaptivecards.objectmodel.BaseInputElement;
 import io.adaptivecards.objectmodel.ErrorMessageConfig;
 import io.adaptivecards.objectmodel.FontType;
 import io.adaptivecards.objectmodel.ForegroundColor;
-import io.adaptivecards.objectmodel.HeightType;
 import io.adaptivecards.objectmodel.HostConfig;
 import io.adaptivecards.objectmodel.InputLabelConfig;
-import io.adaptivecards.renderer.BaseCardElementRenderer;
 import io.adaptivecards.renderer.RenderArgs;
-import io.adaptivecards.renderer.TagContent;
-import io.adaptivecards.renderer.inputhandler.BaseInputHandler;
-import io.adaptivecards.renderer.inputhandler.IInputHandler;
-import io.adaptivecards.renderer.layout.StretchableElementLayout;
-import io.adaptivecards.renderer.layout.StretchableInputLayout;
 import io.adaptivecards.renderer.readonly.RendererUtil;
 import io.adaptivecards.renderer.readonly.RichTextBlockRenderer;
 import io.adaptivecards.renderer.readonly.TextBlockRenderer;
 
 public class InputUtil
 {
-    public static View RenderInputLabel(String label, boolean isRequired, Context context, HostConfig hostConfig, RenderArgs renderArgs)
+    public static TextView RenderInputLabel(String label, boolean isRequired, Context context, HostConfig hostConfig, RenderArgs renderArgs)
     {
         SpannableStringBuilder paragraph = new SpannableStringBuilder();
         CharSequence text = RendererUtil.handleSpecialText(label);

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/ValidatedEditText.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/ValidatedEditText.java
@@ -23,8 +23,7 @@ public class ValidatedEditText extends EditText
         m_errorColor = errorColor;
     }
 
-    public void setValidationResult(boolean isValid)
-    {
+    public void setValidationResult(boolean isValid) {
         if (isValid)
         {
             // Change border color to original color

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/BaseInputHandler.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/BaseInputHandler.java
@@ -68,28 +68,7 @@ public abstract class BaseInputHandler implements IInputHandler
         // without labels or error messages will have no inputLayout
         if (m_inputLayout != null)
         {
-            // Get error message and show it or hide it depending on isValid
-            View errorMessage = m_inputLayout.getErrorMessage();
-
-            if (errorMessage != null)
-            {
-                BaseCardElementRenderer.setVisibility(!isValid, errorMessage);
-
-                if (m_view instanceof EditText)
-                {
-                    CharSequence inputHint = "";
-                    if (!isValid)
-                    {
-                        inputHint = ((TextView)errorMessage).getText();
-                    }
-                    ((EditText) m_view).setContentDescription(inputHint);
-                }
-            }
-        }
-
-        if (m_view instanceof ValidatedEditText)
-        {
-            ((ValidatedEditText)m_view).setValidationResult(isValid);
+            m_inputLayout.setValidationResult(isValid);
         }
     }
 

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/CheckBoxSetInputHandler.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/CheckBoxSetInputHandler.java
@@ -2,10 +2,9 @@
 // Licensed under the MIT License.
 package io.adaptivecards.renderer.inputhandler;
 
-import android.text.Layout;
 import android.text.TextUtils;
+import android.view.accessibility.AccessibilityEvent;
 import android.widget.CheckBox;
-import android.widget.LinearLayout;
 
 import io.adaptivecards.objectmodel.BaseInputElement;
 import io.adaptivecards.objectmodel.ChoiceInputVector;
@@ -80,6 +79,7 @@ public class CheckBoxSetInputHandler extends BaseInputHandler
         {
             m_checkBoxList.get(0).setFocusableInTouchMode(true);
             m_checkBoxList.get(0).requestFocus();
+            m_checkBoxList.get(0).sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED);
         }
     }
 

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/CheckBoxSetInputHandler.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/CheckBoxSetInputHandler.java
@@ -79,7 +79,7 @@ public class CheckBoxSetInputHandler extends BaseInputHandler
         {
             m_checkBoxList.get(0).setFocusableInTouchMode(true);
             m_checkBoxList.get(0).requestFocus();
-            m_checkBoxList.get(0).sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED);
+            m_checkBoxList.get(0).sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED);
         }
     }
 

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/ComboBoxInputHandler.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/ComboBoxInputHandler.java
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 package io.adaptivecards.renderer.inputhandler;
 
+import android.view.accessibility.AccessibilityEvent;
 import android.widget.Spinner;
 
 import io.adaptivecards.objectmodel.BaseInputElement;
@@ -61,6 +62,6 @@ public class ComboBoxInputHandler extends BaseInputHandler
     public void setFocusToView()
     {
         m_view.requestFocus();
-        m_view.performClick();
+        m_view.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED);
     }
 }

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/ComboBoxInputHandler.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/ComboBoxInputHandler.java
@@ -62,6 +62,6 @@ public class ComboBoxInputHandler extends BaseInputHandler
     public void setFocusToView()
     {
         m_view.requestFocus();
-        m_view.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED);
+        m_view.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED);
     }
 }

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/RadioGroupInputHandler.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/RadioGroupInputHandler.java
@@ -82,7 +82,7 @@ public class RadioGroupInputHandler extends BaseInputHandler
 
             radioButton.setFocusableInTouchMode(true);
             radioButton.requestFocus();
-            radioButton.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED);
+            radioButton.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED);
         }
     }
 

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/RadioGroupInputHandler.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/RadioGroupInputHandler.java
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 package io.adaptivecards.renderer.inputhandler;
 
+import android.view.accessibility.AccessibilityEvent;
 import android.widget.RadioButton;
 import android.widget.RadioGroup;
 
@@ -81,6 +82,7 @@ public class RadioGroupInputHandler extends BaseInputHandler
 
             radioButton.setFocusableInTouchMode(true);
             radioButton.requestFocus();
+            radioButton.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED);
         }
     }
 

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/TextInputHandler.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/TextInputHandler.java
@@ -67,7 +67,6 @@ public class TextInputHandler extends BaseInputHandler
     public void setFocusToView()
     {
         m_view.requestFocus();
-        m_view.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED);
         m_view.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED);
     }
 }

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/TextInputHandler.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/TextInputHandler.java
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 package io.adaptivecards.renderer.inputhandler;
 
+import android.view.accessibility.AccessibilityEvent;
 import android.widget.EditText;
 
 import java.util.regex.Pattern;
@@ -66,5 +67,7 @@ public class TextInputHandler extends BaseInputHandler
     public void setFocusToView()
     {
         m_view.requestFocus();
+        m_view.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED);
+        m_view.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED);
     }
 }

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/ToggleInputHandler.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/ToggleInputHandler.java
@@ -61,6 +61,6 @@ public class ToggleInputHandler extends BaseInputHandler
     {
         m_view.setFocusableInTouchMode(true);
         m_view.requestFocus();
-        m_view.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED);
+        m_view.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED);
     }
 }

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/ToggleInputHandler.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/inputhandler/ToggleInputHandler.java
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 package io.adaptivecards.renderer.inputhandler;
 
+import android.view.accessibility.AccessibilityEvent;
 import android.widget.CheckBox;
 
 import io.adaptivecards.objectmodel.BaseInputElement;
@@ -60,5 +61,6 @@ public class ToggleInputHandler extends BaseInputHandler
     {
         m_view.setFocusableInTouchMode(true);
         m_view.requestFocus();
+        m_view.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED);
     }
 }

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/layout/StretchableInputLayout.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/layout/StretchableInputLayout.java
@@ -18,15 +18,10 @@ public class StretchableInputLayout extends StretchableElementLayout
     private TextView m_label = null;
     private View m_inputView = null;
     private TextView m_errorMessage = null;
-//    private TextView m_errorLabel;
-    private boolean isValid = true;
 
     public StretchableInputLayout(Context context, boolean mustStretch)
     {
         super(context, mustStretch);
-
-        // Using setContentDescription on EditText is discouraged, so using hidden TextView instead
-//        m_errorLabel = new TextView(context);
     }
 
     public View getLabel()
@@ -49,9 +44,9 @@ public class StretchableInputLayout extends StretchableElementLayout
     {
         addView(input);
         m_inputView = input;
-//        if(m_inputView.getId() == View.NO_ID) {
-//            m_inputView.setId(View.generateViewId());
-//        }
+        if(m_inputView.getId() == View.NO_ID) {
+            m_inputView.setId(View.generateViewId());
+        }
         m_label.setLabelFor(m_inputView.getId());
     }
 
@@ -83,13 +78,4 @@ public class StretchableInputLayout extends StretchableElementLayout
             m_label.setContentDescription(m_label.getText() + " " + m_errorMessage.getText());
         }
     }
-
-//    private void updateAccessbleLabel() {
-//        m_accessibleLabel.removeAllViews();
-//        m_accessibleLabel.addView(m_label);
-//        m_accessibleLabel.addView(m_errorMessage);
-//    }
-
-
-
 }

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/layout/StretchableInputLayout.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/layout/StretchableInputLayout.java
@@ -1,16 +1,32 @@
 package io.adaptivecards.renderer.layout;
 
 import android.content.Context;
+import android.graphics.PorterDuff;
 import android.view.View;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import io.adaptivecards.renderer.BaseCardElementRenderer;
+import io.adaptivecards.renderer.input.ValidatedEditText;
 
 /**
  * This class is only supposed to be used for inputs that have: label, validation, isRequired or stretch height
  */
 public class StretchableInputLayout extends StretchableElementLayout
 {
+    private TextView m_label = null;
+    private View m_inputView = null;
+    private TextView m_errorMessage = null;
+//    private TextView m_errorLabel;
+    private boolean isValid = true;
+
     public StretchableInputLayout(Context context, boolean mustStretch)
     {
         super(context, mustStretch);
+
+        // Using setContentDescription on EditText is discouraged, so using hidden TextView instead
+//        m_errorLabel = new TextView(context);
     }
 
     public View getLabel()
@@ -18,7 +34,7 @@ public class StretchableInputLayout extends StretchableElementLayout
         return m_label;
     }
 
-    public void setLabel(View label)
+    public void setLabel(TextView label)
     {
         addView(label);
         m_label = label;
@@ -33,6 +49,10 @@ public class StretchableInputLayout extends StretchableElementLayout
     {
         addView(input);
         m_inputView = input;
+//        if(m_inputView.getId() == View.NO_ID) {
+//            m_inputView.setId(View.generateViewId());
+//        }
+        m_label.setLabelFor(m_inputView.getId());
     }
 
     public View getErrorMessage()
@@ -40,13 +60,36 @@ public class StretchableInputLayout extends StretchableElementLayout
         return m_errorMessage;
     }
 
-    public void setErrorMessage(View errorMessage)
+    public void setErrorMessage(TextView errorMessage)
     {
         addView(errorMessage);
         m_errorMessage = errorMessage;
+        m_errorMessage.setImportantForAccessibility(IMPORTANT_FOR_ACCESSIBILITY_NO);
     }
 
-    private View m_label = null;
-    private View m_inputView = null;
-    private View m_errorMessage = null;
+    public void setValidationResult(boolean isValid)
+    {
+        BaseCardElementRenderer.setVisibility(!isValid, m_errorMessage);
+        if(m_inputView instanceof ValidatedEditText)
+        {
+            ((ValidatedEditText) m_inputView).setValidationResult(isValid);
+        }
+        if(isValid)
+        {
+            m_label.setContentDescription(null);
+        }
+        else
+        {
+            m_label.setContentDescription(m_label.getText() + " " + m_errorMessage.getText());
+        }
+    }
+
+//    private void updateAccessbleLabel() {
+//        m_accessibleLabel.removeAllViews();
+//        m_accessibleLabel.addView(m_label);
+//        m_accessibleLabel.addView(m_errorMessage);
+//    }
+
+
+
 }

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/registration/CardRendererRegistration.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/registration/CardRendererRegistration.java
@@ -9,6 +9,7 @@ import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
+import android.widget.TextView;
 
 import com.google.android.flexbox.FlexboxLayout;
 
@@ -469,7 +470,7 @@ public class CardRendererRegistration
 
             if (inputHasLabel)
             {
-                View inputLabel = InputUtil.RenderInputLabel(element.GetLabel(), element.GetIsRequired(), context, hostConfig, renderArgs);
+                TextView inputLabel = InputUtil.RenderInputLabel(element.GetLabel(), element.GetIsRequired(), context, hostConfig, renderArgs);
                 inputLayout.setLabel(inputLabel);
 
                 // Render spacing
@@ -479,8 +480,6 @@ public class CardRendererRegistration
                     false /* separator */,
                     hostConfig,
                     true /* horizontalLine */);
-
-                inputLabel.setLabelFor(actualInput.getId());
             }
             else if (element.GetIsRequired())
             {
@@ -510,7 +509,7 @@ public class CardRendererRegistration
                     hostConfig,
                     true /* horizontalLine */);
 
-                View errorMessage = InputUtil.RenderErrorMessage(element.GetErrorMessage(), context, hostConfig, renderArgs);
+                TextView errorMessage = InputUtil.RenderErrorMessage(element.GetErrorMessage(), context, hostConfig, renderArgs);
                 errorMessage.setTag(new TagContent(null, spacing, null));
                 inputLayout.setErrorMessage(errorMessage);
 

--- a/source/android/mobile/src/main/java/io/adaptivecards/adaptivecardssample/CustomObjects/CardElements/CustomInput.java
+++ b/source/android/mobile/src/main/java/io/adaptivecards/adaptivecardssample/CustomObjects/CardElements/CustomInput.java
@@ -7,6 +7,7 @@ import android.graphics.Color;
 import android.support.v4.app.FragmentManager;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.accessibility.AccessibilityEvent;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 
@@ -71,6 +72,7 @@ public class CustomInput extends BaseInputElement
         public void setFocusToView()
         {
             m_view.requestFocus();
+            m_view.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED);
         }
     }
 

--- a/source/android/mobile/src/main/java/io/adaptivecards/adaptivecardssample/CustomObjects/CardElements/CustomInput.java
+++ b/source/android/mobile/src/main/java/io/adaptivecards/adaptivecardssample/CustomObjects/CardElements/CustomInput.java
@@ -72,7 +72,7 @@ public class CustomInput extends BaseInputElement
         public void setFocusToView()
         {
             m_view.requestFocus();
-            m_view.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED);
+            m_view.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED);
         }
     }
 


### PR DESCRIPTION
## Related Issue
Android part of #4912 

Also fixed ADO 28382490

## Description
Set inputs' accessible text to Input element's `label` + `errorMessage` when input has been invalidated (but only `label` when input is valid).

On submit, move keyboard focus, accessibility focus, and scroll position to first invalid input. So, above accessible text is spoken for first invalid input on submit.

## How Verified
Video:






###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4958)