### PR TITLE
[Accessibility] Add aria-labels to the data binding buttons in the designer

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/designer-peers.ts
+++ b/source/nodejs/adaptivecards-designer/src/designer-peers.ts
@@ -201,8 +201,8 @@ export class CustomPropertySheetEntry extends PropertySheetEntry {
 
 export interface IPropertySheetEditorCommand {
     caption: string;
-    altText: string;
-    expanded?: string;
+    altText?: string;
+    expanded?: boolean;
     onExecute: (sender: SingleInputPropertyEditor, clickedElement: HTMLElement) => void;
 }
 
@@ -307,7 +307,7 @@ export class StringPropertyEditor extends SingleInputPropertyEditor {
                 {
                     caption: "...",
                     altText: (this.label + " " + "Data Binding"),
-                    expanded: "false",
+                    expanded: false,
                     onExecute: (sender: SingleInputPropertyEditor, clickedElement: HTMLElement) => {
                                                
                         clickedElement.setAttribute("aria-label", this.label + " " + "Data Binding");

--- a/source/nodejs/adaptivecards-designer/src/designer-peers.ts
+++ b/source/nodejs/adaptivecards-designer/src/designer-peers.ts
@@ -201,6 +201,7 @@ export class CustomPropertySheetEntry extends PropertySheetEntry {
 
 export interface IPropertySheetEditorCommand {
     caption: string;
+    altText: string;
     onExecute: (sender: SingleInputPropertyEditor, clickedElement: HTMLElement) => void;
 }
 
@@ -266,6 +267,7 @@ export abstract class SingleInputPropertyEditor extends PropertySheetEntry {
             for (let command of additionalCommands) {
                 let action = new Adaptive.SubmitAction();
                 action.title = command.caption;
+                action.accessibleTitle = command.altText;
                 action.onExecute = (sender: Adaptive.Action) => { command.onExecute(this, sender.renderedElement); };
 
                 actionSet.addAction(action);
@@ -302,14 +304,21 @@ export class StringPropertyEditor extends SingleInputPropertyEditor {
             return [
                 {
                     caption: "...",
+                    altText: (this.label + " " + "Data Binding Collapsed"),
                     onExecute: (sender: SingleInputPropertyEditor, clickedElement: HTMLElement) => {
+                                               
+                        clickedElement.setAttribute("aria-label",this.label + " " + "Data Binding Expanded");
+                        
                         let fieldPicker = new FieldPicker(context.designContext.dataStructure);
                         fieldPicker.onClose = (sender, wasCancelled) => {
+                            clickedElement.setAttribute("aria-label",this.label + " " + "Data Binding Collapsed");
                             if (!wasCancelled) {
+                                
                                 this.setPropertyValue(context, fieldPicker.selectedField.asExpression());
 
                                 context.peer.changed(true);
                             }
+                            clickedElement.focus();
                         }
                         fieldPicker.popup(clickedElement);
                     }

--- a/source/nodejs/adaptivecards-designer/src/designer-peers.ts
+++ b/source/nodejs/adaptivecards-designer/src/designer-peers.ts
@@ -202,6 +202,7 @@ export class CustomPropertySheetEntry extends PropertySheetEntry {
 export interface IPropertySheetEditorCommand {
     caption: string;
     altText: string;
+    expanded?: string;
     onExecute: (sender: SingleInputPropertyEditor, clickedElement: HTMLElement) => void;
 }
 
@@ -268,6 +269,7 @@ export abstract class SingleInputPropertyEditor extends PropertySheetEntry {
                 let action = new Adaptive.SubmitAction();
                 action.title = command.caption;
                 action.accessibleTitle = command.altText;
+                action.expanded = command.expanded;
                 action.onExecute = (sender: Adaptive.Action) => { command.onExecute(this, sender.renderedElement); };
 
                 actionSet.addAction(action);
@@ -304,14 +306,17 @@ export class StringPropertyEditor extends SingleInputPropertyEditor {
             return [
                 {
                     caption: "...",
-                    altText: (this.label + " " + "Data Binding Collapsed"),
+                    altText: (this.label + " " + "Data Binding"),
+                    expanded: "false",
                     onExecute: (sender: SingleInputPropertyEditor, clickedElement: HTMLElement) => {
                                                
-                        clickedElement.setAttribute("aria-label",this.label + " " + "Data Binding Expanded");
+                        clickedElement.setAttribute("aria-label", this.label + " " + "Data Binding");
+                        clickedElement.setAttribute("aria-expanded", "true");
                         
                         let fieldPicker = new FieldPicker(context.designContext.dataStructure);
                         fieldPicker.onClose = (sender, wasCancelled) => {
-                            clickedElement.setAttribute("aria-label",this.label + " " + "Data Binding Collapsed");
+                            clickedElement.setAttribute("aria-label", this.label + " " + "Data Binding");
+                            clickedElement.setAttribute("aria-expanded", "false");
                             if (!wasCancelled) {
                                 
                                 this.setPropertyValue(context, fieldPicker.selectedField.asExpression());

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -3813,7 +3813,7 @@ export abstract class Action extends CardObject {
             buttonElement.setAttribute("aria-label", this.title);
         }
 
-        if (this.expanded != undefined){
+        if (this.expanded != undefined) {
             buttonElement.setAttribute("aria-expanded", this.expanded.toString())
         }
 

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -3778,7 +3778,7 @@ export abstract class Action extends CardObject {
     }
 
     accessibleTitle?: string;
-    expanded?: string;
+    expanded?: boolean;
 
     onExecute: (sender: Action) => void;
 
@@ -3813,8 +3813,8 @@ export abstract class Action extends CardObject {
             buttonElement.setAttribute("aria-label", this.title);
         }
 
-        if (this.expanded){
-            buttonElement.setAttribute("aria-expanded", this.expanded)
+        if (this.expanded != undefined){
+            buttonElement.setAttribute("aria-expanded", this.expanded.toString())
         }
 
         buttonElement.type = "button";

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -3778,6 +3778,7 @@ export abstract class Action extends CardObject {
     }
 
     accessibleTitle?: string;
+    expanded?: string;
 
     onExecute: (sender: Action) => void;
 
@@ -3810,6 +3811,10 @@ export abstract class Action extends CardObject {
         }
         else if (this.title) {
             buttonElement.setAttribute("aria-label", this.title);
+        }
+
+        if (this.expanded){
+            buttonElement.setAttribute("aria-expanded", this.expanded)
         }
 
         buttonElement.type = "button";


### PR DESCRIPTION
## Related Issue
Partial fix for ADO [30909272](https://microsoft.visualstudio.com/OS/_workitems/edit/30909272)

## Description
Added aria-labels to describe the "..." data binding button in it's expanded and collapsed states

## How Verified
Verified using narrator.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5419)