### PR TITLE
Fixed the voiceover to announce 'space' when label has only whitespace chars

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRichTextBlockRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRichTextBlockRenderer.mm
@@ -180,6 +180,9 @@
     lab.textContainer.lineBreakMode = NSLineBreakByTruncatingTail;
     lab.attributedText = content;
     lab.isAccessibilityElement = YES;
+    if ([content.string stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet].length == 0) {
+        lab.accessibilityElementsHidden = YES;
+    }
     lab.area = lab.frame.size.width * lab.frame.size.height;
 
     lab.translatesAutoresizingMaskIntoConstraints = NO;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextBlockRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextBlockRenderer.mm
@@ -109,7 +109,9 @@
 
         lab.textContainer.lineBreakMode = NSLineBreakByTruncatingTail;
         lab.attributedText = content;
-        lab.isAccessibilityElement = YES;
+        if ([content.string stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet].length == 0) {
+            lab.accessibilityElementsHidden = YES;
+        }
     }
 
     lab.translatesAutoresizingMaskIntoConstraints = NO;


### PR DESCRIPTION
## Related Issue
ADO https://microsoft.visualstudio.com/OS/_queries/edit/29468860/?triage=true
## Description
String consisted only with the whitespace chars is being read by the voiceover as "space". Fixed the issue by making the label accessibility hidden as making it an inaccessibility item caused the voiceover to announce the label "space" regardlessly.

## Sample Card
https://github.com/microsoft/AdaptiveCards/blob/main/samples/v1.0/Tests/Feedback.json

## How Verified
1. Ran the repro steps specified in ADO to verify.
2. Tested with TextBlock cards to make sure there are no regressions in the voiceover.
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it; N/A 



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5067)