### PR TITLE
[Site] Mark space-only items as role="presentation"

### DIFF
--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/_partial/footer.ejs
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/_partial/footer.ejs
@@ -36,7 +36,7 @@
 		</div>
 
 	
-		<div style="clear:both">&nbsp;</div>
+		<div style="clear:both" role="presentation">&nbsp;</div>
 
 	</div>
 

--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/_partial/section-details.ejs
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/_partial/section-details.ejs
@@ -1,31 +1,31 @@
 <div class="w3-row-padding w3-margin-top">
-	<div class="w3-col m1 w3-hide-small">&nbsp;</div>
+	<div class="w3-col m1 w3-hide-small" role="presentation">&nbsp;</div>
 
 	<div class="w3-col s12 m4 center-large">
 		<%- partial("_partial/section-details-item", sections[0]) %>
 	</div>
 
-	<div class="w3-col m2 w3-hide-small">&nbsp;</div>
+	<div class="w3-col m2 w3-hide-small" role="presentation">&nbsp;</div>
 
 	<div class="w3-col s12 m4 center-large">
 		<%- partial("_partial/section-details-item", sections[1]) %>
 	</div>
 
-	<div class="w3-col m1 w3-hide-small">&nbsp;</div>
+	<div class="w3-col m1 w3-hide-small" role="presentation">&nbsp;</div>
 </div>
 
 <div class="w3-row-padding w3-margin-top">
-	<div class="w3-col m1 w3-hide-small">&nbsp;</div>
+	<div class="w3-col m1 w3-hide-small" role="presentation">&nbsp;</div>
 
 	<div class="w3-col s12 m4 center-large">
 		<%- partial("_partial/section-details-item", sections[2]) %>
 	</div>
 
-	<div class="w3-col m2 w3-hide-small">&nbsp;</div>
+	<div class="w3-col m2 w3-hide-small" role="presentation">&nbsp;</div>
 
 	<div class="w3-col s12 m4 center-large">
 		<%- partial("_partial/section-details-item", sections[3]) %>
 	</div>
 
-	<div class="w3-col m1 w3-hide-small">&nbsp;</div>
+	<div class="w3-col m1 w3-hide-small" role="presentation">&nbsp;</div>
 </div>

--- a/source/nodejs/adaptivecards/package.json
+++ b/source/nodejs/adaptivecards/package.json
@@ -28,7 +28,7 @@
 		"start": "webpack-dev-server --open",
 		"dts": "dts-generator --prefix adaptivecards --project . --out dist/adaptivecards.d.ts",
 		"lint": "eslint src/*.ts",
-		"release": "npm run clean && concurrently \"npm:build\" \"webpack --mode=production\" \"npm:docs\" && concurrently \"npm:test\" \"npm:dts\"",
+		"release": "npm run clean && concurrently \"npm:build\" \"webpack --mode=production\" && concurrently \"npm:test\" \"npm:dts\"",
 		"docs": "npx typedoc"
 	},
 	"repository": {


### PR DESCRIPTION
## Description
While looking at some other a11y issues, I noticed that we have some elements on our site that are spacers, but they get read out by Narrator. This fixes that.

Also, don't generate docs automatically in build -- it adds too much noise.

## How Verified
* local build, devtools, narrator

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5379)