### PR TITLE
[Android] No prerelease tag for release

### DIFF
--- a/.pipelines/android-release.yml
+++ b/.pipelines/android-release.yml
@@ -8,16 +8,6 @@ pool:
   vmImage: vs2017-win2016
   demands: java
 
-parameters:
-- name: prerelease_tag
-  displayName: Prerelease Tag (leave empty for final releases)
-  type: string
-  default: ''
-
-variables:
-  # Capture build parameter to use as environment variable
-  prerelease_tag: ${{ parameters.prerelease_tag }}
-
 steps:
   # TODO: Remove when Android Gradle Plugin 4.1 is stable.
   # Starting from AGP 4.1+, the required NDK version will be retrieved automatically, so this script will not be needed.


### PR DESCRIPTION
Remove pre-release tag from release pipeline.

Clean cherry-pick from release/20.09

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5003)