### PR TITLE
[iOS] added RTL support

### DIFF
--- a/samples/1.5/Tests/AdaptiveCard.Rtl.False.json
+++ b/samples/1.5/Tests/AdaptiveCard.Rtl.False.json
@@ -50,6 +50,7 @@
         {
             "type": "Input.Text",
             "label": "Input w/ Inline Action",
+            "id" :"0",
             "inlineAction": {
                 "type": "Action.Submit"
             }
@@ -115,6 +116,7 @@
                 {
                     "type": "Input.Text",
                     "label": "Input w/ Inline Action",
+                    "id" :"1",
                     "inlineAction": {
                         "type": "Action.Submit"
                     }
@@ -183,6 +185,7 @@
                 {
                     "type": "Input.Text",
                     "label": "Input w/ Inline Action",
+                    "id" :"2",
                     "inlineAction": {
                         "type": "Action.Submit"
                     }

--- a/samples/1.5/Tests/AdaptiveCard.Rtl.True.json
+++ b/samples/1.5/Tests/AdaptiveCard.Rtl.True.json
@@ -51,6 +51,7 @@
         {
             "type": "Input.Text",
             "label": "Input w/ Inline Action",
+            "id": "0",
             "inlineAction": {
                 "type": "Action.Submit"
             }
@@ -116,6 +117,7 @@
                 {
                     "type": "Input.Text",
                     "label": "Input w/ Inline Action",
+                    "id": "1",
                     "inlineAction": {
                         "type": "Action.Submit"
                     }
@@ -184,6 +186,7 @@
                 {
                     "type": "Input.Text",
                     "label": "Input w/ Inline Action",
+                    "id": "2",
                     "inlineAction": {
                         "type": "Action.Submit"
                     }

--- a/samples/1.5/Tests/AdaptiveCard.Rtl.unset.json
+++ b/samples/1.5/Tests/AdaptiveCard.Rtl.unset.json
@@ -51,6 +51,7 @@
         {
             "type": "Input.Text",
             "label": "Input w/ Inline Action",
+            "id": "0",
             "inlineAction": {
                 "type": "Action.Submit"
             }
@@ -116,6 +117,7 @@
                 {
                     "type": "Input.Text",
                     "label": "Input w/ Inline Action",
+                    "id": "1",
                     "inlineAction": {
                         "type": "Action.Submit"
                     }
@@ -184,6 +186,7 @@
                 {
                     "type": "Input.Text",
                     "label": "Input w/ Inline Action",
+                    "id": "2",
                     "inlineAction": {
                         "type": "Action.Submit"
                     }

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/CustomTextBlockRenderer.mm
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/CustomTextBlockRenderer.mm
@@ -71,7 +71,7 @@
     // Set paragraph style such as line break mode and alignment
     NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
     paragraphStyle.lineBreakMode = textConfigForBlock.wrap ? NSLineBreakByWordWrapping : NSLineBreakByTruncatingTail;
-    paragraphStyle.alignment = [ACOHostConfig getTextBlockAlignment:textBlockElement->GetHorizontalAlignment()];
+    paragraphStyle.alignment = [ACOHostConfig getTextBlockAlignment:textBlockElement->GetHorizontalAlignment() context:rootView.context];
 
     // Obtain text color to apply to the attributed string
     ACRContainerStyle style = viewGroup.style;

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/resources/filebrowserHostConfig.json
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/resources/filebrowserHostConfig.json
@@ -208,7 +208,7 @@
 		"lineColor": "#FF000000"
 	},
 	"actions": {
-		"maxActions": 6,
+		"maxActions": 7,
 		"spacing": "Default",
 		"buttonSpacing": 10,
 		"showCard": {

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards.xcodeproj/project.pbxproj
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards.xcodeproj/project.pbxproj
@@ -885,9 +885,6 @@
 		F423C0B71EE1FBA900905679 /* AdaptiveCards */ = {
 			isa = PBXGroup;
 			children = (
-				6B25D3E92613D83700A47AFB /* ACORenderContext.h */,
-				6B25D3EA2613D83700A47AFB /* ACORenderContext.mm */,
-				6B25D3E126138E3600A47AFB /* ACOEnums.h */,
 				F423C0B81EE1FBAA00905679 /* ACFramework.h */,
 				F4CAE77F1F75AB9000545555 /* ACOAdaptiveCard.h */,
 				F4CAE7801F75AB9000545555 /* ACOAdaptiveCard.mm */,
@@ -898,6 +895,7 @@
 				F4F44B8A2048F83F00A2F24C /* ACOBaseCardElement.h */,
 				F4F44B882048F82F00A2F24C /* ACOBaseCardElement.mm */,
 				F42C2F4B20351A8E008787B0 /* ACOBaseCardElementPrivate.h */,
+				6B25D3E126138E3600A47AFB /* ACOEnums.h */,
 				F431103F1F357487001AAE30 /* ACOHostConfig.h */,
 				F43110401F357487001AAE30 /* ACOHostConfig.mm */,
 				F4D4020F1F7DAC2C00D0356B /* ACOHostConfigParseResult.h */,
@@ -907,6 +905,8 @@
 				6B5D240A212C89E70010EB07 /* ACORemoteResourceInformation.h */,
 				6B5D240B212C89E70010EB07 /* ACORemoteResourceInformation.mm */,
 				6B5D2409212C89E60010EB07 /* ACORemoteResourceInformationPrivate.h */,
+				6B25D3E92613D83700A47AFB /* ACORenderContext.h */,
+				6B25D3EA2613D83700A47AFB /* ACORenderContext.mm */,
 				6B9BDF7E20F40D1000F13155 /* ACOResourceResolvers.h */,
 				6B9BDF7D20F40D0F00F13155 /* ACOResourceResolvers.mm */,
 				6BBE841823CD184D00ECA586 /* ACOWarning.h */,

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards.xcodeproj/project.pbxproj
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards.xcodeproj/project.pbxproj
@@ -49,6 +49,9 @@
 		6B2242B022334452000ACDA1 /* Inline.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B2242AB22334451000ACDA1 /* Inline.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6B2242B422334492000ACDA1 /* Inline.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6B2242B322334492000ACDA1 /* Inline.cpp */; };
 		6B250FB2253F5F8F007FFCFB /* ACRTargetBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B250FB1253F5F8E007FFCFB /* ACRTargetBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6B25D3E226138E3700A47AFB /* ACOEnums.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B25D3E126138E3600A47AFB /* ACOEnums.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6B25D3EB2613D83700A47AFB /* ACORenderContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B25D3E92613D83700A47AFB /* ACORenderContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6B25D3EC2613D83700A47AFB /* ACORenderContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6B25D3EA2613D83700A47AFB /* ACORenderContext.mm */; };
 		6B268FE720CF19E200D99C1B /* RemoteResourceInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B268FE620CF19E100D99C1B /* RemoteResourceInformation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6B27CD6324BD343C00C0F90F /* ACRInputTableView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6B27CD6224BD343C00C0F90F /* ACRInputTableView.xib */; };
 		6B27CD6624BD52D600C0F90F /* ACRInputLabelView.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B27CD6424BD52D500C0F90F /* ACRInputLabelView.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -429,6 +432,9 @@
 		6B2242AB22334451000ACDA1 /* Inline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Inline.h; path = ../../../../shared/cpp/ObjectModel/Inline.h; sourceTree = "<group>"; };
 		6B2242B322334492000ACDA1 /* Inline.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Inline.cpp; path = ../../../../shared/cpp/ObjectModel/Inline.cpp; sourceTree = "<group>"; };
 		6B250FB1253F5F8E007FFCFB /* ACRTargetBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ACRTargetBuilder.h; sourceTree = "<group>"; };
+		6B25D3E126138E3600A47AFB /* ACOEnums.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ACOEnums.h; sourceTree = "<group>"; };
+		6B25D3E92613D83700A47AFB /* ACORenderContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ACORenderContext.h; sourceTree = "<group>"; };
+		6B25D3EA2613D83700A47AFB /* ACORenderContext.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ACORenderContext.mm; sourceTree = "<group>"; };
 		6B268FE620CF19E100D99C1B /* RemoteResourceInformation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RemoteResourceInformation.h; path = ../../../../shared/cpp/ObjectModel/RemoteResourceInformation.h; sourceTree = "<group>"; };
 		6B27CD6224BD343C00C0F90F /* ACRInputTableView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ACRInputTableView.xib; sourceTree = "<group>"; };
 		6B27CD6424BD52D500C0F90F /* ACRInputLabelView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ACRInputLabelView.h; sourceTree = "<group>"; };
@@ -879,6 +885,9 @@
 		F423C0B71EE1FBA900905679 /* AdaptiveCards */ = {
 			isa = PBXGroup;
 			children = (
+				6B25D3E92613D83700A47AFB /* ACORenderContext.h */,
+				6B25D3EA2613D83700A47AFB /* ACORenderContext.mm */,
+				6B25D3E126138E3600A47AFB /* ACOEnums.h */,
 				F423C0B81EE1FBAA00905679 /* ACFramework.h */,
 				F4CAE77F1F75AB9000545555 /* ACOAdaptiveCard.h */,
 				F4CAE7801F75AB9000545555 /* ACOAdaptiveCard.mm */,
@@ -1442,6 +1451,8 @@
 				6B94F2DD24C7997D00E2B310 /* ACRTextInputHandler.h in Headers */,
 				6BD025ED254784670009B019 /* ACOInputResults.h in Headers */,
 				6B377284260194000024E527 /* ACRActionExecuteRenderer.h in Headers */,
+				6B25D3E226138E3700A47AFB /* ACOEnums.h in Headers */,
+				6B25D3EB2613D83700A47AFB /* ACORenderContext.h in Headers */,
 				6B250FB2253F5F8F007FFCFB /* ACRTargetBuilder.h in Headers */,
 				6B5E9CBB24B644B100757882 /* ACRToggleInputView.h in Headers */,
 			);
@@ -1674,6 +1685,7 @@
 				F42741131EF873A600399FBB /* ACRImageRenderer.mm in Sources */,
 				6B94F2DE24C7997D00E2B310 /* ACRTextInputHandler.mm in Sources */,
 				F448730B1EE2261F00FCAFAE /* Fact.cpp in Sources */,
+				6B25D3EC2613D83700A47AFB /* ACORenderContext.mm in Sources */,
 				6BCE4B272108FA9300021A62 /* ACRLongPressGestureRecognizerFactory.mm in Sources */,
 				6BD025EE254784670009B019 /* ACOInputResults.mm in Sources */,
 				6BFF99CB25FFF53E0028069F /* TokenExchangeResource.cpp in Sources */,

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACFramework.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACFramework.h
@@ -2,7 +2,7 @@
 //  ACFramework.h
 //  ACFramework
 //
-//  Copyright © 2020 Microsoft. All rights reserved.
+//  Copyright © 2021 Microsoft. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>
@@ -15,12 +15,14 @@ FOUNDATION_EXPORT const unsigned char AdaptiveCarsFrameworkVersionString[];
 #import <AdaptiveCards/ACOAdaptiveCard.h>
 #import <AdaptiveCards/ACOAdaptiveCardParseResult.h>
 #import <AdaptiveCards/ACOBaseCardElement.h>
+#import <AdaptiveCards/ACOEnums.h>
 #import <AdaptiveCards/ACOHostConfig.h>
 #import <AdaptiveCards/ACOHostConfigParseResult.h>
 #import <AdaptiveCards/ACOIResourceResolver.h>
 #import <AdaptiveCards/ACOInputResults.h>
 #import <AdaptiveCards/ACOMediaEvent.h>
 #import <AdaptiveCards/ACORemoteResourceInformation.h>
+#import <AdaptiveCards/ACORenderContext.h>
 #import <AdaptiveCards/ACOResourceResolvers.h>
 #import <AdaptiveCards/ACRActionDelegate.h>
 #import <AdaptiveCards/ACRActionOpenURLRenderer.h>

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOAdaptiveCard.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOAdaptiveCard.mm
@@ -61,7 +61,7 @@ using namespace AdaptiveCards;
     if (payload) {
         try {
             ACOAdaptiveCard *card = [[ACOAdaptiveCard alloc] init];
-            std::shared_ptr<ParseResult> parseResult = AdaptiveCard::DeserializeFromString(std::string([payload UTF8String]), std::string("1.4"));
+            std::shared_ptr<ParseResult> parseResult = AdaptiveCard::DeserializeFromString(std::string([payload UTF8String]), std::string("1.5"));
             NSMutableArray *acrParseWarnings;
             std::vector<std::shared_ptr<AdaptiveCardParseWarning>> parseWarnings = parseResult->GetWarnings();
             for (const auto &warning : parseWarnings) {

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOBaseActionElement.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOBaseActionElement.h
@@ -6,26 +6,12 @@
 //
 
 #import "ACOParseContext.h"
+#import "ACOEnums.h"
 #import <Foundation/Foundation.h>
 
 @class ACOFeatureRegistration;
 
 @interface ACOBaseActionElement : NSObject
-
-typedef NS_ENUM(NSInteger, ACRActionType) {
-    ACRExecute = 1,
-    ACROpenUrl,
-    ACRShowCard,
-    ACRSubmit,
-    ACRToggleVisibility,
-    ACRUnknownAction = 7,
-};
-
-typedef NS_ENUM(NSInteger, ACRIconPlacement) {
-    ACRAboveTitle = 0,
-    ACRLeftOfTitle,
-    ACRNoTitle,
-};
 
 @property ACRActionType type;
 @property NSString *sentiment;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOBaseCardElement.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOBaseCardElement.h
@@ -6,6 +6,7 @@
 //
 
 #import "ACOParseContext.h"
+#import "ACOEnums.h"
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
@@ -14,50 +15,6 @@
 @interface ACOBaseCardElement : NSObject
 
 - (NSData *)additionalProperty;
-
-typedef NS_ENUM(NSInteger, ACRCardElementType) {
-    // The order of enums must match with ones in enums.h
-    ACRActionSet = 0,
-    ACRAdaptiveCard,
-    ACRChoiceInput,
-    ACRChoiceSetInput,
-    ACRColumn,
-    ACRColumnSet,
-    ACRContainer,
-    ACRCustom,
-    ACRDateInput,
-    ACRFact,
-    ACRFactSet,
-    ACRImage,
-    ACRImageSet,
-    ACRMedia,
-    ACRNumberInput,
-    ACRRichTextBlock,
-    ACRTextBlock,
-    ACRTextInput,
-    ACRTimeInput,
-    ACRToggleInput,
-    ACRUnknown
-};
-
-typedef NS_ENUM(NSInteger, ACRContainerStyle) {
-    ACRNone,
-    ACRDefault,
-    ACREmphasis,
-    ACRGood,
-    ACRWarning,
-    ACRAttention,
-    ACRAccent
-};
-
-typedef NS_ENUM(NSInteger, ACRBleedDirection) {
-    ACRBleedRestricted = 0x0000,
-    ACRBleedToLeadingEdge = 0x0001,
-    ACRBleedToTrailingEdge = 0x0010,
-    ACRBleedToTopEdge = 0x0100,
-    ACRBleedToBottomEdge = 0x1000,
-    ACRBleedToAll = ACRBleedToLeadingEdge | ACRBleedToTrailingEdge | ACRBleedToTopEdge | ACRBleedToBottomEdge
-};
 
 @property ACRCardElementType type;
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOBaseCardElement.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOBaseCardElement.mm
@@ -39,6 +39,7 @@ using namespace AdaptiveCards;
 
 - (void)setElem:(std::shared_ptr<BaseCardElement> const &)elem
 {
+    _type = (ACRCardElementType)elem->GetElementType();
     _elem = elem;
 }
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOEnums.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOEnums.h
@@ -1,0 +1,71 @@
+//
+//  ACOEnums
+//  ACOEnums.h
+//
+//  Copyright © 2021 Microsoft. All rights reserved.
+//
+//
+typedef NS_ENUM(NSInteger, ACRActionType) {
+    ACRExecute = 1,
+    ACROpenUrl,
+    ACRShowCard,
+    ACRSubmit,
+    ACRToggleVisibility,
+    ACRUnknownAction = 7,
+};
+
+typedef NS_ENUM(NSInteger, ACRIconPlacement) {
+    ACRAboveTitle = 0,
+    ACRLeftOfTitle,
+    ACRNoTitle,
+};
+
+typedef NS_ENUM(NSInteger, ACRCardElementType) {
+    // The order of enums must match with ones in enums.h
+    ACRActionSet = 0,
+    ACRAdaptiveCard,
+    ACRChoiceInput,
+    ACRChoiceSetInput,
+    ACRColumn,
+    ACRColumnSet,
+    ACRContainer,
+    ACRCustom,
+    ACRDateInput,
+    ACRFact,
+    ACRFactSet,
+    ACRImage,
+    ACRImageSet,
+    ACRMedia,
+    ACRNumberInput,
+    ACRRichTextBlock,
+    ACRTextBlock,
+    ACRTextInput,
+    ACRTimeInput,
+    ACRToggleInput,
+    ACRUnknown
+};
+
+typedef NS_ENUM(NSInteger, ACRContainerStyle) {
+    ACRNone,
+    ACRDefault,
+    ACREmphasis,
+    ACRGood,
+    ACRWarning,
+    ACRAttention,
+    ACRAccent
+};
+
+typedef NS_ENUM(NSInteger, ACRBleedDirection) {
+    ACRBleedRestricted = 0x0000,
+    ACRBleedToLeadingEdge = 0x0001,
+    ACRBleedToTrailingEdge = 0x0010,
+    ACRBleedToTopEdge = 0x0100,
+    ACRBleedToBottomEdge = 0x1000,
+    ACRBleedToAll = ACRBleedToLeadingEdge | ACRBleedToTrailingEdge | ACRBleedToTopEdge | ACRBleedToBottomEdge
+};
+
+typedef NS_ENUM(NSInteger, ACRRtl) {
+    ACRRtlNone,
+    ACRRtlRTL,
+    ACRRtlLTR
+};

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOHostConfig.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOHostConfig.mm
@@ -132,15 +132,15 @@ using namespace AdaptiveCards;
     return _config->GetFontSize(type, txtSz);
 }
 
-+ (NSTextAlignment)getTextBlockAlignment:(HorizontalAlignment)alignment
++ (NSTextAlignment)getTextBlockAlignment:(HorizontalAlignment)alignment context:(ACORenderContext *)context
 {
     switch (alignment) {
         case HorizontalAlignment::Center:
             return NSTextAlignmentCenter;
         case HorizontalAlignment::Left:
-            return NSTextAlignmentLeft;
+            return (context.rtl == ACRRtlRTL) ? NSTextAlignmentRight : NSTextAlignmentLeft;
         case HorizontalAlignment::Right:
-            return NSTextAlignmentRight;
+            return (context.rtl == ACRRtlRTL) ? NSTextAlignmentLeft : NSTextAlignmentRight;
         default:
             return NSTextAlignmentLeft;
     }
@@ -181,8 +181,7 @@ using namespace AdaptiveCards;
             sz = _config->GetImageSizes().smallSize;
             break;
 
-        case ACRImageSizeExplicit:
-        {
+        case ACRImageSizeExplicit: {
             BOOL isAspectRatioNeeded = !(width && height);
             CGSize imageSizeAsCGSize = CGSizeZero;
             if (width) {

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOHostConfigPrivate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOHostConfigPrivate.h
@@ -10,6 +10,7 @@
 #import "ACOHostConfig.h"
 #import "HostConfig.h"
 #import "TextBlock.h"
+#import "ACORenderContext.h"
 #import <UIKit/UIKit.h>
 
 using namespace AdaptiveCards;
@@ -38,7 +39,7 @@ using namespace AdaptiveCards;
                foregroundColor:(ForegroundColor)color
                   subtleOption:(bool)isSubtle;
 
-+ (NSTextAlignment)getTextBlockAlignment:(HorizontalAlignment)alignment;
++ (NSTextAlignment)getTextBlockAlignment:(HorizontalAlignment)alignment context:(ACORenderContext *)context;
 
 - (CGSize)getImageSizeAsCGSize:(ACRImageSize)imageSize width:(CGFloat)width height:(CGFloat)height;
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACORenderContext.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACORenderContext.h
@@ -1,0 +1,28 @@
+//
+//  ACORenderContext
+//  ACORenderContext.h
+//
+//  Copyright © 2021 Microsoft. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "ACOBaseActionElement.h"
+#import "ACOBaseCardElement.h"
+
+@class ACOAdaptiveCard;
+
+@interface ACORenderContext : NSObject
+
+@property (readonly) ACRRtl rtl;
+@property (readonly) BOOL hasSelectAction;
+
+- (void)pushBaseCardElementContext:(ACOBaseCardElement *)element;
+- (void)popBaseCardElementContext:(ACOBaseCardElement *)element;
+
+- (void)pushBaseActionElementContext:(ACOBaseActionElement *)element;
+- (void)popBaseActionElementContext:(ACOBaseActionElement *)element;
+
+- (void)pushCardContext:(ACOAdaptiveCard *)card;
+- (void)popCardContext:(ACOAdaptiveCard *)card;
+
+@end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACORenderContext.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACORenderContext.mm
@@ -1,0 +1,170 @@
+//
+//  ACORenderContext
+//  ACORenderContext.mm
+//
+//  Copyright © 2021 Microsoft. All rights reserved.
+//
+
+#import "ACORenderContext.h"
+#import "ACOAdaptiveCardPrivate.h"
+#import "ACOBaseCardElementPrivate.h"
+#import "BaseElement.h"
+#import "Column.h"
+#import "ColumnSet.h"
+#import "Container.h"
+#import "UtiliOS.h"
+
+@implementation ACORenderContext {
+    NSMutableDictionary<NSNumber *, NSMutableArray *> *_internalIdContext;
+    NSMutableArray<NSNumber *> *_rtlContext;
+    NSMutableArray<NSNumber *> *_selectActionContext;
+}
+
+- (instancetype)init
+{
+    self = [super init];
+
+    if (self) {
+        _internalIdContext = [[NSMutableDictionary alloc] init];
+        _rtlContext = [[NSMutableArray alloc] init];
+        _selectActionContext = [[NSMutableArray alloc] init];
+    }
+
+    return self;
+}
+
+- (ACRRtl)rtl
+{
+    if (_rtlContext && [_rtlContext count]) {
+        NSNumber *number = [_rtlContext lastObject];
+        return (ACRRtl)[number intValue];
+    }
+    return ACRRtlNone;
+}
+
+- (BOOL)hasSelectAction
+{
+    if (_selectActionContext && [_selectActionContext count]) {
+        NSNumber *number = [_selectActionContext lastObject];
+        return [number boolValue];
+    }
+    return NO;
+}
+
+- (void)pushBaseActionElementContext:(ACOBaseActionElement *)element
+{
+    return;
+}
+
+- (void)popBaseActionElementContext:(ACOBaseActionElement *)element
+{
+    return;
+}
+
+- (void)addToANewContext:(const std::optional<bool> &)crtl key:(NSNumber *)key hasSelectAction:(BOOL)hasSelectAction
+{
+    NSMutableArray<NSMutableArray *> *contexts = [[NSMutableArray alloc] init];
+    ACRRtl rtl = ACRRtlNone;
+    rtl = getiOSRtl(crtl);
+    BOOL shouldPush = NO;
+    if (rtl != ACRRtlNone) {
+        shouldPush = YES;
+        [_rtlContext addObject:[NSNumber numberWithInt:(int)rtl]];
+        [contexts addObject:_rtlContext];
+    }
+
+    if (hasSelectAction) {
+        shouldPush = YES;
+        [_selectActionContext addObject:[NSNumber numberWithBool:hasSelectAction]];
+        [contexts addObject:_selectActionContext];
+    }
+
+    if (shouldPush) {
+        _internalIdContext[key] = contexts;
+    }
+}
+
+- (void)pushBaseCardElementContext:(ACOBaseCardElement *)acoElement
+{
+    if (!acoElement || ![acoElement element]) {
+        return;
+    }
+
+    std::optional<bool> crtl;
+    BOOL hasSelectAction = NO;
+    std::shared_ptr<BaseCardElement> element = [acoElement element];
+    if (acoElement.type == ACRColumn) {
+        std::shared_ptr<Column> column = std::dynamic_pointer_cast<Column>(element);
+        crtl = column->GetRtl();
+        if (column->GetSelectAction()) {
+            hasSelectAction = YES;
+        }
+    }
+
+    if (acoElement.type == ACRColumnSet) {
+        std::shared_ptr<ColumnSet> columnSet = std::dynamic_pointer_cast<ColumnSet>(element);
+        if (columnSet->GetSelectAction()) {
+            hasSelectAction = YES;
+        }
+    }
+
+    if (acoElement.type == ACRContainer) {
+        std::shared_ptr<Container> container = std::dynamic_pointer_cast<Container>(element);
+        crtl = container->GetRtl();
+        if (container->GetSelectAction()) {
+            hasSelectAction = YES;
+        }
+    }
+
+    std::shared_ptr<BaseElement> baseElement = std::dynamic_pointer_cast<BaseElement>(element);
+    NSNumber *key = [NSNumber numberWithLong:(baseElement->GetInternalId()).Hash()];
+
+    [self addToANewContext:crtl key:key hasSelectAction:hasSelectAction];
+}
+
+- (void)removeContext:(NSNumber *)key
+{
+    NSMutableArray *contexts = [_internalIdContext objectForKey:key];
+    if (contexts) {
+        for (NSMutableArray *context in contexts) {
+            [context removeLastObject];
+        }
+        [_internalIdContext removeObjectForKey:key];
+    }
+}
+
+- (void)popBaseCardElementContext:(ACOBaseCardElement *)element
+{
+    if (!element || ![element element]) {
+        return;
+    }
+
+    std::shared_ptr<BaseElement> baseElement = std::dynamic_pointer_cast<BaseElement>([element element]);
+    NSNumber *key = [NSNumber numberWithLong:(baseElement->GetInternalId()).Hash()];
+    [self removeContext:key];
+}
+
+- (void)pushCardContext:(ACOAdaptiveCard *)card
+{
+    if (!card || ![card card]) {
+        return;
+    }
+
+    std::shared_ptr<AdaptiveCard> adaptiveCard = [card card];
+    auto crtl = adaptiveCard->GetRtl();
+    NSNumber *key = [NSNumber numberWithLong:(adaptiveCard->GetInternalId()).Hash()];
+    BOOL hasSelectAction = adaptiveCard->GetSelectAction() ? YES : NO;
+    [self addToANewContext:crtl key:key hasSelectAction:hasSelectAction];
+}
+
+- (void)popCardContext:(ACOAdaptiveCard *)card
+{
+    if (!card || ![card card]) {
+        return;
+    }
+    std::shared_ptr<AdaptiveCard> adaptiveCard = [card card];
+    NSNumber *key = [NSNumber numberWithLong:(adaptiveCard->GetInternalId()).Hash()];
+    [self removeContext:key];
+}
+
+@end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionSetRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionSetRenderer.mm
@@ -54,7 +54,7 @@
                      card:(ACOAdaptiveCard *)card
                hostConfig:(ACOHostConfig *)config
 {
-    std::vector<std::shared_ptr<BaseActionElement>> elems = [card card] -> GetActions();
+    std::vector<std::shared_ptr<BaseActionElement>> elems = [card card]->GetActions();
     return [self renderButtons:rootView
                         inputs:inputs
                      superview:superview
@@ -72,8 +72,11 @@
     ACOFeatureRegistration *featureReg = [ACOFeatureRegistration getInstance];
 
     UIStackView *childview = [[UIStackView alloc] init];
+
+    configRtl(childview, rootView.context);
+
     childview.distribution = UIStackViewDistributionFillProportionally;
-    AdaptiveCards::ActionsConfig adaptiveActionConfig = [config getHostConfig] -> GetActions();
+    AdaptiveCards::ActionsConfig adaptiveActionConfig = [config getHostConfig]->GetActions();
 
     if (ActionsOrientation::Horizontal == adaptiveActionConfig.actionsOrientation) {
         childview.axis = UILayoutConstraintAxisHorizontal;
@@ -98,6 +101,8 @@
 
     // set width
     ACRContentHoldingUIScrollView *containingView = [[ACRContentHoldingUIScrollView alloc] init];
+
+    configRtl(containingView, rootView.context);
 
     float accumulatedWidth = 0, accumulatedHeight = 0, spacing = adaptiveActionConfig.buttonSpacing,
           maxWidth = 0, maxHeight = 0;
@@ -144,6 +149,9 @@
                                         superview:superview
                                 baseActionElement:acoElem
                                        hostConfig:config];
+
+            configRtl(button, rootView.context);
+
             [childview addArrangedSubview:button];
         } @catch (ACOFallbackException *exception) {
             handleActionFallbackException(exception, superview, rootView, inputs, acoElem, config,

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRColumnRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRColumnRenderer.mm
@@ -37,10 +37,13 @@
     std::shared_ptr<BaseCardElement> elem = [acoElem element];
     std::shared_ptr<Column> columnElem = std::dynamic_pointer_cast<Column>(elem);
 
+    [rootView.context pushBaseCardElementContext:acoElem];
+
     ACRColumnView *column = [[ACRColumnView alloc] initWithStyle:(ACRContainerStyle)columnElem->GetStyle()
                                                      parentStyle:[viewGroup style]
                                                       hostConfig:acoConfig
                                                        superview:viewGroup];
+    column.rtl = rootView.context.rtl;
 
     renderBackgroundImage(columnElem->GetBackgroundImage(), column, rootView);
 
@@ -127,6 +130,8 @@
 
     // viewGroup and column has to be in view hierarchy before configBleed is called
     configBleed(rootView, elem, column, acoConfig, viewGroup);
+
+    [rootView.context popBaseCardElementContext:acoElem];
 
     return column;
 }

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRColumnSetRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRColumnSetRenderer.mm
@@ -46,6 +46,7 @@
                                                                   parentStyle:[viewGroup style]
                                                                    hostConfig:acoConfig
                                                                     superview:viewGroup];
+    columnSetView.rtl = rootView.context.rtl;
 
     [viewGroup addArrangedSubview:columnSetView];
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRColumnSetRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRColumnSetRenderer.mm
@@ -41,6 +41,8 @@
     std::shared_ptr<HostConfig> config = [acoConfig getHostConfig];
     std::shared_ptr<BaseCardElement> elem = [acoElem element];
     std::shared_ptr<ColumnSet> columnSetElem = std::dynamic_pointer_cast<ColumnSet>(elem);
+    
+    [rootView.context pushBaseCardElementContext:acoElem];
 
     ACRColumnSetView *columnSetView = [[ACRColumnSetView alloc] initWithStyle:(ACRContainerStyle)columnSetElem->GetStyle()
                                                                   parentStyle:[viewGroup style]
@@ -236,6 +238,8 @@
     [columnSetView hideIfSubviewsAreAllHidden];
 
     [columnSetView setNeedsLayout];
+    
+    [rootView.context popBaseCardElementContext:acoElem];
 
     return columnSetView;
 }

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContainerRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContainerRenderer.mm
@@ -37,10 +37,15 @@
     std::shared_ptr<BaseCardElement> elem = [acoElem element];
     std::shared_ptr<Container> containerElem = std::dynamic_pointer_cast<Container>(elem);
 
+    [rootView.context pushBaseCardElementContext:acoElem];
+
+
     ACRColumnView *container = [[ACRColumnView alloc] initWithStyle:(ACRContainerStyle)containerElem->GetStyle()
                                                         parentStyle:[viewGroup style]
                                                          hostConfig:acoConfig
                                                           superview:viewGroup];
+    container.rtl = rootView.context.rtl;
+
     [viewGroup addArrangedSubview:container];
 
     configBleed(rootView, elem, container, acoConfig);
@@ -93,10 +98,11 @@
     std::shared_ptr<BaseActionElement> selectAction = containerElem->GetSelectAction();
     ACOBaseActionElement *acoSelectAction = [ACOBaseActionElement getACOActionElementFromAdaptiveElement:selectAction];
     [container configureForSelectAction:acoSelectAction rootView:rootView];
-
     configVisibility(container, elem);
 
     [container hideIfSubviewsAreAllHidden];
+
+    [rootView.context popBaseCardElementContext:acoElem];
 
     return viewGroup;
 }

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentStackView.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentStackView.h
@@ -22,6 +22,8 @@
 @property BOOL isActionSet;
 // tells if a background image is set
 @property BOOL isBackgroundImageSet;
+// if true, RTL's set
+@property ACRRtl rtl;
 
 - (instancetype _Nonnull)initWithFrame:(CGRect)frame;
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentStackView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentStackView.mm
@@ -22,6 +22,7 @@ static int kToggleVisibilityContext;
     UIStackView *_stackView;
     NSHashTable<UIView *> *_hiddenSubviews;
     NSMutableDictionary<NSString *, NSValue *> *_subviewIntrinsicContentSizeCollection;
+    ACRRtl _rtl;
 }
 
 - (instancetype)initWithStyle:(ACRContainerStyle)style
@@ -116,6 +117,21 @@ static int kToggleVisibilityContext;
 - (void)setAxis:(UILayoutConstraintAxis)axis
 {
     _stackView.axis = axis;
+}
+
+- (void)setRtl:(ACRRtl)rtl
+{
+    _rtl = rtl;
+    if (!_stackView || rtl == ACRRtlNone) {
+        return;
+    }
+    
+    _stackView.semanticContentAttribute = (rtl == ACRRtlRTL) ? UISemanticContentAttributeForceRightToLeft : UISemanticContentAttributeForceLeftToRight;
+}
+
+- (ACRRtl)rtl
+{
+    return _rtl;
 }
 
 + (UIColor *)colorFromString:(const std::string &)colorString

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRFactSetRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRFactSetRenderer.mm
@@ -118,6 +118,11 @@
     valueStack.axis = UILayoutConstraintAxisVertical;
     FactSetConfig factSetConfig = config->GetFactSet();
     ACRColumnSetView *factSetWrapperView = [[ACRColumnSetView alloc] init];
+
+    configRtl(titleStack, rootView.context);
+    configRtl(valueStack, rootView.context);
+    factSetWrapperView.rtl = rootView.rtl;
+
     [factSetWrapperView addArrangedSubview:titleStack];
     [ACRSeparator renderSeparationWithFrame:CGRectMake(0, 0, factSetConfig.spacing, factSetConfig.spacing) superview:factSetWrapperView axis:UILayoutConstraintAxisHorizontal];
     [factSetWrapperView addArrangedSubview:valueStack];
@@ -180,6 +185,8 @@
             [NSLayoutConstraint constraintWithItem:valueLab attribute:NSLayoutAttributeHeight relatedBy:NSLayoutRelationEqual toItem:titleLab attribute:NSLayoutAttributeHeight multiplier:1.0 constant:0].active = YES;
             nValidFacts++;
         }
+        configRtl(titleLab, rootView.context);
+        configRtl(valueLab, rootView.context);
     }
 
     if (!nValidFacts) {

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRImageRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRImageRenderer.mm
@@ -71,6 +71,9 @@
         return wrappingView;
     }
 
+    configRtl(view, rootView.context);
+    configRtl(wrappingView, rootView.context);
+
     view.clipsToBounds = YES;
 
     std::string backgroundColor = imgElem->GetBackgroundColor();

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRImageSetRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRImageSetRenderer.mm
@@ -47,6 +47,8 @@ using namespace AdaptiveCards;
 
     [view setContentHuggingPriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisVertical];
 
+    configRtl(view, rootView.context);
+
     configVisibility(view, elem);
 
     return view;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.h
@@ -7,6 +7,7 @@
 
 #import <UIKit/UIKit.h>
 #import "ACRIBaseInputHandler.h"
+#import "ACOEnums.h"
 
 @interface ACRInputLabelView : UIView <ACRIBaseInputHandler>
 @property (weak, nonatomic) IBOutlet UILabel *errorMessage;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.mm
@@ -133,7 +133,32 @@
             [rootView addWarnings:ACRMissingInputErrorMessage mesage:@"There exist required input, but there is no associated label with it, consider adding label to the input"];
         }
     }
+    [self setRtl:rootView.context.rtl];
     return self;
+}
+
+- (void)setRtl:(ACRRtl)rtl
+{
+    if (rtl == ACRRtlNone) {
+        return;
+    }
+    UISemanticContentAttribute semanticAttribute = (rtl == ACRRtlRTL) ? UISemanticContentAttributeForceRightToLeft : UISemanticContentAttributeForceLeftToRight;
+
+    if (self.errorMessage) {
+        self.errorMessage.semanticContentAttribute = semanticAttribute;
+    }
+
+    if (self.label) {
+        self.label.semanticContentAttribute = semanticAttribute;
+    }
+
+    if (self.stack) {
+        self.stack.semanticContentAttribute = semanticAttribute;
+    }
+
+    if (self.inputView) {
+        self.inputView.semanticContentAttribute = semanticAttribute;
+    }
 }
 
 - (BOOL)validate:(NSError **)error

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputRenderer.mm
@@ -98,9 +98,9 @@
     ACRQuickReplyView *quickReplyView = nil;
 
     BOOL renderAction = NO;
-    if (action != nullptr && [acoConfig getHostConfig] -> GetSupportsInteractivity()) {
+    if (action != nullptr && [acoConfig getHostConfig]->GetSupportsInteractivity()) {
         if (action->GetElementType() == ActionType::ShowCard) {
-            if ([acoConfig getHostConfig] -> GetActions().showCard.actionMode != ActionMode::Inline) {
+            if ([acoConfig getHostConfig]->GetActions().showCard.actionMode != ActionMode::Inline) {
                 renderAction = YES;
             }
         } else {
@@ -130,7 +130,9 @@
                                           constant:0]
                 .active = YES;
             inputview = multilineview;
-
+            configRtl(multilineview.contentView, rootView.context);
+            configRtl(txtview, rootView.context);
+            configRtl(button, rootView.context);
         } else {
             txtview = [[ACRTextView alloc] initWithFrame:CGRectMake(0, 0, viewGroup.frame.size.width, 0) element:acoElem];
             txtview.allowsEditingTextAttributes = YES;
@@ -152,7 +154,9 @@
             [quickReplyView addTextField:txtInput];
             ACRInputLabelView *inputLabelView = [[ACRInputLabelView alloc] initInputLabelView:rootView acoConfig:acoConfig adptiveInputElement:inputBlck inputView:quickReplyView accessibilityItem:quickReplyView viewGroup:viewGroup dataSource:textInputHandler];
             inputview = inputLabelView;
-
+            configRtl(quickReplyView.stack, rootView.context);
+            configRtl(txtInput, rootView.context);
+            configRtl(button, rootView.context);
         } else {
             txtInput = [ACRInputRenderer configTextFiled:inputBlck renderAction:renderAction rootView:rootView viewGroup:viewGroup];
             ACRInputLabelView *inputLabelView = [[ACRInputLabelView alloc] initInputLabelView:rootView acoConfig:acoConfig adptiveInputElement:inputBlck inputView:txtInput accessibilityItem:txtInput viewGroup:viewGroup dataSource:textInputHandler];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRenderer.mm
@@ -77,6 +77,13 @@ using namespace AdaptiveCards;
     std::vector<std::shared_ptr<BaseCardElement>> body = adaptiveCard->GetBody();
     ACRColumnView *verticalView = containingView;
 
+    // set context
+    ACOAdaptiveCard *wrapperCard = [[ACOAdaptiveCard alloc] init];
+    [wrapperCard setCard:adaptiveCard];
+    [rootView.context pushCardContext:wrapperCard];
+
+    verticalView.rtl = rootView.context.rtl;
+
     std::shared_ptr<BaseActionElement> selectAction = adaptiveCard->GetSelectAction();
     if (selectAction) {
         ACOBaseActionElement *acoSelectAction = [ACOBaseActionElement getACOActionElementFromAdaptiveElement:selectAction];
@@ -145,6 +152,8 @@ using namespace AdaptiveCards;
 
     // renders background image for AdaptiveCard and an inner AdaptiveCard in a ShowCard
     renderBackgroundImage(backgroundImageProperties, verticalView, rootView);
+
+    [rootView.context popCardContext:wrapperCard];
 
     return verticalView;
 }

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRichTextBlockRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRichTextBlockRenderer.mm
@@ -100,7 +100,8 @@
                 // Set paragraph style such as line break mode and alignment
                 NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
                 paragraphStyle.alignment =
-                    [ACOHostConfig getTextBlockAlignment:rTxtBlck->GetHorizontalAlignment()];
+                    [ACOHostConfig getTextBlockAlignment:rTxtBlck->GetHorizontalAlignment()
+                                                 context:rootView.context];
 
                 // Obtain text color to apply to the attributed string
                 ACRContainerStyle style = lab.style;
@@ -214,7 +215,11 @@
                                          forAxis:UILayoutConstraintAxisHorizontal];
 
     [lab setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisVertical];
+
+    configRtl(lab, rootView.context);
+
     configVisibility(lab, elem);
+
     return lab;
 }
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextBlockRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextBlockRenderer.mm
@@ -92,13 +92,14 @@
 
         // Set paragraph style such as line break mode and alignment
         NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
-        paragraphStyle.alignment = [ACOHostConfig getTextBlockAlignment:txtBlck->GetHorizontalAlignment()];
+        paragraphStyle.alignment = [ACOHostConfig getTextBlockAlignment:txtBlck->GetHorizontalAlignment() context:rootView.context];
 
         // Obtain text color to apply to the attributed string
         ACRContainerStyle style = lab.style;
         auto foregroundColor = [acoConfig getTextBlockColor:style textColor:txtBlck->GetTextColor() subtleOption:txtBlck->GetIsSubtle()];
 
         // Add paragraph style, text color, text weight as attributes to a NSMutableAttributedString, content.
+
         [content addAttributes:@{
             NSParagraphStyleAttributeName : paragraphStyle,
             NSForegroundColorAttributeName : foregroundColor,
@@ -129,17 +130,7 @@
         [lab setContentHuggingPriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisVertical];
     }
 
-    HorizontalAlignment adaptiveAlignment = txtBlck->GetHorizontalAlignment();
-
-    if (adaptiveAlignment == HorizontalAlignment::Left) {
-        lab.textAlignment = NSTextAlignmentLeft;
-    }
-    if (adaptiveAlignment == HorizontalAlignment::Right) {
-        lab.textAlignment = NSTextAlignmentRight;
-    }
-    if (adaptiveAlignment == HorizontalAlignment::Center) {
-        lab.textAlignment = NSTextAlignmentCenter;
-    }
+    configRtl(lab, rootView.context);
 
     configVisibility(lab, elem);
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.h
@@ -2,11 +2,12 @@
 //  ACRView.h
 //  ACRView
 //
-//  Copyright © 2018 Microsoft. All rights reserved.
+//  Copyright © 2021 Microsoft. All rights reserved.
 //
 
 #import "ACOAdaptiveCard.h"
 #import "ACOHostConfig.h"
+#import "ACORenderContext.h"
 #import "ACOWarning.h"
 #import "ACRActionDelegate.h"
 #import "ACRColumnView.h"
@@ -19,6 +20,7 @@
 @property (weak) id<ACRActionDelegate> acrActionDelegate;
 @property (weak) id<ACRMediaDelegate> mediaDelegate;
 @property NSArray<ACOWarning *> *warnings;
+@property (readonly) ACORenderContext *context;
 
 - (instancetype)init:(ACOAdaptiveCard *)card hostconfig:(ACOHostConfig *)config widthConstraint:(float)width;
 - (instancetype)init:(ACOAdaptiveCard *)card

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm
@@ -85,6 +85,7 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
         _paddingMap = [[NSMutableDictionary alloc] init];
         _inputHandlerLookupTable = [[NSMapTable alloc] initWithKeyOptions:NSMapTableWeakMemory valueOptions:NSMapTableWeakMemory capacity:5];
         _showcards = [[NSMutableArray alloc] init];
+        _context = [[ACORenderContext alloc] init];
     }
     return self;
 }

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.h
@@ -1,9 +1,10 @@
 //
 //  UtiliOS
 //
-//  Copyfight © 2019 Microsoft. All rights reserved.
+//  Copyfight © 2021 Microsoft. All rights reserved.
 //
 
+#import "ACORenderContext.h"
 #import "ACRErrors.h"
 #import "ACRIBaseCardElementRenderer.h"
 #import "ACRSeparator.h"
@@ -24,6 +25,10 @@ void configVisibility(UIView *view, std::shared_ptr<BaseCardElement> const &visi
 
 void configSeparatorVisibility(ACRSeparator *view,
                                std::shared_ptr<BaseCardElement> const &visibilityInfo);
+
+void configRtl(UIView *view, ACORenderContext *context);
+
+ACRRtl getiOSRtl(std::optional<bool> const rtl);
 
 void configBleed(ACRView *rootView, std::shared_ptr<BaseCardElement> const &elem,
                  ACRContentStackView *container, ACOHostConfig *acoConfig);

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
@@ -55,6 +55,36 @@ void configSeparatorVisibility(ACRSeparator *view,
     view.isVisibilityObserved = YES;
 }
 
+ACRRtl getiOSRtl(std::optional<bool> const rtl)
+{
+    ACRRtl acrtl = ACRRtlNone;
+    if (rtl.has_value()) {
+        BOOL doSetRTL = rtl.value_or(false);
+        if (doSetRTL) {
+            acrtl = ACRRtlRTL;
+        } else {
+            acrtl = ACRRtlLTR;
+        }
+    }
+    return acrtl;
+}
+
+void configRtl(UIView *view, ACORenderContext *context)
+{
+    if (!view || !context) {
+        return;
+    }
+
+    ACRRtl rtl = context.rtl;
+    if (rtl == ACRRtlNone) {
+        return;
+    } else if (rtl == ACRRtlRTL) {
+        view.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
+    } else if (rtl == ACRRtlRTL) {
+        view.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+    }
+}
+
 void renderBackgroundImage(const std::shared_ptr<AdaptiveCards::BackgroundImage> backgroundImage,
                            ACRContentStackView *containerView, ACRView *rootView)
 {

--- a/source/shared/cpp/ObjectModel/Column.cpp
+++ b/source/shared/cpp/ObjectModel/Column.cpp
@@ -88,7 +88,7 @@ Json::Value Column::SerializeToJsonValue() const
 
     if (m_rtl.has_value())
     {
-        root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Rtl)] = m_rtl.value();
+        root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Rtl)] = m_rtl.value_or("");
     }
 
     return root;

--- a/source/shared/cpp/ObjectModel/Container.cpp
+++ b/source/shared/cpp/ObjectModel/Container.cpp
@@ -47,7 +47,7 @@ Json::Value Container::SerializeToJsonValue() const
 
     if (m_rtl.has_value())
     {
-        root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Rtl)] = m_rtl.value();
+        root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Rtl)] = m_rtl.value_or("");
     }
 
     return root;

--- a/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
+++ b/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
@@ -324,7 +324,7 @@ Json::Value AdaptiveCard::SerializeToJsonValue() const
 
     if (m_rtl.has_value())
     {
-        root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Rtl)] = m_rtl.value();
+        root[AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Rtl)] = m_rtl.value_or("");
     }
 
     const HeightType height = GetHeight();


### PR DESCRIPTION
## Related Issue
fixed #5491, mentioned #5603 

## Description
* fixed shared model to support iOS
* added render context to iOS
* added selectionAction & rtl properties to render context
* added rtl support
* rtl is needed to be set in each and every UI element in iOS.
* fixed samples

### References
1 https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPInternational/SupportingRight-To-LeftLanguages/SupportingRight-To-LeftLanguages.html
2 https://developer.apple.com/forums/thread/34660

## Sample Card
N/A

## How Verified
![Screen Shot 2021-03-30 at 10 33 40 PM](https://user-images.githubusercontent.com/4112696/113098491-608aa200-91ad-11eb-8835-dc2c66e7198b.png)
![Screen Shot 2021-03-30 at 9 58 42 PM](https://user-images.githubusercontent.com/4112696/113092584-1d2b3600-91a3-11eb-95fd-27ddc58bfbfe.png)
![Screen Shot 2021-03-30 at 9 59 01 PM](https://user-images.githubusercontent.com/4112696/113092604-287e6180-91a3-11eb-9192-56c1935acf3b.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5604)