### PR TITLE
[Site] Add underlines to Feedback and Github links on the Samples, Schema Explorer, and Samples pages

### DIFF
--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/source/css/style.css
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/source/css/style.css
@@ -679,3 +679,7 @@ input.bigbox {
   transform: scale(2.5);
   transform-origin: left;
 }
+
+.action-bar .action-item-text{
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Related Issue
Fixes ADO [30927092](https://microsoft.visualstudio.com/OS/_workitems/edit/30927092) for the Github and Feedback links in the action bar

## Description
Added text-decoration: underline to the link text in the action bar

## How Verified
Manually verified expected result:
![image](https://user-images.githubusercontent.com/9091833/107562200-59bfb580-6b94-11eb-9665-7fffa2f37e6a.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5378)