### PR TITLE
[Site] Fix mobile tabindex

### DIFF
--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/sample.ejs
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/sample.ejs
@@ -52,7 +52,7 @@
 				<div class="w3-cell-row2">
 					<div class="w3-cell" style="width: 50px;">
 						<label>
-							<input type="checkbox" checked id="enableTemplating" class="bigbox" />
+							<input type="checkbox" checked id="enableTemplating" class="bigbox" tabIndex="0" />
 						</label>
 					</div>
 					<div class="w3-cell w3-cell-middle">

--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/source/js/script.js
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/source/js/script.js
@@ -597,7 +597,7 @@ $(function () {
 
     function makeTabIndicesZero() {
         $("[tabindex]").each((i, elem) => {
-            if (elem.tabIndex !== 0) {
+            if (elem.tabIndex > 0) {
                 elem.setAttribute("tabindex", 0);
             }
         });

--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/source/js/script.js
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/source/js/script.js
@@ -595,6 +595,20 @@ $(function () {
 		// Kick off one resize to fix all videos on page load
 	}).resize();
 
+    function makeTabIndicesZero() {
+        $("[tabindex]").each((i, elem) => {
+            if (elem.tabIndex !== 0) {
+                elem.setAttribute("tabindex", 0);
+            }
+        });
+    }
+
+    // rewrite non-zero tabindex values (UHF script can add explicit tabindices, breaking keyboard tab order)
+    $(window).resize(makeTabIndicesZero);
+
+    // this is sadly fragile, but should work in the majority of cases (I'm so sorry).
+    $(document).ready(() => { setTimeout(makeTabIndicesZero, 200); });
+
 	// Code for making sidebar sticky
 	var headerHolder;
 	var footerHolder;


### PR DESCRIPTION
## Related Issue
Fixes VSO [30943285](https://microsoft.visualstudio.com/OS/_workitems/edit/30943285)

## Description
I apologize in advance. Header and mobile nav is powered by some JS we don't own (and can't change on any reasonable time scale). There are a couple of problems with this script. The first is that it puts explicit positive `tabindex` attributes on some DOM elements when in what it considers to be a "mobile" view (this is keyed off of the window width, so it is also affected by DPI and zoom levels). Using positive `tabindex` values is considered bad practice because it's easy to get wrong. Anyways, this is the reason why the tab order is messed up in mobile. The second (relatively minor) problem is that it views the templating checkbox as a search box (it just looks for the first `<input />` in the DOM).

The fix reads easy enough, but I'm not proud of it (though it works):
* Add an explicit `tabindex="0"` to the templating checkbox to give it a reasonable default.
* Introduce `makeTabIndicesZero()`, which finds everything on the page that has a `tabindex` property, and then sets that property to `0` as it should be.
* Call `makeTabIndicesZero()` on window resize (covers active zooming case).
* Call `makeTabIndicesZero()` on document load, but do it behind a `setTimeout` call so that it runs *after* the offending JS. This is the part I'm least happy about, but the offending JS is itself being run something like `setTimeout(ruinSomeTabIndices, 4);` (yes, `4`).

## How Verified
* local build, devtools, keyboard

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5426)