### PR TITLE
[Samples] Update alttext on ExpenseReport expand collapse buttons to include more information

### DIFF
--- a/samples/v1.2/Scenarios/ExpenseReport.json
+++ b/samples/v1.2/Scenarios/ExpenseReport.json
@@ -220,14 +220,14 @@
 							"id": "chevronDown1",
 							"url": "https://adaptivecards.io/content/down.png",
 							"width": "20px",
-							"altText": "Details collapsed"
+							"altText": "Air Travel Expense $300 collapsed"
 						},
 						{
 							"type": "Image",
 							"id": "chevronUp1",
 							"url": "https://adaptivecards.io/content/up.png",
 							"width": "20px",
-							"altText": "Details expanded",
+							"altText": "Air Travel Expense $300 expanded",
 							"isVisible": false
 						}
 					],
@@ -355,14 +355,14 @@
 							"id": "chevronDown2",
 							"url": "https://adaptivecards.io/content/down.png",
 							"width": "20px",
-							"altText": "Details collapsed"
+							"altText": "Auto Mobile Expense $100 collapsed"
 						},
 						{
 							"type": "Image",
 							"id": "chevronUp2",
 							"url": "https://adaptivecards.io/content/up.png",
 							"width": "20px",
-							"altText": "Details expanded",
+							"altText": "Auto Mobile Expense $100 expanded",
 							"isVisible": false
 						}
 					],
@@ -484,14 +484,14 @@
 							"id": "chevronDown3",
 							"url": "https://adaptivecards.io/content/down.png",
 							"width": "20px",
-							"altText": "Details collapsed"
+							"altText": "Excess Baggage Cost $50.38 collapsed"
 						},
 						{
 							"type": "Image",
 							"id": "chevronUp3",
 							"url": "https://adaptivecards.io/content/up.png",
 							"width": "20px",
-							"altText": "Details expanded",
+							"altText": "Excess Baggage Cost $50.38 expanded",
 							"isVisible": false
 						}
 					],


### PR DESCRIPTION
## Related Issue
Fixes ADO [30961605](https://microsoft.visualstudio.com/OS/_workitems/edit/30961605)

## Description
Per request in the bug, expanded the altText on the expand/collapse button images to describe what was being expanded/collapsed

## Sample Card
https://github.com/microsoft/AdaptiveCards/blob/main/samples/v1.2/Scenarios/ExpenseReport.json

## How Verified
Confirmed Narrator now reads the details of what is being expanded/collapsed.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5387)