### PR TITLE
Fix break caused by AEL behavioral change in v4.10

### DIFF
--- a/source/nodejs/adaptivecards-designer-app/package-lock.json
+++ b/source/nodejs/adaptivecards-designer-app/package-lock.json
@@ -45,13 +45,13 @@
 		},
 		"@microsoft/recognizers-text-data-types-timex-expression": {
 			"version": "1.1.4",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/recognizers-text-data-types-timex-expression/-/recognizers-text-data-types-timex-expression-1.1.4.tgz",
-			"integrity": "sha1-YjRTrmXo3yEtgVb2oxRnXDBpbB0="
+			"resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-data-types-timex-expression/-/recognizers-text-data-types-timex-expression-1.1.4.tgz",
+			"integrity": "sha512-2vICaEJfV9EpaDKs5P1PLAEs+WpNqrtpkl7CLsmc5gKmxgpQtsojG4tk6km5JRKg1mYuLV5ZzJ/65oOEeyTMvQ=="
 		},
 		"@types/atob-lite": {
 			"version": "2.0.0",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@types/atob-lite/-/atob-lite-2.0.0.tgz",
-			"integrity": "sha1-vUTKcuZaWEd+gTCaZuQBUk8YcFM="
+			"resolved": "https://registry.npmjs.org/@types/atob-lite/-/atob-lite-2.0.0.tgz",
+			"integrity": "sha512-7bjymPR7Ffa1/L3HskkaxMgTQDtwFObbISzHm9g3T12VyD89IiHS3BBVojlQHyZRiIilzdh0WT1gwwgyyBtLGQ=="
 		},
 		"@types/color-name": {
 			"version": "1.1.1",
@@ -83,8 +83,8 @@
 		},
 		"@types/lru-cache": {
 			"version": "5.1.0",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@types/lru-cache/-/lru-cache-5.1.0.tgz",
-			"integrity": "sha1-V/Io8rgMBGtKG9XKwDH4HyB/TwM="
+			"resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.0.tgz",
+			"integrity": "sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w=="
 		},
 		"@types/minimatch": {
 			"version": "3.0.3",
@@ -94,8 +94,8 @@
 		},
 		"@types/moment-timezone": {
 			"version": "0.5.30",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@types/moment-timezone/-/moment-timezone-0.5.30.tgz",
-			"integrity": "sha1-NA7UX+PnFfSgEfXPzrfLUqrUb8c=",
+			"resolved": "https://registry.npmjs.org/@types/moment-timezone/-/moment-timezone-0.5.30.tgz",
+			"integrity": "sha512-aDVfCsjYnAQaV/E9Qc24C5Njx1CoDjXsEgkxtp9NyXDpYu4CCbmclb6QhWloS9UTU/8YROUEEdEkWI0D7DxnKg==",
 			"requires": {
 				"moment-timezone": "*"
 			}
@@ -108,8 +108,8 @@
 		},
 		"@types/xmldom": {
 			"version": "0.1.30",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@types/xmldom/-/xmldom-0.1.30.tgz",
-			"integrity": "sha1-022afWSvRpPTsY1dwCzkMqlb4S4="
+			"resolved": "https://registry.npmjs.org/@types/xmldom/-/xmldom-0.1.30.tgz",
+			"integrity": "sha512-edqgAFXMEtVvaBZ3YnhamvmrHjoYpuxETmnb0lbTZmf/dXpAsO9ZKotUO4K2rn2SIZBDFCMOuA7fOe0H6dRZcA=="
 		},
 		"@typescript-eslint/eslint-plugin": {
 			"version": "3.6.1",
@@ -392,9 +392,9 @@
 			"dev": true
 		},
 		"adaptive-expressions": {
-			"version": "4.10.4",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/adaptive-expressions/-/adaptive-expressions-4.10.4.tgz",
-			"integrity": "sha1-9/QS2Y1dJ1OuQKcueIcwcdj/1ZQ=",
+			"version": "4.11.0",
+			"resolved": "https://registry.npmjs.org/adaptive-expressions/-/adaptive-expressions-4.11.0.tgz",
+			"integrity": "sha512-CrSPRrnevGbjA0tSoNQc2q1P4iBmsFvMi1Nx56Qz6pxImMFTCKYhSYR88jvPwGIl5z+UlAWz2zmidMw9lVt9fg==",
 			"requires": {
 				"@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
 				"@types/atob-lite": "^2.0.0",
@@ -404,52 +404,12 @@
 				"antlr4ts": "0.5.0-alpha.3",
 				"atob-lite": "^2.0.0",
 				"big-integer": "^1.6.48",
+				"d3-format": "^1.4.4",
 				"jspath": "^0.4.0",
 				"lodash": "^4.17.19",
 				"lru-cache": "^5.1.1",
 				"moment": "^2.25.1",
 				"moment-timezone": "^0.5.28"
-			}
-		},
-		"adaptivecards": {
-			"version": "2.4.0",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/adaptivecards/-/adaptivecards-2.4.0.tgz",
-			"integrity": "sha1-isjrM7po79lJmkbcydRQVUtOhvY=",
-			"dev": true
-		},
-		"adaptivecards-controls": {
-			"version": "0.4.0",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/adaptivecards-controls/-/adaptivecards-controls-0.4.0.tgz",
-			"integrity": "sha1-2Y3BtuqAJ/Uo4gwgWvO5I72syBc=",
-			"dev": true
-		},
-		"adaptivecards-designer": {
-			"version": "1.4.0",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/adaptivecards-designer/-/adaptivecards-designer-1.4.0.tgz",
-			"integrity": "sha1-mq8ijd+TEcZj/Lj2a7dGNk7Xz2k=",
-			"dev": true,
-			"requires": {
-				"adaptive-expressions": "^4.9.2",
-				"adaptivecards": "^2.4.0",
-				"adaptivecards-controls": "^0.5.0",
-				"adaptivecards-templating": "^1.4.0",
-				"clipboard": "^2.0.1"
-			},
-			"dependencies": {
-				"adaptivecards-controls": {
-					"version": "0.5.0",
-					"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/adaptivecards-controls/-/adaptivecards-controls-0.5.0.tgz",
-					"integrity": "sha1-n0yXF94m7uZWAPq7si1FsX9WLN8=",
-					"dev": true
-				}
-			}
-		},
-		"adaptivecards-templating": {
-			"version": "1.4.0",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/adaptivecards-templating/-/adaptivecards-templating-1.4.0.tgz",
-			"integrity": "sha1-upPEGXCxoC+4j+3ppQTSkc0vuLE=",
-			"requires": {
-				"adaptive-expressions": "^4.9.2"
 			}
 		},
 		"ajv": {
@@ -505,8 +465,8 @@
 		},
 		"antlr4ts": {
 			"version": "0.5.0-alpha.3",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/antlr4ts/-/antlr4ts-0.5.0-alpha.3.tgz",
-			"integrity": "sha1-+m052I1rljQaiv70WGevmryzh2Y="
+			"resolved": "https://registry.npmjs.org/antlr4ts/-/antlr4ts-0.5.0-alpha.3.tgz",
+			"integrity": "sha512-La89tKkGcHFIVuruv4Bm1esc3zLmES2NOTEwwNS1pudz+zx/0FNqQeUu9p48i9/QHKPVqjN87LB+q3buTg7oDQ=="
 		},
 		"anymatch": {
 			"version": "3.1.1",
@@ -666,7 +626,7 @@
 		},
 		"atob-lite": {
 			"version": "2.0.0",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/atob-lite/-/atob-lite-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
 			"integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY="
 		},
 		"balanced-match": {
@@ -744,8 +704,8 @@
 		},
 		"big-integer": {
 			"version": "1.6.48",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/big-integer/-/big-integer-1.6.48.tgz",
-			"integrity": "sha1-j9iL0WMsukocjD49cVnwi7lbS54="
+			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
+			"integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w=="
 		},
 		"big.js": {
 			"version": "5.2.2",
@@ -1232,17 +1192,6 @@
 				}
 			}
 		},
-		"clipboard": {
-			"version": "2.0.6",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/clipboard/-/clipboard-2.0.6.tgz",
-			"integrity": "sha1-UpISlu7A/fd+rRdJQhshyWhkc3Y=",
-			"dev": true,
-			"requires": {
-				"good-listener": "^1.2.2",
-				"select": "^1.1.2",
-				"tiny-emitter": "^2.0.0"
-			}
-		},
 		"cliui": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -1536,6 +1485,11 @@
 			"integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
 			"dev": true
 		},
+		"d3-format": {
+			"version": "1.4.5",
+			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+			"integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
+		},
 		"debug": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -1662,12 +1616,6 @@
 					}
 				}
 			}
-		},
-		"delegate": {
-			"version": "3.2.0",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/delegate/-/delegate-3.2.0.tgz",
-			"integrity": "sha1-tmtxwxWFIuirV0T3INjKDCr1kWY=",
-			"dev": true
 		},
 		"depd": {
 			"version": "1.1.2",
@@ -2738,15 +2686,6 @@
 				}
 			}
 		},
-		"good-listener": {
-			"version": "1.2.2",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/good-listener/-/good-listener-1.2.2.tgz",
-			"integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-			"dev": true,
-			"requires": {
-				"delegate": "^3.1.2"
-			}
-		},
 		"graceful-fs": {
 			"version": "4.2.4",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
@@ -3345,8 +3284,8 @@
 		},
 		"jspath": {
 			"version": "0.4.0",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/jspath/-/jspath-0.4.0.tgz",
-			"integrity": "sha1-L1/RgI/yJJqIo8ReZCKIoib4Xh0="
+			"resolved": "https://registry.npmjs.org/jspath/-/jspath-0.4.0.tgz",
+			"integrity": "sha512-2/R8wkot8NCXrppBT/onp+4mcAUAZqtPxsW6aSJU3hrFAVqKqtFYcat2XJZ7inN4RtATUxfv0UQSYOmvJKiIGA=="
 		},
 		"killable": {
 			"version": "1.0.1",
@@ -3653,13 +3592,13 @@
 		},
 		"moment": {
 			"version": "2.29.1",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/moment/-/moment-2.29.1.tgz",
-			"integrity": "sha1-sr52n6MZQL6e7qZGnAdeNQBvo9M="
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+			"integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
 		},
 		"moment-timezone": {
-			"version": "0.5.31",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/moment-timezone/-/moment-timezone-0.5.31.tgz",
-			"integrity": "sha1-nEDYxQJvDHq0bto9Y+ScFVFI3gU=",
+			"version": "0.5.32",
+			"resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.32.tgz",
+			"integrity": "sha512-Z8QNyuQHQAmWucp8Knmgei8YNo28aLjJq6Ma+jy1ZSpSk5nyfRT8xgUbSQvD2+2UajISfenndwvFuH3NGS+nvA==",
 			"requires": {
 				"moment": ">= 2.9.0"
 			}
@@ -4626,12 +4565,6 @@
 				"ajv-keywords": "^3.4.1"
 			}
 		},
-		"select": {
-			"version": "1.1.2",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/select/-/select-1.1.2.tgz",
-			"integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
-			"dev": true
-		},
 		"select-hose": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -5395,12 +5328,6 @@
 			"requires": {
 				"setimmediate": "^1.0.4"
 			}
-		},
-		"tiny-emitter": {
-			"version": "2.1.0",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-			"integrity": "sha1-HRpW7fxRxD6GPLtTgqcjMONVVCM=",
-			"dev": true
 		},
 		"to-arraybuffer": {
 			"version": "1.0.1",

--- a/source/nodejs/adaptivecards-designer-app/package.json
+++ b/source/nodejs/adaptivecards-designer-app/package.json
@@ -30,7 +30,7 @@
 		"webpack-dev-server": "^3.11.0"
 	},
 	"dependencies": {
-		"adaptive-expressions": "^4.9.2",
+		"adaptive-expressions": "^4.11.0",
 		"adaptivecards-templating": "^1.1.0"
 	}
 }

--- a/source/nodejs/adaptivecards-designer/package-lock.json
+++ b/source/nodejs/adaptivecards-designer/package-lock.json
@@ -32,8 +32,8 @@
 		},
 		"@microsoft/recognizers-text-data-types-timex-expression": {
 			"version": "1.1.4",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@microsoft/recognizers-text-data-types-timex-expression/-/@microsoft/recognizers-text-data-types-timex-expression-1.1.4.tgz",
-			"integrity": "sha1-YjRTrmXo3yEtgVb2oxRnXDBpbB0=",
+			"resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-data-types-timex-expression/-/recognizers-text-data-types-timex-expression-1.1.4.tgz",
+			"integrity": "sha512-2vICaEJfV9EpaDKs5P1PLAEs+WpNqrtpkl7CLsmc5gKmxgpQtsojG4tk6km5JRKg1mYuLV5ZzJ/65oOEeyTMvQ==",
 			"dev": true
 		},
 		"@mrmlnc/readdir-enhanced": {
@@ -54,8 +54,8 @@
 		},
 		"@types/atob-lite": {
 			"version": "2.0.0",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/atob-lite/-/@types/atob-lite-2.0.0.tgz",
-			"integrity": "sha1-vUTKcuZaWEd+gTCaZuQBUk8YcFM=",
+			"resolved": "https://registry.npmjs.org/@types/atob-lite/-/atob-lite-2.0.0.tgz",
+			"integrity": "sha512-7bjymPR7Ffa1/L3HskkaxMgTQDtwFObbISzHm9g3T12VyD89IiHS3BBVojlQHyZRiIilzdh0WT1gwwgyyBtLGQ==",
 			"dev": true
 		},
 		"@types/color-name": {
@@ -88,8 +88,8 @@
 		},
 		"@types/lru-cache": {
 			"version": "5.1.0",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/lru-cache/-/@types/lru-cache-5.1.0.tgz",
-			"integrity": "sha1-V/Io8rgMBGtKG9XKwDH4HyB/TwM=",
+			"resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.0.tgz",
+			"integrity": "sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w==",
 			"dev": true
 		},
 		"@types/minimatch": {
@@ -106,8 +106,8 @@
 		},
 		"@types/moment-timezone": {
 			"version": "0.5.30",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/moment-timezone/-/@types/moment-timezone-0.5.30.tgz",
-			"integrity": "sha1-NA7UX+PnFfSgEfXPzrfLUqrUb8c=",
+			"resolved": "https://registry.npmjs.org/@types/moment-timezone/-/moment-timezone-0.5.30.tgz",
+			"integrity": "sha512-aDVfCsjYnAQaV/E9Qc24C5Njx1CoDjXsEgkxtp9NyXDpYu4CCbmclb6QhWloS9UTU/8YROUEEdEkWI0D7DxnKg==",
 			"dev": true,
 			"requires": {
 				"moment-timezone": "*"
@@ -127,8 +127,8 @@
 		},
 		"@types/xmldom": {
 			"version": "0.1.30",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/xmldom/-/@types/xmldom-0.1.30.tgz",
-			"integrity": "sha1-022afWSvRpPTsY1dwCzkMqlb4S4=",
+			"resolved": "https://registry.npmjs.org/@types/xmldom/-/xmldom-0.1.30.tgz",
+			"integrity": "sha512-edqgAFXMEtVvaBZ3YnhamvmrHjoYpuxETmnb0lbTZmf/dXpAsO9ZKotUO4K2rn2SIZBDFCMOuA7fOe0H6dRZcA==",
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {
@@ -412,9 +412,9 @@
 			"dev": true
 		},
 		"adaptive-expressions": {
-			"version": "4.10.4",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/adaptive-expressions/-/adaptive-expressions-4.10.4.tgz",
-			"integrity": "sha1-9/QS2Y1dJ1OuQKcueIcwcdj/1ZQ=",
+			"version": "4.11.0",
+			"resolved": "https://registry.npmjs.org/adaptive-expressions/-/adaptive-expressions-4.11.0.tgz",
+			"integrity": "sha512-CrSPRrnevGbjA0tSoNQc2q1P4iBmsFvMi1Nx56Qz6pxImMFTCKYhSYR88jvPwGIl5z+UlAWz2zmidMw9lVt9fg==",
 			"dev": true,
 			"requires": {
 				"@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
@@ -425,31 +425,12 @@
 				"antlr4ts": "0.5.0-alpha.3",
 				"atob-lite": "^2.0.0",
 				"big-integer": "^1.6.48",
+				"d3-format": "^1.4.4",
 				"jspath": "^0.4.0",
 				"lodash": "^4.17.19",
 				"lru-cache": "^5.1.1",
 				"moment": "^2.25.1",
 				"moment-timezone": "^0.5.28"
-			}
-		},
-		"adaptivecards": {
-			"version": "2.4.0",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/adaptivecards/-/adaptivecards-2.4.0.tgz",
-			"integrity": "sha1-isjrM7po79lJmkbcydRQVUtOhvY=",
-			"dev": true
-		},
-		"adaptivecards-controls": {
-			"version": "0.4.0",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/adaptivecards-controls/-/adaptivecards-controls-0.4.0.tgz",
-			"integrity": "sha1-2Y3BtuqAJ/Uo4gwgWvO5I72syBc="
-		},
-		"adaptivecards-templating": {
-			"version": "1.4.0",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/adaptivecards-templating/-/adaptivecards-templating-1.4.0.tgz",
-			"integrity": "sha1-upPEGXCxoC+4j+3ppQTSkc0vuLE=",
-			"dev": true,
-			"requires": {
-				"adaptive-expressions": "^4.9.2"
 			}
 		},
 		"aggregate-error": {
@@ -515,8 +496,8 @@
 		},
 		"antlr4ts": {
 			"version": "0.5.0-alpha.3",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/antlr4ts/-/antlr4ts-0.5.0-alpha.3.tgz",
-			"integrity": "sha1-+m052I1rljQaiv70WGevmryzh2Y=",
+			"resolved": "https://registry.npmjs.org/antlr4ts/-/antlr4ts-0.5.0-alpha.3.tgz",
+			"integrity": "sha512-La89tKkGcHFIVuruv4Bm1esc3zLmES2NOTEwwNS1pudz+zx/0FNqQeUu9p48i9/QHKPVqjN87LB+q3buTg7oDQ==",
 			"dev": true
 		},
 		"anymatch": {
@@ -683,7 +664,7 @@
 		},
 		"atob-lite": {
 			"version": "2.0.0",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/atob-lite/-/atob-lite-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
 			"integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=",
 			"dev": true
 		},
@@ -762,8 +743,8 @@
 		},
 		"big-integer": {
 			"version": "1.6.48",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/big-integer/-/big-integer-1.6.48.tgz",
-			"integrity": "sha1-j9iL0WMsukocjD49cVnwi7lbS54=",
+			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
+			"integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
 			"dev": true
 		},
 		"big.js": {
@@ -1600,6 +1581,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
 			"integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
+			"dev": true
+		},
+		"d3-format": {
+			"version": "1.4.5",
+			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+			"integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==",
 			"dev": true
 		},
 		"debug": {
@@ -3621,8 +3608,8 @@
 		},
 		"jspath": {
 			"version": "0.4.0",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/jspath/-/jspath-0.4.0.tgz",
-			"integrity": "sha1-L1/RgI/yJJqIo8ReZCKIoib4Xh0=",
+			"resolved": "https://registry.npmjs.org/jspath/-/jspath-0.4.0.tgz",
+			"integrity": "sha512-2/R8wkot8NCXrppBT/onp+4mcAUAZqtPxsW6aSJU3hrFAVqKqtFYcat2XJZ7inN4RtATUxfv0UQSYOmvJKiIGA==",
 			"dev": true
 		},
 		"junk": {
@@ -3970,14 +3957,14 @@
 		},
 		"moment": {
 			"version": "2.29.1",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/moment/-/moment-2.29.1.tgz",
-			"integrity": "sha1-sr52n6MZQL6e7qZGnAdeNQBvo9M=",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+			"integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
 			"dev": true
 		},
 		"moment-timezone": {
-			"version": "0.5.31",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/moment-timezone/-/moment-timezone-0.5.31.tgz",
-			"integrity": "sha1-nEDYxQJvDHq0bto9Y+ScFVFI3gU=",
+			"version": "0.5.32",
+			"resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.32.tgz",
+			"integrity": "sha512-Z8QNyuQHQAmWucp8Knmgei8YNo28aLjJq6Ma+jy1ZSpSk5nyfRT8xgUbSQvD2+2UajISfenndwvFuH3NGS+nvA==",
 			"dev": true,
 			"requires": {
 				"moment": ">= 2.9.0"

--- a/source/nodejs/adaptivecards-designer/package.json
+++ b/source/nodejs/adaptivecards-designer/package.json
@@ -39,7 +39,7 @@
 	},
 	"peerDependencies": {
 		"adaptivecards": "^2.1.0",
-		"adaptive-expressions": "^4.9.2",
+		"adaptive-expressions": "^4.11.0",
 		"adaptivecards-templating": "^1.1.0",
 		"monaco-editor": "^0.20.0"
 	},
@@ -47,7 +47,7 @@
 		"@typescript-eslint/eslint-plugin": "^3.4.0",
 		"@typescript-eslint/parser": "^3.4.0",
 		"adaptivecards": "^2.1.0",
-		"adaptive-expressions": "^4.9.2",
+		"adaptive-expressions": "^4.11.0",
 		"adaptivecards-templating": "^1.1.0",
 		"cpy-cli": "^3.1.1",
 		"eslint": "^7.3.1",

--- a/source/nodejs/adaptivecards-site/package-lock.json
+++ b/source/nodejs/adaptivecards-site/package-lock.json
@@ -12,8 +12,8 @@
 		},
 		"@microsoft/recognizers-text-data-types-timex-expression": {
 			"version": "1.1.4",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@microsoft/recognizers-text-data-types-timex-expression/-/recognizers-text-data-types-timex-expression-1.1.4.tgz",
-			"integrity": "sha1-YjRTrmXo3yEtgVb2oxRnXDBpbB0=",
+			"resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-data-types-timex-expression/-/recognizers-text-data-types-timex-expression-1.1.4.tgz",
+			"integrity": "sha512-2vICaEJfV9EpaDKs5P1PLAEs+WpNqrtpkl7CLsmc5gKmxgpQtsojG4tk6km5JRKg1mYuLV5ZzJ/65oOEeyTMvQ==",
 			"dev": true
 		},
 		"@mrmlnc/readdir-enhanced": {
@@ -40,8 +40,8 @@
 		},
 		"@types/atob-lite": {
 			"version": "2.0.0",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@types/atob-lite/-/atob-lite-2.0.0.tgz",
-			"integrity": "sha1-vUTKcuZaWEd+gTCaZuQBUk8YcFM=",
+			"resolved": "https://registry.npmjs.org/@types/atob-lite/-/atob-lite-2.0.0.tgz",
+			"integrity": "sha512-7bjymPR7Ffa1/L3HskkaxMgTQDtwFObbISzHm9g3T12VyD89IiHS3BBVojlQHyZRiIilzdh0WT1gwwgyyBtLGQ==",
 			"dev": true
 		},
 		"@types/color-name": {
@@ -62,8 +62,8 @@
 		},
 		"@types/lru-cache": {
 			"version": "5.1.0",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@types/lru-cache/-/lru-cache-5.1.0.tgz",
-			"integrity": "sha1-V/Io8rgMBGtKG9XKwDH4HyB/TwM=",
+			"resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.0.tgz",
+			"integrity": "sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w==",
 			"dev": true
 		},
 		"@types/minimatch": {
@@ -74,8 +74,8 @@
 		},
 		"@types/moment-timezone": {
 			"version": "0.5.30",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@types/moment-timezone/-/moment-timezone-0.5.30.tgz",
-			"integrity": "sha1-NA7UX+PnFfSgEfXPzrfLUqrUb8c=",
+			"resolved": "https://registry.npmjs.org/@types/moment-timezone/-/moment-timezone-0.5.30.tgz",
+			"integrity": "sha512-aDVfCsjYnAQaV/E9Qc24C5Njx1CoDjXsEgkxtp9NyXDpYu4CCbmclb6QhWloS9UTU/8YROUEEdEkWI0D7DxnKg==",
 			"dev": true,
 			"requires": {
 				"moment-timezone": "*"
@@ -95,8 +95,8 @@
 		},
 		"@types/xmldom": {
 			"version": "0.1.30",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/@types/xmldom/-/xmldom-0.1.30.tgz",
-			"integrity": "sha1-022afWSvRpPTsY1dwCzkMqlb4S4=",
+			"resolved": "https://registry.npmjs.org/@types/xmldom/-/xmldom-0.1.30.tgz",
+			"integrity": "sha512-edqgAFXMEtVvaBZ3YnhamvmrHjoYpuxETmnb0lbTZmf/dXpAsO9ZKotUO4K2rn2SIZBDFCMOuA7fOe0H6dRZcA==",
 			"dev": true
 		},
 		"@webassemblyjs/ast": {
@@ -325,9 +325,9 @@
 			"dev": true
 		},
 		"adaptive-expressions": {
-			"version": "4.11.0",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/adaptive-expressions/-/adaptive-expressions-4.11.0.tgz",
-			"integrity": "sha1-dB/Hz3HRj88oxFXsY2tze1gDYt8=",
+			"version": "4.11.1-rc0",
+			"resolved": "https://registry.npmjs.org/adaptive-expressions/-/adaptive-expressions-4.11.1-rc0.tgz",
+			"integrity": "sha512-z83TaTCyf/PQsADgQK1FYHzGppG6MRTvlcpWCczg6wFi930MjJtgeMQjAlm4snBUat8jLic2wX2mssUudIPk9Q==",
 			"dev": true,
 			"requires": {
 				"@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
@@ -348,8 +348,8 @@
 			"dependencies": {
 				"lru-cache": {
 					"version": "5.1.1",
-					"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/lru-cache/-/lru-cache-5.1.1.tgz",
-					"integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
 					"dev": true,
 					"requires": {
 						"yallist": "^3.0.2"
@@ -357,8 +357,8 @@
 				},
 				"yallist": {
 					"version": "3.1.1",
-					"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/yallist/-/yallist-3.1.1.tgz",
-					"integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0=",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 					"dev": true
 				}
 			}
@@ -440,8 +440,8 @@
 		},
 		"antlr4ts": {
 			"version": "0.5.0-alpha.3",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/antlr4ts/-/antlr4ts-0.5.0-alpha.3.tgz",
-			"integrity": "sha1-+m052I1rljQaiv70WGevmryzh2Y=",
+			"resolved": "https://registry.npmjs.org/antlr4ts/-/antlr4ts-0.5.0-alpha.3.tgz",
+			"integrity": "sha512-La89tKkGcHFIVuruv4Bm1esc3zLmES2NOTEwwNS1pudz+zx/0FNqQeUu9p48i9/QHKPVqjN87LB+q3buTg7oDQ==",
 			"dev": true
 		},
 		"anymatch": {
@@ -672,7 +672,7 @@
 		},
 		"atob-lite": {
 			"version": "2.0.0",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/atob-lite/-/atob-lite-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
 			"integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=",
 			"dev": true
 		},
@@ -858,8 +858,8 @@
 		},
 		"big-integer": {
 			"version": "1.6.48",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/big-integer/-/big-integer-1.6.48.tgz",
-			"integrity": "sha1-j9iL0WMsukocjD49cVnwi7lbS54=",
+			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
+			"integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
 			"dev": true
 		},
 		"big.js": {
@@ -2540,8 +2540,8 @@
 		},
 		"d3-format": {
 			"version": "1.4.5",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/d3-format/-/d3-format-1.4.5.tgz",
-			"integrity": "sha1-N08roTIONxfrdKk1bGfa7hen7bQ=",
+			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+			"integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==",
 			"dev": true
 		},
 		"dashdash": {
@@ -7061,8 +7061,8 @@
 		},
 		"jspath": {
 			"version": "0.4.0",
-			"resolved": "https://onedrive.pkgs.visualstudio.com/_packaging/odsp-npm/npm/registry/jspath/-/jspath-0.4.0.tgz",
-			"integrity": "sha1-L1/RgI/yJJqIo8ReZCKIoib4Xh0=",
+			"resolved": "https://registry.npmjs.org/jspath/-/jspath-0.4.0.tgz",
+			"integrity": "sha512-2/R8wkot8NCXrppBT/onp+4mcAUAZqtPxsW6aSJU3hrFAVqKqtFYcat2XJZ7inN4RtATUxfv0UQSYOmvJKiIGA==",
 			"dev": true
 		},
 		"jsprim": {

--- a/source/nodejs/adaptivecards-templating/package-lock.json
+++ b/source/nodejs/adaptivecards-templating/package-lock.json
@@ -65,10 +65,10 @@
 			"integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
 			"dev": true
 		},
-		"@types/atob": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/@types/atob/-/atob-2.1.2.tgz",
-			"integrity": "sha512-8GAYQ1jDRUQkSpHzJUqXwAkYFOxuWAOGLhIR4aPd/Y/yL12Q/9m7LsKpHKlfKdNE/362Hc9wPI1Yh6opDfxVJg==",
+		"@types/atob-lite": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@types/atob-lite/-/atob-lite-2.0.0.tgz",
+			"integrity": "sha512-7bjymPR7Ffa1/L3HskkaxMgTQDtwFObbISzHm9g3T12VyD89IiHS3BBVojlQHyZRiIilzdh0WT1gwwgyyBtLGQ==",
 			"dev": true
 		},
 		"@types/color-name": {
@@ -112,12 +112,12 @@
 			"dev": true
 		},
 		"@types/moment-timezone": {
-			"version": "0.5.13",
-			"resolved": "https://registry.npmjs.org/@types/moment-timezone/-/moment-timezone-0.5.13.tgz",
-			"integrity": "sha512-SWk1qM8DRssS5YR9L4eEX7WUhK/wc96aIr4nMa6p0kTk9YhGGOJjECVhIdPEj13fvJw72Xun69gScXSZ/UmcPg==",
+			"version": "0.5.30",
+			"resolved": "https://registry.npmjs.org/@types/moment-timezone/-/moment-timezone-0.5.30.tgz",
+			"integrity": "sha512-aDVfCsjYnAQaV/E9Qc24C5Njx1CoDjXsEgkxtp9NyXDpYu4CCbmclb6QhWloS9UTU/8YROUEEdEkWI0D7DxnKg==",
 			"dev": true,
 			"requires": {
-				"moment": ">=2.14.0"
+				"moment-timezone": "*"
 			}
 		},
 		"@types/node": {
@@ -413,21 +413,22 @@
 			"dev": true
 		},
 		"adaptive-expressions": {
-			"version": "4.9.2",
-			"resolved": "https://registry.npmjs.org/adaptive-expressions/-/adaptive-expressions-4.9.2.tgz",
-			"integrity": "sha512-hywLFmj0NwMR2GoIg185p/oSc7hp+fagEwG4/1415fhL+lsbR25E/GS1InCUhWa8JSoyn+0EuneLey+BCGlOiA==",
+			"version": "4.11.0",
+			"resolved": "https://registry.npmjs.org/adaptive-expressions/-/adaptive-expressions-4.11.0.tgz",
+			"integrity": "sha512-CrSPRrnevGbjA0tSoNQc2q1P4iBmsFvMi1Nx56Qz6pxImMFTCKYhSYR88jvPwGIl5z+UlAWz2zmidMw9lVt9fg==",
 			"dev": true,
 			"requires": {
 				"@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
-				"@types/atob": "^2.1.2",
+				"@types/atob-lite": "^2.0.0",
 				"@types/lru-cache": "^5.1.0",
-				"@types/moment-timezone": "^0.5.12",
+				"@types/moment-timezone": "^0.5.13",
 				"@types/xmldom": "^0.1.29",
-				"antlr4ts": "0.5.0-alpha.1",
-				"atob": "^2.1.2",
+				"antlr4ts": "0.5.0-alpha.3",
+				"atob-lite": "^2.0.0",
 				"big-integer": "^1.6.48",
+				"d3-format": "^1.4.4",
 				"jspath": "^0.4.0",
-				"lodash": "^4.17.15",
+				"lodash": "^4.17.19",
 				"lru-cache": "^5.1.1",
 				"moment": "^2.25.1",
 				"moment-timezone": "^0.5.28"
@@ -485,9 +486,9 @@
 			}
 		},
 		"antlr4ts": {
-			"version": "0.5.0-alpha.1",
-			"resolved": "https://registry.npmjs.org/antlr4ts/-/antlr4ts-0.5.0-alpha.1.tgz",
-			"integrity": "sha512-LU5FLWq2fUwg2cTL/DeIL16ucUm5jv6SNVFoMjbYLviXAp6p5g1ZzkTAnWiOKX/muEEy0PY78perPj6WUBSQCw==",
+			"version": "0.5.0-alpha.3",
+			"resolved": "https://registry.npmjs.org/antlr4ts/-/antlr4ts-0.5.0-alpha.3.tgz",
+			"integrity": "sha512-La89tKkGcHFIVuruv4Bm1esc3zLmES2NOTEwwNS1pudz+zx/0FNqQeUu9p48i9/QHKPVqjN87LB+q3buTg7oDQ==",
 			"dev": true
 		},
 		"anymatch": {
@@ -656,6 +657,12 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+			"dev": true
+		},
+		"atob-lite": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
+			"integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=",
 			"dev": true
 		},
 		"balanced-match": {
@@ -1528,6 +1535,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
 			"integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
+			"dev": true
+		},
+		"d3-format": {
+			"version": "1.4.5",
+			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+			"integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==",
 			"dev": true
 		},
 		"debug": {
@@ -3740,15 +3753,15 @@
 			}
 		},
 		"moment": {
-			"version": "2.27.0",
-			"resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
-			"integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==",
+			"version": "2.29.1",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+			"integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
 			"dev": true
 		},
 		"moment-timezone": {
-			"version": "0.5.31",
-			"resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.31.tgz",
-			"integrity": "sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==",
+			"version": "0.5.32",
+			"resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.32.tgz",
+			"integrity": "sha512-Z8QNyuQHQAmWucp8Knmgei8YNo28aLjJq6Ma+jy1ZSpSk5nyfRT8xgUbSQvD2+2UajISfenndwvFuH3NGS+nvA==",
 			"dev": true,
 			"requires": {
 				"moment": ">= 2.9.0"

--- a/source/nodejs/adaptivecards-templating/package.json
+++ b/source/nodejs/adaptivecards-templating/package.json
@@ -38,7 +38,7 @@
 	"devDependencies": {
 		"@typescript-eslint/eslint-plugin": "^3.4.0",
 		"@typescript-eslint/parser": "^3.4.0",
-		"adaptive-expressions": "^4.9.2",
+		"adaptive-expressions": "^4.11.0",
 		"eslint": "^7.3.1",
 		"rimraf": "^3.0.2",
 		"typedoc": "0.19.2",
@@ -50,6 +50,6 @@
 		"webpack-dev-server": "^3.11.0"
 	},
 	"peerDependencies": {
-		"adaptive-expressions": "^4.9.2"
+		"adaptive-expressions": "^4.11.0"
 	}
 }

--- a/source/nodejs/adaptivecards-templating/src/template-engine.ts
+++ b/source/nodejs/adaptivecards-templating/src/template-engine.ts
@@ -239,6 +239,17 @@ export class Template {
                     // of that single expression
                     return parsedExpression.children[0];
                 }
+                else if (parsedExpression.children.length === 2) {
+                    let firstChild = parsedExpression.children[0];
+
+                    if (firstChild instanceof AEL.Constant && firstChild.value === "" && !(parsedExpression.children[1] instanceof AEL.Constant)) {
+                        // The concat contains 2 children, and the first one is an empty string constant and the second isn't a constant.
+                        // From version 4.10.3, AEL always inserts an empty string constant in all concat expression. Thus the original
+                        // string was a single expression in this case as well. When evaluated, we want it to produce the type
+                        // of that single expression.
+                        return parsedExpression.children[1];
+                    }
+                }
 
                 // Otherwise, we want the expression to produce a string
                 return parsedExpression;


### PR DESCRIPTION
## Related Issue
Fixes https://github.com/microsoft/AdaptiveCards/issues/5100

## Description
Works around a behavioral change in AEL introduced in version 4.10 which causes single expressions such as `${age}` to be generated as `concat` and produce strings instead of the actual type of the expression.

## Test card
```
{
    "type": "AdaptiveCard",
    "$data": {
        "title": "Not empty"
    },
    "body": [
        {
            "type": "TextBlock",
            "size": "Medium",
            "weight": "Bolder",
            "text": "Test card"
        },
        {
            "type": "TextBlock",
            "text": "Should be visible only if title isn't empty",
            "wrap": true,
            "$when": "${title != ''}"
        }
    ],
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
    "version": "1.3"
}
```

Without this fix, the "$when" clause will incorrectly evaluate to the string "true". With the fix, it will correctly evaluate to the boolean value `true`.

## How Verified
Verified manually in adaptivecards-designer-app

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5101)