### PR TITLE
[.NET] Add RTL support to WPF renderer

### DIFF
--- a/samples/v1.5/Elements/Column.Rtl.json
+++ b/samples/v1.5/Elements/Column.Rtl.json
@@ -1,7 +1,7 @@
-﻿{
+{
   "type": "AdaptiveCard",
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
-  "version": "1.3",
+  "version": "1.5",
   "body": [
     {
       "type": "TextBlock",

--- a/samples/v1.5/Test/RtlTestCard.json
+++ b/samples/v1.5/Test/RtlTestCard.json
@@ -1,7 +1,7 @@
-﻿{
+{
   "type": "AdaptiveCard",
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
-  "version": "1.3",
+  "version": "1.5",
   "body": [
     {
       "type": "TextBlock",

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveCardRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveCardRenderer.cs
@@ -17,7 +17,7 @@ namespace AdaptiveCards.Rendering.Wpf
     {
         protected override AdaptiveSchemaVersion GetSupportedSchemaVersion()
         {
-            return new AdaptiveSchemaVersion(1, 3);
+            return new AdaptiveSchemaVersion(1, 5);
         }
 
         protected Action<object, AdaptiveActionEventArgs> ActionCallback;

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveColumnRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveColumnRenderer.cs
@@ -15,6 +15,22 @@ namespace AdaptiveCards.Rendering.Wpf
             uiContainer.Style = context.GetStyle("Adaptive.Column");
             uiContainer.SetBackgroundSource(column.BackgroundImage, context);
 
+            bool? previousContextRtl = context.Rtl;
+            bool? currentRtl = previousContextRtl;
+
+            bool updatedRtl = false;
+            if (column.Rtl.HasValue)
+            {
+                currentRtl = column.Rtl;
+                context.Rtl = currentRtl;
+                updatedRtl = true;
+            }
+
+            if (currentRtl.HasValue)
+            {
+                uiContainer.FlowDirection = currentRtl.Value ? FlowDirection.RightToLeft : FlowDirection.LeftToRight;
+            }
+
             // Keep track of ContainerStyle.ForegroundColors before Container is rendered
             var parentRenderArgs = context.RenderArgs;
             // This is the renderArgs that will be passed down to the children
@@ -58,6 +74,11 @@ namespace AdaptiveCards.Rendering.Wpf
 
             // Revert context's value to that of outside the Column
             context.RenderArgs = parentRenderArgs;
+
+            if (updatedRtl)
+            {
+                context.Rtl = previousContextRtl;
+            }
 
             return RendererUtil.ApplySelectAction(border, column, context);
         }

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveContainerRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveContainerRenderer.cs
@@ -18,6 +18,22 @@ namespace AdaptiveCards.Rendering.Wpf
             uiContainer.Style = context.GetStyle("Adaptive.Container");
             uiContainer.SetBackgroundSource(container.BackgroundImage, context);
 
+            bool? previousContextRtl = context.Rtl;
+            bool? currentRtl = previousContextRtl;
+
+            bool updatedRtl = false;
+            if (container.Rtl.HasValue)
+            {
+                currentRtl = container.Rtl;
+                context.Rtl = currentRtl;
+                updatedRtl = true;
+            }
+
+            if (currentRtl.HasValue)
+            {
+                uiContainer.FlowDirection = currentRtl.Value ? FlowDirection.RightToLeft : FlowDirection.LeftToRight;
+            }
+
             // Keep track of ContainerStyle.ForegroundColors before Container is rendered
             var parentRenderArgs = context.RenderArgs;
             // This is the renderArgs that will be passed down to the children
@@ -72,6 +88,11 @@ namespace AdaptiveCards.Rendering.Wpf
 
             // Revert context's value to that of outside the Container
             context.RenderArgs = parentRenderArgs;
+
+            if (updatedRtl)
+            {
+                context.Rtl = previousContextRtl;
+            }
 
             return RendererUtil.ApplySelectAction(border, container, context);
         }
@@ -212,7 +233,7 @@ namespace AdaptiveCards.Rendering.Wpf
 
             context.ResetSeparatorVisibilityInsideContainer(uiContainer);
         }
-        
+
         /// <summary>
         /// Adds spacing as a grid element to the container
         /// </summary>
@@ -370,7 +391,7 @@ namespace AdaptiveCards.Rendering.Wpf
                     }
                 }
 
-                AutomationProperties.SetIsRequiredForForm(GetVisualElementForAccessibility(context, inputElement)?? elementForAccessibility, inputElement.IsRequired);
+                AutomationProperties.SetIsRequiredForForm(GetVisualElementForAccessibility(context, inputElement) ?? elementForAccessibility, inputElement.IsRequired);
 
                 if ((!String.IsNullOrEmpty(inputElement.Label)) || (!String.IsNullOrEmpty(inputElement.ErrorMessage)))
                 {
@@ -496,7 +517,8 @@ namespace AdaptiveCards.Rendering.Wpf
         /// <returns>The rendered error message</returns>
         public static TextBlock RenderErrorMessage(AdaptiveRenderContext context, AdaptiveInput input)
         {
-            TextBlock uiTextBlock = new TextBlock() {
+            TextBlock uiTextBlock = new TextBlock()
+            {
                 Text = input.ErrorMessage,
                 TextWrapping = TextWrapping.Wrap,
                 Visibility = Visibility.Collapsed

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveRenderContext.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveRenderContext.cs
@@ -53,6 +53,8 @@ namespace AdaptiveCards.Rendering.Wpf
 
         public bool IsRenderingSelectAction { get; set; }
 
+        public bool? Rtl { get; set; }
+
         public IDictionary<Uri, MemoryStream> CardAssets { get; set; } = new Dictionary<Uri, MemoryStream>();
 
         public IDictionary<string, Func<string>> InputBindings = new Dictionary<string, Func<string>>();

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveCard.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveCard.cs
@@ -38,7 +38,7 @@ namespace AdaptiveCards
         /// <summary>
         /// The latest known schema version supported by this library.
         /// </summary>
-        public static AdaptiveSchemaVersion KnownSchemaVersion = new AdaptiveSchemaVersion(1, 4);
+        public static AdaptiveSchemaVersion KnownSchemaVersion = new AdaptiveSchemaVersion(1, 5);
 
         /// <summary>
         /// Creates an AdaptiveCard using a specific schema version.

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveColumn.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveColumn.cs
@@ -42,5 +42,14 @@ namespace AdaptiveCards
         [DefaultValue(null)]
         public string Width { get; set; } // TODO: this should be a ColumnWidth type with implicit converter
 
+        /// <summary>
+        /// Sets the text flow direction
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+#if !NETSTANDARD1_3
+        [XmlElement]
+#endif
+        [DefaultValue(null)]
+        public bool? Rtl { get; set; } = null;
     }
 }

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveContainer.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveContainer.cs
@@ -57,5 +57,14 @@ namespace AdaptiveCards
 #endif
         public List<AdaptiveElement> Items { get; set; } = new List<AdaptiveElement>();
 
+        /// <summary>
+        /// Sets the text flow direction
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+#if !NETSTANDARD1_3
+        [XmlElement]
+#endif
+        [DefaultValue(null)]
+        public bool? Rtl { get; set; } = null;
     }
 }

--- a/source/dotnet/Library/AdaptiveCards/Globals.cs
+++ b/source/dotnet/Library/AdaptiveCards/Globals.cs
@@ -2,6 +2,6 @@ namespace AdaptiveCards
 {
     class Globals
     {
-        public static readonly string ObjectModelVersion = "1.4";
+        public static readonly string ObjectModelVersion = "1.5";
     }
 }

--- a/source/dotnet/Test/AdaptiveCards.Test/SerializationTests.cs
+++ b/source/dotnet/Test/AdaptiveCards.Test/SerializationTests.cs
@@ -1111,5 +1111,90 @@ namespace AdaptiveCards.Test
             Assert.AreEqual(expected: expected, actual: deserializedActual);
         }
 
+        [TestMethod]
+        public void RTL()
+        {
+            var card = new AdaptiveCard("1.5")
+            {
+                Body =
+                {
+                    new AdaptiveContainer()
+                    {
+                        Rtl = true
+                    },
+                    new AdaptiveContainer()
+                    {
+                        Rtl = false
+                    },
+                    new AdaptiveContainer()
+                    {
+                    },
+                    new AdaptiveColumnSet()
+                    {
+                        Columns =
+                        {
+                            new AdaptiveColumn()
+                            {
+                                Rtl = true
+                            },
+                            new AdaptiveColumn()
+                            {
+                                Rtl = false
+                            },
+                            new AdaptiveColumn()
+                            {                                
+                            }
+                        }
+                    }
+                }
+            };
+
+
+            var expected = @"{
+  ""type"": ""AdaptiveCard"",
+  ""version"": ""1.5"",
+  ""body"": [
+    {
+      ""type"": ""Container"",
+      ""items"": [],
+      ""rtl"": true
+    },
+    {
+      ""type"": ""Container"",
+      ""items"": [],
+      ""rtl"": false
+    },
+    {
+      ""type"": ""Container"",
+      ""items"": []
+    },
+    {
+      ""type"": ""ColumnSet"",
+      ""columns"": [
+        {
+          ""type"": ""Column"",
+          ""rtl"": true,
+          ""items"": []
+        },
+        {
+          ""type"": ""Column"",
+          ""rtl"": false,
+          ""items"": []
+        },
+        {
+          ""type"": ""Column"",
+          ""items"": []
+        }
+      ]
+    }
+  ]
+}";
+
+            var actual = card.ToJson();
+            Assert.AreEqual(expected, actual);
+            var deserializedCard = AdaptiveCard.FromJson(expected).Card;
+            var deserializedActual = deserializedCard.ToJson();
+            Assert.AreEqual(expected, deserializedActual);
+        }
     }
 }


### PR DESCRIPTION
## Related Issue
Fixes #5486 
Fixes #5487

## Description
Add RTL support to container and column in .NET and WPF

## Sample Card
samples/v1.5/Elements/Column.Rtl.json
samples/v1.5/Elements/Container.Rtl.Json
samples/v1.5/Test/RtlTestCard.json

## How Verified
- Unit tests to validate Serialization of new property
- Sample cards validated in the visualizer


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5611)