### PR TITLE
[iOS] Fixed zero padding issue around the card

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm
@@ -106,9 +106,9 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
         _quickReplyTargetBuilderDirector = [[ACRTargetBuilderDirector alloc] init:self capability:ACRQuickReply adaptiveHostConfig:_hostConfig];
         unsigned int padding = [_hostConfig getHostConfig] -> GetSpacing().paddingSpacing;
         [self removeConstraints:self.constraints];
-        if (padding) {
-            [self applyPadding:padding priority:1000];
-        }
+        
+        [self applyPadding:padding priority:1000];
+        
         self.acrActionDelegate = acrActionDelegate;
         [self render];
     }


### PR DESCRIPTION
## Related Issue
Fixed #5501 

## Description
Not applying padding at zero causes the ACRView to assume default layout configuration, this isn't wrong, but it is an inconsistent behavior compared to when padding > 0. This fix applies padding even if it's zero.
## Sample Card
Payload
```json
{
    "type": "AdaptiveCard",
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
    "version": "1.3",
    "body": [
        {
            "type": "Container",
            "style": "accent",
            "items": [
                {
                    "type": "ColumnSet",
                    "height": "stretch",
                    "columns": [
                        {
                            "type": "Column",
                            "items": [
                                {
                                    "type": "TextBlock",
                                    "text": "Some text!",
                                    "size": "extraLarge",
                                    "weight": "bolder",
                                    "horizontalAlignment": "center"
                                }
                            ]
                        }
                    ]
                }
            ]
        }
    ]
}
```

Hostconfig
```json
{
    "spacing" : {
        "padding" : 0
    }
}
```
## How Verified
Before Fix
![Not Fixed](https://user-images.githubusercontent.com/4112696/110014306-7e143b00-7cd7-11eb-8801-f583f31e4fc7.png)


After Fix
![Fixed](https://user-images.githubusercontent.com/4112696/110014340-89676680-7cd7-11eb-89ea-5da3b5fd7085.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5516)