### PR TITLE
[Designer] Add i18n support to designer

### DIFF
--- a/source/nodejs/adaptivecards-designer/assets/languages/en/designer.json
+++ b/source/nodejs/adaptivecards-designer/assets/languages/en/designer.json
@@ -1,0 +1,83 @@
+{
+	"cardElements": "CARD ELEMENTS",
+	"cardEditor": "CARD PAYLOAD EDITOR",
+	"cardPreview": "Card Preview",
+	"sampleEditor": "SAMPLE DATA EDITOR",
+	"sampleData": "Sample data",
+	"elementProperties": "ELEMENT PROPERTIES",
+	"ellipsis": "...",
+	"dataBinding": "Data Binding",
+	"cardStructure": "CARD STRUCTURE",
+	"dataStructure": "DATA STRUCTURE",
+	"loadingEditor": "Loading editor...",
+	"expandCollapseAria": "{{action}} {{label}} element",
+	"collapse": "collapse",
+	"expand": "expand",
+	"remove": "Remove",
+	"dragElement": "Drag to move this element",
+	"returnToDesign": "Return to Design mode",
+	"switchToPreview": "Switch to Preview mode",
+	"noStructure": "The Card Structure isn't available in Preview mode.",
+	"noSelection": "**Nothing is selected**",
+	"selectAnElement": "Select an element in the card to modify its properties.",
+	"clickToSelect": "Click to select this element",
+	"versionWarning": "[Warning] The selected Target Version ({{version}}) is greater than the version supported by {{hostContainerName}} ({{hostVersion}})",
+	"errorPaneMessage": "[{{phase}}] {{message}}",
+	"targetVersion": "Target version:",
+	"genericCloseButtonCaption": "Cancel",
+	"newCard": {
+		"label": "New card",
+		"dialog": {
+			"title": "Pick a sample as a starting point",
+			"cannotLoad": "The sample could not be loaded."
+		}
+	},
+	"undo": {
+		"label": "Undo",
+		"tooltip": "Undo your last change"
+	},
+	"redo": {
+		"label": "Redo",
+		"tooltip": "Redo your last changes"
+	},
+	"preview": {
+		"label": "Preview mode"
+	},
+	"help": {
+		"label": "Help",
+		"tooltip": "Display help"
+	},
+	"blankCard": "Blank card",
+	"enterFullScreen": "Enter full screen",
+	"existFullScreen": "Exit full screen",
+	"copy": {
+		"label": "Copy card payload",
+		"tooltip": "Copy the generated JSON payload of the card (template bound with data) to the clipboard. To copy only the template payload, use the Card Payload Editor."
+	},
+	"hostContainer": {
+		"label": "Select host app:",
+		"names": {
+			"webChat": "Bot Framework WebChat",
+			"outlook": "Outlook Actionable Messages",
+			"darkTeams": "Microsoft Teams - Dark",
+			"lightTeams": "Microsoft Teams - Light",
+			"darkCortana": "Cortana Skills - Dark",
+			"lightCortana": "Cortana Skills - Light",
+			"timeline": "Windows Timeline",
+			"botFramework": "Bot Framework Other Channels (Image render)",
+			"cortanaClassic": "Cortana Skills (Classic)",
+			"toast": "Windows Notifications (Preview)"
+		}
+	},
+	"pic2card":	{
+		"title": "Pic2card Dialog for Image Upload",
+		"notificationLabel": "Pic2Card generated Adaptive Card loaded"
+	},
+	"peerCategory": {
+		"unknown": "Unknown",
+		"containers": "Containers",
+		"elements": "Elements",
+		"inputs": "Inputs",
+		"actions": "Actions"
+	}
+}

--- a/source/nodejs/adaptivecards-designer/assets/languages/index.js
+++ b/source/nodejs/adaptivecards-designer/assets/languages/index.js
@@ -1,0 +1,1 @@
+// do not delete

--- a/source/nodejs/adaptivecards-designer/package-lock.json
+++ b/source/nodejs/adaptivecards-designer/package-lock.json
@@ -30,6 +30,14 @@
 				"js-tokens": "^4.0.0"
 			}
 		},
+		"@babel/runtime": {
+			"version": "7.13.10",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+			"integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+			"requires": {
+				"regenerator-runtime": "^0.13.4"
+			}
+		},
 		"@microsoft/recognizers-text-data-types-timex-expression": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-data-types-timex-expression/-/recognizers-text-data-types-timex-expression-1.1.4.tgz",
@@ -3208,6 +3216,56 @@
 			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
 			"dev": true
 		},
+		"i18next": {
+			"version": "20.2.1",
+			"resolved": "https://registry.npmjs.org/i18next/-/i18next-20.2.1.tgz",
+			"integrity": "sha512-JLruWDEQ3T6tKT6P7u+DsNtToMHUwUcQIYOMRcnNBdUhSfKkoIDUKdVDKgGtmqr//LrirxjADUdr3d5Gwbow6g==",
+			"requires": {
+				"@babel/runtime": "^7.12.0"
+			}
+		},
+		"i18next-resource-store-loader": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/i18next-resource-store-loader/-/i18next-resource-store-loader-0.1.2.tgz",
+			"integrity": "sha1-Dit6pJjkej2Jyy8o3MWP4/9QKyY=",
+			"dev": true,
+			"requires": {
+				"loader-utils": "^0.2.11",
+				"lodash": "^4.6.1"
+			},
+			"dependencies": {
+				"big.js": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+					"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+					"dev": true
+				},
+				"emojis-list": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+					"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+					"dev": true
+				},
+				"json5": {
+					"version": "0.5.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+					"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+					"dev": true
+				},
+				"loader-utils": {
+					"version": "0.2.17",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+					"dev": true,
+					"requires": {
+						"big.js": "^3.1.3",
+						"emojis-list": "^2.0.0",
+						"json5": "^0.5.0",
+						"object-assign": "^4.0.1"
+					}
+				}
+			}
+		},
 		"iconv-lite": {
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -4937,6 +4995,11 @@
 				"indent-string": "^4.0.0",
 				"strip-indent": "^3.0.0"
 			}
+		},
+		"regenerator-runtime": {
+			"version": "0.13.7",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+			"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
 		},
 		"regex-not": {
 			"version": "1.0.2",

--- a/source/nodejs/adaptivecards-designer/package.json
+++ b/source/nodejs/adaptivecards-designer/package.json
@@ -35,7 +35,8 @@
 	},
 	"dependencies": {
 		"adaptivecards-controls": "^0.8.0",
-		"clipboard": "^2.0.1"
+		"clipboard": "^2.0.1",
+		"i18next": "^20.2.1"
 	},
 	"peerDependencies": {
 		"adaptive-expressions": "^4.11.0",
@@ -52,6 +53,7 @@
 		"cpy-cli": "^3.1.1",
 		"dotenv-webpack": "^1.7.0",
 		"eslint": "^7.3.1",
+		"i18next-resource-store-loader": "^0.1.2",
 		"monaco-editor": "^0.20.0",
 		"rimraf": "^3.0.2",
 		"typescript": "^3.9.5",

--- a/source/nodejs/adaptivecards-designer/src/adaptivecards-designer.ts
+++ b/source/nodejs/adaptivecards-designer/src/adaptivecards-designer.ts
@@ -1,19 +1,20 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as containers from "./containers";
+import { __ } from './i18n';
 
 export * from "./adaptivecards-designer-standalone";
 export * from "./containers/index";
 
 export const defaultMicrosoftHosts: containers.HostContainer[] = [
-	new containers.WebChatContainer("Bot Framework WebChat", "containers/webchat-container.css"),
-	new containers.OutlookContainer("Outlook Actionable Messages", "containers/outlook-container.css"),
-	new containers.DarkTeamsContainer("Microsoft Teams - Dark", "containers/teams-container-dark.css"),
-	new containers.LightTeamsContainer("Microsoft Teams - Light", "containers/teams-container-light.css"),
-	new containers.DarkCortanaContainer("Cortana Skills - Dark", "containers/cortana-container-dark.css"),
-	new containers.LightCortanaContainer("Cortana Skills - Light", "containers/cortana-container-light.css"),
-	new containers.TimelineContainer("Windows Timeline", "containers/timeline-container.css"),
-	new containers.BotFrameworkContainer("Bot Framework Other Channels (Image render)", "containers/bf-image-container.css"),
-	new containers.CortanaClassicContainer("Cortana Skills (Classic)", "containers/cortana-classic-container.css"),
-	new containers.ToastContainer("Windows Notifications (Preview)", "containers/toast-container.css"),
+	new containers.WebChatContainer(__("hostContainer.names.webChat"), "containers/webchat-container.css"),
+	new containers.OutlookContainer(__("hostContainer.names.outlook"), "containers/outlook-container.css"),
+	new containers.DarkTeamsContainer(__("hostContainer.names.darkTeams"), "containers/teams-container-dark.css"),
+	new containers.LightTeamsContainer(__("hostContainer.names.lightTeams"), "containers/teams-container-light.css"),
+	new containers.DarkCortanaContainer(__("hostContainer.names.darkCortana"), "containers/cortana-container-dark.css"),
+	new containers.LightCortanaContainer(__("hostContainer.names.lightCortana"), "containers/cortana-container-light.css"),
+	new containers.TimelineContainer(__("hostContainer.names.timeline"), "containers/timeline-container.css"),
+	new containers.BotFrameworkContainer(__("hostContainer.names.botFramework"), "containers/bf-image-container.css"),
+	new containers.CortanaClassicContainer(__("hostContainer.names.cortanaClassic"), "containers/cortana-classic-container.css"),
+	new containers.ToastContainer(__("hostContainer.names.toast"), "containers/toast-container.css"),
 ]

--- a/source/nodejs/adaptivecards-designer/src/base-tree-item.ts
+++ b/source/nodejs/adaptivecards-designer/src/base-tree-item.ts
@@ -1,6 +1,7 @@
 import { DraggableElement } from "./draggable-element";
 import { Constants } from "adaptivecards-controls";
 import { v4 as uuidv4 } from "uuid";
+import { __ } from './i18n';
 
 export abstract class BaseTreeItem extends DraggableElement {
     private static collapsedIconClass = "acd-icon-chevronRight";
@@ -69,7 +70,8 @@ export abstract class BaseTreeItem extends DraggableElement {
     }
 
     private getExpandCollapseAriaText() : string {
-        return (this._isExpanded ? "collapse" : "expand") + " " + this.getLabelText() + " element";
+        const labelText = this.getLabelText();
+        return __("expandCollapseAria", { action:(this._isExpanded ? "$t(collapse)" : "$t(expand)"), label: labelText });
     }
 
     protected internalRender(): HTMLElement {

--- a/source/nodejs/adaptivecards-designer/src/card-designer-surface.ts
+++ b/source/nodejs/adaptivecards-designer/src/card-designer-surface.ts
@@ -9,6 +9,7 @@ import * as ACData from "adaptivecards-templating";
 import * as Shared from "./shared";
 import { HostContainer } from "./containers";
 import { FieldDefinition } from "./data";
+import { __ } from './i18n';
 
 export enum BindingPreviewMode {
     NoPreview,
@@ -36,11 +37,11 @@ export type ActionPeerType = {
 };
 
 class DesignerPeerCategory {
-    static Unknown = "Unknown";
-    static Containers = "Containers";
-    static Elements = "Elements";
-    static Inputs = "Inputs";
-    static Actions = "Actions";
+    static Unknown = __("peerCategory.unknown");
+    static Containers = __("peerCategory.containers");
+    static Elements = __("peerCategory.elements");
+    static Inputs = __("peerCategory.inputs");
+    static Actions = __("peerCategory.actions");
 }
 
 export abstract class DesignerPeerRegistry<TSource, TPeer> {
@@ -155,7 +156,7 @@ class DragHandle extends DraggableElement {
     protected internalRender(): HTMLElement {
         let element = document.createElement("div");
         element.classList.add("acd-peerButton", "acd-peerButton-icon", "fixedWidth", "circular", "acd-icon-drag");
-        element.title = "Drag to move this element";
+        element.title = __("dragElement");
         element.style.visibility = "hidden";
         element.style.position = "absolute";
         element.style.zIndex = "500";
@@ -666,7 +667,7 @@ export class CardDesignerSurface {
 
         this._removeCommandElement = document.createElement("div");
         this._removeCommandElement.classList.add("acd-peerButton", "acd-peerButton-icon", "fixedWidth", "circular", "acd-icon-remove");
-        this._removeCommandElement.title = "Remove";
+        this._removeCommandElement.title = __("remove");
         this._removeCommandElement.style.visibility = "hidden";
         this._removeCommandElement.style.position = "absolute";
         this._removeCommandElement.style.zIndex = "500";

--- a/source/nodejs/adaptivecards-designer/src/card-designer.ts
+++ b/source/nodejs/adaptivecards-designer/src/card-designer.ts
@@ -24,6 +24,7 @@ import * as Shared from "./shared";
 import { TreeView } from "./tree-view";
 import { SampleCatalogue } from "./catalogue";
 import { HelpDialog } from "./help-dialog";
+import { __ } from './i18n';
 
 export class CardDesigner extends Designer.DesignContext {
     private static internalProcessMarkdown(text: string, result: Adaptive.IMarkdownProcessingResult) {
@@ -75,11 +76,11 @@ export class CardDesigner extends Designer.DesignContext {
         this._designerSurface.isPreviewMode = !this._designerSurface.isPreviewMode;
 
         if (this._designerSurface.isPreviewMode) {
-            this._togglePreviewButton.toolTip = "Return to Design mode";
+            this._togglePreviewButton.toolTip = __("returnToDesign");
             this._designerSurface.setCardPayloadAsString(this.getCurrentCardEditorPayload());
         }
         else {
-            this._togglePreviewButton.toolTip = "Switch to Preview mode";
+            this._togglePreviewButton.toolTip = __("switchToPreview");
             this.updateCardFromJson(false);
         }
 
@@ -93,7 +94,7 @@ export class CardDesigner extends Designer.DesignContext {
             if (this.designerSurface.isPreviewMode) {
                 this.treeViewToolbox.content.innerHTML =
                     '<div style="padding: 8px; display: flex; justify-content: center;">' +
-                        '<div>The Card Structure isn\'t available in Preview mode.</div>' +
+                    '<div>' + __("noStructure") + '</div>' +
                     '</div>';
             }
             else {
@@ -136,12 +137,12 @@ export class CardDesigner extends Designer.DesignContext {
                             {
                                 type: "TextBlock",
                                 wrap: true,
-                                text: "**Nothing is selected**"
+                                text: __("noSelection")
                             },
                             {
                                 type: "TextBlock",
                                 wrap: true,
-                                text: "Select an element in the card to modify its properties."
+                                text: __("selectAnElement")
                             }
                         ]
                     },
@@ -265,7 +266,7 @@ export class CardDesigner extends Designer.DesignContext {
 
         if (source && source instanceof Adaptive.CardObject) {
             errorElement.classList.add("selectable");
-            errorElement.title = "Click to select this element";
+            errorElement.title = __("clickToSelect");
             errorElement.onclick = (e) => {
                 let peer = this.designerSurface.findPeer(source);
 
@@ -336,7 +337,7 @@ export class CardDesigner extends Designer.DesignContext {
             errorPane.innerHTML = "";
 
             if (this.targetVersion.compareTo(this.hostContainer.targetVersion) > 0 && Shared.GlobalSettings.showTargetVersionMismatchWarning) {
-                errorPane.appendChild(this.renderErrorPaneElement("[Warning] The selected Target Version (" + this.targetVersion.toString() + ") is greater than the version supported by " + this.hostContainer.name + " (" + this.hostContainer.targetVersion.toString() + ")"));
+                errorPane.appendChild(this.renderErrorPaneElement(__("versionWarning", { version: this.targetVersion.toString(), hostContainerName: this.hostContainer.name, hostVersion: this.hostContainer.targetVersion.toString() })));
             }
 
             if (logEntries.length > 0) {
@@ -363,7 +364,7 @@ export class CardDesigner extends Designer.DesignContext {
                             break;
                     }
 
-                    errorPane.appendChild(this.renderErrorPaneElement(s + " " + entry.message, entry.source));
+                    errorPane.appendChild(this.renderErrorPaneElement(__("errorPaneMessage", { phase: s, message: entry.message }), entry.source));
                 }
             }
 
@@ -610,7 +611,7 @@ export class CardDesigner extends Designer.DesignContext {
     private prepareToolbar() {
         if (Shared.GlobalSettings.showVersionPicker) {
             this._versionChoicePicker = new ToolbarChoicePicker(CardDesigner.ToolbarCommands.VersionPicker);
-            this._versionChoicePicker.label = "Target version:"
+            this._versionChoicePicker.label = __("targetVersion");
             this._versionChoicePicker.alignment = ToolbarElementAlignment.Right;
             this._versionChoicePicker.separator = true;
 
@@ -627,12 +628,12 @@ export class CardDesigner extends Designer.DesignContext {
 
         this._newCardButton = new ToolbarButton(
             CardDesigner.ToolbarCommands.NewCard,
-            "New card",
+            __("newCard.label"),
             "acd-icon-newCard",
             (sender: ToolbarButton) => {
                 let dialog = new OpenSampleDialog(this._sampleCatalogue);
-                dialog.title = "Pick a sample as a starting point";
-                dialog.closeButton.caption = "Cancel";
+                dialog.title = __("newCard.dialog.title");
+                dialog.closeButton.caption = __("genericCloseButtonCaption");
                 dialog.width = "80%";
                 dialog.height = "80%";
                 dialog.onClose = (d) => {
@@ -644,7 +645,7 @@ export class CardDesigner extends Designer.DesignContext {
 
                                 this.setCardPayload(cardPayload, true);
                             } catch {
-                                alert("The sample could not be loaded.");
+                                alert(__("newCard.button.dialog.cannotLoad"));
                             }
 
                             if (dialog.selectedSample.sampleData) {
@@ -654,7 +655,7 @@ export class CardDesigner extends Designer.DesignContext {
                                     this.setSampleDataPayload(sampleDataPayload);
                                     this.dataStructure = FieldDefinition.deriveFrom(sampleDataPayload);
                                 } catch {
-                                    alert("The sample could not be loaded.")
+                                    alert(__("newCard.button.dialog.cannotLoad"));
                                 }
                             }
                         };
@@ -681,7 +682,7 @@ export class CardDesigner extends Designer.DesignContext {
         if (this._hostContainers && this._hostContainers.length > 0) {
             this._hostContainerChoicePicker = new ToolbarChoicePicker(CardDesigner.ToolbarCommands.HostAppPicker);
             this._hostContainerChoicePicker.separator = true;
-            this._hostContainerChoicePicker.label = "Select host app:"
+            this._hostContainerChoicePicker.label = __("hostContainer.label");
 
             for (let i = 0; i < this._hostContainers.length; i++) {
                 this._hostContainerChoicePicker.choices.push(
@@ -703,35 +704,35 @@ export class CardDesigner extends Designer.DesignContext {
 
         this._undoButton = new ToolbarButton(
             CardDesigner.ToolbarCommands.Undo,
-            "Undo",
+            __("undo.label"),
             "acd-icon-undo",
             (sender: ToolbarButton) => { this.undo(); });
         this._undoButton.separator = true;
-        this._undoButton.toolTip = "Undo your last change";
+        this._undoButton.toolTip = __("undo.tooltip");
         this._undoButton.isEnabled = false;
 
         this.toolbar.addElement(this._undoButton);
 
         this._redoButton = new ToolbarButton(
             CardDesigner.ToolbarCommands.Redo,
-            "Redo",
+            __("redo.label"),
             "acd-icon-redo",
             (sender: ToolbarButton) => { this.redo(); });
-        this._redoButton.toolTip = "Redo your last changes";
+        this._redoButton.toolTip = __("redo.tooltip");
         this._redoButton.isEnabled = false;
 
         this.toolbar.addElement(this._redoButton);
 
         this._copyJSONButton = new ToolbarButton(
             CardDesigner.ToolbarCommands.CopyJSON,
-            "Copy card payload",
+            __("copy.label"),
             "acd-icon-copy");
-        this._copyJSONButton.toolTip = "Copy the generated JSON payload of the card (template bound with data) to the clipboard. To copy only the template payload, use the Card Payload Editor.";
+        this._copyJSONButton.toolTip = __("copy.tooltip");
         this.toolbar.addElement(this._copyJSONButton);
 
         this._togglePreviewButton = new ToolbarButton(
             CardDesigner.ToolbarCommands.TogglePreview,
-            "Preview mode",
+            __("preview.label"),
             "acd-icon-preview",
             (sender: ToolbarButton) => { this.togglePreview(); });
         this._togglePreviewButton.separator = true;
@@ -742,17 +743,17 @@ export class CardDesigner extends Designer.DesignContext {
 
         this._helpButton = new ToolbarButton(
             CardDesigner.ToolbarCommands.Help,
-            "Help",
+            __("help.label"),
             "acd-icon-help",
             (sender: ToolbarButton) => { this.showHelp(); });
-        this._helpButton.toolTip = "Display help.";
+        this._helpButton.toolTip = __("help.tooltip");
         this._helpButton.separator = true;
         this._helpButton.alignment = ToolbarElementAlignment.Right;
         this.toolbar.addElement(this._helpButton);
 
         this._fullScreenHandler = new FullScreenHandler();
         this._fullScreenHandler.onFullScreenChanged = (isFullScreen: boolean) => {
-            this._fullScreenButton.toolTip = isFullScreen ? "Exit full screen" : "Enter full screen";
+            this._fullScreenButton.toolTip = isFullScreen ? __("exitFullScreen") : __("enterFullScreen");
 
             this.updateFullLayout();
         }
@@ -760,8 +761,8 @@ export class CardDesigner extends Designer.DesignContext {
 
     private launchImagePopup() {
         let dialog = new OpenImageDialog();
-        dialog.title = "Pic2card Dialog for Image Upload";
-        dialog.closeButton.caption = "Cancel";
+        dialog.title = __("pic2card.title");
+        dialog.closeButton.caption = __("genericCloseButtonCaption");
         dialog.preventLightDismissal = true;
         dialog.width = "80%";
         dialog.height = "80%";
@@ -779,7 +780,7 @@ export class CardDesigner extends Designer.DesignContext {
                 let loadNotification = document.createElement("span");
                 loadNotification.id = "pic2cardLoadNotification";
                 loadNotification.setAttribute("role", "status");
-                loadNotification.setAttribute("aria-label", "Pic2Card generated Adaptive Card loaded");
+                loadNotification.setAttribute("aria-label", __("pic2card.notificationLabel"));
 
                 // It's a bit odd to jump up to the parent element here, but we need a place to park this empty element
                 // so that it's seen by accessibility tools. If we put it on the button itself, the status message gets
@@ -929,7 +930,7 @@ export class CardDesigner extends Designer.DesignContext {
         // Setup card JSON editor
         this._cardEditorToolbox.content = document.createElement("div");
         this._cardEditorToolbox.content.setAttribute("role", "region");
-        this._cardEditorToolbox.content.setAttribute("aria-label", "card payload editor");
+        this._cardEditorToolbox.content.setAttribute("aria-label", __("cardEditor"));
         this._cardEditorToolbox.content.style.overflow = "hidden";
 
         this._cardEditor = monaco.editor.create(
@@ -954,7 +955,7 @@ export class CardDesigner extends Designer.DesignContext {
             // Setup sample data JSON editor
             this._sampleDataEditorToolbox.content = document.createElement("div");
             this._sampleDataEditorToolbox.content.setAttribute("role", "region");
-            this._sampleDataEditorToolbox.content.setAttribute("aria-label", "sample data editor");
+            this._sampleDataEditorToolbox.content.setAttribute("aria-label", __("sampleEditor"));
             this._sampleDataEditorToolbox.content.style.overflow = "hidden";
 
             this._sampleDataEditor = monaco.editor.create(
@@ -1018,17 +1019,17 @@ export class CardDesigner extends Designer.DesignContext {
             '<div id="toolbarHost" role="region" aria-label="toolbar"></div>' +
             '<div class="content" style="display: flex; flex: 1 1 auto; overflow-y: hidden;">' +
                 '<div id="leftCollapsedPaneTabHost" class="acd-verticalCollapsedTabContainer acd-dockedLeft" style="border-right: 1px solid #D2D2D2;"></div>' +
-                '<div id="toolPalettePanel" class="acd-toolPalette-pane" role="region" aria-label="card elements"></div>' +
+                '<div id="toolPalettePanel" class="acd-toolPalette-pane" role="region" aria-label="' + __("cardElements") + '"></div>' +
                 '<div style="display: flex; flex-direction: column; flex: 1 1 100%; overflow: hidden;">' +
                     '<div style="display: flex; flex: 1 1 100%; overflow: hidden;">' +
-                        '<div id="cardArea" class="acd-designer-cardArea" role="region" aria-label="card preview">' +
+                        '<div id="cardArea" class="acd-designer-cardArea" role="region" aria-label="' + __("cardPreview") + '">' +
                             '<div style="flex: 1 1 100%; overflow: auto;">' +
                                 '<div id="designerHost" style="margin: 20px 40px 20px 20px;"></div>' +
                             '</div>' +
                             '<div id="errorPane" class="acd-error-pane acd-hidden"></div>' +
                         '</div>' +
-                        '<div id="treeViewPanel" class="acd-treeView-pane" role="region" aria-label="card structure"></div>' +
-                       '<div id="propertySheetPanel" class="acd-propertySheet-pane" role="region" aria-label="element properties"></div>' +
+                       '<div id="treeViewPanel" class="acd-treeView-pane" role="region" aria-label="' + __("cardStructure") + '"></div>' +
+                       '<div id="propertySheetPanel" class="acd-propertySheet-pane" role="region" aria-label="' + __("elementProperties") + '"></div>' +
                     '</div>' +
                     '<div id="jsonEditorPanel" class="acd-json-editor-pane"></div>' +
                     '<div id="bottomCollapsedPaneTabHost" class="acd-horizontalCollapsedTabContainer" style="border-top: 1px solid #D2D2D2;"></div>' +
@@ -1204,7 +1205,7 @@ export class CardDesigner extends Designer.DesignContext {
 
     showHelp() {
         let helpDialog = new HelpDialog();
-        helpDialog.title = "Help";
+        helpDialog.title = __("help.label");
         helpDialog.open();
     }
 

--- a/source/nodejs/adaptivecards-designer/src/catalogue.ts
+++ b/source/nodejs/adaptivecards-designer/src/catalogue.ts
@@ -1,9 +1,10 @@
 import * as Adaptive from "adaptivecards";
 import { Downloader } from "./downloader";
+import { __ } from './i18n';
 
 export class CatalogueEntry {
     static createEmptyCardEntry(): CatalogueEntry {
-        let result = new CatalogueEntry("Blank card", "");
+        let result = new CatalogueEntry(__("blankCard"), "");
         result._cardPayload = JSON.stringify(
             {
                 type: "AdaptiveCard",
@@ -169,7 +170,7 @@ export class SampleCatalogue {
                 if (this._entries.length === 0) {
                     this._entries = [ CatalogueEntry.createEmptyCardEntry() ];
                 }
-                
+
                 this.downloaded();
             };
             downloader.onSuccess = () => {

--- a/source/nodejs/adaptivecards-designer/src/data.ts
+++ b/source/nodejs/adaptivecards-designer/src/data.ts
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { __ } from './i18n';
+
 function shouldUseIndexerSyntax(name: string): boolean {
     let regEx = /[a-zA-Z0-9_$]*/;
     let matches = regEx.exec(name);
@@ -7,7 +9,7 @@ function shouldUseIndexerSyntax(name: string): boolean {
     // If name doesn't only contain letters/digits/_
     // the accessor must use the indexer syntax
     return !(matches && matches[0] === name);
-}   
+}
 
 export type ValueType = "String" | "Boolean" | "Number" | "Array" | "Object";
 
@@ -55,7 +57,7 @@ export abstract class DataType {
     static parse(parent: FieldDefinition, data: IData): DataType {
         switch (data.valueType) {
             case "String":
-                return new ValueTypeData<string>(parent, "Sample data", data.sampleValue);
+                return new ValueTypeData<string>(parent, __("sampleData"), data.sampleValue);
             case "Number":
                 return new ValueTypeData<number>(parent, 123, data.sampleValue);
             case "Boolean":
@@ -69,7 +71,7 @@ export abstract class DataType {
 
     static deriveFrom(parent: FieldDefinition, value: any): DataType {
         if (typeof value === "string") {
-            return new ValueTypeData<string>(parent, "Sample data", value);
+            return new ValueTypeData<string>(parent, __("sampleData"), value);
         }
         else if (typeof value === "boolean") {
             return new ValueTypeData<boolean>(parent, true, value);

--- a/source/nodejs/adaptivecards-designer/src/i18n.ts
+++ b/source/nodejs/adaptivecards-designer/src/i18n.ts
@@ -1,0 +1,18 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import i18next from "i18next";
+
+var resBundle = require("i18next-resource-store-loader!../assets/languages/index.js");
+
+i18next.init({
+    debug: true, // TODO: remove
+    lng: 'en',
+    ns: 'designer',
+    defaultNS: 'designer',
+    resources: resBundle
+});
+
+export function __(key: any, options?: any) {
+    const result = i18next.t(key, options);
+    return result;
+}

--- a/source/nodejs/adaptivecards-designer/src/strings.ts
+++ b/source/nodejs/adaptivecards-designer/src/strings.ts
@@ -1,29 +1,56 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { __ } from './i18n';
+
+class OverrideableString {
+    private _title: string;
+    private readonly _defaultKey: string;
+
+    constructor(defaultKey: string) {
+        this._defaultKey = defaultKey;
+    }
+
+    get title() : string {
+        if (this._title) {
+            return this._title;
+        }
+        else {
+            return __(this._defaultKey);
+        }
+    }
+
+    set title(value: string) {
+        this._title = value;
+    }
+}
+
+class OverrideablePropertySheetStrings extends OverrideableString {
+    commands: any;
+
+    constructor({ title, commands }) {
+        super(title);
+        this.commands = commands;
+    }
+}
+
 export class Strings {
     static readonly toolboxes = {
-        toolPalette: {
-            title: "CARD ELEMENTS"
-        },
-        cardEditor: {
-            title: "CARD PAYLOAD EDITOR"
-        },
-        sampleDataEditor: {
-            title: "SAMPLE DATA EDITOR"
-        },
-        propertySheet: {
-            title: "ELEMENT PROPERTIES",
+        toolPalette: new OverrideableString("cardElements"),
+        cardEditor: new OverrideableString("cardEditor"),
+        sampleDataEditor: new OverrideableString("sampleEditor"),
+        propertySheet: new OverrideablePropertySheetStrings({
+            title: "elementProperties",
             commands: {
                 bindData: {
-                    displayText: () => "...",
-                    accessibleText: (propertyLabel: string) => "Data Binding"
+                    // TODO: fix this up
+                    displayText: () => __("ellipsis"),
+                    accessibleText: (propertyLabel: string) => __("dataBinding")
                 }
             }
-        },
-        cardStructure: {
-            title: "CARD STRUCTURE"
-        },
-        dataStructure: {
-            title: "DATA STRUCTURE"
-        }
+        }),
+        cardStructure: new OverrideableString("cardStructure"),
+        dataStructure: new OverrideableString("dataStructure")
     };
-    static loadingEditor = "Loading editor...";
+    static loadingEditor = __("loadingEditor");
 }

--- a/source/nodejs/adaptivecards-designer/webpack.config.js
+++ b/source/nodejs/adaptivecards-designer/webpack.config.js
@@ -108,7 +108,12 @@ module.exports = (env, argv) => {
 					from: 'src/containers/**/*.jpg',
 					to: 'containers/',
 					flatten: true
-				}],
+				},
+                {
+                    from: 'assets/languages/**',
+                    to: '.',
+                    flatten: false
+                }],
 				options: {
 					concurrency: 8
 				}


### PR DESCRIPTION
## Description
Add i18n support to designer. Not complete yet (was going through files alphabetically and stopped at `designer-peers.ts`).

@dclaux - before I got too far, I wanted to see what you thought about this approach. I think I want to restructure the translation file a bit, but haven't done that yet. Also, I know that this isn't the framework we talked about, but `i18n` isn't suited for browser apps. 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5685)