### PR TITLE
[JS] Stretch multiline Input.Text when height = stretch

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/designer-peers.ts
+++ b/source/nodejs/adaptivecards-designer/src/designer-peers.ts
@@ -2296,6 +2296,11 @@ export class TextInputPeer extends InputPeer<Adaptive.TextInput> {
                 PropertySheetCategory.DefaultCategory,
                 TextInputPeer.styleProperty);
         }
+        else {
+            propertySheet.add(
+                PropertySheetCategory.LayoutCategory,
+                CardElementPeer.heightProperty);
+        }
 
         propertySheet.add(
             PropertySheetCategory.InlineAction,

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -2533,6 +2533,11 @@ export abstract class Input extends CardElement implements IInput {
         this._inputControlContainerElement.className = hostConfig.makeCssClassName("ac-input-container");
         this._inputControlContainerElement.style.display = "flex";
 
+        if (this.height === "stretch") {
+            this._inputControlContainerElement.style.alignItems = "stretch";
+            this._inputControlContainerElement.style.flex = "1 1 auto";
+        }
+
         this._renderedInputControlElement = this.internalRender();
 
         if (this._renderedInputControlElement) {
@@ -2734,6 +2739,10 @@ export class TextInput extends Input {
         if (this.isMultiline) {
             result = document.createElement("textarea");
             result.className = this.hostConfig.makeCssClassName("ac-input", "ac-textInput", "ac-multiline");
+
+            if (this.height === "stretch") {
+                result.style.height = "initial";
+            }
         }
         else {
             result = document.createElement("input");


### PR DESCRIPTION
## Related Issue
Fixes https://github.com/microsoft/AdaptiveCards/issues/4097

## Description
- Exposes the `height` property on **Input.Text** in the designer when `isMultiline` is set to `true`
- Vertically stretch **Input.Text** when its `height` property is set to `"stretch"`

## Sample Card
```json
{
    "type": "AdaptiveCard",
    "body": [
        {
            "type": "Input.Text",
            "placeholder": "This multiline Input.Text stretches into the available vertical space",
            "isMultiline": true,
            "height": "stretch"
        },
        {
            "type": "TextBlock",
            "text": "This TextBlock is pushed to the bottom of the card",
            "wrap": true
        }
    ],
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
    "version": "1.3",
    "minHeight": "200px"
}
```
As rendered:
![image](https://user-images.githubusercontent.com/1334689/109205676-c5408000-775b-11eb-901f-bc1c8edbc183.png)

## How Verified
Verified manually in adaptivecards-designer-app

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5436)