### PR TITLE
[UWP] Initialize empty input object for OpenUrl action invoke

### DIFF
--- a/source/uwp/Renderer/lib/RenderedAdaptiveCard.cpp
+++ b/source/uwp/Renderer/lib/RenderedAdaptiveCard.cpp
@@ -324,7 +324,12 @@ namespace AdaptiveNamespace
         default:
         {
             ComPtr<IAdaptiveActionEventArgs> eventArgs;
-            RETURN_IF_FAILED(MakeAndInitialize<AdaptiveActionEventArgs>(&eventArgs, actionElement, nullptr));
+
+            // Create an empty inputs object
+            ComPtr<IAdaptiveInputs> inputs;
+            RETURN_IF_FAILED(MakeAndInitialize<AdaptiveInputs>(&inputs));
+
+            RETURN_IF_FAILED(MakeAndInitialize<AdaptiveActionEventArgs>(&eventArgs, actionElement, inputs.Get()));
             return m_actionEvents->InvokeAll(this, eventArgs.Get());
         }
         }


### PR DESCRIPTION
## Related Issue
Fixes #5330

## Description
As part of the work to implement `"associatedInputs":"none"`, the action invoke code was refactored in such a way that OpenUrl action invokes no longer had an Inputs object. Although this object was always empty for OpenUrl types, our Visualizer depended on it being non-null. Because it's technically a breaking change (that actually broke the visualizer), I restored the old behavior where OpenUrl action invocations have an empty but non-null inputs object. 

## Sample Card
ActivityUpdate.json scenario card

## How Verified
Confirmed OpenUrl button now works as expected


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5336)