### PR TITLE
iOS input updates

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSource.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSource.h
@@ -17,6 +17,8 @@ extern NSString *uncheckedCheckboxReuseID;
 extern NSString *checkedRadioButtonReuseID;
 extern NSString *uncheckedRadioButtonReuseID;
 
+@interface ACRChoiceSetCell : UITableViewCell
+@end
 @interface ACRChoiceSetViewDataSource : NSObject <UITableViewDataSource, UITableViewDelegate, ACRIBaseInputHandler>
 @property NSString *id;
 @property BOOL isMultiChoicesAllowed;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSource.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSource.mm
@@ -17,6 +17,35 @@ NSString *uncheckedCheckboxReuseID = @"unchecked-checkbox";
 NSString *checkedRadioButtonReuseID = @"checked-radiobutton";
 NSString *uncheckedRadioButtonReuseID = @"unchecked-radiobutton";
 
+const CGFloat padding = 16.0f;
+
+@implementation ACRChoiceSetCell
+
+- (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(nullable NSString *)reuseIdentifier
+{
+    self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
+    if (self) {
+        UIImage *iconImage = nil;
+        if ([reuseIdentifier isEqualToString:@"checked-checkbox"]) {
+            iconImage = [UIImage imageNamed:@"checked-checkbox-24.png" inBundle:[NSBundle bundleWithIdentifier:@"MSFT.AdaptiveCards"] compatibleWithTraitCollection:nil];
+        } else if ([reuseIdentifier isEqualToString:@"checked-radiobutton"]) {
+            iconImage = [UIImage imageNamed:@"checked.png" inBundle:[NSBundle bundleWithIdentifier:@"MSFT.AdaptiveCards"] compatibleWithTraitCollection:nil];
+        } else if ([reuseIdentifier isEqualToString:@"unchecked-checkbox"]) {
+            iconImage = [UIImage imageNamed:@"unchecked-checkbox-24.png" inBundle:[NSBundle bundleWithIdentifier:@"MSFT.AdaptiveCards"] compatibleWithTraitCollection:nil];
+        } else {
+            iconImage = [UIImage imageNamed:@"unchecked.png" inBundle:[NSBundle bundleWithIdentifier:@"MSFT.AdaptiveCards"] compatibleWithTraitCollection:nil];
+        }
+        self.imageView.image = iconImage;
+        self.textLabel.numberOfLines = 0;
+        self.textLabel.lineBreakMode = NSLineBreakByWordWrapping;
+        self.textLabel.adjustsFontSizeToFitWidth = NO;
+        self.backgroundColor = UIColor.clearColor;
+    }
+    return self;
+}
+
+@end
+
 @implementation ACRChoiceSetViewDataSource {
     std::shared_ptr<ChoiceSetInput> _choiceSetDataSource;
     NSMutableDictionary *_userSelections;
@@ -106,6 +135,7 @@ NSString *uncheckedRadioButtonReuseID = @"unchecked-radiobutton";
     cell.textLabel.text = title;
     cell.textLabel.numberOfLines = _choiceSetDataSource->GetWrap() ? 0 : 1;
     cell.textLabel.textColor = getForegroundUIColorFromAdaptiveAttribute(_config, _parentStyle);
+    cell.selectionStyle = UITableViewCellSelectionStyleNone;
     if (!_accessibilityString) {
         _accessibilityString = tableView.accessibilityLabel;
         tableView.accessibilityLabel = nil;
@@ -262,7 +292,7 @@ NSString *uncheckedRadioButtonReuseID = @"unchecked-radiobutton";
 
 - (float)getNonInputWidth:(UITableViewCell *)cell
 {
-    return cell.separatorInset.left + cell.indentationWidth + cell.accessoryView.frame.size.width + cell.imageView.image.size.width;
+    return padding * 3 + cell.imageView.image.size.width;
 }
 
 @synthesize isRequired;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSource.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSource.mm
@@ -187,7 +187,6 @@ const CGFloat padding = 16.0f;
 
     [tableView reloadData];
     _currentSelectedIndexPath = indexPath;
-
 }
 
 - (void)tableView:(UITableView *)tableView didDeselectRowAtIndexPath:(nonnull NSIndexPath *)indexPath
@@ -269,7 +268,7 @@ const CGFloat padding = 16.0f;
     if (shouldBecomeFirstResponder) {
         UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, view);
         [ACRInputLabelView commonSetFocus:shouldBecomeFirstResponder view:view];
-    }        
+    }
 }
 
 - (NSString *)getTitlesOfChoices

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRColumnSetRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRColumnSetRenderer.mm
@@ -47,6 +47,7 @@
                                                                   parentStyle:[viewGroup style]
                                                                    hostConfig:acoConfig
                                                                     superview:viewGroup];
+
     [viewGroup addArrangedSubview:columnSetView];
 
     configBleed(rootView, elem, columnSetView, acoConfig);

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputChoiceSetRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputChoiceSetRenderer.mm
@@ -46,11 +46,18 @@
     choiceSetView.frame = CGRectMake(0, 0, viewGroup.frame.size.width, viewGroup.frame.size.height);
     NSObject<UITableViewDelegate, UITableViewDataSource, ACRIBaseInputHandler> *dataSource = nil;
 
-    if (choiceSet->GetChoiceSetStyle() == ChoiceSetStyle::Compact && choiceSet->GetIsMultiSelect() == false) {
+    [choiceSetView registerClass:[ACRChoiceSetCell class] forCellReuseIdentifier:checkedCheckboxReuseID];
+    [choiceSetView registerClass:[ACRChoiceSetCell class] forCellReuseIdentifier:uncheckedCheckboxReuseID];
+    [choiceSetView registerClass:[ACRChoiceSetCell class] forCellReuseIdentifier:checkedRadioButtonReuseID];
+    [choiceSetView registerClass:[ACRChoiceSetCell class] forCellReuseIdentifier:uncheckedRadioButtonReuseID];
+
+    if(choiceSet->GetChoiceSetStyle() == ChoiceSetStyle::Compact && choiceSet->GetIsMultiSelect() == false) {
         dataSource = [[ACRChoiceSetViewDataSourceCompactStyle alloc] initWithInputChoiceSet:choiceSet rootView:rootView];
+        [choiceSetView setSeparatorStyle:UITableViewCellSeparatorStyleNone];
     } else {
         dataSource = [[ACRChoiceSetViewDataSource alloc] initWithInputChoiceSet:choiceSet WithHostConfig:config];
         ((ACRChoiceSetViewDataSource *)dataSource).spacing = choiceSetView.inputTableViewSpacing;
+        [choiceSetView setSeparatorStyle:UITableViewCellSeparatorStyleNone];
     }
 
     [choiceSetView registerNib:[UINib nibWithNibName:@"ACRChoiceSetCellUnchecked" bundle:bundle] forCellReuseIdentifier:uncheckedCheckboxReuseID];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputChoiceSetRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputChoiceSetRenderer.mm
@@ -58,12 +58,7 @@
         dataSource = [[ACRChoiceSetViewDataSource alloc] initWithInputChoiceSet:choiceSet WithHostConfig:config];
         ((ACRChoiceSetViewDataSource *)dataSource).spacing = choiceSetView.inputTableViewSpacing;
         [choiceSetView setSeparatorStyle:UITableViewCellSeparatorStyleNone];
-    }
-
-    [choiceSetView registerNib:[UINib nibWithNibName:@"ACRChoiceSetCellUnchecked" bundle:bundle] forCellReuseIdentifier:uncheckedCheckboxReuseID];
-    [choiceSetView registerNib:[UINib nibWithNibName:@"ACRChoiceSetCellChecked" bundle:bundle] forCellReuseIdentifier:checkedCheckboxReuseID];
-    [choiceSetView registerNib:[UINib nibWithNibName:@"ACRChoiceSetCellCompactChecked" bundle:bundle] forCellReuseIdentifier:checkedRadioButtonReuseID];
-    [choiceSetView registerNib:[UINib nibWithNibName:@"ACRChoiceSetCellCompactUnchecked" bundle:bundle] forCellReuseIdentifier:uncheckedRadioButtonReuseID];
+    } 
 
     choiceSetView.delegate = dataSource;
     choiceSetView.dataSource = dataSource;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.mm
@@ -103,20 +103,20 @@
 
         [self.stack insertArrangedSubview:inputView atIndex:1];
 
-        self.inputView = inputView;        
+        self.inputView = inputView;
         self.label.isAccessibilityElement = NO;
         self.isAccessibilityElement = NO;
         inputView.accessibilityLabel = self.label.text;
         self.inputAccessibilityItem = inputView;
-        
+
         if (inputView != accessibilityItem) {
             self.inputAccessibilityItem = accessibilityItem;
             self.inputAccessibilityItem.accessibilityLabel = inputView.accessibilityLabel;
         }
-        
+
         self.inputAccessibilityItem.isAccessibilityElement = YES;
         self.labelText = self.inputAccessibilityItem.accessibilityLabel;
-        
+
         self.shouldGroupAccessibilityChildren = NO;
 
         NSObject<ACRIBaseInputHandler> *inputHandler = [self getInputHandler];
@@ -147,12 +147,7 @@
                 self.hasVisibilityChanged = self.errorMessage.hidden == YES;
                 self.errorMessage.hidden = NO;
                 self.errorMessage.isAccessibilityElement = NO;
-                if(self.inputAccessibilityItem.accessibilityLabel) {
-                    self.labelText = self.inputAccessibilityItem.accessibilityLabel;
-                    self.inputAccessibilityItem.accessibilityLabel = [NSString stringWithFormat:@"%@, %@,", self.inputAccessibilityItem.accessibilityLabel, self.errorMessage.text];
-                } else {
-                    self.inputAccessibilityItem.accessibilityLabel = [NSString stringWithFormat:@"%@, %@,", self.labelText, self.errorMessage.text];
-                }
+                self.inputAccessibilityItem.accessibilityLabel = [NSString stringWithFormat:@"%@, %@,", self.labelText, self.errorMessage.text];
             }
         } else {
             if (self.hasErrorMessage) {
@@ -199,8 +194,8 @@
     UIView *viewToFocus = [self getInputView];
     if (!inputHandler || !viewToFocus) {
         return;
-    }  
-   
+    }
+
     [inputHandler setFocus:shouldBecomeFirstResponder view:self.inputAccessibilityItem];
 }
 
@@ -214,7 +209,7 @@
 
 + (void)commonSetFocus:(BOOL)shouldBecomeFirstResponder view:(UIView *)view
 {
-    if (shouldBecomeFirstResponder) {    
+    if (shouldBecomeFirstResponder) {
         [view becomeFirstResponder];
     } else {
         [view resignFirstResponder];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.mm
@@ -215,6 +215,7 @@
 + (void)commonSetFocus:(BOOL)shouldBecomeFirstResponder view:(UIView *)view
 {
     if (shouldBecomeFirstResponder) {
+        UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, view);
         [view becomeFirstResponder];
     } else {
         [view resignFirstResponder];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.mm
@@ -214,8 +214,7 @@
 
 + (void)commonSetFocus:(BOOL)shouldBecomeFirstResponder view:(UIView *)view
 {
-    if (shouldBecomeFirstResponder) {
-        UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, view);
+    if (shouldBecomeFirstResponder) {    
         [view becomeFirstResponder];
     } else {
         [view resignFirstResponder];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextInputHandler.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextInputHandler.mm
@@ -57,16 +57,11 @@
 
 - (void)setFocus:(BOOL)shouldBecomeFirstResponder view:(UIView *)view
 {
-    UIView *inputview = nil;
-    if ([view isKindOfClass:[UITextField class]]) {
-        inputview = ((UITextField *)view).inputView;
-    } else {
-        inputview = view;
-    }
+    UIView *inputview = ([view isKindOfClass:[UITextField class]]) ? ((UITextField *)view).inputView : view;
     if (shouldBecomeFirstResponder) {
         UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, view);
+        [ACRInputLabelView commonSetFocus:shouldBecomeFirstResponder view:inputview];
     }
-    [ACRInputLabelView commonSetFocus:shouldBecomeFirstResponder view:inputview];
 }
 
 - (BOOL)textFieldShouldReturn:(UITextField *)textField
@@ -111,7 +106,7 @@
         auto value = numberInputBlock->GetValue();
         self.text = (value.has_value()) ? [NSString stringWithFormat:@"%d", value.value_or(0)] : nil;
         self.hasText = self.text != nil;
-        
+
         NSMutableCharacterSet *characterSets = [NSMutableCharacterSet characterSetWithCharactersInString:@"-."];
         [characterSets formUnionWithCharacterSet:[NSCharacterSet decimalDigitCharacterSet]];
         _notDigits = [characterSets invertedSet];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextInputHandler.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextInputHandler.mm
@@ -57,7 +57,16 @@
 
 - (void)setFocus:(BOOL)shouldBecomeFirstResponder view:(UIView *)view
 {
-    [ACRInputLabelView commonSetFocus:shouldBecomeFirstResponder view:view];
+    UIView *inputview = nil;
+    if ([view isKindOfClass:[UITextField class]]) {
+        inputview = ((UITextField *)view).inputView;
+    } else {
+        inputview = view;
+    }
+    if (shouldBecomeFirstResponder) {
+        UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, view);
+    }
+    [ACRInputLabelView commonSetFocus:shouldBecomeFirstResponder view:inputview];
 }
 
 - (BOOL)textFieldShouldReturn:(UITextField *)textField


### PR DESCRIPTION
## Related Issue
Fixed #5023, Fixed #5024 

## Description
Input.ChoiceSet had a regression in its layout; reverted ChoiceSet Xib related update
Setting focus on Input.Text and Input.Number caused erratic scrolling behavior. Updated to have the focus to be set on InputView of input, and allowed the scrolling to be handled by the host app, and explicitly set the accessibility focus on the input handler to announce the accessibility l

## Sample Card
https://github.com/microsoft/AdaptiveCards/blob/main/samples/v1.3/Elements/Input.ChoiceSet.ErrorMessage.json
https://github.com/microsoft/AdaptiveCards/blob/main/samples/v1.3/Elements/Input.Number.Label.json
https://github.com/microsoft/AdaptiveCards/blob/main/samples/v1.3/Elements/Input.Text.Label.json

## How Verified
How you verified the fix, including one or all of the following: 
1. Run most of the cards in 1.0/1.1/1.2 cards and run all of 1.3/elements


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5030)