### PR TITLE
Fixed #5269

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRColumnSetRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRColumnSetRenderer.mm
@@ -86,6 +86,7 @@
     auto lastColumn = columns.empty() ? nullptr : columns.back();
     ACOFeatureRegistration *featureReg = [ACOFeatureRegistration getInstance];
     ACRSeparator *separator = nil;
+    BOOL hasPixelWidthColumn = NO;
 
     for (std::shared_ptr<Column> column : columns) {
         if (*firstColumn != column) {
@@ -128,6 +129,7 @@
 
         // when stretch, views with stretch properties should have equal width
         if (curView.pixelWidth) {
+            hasPixelWidthColumn = YES;
             [constraints addObject:
                              [NSLayoutConstraint constraintWithItem:curView
                                                           attribute:NSLayoutAttributeWidth
@@ -188,6 +190,10 @@
 
     if ([constraints count]) {
         [NSLayoutConstraint activateConstraints:constraints];
+    }
+
+    if (hasPixelWidthColumn && columns.size() == 1) {
+        [columnSetView addPaddingSpace];
     }
 
     std::shared_ptr<BaseActionElement> selectAction = columnSetElem->GetSelectAction();

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRColumnView.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRColumnView.h
@@ -21,6 +21,4 @@ typedef NS_ENUM(NSInteger, ACRColumnWidthPriority) {
 @property BOOL isLastColumn;
 @property NSMutableArray<ACRIBaseInputHandler> *inputHandlers;
 
-- (UIView *)addPaddingSpace;
-
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRColumnView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRColumnView.mm
@@ -83,13 +83,4 @@
     self.combinedContentSize = CGSizeMake(newWidth, self.combinedContentSize.height - size.height);
 }
 
-- (UIView *)addPaddingSpace
-{
-    UIView *blankTrailingSpace = [[UIView alloc] init];
-    blankTrailingSpace.translatesAutoresizingMaskIntoConstraints = NO;
-    [blankTrailingSpace setContentHuggingPriority:UILayoutPriorityDefaultLow - 10 forAxis:UILayoutConstraintAxisVertical];
-    [self addArrangedSubview:blankTrailingSpace];
-    return blankTrailingSpace;
-}
-
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentStackView.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentStackView.h
@@ -60,4 +60,7 @@
 - (void)bleed:(unsigned int)padding priority:(unsigned int)priority target:(UIView *_Nonnull)target direction:(ACRBleedDirection)direction parentView:(UIView *_Nullable)parent;
 
 - (void)removeViewFromContentStackView:(UIView *_Nonnull)view;
+
+- (UIView *_Nonnull)addPaddingSpace;
+
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentStackView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentStackView.mm
@@ -520,6 +520,15 @@ static int kToggleVisibilityContext;
     }
 }
 
+- (UIView *)addPaddingSpace
+{
+    UIView *blankTrailingSpace = [[UIView alloc] init];
+    blankTrailingSpace.translatesAutoresizingMaskIntoConstraints = NO;
+    [blankTrailingSpace setContentHuggingPriority:UILayoutPriorityDefaultLow - 10 forAxis:UILayoutConstraintAxisVertical];
+    [self addArrangedSubview:blankTrailingSpace];
+    return blankTrailingSpace;
+}
+
 - (void)dealloc
 {
     for (UIView *view in _stackView.arrangedSubviews) {


### PR DESCRIPTION
## Related Issue
Fixed #5269 

## Description
When a column has pixel width, and the columnset has the column as the only column, the columnset will fail to honour the column's width with the AutoLayout of iOS.

Added an empty view to be used as a filler in such a case.

## Sample Card
```json
{
    "type": "AdaptiveCard",
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
    "version": "1.3",
    "body": [
        {
            "type": "Container",
            "style": "emphasis",
            "backgroundImage": "https://messagecardplayground.azurewebsites.net/assets/Mostly%20Cloudy-Background.jpg",
            "minHeight": "400px",
            "items": [
                {
                    "type": "Container",
                    "minHeight": "380px"
                },
                {
                    "type": "ColumnSet",
                    "columns": [
                        {
                            "type": "Column",
                            "width": "180px",
                            "items": [
                                {
                                    "type": "Container",
                                    "style": "accent"
                                }
                            ]
                        }
                    ]
                }
            ]
        }
    ]
}

```
## How Verified
Bad image available in #5269 
![image](https://user-images.githubusercontent.com/4112696/108445494-58842d80-7211-11eb-929a-6b93f13c076a.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5407)