### PR TITLE
[JS] Universal Action designer support + some bug fixes

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/card-designer-surface.ts
+++ b/source/nodejs/adaptivecards-designer/src/card-designer-surface.ts
@@ -136,6 +136,7 @@ export class ActionPeerRegistry extends DesignerPeerRegistry<ActionType, ActionP
 
         this.registerPeer(Adaptive.HttpAction, DesignerPeers.HttpActionPeer, DesignerPeerCategory.Actions, "acd-icon-actionHttp");
         this.registerPeer(Adaptive.SubmitAction, DesignerPeers.SubmitActionPeer, DesignerPeerCategory.Actions, "acd-icon-actionSubmit");
+        this.registerPeer(Adaptive.ExecuteAction, DesignerPeers.ExecuteActionPeer, DesignerPeerCategory.Actions, "acd-icon-actionSubmit");
         this.registerPeer(Adaptive.OpenUrlAction, DesignerPeers.OpenUrlActionPeer, DesignerPeerCategory.Actions, "acd-icon-actionOpenUrl");
         this.registerPeer(Adaptive.ShowCardAction, DesignerPeers.ShowCardActionPeer, DesignerPeerCategory.Actions, "acd-icon-actionShowCard");
         this.registerPeer(Adaptive.ToggleVisibilityAction, DesignerPeers.ToggleVisibilityActionPeer, DesignerPeerCategory.Actions, "acd-icon-actionToggleVisibility");
@@ -325,34 +326,7 @@ export class CardDesignerSurface {
 
         if (this.isPreviewMode) {
             cardToRender.onExecuteAction = (action: Adaptive.Action) => {
-                let message: string = "Action executed\n";
-                message += "    Title: " + action.title + "\n";
-
-                if (action instanceof Adaptive.OpenUrlAction) {
-                    message += "    Type: OpenUrl\n";
-                    message += "    Url: " + action.url + "\n";
-                }
-                else if (action instanceof Adaptive.SubmitAction) {
-                    message += "    Type: Submit";
-                    message += "    Data: " + JSON.stringify(action.data);
-                }
-                else if (action instanceof Adaptive.HttpAction) {
-                    message += "    Type: Http\n";
-                    message += "    Url: " + action.url + "\n";
-                    message += "    Method: " + action.method + "\n";
-                    message += "    Headers:\n";
-
-                    for (let header of action.headers) {
-                        message += "        " + header.name + ": " + header.value + "\n";
-                    }
-
-                    message += "    Body: " + action.body + "\n";
-                }
-                else {
-                    message += "    Type: <unknown>";
-                }
-
-                alert(message);
+                alert("Action executed\n" + JSON.stringify(action.toJSON(this._serializationContext), undefined, 4));
             };
         }
 

--- a/source/nodejs/adaptivecards-designer/src/designer-peers.ts
+++ b/source/nodejs/adaptivecards-designer/src/designer-peers.ts
@@ -10,7 +10,6 @@ import { Rect, IPoint, Utils } from "./miscellaneous";
 import { GlobalSettings } from "./shared";
 import { FieldPicker } from "./field-picker";
 import { Strings } from "./strings";
-import { stringToCssColor } from "adaptivecards";
 
 export abstract class DesignerPeerInplaceEditor {
     onClose: (applyChanges: boolean) => void;

--- a/source/nodejs/adaptivecards-designer/src/designer-peers.ts
+++ b/source/nodejs/adaptivecards-designer/src/designer-peers.ts
@@ -10,6 +10,7 @@ import { Rect, IPoint, Utils } from "./miscellaneous";
 import { GlobalSettings } from "./shared";
 import { FieldPicker } from "./field-picker";
 import { Strings } from "./strings";
+import { stringToCssColor } from "adaptivecards";
 
 export abstract class DesignerPeerInplaceEditor {
     onClose: (applyChanges: boolean) => void;
@@ -59,6 +60,7 @@ export class PropertySheetCategory {
     static readonly SelectionAction = "Selection action";
     static readonly InlineAction = "Inline action";
     static readonly Validation = "Validation";
+    static readonly Refresh = "Refresh"
 
     private _entries: PropertySheetEntry[] = [];
 
@@ -136,6 +138,26 @@ export class PropertySheet {
         }
 
         category.add(...entries);
+    }
+
+    addActionProperties(
+        targetVersion: Adaptive.Version,
+        peer: DesignerPeer,
+        action: Adaptive.Action,
+        category: string) {
+        let actionPeer = CardDesignerSurface.actionPeerRegistry.createPeerInstance(peer.designerSurface, null, action);
+        actionPeer.onChanged = (sender: DesignerPeer, updatePropertySheet: boolean) => { peer.changed(updatePropertySheet); };
+
+        let subPropertySheet = new PropertySheet(false);
+        actionPeer.populatePropertySheet(subPropertySheet, category);
+
+        subPropertySheet.remove(
+            ActionPeer.iconUrlProperty,
+            ActionPeer.styleProperty);
+
+        this.add(
+            category,
+            new SubPropertySheetEntry(targetVersion, action, subPropertySheet));
     }
 
     remove(...entries: PropertySheetEntry[]) {
@@ -294,16 +316,30 @@ export abstract class SingleInputPropertyEditor extends PropertySheetEntry {
     }
 }
 
-export class StringPropertyEditor extends SingleInputPropertyEditor {
+export class BaseStringPropertyEditor extends SingleInputPropertyEditor {
+    protected placeHolder: string = "(not set)";
+
     protected createInput(context: PropertySheetContext): Adaptive.Input {
         let input = new Adaptive.TextInput();
         input.defaultValue = this.getPropertyValue(context);
-        input.placeholder = "(not set)";
+        input.placeholder = this.placeHolder;
         input.isMultiline = this.isMultiline;
 
         return input;
     }
 
+    constructor(
+        readonly targetVersion: Adaptive.TargetVersion,
+        readonly propertyName: string,
+        readonly label: string,
+        readonly allowBinding: boolean = false,
+        readonly isMultiline: boolean = false,
+        readonly causesPropertySheetRefresh: boolean = false) {
+        super(targetVersion, propertyName, label, causesPropertySheetRefresh);
+    }
+}
+
+export class StringPropertyEditor extends BaseStringPropertyEditor {
     protected getAdditionalCommands(context: PropertySheetContext): IPropertySheetEditorCommand[] {
         if (GlobalSettings.enableDataBindingSupport && this.allowBinding) {
             return [
@@ -334,6 +370,38 @@ export class StringPropertyEditor extends SingleInputPropertyEditor {
             return super.getAdditionalCommands(context);
         }
     }
+}
+
+export class StringArrayPropertyEditor extends BaseStringPropertyEditor {
+    protected getPropertyValue(context: PropertySheetContext): any {
+        let rawValue = context.target[this.propertyName];
+        let result: string[] = [];
+
+        if (rawValue !== undefined && Array.isArray(rawValue)) {
+            for (let item of rawValue) {
+                if (typeof item === "string") {
+                    result.push(item);
+                }
+            }
+        }
+
+        return result.length > 0 ? result.join(",") : undefined;
+    }
+
+    protected setPropertyValue(context: PropertySheetContext, value: string) {
+        if (value !== undefined) {
+            let rawValues = value.split(",");
+            let result: string[] = [];
+
+            for (let rawValue of rawValues) {
+                if (rawValue) {
+                    result.push(rawValue);
+                }
+            }
+
+            context.target[this.propertyName] = result.length > 0 ? result : undefined;
+        }
+    }    
 
     constructor(
         readonly targetVersion: Adaptive.TargetVersion,
@@ -342,7 +410,9 @@ export class StringPropertyEditor extends SingleInputPropertyEditor {
         readonly allowBinding: boolean = false,
         readonly isMultiline: boolean = false,
         readonly causesPropertySheetRefresh: boolean = false) {
-        super(targetVersion, propertyName, label, causesPropertySheetRefresh);
+        super(targetVersion, propertyName, label, allowBinding, isMultiline, causesPropertySheetRefresh);
+
+        this.placeHolder = "(not set, comma-separated list)";
     }
 }
 
@@ -558,10 +628,8 @@ export class ActionPropertyEditor extends SingleInputPropertyEditor {
     }
 
     protected setPropertyValue(context: PropertySheetContext, value: string) {
-        context.target[this.propertyName] = parseInt(value, 10);
-
         if (value == "none") {
-            context.target[this.propertyName] = null;
+            context.target[this.propertyName] = undefined;
         }
         else {
             context.target[this.propertyName] = context.designContext.hostContainer.actionsRegistry.createInstance(value, context.designContext.targetVersion);
@@ -577,9 +645,22 @@ export class ActionPropertyEditor extends SingleInputPropertyEditor {
 
         for (var i = 0; i < context.designContext.hostContainer.actionsRegistry.getItemCount(); i++) {
             let actionType = context.designContext.hostContainer.actionsRegistry.getItemAt(i).typeName;
-            let doAddActionType = this.forbiddenActionTypes ? this.forbiddenActionTypes.indexOf(actionType) < 0 : true;
+            let excludeAction = true;
 
-            if (doAddActionType) {
+            if (this.forbiddenActionTypes) {
+                // If the list contains "*", all action types are disallowed...
+                excludeAction = this.forbiddenActionTypes.indexOf("*") >= 0 || this.forbiddenActionTypes.indexOf(actionType) >= 0;
+
+                if (excludeAction) {
+                    // ...except if the list explicitly contains the type name prefixed with a "-" character
+                    // Example:
+                    //    [ "*", "-Action.Execute", "-Action.Submit" ]
+                    //    Meaning: all actions are disallowed except Action.Execute and Action.Submit
+                    excludeAction = this.forbiddenActionTypes.indexOf("-" + actionType) < 0;
+                }
+            }
+
+            if (!excludeAction) {
                 let choice = new Adaptive.Choice(actionType, actionType);
 
                 input.choices.push(choice);
@@ -603,14 +684,24 @@ export class CompoundPropertyEditor extends PropertySheetEntry {
     render(context: PropertySheetContext): Adaptive.CardElement {
         let container = new Adaptive.Container();
 
-        for (let entry of this.entries) {
-            if (Adaptive.isVersionLessOrEqual(entry.targetVersion, context.designContext.targetVersion)) {
-                container.addItem(
-                    entry.render(
-                        new PropertySheetContext(
-                            context.designContext,
-                            context.peer,
-                            context.target[this.propertyName])));
+        let target = context.target[this.propertyName];
+
+        if (target === undefined && this.initializeProperty) {
+            target = this.initializeProperty();
+
+            context.target[this.propertyName] = target;
+        }
+
+        if (target) {
+            for (let entry of this.entries) {
+                if (Adaptive.isVersionLessOrEqual(entry.targetVersion, context.designContext.targetVersion)) {
+                    container.addItem(
+                        entry.render(
+                            new PropertySheetContext(
+                                context.designContext,
+                                context.peer,
+                                target)));
+                }
             }
         }
 
@@ -620,7 +711,8 @@ export class CompoundPropertyEditor extends PropertySheetEntry {
     constructor(
         readonly targetVersion: Adaptive.TargetVersion,
         readonly propertyName: string,
-        readonly entries: PropertySheetEntry[] = []) {
+        readonly entries: PropertySheetEntry[] = [],
+        readonly initializeProperty?: () => object) {
         super(targetVersion);
     }
 }
@@ -1335,7 +1427,7 @@ export class HttpActionPeer extends TypedActionPeer<Adaptive.HttpAction> {
     }
 }
 
-export class SubmitActionPeer extends TypedActionPeer<Adaptive.SubmitAction> {
+export abstract class BaseSubmitActionPeer<TAction extends Adaptive.SubmitAction> extends TypedActionPeer<TAction> {
     static readonly dataProperty = new ObjectPropertyEditor(Adaptive.Versions.v1_0, "data", "Data");
     static readonly associatedInputsProperty = new ChoicePropertyEditor(
         Adaptive.Versions.v1_3,
@@ -1351,8 +1443,20 @@ export class SubmitActionPeer extends TypedActionPeer<Adaptive.SubmitAction> {
 
         propertySheet.add(
             defaultCategory,
-            SubmitActionPeer.dataProperty,
-            SubmitActionPeer.associatedInputsProperty);
+            BaseSubmitActionPeer.dataProperty,
+            BaseSubmitActionPeer.associatedInputsProperty);
+    }
+}
+
+export class SubmitActionPeer extends BaseSubmitActionPeer<Adaptive.SubmitAction> { }
+
+export class ExecuteActionPeer extends BaseSubmitActionPeer<Adaptive.ExecuteAction> {
+    static readonly verbProperty = new StringPropertyEditor(Adaptive.Versions.v1_4, "verb", "Verb");
+
+    populatePropertySheet(propertySheet: PropertySheet, defaultCategory: string = PropertySheetCategory.DefaultCategory) {
+        super.populatePropertySheet(propertySheet, defaultCategory);
+
+        propertySheet.add(defaultCategory, ExecuteActionPeer.verbProperty);
     }
 }
 
@@ -1620,6 +1724,14 @@ export class AdaptiveCardPeer extends TypedCardElementPeer<Adaptive.AdaptiveCard
     static readonly langProperty = new StringPropertyEditor(Adaptive.Versions.v1_1, "lang", "Language");
     static readonly fallbackTextProperty = new StringPropertyEditor(Adaptive.Versions.v1_0, "fallbackText", "Fallback text", false, true);
     static readonly speakProperty = new StringPropertyEditor(Adaptive.Versions.v1_0, "speak", "Speak");
+    static readonly refreshProperty = new CompoundPropertyEditor(
+        Adaptive.Versions.v1_4,
+        "refresh",
+        [
+            new StringArrayPropertyEditor(Adaptive.Versions.v1_4, "userIds", "User IDs", false, true),
+            new ActionPropertyEditor(Adaptive.Versions.v1_4, "action", "Action", [ "*", "-Action.Execute" ], true)
+        ],
+        () => { return new Adaptive.RefreshDefinition() });
 
     protected addAction(action: Adaptive.Action) {
         this.cardElement.addAction(action);
@@ -1703,6 +1815,18 @@ export class AdaptiveCardPeer extends TypedCardElementPeer<Adaptive.AdaptiveCard
             AdaptiveCardPeer.speakProperty);
 
         propertySheet.add(
+            PropertySheetCategory.Refresh,
+            AdaptiveCardPeer.refreshProperty);
+
+        if (this.cardElement.refresh && this.cardElement.refresh.action) {
+            propertySheet.addActionProperties(
+                Adaptive.Versions.v1_4,
+                this,
+                this.cardElement.refresh.action,
+                PropertySheetCategory.Refresh);
+        }
+
+        propertySheet.add(
             PropertySheetCategory.LayoutCategory,
             ContainerPeer.minHeightProperty,
             ContainerPeer.verticalContentAlignmentProperty);
@@ -1716,19 +1840,11 @@ export class AdaptiveCardPeer extends TypedCardElementPeer<Adaptive.AdaptiveCard
             ContainerPeer.selectActionProperty);
 
         if (this.cardElement.selectAction) {
-            let selectActionPeer = CardDesignerSurface.actionPeerRegistry.createPeerInstance(this.designerSurface, null, this.cardElement.selectAction);
-            selectActionPeer.onChanged = (sender: DesignerPeer, updatePropertySheet: boolean) => { this.changed(updatePropertySheet); };
-
-            let subPropertySheet = new PropertySheet(false);
-            selectActionPeer.populatePropertySheet(subPropertySheet, PropertySheetCategory.SelectionAction);
-
-            subPropertySheet.remove(
-                ActionPeer.iconUrlProperty,
-                ActionPeer.styleProperty);
-
-            propertySheet.add(
-                PropertySheetCategory.SelectionAction,
-                new SubPropertySheetEntry(Adaptive.Versions.v1_0, this.cardElement.selectAction, subPropertySheet));
+            propertySheet.addActionProperties(
+                Adaptive.Versions.v1_0,
+                this,
+                this.cardElement.selectAction,
+                PropertySheetCategory.SelectionAction);
         }
     }
 }
@@ -1817,19 +1933,11 @@ export class ColumnPeer extends TypedCardElementPeer<Adaptive.Column> {
             ContainerPeer.selectActionProperty);
 
         if (this.cardElement.selectAction) {
-            let selectActionPeer = CardDesignerSurface.actionPeerRegistry.createPeerInstance(this.designerSurface, null, this.cardElement.selectAction);
-            selectActionPeer.onChanged = (sender: DesignerPeer, updatePropertySheet: boolean) => { this.changed(updatePropertySheet); };
-
-            let subPropertySheet = new PropertySheet(false);
-            selectActionPeer.populatePropertySheet(subPropertySheet, PropertySheetCategory.SelectionAction);
-
-            subPropertySheet.remove(
-                ActionPeer.iconUrlProperty,
-                ActionPeer.styleProperty);
-
-            propertySheet.add(
-                PropertySheetCategory.SelectionAction,
-                new SubPropertySheetEntry(Adaptive.Versions.v1_0, this.cardElement.selectAction, subPropertySheet));
+            propertySheet.addActionProperties(
+                Adaptive.Versions.v1_0,
+                this,
+                this.cardElement.selectAction,
+                PropertySheetCategory.SelectionAction);
         }
     }
 }
@@ -1887,19 +1995,11 @@ export class ColumnSetPeer extends TypedCardElementPeer<Adaptive.ColumnSet> {
             ContainerPeer.selectActionProperty);
 
         if (this.cardElement.selectAction) {
-            let selectActionPeer = CardDesignerSurface.actionPeerRegistry.createPeerInstance(this.designerSurface, null, this.cardElement.selectAction);
-            selectActionPeer.onChanged = (sender: DesignerPeer, updatePropertySheet: boolean) => { this.changed(updatePropertySheet); };
-
-            let subPropertySheet = new PropertySheet(false);
-            selectActionPeer.populatePropertySheet(subPropertySheet, PropertySheetCategory.SelectionAction);
-
-            subPropertySheet.remove(
-                ActionPeer.iconUrlProperty,
-                ActionPeer.styleProperty);
-
-            propertySheet.add(
-                PropertySheetCategory.SelectionAction,
-                new SubPropertySheetEntry(Adaptive.Versions.v1_0, this.cardElement.selectAction, subPropertySheet));
+            propertySheet.addActionProperties(
+                Adaptive.Versions.v1_0,
+                this,
+                this.cardElement.selectAction,
+                PropertySheetCategory.SelectionAction);
         }
     }
 
@@ -1951,19 +2051,12 @@ export class ContainerPeer extends TypedCardElementPeer<Adaptive.Container> {
             ContainerPeer.selectActionProperty);
 
         if (this.cardElement.selectAction) {
-            let selectActionPeer = CardDesignerSurface.actionPeerRegistry.createPeerInstance(this.designerSurface, null, this.cardElement.selectAction);
-            selectActionPeer.onChanged = (sender: DesignerPeer, updatePropertySheet: boolean) => { this.changed(updatePropertySheet); };
+            propertySheet.addActionProperties(
+                Adaptive.Versions.v1_0,
+                this,
+                this.cardElement.selectAction,
+                PropertySheetCategory.SelectionAction);
 
-            let subPropertySheet = new PropertySheet(false);
-            selectActionPeer.populatePropertySheet(subPropertySheet, PropertySheetCategory.SelectionAction);
-
-            subPropertySheet.remove(
-                ActionPeer.iconUrlProperty,
-                ActionPeer.styleProperty);
-
-            propertySheet.add(
-                PropertySheetCategory.SelectionAction,
-                new SubPropertySheetEntry(Adaptive.Versions.v1_0, this.cardElement.selectAction, subPropertySheet));
         }
     }
 }
@@ -2139,19 +2232,12 @@ export class ImagePeer extends TypedCardElementPeer<Adaptive.Image> {
                 ContainerPeer.selectActionProperty);
 
             if (this.cardElement.selectAction) {
-                let selectActionPeer = CardDesignerSurface.actionPeerRegistry.createPeerInstance(this.designerSurface, null, this.cardElement.selectAction);
-                selectActionPeer.onChanged = (sender: DesignerPeer, updatePropertySheet: boolean) => { this.changed(updatePropertySheet); };
-
-                let subPropertySheet = new PropertySheet(false);
-                selectActionPeer.populatePropertySheet(subPropertySheet, PropertySheetCategory.SelectionAction);
-
-                subPropertySheet.remove(
-                    ActionPeer.iconUrlProperty,
-                    ActionPeer.styleProperty);
-
-                propertySheet.add(
-                    PropertySheetCategory.SelectionAction,
-                    new SubPropertySheetEntry(Adaptive.Versions.v1_0, this.cardElement.selectAction, subPropertySheet));            }
+                propertySheet.addActionProperties(
+                    Adaptive.Versions.v1_0,
+                    this,
+                    this.cardElement.selectAction,
+                    PropertySheetCategory.SelectionAction);
+            }
         }
     }
 }
@@ -2307,17 +2393,11 @@ export class TextInputPeer extends InputPeer<Adaptive.TextInput> {
             TextInputPeer.inlineActionProperty);
 
         if (this.cardElement.inlineAction) {
-            let inlineActionPeer = CardDesignerSurface.actionPeerRegistry.createPeerInstance(this.designerSurface, null, this.cardElement.inlineAction);
-            inlineActionPeer.onChanged = (sender: DesignerPeer, updatePropertySheet: boolean) => { this.changed(updatePropertySheet); };
-
-            let subPropertySheet = new PropertySheet(false);
-            inlineActionPeer.populatePropertySheet(subPropertySheet, PropertySheetCategory.InlineAction);
-
-            subPropertySheet.remove(ActionPeer.styleProperty);
-
-            propertySheet.add(
-                PropertySheetCategory.InlineAction,
-                new SubPropertySheetEntry(Adaptive.Versions.v1_2, this.cardElement.inlineAction, subPropertySheet));
+            propertySheet.addActionProperties(
+                Adaptive.Versions.v1_2,
+                this,
+                this.cardElement.inlineAction,
+                PropertySheetCategory.SelectionAction);
         }
 
         propertySheet.add(

--- a/source/nodejs/adaptivecards-designer/src/shared.ts
+++ b/source/nodejs/adaptivecards-designer/src/shared.ts
@@ -11,7 +11,8 @@ export class GlobalSettings {
         Adaptive.Versions.v1_0,
         Adaptive.Versions.v1_1,
         Adaptive.Versions.v1_2,
-        Adaptive.Versions.v1_3
+        Adaptive.Versions.v1_3,
+        Adaptive.Versions.v1_4
     ];
 }
 

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -624,7 +624,7 @@ export class ActionProperty extends PropertyDefinition {
     }
 
     toJSON(sender: SerializableObject, target: PropertyBag, value: Action | undefined, context: SerializationContext) {
-        context.serializeValue(target, this.name, value ? value.toJSON(context) : undefined);
+        context.serializeValue(target, this.name, value ? value.toJSON(context) : undefined, undefined, true);
     }
 
     constructor(
@@ -4218,6 +4218,17 @@ export class ToggleVisibilityAction extends Action {
         }
     }
 
+    internalValidateProperties(context: ValidationResults) {
+        super.internalValidateProperties(context);
+
+        if (!this.targetElements) {
+            context.addFailure(
+                this,
+                Enums.ValidationEvent.PropertyCantBeNull,
+                Strings.errors.propertyMustBeSet("targetElements"));
+        }
+    }
+
     getJsonTypeName(): string {
         return ToggleVisibilityAction.JsonTypeName;
     }
@@ -6460,14 +6471,14 @@ export class RefreshActionProperty extends PropertyDefinition {
 
         context.logParseEvent(
             sender,
-            Enums.ValidationEvent.ActionTypeNotAllowed,
+            Enums.ValidationEvent.PropertyCantBeNull,
             Strings.errors.propertyMustBeSet("action"));
 
         return undefined;
     }
 
     toJSON(sender: SerializableObject, target: PropertyBag, value: ExecuteAction | undefined, context: SerializationContext) {
-        context.serializeValue(target, this.name, value ? value.toJSON(context) : undefined);
+        context.serializeValue(target, this.name, value ? value.toJSON(context) : undefined, undefined, true);
     }
 
     constructor(readonly targetVersion: Version, readonly name: string) {
@@ -6479,6 +6490,7 @@ export class RefreshDefinition extends SerializableObject {
     //#region Schema
 
     static readonly actionProperty = new RefreshActionProperty(Versions.v1_4, "action");
+    static readonly userIdsProperty = new StringArrayProperty(Versions.v1_4, "userIds");
 
     @property(RefreshDefinition.actionProperty)
     get action(): ExecuteAction {
@@ -6492,6 +6504,9 @@ export class RefreshDefinition extends SerializableObject {
             value.setParent(this.parent);
         }
     }
+
+    @property(RefreshDefinition.userIdsProperty)
+    userIds?: string[];
 
     protected getSchemaKey(): string {
         return "RefreshDefinition";
@@ -6511,7 +6526,7 @@ export class AuthCardButton extends SerializableObject {
     static readonly valueProperty = new StringProperty(Versions.v1_4, "value");
 
     protected getSchemaKey(): string {
-        return "SigninButton";
+        return "AuthCardButton";
     }
 
     //#endregion


### PR DESCRIPTION
## Related Issue
- Finalizes implementation of https://github.com/microsoft/AdaptiveCards/issues/3076

## Description
- Adds missing `AdaptiveCard.refresh.userIds` property
- Adds support for `Action.Execute` and `AdaptiveCard.refresh` in the designer
  - Note that the `AdaptiveCard.authentication` property isn't surfaced in the designer, at least not at this time. This is typicall a property that a service will dynamically add to a card, not something that is "authored"
- Fixes a couple designer bugs related to serialization

## Sample Card
```
{
    "type": "AdaptiveCard",
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
    "version": "1.4",
    "refresh": {
        "userIds": [
            "john.doe@contoso.com",
            "jane.doe@fabrikam.com"
        ],
        "action": {
            "type": "Action.Execute",
            "id": "abc",
            "verb": "refreshAction",
            "data": {
                "property1": "value1"
            }
        }
    }
}
```

## How Verified
Verified manually in adaptivecards-designer-app

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5565)