### PR TITLE
[Android] Set density only when non-null

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/GenericImageLoaderAsync.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/GenericImageLoaderAsync.java
@@ -256,7 +256,9 @@ public abstract class GenericImageLoaderAsync extends AsyncTask<String, Void, Ht
         if (result.isSuccessful())
         {
             Bitmap image = result.getResult();
-            image.setDensity(DisplayMetrics.DENSITY_DEFAULT);
+            if(image != null) {
+                image.setDensity(DisplayMetrics.DENSITY_DEFAULT);
+            }
             onSuccessfulPostExecute(image);
         }
         else

--- a/source/android/mobilechatapp/build.gradle
+++ b/source/android/mobilechatapp/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 
     implementation 'com.android.support:support-annotations:28.0.0'
     implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.android.support.constraint:constraint-layout:2.0.1'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation 'com.android.support:design:28.0.0'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'


### PR DESCRIPTION
## Related Issue
No linked issue.

## Description
Empty image returns null, so shouldn't attempt to scale in those cases.

## Sample Card
`v1.2/Tests/Image.DataUri.InvalidChars.json`

## How Verified
Manual verification with fix. Doesn't crash.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5046)