### PR TITLE
[Site] Set aria-current on current sample (and misc a11y fixes)

### DIFF
--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/explorer.ejs
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/explorer.ejs
@@ -26,7 +26,7 @@
 			<!-- mobile nav -->
 			<div class="w3-hide-large">
 				<span>Choose element: </span>
-				<select id="menu-nav" class="w3-select w3-border w3-margin-bottom">
+				<select id="menu-nav" class="w3-select w3-border w3-margin-bottom" title="Element menu">
 					<% page.schema.forEach(function(root) { %>
 					<optgroup class="noLink" label='<%= root.title %>'>
 						<% root.children.forEach(function(child) { %>
@@ -44,7 +44,7 @@
 			</div>
 
 			<p><strong>Important note about accessibility:</strong> 
-				In version 1.3 of the schema we introduced a <a href="https://docs.microsoft.com/en-us/adaptive-cards/authoring-cards/input-validation#labels"><strong>label</strong></a> property on Inputs to improve accessibility. If the <a href="https://docs.microsoft.com/en-us/adaptive-cards/resources/partners">Host app you are targetting</a> supports v1.3 you should use <strong>label</strong> instead of a <strong>TextBlock</strong> as seen in some samples below. Once most Host apps have updated to the latest version we will update the samples accordingly.</a>
+				In version 1.3 of the schema we introduced a <a href="https://docs.microsoft.com/en-us/adaptive-cards/authoring-cards/input-validation#labels"><strong>label</strong></a> property on Inputs to improve accessibility. If the <a href="https://docs.microsoft.com/en-us/adaptive-cards/resources/partners">Host app you are targeting</a> supports v1.3 you should use <strong>label</strong> instead of a <strong>TextBlock</strong> as seen in some samples below. Once most Host apps have updated to the latest version we will update the samples accordingly.</a>
 			</p>
 
 			<h2><%= page.element.name %></h2>

--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/sample.ejs
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/sample.ejs
@@ -7,13 +7,12 @@
 				<% page.samples.forEach(function(sample, i) {
                     const isSelected = (page.samplePath === sample.htmlPath);
                 %>
-				<li <%= isSelected ? "class=selectedHolder" : "" %>>
 					<a role="listitem"
-                       aria-selected='<%= isSelected.toString() %>'
+                       <%= isSelected ? "class=selectedHolder" : "" %>
+                       aria-current='<%= isSelected.toString() %>'
                        aria-posinset='<%= (i+1).toString() %>'
                        aria-setsize='<%= page.samples.length.toString() %>'
                        href="<%- url_for(sample.htmlPath) %>"><%= sample.name %></a>
-				</li>
 				<% }) %>
 
 			</ul>
@@ -29,14 +28,14 @@
 					Go ahead and tweak them to make any scenario possible!</p>
 
 				<p><strong>Important note about accessibility:</strong> 
-					In version 1.3 of the schema we introduced a <a href="https://docs.microsoft.com/en-us/adaptive-cards/authoring-cards/input-validation#labels"><strong>label</strong></a> property on Inputs to improve accessibility. If the <a href="https://docs.microsoft.com/en-us/adaptive-cards/resources/partners">Host app you are targetting</a> supports v1.3 you should use <strong>label</strong> instead of a <strong>TextBlock</strong> as seen in some samples below. Once most Host apps have updated to the latest version we will update the samples accordingly.</a>
+					In version 1.3 of the schema we introduced a <a href="https://docs.microsoft.com/en-us/adaptive-cards/authoring-cards/input-validation#labels"><strong>label</strong></a> property on Inputs to improve accessibility. If the <a href="https://docs.microsoft.com/en-us/adaptive-cards/resources/partners">Host app you are target ing</a> supports v1.3 you should use <strong>label</strong> instead of a <strong>TextBlock</strong> as seen in some samples below. Once most Host apps have updated to the latest version we will update the samples accordingly.</a>
 				</p>
 		
 
 				<!-- mobile nav -->
 				<div class="w3-hide-large">
 					<span>Choose sample: </span>
-					<select id="menu-nav" class="w3-select w3-border w3-margin-bottom">
+					<select id="menu-nav" class="w3-select w3-border w3-margin-bottom" title="Samples menu">
 						<% page.samples.forEach(function(sample) { %>
 						<% if(is_current(sample.htmlPath)) { %>
 						<option value='<%- url_for(sample.htmlPath) %>' selected="selected"><%= sample.name %></option>

--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/source/css/style.css
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/source/css/style.css
@@ -307,16 +307,19 @@ ul.action-list {
   margin: 0;
 }
 
-.toc-todo > div > ul > li {
+.toc-todo > div > ul > li,
+.toc-todo > div > ul > a {
   padding-left: 30px;
 }
 
 /* For samples, since there's no heirarchy, don't indent the left as much */
-.toc-todo .samples-sidebar-list li {
+.toc-todo .samples-sidebar-list li,
+.toc-todo .samples-sidebar-list a {
   padding-left: 12px;
 }
 
-.toc-todo li {
+.toc-todo li,
+.toc-todo a {
   padding-left: 30px;
   padding-top: 3px;
   padding-bottom: 3px;
@@ -333,8 +336,11 @@ s {
     background-color: #0050c5;
 }
 
+.toc-todo .selectedHolder,
 .toc-todo .selectedHolder > a,
-.toc-todo .selectedHolder > a:hover {
+.toc-todo .selectedHolder > a:hover,
+.toc-todo a.selectedHolder:hover
+{
     color: #fff;
 }
 


### PR DESCRIPTION
## Related Issue
Fixes VSO #30961004

## Description
Applies `aria-current` to items in the samples list. Also restructure things a bit so that the value is actually honored. Also includes a couple of small accessibility fixes for the mobile site (adding `title` to a couple of `select` elements). Lastly, fix up a misspelled word ("targetting" -> "targeting"). Note that Narrator doesn't read `aria-current`, but NVDA does the right thing.

## How Verified
* local build, devtools, NVDA

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5534)