### PR TITLE
Fixed #5348

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputRenderer.mm
@@ -163,7 +163,7 @@
         [inputview setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisVertical];
     }
 
-    if (elem->GetHeight() == HeightType::Stretch) {
+    if (elem->GetHeight() == HeightType::Stretch && !inputBlck->GetIsMultiline()) {
         ACRColumnView *textInputContainer = [[ACRColumnView alloc] init];
         [textInputContainer addArrangedSubview:inputview];
 


### PR DESCRIPTION
## Related Issue
Fixed #5348 

## Description
Changed Input.Text to stretch the input text box when it's multi-line and height is set to stretch.

## Sample Card
```json
{
      "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
      "type": "AdaptiveCard",
      "version": "1.0",
      "body": [
        {
          "type": "TextBlock",
          "size": "Medium",
          "weight": "Bolder",
          "text": "Custom JSON Design Input",
          "horizontalAlignment": "Center"
        },
        {
          "type": "TextBlock",
          "text": "In addition to showing your our pre-built samples, I can submit your custom design for you.  This helps to see how it will render or to see what type of payload your app will need to process if a user hits an Action.Submit button.",
          "wrap": true
        },
        {
          "type": "TextBlock",
          "text": "One way to get design JSON to paste here is to use the \"Copy Card JSON\" button from the [Buttons and Cards Designer](https://developer.webex.com/buttons-and-cards-designer) "
        },
        {
          "type": "Container",
          "items": [
            {
              "type": "Input.Text",
              "placeholder": "Paste card JSON here",
              "id": "cardJson",
              "isMultiline": true,
              "height": "stretch",
              "maxLength": 8000
            }
          ],
          "minHeight": "266px"
        }
      ],
      "actions": [
        {
          "type": "Action.Submit",
          "title": "Display My Card",
          "data": {
            "cardType": "customJsonInput",
            "nextAction": "submitJson"
          }
        },
        {
          "type": "Action.Submit",
          "title": "Go Back To The Built In Samples",
          "data": {
            "cardType": "customJsonInput",
            "nextAction": "samplePicker"
          }
        }
      ]
    }
```

## How Verified
![image](https://user-images.githubusercontent.com/4112696/109202752-30885300-7758-11eb-926c-57a47c0b1a93.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5435)