### PR TITLE
[Site] Process explorer element descriptions with markdown

### DIFF
--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/explorer.ejs
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/explorer.ejs
@@ -49,7 +49,7 @@
 
 			<h2><%= page.element.name %></h2>
 
-			<p><%= page.element.description %></p>
+			<p><%- markdown(page.element.description) %></p>
 
 			<div class="ac-properties w3-margin-top w3-responsive">
 				<%- markdown(page.propertiesSummary) %>


### PR DESCRIPTION
## Related Issue
Fixes #5642

## Description
Minor oversight -- element descriptions should be markdown processed for display

![image](https://user-images.githubusercontent.com/16614499/114943207-7c6f8400-9dfa-11eb-89f9-b3856e9bddc4.png)

## How Verified
* local build

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5676)