### PR TITLE
[Site] Emit samples list with aria attributes

### DIFF
--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/sample.ejs
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/sample.ejs
@@ -1,17 +1,22 @@
 <div id="content-wrapper" class="sample-browser w3-margin-bottom" style="max-width:1550px">
 
 	<nav id="sidebar-todo" class="toc-todo sidebar w3-cell w3-hide-small w3-hide-medium w3-bar-block"
-		style="width: 200px">
+		style="width: 200px" aria-label="Sample cards">
 		<div class="sidebar__inner">
 			<ul class="samples-sidebar-list">
-				<% page.samples.forEach(function(sample, i) { %>
-				<li class='<%= page.samplePath === sample.htmlPath ? "selectedHolder" : "" %>'>
-					<a href="<%- url_for(sample.htmlPath) %>"><%= sample.name %></a>
+				<% page.samples.forEach(function(sample, i) {
+                    const isSelected = (page.samplePath === sample.htmlPath);
+                %>
+				<li <%= isSelected ? "class=selectedHolder" : "" %>>
+					<a role="listitem"
+                       aria-selected='<%= isSelected.toString() %>'
+                       aria-posinset='<%= (i+1).toString() %>'
+                       aria-setsize='<%= page.samples.length.toString() %>'
+                       href="<%- url_for(sample.htmlPath) %>"><%= sample.name %></a>
 				</li>
 				<% }) %>
 
 			</ul>
-
 		</div>
 	</nav>
 

--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/source/css/style.css
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/source/css/style.css
@@ -329,15 +329,13 @@ s {
   text-decoration: none;
 }
 
-@media not (forced-colors: active) {
-    .toc-todo .selectedHolder {
-        background-color: #0050c5;
-    }
+.toc-todo .selectedHolder {
+    background-color: #0050c5;
+}
 
-    .toc-todo .selectedHolder > a,
-    .toc-todo .selectedHolder > a:hover {
-        color: #fff;
-    }
+.toc-todo .selectedHolder > a,
+.toc-todo .selectedHolder > a:hover {
+    color: #fff;
 }
 
 @media (forced-colors: active) {


### PR DESCRIPTION
## Related Issue
Fixes VSO 30961004

## Description
We currently don't do anything special aria-wise with our sample list. We should be marking the links up so that they're read with extra context (e.g. instead of "Food Order, link", it should read "Food Order, selected, 8 of 25").

## How Verified
* local build, devtools, narrator

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5409)