### PR TITLE
[JS] Focus media element after it's inserted

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -2216,6 +2216,7 @@ export class Media extends CardElement {
                 this.renderedElement.appendChild(mediaPlayerElement);
 
                 mediaPlayerElement.play();
+                mediaPlayerElement.focus();
             }
         }
         else {


### PR DESCRIPTION
## Related Issue
Fixes VSO 30864226

## Description
When a media player element is inserted into the DOM, it needs to be explicitly focused -- otherwise keyboard focus can get lost on invocation.

## How Verified
* local build, devtools

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5258)