### PR TITLE
[JS] Fix dropdown control and host container high contrast

### DIFF
--- a/source/nodejs/adaptivecards-controls/src/adaptivecards-controls.css
+++ b/source/nodejs/adaptivecards-controls/src/adaptivecards-controls.css
@@ -137,9 +137,11 @@
     border: 1px solid #0078D7;
 }
 
-.ms-ctrl-dropdown:focus {
-    border: 1px solid #0078D7;
-    outline: 0;
+@media not (forced-colors: active) {
+    .ms-ctrl-dropdown:focus {
+        border: 1px solid #0078D7;
+        outline: 0;
+    }
 }
 
 .ms-dropdown-label {
@@ -182,9 +184,11 @@
     background-color: #EEEEEE;
 }
 
-.ms-ctrl-dropdown-item:focus {
-    outline: 0;
-    background-color: #CCCCCC;
+@media not (forced-colors: active) {
+    .ms-ctrl-dropdown-item:focus {
+        outline: 0;
+        background-color: #CCCCCC;
+    }
 }
 
 .ms-ctrl-popup-container {

--- a/source/nodejs/adaptivecards-designer-app/dist/containers/outlook-container.css
+++ b/source/nodejs/adaptivecards-designer-app/dist/containers/outlook-container.css
@@ -130,10 +130,20 @@ a.ac-anchor:visited:active {
     border: 1px solid #0078D7;
 }
 
-.ac-pushButton.expanded {
-    background-color: #0078D7;
-    color: white;
-    border: 1px solid #0078D7;
+@media not (forced-colors: active) {
+    .ac-pushButton.expanded {
+        background-color: #0078D7;
+        color: white;
+        border: 1px solid #0078D7;
+    }
+}
+
+@media (forced-colors: active) {
+    .ac-pushButton.expanded {
+        background-color: highlight;
+        color: highlightText;
+        forced-color-adjust: none;
+    }
 }
 
 .ac-pushButton.expandable:after {

--- a/source/nodejs/adaptivecards-designer-app/dist/containers/teams-container-dark.css
+++ b/source/nodejs/adaptivecards-designer-app/dist/containers/teams-container-dark.css
@@ -149,10 +149,20 @@ a.ac-anchor:visited:active {
     color: black;
 }
 
-.ac-pushButton.expanded {
-    background-color: #6165A4;
-    border: 2px solid #A7A8DA;
-    color: black;
+@media not (forced-colors: active) {
+    .ac-pushButton.expanded {
+        background-color: #6165A4;
+        border: 2px solid #A7A8DA;
+        color: black;
+    }
+}
+
+@media (forced-colors: active) {
+    .ac-pushButton.expanded {
+        background-color: highlight;
+        color: highlightText;
+        forced-color-adjust: none;
+    }
 }
 
 .ac-pushButton.style-emphasis {

--- a/source/nodejs/adaptivecards-designer-app/dist/containers/teams-container-light.css
+++ b/source/nodejs/adaptivecards-designer-app/dist/containers/teams-container-light.css
@@ -149,10 +149,20 @@ a.ac-anchor:visited:active {
     color: white;
 }
 
-.ac-pushButton.expanded {
-    background-color: #6264A7;
-    border: 2px solid #6264A7;
-    color: white;
+@media not (forced-colors: active) {
+    .ac-pushButton.expanded {
+        background-color: #6264A7;
+        border: 2px solid #6264A7;
+        color: white;
+    }
+}
+
+@media (forced-colors: active) {
+    .ac-pushButton.expanded {
+        background-color: highlight;
+        color: highlightText;
+        forced-color-adjust: none;
+    }
 }
 
 .ac-pushButton.style-emphasis {

--- a/source/nodejs/adaptivecards-designer/src/adaptivecards-designer.css
+++ b/source/nodejs/adaptivecards-designer/src/adaptivecards-designer.css
@@ -793,8 +793,18 @@
     background-color: transparent;
 }
 
-.acd-toolbar-button.acd-toolbar-button-toggled {
-    background-color: rgba(0, 0, 0, 0.1);
+@media not (forced-colors: active) {
+    .acd-toolbar-button.acd-toolbar-button-toggled {
+        background-color: rgba(0, 0, 0, 0.1);
+    }
+}
+
+@media (forced-colors: active) {
+    .acd-toolbar-button.acd-toolbar-button-toggled {
+        background-color: highlight;
+        color: highlightText;
+        forced-color-adjust: none;
+    }
 }
 
 .acd-toolbar-button-iconOnly::before {
@@ -925,10 +935,20 @@ a.default-ac-anchor:visited:active {
     border: 1px solid #0078D7;
 }
 
-.default-ac-pushButton.expanded {
-    background-color: #0078D7;
-    color: white;
-    border: 1px solid #0078D7;
+@media not (forced-colors: active) {
+    .default-ac-pushButton.expanded {
+        background-color: #0078D7;
+        color: white;
+        border: 1px solid #0078D7;
+    }
+}
+
+@media (forced-colors: active) {
+    .default-ac-pushButton.expanded {
+        background-color: highlight;
+        color: highlightText;
+        forced-color-adjust: none;
+    }
 }
 
 .default-ac-pushButton.expandable:after {

--- a/source/nodejs/adaptivecards-designer/src/containers/cortana/cortana-container-dark.css
+++ b/source/nodejs/adaptivecards-designer/src/containers/cortana/cortana-container-dark.css
@@ -100,10 +100,20 @@ a.ac-anchor:visited:active {
     color: black;
 }
 
-.ac-pushButton.expanded {
-    background-color: #6165A4;
-    border: 2px solid #A7A8DA;
-    color: black;
+@media not (forced-colors: active) {
+    .ac-pushButton.expanded {
+        background-color: #6165A4;
+        border: 2px solid #A7A8DA;
+        color: black;
+    }
+}
+
+@media (forced-colors: active) {
+    .ac-pushButton.expanded {
+        background-color: highlight;
+        color: highlightText;
+        forced-color-adjust: none;
+    }
 }
 
 .ac-pushButton.style-emphasis {

--- a/source/nodejs/adaptivecards-designer/src/containers/cortana/cortana-container-light.css
+++ b/source/nodejs/adaptivecards-designer/src/containers/cortana/cortana-container-light.css
@@ -100,10 +100,20 @@ a.ac-anchor:visited:active {
     color: white;
 }
 
-.ac-pushButton.expanded {
-    background-color: #6264A7;
-    border: 2px solid #6264A7;
-    color: white;
+@media not (forced-colors: active) {
+    .ac-pushButton.expanded {
+        background-color: #6264A7;
+        border: 2px solid #6264A7;
+        color: white;
+    }
+}
+
+@media (forced-colors: active) {
+    .ac-pushButton.expanded {
+        background-color: highlight;
+        color: highlightText;
+        forced-color-adjust: none;
+    }
 }
 
 .ac-pushButton.style-emphasis {

--- a/source/nodejs/adaptivecards-designer/src/containers/outlook/outlook-container.css
+++ b/source/nodejs/adaptivecards-designer/src/containers/outlook/outlook-container.css
@@ -130,10 +130,20 @@ a.ac-anchor:visited:active {
     border: 1px solid #0078D7;
 }
 
-.ac-pushButton.expanded {
-    background-color: #0078D7;
-    color: white;
-    border: 1px solid #0078D7;
+@media not (forced-colors: active) {
+    .ac-pushButton.expanded {
+        background-color: #0078D7;
+        color: white;
+        border: 1px solid #0078D7;
+    }
+}
+
+@media (forced-colors: active) {
+    .ac-pushButton.expanded {
+        background-color: highlight;
+        color: highlightText;
+        forced-color-adjust: none;
+    }
 }
 
 .ac-pushButton.expandable:after {

--- a/source/nodejs/adaptivecards-designer/src/containers/teams/teams-container-dark.css
+++ b/source/nodejs/adaptivecards-designer/src/containers/teams/teams-container-dark.css
@@ -149,10 +149,20 @@ a.ac-anchor:visited:active {
     color: black;
 }
 
-.ac-pushButton.expanded {
-    background-color: #6165A4;
-    border: 2px solid #A7A8DA;
-    color: black;
+@media not (forced-colors: active) {
+    .ac-pushButton.expanded {
+        background-color: #6165A4;
+        border: 2px solid #A7A8DA;
+        color: black;
+    }
+}
+
+@media (forced-colors: active) {
+    .ac-pushButton.expanded {
+        background-color: highlight;
+        color: highlightText;
+        forced-color-adjust: none;
+    }
 }
 
 .ac-pushButton.style-emphasis {

--- a/source/nodejs/adaptivecards-designer/src/containers/teams/teams-container-light.css
+++ b/source/nodejs/adaptivecards-designer/src/containers/teams/teams-container-light.css
@@ -149,10 +149,20 @@ a.ac-anchor:visited:active {
     color: white;
 }
 
-.ac-pushButton.expanded {
-    background-color: #6264A7;
-    border: 2px solid #6264A7;
-    color: white;
+@media not (forced-colors: active) {
+    .ac-pushButton.expanded {
+        background-color: #6264A7;
+        border: 2px solid #6264A7;
+        color: white;
+    }
+}
+
+@media (forced-colors: active) {
+    .ac-pushButton.expanded {
+        background-color: highlight;
+        color: highlightText;
+        forced-color-adjust: none;
+    }
 }
 
 .ac-pushButton.style-emphasis {

--- a/source/nodejs/adaptivecards-visualizer/css/outlook.css
+++ b/source/nodejs/adaptivecards-visualizer/css/outlook.css
@@ -139,10 +139,20 @@ a.ac-anchor:visited:active {
     border: 1px solid #0078D7;
 }
 
-.ac-pushButton.expanded {
-    background-color: #004980;
-    color: white;
-    border: 1px solid #0078D7;
+@media not (forced-colors: active) {
+    .ac-pushButton.expanded {
+        background-color: #004980;
+        color: white;
+        border: 1px solid #0078D7;
+    }
+}
+
+@media (forced-colors: active) {
+    .ac-pushButton.expanded {
+        background-color: highlight;
+        color: highlightText;
+        forced-color-adjust: none;
+    }
 }
 
 .ac-pushButton.expandable:after {

--- a/source/nodejs/adaptivecards-visualizer/css/teams.css
+++ b/source/nodejs/adaptivecards-visualizer/css/teams.css
@@ -95,9 +95,19 @@ a.ac-anchor:visited:active {
     color: white;
 }
 
-.ac-pushButton.expanded {
-    background-color: #4F5399;
-    color: white;
+@media not (forced-colors: active) {
+    .ac-pushButton.expanded {
+        background-color: #4F5399;
+        color: white;
+    }
+}
+
+@media (forced-colors: active) {
+    .ac-pushButton.expanded {
+        background-color: highlight;
+        color: highlightText;
+        forced-color-adjust: none;
+    }
 }
 
 .ac-input-container {


### PR DESCRIPTION
## Related Issue
Fixes VSO 30866987

## Description
There are a few places where our CSS styling doesn't play nice with High Contrast mode. Thankfully, we have a [new standard](https://blogs.windows.com/msedgedev/2020/09/17/styling-for-windows-high-contrast-with-new-standards-for-forced-colors/) we can use to implement fixes. It's only supported by default in Edge at the moment, but is implemented/off-by-default in Chrome and FireFox. It's the best we have for now -- hopefully those defaults will change at some point.

![image](https://user-images.githubusercontent.com/16614499/106975495-847cba80-670b-11eb-85f3-36d3858001e1.png)

1. Keyboard focus now visible in dropdown menus
2. Expanded expandable buttons now show as selected
3. Toggled toggleable buttons in the designer now show as active

## Sample Card
Partly covered by `FoodOrder.json`

## How Verified
* local build

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5359)