### PR TITLE
[Designer][Accessibility] Group Card Elements sections with label for accessibility

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/card-designer.ts
+++ b/source/nodejs/adaptivecards-designer/src/card-designer.ts
@@ -675,7 +675,6 @@ export class CardDesigner extends Designer.DesignContext {
             this._hostContainerChoicePicker = new ToolbarChoicePicker(CardDesigner.ToolbarCommands.HostAppPicker);
             this._hostContainerChoicePicker.separator = true;
             this._hostContainerChoicePicker.label = "Select host app:"
-            this._hostContainerChoicePicker.width = 350;
 
             for (let i = 0; i < this._hostContainers.length; i++) {
                 this._hostContainerChoicePicker.choices.push(
@@ -703,7 +702,6 @@ export class CardDesigner extends Designer.DesignContext {
         this._undoButton.separator = true;
         this._undoButton.toolTip = "Undo your last change";
         this._undoButton.isEnabled = false;
-        this._undoButton.displayCaption = false;
 
         this.toolbar.addElement(this._undoButton);
 
@@ -714,7 +712,6 @@ export class CardDesigner extends Designer.DesignContext {
             (sender: ToolbarButton) => { this.redo(); });
         this._redoButton.toolTip = "Redo your last changes";
         this._redoButton.isEnabled = false;
-        this._redoButton.displayCaption = false;
 
         this.toolbar.addElement(this._redoButton);
 

--- a/source/nodejs/adaptivecards-designer/src/card-designer.ts
+++ b/source/nodejs/adaptivecards-designer/src/card-designer.ts
@@ -225,14 +225,19 @@ export class CardDesigner extends Designer.DesignContext {
         }
 
         for (let category in categorizedTypes) {
+
+            let categoryList = document.createElement('div');
+            categoryList.setAttribute("aria-label", category)
+            
             let node = document.createElement('div');
+            categoryList.appendChild(node);
             node.innerText = category;
             node.className = "acd-palette-category";
 
-            this._toolPaletteToolbox.content.appendChild(node);
+            this._toolPaletteToolbox.content.appendChild(categoryList);
 
             for (var i = 0; i < categorizedTypes[category].length; i++) {
-                this.addPaletteItem(categorizedTypes[category][i], this._toolPaletteToolbox.content);
+                this.addPaletteItem(categorizedTypes[category][i], categoryList);
             }
         }
     }
@@ -670,6 +675,7 @@ export class CardDesigner extends Designer.DesignContext {
             this._hostContainerChoicePicker = new ToolbarChoicePicker(CardDesigner.ToolbarCommands.HostAppPicker);
             this._hostContainerChoicePicker.separator = true;
             this._hostContainerChoicePicker.label = "Select host app:"
+            this._hostContainerChoicePicker.width = 350;
 
             for (let i = 0; i < this._hostContainers.length; i++) {
                 this._hostContainerChoicePicker.choices.push(
@@ -697,6 +703,7 @@ export class CardDesigner extends Designer.DesignContext {
         this._undoButton.separator = true;
         this._undoButton.toolTip = "Undo your last change";
         this._undoButton.isEnabled = false;
+        this._undoButton.displayCaption = false;
 
         this.toolbar.addElement(this._undoButton);
 
@@ -707,6 +714,7 @@ export class CardDesigner extends Designer.DesignContext {
             (sender: ToolbarButton) => { this.redo(); });
         this._redoButton.toolTip = "Redo your last changes";
         this._redoButton.isEnabled = false;
+        this._redoButton.displayCaption = false;
 
         this.toolbar.addElement(this._redoButton);
 


### PR DESCRIPTION
## Related Issue
Fixes ADO [30898371](https://microsoft.visualstudio.com/OS/_workitems/edit/30898371/)

## Description
Group elements for each element category (Containers, Elements, Inputs) in a div with a label so that the group heading is read out by narrator when that section is entered via tab navigation.

## How Verified
Confirmed expected behavior locally using narrator.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5405)