### PR TITLE
Fixed #5428

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRFactSetRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRFactSetRenderer.mm
@@ -66,10 +66,7 @@
             // Drop newline char
             [content deleteCharactersInRange:NSMakeRange([content length] - 1, 1)];
         } else {
-            // if html rendering is skipped, remove p tags from both ends (<p>, </p>)
             content = [[NSMutableAttributedString alloc] initWithString:text attributes:descriptor];
-            [content deleteCharactersInRange:NSMakeRange(0, 3)];
-            [content deleteCharactersInRange:NSMakeRange([content length] - 4, 4)];
         }
         // Set paragraph style such as line break mode and alignment
         lab.textContainer.lineBreakMode = textConfig.wrap ? NSLineBreakByWordWrapping : NSLineBreakByTruncatingTail;
@@ -197,7 +194,7 @@
         [titleStack addArrangedSubview:blankTrailingSpace0];
         [blankTrailingSpace0 setContentHuggingPriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisHorizontal];
         [blankTrailingSpace0 setContentHuggingPriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisVertical];
-        
+
         UIView *blankTrailingSpace1 = [[UIView alloc] init];
         blankTrailingSpace1.translatesAutoresizingMaskIntoConstraints = NO;
         [valueStack addArrangedSubview:blankTrailingSpace1];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRichTextBlockRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRichTextBlockRenderer.mm
@@ -96,11 +96,6 @@
                 } else {
                     textRunContent = [[NSMutableAttributedString alloc] initWithString:text
                                                                             attributes:descriptor];
-                    // text is preprocessed by markdown parser, and will wrapped by <p></P>
-                    // lines below remove the p tags
-                    [textRunContent deleteCharactersInRange:NSMakeRange(0, 3)];
-                    [textRunContent
-                        deleteCharactersInRange:NSMakeRange([textRunContent length] - 4, 4)];
                 }
                 // Set paragraph style such as line break mode and alignment
                 NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextBlockRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextBlockRenderer.mm
@@ -84,8 +84,6 @@
         } else {
             // if html rendering is skipped, remove p tags from both ends (<p>, </p>)
             content = [[NSMutableAttributedString alloc] initWithString:text attributes:descriptor];
-            [content deleteCharactersInRange:NSMakeRange(0, 3)];
-            [content deleteCharactersInRange:NSMakeRange([content length] - 4, 4)];
         }
         lab.editable = NO;
         lab.textContainer.lineFragmentPadding = 0;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
@@ -584,7 +584,7 @@ void buildIntermediateResultForText(ACRView *rootView, ACOHostConfig *hostConfig
     NSDictionary *data = nil;
 
     // use Apple's html rendering only if the string has markdowns
-    if (markDownParser->HasHtmlTags() || markDownParser->IsEscaped()) {
+    if (markDownParser->HasHtmlTags()) {
         NSString *fontFamilyName = nil;
 
         if (![hostConfig getFontFamily:textProperties.GetFontType()]) {

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
@@ -581,7 +581,7 @@ void buildIntermediateResultForText(ACRView *rootView, ACOHostConfig *hostConfig
 
     // MarkDownParser transforms text with MarkDown to a html string
     auto markdownString = markDownParser->TransformToHtml();
-    NSString *parsedString = (markDownParser->HasHtmlTags()) ? [NSString stringWithCString:markdownString.c_str() encoding:NSUTF8StringEncoding] : [NSString stringWithCString:markDownParser->GetText().c_str() encoding:NSUTF8StringEncoding];
+    NSString *parsedString = (markDownParser->HasHtmlTags()) ? [NSString stringWithCString:markdownString.c_str() encoding:NSUTF8StringEncoding] : [NSString stringWithCString:markDownParser->GetRawText().c_str() encoding:NSUTF8StringEncoding];
 
     NSDictionary *data = nil;
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
@@ -580,7 +580,9 @@ void buildIntermediateResultForText(ACRView *rootView, ACOHostConfig *hostConfig
     std::shared_ptr<MarkDownParser> markDownParser = std::make_shared<MarkDownParser>([ACOHostConfig getLocalizedDate:textProperties.GetText() language:textProperties.GetLanguage()]);
 
     // MarkDownParser transforms text with MarkDown to a html string
-    NSString *parsedString = [NSString stringWithCString:markDownParser->TransformToHtml().c_str() encoding:NSUTF8StringEncoding];
+    auto markdownString = markDownParser->TransformToHtml();
+    NSString *parsedString = (markDownParser->HasHtmlTags()) ? [NSString stringWithCString:markdownString.c_str() encoding:NSUTF8StringEncoding] : [NSString stringWithCString:markDownParser->GetText().c_str() encoding:NSUTF8StringEncoding];
+
     NSDictionary *data = nil;
 
     // use Apple's html rendering only if the string has markdowns

--- a/source/shared/cpp/ObjectModel/MarkDownParser.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownParser.cpp
@@ -30,7 +30,19 @@ std::string MarkDownParser::TransformToHtml()
     m_parsedResult.AddBlockTags();
 
     m_hasHTMLTag = m_parsedResult.HasHtmlTags();
-    return m_parsedResult.GenerateHtmlString();
+
+    if (HasHtmlTags())
+    {
+        return m_parsedResult.GenerateHtmlString();
+    }
+    // return original text if there are no MarkDown
+    else
+    {
+        std::string parsed("<p>");
+        parsed.append(m_text);
+        parsed.append("</p>");
+        return parsed;
+    }
 }
 
 bool MarkDownParser::HasHtmlTags()

--- a/source/shared/cpp/ObjectModel/MarkDownParser.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownParser.cpp
@@ -30,19 +30,7 @@ std::string MarkDownParser::TransformToHtml()
     m_parsedResult.AddBlockTags();
 
     m_hasHTMLTag = m_parsedResult.HasHtmlTags();
-
-    if (HasHtmlTags())
-    {
-        return m_parsedResult.GenerateHtmlString();
-    }
-    // return original text if there are no MarkDown
-    else
-    {
-        std::string parsed("<p>");
-        parsed.append(m_text);
-        parsed.append("</p>");
-        return parsed;
-    }
+    return m_parsedResult.GenerateHtmlString();
 }
 
 bool MarkDownParser::HasHtmlTags()
@@ -53,6 +41,11 @@ bool MarkDownParser::HasHtmlTags()
 bool MarkDownParser::IsEscaped() const
 {
     return m_isEscaped;
+}
+
+std::string MarkDownParser::GetText() const
+{
+    return m_text;
 }
 
 // MarkDown is consisted of Blocks, this methods parses blocks

--- a/source/shared/cpp/ObjectModel/MarkDownParser.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownParser.cpp
@@ -43,7 +43,7 @@ bool MarkDownParser::IsEscaped() const
     return m_isEscaped;
 }
 
-std::string MarkDownParser::GetText() const
+std::string MarkDownParser::GetRawText() const
 {
     return m_text;
 }

--- a/source/shared/cpp/ObjectModel/MarkDownParser.h
+++ b/source/shared/cpp/ObjectModel/MarkDownParser.h
@@ -17,7 +17,7 @@ namespace AdaptiveSharedNamespace
 
         std::string TransformToHtml();
 
-        std::string GetText() const;
+        std::string GetRawText() const;
 
         bool HasHtmlTags();
 

--- a/source/shared/cpp/ObjectModel/MarkDownParser.h
+++ b/source/shared/cpp/ObjectModel/MarkDownParser.h
@@ -17,6 +17,8 @@ namespace AdaptiveSharedNamespace
 
         std::string TransformToHtml();
 
+        std::string GetText() const;
+
         bool HasHtmlTags();
 
         bool IsEscaped() const;


### PR DESCRIPTION
## Related Issue
Fixed #5428 

## Description
We escape whenever `<`, `>`, `&` and `"`, and iOS renders the text as HTML. We don't have to render the text as HTML if we have such chars but MarkDown.
This change gives more flexibility to developers who develops on stacks that may run into issues when HTML text rendering is used.

## Sample Card
```json
{
  "type" : "AdaptiveCard",
  "$schema" : "http://adaptivecards.io/schemas/adaptive-card.json",
  "version" : "1.3",
  "body" : [
      {
          "type" : "TextBlock",
          "text" : "Foo & bar"
      }
  ]
}
```
## How Verified
Tested that HTML text rendering is not run with the sample card.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5439)