### PR TITLE
added link to Action.OpenUrl buttons

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionOpenURLRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionOpenURLRenderer.mm
@@ -40,6 +40,8 @@
     if (ACRRenderingStatus::ACROk == buildTargetForButton([rootView getActionsTargetBuilderDirector], acoElem, button, &target)) {
         [superview addTarget:target];
     }
+    
+    button.accessibilityTraits |= UIAccessibilityTraitLink;
 
     [button setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisVertical];
 


### PR DESCRIPTION
## Related Issue
ADO https://microsoft.visualstudio.com/OS/_queries/edit/29139727/?triage=true

## Description
Action.OpenURL buttons should have links as the role. This change adds the link to the role.

## Sample Card
https://github.com/microsoft/AdaptiveCards/blob/main/samples/v1.0/Elements/Action.OpenUrl.json

## How Verified
1. New unit tests that were added if any. was able to repro using Action.OpenUrl.json
2. Existing relevant unit/regression tests that you ran; Action.OpenUrl.json


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5071)