### PR TITLE
Fixing 1 high pri vulnerability and also removing the typeDoc step from release script

### DIFF
--- a/source/nodejs/adaptivecards/package-lock.json
+++ b/source/nodejs/adaptivecards/package-lock.json
@@ -1701,20 +1701,10 @@
 				"babel-preset-current-node-syntax": "^0.1.2"
 			}
 		},
-		"backbone": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.0.tgz",
-			"integrity": "sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==",
-			"dev": true,
-			"requires": {
-				"underscore": ">=1.8.3"
-			}
-		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"base": {
 			"version": "0.11.2",
@@ -1882,7 +1872,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -2343,8 +2332,7 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"concat-stream": {
 			"version": "1.6.2",
@@ -2930,6 +2918,20 @@
 					"integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
 					"dev": true
 				}
+			}
+		},
+		"dts": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/dts/-/dts-0.1.1.tgz",
+			"integrity": "sha1-IFSAvC+IZhO91bZVQQefqoyD/5Q="
+		},
+		"dts-generator": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/dts-generator/-/dts-generator-3.0.0.tgz",
+			"integrity": "sha512-IrFP0TUGnBOxr8Lth0hLh/iM9odZTRGYyr4Y46IRxyw1SGO1Vvf30+x4npck9yP4FbaRXbB0Zh7gvmiqUta7mg==",
+			"requires": {
+				"glob": "^7.1.3",
+				"mkdirp": "^0.5.1"
 			}
 		},
 		"duplexify": {
@@ -4045,14 +4047,15 @@
 			}
 		},
 		"fs-extra": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+			"integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
 			"dev": true,
 			"requires": {
+				"at-least-node": "^1.0.0",
 				"graceful-fs": "^4.2.0",
-				"jsonfile": "^4.0.0",
-				"universalify": "^0.1.0"
+				"jsonfile": "^6.0.1",
+				"universalify": "^1.0.0"
 			}
 		},
 		"fs-write-stream-atomic": {
@@ -4070,8 +4073,7 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
 			"version": "2.1.3",
@@ -4138,7 +4140,6 @@
 			"version": "7.1.6",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
 			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -4404,9 +4405,9 @@
 			}
 		},
 		"highlight.js": {
-			"version": "9.18.3",
-			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.3.tgz",
-			"integrity": "sha512-zBZAmhSupHIl5sITeMqIJnYCDfAEc3Gdkqj65wC1lpI468MMQeeQkhcIAvk+RylAkxrCcI9xy9piHiXeQ1BdzQ==",
+			"version": "10.3.2",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.3.2.tgz",
+			"integrity": "sha512-3jRT7OUYsVsKvukNKZCtnvRcFyCJqSEIuIMsEybAXRiFSwpt65qjPd/Pr+UOdYt7WJlt+lj3+ypUsHiySBp/Jw==",
 			"dev": true
 		},
 		"hmac-drbg": {
@@ -4709,7 +4710,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -4718,8 +4718,7 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"ini": {
 			"version": "1.3.5",
@@ -6417,12 +6416,6 @@
 				"supports-color": "^7.0.0"
 			}
 		},
-		"jquery": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
-			"integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==",
-			"dev": true
-		},
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6531,12 +6524,13 @@
 			}
 		},
 		"jsonfile": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+			"integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.6"
+				"graceful-fs": "^4.1.6",
+				"universalify": "^1.0.0"
 			}
 		},
 		"jsprim": {
@@ -6704,9 +6698,9 @@
 			}
 		},
 		"marked": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
-			"integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-1.2.2.tgz",
+			"integrity": "sha512-5jjKHVl/FPo0Z6ocP3zYhKiJLzkwJAw4CZoLjv57FkvbUuwOX4LIBBGGcXjAY6ATcd1q9B8UTj5T9Umauj0QYQ==",
 			"dev": true
 		},
 		"md5.js": {
@@ -6825,7 +6819,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -6833,8 +6826,7 @@
 		"minimist": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-			"dev": true
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
 		},
 		"mississippi": {
 			"version": "3.0.0",
@@ -6879,7 +6871,6 @@
 			"version": "0.5.5",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
 			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-			"dev": true,
 			"requires": {
 				"minimist": "^1.2.5"
 			}
@@ -7215,7 +7206,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -7421,8 +7411,7 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-is-inside": {
 			"version": "1.0.2",
@@ -9474,34 +9463,37 @@
 			}
 		},
 		"typedoc": {
-			"version": "0.17.0-3",
-			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.17.0-3.tgz",
-			"integrity": "sha512-DO2djkR4NHgzAWfNbJb2eQKsFMs+gOuYBXlQ8dOSCjkAK5DRI7ZywDufBGPUw7Ue9Qwi2Cw1DxLd3reDq8wFuQ==",
+			"version": "0.20.0-beta.4",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.0-beta.4.tgz",
+			"integrity": "sha512-m+hxadhqIi6wKsO2zlrl2zHyaUDuaZi/9tW1k15g94tauR+G2WU6f7TEZzSZiedV2ag4OyruGvIYD+PAbcAVaQ==",
 			"dev": true,
 			"requires": {
-				"@types/minimatch": "3.0.3",
-				"fs-extra": "^8.1.0",
-				"handlebars": "^4.7.2",
-				"highlight.js": "^9.18.0",
-				"lodash": "^4.17.15",
-				"marked": "^0.8.0",
+				"fs-extra": "^9.0.1",
+				"handlebars": "^4.7.6",
+				"highlight.js": "^10.3.1",
+				"lodash": "^4.17.20",
+				"lunr": "^2.3.9",
+				"marked": "^1.2.2",
 				"minimatch": "^3.0.0",
 				"progress": "^2.0.3",
-				"shelljs": "^0.8.3",
-				"typedoc-default-themes": "0.8.0-0"
+				"semver": "^7.3.2",
+				"shelljs": "^0.8.4",
+				"typedoc-default-themes": "^0.12.0-beta.4"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.20",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+					"dev": true
+				}
 			}
 		},
 		"typedoc-default-themes": {
-			"version": "0.8.0-0",
-			"resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.8.0-0.tgz",
-			"integrity": "sha512-blFWppm5aKnaPOa1tpGO9MLu+njxq7P3rtkXK4QxJBNszA+Jg7x0b+Qx0liXU1acErur6r/iZdrwxp5DUFdSXw==",
-			"dev": true,
-			"requires": {
-				"backbone": "^1.4.0",
-				"jquery": "^3.4.1",
-				"lunr": "^2.3.8",
-				"underscore": "^1.9.1"
-			}
+			"version": "0.12.0-beta.4",
+			"resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.12.0-beta.4.tgz",
+			"integrity": "sha512-WQk7FDARYRAC43Cm2qgIu+GBcxYDFi3Id2ncG9QuAz2eNVWD4h6HywRMV98gEPy6J2kqH2rsfm2uvnjUjDpidA==",
+			"dev": true
 		},
 		"typedoc-plugin-markdown": {
 			"version": "2.3.1",
@@ -9556,12 +9548,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"underscore": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.11.0.tgz",
-			"integrity": "sha512-xY96SsN3NA461qIRKZ/+qox37YXPtSBswMGfiNptr+wrt6ds4HaMw23TP612fEyGekRE6LNRiLYr/aqbHXNedw==",
-			"dev": true
-		},
 		"union-value": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -9593,9 +9579,9 @@
 			}
 		},
 		"universalify": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+			"integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
 			"dev": true
 		},
 		"unpipe": {
@@ -10890,8 +10876,7 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"write": {
 			"version": "1.0.3",

--- a/source/nodejs/adaptivecards/package.json
+++ b/source/nodejs/adaptivecards/package.json
@@ -63,9 +63,5 @@
 			"jsx",
 			"json"
 		]
-	},
-	"dependencies": {
-		"dts": "^0.1.1",
-		"dts-generator": "^3.0.0"
 	}
 }

--- a/source/nodejs/adaptivecards/package.json
+++ b/source/nodejs/adaptivecards/package.json
@@ -28,7 +28,7 @@
 		"start": "webpack-dev-server --open",
 		"dts": "dts-generator --prefix adaptivecards --project . --out dist/adaptivecards.d.ts",
 		"lint": "eslint src/*.ts",
-		"release": "npm run clean && concurrently \"npm:build\" \"webpack --mode=production\" \"npm:docs\" && concurrently \"npm:test\" \"npm:dts\"",
+		"release": "npm run clean && concurrently \"npm:build\" \"webpack --mode=production\" && concurrently \"npm:test\" \"npm:dts\"",
 		"docs": "npx typedoc"
 	},
 	"repository": {
@@ -63,5 +63,9 @@
 			"jsx",
 			"json"
 		]
+	},
+	"dependencies": {
+		"dts": "^0.1.1",
+		"dts-generator": "^3.0.0"
 	}
 }

--- a/source/nodejs/package-lock.json
+++ b/source/nodejs/package-lock.json
@@ -12385,9 +12385,9 @@
 			}
 		},
 		"node-forge": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-			"integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+			"integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
 			"dev": true
 		},
 		"node-gyp": {
@@ -14284,12 +14284,12 @@
 			"dev": true
 		},
 		"selfsigned": {
-			"version": "1.10.7",
-			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-			"integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+			"version": "1.10.8",
+			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+			"integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
 			"dev": true,
 			"requires": {
-				"node-forge": "0.9.0"
+				"node-forge": "^0.10.0"
 			}
 		},
 		"semver": {


### PR DESCRIPTION
# Description
1. Updating results of `npm audit fix`
2. Also addressing npm release failures by removing the typeDoc compilation step for now. (it;s not liking the command line options for some reason as specified in typeDoc.json at the moment, and after fighting with it for a while decided to give up on it for now to allow release to be unblocked. These docs currently are not being published to microsoftDocs anyways).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5009)