### PR TITLE
[Site] Display action item text at lower screen widths

### DIFF
--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/source/css/extracted.css
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/source/css/extracted.css
@@ -420,16 +420,8 @@ screen and (min-width:768px) {
 	padding: 4px 8px;
 }
 
-
-
 .action-bar .action-list>li .action-item-text {
-	display: none;
-}
-
-@media screen and (min-width:1088px) {
-	.action-bar .action-list>li .action-item-text {
-		display: inline-block;
-	}
+	display: inline-block;
 }
 
 .button.is-small {


### PR DESCRIPTION
## Related Issue
Fixes VSO 30941092

## Description
We have some (presumably) imported CSS that hides our feedback and github icons' text at smaller screen widths. This would make sense from a design perspective *if* we had more than the two icons. As it is, they both fit fine at smaller widths, so we shouldn't be hiding them.

### Before
![image](https://user-images.githubusercontent.com/16614499/108924662-e84e2100-75ef-11eb-9946-3ccce192cf3a.png)

### After
![image](https://user-images.githubusercontent.com/16614499/108924692-f4d27980-75ef-11eb-877c-25161562858d.png)

## How Verified
* local build

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5420)