### PR TITLE
[Site] Fix a couple typos

### DIFF
--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/explorer.ejs
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/explorer.ejs
@@ -44,7 +44,7 @@
 			</div>
 
 			<p><strong>Important note about accessibility:</strong> 
-				In version 1.3 of the schema we introduced a <a href="https://docs.microsoft.com/en-us/adaptive-cards/authoring-cards/input-validation#labels"><strong>label</strong></a> property on Inputs to improve accessibility. If the <a href="https://docs.microsoft.com/en-us/adaptive-cards/resources/partners">Host app you are targetting</a> supports v1.3 you should use <strong>label</strong> intead of a <strong>TextBlock</strong> as seen in some samples below. Once most Host apps have updated to the latest version we will update the samples accordingly.</a>
+				In version 1.3 of the schema we introduced a <a href="https://docs.microsoft.com/en-us/adaptive-cards/authoring-cards/input-validation#labels"><strong>label</strong></a> property on Inputs to improve accessibility. If the <a href="https://docs.microsoft.com/en-us/adaptive-cards/resources/partners">Host app you are targetting</a> supports v1.3 you should use <strong>label</strong> instead of a <strong>TextBlock</strong> as seen in some samples below. Once most Host apps have updated to the latest version we will update the samples accordingly.</a>
 			</p>
 
 			<h2><%= page.element.name %></h2>

--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/sample.ejs
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/sample.ejs
@@ -24,7 +24,7 @@
 					Go ahead and tweak them to make any scenario possible!</p>
 
 				<p><strong>Important note about accessibility:</strong> 
-					In version 1.3 of the schema we introduced a <a href="https://docs.microsoft.com/en-us/adaptive-cards/authoring-cards/input-validation#labels"><strong>label</strong></a> property on Inputs to improve accessibility. If the <a href="https://docs.microsoft.com/en-us/adaptive-cards/resources/partners">Host app you are targetting</a> supports v1.3 you should use <strong>label</strong> intead of a <strong>TextBlock</strong> as seen in some samples below. Once most Host apps have updated to the latest version we will update the samples accordingly.</a>
+					In version 1.3 of the schema we introduced a <a href="https://docs.microsoft.com/en-us/adaptive-cards/authoring-cards/input-validation#labels"><strong>label</strong></a> property on Inputs to improve accessibility. If the <a href="https://docs.microsoft.com/en-us/adaptive-cards/resources/partners">Host app you are targetting</a> supports v1.3 you should use <strong>label</strong> instead of a <strong>TextBlock</strong> as seen in some samples below. Once most Host apps have updated to the latest version we will update the samples accordingly.</a>
 				</p>
 		
 


### PR DESCRIPTION
## Description

Noticed a couple typos on the website -- `intead` rather than `instead` :)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5318)