### PR TITLE
[JS] Handle explicit rtl: false

### DIFF
--- a/samples/1.5/Tests/AdaptiveCard.Rtl.False.json
+++ b/samples/1.5/Tests/AdaptiveCard.Rtl.False.json
@@ -1,0 +1,204 @@
+{
+    "type": "AdaptiveCard",
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.3",
+    "body": [
+        {
+            "type": "TextBlock",
+            "text": "Card (rtl: unset)",
+            "wrap": true,
+            "weight": "Bolder"
+        },
+        {
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Column 1",
+                            "wrap": true
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Column 2",
+                            "wrap": true
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Column 3",
+                            "wrap": true
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "Input.Text",
+            "label": "Input w/ Inline Action",
+            "inlineAction": {
+                "type": "Action.Submit"
+            }
+        },
+        {
+            "type": "TextBlock",
+            "text": "Lorem ipsum dolor sit amet.",
+            "wrap": true
+        },
+        {
+            "type": "TextBlock",
+            "text": "لكن لا بد أن أوضح لك أن كل هذه الأفكار.",
+            "wrap": true
+        },
+        {
+            "type": "Container",
+            "rtl": true,
+            "items": [
+                {
+                    "type": "TextBlock",
+                    "text": "Container (rtl: true)",
+                    "wrap": true,
+                    "weight": "Bolder"
+                },
+                {
+                    "type": "ColumnSet",
+                    "columns": [
+                        {
+                            "type": "Column",
+                            "width": "stretch",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Column 1",
+                                    "wrap": true
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Column",
+                            "width": "stretch",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Column 2",
+                                    "wrap": true
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Column",
+                            "width": "stretch",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Column 3",
+                                    "wrap": true
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "Input.Text",
+                    "label": "Input w/ Inline Action",
+                    "inlineAction": {
+                        "type": "Action.Submit"
+                    }
+                },
+                {
+                    "type": "TextBlock",
+                    "text": "Lorem ipsum dolor sit amet.",
+                    "wrap": true
+                },
+                {
+                    "type": "TextBlock",
+                    "text": "لكن لا بد أن أوضح لك أن كل هذه الأفكار.",
+                    "wrap": true
+                }
+            ],
+            "style": "emphasis"
+        },
+        {
+            "type": "Container",
+            "rtl": false,
+            "items": [
+                {
+                    "type": "TextBlock",
+                    "text": "Container (rtl: false)",
+                    "wrap": true,
+                    "weight": "Bolder"
+                },
+                {
+                    "type": "ColumnSet",
+                    "columns": [
+                        {
+                            "type": "Column",
+                            "width": "stretch",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Column 1",
+                                    "wrap": true
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Column",
+                            "width": "stretch",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Column 2",
+                                    "wrap": true
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Column",
+                            "width": "stretch",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Column 3",
+                                    "wrap": true
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "Input.Text",
+                    "label": "Input w/ Inline Action",
+                    "inlineAction": {
+                        "type": "Action.Submit"
+                    }
+                },
+                {
+                    "type": "TextBlock",
+                    "text": "Lorem ipsum dolor sit amet.",
+                    "wrap": true
+                },
+                {
+                    "type": "TextBlock",
+                    "text": "لكن لا بد أن أوضح لك أن كل هذه الأفكار.",
+                    "wrap": true
+                }
+            ],
+            "style": "emphasis"
+        }
+    ]
+}

--- a/samples/1.5/Tests/AdaptiveCard.Rtl.True.json
+++ b/samples/1.5/Tests/AdaptiveCard.Rtl.True.json
@@ -1,0 +1,205 @@
+{
+    "type": "AdaptiveCard",
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.3",
+	"rtl":true,
+    "body": [
+        {
+            "type": "TextBlock",
+            "text": "Card (rtl: true)",
+            "wrap": true,
+            "weight": "Bolder"
+        },
+        {
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Column 1",
+                            "wrap": true
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Column 2",
+                            "wrap": true
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Column 3",
+                            "wrap": true
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "Input.Text",
+            "label": "Input w/ Inline Action",
+            "inlineAction": {
+                "type": "Action.Submit"
+            }
+        },
+        {
+            "type": "TextBlock",
+            "text": "Lorem ipsum dolor sit amet.",
+            "wrap": true
+        },
+        {
+            "type": "TextBlock",
+            "text": "لكن لا بد أن أوضح لك أن كل هذه الأفكار.",
+            "wrap": true
+        },
+        {
+            "type": "Container",
+            "rtl": true,
+            "items": [
+                {
+                    "type": "TextBlock",
+                    "text": "Container (rtl: true)",
+                    "wrap": true,
+                    "weight": "Bolder"
+                },
+                {
+                    "type": "ColumnSet",
+                    "columns": [
+                        {
+                            "type": "Column",
+                            "width": "stretch",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Column 1",
+                                    "wrap": true
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Column",
+                            "width": "stretch",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Column 2",
+                                    "wrap": true
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Column",
+                            "width": "stretch",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Column 3",
+                                    "wrap": true
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "Input.Text",
+                    "label": "Input w/ Inline Action",
+                    "inlineAction": {
+                        "type": "Action.Submit"
+                    }
+                },
+                {
+                    "type": "TextBlock",
+                    "text": "Lorem ipsum dolor sit amet.",
+                    "wrap": true
+                },
+                {
+                    "type": "TextBlock",
+                    "text": "لكن لا بد أن أوضح لك أن كل هذه الأفكار.",
+                    "wrap": true
+                }
+            ],
+            "style": "emphasis"
+        },
+        {
+            "type": "Container",
+            "rtl": false,
+            "items": [
+                {
+                    "type": "TextBlock",
+                    "text": "Container (rtl: false)",
+                    "wrap": true,
+                    "weight": "Bolder"
+                },
+                {
+                    "type": "ColumnSet",
+                    "columns": [
+                        {
+                            "type": "Column",
+                            "width": "stretch",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Column 1",
+                                    "wrap": true
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Column",
+                            "width": "stretch",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Column 2",
+                                    "wrap": true
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Column",
+                            "width": "stretch",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Column 3",
+                                    "wrap": true
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "Input.Text",
+                    "label": "Input w/ Inline Action",
+                    "inlineAction": {
+                        "type": "Action.Submit"
+                    }
+                },
+                {
+                    "type": "TextBlock",
+                    "text": "Lorem ipsum dolor sit amet.",
+                    "wrap": true
+                },
+                {
+                    "type": "TextBlock",
+                    "text": "لكن لا بد أن أوضح لك أن كل هذه الأفكار.",
+                    "wrap": true
+                }
+            ],
+            "style": "emphasis"
+        }
+    ]
+}

--- a/samples/1.5/Tests/AdaptiveCard.Rtl.unset.json
+++ b/samples/1.5/Tests/AdaptiveCard.Rtl.unset.json
@@ -1,0 +1,205 @@
+{
+    "type": "AdaptiveCard",
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.3",
+	"rtl":false,
+    "body": [
+        {
+            "type": "TextBlock",
+            "text": "Card (rtl: false)",
+            "wrap": true,
+            "weight": "Bolder"
+        },
+        {
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Column 1",
+                            "wrap": true
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Column 2",
+                            "wrap": true
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Column 3",
+                            "wrap": true
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "Input.Text",
+            "label": "Input w/ Inline Action",
+            "inlineAction": {
+                "type": "Action.Submit"
+            }
+        },
+        {
+            "type": "TextBlock",
+            "text": "Lorem ipsum dolor sit amet.",
+            "wrap": true
+        },
+        {
+            "type": "TextBlock",
+            "text": "لكن لا بد أن أوضح لك أن كل هذه الأفكار.",
+            "wrap": true
+        },
+        {
+            "type": "Container",
+            "rtl": true,
+            "items": [
+                {
+                    "type": "TextBlock",
+                    "text": "Container (rtl: true)",
+                    "wrap": true,
+                    "weight": "Bolder"
+                },
+                {
+                    "type": "ColumnSet",
+                    "columns": [
+                        {
+                            "type": "Column",
+                            "width": "stretch",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Column 1",
+                                    "wrap": true
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Column",
+                            "width": "stretch",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Column 2",
+                                    "wrap": true
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Column",
+                            "width": "stretch",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Column 3",
+                                    "wrap": true
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "Input.Text",
+                    "label": "Input w/ Inline Action",
+                    "inlineAction": {
+                        "type": "Action.Submit"
+                    }
+                },
+                {
+                    "type": "TextBlock",
+                    "text": "Lorem ipsum dolor sit amet.",
+                    "wrap": true
+                },
+                {
+                    "type": "TextBlock",
+                    "text": "لكن لا بد أن أوضح لك أن كل هذه الأفكار.",
+                    "wrap": true
+                }
+            ],
+            "style": "emphasis"
+        },
+        {
+            "type": "Container",
+            "rtl": false,
+            "items": [
+                {
+                    "type": "TextBlock",
+                    "text": "Container (rtl: false)",
+                    "wrap": true,
+                    "weight": "Bolder"
+                },
+                {
+                    "type": "ColumnSet",
+                    "columns": [
+                        {
+                            "type": "Column",
+                            "width": "stretch",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Column 1",
+                                    "wrap": true
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Column",
+                            "width": "stretch",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Column 2",
+                                    "wrap": true
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Column",
+                            "width": "stretch",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Column 3",
+                                    "wrap": true
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "Input.Text",
+                    "label": "Input w/ Inline Action",
+                    "inlineAction": {
+                        "type": "Action.Submit"
+                    }
+                },
+                {
+                    "type": "TextBlock",
+                    "text": "Lorem ipsum dolor sit amet.",
+                    "wrap": true
+                },
+                {
+                    "type": "TextBlock",
+                    "text": "لكن لا بد أن أوضح لك أن كل هذه الأفكار.",
+                    "wrap": true
+                }
+            ],
+            "style": "emphasis"
+        }
+    ]
+}

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -5462,12 +5462,8 @@ export class Container extends StylableCardElementContainer {
 
         let element = document.createElement("div");
 
-        if (this.rtl === undefined) {
-            element.removeAttribute("dir");
-        } else if (this.rtl) {
-            element.dir = "rtl";
-        } else {
-            element.dir = "ltr";
+        if (this.rtl !== undefined) {
+            element.dir = this.rtl ? "rtl" : "ltr";
         }
 
         element.classList.add(hostConfig.makeCssClassName("ac-container"));

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -1082,18 +1082,15 @@ export class TextBlock extends BaseTextBlock {
     applyStylesTo(targetElement: HTMLElement) {
         super.applyStylesTo(targetElement);
 
-        let parentContainer = this.getParentContainer();
-        let isRtl = parentContainer ? parentContainer.isRtl() : false;
-
         switch (this.horizontalAlignment) {
             case Enums.HorizontalAlignment.Center:
                 targetElement.style.textAlign = "center";
                 break;
             case Enums.HorizontalAlignment.Right:
-                targetElement.style.textAlign = isRtl ? "left" : "right";
+                targetElement.style.textAlign = "end";
                 break;
             default:
-                targetElement.style.textAlign = isRtl ? "right" : "left";
+                targetElement.style.textAlign = "start";
                 break;
         }
 
@@ -1336,18 +1333,15 @@ export class RichTextBlock extends CardElement {
 
             element.className = this.hostConfig.makeCssClassName("ac-richTextBlock");
 
-            let parentContainer = this.getParentContainer();
-            let isRtl = parentContainer ? parentContainer.isRtl() : false;
-
             switch (this.horizontalAlignment) {
                 case Enums.HorizontalAlignment.Center:
                     element.style.textAlign = "center";
                     break;
                 case Enums.HorizontalAlignment.Right:
-                    element.style.textAlign = isRtl ? "left" : "right";
+                    element.style.textAlign = "end";
                     break;
                 default:
-                    element.style.textAlign = isRtl ? "right" : "left";
+                    element.style.textAlign = "start";
                     break;
             }
 
@@ -5468,8 +5462,12 @@ export class Container extends StylableCardElementContainer {
 
         let element = document.createElement("div");
 
-        if (this.rtl !== undefined && this.rtl) {
+        if (this.rtl === undefined) {
+            element.removeAttribute("dir");
+        } else if (this.rtl) {
             element.dir = "rtl";
+        } else {
+            element.dir = "ltr";
         }
 
         element.classList.add(hostConfig.makeCssClassName("ac-container"));


### PR DESCRIPTION
## Related Issue
Untracked. JS is only respecting explicit rtl: false if a parent Element has rtl: true.

## Description
This explicitly sets or unsets the dir property. Additionally, allows the browser to set text alignment based on the inherited layout direction, rather than using the card tree to determine alignment.

## Sample Card
`v1.5\Tests\AdaptiveCard.Rtl.unset`
`v1.5\Tests\AdaptiveCard.Rtl.True`
`v1.5\Tests\AdaptiveCard.Rtl.False`

## How Verified

`v1.5\Tests\AdaptiveCard.Rtl.unset`, `document.dir=ltr`:
![image](https://user-images.githubusercontent.com/4442788/112873017-11e6e600-908f-11eb-9b75-3c90a16ff8f7.png)

`v1.5\Tests\AdaptiveCard.Rtl.unset`, `document.dir=rtl`:
![image](https://user-images.githubusercontent.com/4442788/112873050-1ca17b00-908f-11eb-9e86-7fabcc161e7d.png)

`v1.5\Tests\AdaptiveCard.Rtl.True`, `document.dir=ltr`:
![image](https://user-images.githubusercontent.com/4442788/112873092-2cb95a80-908f-11eb-9d64-55d192549146.png)

`v1.5\Tests\AdaptiveCard.Rtl.True`, `document.dir=rtl`:
![image](https://user-images.githubusercontent.com/4442788/112873125-3642c280-908f-11eb-98ef-cd733adb9613.png)

`v1.5\Tests\AdaptiveCard.Rtl.False`, `document.dir=ltr`:
![image](https://user-images.githubusercontent.com/4442788/112873210-583c4500-908f-11eb-9c41-aca44c49c32d.png)

`v1.5\Tests\AdaptiveCard.Rtl.False`, `document.dir=rtl`:
![image](https://user-images.githubusercontent.com/4442788/112873242-5ecabc80-908f-11eb-92d5-dd0640b8e1fa.png)



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5589)