### PR TITLE
[Android] Cherrypick of fixes for #5020 and #5021

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/ChoiceSetInputRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/ChoiceSetInputRenderer.java
@@ -258,7 +258,16 @@ public class ChoiceSetInputRenderer extends BaseCardElementRenderer
         boolean hasEmptyDefault = value.isEmpty();
         if (hasEmptyDefault)
         {
-            titleList.addElement(choiceSetInput.GetPlaceholder());
+            // Android has an undocumented behaviour where a spinner with an empty option selected
+            // will not receive accessibility focus, if we add an single space ' ' then the spinner
+            // can receive focus.
+            String placeholder = choiceSetInput.GetPlaceholder();
+            if (placeholder.isEmpty())
+            {
+                placeholder = " ";
+            }
+            titleList.addElement(placeholder);
+
             selection = (int) size;
         }
 

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/DateInputRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/DateInputRenderer.java
@@ -84,7 +84,6 @@ public class DateInputRenderer extends TextInputRenderer
                 ((!dateInput.GetMin().isEmpty()) || (!dateInput.GetMax().isEmpty())));
 
         editText.setRawInputType(TYPE_NULL);
-        editText.setFocusable(false);
         editText.setOnClickListener(new View.OnClickListener()
         {
             @Override

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/TimeInputRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/TimeInputRenderer.java
@@ -82,7 +82,6 @@ public class TimeInputRenderer extends TextInputRenderer
                 renderArgs,
                 (!timeInput.GetMin().isEmpty()) || (!timeInput.GetMax().isEmpty()) /* hasSpecificValidation */);
         editText.setRawInputType(TYPE_NULL);
-        editText.setFocusable(false);
         editText.setOnClickListener(new View.OnClickListener()
         {
             @Override

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/layout/StretchableInputLayout.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/layout/StretchableInputLayout.java
@@ -5,11 +5,14 @@ package io.adaptivecards.renderer.layout;
 
 import android.content.Context;
 import android.view.View;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import io.adaptivecards.renderer.BaseCardElementRenderer;
 import io.adaptivecards.renderer.Util;
 import io.adaptivecards.renderer.input.customcontrols.IValidatedInputView;
+import io.adaptivecards.renderer.input.customcontrols.ValidatedCheckBoxLayout;
+import io.adaptivecards.renderer.input.customcontrols.ValidatedRadioGroup;
 import io.adaptivecards.renderer.input.customcontrols.ValidatedSpinnerLayout;
 
 /**
@@ -20,6 +23,7 @@ public class StretchableInputLayout extends StretchableElementLayout
     private TextView m_label = null;
     private View m_inputView = null;
     private TextView m_errorMessage = null;
+    private View m_viewWithVisualCues = null;
 
     public StretchableInputLayout(Context context, boolean mustStretch)
     {
@@ -46,14 +50,29 @@ public class StretchableInputLayout extends StretchableElementLayout
     {
         addView(input);
 
+        // If input is a compact ChoiceSet, the spinners render inside of a LinearLayout,
+        // the LinearLayout is the view styled to have a visual cue when validation fails
         if (input instanceof ValidatedSpinnerLayout)
         {
             ValidatedSpinnerLayout layout = (ValidatedSpinnerLayout)input;
             m_inputView = layout.getChildAt(0);
+            m_viewWithVisualCues = input;
         }
+        // Input.Text with an inline action render inside a regular LinearLayout, but in this case
+        // the view inside of the Layout has the visual cue. We have to verify that the expanded
+        // ChoiceSet are not considered in this step as in that case they both use LinearLayout but
+        // the visual cue is in the layout
+        else if (input instanceof LinearLayout && !(input instanceof ValidatedRadioGroup || input instanceof ValidatedCheckBoxLayout))
+        {
+            LinearLayout textInputWithActionLayout = (LinearLayout)input;
+            m_inputView = textInputWithActionLayout.getChildAt(0);
+            m_viewWithVisualCues = m_inputView;
+        }
+        // Any other views don't deal with the issues above
         else
         {
             m_inputView = input;
+            m_viewWithVisualCues = input;
         }
 
         int viewId = (int)Util.getViewId(m_inputView);
@@ -78,9 +97,9 @@ public class StretchableInputLayout extends StretchableElementLayout
     public void setValidationResult(boolean isValid)
     {
         BaseCardElementRenderer.setVisibility(!isValid, m_errorMessage);
-        if (m_inputView instanceof IValidatedInputView)
+        if (m_viewWithVisualCues instanceof IValidatedInputView)
         {
-            ((IValidatedInputView) m_inputView).setValidationResult(isValid);
+            ((IValidatedInputView) m_viewWithVisualCues).setValidationResult(isValid);
         }
 
         if (m_label != null)

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/layout/StretchableInputLayout.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/layout/StretchableInputLayout.java
@@ -8,7 +8,9 @@ import android.view.View;
 import android.widget.TextView;
 
 import io.adaptivecards.renderer.BaseCardElementRenderer;
+import io.adaptivecards.renderer.Util;
 import io.adaptivecards.renderer.input.customcontrols.IValidatedInputView;
+import io.adaptivecards.renderer.input.customcontrols.ValidatedSpinnerLayout;
 
 /**
  * This class is only supposed to be used for inputs that have: label, validation, isRequired or stretch height
@@ -43,15 +45,21 @@ public class StretchableInputLayout extends StretchableElementLayout
     public void setInputView(View input)
     {
         addView(input);
-        m_inputView = input;
-        if(m_inputView.getId() == View.NO_ID)
+
+        if (input instanceof ValidatedSpinnerLayout)
         {
-            m_inputView.setId(View.generateViewId());
+            ValidatedSpinnerLayout layout = (ValidatedSpinnerLayout)input;
+            m_inputView = layout.getChildAt(0);
+        }
+        else
+        {
+            m_inputView = input;
         }
 
+        int viewId = (int)Util.getViewId(m_inputView);
         if (m_label != null)
         {
-            m_label.setLabelFor(m_inputView.getId());
+            m_label.setLabelFor(viewId);
         }
     }
 


### PR DESCRIPTION
## Related Issue
CP of #5020 (#5028 ) and #5021 (#5029 )


## Description
Fixes focus setting in Input. Time, Date and ChoiceSet and fixes visual cues for input.Text with inline actions



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5031)