### PR TITLE
[TS][Renderer] Input.Number.value as string in Action.Submit

### DIFF
--- a/source/nodejs/adaptivecards-site/package.json
+++ b/source/nodejs/adaptivecards-site/package.json
@@ -11,7 +11,7 @@
     "start": "hexo server"
   },
   "hexo": {
-    "version": "5.2.0"
+    "version": "4.2.1"
   },
   "devDependencies": {
     "@fortawesome/fontawesome-free": "^5.11.2",

--- a/source/nodejs/adaptivecards-site/package.json
+++ b/source/nodejs/adaptivecards-site/package.json
@@ -11,7 +11,7 @@
     "start": "hexo server"
   },
   "hexo": {
-    "version": "4.2.1"
+    "version": "5.2.0"
   },
   "devDependencies": {
     "@fortawesome/fontawesome-free": "^5.11.2",

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -3983,7 +3983,7 @@ export class SubmitAction extends Action {
                 let input = inputs[key];
 
                 if (input.id) {
-                    this._processedData[input.id] = input.value;
+                    this._processedData[input.id] = typeof input.value === "string" ? input.value : input.value.toString();
                 }
             }
         }


### PR DESCRIPTION
## Related Issue
Fixes https://github.com/microsoft/AdaptiveCards/issues/5111

## Description
Reverts to emitting Input.Number.value as a string in an Action.Submit.data

## Sample Card
```
{
    "type": "AdaptiveCard",
    "body": [
        {
            "type": "Input.Number",
            "placeholder": "Placeholder text",
            "min": 1,
            "max": 10,
            "value": 8,
            "id": "fsd"
        }
    ],
    "actions": [
        {
            "type": "Action.Submit",
            "title": "Action.Submit"
        }
    ],
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
    "version": "1.3"
}
```
## How Verified
Verified manually in adaptivecards-designer-app

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5134)