### PR TITLE
[iOS]Updated action registration API

### DIFF
--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ViewController.m
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ViewController.m
@@ -123,7 +123,7 @@ CGFloat kAdaptiveCardsWidth = 0;
         // enum will be part of API in next iterations when custom renderer extended to non-action
         // type - tracked by issue #809
         [registration setActionRenderer:[CustomActionOpenURLRenderer getInstance]
-                        cardElementType:@3];
+                      actionElementType:ACROpenUrl];
         [registration setBaseCardElementRenderer:[CustomTextBlockRenderer getInstance]
                                  cardElementType:ACRTextBlock];
         [registration setBaseCardElementRenderer:[CustomInputNumberRenderer getInstance]
@@ -136,7 +136,7 @@ CGFloat kAdaptiveCardsWidth = 0;
         _defaultRenderer = [registration getActionSetRenderer];
         [registration setActionSetRenderer:self];
     } else {
-        [registration setActionRenderer:nil cardElementType:@3];
+        [registration setActionRenderer:nil actionElementType:ACROpenUrl];
         [registration setBaseCardElementRenderer:nil cardElementType:ACRTextBlock];
         [registration setBaseCardElementRenderer:nil cardElementType:ACRNumberInput];
         [registration setBaseCardElementRenderer:nil cardElementType:ACRImage];

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizerTests/ADCIOSVisualizerTests.mm
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizerTests/ADCIOSVisualizerTests.mm
@@ -263,6 +263,18 @@
     XCTAssert([dictionary count] == 1);
 }
 
+- (void)testActionRegistration
+{
+    ACRRegistration *registration = [ACRRegistration getInstance];
+    // override default Action.OpenUrl renderer
+    [registration setActionRenderer:[CustomActionNewTypeRenderer getInstance] actionElementType:ACROpenUrl];
+    // make sure it's registered
+    XCTAssertEqual([CustomActionNewTypeRenderer getInstance], [registration getActionRendererByType:ACROpenUrl]);
+    // reset
+    [registration setActionRenderer:nil actionElementType:ACROpenUrl];
+    // check the renderer is reset to the default renderer
+    XCTAssertEqual([ACRActionOpenURLRenderer getInstance], [registration getActionRendererByType:ACROpenUrl]);
+}
 // this test ensure that extending text render doesn't crash
 // in use case where custom renderer uses default text renderer
 - (void)testExtendingTextRenderersDoesNotCrash

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRegistration.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRegistration.h
@@ -17,9 +17,13 @@
 
 - (ACRBaseCardElementRenderer *_Nullable)getRenderer:(NSNumber *_Nonnull)cardElementType;
 
+- (ACRBaseActionElementRenderer *_Nullable)getActionRendererByType:(ACRActionType)actionElementType;
+
 - (ACRBaseActionElementRenderer *_Nullable)getActionRenderer:(NSNumber *_Nonnull)cardElementType;
 
 - (id<ACRIBaseActionSetRenderer>_Nullable)getActionSetRenderer;
+
+- (void)setActionRenderer:(ACRBaseActionElementRenderer *_Nullable)renderer actionElementType:(ACRActionType)actionElementType;
 
 - (void)setActionRenderer:(ACRBaseActionElementRenderer *_Nullable)renderer cardElementType:(NSNumber *_Nonnull)cardElementType;
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRegistration.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRegistration.mm
@@ -113,6 +113,11 @@ using namespace AdaptiveCards;
     return [typeToRendererDict objectForKey:cardElementType];
 }
 
+- (ACRBaseActionElementRenderer *)getActionRendererByType:(ACRActionType)actionElementType
+{
+    return [self getActionRenderer:[NSNumber numberWithLong:actionElementType]];
+}
+
 - (ACRBaseActionElementRenderer *)getActionRenderer:(NSNumber *)cardElementType
 {
     if ([overridenBaseActionRendererList objectForKey:cardElementType]) {
@@ -129,6 +134,11 @@ using namespace AdaptiveCards;
 - (void)setActionSetRenderer:(id<ACRIBaseActionSetRenderer>)actionsetRenderer
 {
     _actionSetRenderer = actionsetRenderer;
+}
+
+- (void)setActionRenderer:(ACRBaseActionElementRenderer *)renderer actionElementType:(ACRActionType)actionElementType
+{
+    [self setActionRenderer:renderer cardElementType:[NSNumber numberWithLong:actionElementType]];
 }
 
 - (void)setActionRenderer:(ACRBaseActionElementRenderer *)renderer cardElementType:(NSNumber *)cardElementType


### PR DESCRIPTION
## Related Issue
Fixed #5271 

## Description
the method that overrides default actions renderers take NSNumber as a key, it's very cumbersome to use in Swift & it's not intuitive to use. Changed it to use enum type for the default renderers.

## How Verified
1. Updated sample app to use the new method.
2. Added a new unit test.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5527)