### PR TITLE
[shared] Parser support for TextBlock headings changes

### DIFF
--- a/samples/v1.5/Elements/TextBlock.Style.json
+++ b/samples/v1.5/Elements/TextBlock.Style.json
@@ -6,13 +6,13 @@
 		{
 			"type": "TextBlock",
 			"text": "Style: Heading",
-            "style": "heading",
+			"style": "heading",
 			"weight": "bolder"
 		},
 		{
 			"type": "TextBlock",
 			"text": "Style: Paragraph",
-            "style": "paragraph",
+			"style": "paragraph",
 			"weight": "default"
 		},
 		{

--- a/samples/v1.5/Elements/TextBlock.Style.json
+++ b/samples/v1.5/Elements/TextBlock.Style.json
@@ -1,0 +1,24 @@
+{
+	"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+	"type": "AdaptiveCard",
+	"version": "1.5",
+	"body": [
+		{
+			"type": "TextBlock",
+			"text": "Style: Heading",
+            "style": "heading",
+			"weight": "bolder"
+		},
+		{
+			"type": "TextBlock",
+			"text": "Style: Paragraph",
+            "style": "paragraph",
+			"weight": "default"
+		},
+		{
+			"type": "TextBlock",
+			"text": "Style: Default",
+			"weight": "default"
+		}
+	]
+}

--- a/samples/v1.5/Scenarios/InputFormWithLabels.json
+++ b/samples/v1.5/Scenarios/InputFormWithLabels.json
@@ -1,0 +1,82 @@
+{
+	"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+	"type": "AdaptiveCard",
+	"version": "1.0",
+	"body": [
+		{
+			"type": "ColumnSet",
+			"columns": [
+				{
+					"type": "Column",
+					"width": 2,
+					"items": [
+						{
+							"type": "TextBlock",
+							"text": "Tell us about yourself",
+							"weight": "bolder",
+                            "style" : "heading",
+							"size": "medium",
+							"wrap": true
+						},
+						{
+							"type": "TextBlock",
+							"text": "We just need a few more details to get you booked for the trip of a lifetime!",
+							"isSubtle": true,
+							"wrap": true
+						},
+						{
+							"type": "TextBlock",
+							"text": "Don't worry, we'll never share or sell your information.",
+							"isSubtle": true,
+							"wrap": true,
+							"size": "small"
+						},
+						{
+							"type": "Input.Text",
+							"id": "myName",
+							"label": "Your name (Last, First)",
+							"isRequired": true,
+							"regex": "^[A-Z][a-z]+, [A-Z][a-z]+$",
+							"errorMessage": "Please enter your name in the specified format"
+						},
+						{
+							"type": "Input.Text",
+							"id": "myEmail",
+							"label": "Your email",
+							"regex": "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+[.][A-Za-z0-9-]{2,4}$",
+							"isRequired": true,
+							"errorMessage": "Please enter a valid email address",
+							"style": "email"
+						},
+						{
+							"type": "Input.Text",
+							"id": "myTel",
+							"label": "Phone Number (xxx-xxx-xxxx)",
+							"regex": "^[0-9]{3}-[0-9]{3}-[0-9]{4}$",
+							"errorMessage": "Invalid phone number. Use the specified format: 3 numbers, hyphen, 3 numbers, hyphen and 4 numbers",
+							"style": "tel"
+						}
+					]
+				},
+				{
+					"type": "Column",
+					"width": 1,
+					"items": [
+						{
+							"type": "Image",
+							"url": "https://upload.wikimedia.org/wikipedia/commons/b/b2/Diver_Silhouette%2C_Great_Barrier_Reef.jpg",
+							"size": "auto",
+							"altText": "Diver in the Great Barrier Reef"
+						}
+					]
+				}
+			]
+		}
+	],
+	"actions": [
+		{
+			"type": "Action.Submit",
+			"title": "Submit"
+		}
+	]
+}

--- a/samples/v1.5/Scenarios/InputFormWithLabels.json
+++ b/samples/v1.5/Scenarios/InputFormWithLabels.json
@@ -14,7 +14,7 @@
 							"type": "TextBlock",
 							"text": "Tell us about yourself",
 							"weight": "bolder",
-                            "style" : "heading",
+							"style" : "heading",
 							"size": "medium",
 							"wrap": true
 						},

--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/EverythingBagel.cpp
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/EverythingBagel.cpp
@@ -91,6 +91,7 @@ namespace AdaptiveCardsSharedModelUnitTest
         Assert::AreEqual(CardElementTypeToString(CardElementType::TextBlock), textBlock.GetElementTypeString());
         Assert::AreEqual(id, textBlock.GetId());
         Assert::AreEqual("TextBlock_text"s, textBlock.GetText());
+        Assert::IsTrue(TextStyle::Paragraph == textBlock.GetStyle());
         Assert::IsTrue(ForegroundColor::Default == textBlock.GetTextColor());
         Assert::IsTrue(HorizontalAlignment::Left == textBlock.GetHorizontalAlignment());
         Assert::IsTrue(Spacing::Default == textBlock.GetSpacing());
@@ -308,7 +309,7 @@ namespace AdaptiveCardsSharedModelUnitTest
         Assert::AreEqual("Input.Date_placeholder"s, dateInput.GetPlaceholder());
         Assert::IsFalse(dateInput.GetIsRequired());
         Assert::IsTrue(dateInput.GetErrorMessage().empty());
-		Assert::AreEqual("Input.Date_label"s, dateInput.GetLabel());
+        Assert::AreEqual("Input.Date_label"s, dateInput.GetLabel());
     }
 
     void ValidateInputTime(const TimeInput &timeInput)
@@ -374,7 +375,7 @@ namespace AdaptiveCardsSharedModelUnitTest
             Assert::AreEqual(expectedTitle, currChoice->GetTitle());
         }
 
-		Assert::AreEqual("Input.ChoiceSet_label"s, choiceSet.GetLabel());
+        Assert::AreEqual("Input.ChoiceSet_label"s, choiceSet.GetLabel());
     }
 
     void ValidateInputContainer(const Container &container)

--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/ObjectModelTest.cpp
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/ObjectModelTest.cpp
@@ -578,5 +578,52 @@ namespace AdaptiveCardsSharedModelUnitTest
                 Assert::AreEqual("Unable to parse element of type Elephant", e.GetReason().c_str(), L"GetReason incorrect");
             }
         }
+
+        TEST_METHOD(TextBlockStyleParsingTest)
+        {
+            std::string testjson{ R"(
+                {
+                    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                    "type": "AdaptiveCard",
+                    "version": "1.2",
+                    "body": [
+                        {
+                            "type": "TextBlock",
+                            "id": "heading",
+                            "style": "heading",
+                            "text" : "hello"
+                        },
+                        {
+                            "type": "TextBlock",
+                            "id": "heading2",
+                            "style": "Heading",
+                            "text" : "hello"
+                        },
+                        {
+                            "type": "TextBlock",
+                            "id": "invalid-heading",
+                            "style": "Footer",
+                            "text" : "hello"
+                        },
+                        {
+                            "type": "TextBlock",
+                            "id": "default style",
+                            "text" : "hello"
+                        }
+                    ]
+                }
+            )"};
+
+            auto parseResult = AdaptiveCard::DeserializeFromString(testjson, "1.2");
+            auto card = parseResult->GetAdaptiveCard();
+            auto body = card->GetBody();
+            std::vector<TextStyle> expectedStyles = { TextStyle::Heading, TextStyle::Heading, TextStyle::Paragraph, TextStyle::Paragraph };
+
+            auto i = 0;
+            for (const auto& elem : body) {
+                std::shared_ptr<TextBlock> textBlock = std::dynamic_pointer_cast<TextBlock>(elem);
+				Assert::IsTrue(textBlock->GetStyle() == expectedStyles[i++]);
+            }
+        }
     };
 }

--- a/source/shared/cpp/ObjectModel/Enums.cpp
+++ b/source/shared/cpp/ObjectModel/Enums.cpp
@@ -97,7 +97,7 @@ namespace AdaptiveSharedNamespace
             {AdaptiveCardSchemaKey::IsVisible, "isVisible"},
             {AdaptiveCardSchemaKey::Italic, "italic"},
             {AdaptiveCardSchemaKey::Items, "items"},
-			{AdaptiveCardSchemaKey::Label, "label"},
+            {AdaptiveCardSchemaKey::Label, "label"},
             {AdaptiveCardSchemaKey::Language, "lang"},
             {AdaptiveCardSchemaKey::Large, "large"},
             {AdaptiveCardSchemaKey::Left, "left"},
@@ -270,6 +270,10 @@ namespace AdaptiveSharedNamespace
             {ForegroundColor::Good, "Good"},
             {ForegroundColor::Light, "Light"},
             {ForegroundColor::Warning, "Warning"}});
+
+    DEFINE_ADAPTIVECARD_ENUM_DEFAULT(TextStyle , TextStyle::Paragraph, {
+            {TextStyle::Paragraph, "paragraph"},
+            {TextStyle::Heading, "heading"}});
 
     DEFINE_ADAPTIVECARD_ENUM(TextWeight, {
             {

--- a/source/shared/cpp/ObjectModel/Enums.h
+++ b/source/shared/cpp/ObjectModel/Enums.h
@@ -187,7 +187,7 @@ namespace AdaptiveSharedNamespace
 
     enum class CardElementType
     {
-        // When the order of existing enums are changed, coresponding changes are needed in iOS (ACOBaseCardElement.h)
+        // When the order of existing enums are changed, corresponding changes are needed in iOS (ACOBaseCardElement.h)
         ActionSet = 0,
         AdaptiveCard,
         ChoiceInput,
@@ -217,6 +217,13 @@ namespace AdaptiveSharedNamespace
         TextRun = 0
     };
     DECLARE_ADAPTIVECARD_ENUM(InlineElementType);
+
+    enum class TextStyle
+    {
+        Paragraph = 0,
+        Heading
+    };
+    DECLARE_ADAPTIVECARD_ENUM(TextStyle);
 
     enum class TextSize
     {

--- a/source/shared/cpp/ObjectModel/TextBlock.cpp
+++ b/source/shared/cpp/ObjectModel/TextBlock.cpp
@@ -60,6 +60,16 @@ DateTimePreparser TextBlock::GetTextForDateParsing() const
     return m_textElementProperties->GetTextForDateParsing();
 }
 
+TextStyle AdaptiveSharedNamespace::TextBlock::GetStyle() const
+{
+    return m_textStyle;
+}
+
+void AdaptiveSharedNamespace::TextBlock::SetStyle(const TextStyle value)
+{
+    m_textStyle = value;
+}
+
 TextSize TextBlock::GetTextSize() const
 {
     return m_textElementProperties->GetTextSize();
@@ -158,6 +168,7 @@ std::shared_ptr<BaseCardElement> TextBlockParser::Deserialize(ParseContext& cont
     textBlock->m_textElementProperties->Deserialize(context, json);
 
     textBlock->SetWrap(ParseUtil::GetBool(json, AdaptiveCardSchemaKey::Wrap, false));
+    textBlock->SetStyle(ParseUtil::GetEnumValue<TextStyle>(json, AdaptiveCardSchemaKey::Style, TextStyle::Paragraph, TextStyleFromString));
     textBlock->SetMaxLines(ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::MaxLines, 0));
     textBlock->SetHorizontalAlignment(ParseUtil::GetEnumValue<HorizontalAlignment>(
         json, AdaptiveCardSchemaKey::HorizontalAlignment, HorizontalAlignment::Left, HorizontalAlignmentFromString));
@@ -175,6 +186,7 @@ void TextBlock::PopulateKnownPropertiesSet()
     m_textElementProperties->PopulateKnownPropertiesSet(m_knownProperties);
 
     m_knownProperties.insert({AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Wrap),
+                              AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Style),
                               AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::MaxLines),
                               AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::HorizontalAlignment)});
 }

--- a/source/shared/cpp/ObjectModel/TextBlock.h
+++ b/source/shared/cpp/ObjectModel/TextBlock.h
@@ -29,6 +29,9 @@ namespace AdaptiveSharedNamespace
         void SetText(const std::string& value);
         DateTimePreparser GetTextForDateParsing() const;
 
+        TextStyle GetStyle() const;
+        void SetStyle(const TextStyle value);
+
         TextSize GetTextSize() const;
         void SetTextSize(const TextSize value);
 
@@ -60,6 +63,7 @@ namespace AdaptiveSharedNamespace
         bool m_wrap;
         unsigned int m_maxLines;
         HorizontalAlignment m_hAlignment;
+        TextStyle m_textStyle;
         std::shared_ptr<TextElementProperties> m_textElementProperties;
         void PopulateKnownPropertiesSet();
     };


### PR DESCRIPTION
## Related Issue
Fixed #5475

## Description
Added Support for TextBlock heading to the shared model.

## Sample Card
![Screen Shot 2021-03-24 at 12 12 58 PM](https://user-images.githubusercontent.com/4112696/112370197-52fb8680-8c9a-11eb-904a-72b9b71ca449.png)

## How Verified
How you verified the fix, including one or all of the following: 
1. Added and ran new unit tests.
2. Ran existing unit tests

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5577)