### PR TITLE
[iOS] Updated resource resolver behaviors for renderer overrides

### DIFF
--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer.xcodeproj/project.pbxproj
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		6BF339E320A66A3F00DA5973 /* AdaptiveCards.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6BF339E220A66A3F00DA5973 /* AdaptiveCards.framework */; };
 		6BF339E420A66A4D00DA5973 /* AdaptiveCards.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6BF339E220A66A3F00DA5973 /* AdaptiveCards.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6BFBF9612457ADD0006FF8FB /* ActionSet.Inputs.Tests.json in Resources */ = {isa = PBXBuildFile; fileRef = 6BFBF9602457ADCF006FF8FB /* ActionSet.Inputs.Tests.json */; };
+		6BFF998525F941BE0028069F /* CustomActionOpenURLRenderer.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4F255711F993CD200A80D39 /* CustomActionOpenURLRenderer.mm */; };
 		F423C0771EE1FB6100905679 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = F423C0761EE1FB6100905679 /* main.m */; };
 		F423C07A1EE1FB6100905679 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = F423C0791EE1FB6100905679 /* AppDelegate.m */; };
 		F423C07D1EE1FB6100905679 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F423C07C1EE1FB6100905679 /* ViewController.m */; };
@@ -685,6 +686,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6BFF998525F941BE0028069F /* CustomActionOpenURLRenderer.mm in Sources */,
 				6B9FAF5425D7182600D1A791 /* MockRenderer.mm in Sources */,
 				6B70ABB5257B18390095D925 /* CustomActionNewType.mm in Sources */,
 				F423C0931EE1FB6100905679 /* ADCIOSVisualizerTests.mm in Sources */,

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ViewController.m
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ViewController.m
@@ -123,12 +123,12 @@ CGFloat kAdaptiveCardsWidth = 0;
         // enum will be part of API in next iterations when custom renderer extended to non-action
         // type - tracked by issue #809
         [registration setActionRenderer:[CustomActionOpenURLRenderer getInstance]
-                      actionElementType:ACROpenUrl];
+                      actionElementType:ACROpenUrl useResourceResolver:YES];
         [registration setBaseCardElementRenderer:[CustomTextBlockRenderer getInstance]
-                                 cardElementType:ACRTextBlock];
+                                 cardElementType:ACRTextBlock useResourceResolver:YES];
         [registration setBaseCardElementRenderer:[CustomInputNumberRenderer getInstance]
-                                 cardElementType:ACRNumberInput];
-        [registration setBaseCardElementRenderer:[CustomActionSetRenderer getInstance] cardElementType:ACRActionSet];
+                                 cardElementType:ACRNumberInput useResourceResolver:YES];
+        [registration setBaseCardElementRenderer:[CustomActionSetRenderer getInstance] cardElementType:ACRActionSet useResourceResolver:YES];
 
         [[ACRTargetBuilderRegistration getInstance] setTargetBuilder:[ACRCustomSubmitTargetBuilder getInstance] actionElementType:ACRSubmit capability:ACRAction];
         [[ACRTargetBuilderRegistration getInstance] setTargetBuilder:[ACRCustomSubmitTargetBuilder getInstance] actionElementType:ACRSubmit capability:ACRQuickReply];
@@ -139,7 +139,6 @@ CGFloat kAdaptiveCardsWidth = 0;
         [registration setActionRenderer:nil actionElementType:ACROpenUrl];
         [registration setBaseCardElementRenderer:nil cardElementType:ACRTextBlock];
         [registration setBaseCardElementRenderer:nil cardElementType:ACRNumberInput];
-        [registration setBaseCardElementRenderer:nil cardElementType:ACRImage];
         [registration setBaseCardElementRenderer:nil cardElementType:ACRActionSet];
         [registration setActionSetRenderer:nil];
         _enableCustomRendererButton.backgroundColor = [UIColor colorWithRed:0 / 255

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ViewController.m
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ViewController.m
@@ -123,7 +123,7 @@ CGFloat kAdaptiveCardsWidth = 0;
         // enum will be part of API in next iterations when custom renderer extended to non-action
         // type - tracked by issue #809
         [registration setActionRenderer:[CustomActionOpenURLRenderer getInstance]
-                        cardElementType:@3];
+                      actionElementType:ACROpenUrl];
         [registration setBaseCardElementRenderer:[CustomTextBlockRenderer getInstance]
                                  cardElementType:ACRTextBlock];
         [registration setBaseCardElementRenderer:[CustomInputNumberRenderer getInstance]
@@ -136,7 +136,7 @@ CGFloat kAdaptiveCardsWidth = 0;
         _defaultRenderer = [registration getActionSetRenderer];
         [registration setActionSetRenderer:self];
     } else {
-        [registration setActionRenderer:nil cardElementType:@3];
+        [registration setActionRenderer:nil actionElementType:ACROpenUrl];
         [registration setBaseCardElementRenderer:nil cardElementType:ACRTextBlock];
         [registration setBaseCardElementRenderer:nil cardElementType:ACRNumberInput];
         [registration setBaseCardElementRenderer:nil cardElementType:ACRImage];

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizerTests/ADCIOSVisualizerTests.mm
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizerTests/ADCIOSVisualizerTests.mm
@@ -263,6 +263,18 @@
     XCTAssert([dictionary count] == 1);
 }
 
+- (void)testActionRegistration
+{
+    ACRRegistration *registration = [ACRRegistration getInstance];
+    // override default Action.OpenUrl renderer
+    [registration setActionRenderer:[CustomActionNewTypeRenderer getInstance] actionElementType:ACROpenUrl];
+    // make sure it's registered
+    XCTAssertEqual([CustomActionNewTypeRenderer getInstance], [registration getActionRendererByType:ACROpenUrl]);
+    // reset
+    [registration setActionRenderer:nil actionElementType:ACROpenUrl];
+    // check the renderer is reset to the default renderer
+    XCTAssertEqual([ACRActionOpenURLRenderer getInstance], [registration getActionRendererByType:ACROpenUrl]);
+}
 // this test ensure that extending text render doesn't crash
 // in use case where custom renderer uses default text renderer
 - (void)testExtendingTextRenderersDoesNotCrash

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizerTests/ADCIOSVisualizerTests.mm
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizerTests/ADCIOSVisualizerTests.mm
@@ -9,6 +9,7 @@
 #import "AdaptiveCards/ACOBaseActionElementPrivate.h"
 #import "AdaptiveCards/ACOBaseCardElementPrivate.h"
 #import "AdaptiveCards/ACOHostConfigPrivate.h"
+#import "Adaptivecards/ACRRegistrationPrivate.h"
 #import "AdaptiveCards/ACORemoteResourceInformationPrivate.h"
 #import "AdaptiveCards/ACRImageProperties.h"
 #import "AdaptiveCards/ACRShowCardTarget.h"
@@ -21,6 +22,7 @@
 #import "AdaptiveCards/UtiliOS.h"
 #import "CustomActionNewType.h"
 #import "MockRenderer.h"
+#import "CustomActionOpenURLRenderer.h"
 #import <AdaptiveCards/ACFramework.h>
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
@@ -77,6 +79,7 @@
     [[ACRRegistration getInstance] setBaseCardElementRenderer:nil cardElementType:ACRCardElementType::ACRRichTextBlock];
     [[ACRRegistration getInstance] setBaseCardElementRenderer:nil cardElementType:ACRCardElementType::ACRFactSet];
     [[ACRRegistration getInstance] setBaseCardElementRenderer:nil cardElementType:ACRCardElementType::ACRContainer];
+    [[ACRRegistration getInstance] setActionRenderer:nil actionElementType:ACROpenUrl];    
     [super tearDown];
 }
 
@@ -758,6 +761,27 @@
                  config:nil
         widthConstraint:300
                delegate:nil];
+}
+
+// Test that overriden default renders can be chosen to use resource resolvers
+- (void)testResourceResolverSelectivelyWorksForElements
+{
+    ACRRegistration *registration = [ACRRegistration getInstance];
+    [registration setBaseCardElementRenderer:[MockRenderer getInstance]
+                             cardElementType:ACRContainer];
+    XCTAssertFalse([registration shouldUseResourceResolverForOverridenDefaultElementRenderers:ACRContainer]);
+    [registration setBaseCardElementRenderer:[MockRenderer getInstance] cardElementType:ACRContainer useResourceResolver:YES];
+    XCTAssertTrue([registration shouldUseResourceResolverForOverridenDefaultElementRenderers:ACRContainer]);    
+}
+
+// Test that overriden default renders can be chosen to use resource resolvers
+- (void)testResourceResolverSelectivelyWorksForActions
+{
+    ACRRegistration *registration = [ACRRegistration getInstance];
+    [registration setActionRenderer:[CustomActionOpenURLRenderer getInstance] cardElementType:@(ACROpenUrl)];
+    XCTAssertFalse([registration shouldUseResourceResolverForOverridenDefaultActionRenderers:ACROpenUrl]);
+    [registration setActionRenderer:[CustomActionOpenURLRenderer getInstance] actionElementType:ACROpenUrl useResourceResolver:YES];
+    XCTAssertTrue([registration shouldUseResourceResolverForOverridenDefaultActionRenderers:ACROpenUrl]);
 }
 
 @end

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizerTests/ADCIOSVisualizerTests.mm
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizerTests/ADCIOSVisualizerTests.mm
@@ -9,7 +9,6 @@
 #import "AdaptiveCards/ACOBaseActionElementPrivate.h"
 #import "AdaptiveCards/ACOBaseCardElementPrivate.h"
 #import "AdaptiveCards/ACOHostConfigPrivate.h"
-#import "Adaptivecards/ACRRegistrationPrivate.h"
 #import "AdaptiveCards/ACORemoteResourceInformationPrivate.h"
 #import "AdaptiveCards/ACRImageProperties.h"
 #import "AdaptiveCards/ACRShowCardTarget.h"
@@ -20,9 +19,10 @@
 #import "AdaptiveCards/SubmitAction.h"
 #import "AdaptiveCards/TextBlock.h"
 #import "AdaptiveCards/UtiliOS.h"
+#import "Adaptivecards/ACRRegistrationPrivate.h"
 #import "CustomActionNewType.h"
-#import "MockRenderer.h"
 #import "CustomActionOpenURLRenderer.h"
+#import "MockRenderer.h"
 #import <AdaptiveCards/ACFramework.h>
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
@@ -79,7 +79,7 @@
     [[ACRRegistration getInstance] setBaseCardElementRenderer:nil cardElementType:ACRCardElementType::ACRRichTextBlock];
     [[ACRRegistration getInstance] setBaseCardElementRenderer:nil cardElementType:ACRCardElementType::ACRFactSet];
     [[ACRRegistration getInstance] setBaseCardElementRenderer:nil cardElementType:ACRCardElementType::ACRContainer];
-    [[ACRRegistration getInstance] setActionRenderer:nil actionElementType:ACROpenUrl];    
+    [[ACRRegistration getInstance] setActionRenderer:nil actionElementType:ACROpenUrl];
     [super tearDown];
 }
 
@@ -771,7 +771,7 @@
                              cardElementType:ACRContainer];
     XCTAssertFalse([registration shouldUseResourceResolverForOverridenDefaultElementRenderers:ACRContainer]);
     [registration setBaseCardElementRenderer:[MockRenderer getInstance] cardElementType:ACRContainer useResourceResolver:YES];
-    XCTAssertTrue([registration shouldUseResourceResolverForOverridenDefaultElementRenderers:ACRContainer]);    
+    XCTAssertTrue([registration shouldUseResourceResolverForOverridenDefaultElementRenderers:ACRContainer]);
 }
 
 // Test that overriden default renders can be chosen to use resource resolvers

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/TestFiles/AdditionalProperties.json
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/TestFiles/AdditionalProperties.json
@@ -6,7 +6,6 @@
     "body": [
         {
             "type": "Container",
-            "backgroundImage": "bundle:///SmallVerticalLineGray.png",
             "items": [
                 {
                     "type": "TextBlock",

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/TestFiles/AdditionalProperties.json
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/TestFiles/AdditionalProperties.json
@@ -6,6 +6,7 @@
     "body": [
         {
             "type": "Container",
+            "backgroundImage": "bundle:///SmallVerticalLineGray.png",
             "items": [
                 {
                     "type": "TextBlock",

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRColumnSetRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRColumnSetRenderer.mm
@@ -199,7 +199,7 @@
         prevColumn = column;
     }
 
-    if ([viewsWithPaddingView containsObject:viewWithMaxSize]) {
+    if (columns.size() > 1 && [viewsWithPaddingView containsObject:viewWithMaxSize]) {
         viewWithMaxSize.hasPaddingView = NO;
         [viewWithMaxSize removeLastViewFromArrangedSubview];
     }

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRegistration.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRegistration.h
@@ -27,7 +27,11 @@
 
 - (void)setActionRenderer:(ACRBaseActionElementRenderer *_Nullable)renderer cardElementType:(NSNumber *_Nonnull)cardElementType;
 
+- (void)setActionRenderer:(ACRBaseActionElementRenderer *_Nullable)renderer actionElementType:(ACRActionType)actionElementType useResourceResolver:(BOOL)doUse;
+
 - (void)setBaseCardElementRenderer:(ACRBaseCardElementRenderer *_Nullable)renderer cardElementType:(ACRCardElementType)cardElementType;
+
+- (void)setBaseCardElementRenderer:(ACRBaseCardElementRenderer *_Nullable)renderer cardElementType:(ACRCardElementType)cardElementType useResourceResolver:(BOOL)doUse;
 
 - (void)setActionSetRenderer:(id<ACRIBaseActionSetRenderer>_Nullable)actionsetRenderer;
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRegistration.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRegistration.h
@@ -17,9 +17,13 @@
 
 - (ACRBaseCardElementRenderer *_Nullable)getRenderer:(NSNumber *_Nonnull)cardElementType;
 
+- (ACRBaseActionElementRenderer *_Nullable)getActionRendererByType:(ACRActionType)actionElementType;
+
 - (ACRBaseActionElementRenderer *_Nullable)getActionRenderer:(NSNumber *_Nonnull)cardElementType;
 
 - (id<ACRIBaseActionSetRenderer>_Nullable)getActionSetRenderer;
+
+- (void)setActionRenderer:(ACRBaseActionElementRenderer *_Nullable)renderer actionElementType:(ACRActionType)actionElementType;
 
 - (void)setActionRenderer:(ACRBaseActionElementRenderer *_Nullable)renderer cardElementType:(NSNumber *_Nonnull)cardElementType;
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRegistration.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRegistration.mm
@@ -113,6 +113,11 @@ using namespace AdaptiveCards;
     return [typeToRendererDict objectForKey:cardElementType];
 }
 
+- (ACRBaseActionElementRenderer *)getActionRendererByType:(ACRActionType)actionElementType
+{
+    return [self getActionRenderer:[NSNumber numberWithLong:actionElementType]];
+}
+
 - (ACRBaseActionElementRenderer *)getActionRenderer:(NSNumber *)cardElementType
 {
     if ([overridenBaseActionRendererList objectForKey:cardElementType]) {
@@ -129,6 +134,11 @@ using namespace AdaptiveCards;
 - (void)setActionSetRenderer:(id<ACRIBaseActionSetRenderer>)actionsetRenderer
 {
     _actionSetRenderer = actionsetRenderer;
+}
+
+- (void)setActionRenderer:(ACRBaseActionElementRenderer *)renderer actionElementType:(ACRActionType)actionElementType
+{
+    [self setActionRenderer:renderer cardElementType:[NSNumber numberWithLong:actionElementType]];
 }
 
 - (void)setActionRenderer:(ACRBaseActionElementRenderer *)renderer cardElementType:(NSNumber *)cardElementType

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRegistration.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRegistration.mm
@@ -50,6 +50,8 @@ using namespace AdaptiveCards;
     id<ACRIBaseActionSetRenderer> _actionSetRenderer;
     NSMutableDictionary *overridenBaseElementRendererList;
     NSMutableDictionary *overridenBaseActionRendererList;
+    NSMutableSet *_useResourceResolverElementsSet;
+    NSMutableSet *_useResourceResolverActionsSet;
     id<ACRIBaseActionSetRenderer> _defaultActionSetRenderer;
     ACOParseContext *_parseContext;
 }
@@ -95,6 +97,9 @@ using namespace AdaptiveCards;
 
         overridenBaseElementRendererList = [[NSMutableDictionary alloc] init];
         overridenBaseActionRendererList = [[NSMutableDictionary alloc] init];
+        
+        _useResourceResolverElementsSet = [[NSMutableSet alloc] init];
+        _useResourceResolverActionsSet = [[NSMutableSet alloc] init];
     }
     return self;
 }
@@ -136,33 +141,73 @@ using namespace AdaptiveCards;
     _actionSetRenderer = actionsetRenderer;
 }
 
+- (void)setActionRenderer:(ACRBaseActionElementRenderer *)renderer actionElementType:(ACRActionType)actionElementType useResourceResolver:(BOOL)doUse
+{
+    // custom action must be registered through set custom action renderer method
+    // standard actions element enum value must be higher than ACRUnknownAction
+    if (actionElementType > ACRUnknownAction) {
+        return;
+    }
+    NSNumber *key = @(actionElementType);
+    if (!renderer) {
+        [overridenBaseActionRendererList removeObjectForKey:key];
+        [self removeElementFromResourceResolverSet:key isAction:YES];
+    } else {
+        [overridenBaseActionRendererList setObject:renderer forKey:key];
+        [self addElementToResourceResolverSet:key isAction:YES doUse:doUse];
+    }
+}
+
 - (void)setActionRenderer:(ACRBaseActionElementRenderer *)renderer actionElementType:(ACRActionType)actionElementType
 {
-    [self setActionRenderer:renderer cardElementType:[NSNumber numberWithLong:actionElementType]];
+    [self setActionRenderer:renderer actionElementType:actionElementType useResourceResolver:NO];
 }
 
 - (void)setActionRenderer:(ACRBaseActionElementRenderer *)renderer cardElementType:(NSNumber *)cardElementType
 {
-    // custom action must be registered through set custom action renderer method
-    // standard actions element enum value must be higher than ACRUnknownAction
-    if (cardElementType.longValue > ACRUnknownAction) {
+    [self setActionRenderer:renderer actionElementType:(ACRActionType)cardElementType.intValue useResourceResolver:NO];
+}
+
+- (void)removeElementFromResourceResolverSet:(NSNumber *)key isAction:(BOOL)isAction
+{
+    if (isAction) {
+        if ([_useResourceResolverActionsSet containsObject:key]) {
+            [_useResourceResolverActionsSet removeObject:key];
+        }
+    } else {
+        if ([_useResourceResolverElementsSet containsObject:key]) {
+            [_useResourceResolverElementsSet removeObject:key];
+        }
+    }
+}
+
+- (void)addElementToResourceResolverSet:(NSNumber *)key isAction:(BOOL)isAction doUse:(BOOL)doUse
+{
+    if(!doUse) {
         return;
     }
-
-    if (!renderer) {
-        [overridenBaseActionRendererList removeObjectForKey:cardElementType];
+    if (isAction) {
+        [_useResourceResolverActionsSet addObject:key];
     } else {
-        [overridenBaseActionRendererList setObject:renderer forKey:cardElementType];
+        [_useResourceResolverElementsSet addObject:key];
+    }
+}
+
+- (void)setBaseCardElementRenderer:(ACRBaseCardElementRenderer *)renderer cardElementType:(ACRCardElementType)cardElementType useResourceResolver:(BOOL)doUse
+{
+    NSNumber *key = @(cardElementType);
+    if (!renderer) {
+        [overridenBaseElementRendererList removeObjectForKey:key];
+        [self removeElementFromResourceResolverSet:key isAction:NO];
+    } else {
+        [overridenBaseElementRendererList setObject:renderer forKey:key];
+        [self addElementToResourceResolverSet:key isAction:NO doUse:doUse];
     }
 }
 
 - (void)setBaseCardElementRenderer:(ACRBaseCardElementRenderer *)renderer cardElementType:(ACRCardElementType)cardElementType
 {
-    if (!renderer) {
-        [overridenBaseElementRendererList removeObjectForKey:[NSNumber numberWithInteger:cardElementType]];
-    } else {
-        [overridenBaseElementRendererList setObject:renderer forKey:[NSNumber numberWithInteger:cardElementType]];
-    }
+    [self setBaseCardElementRenderer:renderer cardElementType:cardElementType useResourceResolver:NO];
 }
 
 - (void)setCustomElementParser:(NSObject<ACOIBaseCardElementParser> *)customElementParser
@@ -228,7 +273,6 @@ using namespace AdaptiveCards;
     }
 }
 
-
 - (BOOL)isActionRendererOverridden:(NSNumber *)cardElementType
 {
     if ([overridenBaseActionRendererList objectForKey:cardElementType]) {
@@ -243,6 +287,30 @@ using namespace AdaptiveCards;
         return YES;
     }
     return NO;
+}
+
+- (BOOL)shouldUseResourceResolverForOverridenDefaultElementRenderers:(ACRCardElementType)cardElementType
+{
+    if ([self isElementRendererOverridden:cardElementType]) {
+        return [self checkResourceResolverSet:@(cardElementType) isAction:NO];
+    } else {
+        return YES;
+    }
+}
+
+- (BOOL)shouldUseResourceResolverForOverridenDefaultActionRenderers:(ACRActionType)actionType
+{
+    NSNumber *key = @(actionType);
+    if ([self isActionRendererOverridden:key]) {
+        return [self checkResourceResolverSet:key isAction:YES];
+    } else {
+        return YES;
+    }
+}
+
+- (BOOL)checkResourceResolverSet:(NSNumber *)key isAction:(BOOL)isAction
+{
+    return (isAction) ? [_useResourceResolverActionsSet containsObject:key] : [_useResourceResolverElementsSet containsObject:key];
 }
 
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRegistration.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRegistration.mm
@@ -97,7 +97,7 @@ using namespace AdaptiveCards;
 
         overridenBaseElementRendererList = [[NSMutableDictionary alloc] init];
         overridenBaseActionRendererList = [[NSMutableDictionary alloc] init];
-        
+
         _useResourceResolverElementsSet = [[NSMutableSet alloc] init];
         _useResourceResolverActionsSet = [[NSMutableSet alloc] init];
     }
@@ -183,7 +183,7 @@ using namespace AdaptiveCards;
 
 - (void)addElementToResourceResolverSet:(NSNumber *)key isAction:(BOOL)isAction doUse:(BOOL)doUse
 {
-    if(!doUse) {
+    if (!doUse) {
         return;
     }
     if (isAction) {

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRegistrationPrivate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRegistrationPrivate.h
@@ -3,6 +3,14 @@
 
 using namespace AdaptiveCards;
 
+@interface ACRRegistration ()
+
+- (BOOL)shouldUseResourceResolverForOverridenDefaultElementRenderers:(ACRCardElementType)cardElementType;
+
+- (BOOL)shouldUseResourceResolverForOverridenDefaultActionRenderers:(ACRActionType)actionType;
+
+@end
+
 @interface ACOFeatureRegistration ()
 
 - (std::shared_ptr<FeatureRegistration>)getSharedFeatureRegistration;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRenderer.mm
@@ -116,7 +116,7 @@ using namespace AdaptiveCards;
     style = (style == ACRNone) ? ACRDefault : style;
     [verticalView setStyle:style];
 
-    [rootView addTasksToConcurrentQueue:body registration:[ACRRegistration getInstance]];
+    [rootView addBaseCardElementListToConcurrentQueue:body registration:[ACRRegistration getInstance]];
 
     std::vector<std::shared_ptr<BaseActionElement>> actions = adaptiveCard->GetActions();
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRenderer.mm
@@ -116,7 +116,7 @@ using namespace AdaptiveCards;
     style = (style == ACRNone) ? ACRDefault : style;
     [verticalView setStyle:style];
 
-    [rootView addTasksToConcurrentQueue:body];
+    [rootView addTasksToConcurrentQueue:body registration:[ACRRegistration getInstance]];
 
     std::vector<std::shared_ptr<BaseActionElement>> actions = adaptiveCard->GetActions();
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm
@@ -12,7 +12,7 @@
 #import "ACRContentHoldingUIView.h"
 #import "ACRIBaseCardElementRenderer.h"
 #import "ACRImageRenderer.h"
-#import "ACRRegistration.h"
+#import "ACRRegistrationPrivate.h"
 #import "ACRRendererPrivate.h"
 #import "ACRTextBlockRenderer.h"
 #import "ACRUIImageView.h"
@@ -165,7 +165,7 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
     }
 }
 
-- (void)processBaseCardElement:(std::shared_ptr<BaseCardElement> const &)elem
+- (void)processBaseCardElement:(std::shared_ptr<BaseCardElement> const &)elem registration:(ACRRegistration *)registration
 {
     switch (elem->GetElementType()) {
         case CardElementType::TextBlock: {
@@ -347,17 +347,14 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
             }
 
             std::vector<std::shared_ptr<BaseCardElement>> &new_body = container->GetItems();
-            [self addTasksToConcurrentQueue:new_body];
+            [self addTasksToConcurrentQueue:new_body registration:registration];
             break;
         }
         // continue on search
         case CardElementType::ColumnSet: {
             std::shared_ptr<ColumnSet> columSet = std::static_pointer_cast<ColumnSet>(elem);
             std::vector<std::shared_ptr<Column>> &columns = columSet->GetColumns();
-            // ColumnSet is vector of Column, instead of vector of BaseCardElement
-            for (auto const &column : columns) { // update serial number that is used for generating unique key for image_map
-                [self processBaseCardElement:column];
-            }
+            [self addColumnsToConcurrentQueue:columns registration:registration];
             break;
         }
 
@@ -371,8 +368,8 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
             }
 
             // add column fallbacks to async task queue
-            [self processFallback:column];
-            [self addTasksToConcurrentQueue:column->GetItems()];
+            [self processFallback:column registration:registration];
+            [self addTasksToConcurrentQueue:column->GetItems() registration:registration];
             break;
         }
 
@@ -396,20 +393,30 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
     }
 }
 
-// Walk through adaptive cards elements recursively and if images/images set/TextBlocks are found process them concurrently
-- (void)addTasksToConcurrentQueue:(std::vector<std::shared_ptr<BaseCardElement>> const &)body
+- (void)doCommonTaskBeforeProcessBaseCardElement:(std::shared_ptr<BaseCardElement> const &)elem registration:(ACRRegistration *)registration
 {
-    ACRRegistration *rendererRegistration = [ACRRegistration getInstance];
-
+    if ([registration shouldUseResourceResolverForOverridenDefaultElementRenderers:(ACRCardElementType)elem->GetElementType()] == NO) {
+        return;
+    }
+    
+    [self processFallback:elem registration:registration];
+    [self processBaseCardElement:elem registration:registration];
+}
+// Walk through adaptive cards elements recursively and if images/images set/TextBlocks are found process them concurrently
+- (void)addTasksToConcurrentQueue:(std::vector<std::shared_ptr<BaseCardElement>> const &)body registration:(ACRRegistration *)registration
+{
     for (auto &elem : body) {
-        if ([rendererRegistration isElementRendererOverridden:(ACRCardElementType)elem->GetElementType()] == YES) {
-            continue;
-        }
-
-        [self processFallback:elem];
-        [self processBaseCardElement:elem];
+        [self doCommonTaskBeforeProcessBaseCardElement:elem registration:registration];
     }
 }
+
+- (void)addColumnsToConcurrentQueue:(std::vector<std::shared_ptr<Column>> const &)columns registration:(ACRRegistration *)registration
+{
+    for (auto &column : columns) {
+        [self doCommonTaskBeforeProcessBaseCardElement:column registration:registration];
+    }
+}
+
 
 // Walk through the actions found and process them concurrently
 - (void)loadImagesForActionsAndCheckIfAllActionsHaveIconImages:(std::vector<std::shared_ptr<BaseActionElement>> const &)actions hostconfig:(ACOHostConfig *)hostConfig;
@@ -749,13 +756,13 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
 }
 
 // get fallback content and add them async task queue
-- (void)processFallback:(std::shared_ptr<BaseCardElement> const &)elem
+- (void)processFallback:(std::shared_ptr<BaseCardElement> const &)elem registration:(ACRRegistration *)registration
 {
     std::shared_ptr<BaseElement> fallbackElem = elem->GetFallbackContent();
     while (fallbackElem) {
         std::shared_ptr<BaseCardElement> fallbackElemCard = std::static_pointer_cast<BaseCardElement>(fallbackElem);
         if (fallbackElemCard) {
-            [self processBaseCardElement:fallbackElemCard];
+            [self processBaseCardElement:fallbackElemCard registration:registration];
         }
 
         fallbackElem = fallbackElemCard->GetFallbackContent();

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm
@@ -347,7 +347,7 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
             }
 
             std::vector<std::shared_ptr<BaseCardElement>> &new_body = container->GetItems();
-            [self addTasksToConcurrentQueue:new_body registration:registration];
+            [self addBaseCardElementListToConcurrentQueue:new_body registration:registration];
             break;
         }
         // continue on search
@@ -369,7 +369,7 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
 
             // add column fallbacks to async task queue
             [self processFallback:column registration:registration];
-            [self addTasksToConcurrentQueue:column->GetItems() registration:registration];
+            [self addBaseCardElementListToConcurrentQueue:column->GetItems() registration:registration];
             break;
         }
 
@@ -393,27 +393,27 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
     }
 }
 
-- (void)doCommonTaskBeforeProcessBaseCardElement:(std::shared_ptr<BaseCardElement> const &)elem registration:(ACRRegistration *)registration
+- (void)addBaseCardElementToConcurrentQueue:(std::shared_ptr<BaseCardElement> const &)elem registration:(ACRRegistration *)registration
 {
     if ([registration shouldUseResourceResolverForOverridenDefaultElementRenderers:(ACRCardElementType)elem->GetElementType()] == NO) {
         return;
     }
-    
+
     [self processFallback:elem registration:registration];
     [self processBaseCardElement:elem registration:registration];
 }
 // Walk through adaptive cards elements recursively and if images/images set/TextBlocks are found process them concurrently
-- (void)addTasksToConcurrentQueue:(std::vector<std::shared_ptr<BaseCardElement>> const &)body registration:(ACRRegistration *)registration
+- (void)addBaseCardElementListToConcurrentQueue:(std::vector<std::shared_ptr<BaseCardElement>> const &)body registration:(ACRRegistration *)registration
 {
     for (auto &elem : body) {
-        [self doCommonTaskBeforeProcessBaseCardElement:elem registration:registration];
+        [self addBaseCardElementToConcurrentQueue:elem registration:registration];
     }
 }
 
 - (void)addColumnsToConcurrentQueue:(std::vector<std::shared_ptr<Column>> const &)columns registration:(ACRRegistration *)registration
 {
     for (auto &column : columns) {
-        [self doCommonTaskBeforeProcessBaseCardElement:column registration:registration];
+        [self addBaseCardElementToConcurrentQueue:column registration:registration];
     }
 }
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRViewPrivate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRViewPrivate.h
@@ -15,6 +15,7 @@
 #import "CollectionTypeElement.h"
 #import "Image.h"
 #import "SharedAdaptiveCard.h"
+#import "ACRRegistration.h"
 
 using namespace AdaptiveCards;
 
@@ -30,7 +31,7 @@ typedef void (^ObserverActionBlockForBaseAction)(NSObject<ACOIResourceResolver> 
 
 // Walk through adaptive cards elements and if images are found, download and process images concurrently and on different thread
 // from main thread, so images process won't block UI thread.
-- (void)addTasksToConcurrentQueue:(std::vector<std::shared_ptr<BaseCardElement>> const &)body;
+- (void)addTasksToConcurrentQueue:(std::vector<std::shared_ptr<BaseCardElement>> const &)body registration:(ACRRegistration *)registration;
 // async method
 - (void)loadImagesForActionsAndCheckIfAllActionsHaveIconImages:(std::vector<std::shared_ptr<BaseActionElement>> const &)actions hostconfig:(ACOHostConfig *)hostConfig;
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRViewPrivate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRViewPrivate.h
@@ -31,7 +31,7 @@ typedef void (^ObserverActionBlockForBaseAction)(NSObject<ACOIResourceResolver> 
 
 // Walk through adaptive cards elements and if images are found, download and process images concurrently and on different thread
 // from main thread, so images process won't block UI thread.
-- (void)addTasksToConcurrentQueue:(std::vector<std::shared_ptr<BaseCardElement>> const &)body registration:(ACRRegistration *)registration;
+- (void)addBaseCardElementListToConcurrentQueue:(std::vector<std::shared_ptr<BaseCardElement>> const &)body registration:(ACRRegistration *)registration;
 // async method
 - (void)loadImagesForActionsAndCheckIfAllActionsHaveIconImages:(std::vector<std::shared_ptr<BaseActionElement>> const &)actions hostconfig:(ACOHostConfig *)hostConfig;
 


### PR DESCRIPTION
## Related Issue
Fixed #5272 

## Description
Resource resolvers were disabled if the default renderers were overridden per the Team's request. Added two new methods, 
`- (void)setBaseCardElementRenderer:(ACRBaseCardElementRenderer *_Nullable)renderer cardElementType:(ACRCardElementType)cardElementType useResourceResolver:(BOOL)doUse`

`- (void)setActionRenderer:(ACRBaseActionElementRenderer *_Nullable)renderer actionElementType:(ACRActionType)actionElementType useResourceResolver:(BOOL)doUse`

when doUse is `YES`, resource resolver will be used for the overrides.

Also fixed a minor issue with stretch behavior for Column when the vertical alignment is set to Center.

## How Verified
How you verified the fix, including one or all of the following: 
1. New Unit tests are added
2. Checked for the regression.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5528)