### PR TITLE
[Android] Bump renderer to v2.3.1

### DIFF
--- a/source/android/adaptivecards/gradle.properties
+++ b/source/android/adaptivecards/gradle.properties
@@ -4,4 +4,4 @@ azureArtifactsGradleAccessToken=
 
 acVersionMajor = 2
 acVersionMinor = 3
-acVersionPatch = 0
+acVersionPatch = 1


### PR DESCRIPTION
## Description
Bump Android renderer version number to 2.3.1 for patch update

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5037)