### PR TITLE
[.NET] Set accessibility text for rich text block select actions to action title

### DIFF
--- a/samples/v1.3/Tests/RichTextBlock.SelectActionAccessiblityTitle.json
+++ b/samples/v1.3/Tests/RichTextBlock.SelectActionAccessiblityTitle.json
@@ -1,0 +1,20 @@
+{
+  "type": "AdaptiveCard",
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.3",
+  "body": [
+    {
+      "type": "RichTextBlock",
+      "inlines": [
+        {
+          "type": "TextRun",
+          "text": "This is the text",
+          "selectAction": {
+            "type": "Action.Submit",
+            "title": "Click me"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveRichTextBlockRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveRichTextBlockRenderer.cs
@@ -2,17 +2,12 @@
 // Licensed under the MIT License.
 using System;
 using System.Globalization;
-using System.Text;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Data;
-using System.Windows.Markup;
 using System.Windows.Media;
-using Microsoft.MarkedNet;
-using System.IO;
-using System.Xml;
-using System.Drawing.Text;
+using System.Windows.Automation;
 
 namespace AdaptiveCards.Rendering.Wpf
 {
@@ -44,6 +39,11 @@ namespace AdaptiveCards.Rendering.Wpf
                 };
 
                 textRunSpan = selectActionLink as Span;
+
+                if (textRun.SelectAction.Title != null)
+                {
+                    AutomationProperties.SetName(textRunSpan, textRun.SelectAction.Title);
+                }
             }
             else
             {


### PR DESCRIPTION
## Related Issue
.NET fix for #4856

## Description
Set the automation property name to the action title for rich text block select actions

## Sample Card
Added new file at samples/v1.3/Tests/RichTextBlock.SelectActionAccessiblityTitle.json

## How Verified
Verified that narrator now reads the action title rather than the text for text run select actions in the added card.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5295)