### PR TITLE
[iOS] Updated TextView to dynamically compute the intrinsic content size

### DIFF
--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/resources/filebrowserHostConfig.json
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/resources/filebrowserHostConfig.json
@@ -208,7 +208,7 @@
 		"lineColor": "#FF000000"
 	},
 	"actions": {
-		"maxActions": 5,
+		"maxActions": 6,
 		"spacing": "Default",
 		"buttonSpacing": 10,
 		"showCard": {

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOAdaptiveCard.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOAdaptiveCard.mm
@@ -61,7 +61,7 @@ using namespace AdaptiveCards;
     if (payload) {
         try {
             ACOAdaptiveCard *card = [[ACOAdaptiveCard alloc] init];
-            std::shared_ptr<ParseResult> parseResult = AdaptiveCard::DeserializeFromString(std::string([payload UTF8String]), std::string("1.3"));
+            std::shared_ptr<ParseResult> parseResult = AdaptiveCard::DeserializeFromString(std::string([payload UTF8String]), std::string("1.4"));
             NSMutableArray *acrParseWarnings;
             std::vector<std::shared_ptr<AdaptiveCardParseWarning>> parseWarnings = parseResult->GetWarnings();
             for (const auto &warning : parseWarnings) {

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextView.mm
@@ -9,6 +9,7 @@
 #import "ACOBaseCardElementPrivate.h"
 #import "ACRInputLabelView.h"
 #import "TextInput.h"
+#import "UtiliOS.h"
 
 @implementation ACRTextView
 
@@ -45,18 +46,7 @@
                                  encoding:NSUTF8StringEncoding];
     [self registerForKeyboardNotifications];
 
-    BOOL bRemove = NO;
-    if (![self.text length]) {
-        self.text = @"placeholder text";
-        bRemove = YES;
-    }
-    CGRect boundingrect = [self.layoutManager lineFragmentRectForGlyphAtIndex:0 effectiveRange:nil];
-    boundingrect.size.height *= 4;
-    self.frame = boundingrect;
-
-    if (bRemove) {
-        self.text = @"";
-    }
+    self.frame = [self computeBoundingRect];
 
     CGRect frame = CGRectMake(0, 0, self.frame.size.width, 30);
     UIToolbar *toolBar = [[UIToolbar alloc] initWithFrame:frame];
@@ -124,7 +114,7 @@
 
 - (CGSize)intrinsicContentSize
 {
-    return self.frame.size;
+    return [self computeBoundingRect].size;
 }
 
 - (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text;
@@ -166,6 +156,24 @@
         }
     }
     [textView resignFirstResponder];
+}
+
+- (CGRect)computeBoundingRect
+{
+    BOOL bRemove = NO;
+
+    if (![self.text length]) {
+        self.text = @"placeholder text";
+        bRemove = YES;
+    }
+    CGRect boundingrect = [self.layoutManager lineFragmentRectForGlyphAtIndex:0 effectiveRange:nil];
+    boundingrect.size.height *= 4;
+    self.frame = boundingrect;
+    
+    if (bRemove) {
+        self.text = @"";
+    }
+    return boundingrect;
 }
 
 @synthesize hasValidationProperties;


### PR DESCRIPTION
## Related Issue
Fixed #5558 

## Description
1. The intrinsic content size of TextView was returning its frame size, this is wrong as the frame is not dependent on the text content.
2. Increased sample app's allowed button counts to include 1.4 samples
3. Updated parser version after shared mode change.

## Sample Card
![image](https://user-images.githubusercontent.com/4112696/111689695-990fa080-87e9-11eb-92c6-f5efe41d17a0.png)

## How Verified


1. Existing relevant unit/regression tests that you ran

### before fix
 ![Screen Shot 2021-03-18 at 12 52 58 PM](https://user-images.githubusercontent.com/4112696/111689768-b04e8e00-87e9-11eb-9d25-666b45378ebe.png)
### after fix
![Screen Shot 2021-03-18 at 12 49 35 PM](https://user-images.githubusercontent.com/4112696/111689746-a9278000-87e9-11eb-8a16-b12d2b5562bc.png)

### before fix
![Screen Shot 2021-03-18 at 12 53 15 PM](https://user-images.githubusercontent.com/4112696/111689781-b3497e80-87e9-11eb-8667-0bbc1503bb46.png)
### after fix
![Screen Shot 2021-03-18 at 12 54 02 PM](https://user-images.githubusercontent.com/4112696/111689792-b5abd880-87e9-11eb-9998-80abf4cb8ded.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5560)