### PR TITLE
[Designer][Accessibility] Set FieldPicker initial focus to first item

### DIFF
--- a/source/dotnet/Test/AdaptiveCards.Test/SerializationTests.cs
+++ b/source/dotnet/Test/AdaptiveCards.Test/SerializationTests.cs
@@ -1130,7 +1130,7 @@ namespace AdaptiveCards.Test
       ""type"": ""TextBlock"",
       ""text"": ""Text3"",
       ""style"": ""heading""
-    },
+    }
   ]
 }";
             var card = new AdaptiveCard("1.5")

--- a/source/nodejs/.eslintrc.js
+++ b/source/nodejs/.eslintrc.js
@@ -417,18 +417,26 @@ module.exports = {
             }
         ],
 
-        // require empty line before/after blocks
+        // require empty lines
         "padding-line-between-statements": [
             "error",
+            // before block
             {
                 "blankLine": "always",
                 "prev": "*",
                 "next": "multiline-block-like"
             },
+            // after block
             {
                 "blankLine": "always",
                 "prev": "multiline-block-like",
                 "next": "*"
+            },
+            // before return
+            {
+                "blankLine": "always",
+                "prev": "*",
+                "next": "return"
             }
         ],
 

--- a/source/nodejs/adaptivecards-controls/src/inputwithpopup.ts
+++ b/source/nodejs/adaptivecards-controls/src/inputwithpopup.ts
@@ -148,7 +148,7 @@ export abstract class PopupControl {
             this._popupElement.style.left = left + "px";
             this._popupElement.style.top = top + "px";
 
-            this._popupElement.focus();
+            this.focus();
 
             this._isOpen = true;
         }

--- a/source/nodejs/adaptivecards-designer/src/draggable-element.ts
+++ b/source/nodejs/adaptivecards-designer/src/draggable-element.ts
@@ -148,6 +148,12 @@ export abstract class DraggableElement {
         return this._renderedElement;
     }
 
+    focus() {
+        if (this._renderedElement) {
+            this._renderedElement.focus();
+        }
+    }
+
     get renderedElement(): HTMLElement {
         return this._renderedElement;
     }

--- a/source/nodejs/adaptivecards-designer/src/field-picker.ts
+++ b/source/nodejs/adaptivecards-designer/src/field-picker.ts
@@ -36,6 +36,7 @@ export class FieldPicker extends Controls.PopupControl {
     render(rootElementBounds: ClientRect): HTMLElement {
         const rootElement = super.render(rootElementBounds);
         rootElement.tabIndex = -1;
+
         return rootElement;
     }
 

--- a/source/nodejs/adaptivecards-designer/src/field-picker.ts
+++ b/source/nodejs/adaptivecards-designer/src/field-picker.ts
@@ -7,6 +7,7 @@ import { DataTreeItem } from "./data-treeitem";
 
 export class FieldPicker extends Controls.PopupControl {
     private _selectedField: FieldDefinition;
+    private _treeView: TreeView;
 
     protected renderContent(): HTMLElement {
         let element = document.createElement("div");
@@ -14,22 +15,41 @@ export class FieldPicker extends Controls.PopupControl {
 
         let treeItem = new DataTreeItem(this.dataStructure);
 
-        let treeView = new TreeView(treeItem);
-        treeView.onSelectedItemChanged = (sender) => {
-            this._selectedField = (treeView.selectedItem as DataTreeItem).field;
+        this._treeView = new TreeView(treeItem);
+
+        this._treeView.onSelectedItemChanged = (sender) => {
+            this._selectedField = (this._treeView.selectedItem as DataTreeItem).field;
 
             if (this._selectedField) {
                 this.closePopup(false);
             }
-        }
+        };
 
-        element.appendChild(treeView.render());
+        element.appendChild(this._treeView.render());
 
         return element;
     }
 
+    /**
+     * @inheritdoc
+     */
+    render(rootElementBounds: ClientRect): HTMLElement {
+        const rootElement = super.render(rootElementBounds);
+        rootElement.tabIndex = -1;
+        return rootElement;
+    }
+
     constructor(readonly dataStructure: FieldDefinition) {
         super();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    focus() {
+        if (this._treeView) {
+            this._treeView.focus();
+        }
     }
 
     keyDown(e: KeyboardEvent) {

--- a/source/nodejs/adaptivecards-designer/src/tree-view.ts
+++ b/source/nodejs/adaptivecards-designer/src/tree-view.ts
@@ -21,6 +21,12 @@ export class TreeView {
         }
     }
 
+    focus() {
+        if (this.rootItem) {
+            this.rootItem.focus();
+        }
+    }
+
     render(): HTMLElement {
         let treeRoot = document.createElement("ul");
         treeRoot.style.paddingLeft = "0";


### PR DESCRIPTION
## Related Issue
Fixes [ADO 30910259](https://microsoft.visualstudio.com/OS/_workitems/edit/30910259)

## Description
FieldPicker sets its focus on a container view, which isn't useful for keyboard users. PR changes it to set focus on root tree item instead.

## Sample Card
N/A

## How Verified
Local build:
![30910259](https://user-images.githubusercontent.com/4442788/115060005-51963600-9eb5-11eb-9a39-dba93dcbaa24.gif)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5678)