### PR TITLE
[Javascript][Template SDK] Add escape operator before string interpolation

### DIFF
--- a/source/nodejs/adaptivecards-templating/src/template-engine.ts
+++ b/source/nodejs/adaptivecards-templating/src/template-engine.ts
@@ -84,24 +84,24 @@ export class GlobalSettings {
      * and that field is undefined or null. By default, expression evaluation will substitute an undefined
      * field with its binding expression (e.g. `${field}`). This callback makes it possible to customize that
      * behavior.
-     *
+     * 
      * **Example**
      * Given this data object:
-     *
+     * 
      * ```json
      * {
      *     firstName: "David"
      * }
      * ```
-     *
+     * 
      * The expression `${firstName} ${lastName}` will evaluate to "David ${lastName}" because the `lastName`
      * field is undefined.
-     *
+     * 
      * Now let's set the callback:
      * ```typescript
      * GlobalSettings.getUndefinedFieldValueSubstitutionString = (path: string) => { return "<undefined value>"; }
      * ```
-     *
+     * 
      * With that, the above expression will evaluate to "David &lt;undefined value&gt;"
      */
     static getUndefinedFieldValueSubstitutionString?: (path: string) => string | undefined = undefined;
@@ -166,9 +166,9 @@ export class Template {
                 let substitutionValue: string | undefined = undefined;
 
                 if (GlobalSettings.getUndefinedFieldValueSubstitutionString) {
-                    substitutionValue = GlobalSettings.getUndefinedFieldValueSubstitutionString(path);
+                    substitutionValue = GlobalSettings.getUndefinedFieldValueSubstitutionString(path);    
                 }
-
+        
                 return substitutionValue ? substitutionValue : "${" + path + "}";
             }
         }
@@ -182,7 +182,7 @@ export class Template {
 
             for (let childExpression of expression.children) {
                 let evaluationResult: { value: any; error: string };
-
+                
                 try {
                     evaluationResult = childExpression.tryEvaluate(memory, options);
                 }
@@ -203,13 +203,13 @@ export class Template {
 
             return { value: result, error: undefined };
         }
-
+        
         return expression.tryEvaluate(memory, options);
     }
 
     /**
      * Parses an interpolated string into an Expression object ready to evaluate.
-     *
+     * 
      * @param interpolatedString The interpolated string to parse. Example: "Hello ${name}"
      * @returns An Expression object if the provided interpolated string contained at least one expression (e.g. "${expression}"); the original string otherwise.
      */
@@ -251,7 +251,7 @@ export class Template {
 
     /**
      * Tries to evaluate the provided expression using the provided context.
-     *
+     * 
      * @param expression The expression to evaluate.
      * @param context The context (data) used to evaluate the expression.
      * @param allowSubstitutions Indicates if the expression evaluator should substitute undefined value with a default
@@ -363,7 +363,7 @@ export class Template {
                 if (when instanceof AEL.Expression) {
                     let evaluationResult = Template.internalTryEvaluateExpression(when, this._context, false);
                     let whenValue: boolean = false;
-
+                    
                     // If $when fails to evaluate or evaluates to anything but a boolean, consider it is false
                     if (!evaluationResult.error) {
                         whenValue = typeof evaluationResult.value === "boolean" && evaluationResult.value;
@@ -401,8 +401,8 @@ export class Template {
      * Initializes a new Template instance based on the provided payload.
      * Once created, the instance can be bound to different data objects
      * in a loop.
-     *
-     * @param payload The template payload.
+     * 
+     * @param payload The template payload.  
      */
     constructor(payload: any) {
         this._preparedPayload = Template.prepare(payload);
@@ -412,9 +412,9 @@ export class Template {
      * Expands the template using the provided context. Template expansion involves
      * evaluating the expressions used in the original template payload, as well as
      * repeating (expanding) parts of that payload that are bound to arrays.
-     *
+     * 
      * Example:
-     *
+     * 
      * ```typescript
      * let context = {
      *     $root: {
@@ -426,7 +426,7 @@ export class Template {
      *         ]
      *     }
      * }
-     *
+     * 
      * let templatePayload = {
      *     type: "AdaptiveCard",
      *     version: "1.2",
@@ -442,14 +442,14 @@ export class Template {
      *         }
      *     ]
      * }
-     *
+     * 
      * let template = new Template(templatePayload);
-     *
+     * 
      * let expandedTemplate = template.expand(context);
      * ```
-     *
+     * 
      * With the above code, the value of `expandedTemplate` will be
-     *
+     * 
      * ```json
      * {
      *     type: "AdaptiveCard",
@@ -470,7 +470,7 @@ export class Template {
      *     ]
      * }
      * ```
-     *
+     * 
      * @param context The context to bind the template to.
      * @returns A value representing the expanded template. The type of that value
      *   is dependent on the type of the original template payload passed to the constructor.

--- a/source/nodejs/adaptivecards-templating/src/template-engine.ts
+++ b/source/nodejs/adaptivecards-templating/src/template-engine.ts
@@ -230,7 +230,7 @@ export class Template {
 
         // If there is at least one expression start marker, let's attempt to convert into an expression
         if (interpolatedString.indexOf("${") >= 0) {
-            let parsedExpression = AEL.Expression.parse("`" + interpolatedString.replace(/\\/g, '\\\\').replace(/`/g, '\\`') + "`", lookup);
+            let parsedExpression = AEL.Expression.parse("`" + this.stringEscape(interpolatedString) + "`", lookup);
 
             if (parsedExpression.type === "concat") {
                 if (parsedExpression.children.length === 1 && !(parsedExpression.children[0] instanceof AEL.Constant)) {
@@ -266,6 +266,19 @@ export class Template {
 
     private _context: EvaluationContext;
     private _preparedPayload: any;
+
+    /**
+     * Escape a certain string with backslash
+     * @param input input string.
+     */
+    private static stringEscape(input: string) {
+        let result = input;
+        if (input != null) {
+            result = input.replace(/\\/g, '\\\\').replace(/`/g, '\\`');
+        }
+
+        return result;
+    }
 
     private expandSingleObject(node: object): any {
         let result = {};

--- a/source/nodejs/adaptivecards-templating/src/template-engine.ts
+++ b/source/nodejs/adaptivecards-templating/src/template-engine.ts
@@ -84,24 +84,24 @@ export class GlobalSettings {
      * and that field is undefined or null. By default, expression evaluation will substitute an undefined
      * field with its binding expression (e.g. `${field}`). This callback makes it possible to customize that
      * behavior.
-     * 
+     *
      * **Example**
      * Given this data object:
-     * 
+     *
      * ```json
      * {
      *     firstName: "David"
      * }
      * ```
-     * 
+     *
      * The expression `${firstName} ${lastName}` will evaluate to "David ${lastName}" because the `lastName`
      * field is undefined.
-     * 
+     *
      * Now let's set the callback:
      * ```typescript
      * GlobalSettings.getUndefinedFieldValueSubstitutionString = (path: string) => { return "<undefined value>"; }
      * ```
-     * 
+     *
      * With that, the above expression will evaluate to "David &lt;undefined value&gt;"
      */
     static getUndefinedFieldValueSubstitutionString?: (path: string) => string | undefined = undefined;
@@ -166,9 +166,9 @@ export class Template {
                 let substitutionValue: string | undefined = undefined;
 
                 if (GlobalSettings.getUndefinedFieldValueSubstitutionString) {
-                    substitutionValue = GlobalSettings.getUndefinedFieldValueSubstitutionString(path);    
+                    substitutionValue = GlobalSettings.getUndefinedFieldValueSubstitutionString(path);
                 }
-        
+
                 return substitutionValue ? substitutionValue : "${" + path + "}";
             }
         }
@@ -182,7 +182,7 @@ export class Template {
 
             for (let childExpression of expression.children) {
                 let evaluationResult: { value: any; error: string };
-                
+
                 try {
                     evaluationResult = childExpression.tryEvaluate(memory, options);
                 }
@@ -203,13 +203,13 @@ export class Template {
 
             return { value: result, error: undefined };
         }
-        
+
         return expression.tryEvaluate(memory, options);
     }
 
     /**
      * Parses an interpolated string into an Expression object ready to evaluate.
-     * 
+     *
      * @param interpolatedString The interpolated string to parse. Example: "Hello ${name}"
      * @returns An Expression object if the provided interpolated string contained at least one expression (e.g. "${expression}"); the original string otherwise.
      */
@@ -230,7 +230,7 @@ export class Template {
 
         // If there is at least one expression start marker, let's attempt to convert into an expression
         if (interpolatedString.indexOf("${") >= 0) {
-            let parsedExpression = AEL.Expression.parse("`" + interpolatedString + "`", lookup);
+            let parsedExpression = AEL.Expression.parse("`" + interpolatedString.replace(/\\/g, '\\\\').replace(/`/g, '\\`') + "`", lookup);
 
             if (parsedExpression.type === "concat") {
                 if (parsedExpression.children.length === 1 && !(parsedExpression.children[0] instanceof AEL.Constant)) {
@@ -251,7 +251,7 @@ export class Template {
 
     /**
      * Tries to evaluate the provided expression using the provided context.
-     * 
+     *
      * @param expression The expression to evaluate.
      * @param context The context (data) used to evaluate the expression.
      * @param allowSubstitutions Indicates if the expression evaluator should substitute undefined value with a default
@@ -363,7 +363,7 @@ export class Template {
                 if (when instanceof AEL.Expression) {
                     let evaluationResult = Template.internalTryEvaluateExpression(when, this._context, false);
                     let whenValue: boolean = false;
-                    
+
                     // If $when fails to evaluate or evaluates to anything but a boolean, consider it is false
                     if (!evaluationResult.error) {
                         whenValue = typeof evaluationResult.value === "boolean" && evaluationResult.value;
@@ -401,8 +401,8 @@ export class Template {
      * Initializes a new Template instance based on the provided payload.
      * Once created, the instance can be bound to different data objects
      * in a loop.
-     * 
-     * @param payload The template payload.  
+     *
+     * @param payload The template payload.
      */
     constructor(payload: any) {
         this._preparedPayload = Template.prepare(payload);
@@ -412,9 +412,9 @@ export class Template {
      * Expands the template using the provided context. Template expansion involves
      * evaluating the expressions used in the original template payload, as well as
      * repeating (expanding) parts of that payload that are bound to arrays.
-     * 
+     *
      * Example:
-     * 
+     *
      * ```typescript
      * let context = {
      *     $root: {
@@ -426,7 +426,7 @@ export class Template {
      *         ]
      *     }
      * }
-     * 
+     *
      * let templatePayload = {
      *     type: "AdaptiveCard",
      *     version: "1.2",
@@ -442,14 +442,14 @@ export class Template {
      *         }
      *     ]
      * }
-     * 
+     *
      * let template = new Template(templatePayload);
-     * 
+     *
      * let expandedTemplate = template.expand(context);
      * ```
-     * 
+     *
      * With the above code, the value of `expandedTemplate` will be
-     * 
+     *
      * ```json
      * {
      *     type: "AdaptiveCard",
@@ -470,7 +470,7 @@ export class Template {
      *     ]
      * }
      * ```
-     * 
+     *
      * @param context The context to bind the template to.
      * @returns A value representing the expanded template. The type of that value
      *   is dependent on the type of the original template payload passed to the constructor.

--- a/source/nodejs/adaptivecards-templating/src/template-engine.ts
+++ b/source/nodejs/adaptivecards-templating/src/template-engine.ts
@@ -273,7 +273,7 @@ export class Template {
      */
     private static stringEscape(input: string) {
         let result = input;
-        if (input != null) {
+        if (input) {
             result = input.replace(/\\/g, '\\\\').replace(/`/g, '\\`');
         }
 


### PR DESCRIPTION
## Related Issue
Fix: https://github.com/microsoft/AdaptiveCards/issues/4470

## Description
The original logic of parsing template into Expression is simply wrapping the template with the pair of the backticks.
Which would bring in some special characters by mistake. 
This PR aims to add some escape conversions for the  backticks ``` ` ```


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5000)