### PR TITLE
Revert "Bump constraint-layout from 1.1.3 to 2.0.1 in /source/android" (#4976)

### DIFF
--- a/source/android/adaptivecards/build.gradle
+++ b/source/android/adaptivecards/build.gradle
@@ -123,7 +123,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.android.support.constraint:constraint-layout:2.0.1'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation 'com.google.android:flexbox:1.0.0'
     testImplementation 'junit:junit:4.12'
 }


### PR DESCRIPTION
Cherry-pick of #4976 (which dealt with #4964) into release/20.10

Clean cherry-pick (no conflicts)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4978)