### PR TITLE
[pic2card] updated classify font weight 

### DIFF
--- a/source/pic2card/mystique/font_properties.py
+++ b/source/pic2card/mystique/font_properties.py
@@ -27,15 +27,15 @@ def classify_font_weights(design_objects):
             # print(f"{item['data']}, weight is {item['weight']}")
             dynamic_thresh.append(item['weight'][item['uuid']])
 
-    std = statistics.stdev(dynamic_thresh)
-    mean = np.mean(dynamic_thresh)
-    # Setting threshold limits based on difference between mean and
-    # std deviation for collected font weights
-    bold_limit = round(mean + std, 2)
-    light_limit = round(mean - std, 2)
+    if len(set(dynamic_thresh)) > 1:
+        std = statistics.pstdev(dynamic_thresh)
+        mean = np.mean(dynamic_thresh)
+        # Setting threshold limits based on
+        # difference between mean and std deviation
+        bold_limit = round(mean + std, 2)
+        light_limit = round(mean - std, 2)
 
-    # if only one element or negative limits is identified in the given picture
-    if bold_limit == light_limit or light_limit <= 0:
+    else:
         bold_limit = default_host_configs.FONT_WEIGHT_MORPH['bolder']
         light_limit = default_host_configs.FONT_WEIGHT_MORPH['lighter']
 


### PR DESCRIPTION
Have updated the classify_font_weights function to handle images with empty weights and similar weights. 

Image with no textbox property : 
![Screenshot from 2020-12-01 12-27-06](https://user-images.githubusercontent.com/25405858/100767035-4d461080-341f-11eb-91f5-98b216a80153.png)
Image with similar weights for textbox properties identified :
![Screenshot from 2020-12-01 12-27-31](https://user-images.githubusercontent.com/25405858/100767044-4fa86a80-341f-11eb-9a66-1945a1f523df.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5121)