### PR TITLE
Made media icon to be accessible element

### DIFF
--- a/samples/v1.1/Elements/Media.Sources.json
+++ b/samples/v1.1/Elements/Media.Sources.json
@@ -19,6 +19,7 @@
 		{
 			"type": "Media",
 			"poster": "https://adaptivecards.io/content/poster-video.png",
+			"altText": "Adaptive Cards overview video",
 			"sources": [{
 				"mimeType": "video/mp4",
 				"url": "https://adaptivecardsblob.blob.core.windows.net/assets/AdaptiveCardsOverviewVideo.mp4"
@@ -34,6 +35,7 @@
 		{
 			"type": "Media",
 			"poster": "https://adaptivecards.io/content/poster-audio.jpg",
+			"altText": "Adaptive Cards overview audio",
 			"sources": [{
 				"mimeType": "audio/mpeg",
 				"url": "https://adaptivecardsblob.blob.core.windows.net/assets/AdaptiveCardsOverviewVideo.mp3"

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRMediaRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRMediaRenderer.mm
@@ -145,6 +145,14 @@
         UILongPressGestureRecognizer *recognizer = [ACRLongPressGestureRecognizerFactory getGestureRecognizer:viewGroup target:mediaTarget];
         [view addGestureRecognizer:recognizer];
         view.userInteractionEnabled = YES;
+
+        contentholdingview.isAccessibilityElement = NO;
+        view.isAccessibilityElement = YES;
+        view.accessibilityTraits = UIAccessibilityTraitStartsMediaSession | UIAccessibilityTraitButton;
+        NSString *stringForAccessibilityLabel = [NSString stringWithCString:mediaElem->GetAltText().c_str() encoding:NSUTF8StringEncoding];
+        if (stringForAccessibilityLabel.length) {
+            view.accessibilityLabel = stringForAccessibilityLabel;
+        }
     }
 
     configVisibility(contentholdingview, elem);


### PR DESCRIPTION
## Related Issue
ADO https://microsoft.visualstudio.com/OS/_queries/edit/29527290/?triage=true

## Description
Media Source card is not accessible for iOS. Added alt text to the card, and made media element to be accessible by adding the accessible label, and changing the role as the button.

## Sample Card
https://github.com/microsoft/AdaptiveCards/blob/main/samples/v1.1/Elements/Media.Sources.json

## How Verified
How you verified the fix, including one or all of the following: 
1. Existing relevant unit/regression tests that you ran; Media.Source.json is tested & verified.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5068)