### PR TITLE
[Site] Fix sample selection indicator in high contrast

### DIFF
--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/source/css/style.css
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/source/css/style.css
@@ -329,13 +329,23 @@ s {
   text-decoration: none;
 }
 
-.toc-todo .selectedHolder {
-  background-color: #0050c5;
+@media not (forced-colors: active) {
+    .toc-todo .selectedHolder {
+        background-color: #0050c5;
+    }
+
+    .toc-todo .selectedHolder > a,
+    .toc-todo .selectedHolder > a:hover {
+        color: #fff;
+    }
 }
 
-.toc-todo .selectedHolder > a,
-.toc-todo .selectedHolder > a:hover {
-  color: #fff;
+@media (forced-colors: active) {
+    .toc-todo .selectedHolder {
+        background-color: highlight;
+        color: highlightText;
+        forced-color-adjust: none;
+    }
 }
 
 .toc-todo li a {


### PR DESCRIPTION
## Related Issue

Partially fixes VSO 30960937

## Description
When browsing through samples in high contrast, there's no indication on the nav pane to the left as to which sample is currently being viewed. This fixes that.

Before:
![image](https://user-images.githubusercontent.com/16614499/108132038-10290c00-7067-11eb-88bc-3a9e0b864a6e.png)

After:
![image](https://user-images.githubusercontent.com/16614499/108132050-17e8b080-7067-11eb-90bf-e4fa6a3c1058.png)

## How Verified
* local build

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5393)