### PR TITLE
[Site] Add more descriptive label to the "Read more" blog link

### DIFF
--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/_partial/footer.ejs
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/_partial/footer.ejs
@@ -23,7 +23,7 @@
 		<div class="w3-cell w3-container w3-margin-top w3-mobile" style="width: 300px; max-width: 300px">
 			<div class="w3-cell-row" style="margin-top: 6px;">
 				<h6 class="w3-cell w3-cell-middle">Blog</h6>
-				<a class="w3-cell w3-cell-middle w3-small" style="padding-left: 20px;"
+				<a class="w3-cell w3-cell-middle w3-small" aria-label="Read more blog posts" style="padding-left: 20px;"
 					href="<%- url_for('blog') %>">Read more <i class="fa fa-chevron-right"></i></a>
 			</div>
 


### PR DESCRIPTION
## Related Issue
Fixes ADO [30929352](https://microsoft.visualstudio.com/OS/_workitems/edit/30929352)

## Description
Add aria-label tag to "Read more" link to make it more descriptive

## How Verified
Manually verified correct behavior using narrator

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5377)