### PR TITLE
excluded arm64 from pod spec

### DIFF
--- a/source/ios/tools/AdaptiveCards.podspec
+++ b/source/ios/tools/AdaptiveCards.podspec
@@ -13,6 +13,10 @@ Pod::Spec.new do |spec|
   spec.summary          = 'Adaptive Cards are a new way for developers to exchange card content in a common and consistent way'
   
   spec.source           = { :http => 'https://adaptivecardsblob.blob.core.windows.net/adaptivecardsiosblobs/AdaptiveCards.framework.zip' }
+
+  spec.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+
+  spec.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
  
   spec.vendored_frameworks = 'AdaptiveCards.framework'
   


### PR DESCRIPTION
## Related Issue
N/A

## Description
Updated the podspec not to attempt linking with arm64 binary for testing.
[more info](https://stackoverflow.com/questions/63607158/xcode-12-building-for-ios-simulator-but-linking-in-object-file-built-for-ios)
## Sample Card
N/A

## How Verified
Ran the lint locally.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5190)