### PR TITLE
[JS] Fix some accessibility issues

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/card-designer.ts
+++ b/source/nodejs/adaptivecards-designer/src/card-designer.ts
@@ -670,7 +670,6 @@ export class CardDesigner extends Designer.DesignContext {
             this._hostContainerChoicePicker = new ToolbarChoicePicker(CardDesigner.ToolbarCommands.HostAppPicker);
             this._hostContainerChoicePicker.separator = true;
             this._hostContainerChoicePicker.label = "Select host app:"
-            this._hostContainerChoicePicker.width = 350;
 
             for (let i = 0; i < this._hostContainers.length; i++) {
                 this._hostContainerChoicePicker.choices.push(
@@ -698,7 +697,6 @@ export class CardDesigner extends Designer.DesignContext {
         this._undoButton.separator = true;
         this._undoButton.toolTip = "Undo your last change";
         this._undoButton.isEnabled = false;
-        this._undoButton.displayCaption = false;
 
         this.toolbar.addElement(this._undoButton);
 
@@ -709,7 +707,6 @@ export class CardDesigner extends Designer.DesignContext {
             (sender: ToolbarButton) => { this.redo(); });
         this._redoButton.toolTip = "Redo your last changes";
         this._redoButton.isEnabled = false;
-        this._redoButton.displayCaption = false;
 
         this.toolbar.addElement(this._redoButton);
 

--- a/source/nodejs/adaptivecards-designer/src/designer-peers.ts
+++ b/source/nodejs/adaptivecards-designer/src/designer-peers.ts
@@ -204,19 +204,8 @@ export interface IPropertySheetEditorCommand {
     onExecute: (sender: SingleInputPropertyEditor, clickedElement: HTMLElement) => void;
 }
 
-// The element properties pane has the labels to the left of the inputs. Adaptive card elements 
-// do not currently support this positioning for the labels, nor the ability to set labelledby to 
-// indicate the element is labelled by something other than it's label property for accessibility. 
-// This interface and it's implementing classes extend Adaptive.Inputs to add labelled by functionality 
-// to inputs. This allows us to make the designer inputs accessible until such time as we have a way 
-// to support this scenario in the official schema elements.
-interface InputWithLabelledBy extends Adaptive.Input
-{
-    labelledBy?: string;
-}
-
 export abstract class SingleInputPropertyEditor extends PropertySheetEntry {
-    protected abstract createInput(context: PropertySheetContext): InputWithLabelledBy;
+    protected abstract createInput(context: PropertySheetContext): Adaptive.Input;
 
     protected getPropertyValue(context: PropertySheetContext): any {
         return context.target[this.propertyName];
@@ -250,7 +239,7 @@ export abstract class SingleInputPropertyEditor extends PropertySheetEntry {
         label.horizontalAlignment = Adaptive.HorizontalAlignment.Right;
         label.wrap = true;
         label.text = this.label;
-        label.id = this.label.replace(/\s+/g,'') + "Id";
+        label.id = Adaptive.generateUniqueId();
 
         let input = this.createInput(context);
         input.labelledBy = label.id;
@@ -298,34 +287,9 @@ export abstract class SingleInputPropertyEditor extends PropertySheetEntry {
     }
 }
 
-function AppendToLabelledBy(htmlElement: HTMLElement, labelledByToAppend: string) : void
-{    
-    let labelledBy :string = htmlElement.getAttribute("aria-labelledby");
-
-    if(labelledByToAppend)
-    {
-        labelledBy = labelledBy ? labelledBy + " " + labelledByToAppend : labelledByToAppend;
-    }
-
-    if(labelledBy)
-    {
-        htmlElement.setAttribute("aria-labelledby", labelledBy)
-    }
-}
-
-class TextInputWithLabelledBy extends Adaptive.TextInput implements InputWithLabelledBy
-{
-    labelledBy?: string;
-    protected updateInputControlAriaLabelledBy(): void
-    {
-        super.updateInputControlAriaLabelledBy();
-        AppendToLabelledBy(this.renderedInputControlElement, this.labelledBy);
-    }
-}
-
 export class StringPropertyEditor extends SingleInputPropertyEditor {
-    protected createInput(context: PropertySheetContext): InputWithLabelledBy {
-        let input = new TextInputWithLabelledBy();
+    protected createInput(context: PropertySheetContext): Adaptive.Input {
+        let input = new Adaptive.TextInput();
         input.defaultValue = this.getPropertyValue(context);
         input.placeholder = "(not set)";
         input.isMultiline = this.isMultiline;
@@ -368,16 +332,6 @@ export class StringPropertyEditor extends SingleInputPropertyEditor {
     }
 }
 
-class NumberInputWithLabelledBy extends Adaptive.NumberInput implements InputWithLabelledBy
-{
-    labelledBy?: string;
-    protected updateInputControlAriaLabelledBy(): void
-    {
-        super.updateInputControlAriaLabelledBy();
-        AppendToLabelledBy(this.renderedInputControlElement, this.labelledBy);
-    }
-}
-
 export class NumberPropertyEditor extends SingleInputPropertyEditor {
     protected setPropertyValue(context: PropertySheetContext, value: string) {
         try {
@@ -388,8 +342,8 @@ export class NumberPropertyEditor extends SingleInputPropertyEditor {
         }
     }
 
-    protected createInput(context: PropertySheetContext): InputWithLabelledBy {
-        let input = new NumberInputWithLabelledBy();
+    protected createInput(context: PropertySheetContext): Adaptive.Input {
+        let input = new Adaptive.NumberInput();
         input.defaultValue = this.getPropertyValue(context);
         input.placeholder = "(not set)";
 
@@ -426,16 +380,6 @@ export class CustomCardObjectPropertyEditor extends StringPropertyEditor {
     }
 }
 
-class ToggleInputWithLabelledBy extends Adaptive.ToggleInput implements InputWithLabelledBy
-{
-    labelledBy?: string;
-    protected updateInputControlAriaLabelledBy(): void
-    {
-        super.updateInputControlAriaLabelledBy();
-        AppendToLabelledBy(this.renderedInputControlElement, this.labelledBy);
-    }
-}
-
 export class BooleanPropertyEditor extends SingleInputPropertyEditor {
     protected getPropertyValue(context: PropertySheetContext): any {
         let v = context.target[this.propertyName];
@@ -447,8 +391,8 @@ export class BooleanPropertyEditor extends SingleInputPropertyEditor {
         context.target[this.propertyName] = value == "true";
     }
 
-    protected createInput(context: PropertySheetContext): InputWithLabelledBy {
-        let input = new ToggleInputWithLabelledBy();
+    protected createInput(context: PropertySheetContext): Adaptive.Input {
+        let input = new Adaptive.ToggleInput();
         input.defaultValue = this.getPropertyValue(context);
 
         return input;
@@ -461,19 +405,9 @@ export interface IVersionedChoice {
     value: string;
 }
 
-class ChoiceSetInputWithLabelledBy extends Adaptive.ChoiceSetInput implements InputWithLabelledBy
-{
-    labelledBy?: string;
-    protected updateInputControlAriaLabelledBy(): void
-    {
-        super.updateInputControlAriaLabelledBy();
-        AppendToLabelledBy(this.renderedInputControlElement, this.labelledBy);
-    }
-}
-
 export class ChoicePropertyEditor extends SingleInputPropertyEditor {
-    protected createInput(context: PropertySheetContext): InputWithLabelledBy {
-        let input = new ChoiceSetInputWithLabelledBy();
+    protected createInput(context: PropertySheetContext): Adaptive.Input {
+        let input = new Adaptive.ChoiceSetInput();
         input.defaultValue = this.getPropertyValue(context);
         input.isCompact = true;
         input.placeholder = "(not set)";
@@ -620,8 +554,8 @@ export class ActionPropertyEditor extends SingleInputPropertyEditor {
         }
     }
 
-    protected createInput(context: PropertySheetContext): InputWithLabelledBy {
-        let input = new ChoiceSetInputWithLabelledBy();
+    protected createInput(context: PropertySheetContext): Adaptive.Input {
+        let input = new Adaptive.ChoiceSetInput();
         input.defaultValue = this.getPropertyValue(context);
         input.isCompact = true;
         input.placeholder = "(not set)";
@@ -682,8 +616,8 @@ export class EnumPropertyEditor extends SingleInputPropertyEditor {
         context.target[this.propertyName] = parseInt(value, 10);
     }
 
-    protected createInput(context: PropertySheetContext): InputWithLabelledBy {
-        let input = new ChoiceSetInputWithLabelledBy();
+    protected createInput(context: PropertySheetContext): Adaptive.Input {
+        let input = new Adaptive.ChoiceSetInput();
         input.defaultValue = this.getPropertyValue(context);
         input.isCompact = true;
         input.placeholder = "(not set)";

--- a/source/nodejs/adaptivecards-designer/src/toolbar.ts
+++ b/source/nodejs/adaptivecards-designer/src/toolbar.ts
@@ -325,10 +325,12 @@ export class Toolbar {
         let leftContainer = document.createElement("div");
         leftContainer.style.display = "flex";
         leftContainer.style.alignItems = "center";
+        leftContainer.style.flexWrap = "wrap";
 
         let rightContainer = document.createElement("div");
         rightContainer.style.display = "flex";
         rightContainer.style.alignItems = "center";
+        rightContainer.style.flexWrap = "wrap";
 
         this.renderElementsInto(
             leftContainer,

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -2456,6 +2456,10 @@ export abstract class Input extends CardElement implements IInput {
         if (this._renderedInputControlElement) {
             let labelIds: string[] = this.getAllLabelIds();
 
+            if (this.labelledBy) {
+                labelIds.push(this.labelledBy);
+            }
+
             if (this._renderedLabelElement) {
                 labelIds.push(this._renderedLabelElement.id);
             }
@@ -2597,6 +2601,8 @@ export abstract class Input extends CardElement implements IInput {
     }
 
     onValueChanged: (sender: Input) => void;
+
+    labelledBy?: string;
 
     abstract isSet(): boolean;
 


### PR DESCRIPTION
## Related Issue
- Partially fixes ADO 30961076
- Fixes ADO 30868015
- Fixes ADO 30926701

## Description
### ADO 30961076
- The label of the input is now read by narrator when the input gets focus.
  - Note that somehow this bug seemed to already be fixed. However, I found that the fix could be streamlined and more tightly baked into the SDK, so I tweaked it.
- Narrator will however also read the placeholder text ("not set") even when the input has a valid value. This appears to be a Narrator bug.

### ADO 30868015
- It is unclear that the CTRL+SHIFT+F10 keyboard shortcut is actually supposed to force showing the tooltip of a focused element. However showing the tooltips for those buttons on keyboard navigation is really to compensate for the fact the buttons do not have a label. Given the cost of showing tooltips on focus (this isn't a standard HTML5 behavior and requires implementing custom tooltips) this fix actually simply adds "Undo" and "Redo" labels to the buttons.

### ADO 30926701
- The toolbar will now wrap when horizontal space isn't enough to show all commands.
- Note that overlapping and/or truncation can still happen when the width of the window is very narrow.

## How Verified
Verified manually in adaptivecards-designer-app

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5394)