### PR TITLE
[.NET] Handle HTML space entities

### DIFF
--- a/samples/v1.3/Tests/HtmlSpaces.json
+++ b/samples/v1.3/Tests/HtmlSpaces.json
@@ -1,0 +1,23 @@
+{
+	"type": "AdaptiveCard",
+	"version": "1.0",
+	"body": [
+		{
+			"type": "TextBlock",
+			"text": "TextBlock with 4 \"space\" characters    1"
+		},
+		{
+			"type": "TextBlock",
+			"text": "TextBlock with 4 \"&-nbsp;\" characters&nbsp;&nbsp;&nbsp;&nbsp;1"
+		},
+		{
+			"type": "TextBlock",
+			"text": "TextBlock with 4 \"&-ensp;\" characters&ensp;&ensp;&ensp;&ensp;1"
+		},
+		{
+			"type": "TextBlock",
+			"text": "TextBlock with 4 \"&-emsp;\" characters&emsp;&emsp;&emsp;&emsp;1"
+		}
+	],
+	"$schema": "http://adaptivecards.io/schemas/adaptive-card.json"
+}

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveTextBlockRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveTextBlockRenderer.cs
@@ -80,8 +80,12 @@ namespace AdaptiveCards.Rendering.Wpf
             marked.Options.Sanitize = true;
 
             string text = RendererUtilities.ApplyTextFunctions(textBlock.Text, context.Lang);
-            // uiTextBlock.Text = textBlock.Text;
-            string xaml = $"<TextBlock  xmlns=\"http://schemas.microsoft.com/winfx/2006/xaml/presentation\">{marked.Parse(text)}</TextBlock>";
+
+            text = marked.Parse(text);
+            text = RendererUtilities.HandleHtmlSpaces(text);
+            
+            string xaml = $"<TextBlock  xmlns=\"http://schemas.microsoft.com/winfx/2006/xaml/presentation\">{text}</TextBlock>";
+
             StringReader stringReader = new StringReader(xaml);
 
             XmlReader xmlReader = XmlReader.Create(stringReader);

--- a/source/dotnet/Library/AdaptiveCards/Rendering/RendererUtilities.cs
+++ b/source/dotnet/Library/AdaptiveCards/Rendering/RendererUtilities.cs
@@ -22,6 +22,13 @@ namespace AdaptiveCards.Rendering
         private static readonly Regex _regexBinding = new Regex(@"(?<property>\{\{\w+?\}\})+?",
             RegexOptions.ExplicitCapture);
 
+        public static string HandleHtmlSpaces(string text)
+        {
+            return text.Replace("&amp;nbsp;", "&#x00A0;")
+                .Replace("&amp;ensp;", "&#x2002;")
+                .Replace("&amp;emsp;", "&#x2003;");
+        }
+
         /// <summary>
         ///     This funct will return modified text replacing {{DATE|TIME()}} style functions as the formatted text
         /// </summary>


### PR DESCRIPTION
## Related Issue
Fixes #4679 

## Description
Added handling of &nbsp, &ensp, and &emsp by replacing them with the corresponding unicode characters.

## Sample Card
Added sample card at https://github.com/microsoft/AdaptiveCards/blob/main/samples/v1.3/Tests/HtmlSpaces.json

## How Verified
Confirmed using above sample card that the three html entities appear as expected in the rendered card.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5358)