### PR TITLE
Revert "Bump constraint-layout from 1.1.3 to 2.0.1 in /source/android"

### DIFF
--- a/source/android/adaptivecards/build.gradle
+++ b/source/android/adaptivecards/build.gradle
@@ -123,7 +123,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.android.support.constraint:constraint-layout:2.0.1'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation 'com.google.android:flexbox:1.0.0'
     testImplementation 'junit:junit:4.12'
 }


### PR DESCRIPTION
## Related Issue
Fixes #4964 

While this does fix the image sizes, there are still issues with `height: stretch` as you can see in the left column of the payload below. Without `height: stretch`, images are sized correctly.

## Description
This reverts commit dc01f5bc38cd269d8fe3d44ee0e0cd7b0fbe4a42.

Major version bump caused weird layouts. Switching back to old version of dependency.

## How Verified
`v1.2/Tests/ImageSizing.json`:
![4964](https://user-images.githubusercontent.com/4442788/97367510-a13d6280-187f-11eb-83e0-e9e4db45ac75.gif)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4976)