### PR TITLE
[Android] Switch pipelines to use Windows hosted pools

### DIFF
--- a/.pipelines/android-daily.yml
+++ b/.pipelines/android-daily.yml
@@ -42,7 +42,7 @@ steps:
    #!/usr/bin/env bash
    
    unset ANDROID_NDK_HOME
-   sudo ${ANDROID_HOME}/tools/bin/sdkmanager --verbose --install "ndk;21.0.6113669"
+   ${ANDROID_HOME}/tools/bin/sdkmanager --verbose --install "ndk;21.0.6113669"
   displayName: 'Get NDK (TODO: Remove this step)'
 
 - task: Gradle@2

--- a/.pipelines/android-daily.yml
+++ b/.pipelines/android-daily.yml
@@ -47,14 +47,14 @@ steps:
 - task: Gradle@2
   displayName: 'gradlew adaptivecards:build'
   inputs:
-    gradleWrapperFile: source/android/gradlew
+    gradleWrapperFile: source/android/gradlew.bat
     workingDirectory: source/android
     tasks: 'adaptivecards:build'
 
 - task: Gradle@2
   displayName: 'gradlew publish'
   inputs:
-    gradleWrapperFile: source/android/gradlew
+    gradleWrapperFile: source/android/gradlew.bat
     workingDirectory: source/android
     tasks: 'adaptivecards:publish'
     publishJUnitResults: false

--- a/.pipelines/android-daily.yml
+++ b/.pipelines/android-daily.yml
@@ -38,10 +38,10 @@ steps:
 
   # TODO: Remove when Android Gradle Plugin 4.1 is stable.
   # Starting from AGP 4.1+, the required NDK version will be retrieved automatically, so this script will not be needed.
-- script: |
-   setx ANDROID_NDK_HOME ""
-   "%ANDROID_HOME%\tools\bin\sdkmanager.bat" --verbose "ndk;21.0.6113669"
-  displayName: 'Get NDK (TODO: Remove this step)'
+# - script: |
+#    setx ANDROID_NDK_HOME ""
+#    "%ANDROID_HOME%\tools\bin\sdkmanager.bat" --verbose "ndk;21.0.6113669"
+#   displayName: 'Get NDK (TODO: Remove this step)'
 
 - task: Gradle@2
   displayName: 'gradlew adaptivecards:build'

--- a/.pipelines/android-daily.yml
+++ b/.pipelines/android-daily.yml
@@ -11,6 +11,7 @@ schedules:
    - main
 
 pool:
+  name: Azure Pipelines
   vmImage: vs2017-win2016
   demands: java
 

--- a/.pipelines/android-daily.yml
+++ b/.pipelines/android-daily.yml
@@ -40,7 +40,7 @@ steps:
   # Starting from AGP 4.1+, the required NDK version will be retrieved automatically, so this script will not be needed.
 - script: |
    setx ANDROID_NDK_HOME ""
-   ".\%ANDROID_HOME%\tools\bin\sdkmanager.bat" --verbose --install "ndk;21.0.6113669"
+   "%ANDROID_HOME%\tools\bin\sdkmanager.bat" --verbose --install "ndk;21.0.6113669"
   displayName: 'Get NDK (TODO: Remove this step)'
 
 - task: Gradle@2

--- a/.pipelines/android-daily.yml
+++ b/.pipelines/android-daily.yml
@@ -40,7 +40,7 @@ steps:
   # Starting from AGP 4.1+, the required NDK version will be retrieved automatically, so this script will not be needed.
 - script: |
    setx ANDROID_NDK_HOME ""
-   "%ANDROID_HOME%\tools\bin\sdkmanager.bat" --verbose --install "ndk;21.0.6113669"
+   "%ANDROID_HOME%\tools\bin\sdkmanager.bat" --verbose "ndk;21.0.6113669"
   displayName: 'Get NDK (TODO: Remove this step)'
 
 - task: Gradle@2

--- a/.pipelines/android-daily.yml
+++ b/.pipelines/android-daily.yml
@@ -42,7 +42,7 @@ steps:
    #!/usr/bin/env bash
    
    unset ANDROID_NDK_HOME
-   ${ANDROID_HOME}/tools/bin/sdkmanager --verbose --install "ndk;21.0.6113669"
+   ".\${ANDROID_HOME}\tools\bin\sdkmanager.bat" --verbose --install "ndk;21.0.6113669"
   displayName: 'Get NDK (TODO: Remove this step)'
 
 - task: Gradle@2

--- a/.pipelines/android-daily.yml
+++ b/.pipelines/android-daily.yml
@@ -38,11 +38,9 @@ steps:
 
   # TODO: Remove when Android Gradle Plugin 4.1 is stable.
   # Starting from AGP 4.1+, the required NDK version will be retrieved automatically, so this script will not be needed.
-- bash: |
-   #!/usr/bin/env bash
-   
-   unset ANDROID_NDK_HOME
-   ".\${ANDROID_HOME}\tools\bin\sdkmanager.bat" --verbose --install "ndk;21.0.6113669"
+- script: |
+   setx ANDROID_NDK_HOME ""
+   ".\%ANDROID_HOME%\tools\bin\sdkmanager.bat" --verbose --install "ndk;21.0.6113669"
   displayName: 'Get NDK (TODO: Remove this step)'
 
 - task: Gradle@2

--- a/.pipelines/android-daily.yml
+++ b/.pipelines/android-daily.yml
@@ -11,7 +11,7 @@ schedules:
    - main
 
 pool:
-  name: Hosted Ubuntu 1604
+  vmImage: vs2017-win2016
   demands: java
 
 parameters:

--- a/.pipelines/android-release.yml
+++ b/.pipelines/android-release.yml
@@ -30,7 +30,7 @@ steps:
 - task: Gradle@2
   displayName: build
   inputs:
-    gradleWrapperFile: source/android/gradlew
+    gradleWrapperFile: source/android/gradlew.bat
     workingDirectory: source/android
     tasks: 'adaptivecards:build'
     publishJUnitResults: false
@@ -38,7 +38,7 @@ steps:
 - task: Gradle@2
   displayName: 'publish'
   inputs:
-    gradleWrapperFile: source/android/gradlew
+    gradleWrapperFile: source/android/gradlew.bat
     workingDirectory: source/android
     tasks: 'adaptivecards:publish'
     publishJUnitResults: false

--- a/.pipelines/android-release.yml
+++ b/.pipelines/android-release.yml
@@ -23,7 +23,7 @@ steps:
   # Starting from AGP 4.1+, the required NDK version will be retrieved automatically, so this script will not be needed.
 - script: |
    setx ANDROID_NDK_HOME ""
-   "%ANDROID_HOME%\tools\bin\sdkmanager.bat" --verbose --install "ndk;21.0.6113669"
+   "%ANDROID_HOME%\tools\bin\sdkmanager.bat" --verbose "ndk;21.0.6113669"
   displayName: 'Get NDK (TODO: Remove this step)'
 
 - task: Gradle@2

--- a/.pipelines/android-release.yml
+++ b/.pipelines/android-release.yml
@@ -21,10 +21,10 @@ variables:
 steps:
   # TODO: Remove when Android Gradle Plugin 4.1 is stable.
   # Starting from AGP 4.1+, the required NDK version will be retrieved automatically, so this script will not be needed.
-- script: |
-   setx ANDROID_NDK_HOME ""
-   "%ANDROID_HOME%\tools\bin\sdkmanager.bat" --verbose "ndk;21.0.6113669"
-  displayName: 'Get NDK (TODO: Remove this step)'
+# - script: |
+#    setx ANDROID_NDK_HOME ""
+#    "%ANDROID_HOME%\tools\bin\sdkmanager.bat" --verbose "ndk;21.0.6113669"
+#   displayName: 'Get NDK (TODO: Remove this step)'
 
 - task: Gradle@2
   displayName: build

--- a/.pipelines/android-release.yml
+++ b/.pipelines/android-release.yml
@@ -4,7 +4,7 @@ pr: none
 trigger: none
 
 pool:
-  name: Hosted Ubuntu 1604
+  vmImage: vs2017-win2016
   demands: java
 
 parameters:

--- a/.pipelines/android-release.yml
+++ b/.pipelines/android-release.yml
@@ -4,6 +4,7 @@ pr: none
 trigger: none
 
 pool:
+  name: Azure Pipelines
   vmImage: vs2017-win2016
   demands: java
 

--- a/.pipelines/android-release.yml
+++ b/.pipelines/android-release.yml
@@ -25,7 +25,7 @@ steps:
    #!/usr/bin/env bash
    
    unset ANDROID_NDK_HOME
-   sudo ${ANDROID_HOME}/tools/bin/sdkmanager --verbose --install "ndk;21.0.6113669"
+   ${ANDROID_HOME}/tools/bin/sdkmanager --verbose --install "ndk;21.0.6113669"
   displayName: 'Get NDK (TODO: Remove this step)'
 
 - task: Gradle@2

--- a/.pipelines/android-release.yml
+++ b/.pipelines/android-release.yml
@@ -25,7 +25,7 @@ steps:
    #!/usr/bin/env bash
    
    unset ANDROID_NDK_HOME
-   ${ANDROID_HOME}/tools/bin/sdkmanager --verbose --install "ndk;21.0.6113669"
+   ".\${ANDROID_HOME}\tools\bin\sdkmanager.bat" --verbose --install "ndk;21.0.6113669"
   displayName: 'Get NDK (TODO: Remove this step)'
 
 - task: Gradle@2

--- a/.pipelines/android-release.yml
+++ b/.pipelines/android-release.yml
@@ -21,11 +21,9 @@ variables:
 steps:
   # TODO: Remove when Android Gradle Plugin 4.1 is stable.
   # Starting from AGP 4.1+, the required NDK version will be retrieved automatically, so this script will not be needed.
-- bash: |
-   #!/usr/bin/env bash
-   
-   unset ANDROID_NDK_HOME
-   ".\${ANDROID_HOME}\tools\bin\sdkmanager.bat" --verbose --install "ndk;21.0.6113669"
+- script: |
+   setx ANDROID_NDK_HOME ""
+   "%ANDROID_HOME%\tools\bin\sdkmanager.bat" --verbose --install "ndk;21.0.6113669"
   displayName: 'Get NDK (TODO: Remove this step)'
 
 - task: Gradle@2


### PR DESCRIPTION
## Related Issue
Fixes #4972

## Description
Use Windows images to run pipelines to see if it solves Teams' issue

Also commented out the Get NDK task, as it is causing issues. Pipelines should now use the default NDK from the system image.

Will need to investigate further to see what the constraints are with NDK versions we can use/upgrade going forward.

## How Verified
Manual verification with Teams

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/4987)