### PR TITLE
[UWP] Fixed bug where select actions without titles were not set properly

### DIFF
--- a/source/uwp/Renderer/lib/ActionHelpers.cpp
+++ b/source/uwp/Renderer/lib/ActionHelpers.cpp
@@ -693,8 +693,6 @@ namespace AdaptiveNamespace::ActionHelpers
 
                 THROW_IF_FAILED(automationPropertiesStatics->SetName(buttonAsDependencyObject.Get(), title.Get()));
 
-                WireButtonClickToAction(button.Get(), action, renderContext);
-
                 // Also use the title as the tooltip
                 ComPtr<IToolTip> toolTip =
                     XamlHelpers::CreateXamlClass<IToolTip>(HStringReference(RuntimeClass_Windows_UI_Xaml_Controls_ToolTip));
@@ -714,6 +712,8 @@ namespace AdaptiveNamespace::ActionHelpers
 
                 THROW_IF_FAILED(toolTipService->SetToolTip(buttonAsDependencyObject.Get(), toolTip.Get()));
             }
+
+            WireButtonClickToAction(button.Get(), action, renderContext);
         }
 
         THROW_IF_FAILED(button.CopyTo(finalElement));


### PR DESCRIPTION
## Related Issue
Fixes #5331

## Description
As part of setting tool tips on select actions, the code to actually wire up the click handler was accidently trapped inside a `title.IsValid()` check. Moved this call out of the if statement to fix.

## Sample Card
ExpenseReport.json scenario card

## How Verified
Verified toggles in Expense report card now behave as expected.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5337)