### PR TITLE
[Android] Support associatedInputs: none

### DIFF
--- a/source/android/adaptivecards/build.gradle
+++ b/source/android/adaptivecards/build.gradle
@@ -15,7 +15,7 @@ android {
         externalNativeBuild {
             cmake {
                 cppFlags "-std=c++14 -fexceptions -frtti -DNO_LOCALE_SUPPORT"
-                arguments "-DANDROID_STL=c++_shared"
+                arguments "-DANDROID_STL=c++_static"
             }
         }
     }

--- a/source/android/adaptivecards/build.gradle
+++ b/source/android/adaptivecards/build.gradle
@@ -15,7 +15,7 @@ android {
         externalNativeBuild {
             cmake {
                 cppFlags "-std=c++14 -fexceptions -frtti -DNO_LOCALE_SUPPORT"
-                arguments "-DANDROID_STL=c++_static"
+                arguments "-DANDROID_STL=c++_shared"
             }
         }
     }

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/BaseActionElementRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/BaseActionElementRenderer.java
@@ -17,6 +17,7 @@ import java.util.Set;
 
 import io.adaptivecards.objectmodel.ActionMode;
 import io.adaptivecards.objectmodel.ActionType;
+import io.adaptivecards.objectmodel.AssociatedInputs;
 import io.adaptivecards.objectmodel.BaseActionElement;
 import io.adaptivecards.objectmodel.HostConfig;
 import io.adaptivecards.objectmodel.IsVisible;
@@ -332,7 +333,17 @@ public abstract class BaseActionElementRenderer implements IBaseActionElementRen
             {
                 if (m_action.GetElementType() == ActionType.Submit || m_renderedAdaptiveCard.isActionSubmitable(view))
                 {
-                    if (!m_renderedAdaptiveCard.areInputsValid(Util.getViewId(view)))
+                    // Don't gather inputs or perform validation when AssociatedInputs is None
+                    boolean gatherInputs = true;
+                    try
+                    {
+                        gatherInputs = Util.castTo(m_action, SubmitAction.class).GetAssociatedInputs() != AssociatedInputs.None;
+                    }
+                    catch (ClassCastException e)
+                    {
+                        // Custom action with Submit type will continue to gather inputs
+                    }
+                    if (gatherInputs && !m_renderedAdaptiveCard.areInputsValid(Util.getViewId(view)))
                     {
                         return;
                     }

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/RenderedAdaptiveCard.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/RenderedAdaptiveCard.java
@@ -5,15 +5,10 @@ package io.adaptivecards.renderer;
 import android.view.View;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Vector;
 
 import io.adaptivecards.objectmodel.AdaptiveCard;
-import io.adaptivecards.objectmodel.BaseActionElement;
-import io.adaptivecards.objectmodel.BaseCardElement;
-import io.adaptivecards.objectmodel.InternalId;
-import io.adaptivecards.objectmodel.SubmitAction;
 import io.adaptivecards.renderer.inputhandler.BaseInputHandler;
 import io.adaptivecards.renderer.inputhandler.IInputHandler;
 


### PR DESCRIPTION
## Related Issue
Android part of #5078

## Description
When `associatedInputs` is set to `none`, we don't gather inputs or perform validation.

## Sample Card
`v1.3\Elements\Action.Submit.AssociatedInputs.json`
Cancel:
![image](https://user-images.githubusercontent.com/4442788/101708651-b5b67280-3a5b-11eb-84de-d7caa1e0fbb2.png)
![image](https://user-images.githubusercontent.com/4442788/101708705-d1217d80-3a5b-11eb-956e-f2b46793fe94.png)
Submit:
![image](https://user-images.githubusercontent.com/4442788/101708606-9881a400-3a5b-11eb-8010-90fd166cccb4.png)
![image](https://user-images.githubusercontent.com/4442788/101708672-c1a23480-3a5b-11eb-93fc-8d1be3d65ac5.png)

## How Verified
Manual, see screenshots above.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5152)