### PR TITLE
[JS] Ensure associatedInputs values are handled case insensitively

### DIFF
--- a/samples/v1.3/Tests/Action.Submit.AssociatedInputs.CaseInsensitive.json
+++ b/samples/v1.3/Tests/Action.Submit.AssociatedInputs.CaseInsensitive.json
@@ -1,0 +1,32 @@
+{
+  "type": "AdaptiveCard",
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.3",
+  "body": [
+    {
+      "type": "TextBlock",
+      "text": "Validate that associatedInputs 'auto' and 'none' are handled case-insensitively",
+      "wrap": true,
+      "weight": "Bolder"
+    },
+    {
+      "type": "Input.Text",
+      "placeholder": "Placeholder text",
+      "label": "Text Box:",
+      "isRequired": true,
+      "id": "ID"
+    }
+  ],
+  "actions": [
+    {
+      "type": "Action.Submit",
+      "title": "NONE",
+      "associatedInputs": "none"
+    },
+    {
+      "type": "Action.Submit",
+      "title": "AUTO",
+      "associatedInputs": "auto"
+    }
+  ]
+}

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -3948,7 +3948,7 @@ export class SubmitAction extends Action {
             let value = source[property.name];
 
             if (value !== undefined && typeof value === "string") {
-                return value === "none" ? "none" : "auto";
+                return value.toLowerCase() === "none" ? "none" : "auto";
             }
             
             return undefined;


### PR DESCRIPTION
## Related Issue
Fixes #5260

## Description
Updated the string comparison to run the card value through `toLowerCase()` before comparing it to `"none"`

## Sample Card
Added new card [Action.Submit.AssociatedInputs.CaseInsensitive.json](https://github.com/microsoft/AdaptiveCards/blob/main/samples/v1.3/Tests/Action.Submit.AssociatedInputs.CaseInsensitive.json)

## How Verified
Validated against above card and other variations that the auto and none values are handled correctly regardless of casing.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5372)