### PR TITLE
Updated custom registration for ActionSet

### DIFF
--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer.xcodeproj/project.pbxproj
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		6B98093A215AF05A0024B79B /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B980930215AE4310024B79B /* CoreGraphics.framework */; };
 		6B9BDF7020E18E5B00F13155 /* CustomImageRenderer.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6B9BDF6F20E18E5B00F13155 /* CustomImageRenderer.mm */; };
 		6B9BDFCC20F6D11F00F13155 /* ADCResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B9BDFCB20F6D11F00F13155 /* ADCResolver.m */; };
+		6BA88FD12545337C00BF2CDB /* CustomActionSetRenderer.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6BA88FCF2545337B00BF2CDB /* CustomActionSetRenderer.mm */; };
 		6BBE841D23CD1A4900ECA586 /* Action.ShowCard.Style.json in Resources */ = {isa = PBXBuildFile; fileRef = 6BBE841C23CD1A4900ECA586 /* Action.ShowCard.Style.json */; };
 		6BF339D620A665E600DA5973 /* CustomTextBlockRenderer.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6BF339D420A665E600DA5973 /* CustomTextBlockRenderer.mm */; };
 		6BF339E320A66A3F00DA5973 /* AdaptiveCards.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6BF339E220A66A3F00DA5973 /* AdaptiveCards.framework */; };
@@ -152,6 +153,8 @@
 		6B9BDF6F20E18E5B00F13155 /* CustomImageRenderer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CustomImageRenderer.mm; sourceTree = "<group>"; };
 		6B9BDFCB20F6D11F00F13155 /* ADCResolver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ADCResolver.m; sourceTree = "<group>"; };
 		6B9BDFCD20F6D16E00F13155 /* ADCResolver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ADCResolver.h; sourceTree = "<group>"; };
+		6BA88FCF2545337B00BF2CDB /* CustomActionSetRenderer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CustomActionSetRenderer.mm; sourceTree = "<group>"; };
+		6BA88FD02545337B00BF2CDB /* CustomActionSetRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CustomActionSetRenderer.h; sourceTree = "<group>"; };
 		6BA9091A23985CB5009421CA /* Adaptive1.0.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = Adaptive1.0.png; path = ../../../../../assets/Adaptive1.0.png; sourceTree = "<group>"; };
 		6BBE841C23CD1A4900ECA586 /* Action.ShowCard.Style.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = Action.ShowCard.Style.json; path = ../../../../../samples/v1.0/Elements/Action.ShowCard.Style.json; sourceTree = "<group>"; };
 		6BF339D420A665E600DA5973 /* CustomTextBlockRenderer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CustomTextBlockRenderer.mm; sourceTree = "<group>"; };
@@ -311,6 +314,8 @@
 		F423C0741EE1FB6100905679 /* ADCIOSVisualizer */ = {
 			isa = PBXGroup;
 			children = (
+				6BA88FD02545337B00BF2CDB /* CustomActionSetRenderer.h */,
+				6BA88FCF2545337B00BF2CDB /* CustomActionSetRenderer.mm */,
 				6B5E9CBC24B663CA00757882 /* Adaptive1.0.png */,
 				F4D33E841F04705800941E44 /* ACVTableViewController.h */,
 				F4D33E851F04705800941E44 /* ACVTableViewController.m */,
@@ -553,6 +558,7 @@
 				F4D33E861F04705800941E44 /* ACVTableViewController.m in Sources */,
 				6BF339D620A665E600DA5973 /* CustomTextBlockRenderer.mm in Sources */,
 				6B9BDF7020E18E5B00F13155 /* CustomImageRenderer.mm in Sources */,
+				6BA88FD12545337C00BF2CDB /* CustomActionSetRenderer.mm in Sources */,
 				F423C07D1EE1FB6100905679 /* ViewController.m in Sources */,
 				F423C07A1EE1FB6100905679 /* AppDelegate.m in Sources */,
 				6B22426621E92AF9000ACDA1 /* CustomActionNewType.mm in Sources */,

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/CustomActionSetRenderer.h
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/CustomActionSetRenderer.h
@@ -1,0 +1,16 @@
+//
+//  CustomActionSetRenderer.h
+//  ADCIOSVisualizer
+//
+//  Copyright © 2020 Microsoft. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import <AdaptiveCards/ACFramework.h>
+
+@interface CustomActionSetRenderer :  ACRActionSetRenderer
+
++ (CustomActionSetRenderer *)getInstance;
+
+@end

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/CustomActionSetRenderer.mm
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/CustomActionSetRenderer.mm
@@ -1,0 +1,33 @@
+//
+//  Copyright © 2020 Microsoft. All rights reserved.
+//
+
+#import "CustomActionSetRenderer.h"
+#import <AdaptiveCards/ACOBaseActionElementPrivate.h>
+#import <AdaptiveCards/ACRActionSetRenderer.h>
+
+@implementation CustomActionSetRenderer
+
++ (CustomActionSetRenderer *)getInstance
+{
+    static CustomActionSetRenderer *singletonInstance = [[self alloc] init];
+    return singletonInstance;
+}
+
+- (UIView *)render:(UIView<ACRIContentHoldingView> *)viewGroup
+           rootView:(ACRView *)rootView
+             inputs:(NSArray *)inputs
+    baseCardElement:(ACOBaseCardElement *)acoElem
+         hostConfig:(ACOHostConfig *)acoConfig
+{
+    UIView *containingView = [super render:viewGroup
+                                  rootView:rootView
+                                    inputs:(NSMutableArray *)inputs
+                           baseCardElement:acoElem
+                                hostConfig:acoConfig];
+    // customize background color of action set
+    containingView.backgroundColor = UIColor.darkGrayColor;
+    return containingView;
+}
+
+@end

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ViewController.m
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ViewController.m
@@ -2,7 +2,7 @@
 //  ViewController.m
 //  ViewController
 //
-//  Copyright © 2017 Microsoft. All rights reserved.
+//  Copyright © 2020 Microsoft. All rights reserved.
 //
 
 #import "ViewController.h"
@@ -11,6 +11,7 @@
 #import "AdaptiveFileBrowserSource.h"
 #import "CustomActionNewType.h"
 #import "CustomActionOpenURLRenderer.h"
+#import "CustomActionSetRenderer.h"
 #import "CustomImageRenderer.h"
 #import "CustomInputNumberRenderer.h"
 #import "CustomProgressBarRenderer.h"
@@ -124,6 +125,7 @@ const CGFloat kAdaptiveCardsWidth = 330;
                                  cardElementType:ACRNumberInput];
         [registration setBaseCardElementRenderer:[CustomImageRenderer getInstance]
                                  cardElementType:ACRImage];
+        [registration setBaseCardElementRenderer:[CustomActionSetRenderer getInstance] cardElementType:ACRActionSet];
 
         _enableCustomRendererButton.backgroundColor = UIColor.redColor;
         _defaultRenderer = [registration getActionSetRenderer];
@@ -133,6 +135,7 @@ const CGFloat kAdaptiveCardsWidth = 330;
         [registration setBaseCardElementRenderer:nil cardElementType:ACRTextBlock];
         [registration setBaseCardElementRenderer:nil cardElementType:ACRNumberInput];
         [registration setBaseCardElementRenderer:nil cardElementType:ACRImage];
+        [registration setBaseCardElementRenderer:nil cardElementType:ACRActionSet];
         [registration setActionSetRenderer:nil];
         _enableCustomRendererButton.backgroundColor = [UIColor colorWithRed:0 / 255
                                                                       green:122.0 / 255

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACFramework.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACFramework.h
@@ -2,7 +2,7 @@
 //  ACFramework.h
 //  ACFramework
 //
-//  Copyright © 2017 Microsoft. All rights reserved.
+//  Copyright © 2020 Microsoft. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>
@@ -23,6 +23,7 @@ FOUNDATION_EXPORT const unsigned char AdaptiveCarsFrameworkVersionString[];
 #import <AdaptiveCards/ACOResourceResolvers.h>
 #import <AdaptiveCards/ACRActionDelegate.h>
 #import <AdaptiveCards/ACRActionOpenURLRenderer.h>
+#import <AdaptiveCards/ACRActionSetRenderer.h>
 #import <AdaptiveCards/ACRActionShowCardRenderer.h>
 #import <AdaptiveCards/ACRActionSubmitRenderer.h>
 #import <AdaptiveCards/ACRBaseActionElementRenderer.h>
@@ -42,6 +43,7 @@ FOUNDATION_EXPORT const unsigned char AdaptiveCarsFrameworkVersionString[];
 #import <AdaptiveCards/ACRImageSetRenderer.h>
 #import <AdaptiveCards/ACRInputChoiceSetRenderer.h>
 #import <AdaptiveCards/ACRInputDateRenderer.h>
+#import <AdaptiveCards/ACRInputLabelView.h>
 #import <AdaptiveCards/ACRInputNumberRenderer.h>
 #import <AdaptiveCards/ACRInputRenderer.h>
 #import <AdaptiveCards/ACRInputTimeRenderer.h>
@@ -54,8 +56,7 @@ FOUNDATION_EXPORT const unsigned char AdaptiveCarsFrameworkVersionString[];
 #import <AdaptiveCards/ACRRenderer.h>
 #import <AdaptiveCards/ACRRichTextBlockRenderer.h>
 #import <AdaptiveCards/ACRTextBlockRenderer.h>
+#import <AdaptiveCards/ACRTextInputHandler.h>
 #import <AdaptiveCards/ACRTextView.h>
 #import <AdaptiveCards/ACRToggleInputView.h>
 #import <AdaptiveCards/ACRView.h>
-#import <AdaptiveCards/ACRInputLabelView.h>
-#import <AdaptiveCards/ACRTextInputHandler.h>

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionSetRenderer.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionSetRenderer.h
@@ -2,13 +2,13 @@
 //  ACRActionSetRenderer
 //  ACRActionSetRenderer.h
 //
-//  Copyright © 2018 Microsoft. All rights reserved.
+//  Copyright © 2020 Microsoft. All rights reserved.
 //
 
 #import "ACRBaseActionElementRenderer.h"
-#import "ACRIBaseCardElementRenderer.h"
+#import "ACRBaseCardElementRenderer.h"
 
-@interface ACRActionSetRenderer : NSObject <ACRIBaseActionSetRenderer, ACRIBaseCardElementRenderer>
+@interface ACRActionSetRenderer : ACRBaseCardElementRenderer<ACRIBaseActionSetRenderer>
 
 + (ACRActionSetRenderer *)getInstance;
 


### PR DESCRIPTION
## Related Issue
Fixed #4899 

## Description
This change removes warnings if the default ActionSet is subclassed to be registered as a custom base card element render. 
## How Verified
How you verified the fix, including one or all of the following: 
1. Added a code example to sample  for verification and demonstration
2. Regression test with cards with ActionSets.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4965)