### PR TITLE
[Android] Fix input.text with inline actions

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/layout/StretchableInputLayout.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/layout/StretchableInputLayout.java
@@ -5,6 +5,7 @@ package io.adaptivecards.renderer.layout;
 
 import android.content.Context;
 import android.view.View;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import io.adaptivecards.renderer.BaseCardElementRenderer;
@@ -43,7 +44,17 @@ public class StretchableInputLayout extends StretchableElementLayout
     public void setInputView(View input)
     {
         addView(input);
-        m_inputView = input;
+
+        if (input instanceof LinearLayout)
+        {
+            LinearLayout textInputWithActionLayout = (LinearLayout)input;
+            m_inputView = textInputWithActionLayout.getChildAt(0);
+        }
+        else
+        {
+            m_inputView = input;
+        }
+
         if(m_inputView.getId() == View.NO_ID)
         {
             m_inputView.setId(View.generateViewId());


### PR DESCRIPTION
## Related Issue
Fixes #5021 

## Description
Fixes visual cues for Input.Text with inline actions as they represent a special case of an input that doesn't set its accessibility properties in the same place the visual cues render.

## How Verified
The fix was verified manually

* Input.Text with Inline actions
![image](https://user-images.githubusercontent.com/35784165/98058846-8d9f7800-1dfa-11eb-9d71-ab43b25b6452.png)

* Verification that ChoiceSet elements work as expected
![ChoicesetVisualCues](https://user-images.githubusercontent.com/35784165/98058965-d22b1380-1dfa-11eb-9641-671735385eac.gif)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5029)