### PR TITLE
pic2card broken gif url fix

### DIFF
--- a/source/nodejs/adaptivecards-site/pages/_posts/2020/Community-Call-November.md
+++ b/source/nodejs/adaptivecards-site/pages/_posts/2020/Community-Call-November.md
@@ -2,7 +2,7 @@
 title: 🎉 Pic2Card Service Now available on Adaptive Card Designer
 subtitle: Generate cards automatically by uploading an image
 date: 2020-11-01
-featured_image: https://raw.githubusercontent.com/microsoft/AdaptiveCards/pic2card-blog-update/source/nodejs/adaptivecards-site/pages/_posts/2020/Community-Call-November/pic2card.gif
+featured_image: https://raw.githubusercontent.com/microsoft/AdaptiveCards/main/source/nodejs/adaptivecards-site/pages/_posts/2020/Community-Call-November/pic2card.gif
 github_username: Vasanth-S
 twitter: ImagineaTech
 ---


### PR DESCRIPTION
The asset's raw URL was relative to the feature branch instead of the main branch.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5535)