### PR TITLE
[Site] Update role for "Try it yourself" button

### DIFF
--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/scripts/helper-code-and-card.js
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/scripts/helper-code-and-card.js
@@ -55,7 +55,7 @@ hexo.extend.helper.register('code_and_card', function (jsonPath, templatePath = 
 		<div class="w3-container w3-cell w3-mobile card" >
 			<div class="codeHeader">
 				<span class="language">Adaptive Card</span>
-				<button aria-label="Try it yourself" class="w3-button ac-blue action try-adaptivecard">
+				<button aria-label="Try it yourself" class="w3-button ac-blue action try-adaptivecard" role="link">
 					<span>Try it Yourself <i class="fas fa-chevron-right"></i></span>
 				</button>
 			</div>


### PR DESCRIPTION
## Related Issue
Fixes VSO 30854543

## Description
The `Try it yourself` button in schema explorer behaves like a link (invoking it opens a new tab), so set its role accordingly.

## How Verified
* local build, narrator, devtools

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5376)