### PR TITLE
[Android] Bump minor 2.4.0, and reference to new binary EULA (#5187)

### DIFF
--- a/source/android/adaptivecards/build.gradle
+++ b/source/android/adaptivecards/build.gradle
@@ -53,8 +53,8 @@ def projectInfo = {
 
     licenses {
         license {
-            name = 'MIT'
-            url = 'https://github.com/Microsoft/AdaptiveCards/blob/main/LICENSE'
+            name = 'Adaptive Cards Binary EULA'
+            url = 'https://github.com/microsoft/AdaptiveCards/blob/main/source/EULA-Non-Windows.txt'
             distribution = 'repo'
         }
     }

--- a/source/android/adaptivecards/gradle.properties
+++ b/source/android/adaptivecards/gradle.properties
@@ -3,5 +3,5 @@ NexusPassword=
 azureArtifactsGradleAccessToken=
 
 acVersionMajor = 2
-acVersionMinor = 2
+acVersionMinor = 4
 acVersionPatch = 0

--- a/source/android/mobile/src/main/res/raw/importer_card.json
+++ b/source/android/mobile/src/main/res/raw/importer_card.json
@@ -21,7 +21,7 @@
 				  },
 				  {
 					"title": "CalendarReminder",
-					"value": "v1.3/Scenarios/CalendarReminderWithLabels.json "
+					"value": "v1.3/Scenarios/CalendarReminderWithLabels.json"
 				  },
 				  {
 					"title": "FlightItinerary",


### PR DESCRIPTION
* [Android] Bump minor v2.4.0

* Point to new EULA

Clean cherry-pick of #5187, no conflicts.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5188)