### PR TITLE
[UWP] Add support for associatedInputs none value

### DIFF
--- a/samples/v1.3/Elements/Action.Submit.AssociatedInputs.json
+++ b/samples/v1.3/Elements/Action.Submit.AssociatedInputs.json
@@ -1,0 +1,25 @@
+{
+  "type": "AdaptiveCard",
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.3",
+  "body": [
+    {
+      "type": "Input.Text",
+      "id": "name",
+      "label": "Please enter your name:",
+      "isRequired": true,
+      "errorMessage": "Name is required"
+    }
+  ],
+  "actions": [
+    {
+      "type": "Action.Submit",
+      "title": "Cancel",
+      "associatedInputs": "none"
+    },
+    {
+      "type": "Action.Submit",
+      "title": "Submit"
+    }
+  ]
+}

--- a/samples/v1.3/Elements/Action.Submit.AssociatedInputs.json
+++ b/samples/v1.3/Elements/Action.Submit.AssociatedInputs.json
@@ -1,25 +1,25 @@
 {
-  "type": "AdaptiveCard",
-  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
-  "version": "1.3",
-  "body": [
-    {
-      "type": "Input.Text",
-      "id": "name",
-      "label": "Please enter your name:",
-      "isRequired": true,
-      "errorMessage": "Name is required"
-    }
-  ],
-  "actions": [
-    {
-      "type": "Action.Submit",
-      "title": "Cancel",
-      "associatedInputs": "none"
-    },
-    {
-      "type": "Action.Submit",
-      "title": "Submit"
-    }
-  ]
+	"type": "AdaptiveCard",
+	"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+	"version": "1.3",
+	"body": [
+		{
+			"type": "Input.Text",
+			"id": "name",
+			"label": "Please enter your name:",
+			"isRequired": true,
+			"errorMessage": "Name is required"
+		}
+	],
+	"actions": [
+		{
+			"type": "Action.Submit",
+			"title": "Cancel",
+			"associatedInputs": "none"
+		},
+		{
+			"type": "Action.Submit",
+			"title": "Submit"
+		}
+	]
 }

--- a/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
+++ b/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
@@ -358,7 +358,8 @@ AdaptiveNamespaceStart
 
     [version(NTDDI_WIN10_RS1)]
 #ifdef ADAPTIVE_CARDS_WINDOWS
-    [contract(InternalContract, 1)][internal]
+    [contract(InternalContract, 1)]
+    [internal]
 #endif
     typedef[v1_enum] enum IsVisible {
         IsVisibleToggle = 0,
@@ -368,7 +369,8 @@ AdaptiveNamespaceStart
 
     [version(NTDDI_WIN10_RS1)]
 #ifdef ADAPTIVE_CARDS_WINDOWS
-    [contract(InternalContract, 1)][internal]
+    [contract(InternalContract, 1)]
+    [internal]
 #endif
     typedef[v1_enum] enum FallbackType {
         None = 0,
@@ -378,7 +380,8 @@ AdaptiveNamespaceStart
 
     [version(NTDDI_WIN10_RS1), flags]
 #ifdef ADAPTIVE_CARDS_WINDOWS
-    [contract(InternalContract, 1)][internal]
+    [contract(InternalContract, 1)]
+    [internal]
 #endif
     typedef[v1_enum] enum BleedDirection {
         None = 0x0000,
@@ -391,7 +394,8 @@ AdaptiveNamespaceStart
 
     [version(NTDDI_WIN10_RS1)]
 #ifdef ADAPTIVE_CARDS_WINDOWS
-    [contract(InternalContract, 1)][internal]
+    [contract(InternalContract, 1)]
+    [internal]
 #endif
     typedef[v1_enum] enum AssociatedInputs {
         Auto = 0,

--- a/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
+++ b/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
@@ -389,6 +389,15 @@ AdaptiveNamespaceStart
         All = Left | Right | Up | Down
     } BleedDirection;
 
+    [version(NTDDI_WIN10_RS1)]
+#ifdef ADAPTIVE_CARDS_WINDOWS
+    [contract(InternalContract, 1)][internal]
+#endif
+    typedef[v1_enum] enum AssociatedInputs {
+        Auto = 0,
+        None,
+    } AssociatedInputs;
+
     declare
     {
         interface Windows.Foundation.Collections.IVector<IAdaptiveCardElement*>;
@@ -1519,7 +1528,7 @@ AdaptiveNamespaceStart
         AdaptiveSubmitAction();
 
         Windows.Data.Json.JsonValue DataJson;
-        Boolean IgnoreInputValidation;
+        AssociatedInputs AssociatedInputs;
     };
 
     [

--- a/source/uwp/Renderer/lib/AdaptiveSubmitAction.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveSubmitAction.cpp
@@ -33,7 +33,7 @@ namespace AdaptiveNamespace
             RETURN_IF_FAILED(StringToJsonValue(sharedSubmitAction->GetDataJson(), &m_dataJson));
         }
 
-        m_ignoreInputValidation = sharedSubmitAction->GetIgnoreInputValidation();
+        m_associatedInputs = static_cast<ABI::AdaptiveNamespace::AssociatedInputs> (sharedSubmitAction->GetAssociatedInputs());
 
         InitializeBaseElement(std::static_pointer_cast<AdaptiveSharedNamespace::BaseActionElement>(sharedSubmitAction));
         return S_OK;
@@ -54,15 +54,15 @@ namespace AdaptiveNamespace
         return S_OK;
     }
 
-    HRESULT AdaptiveSubmitAction::get_IgnoreInputValidation(boolean* ignoreInputValidation)
+    HRESULT AdaptiveSubmitAction::get_AssociatedInputs(ABI::AdaptiveNamespace::AssociatedInputs* associatedInputs)
     {
-        *ignoreInputValidation = m_ignoreInputValidation;
+        *associatedInputs = m_associatedInputs;
         return S_OK;
     }
 
-    HRESULT AdaptiveSubmitAction::put_IgnoreInputValidation(boolean ignoreInputValidation)
+    HRESULT AdaptiveSubmitAction::put_AssociatedInputs(ABI::AdaptiveNamespace::AssociatedInputs associatedInputs)
     {
-        m_ignoreInputValidation = ignoreInputValidation;
+        m_associatedInputs = associatedInputs;
         return S_OK;
     }
 
@@ -80,7 +80,7 @@ namespace AdaptiveNamespace
             submitAction->SetDataJson(std::move(jsonAsString));
         }
 
-        submitAction->SetIgnoreInputValidation(m_ignoreInputValidation);
+        submitAction->SetAssociatedInputs(static_cast<AdaptiveSharedNamespace::AssociatedInputs> (m_associatedInputs));
 
         sharedModel = std::move(submitAction);
         return S_OK;

--- a/source/uwp/Renderer/lib/AdaptiveSubmitAction.h
+++ b/source/uwp/Renderer/lib/AdaptiveSubmitAction.h
@@ -24,8 +24,8 @@ namespace AdaptiveNamespace
         IFACEMETHODIMP get_DataJson(_COM_Outptr_ ABI::Windows::Data::Json::IJsonValue** data);
         IFACEMETHODIMP put_DataJson(_In_ ABI::Windows::Data::Json::IJsonValue* data);
 
-        IFACEMETHODIMP get_IgnoreInputValidation(_Out_ boolean* ignoreInputValidation);
-        IFACEMETHODIMP put_IgnoreInputValidation(boolean ignoreInputValidation);
+        IFACEMETHODIMP get_AssociatedInputs(_Out_ ABI::AdaptiveNamespace::AssociatedInputs* associatedInputs);
+        IFACEMETHODIMP put_AssociatedInputs(ABI::AdaptiveNamespace::AssociatedInputs associatedInputs);
 
         // IAdaptiveActionElement
         IFACEMETHODIMP get_ActionType(_Out_ ABI::AdaptiveNamespace::ActionType* actionType);
@@ -90,7 +90,7 @@ namespace AdaptiveNamespace
 
     private:
         Microsoft::WRL::ComPtr<ABI::Windows::Data::Json::IJsonValue> m_dataJson;
-        boolean m_ignoreInputValidation;
+        ABI::AdaptiveNamespace::AssociatedInputs m_associatedInputs;
     };
 
     ActivatableClass(AdaptiveSubmitAction);

--- a/source/uwp/Renderer/lib/RenderedAdaptiveCard.cpp
+++ b/source/uwp/Renderer/lib/RenderedAdaptiveCard.cpp
@@ -265,7 +265,7 @@ namespace AdaptiveNamespace
         {
             ComPtr<IAdaptiveActionsConfig> actionConfig;
             RETURN_IF_FAILED(m_originatingHostConfig->get_Actions(&actionConfig));
-
+            
             ComPtr<IAdaptiveShowCardActionConfig> showCardConfig;
             RETURN_IF_FAILED(actionConfig->get_ShowCard(&showCardConfig));
 
@@ -291,14 +291,14 @@ namespace AdaptiveNamespace
             RETURN_IF_FAILED(localActionElement.As(&submitAction));
 
             ABI::AdaptiveNamespace::AssociatedInputs associatedInputs;
-            submitAction->get_AssociatedInputs(&associatedInputs);
+            RETURN_IF_FAILED(submitAction->get_AssociatedInputs(&associatedInputs));
 
             ComPtr<IAdaptiveInputs> gatheredInputs;
             boolean inputsAreValid;
             if (associatedInputs == ABI::AdaptiveNamespace::AssociatedInputs::None)
             {
                 // Create an empty inputs object
-                THROW_IF_FAILED(MakeAndInitialize<AdaptiveInputs>(&gatheredInputs));
+                RETURN_IF_FAILED(MakeAndInitialize<AdaptiveInputs>(&gatheredInputs));
                 inputsAreValid = true;
             }
             else

--- a/source/uwp/UWPUnitTests/ObjectModelTests.cs
+++ b/source/uwp/UWPUnitTests/ObjectModelTests.cs
@@ -780,14 +780,15 @@ namespace UWPUnitTests
                 IconUrl = "http://www.stuff.com/icon.jpg",
                 Id = "OpenUrlId",
                 Style = "Destructive",
-                Title = "Title"
+                Title = "Title",
+                AssociatedInputs = AssociatedInputs.None
             };
 
             ValidateBaseActionProperties(submitAction, "http://www.stuff.com/icon.jpg", "OpenUrlId", "Title", "Destructive");
             Assert.AreEqual(dataJson, submitAction.DataJson);
 
             var jsonString = submitAction.ToJson().ToString();
-            Assert.AreEqual("{\"data\":\"foo\",\"iconUrl\":\"http://www.stuff.com/icon.jpg\",\"id\":\"OpenUrlId\",\"style\":\"Destructive\",\"title\":\"Title\",\"type\":\"Action.Submit\"}", jsonString);
+            Assert.AreEqual("{\"associatedInputs\":\"None\",\"data\":\"foo\",\"iconUrl\":\"http://www.stuff.com/icon.jpg\",\"id\":\"OpenUrlId\",\"style\":\"Destructive\",\"title\":\"Title\",\"type\":\"Action.Submit\"}", jsonString);
         }
 
         [TestMethod]


### PR DESCRIPTION
## Related Issue
UWP implementation for #5078

## Description
Consumed the associatedInputs property in UWP from the shared model. Updated the submit code to not perform validation and to return an empty inputs object when none is set.

## Sample Card
New card added with this change at samples\v1.3\Elements\Action.Submit.AssociatedInputs.json

## How Verified
Updated UWP object model tests and ensured that they still run and pass. Manual validation of scenario using new sample card.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5141)