### PR TITLE
[JS] Remove bool props from JSON when set to default

### DIFF
--- a/source/nodejs/adaptivecards/src/serialization.ts
+++ b/source/nodejs/adaptivecards/src/serialization.ts
@@ -142,6 +142,15 @@ export abstract class BaseSerializationContext {
         }
     }
 
+    serializeBool(target: { [key: string]: any }, propertyName: string, propertyValue: boolean | undefined, defaultValue: boolean | undefined = undefined) {
+        if (propertyValue === null || propertyValue === undefined || propertyValue === defaultValue) {
+            delete target[propertyName];
+        }
+        else {
+            target[propertyName] = propertyValue;
+        }
+    }
+
     serializeNumber(target: { [key: string]: any }, propertyName: string, propertyValue: number | undefined, defaultValue: number | undefined = undefined) {
         if (propertyValue === null || propertyValue === undefined || propertyValue === defaultValue || isNaN(propertyValue)) {
             delete target[propertyName];
@@ -323,7 +332,7 @@ export class BoolProperty extends PropertyDefinition {
     }
 
     toJSON(sender: SerializableObject, target: object, value: boolean | undefined, context: BaseSerializationContext) {
-        context.serializeValue(
+        context.serializeBool(
             target,
             this.name,
             value,


### PR DESCRIPTION
## Related Issue
Fixes https://github.com/microsoft/AdaptiveCards/issues/5429#event-4378437789

## Description
Boolean properties were not removed from the output JSON when they were set to their default value. This affected all boolean properties, with `separator` just being one of them.

## Sample Card
No sample needed:
- In the designer, create a card with at least one element
- Select that element
- In the Element Properties toolbox, check the `Separator` (for example) box
  - Verify that `"separator": true` is added to the JSON for that element
- Now deselect the `Separator` box
  - Verify that the `"separator"` property is removed from the JSON

## How Verified
Verified manually in adaptivecards-designer-app

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5438)