### PR TITLE
[Schema] Schema updates for Heading Styles

### DIFF
--- a/schemas/1.5.0/adaptive-card.json
+++ b/schemas/1.5.0/adaptive-card.json
@@ -894,11 +894,25 @@
               "description": "Text to display. Markdown is not supported."
             },
             "color": {
-              "$ref": "#/definitions/Colors",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Colors"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Controls the color of the text."
             },
             "fontType": {
-              "$ref": "#/definitions/FontType",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/FontType"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "The type of font to use"
             },
             "highlight": {
@@ -906,7 +920,14 @@
               "description": "If `true`, displays the text highlighted."
             },
             "isSubtle": {
-              "type": "boolean",
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "If `true`, displays text slightly toned down to appear less prominent.",
               "default": false
             },
@@ -919,7 +940,14 @@
               "description": "Action to invoke when this text run is clicked. Visually changes the text run into a hyperlink. `Action.ShowCard` is not supported."
             },
             "size": {
-              "$ref": "#/definitions/FontSize",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/FontSize"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Controls size of text."
             },
             "strikethrough": {
@@ -932,7 +960,14 @@
               "version": "1.3"
             },
             "weight": {
-              "$ref": "#/definitions/FontWeight",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/FontWeight"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Controls the weight of the text."
             }
           },
@@ -1405,11 +1440,25 @@
           "description": "Text to display. A subset of markdown is supported (https://aka.ms/ACTextFeatures)"
         },
         "color": {
-          "$ref": "#/definitions/Colors",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Colors"
+            },
+            {
+              "type": "null"
+            }
+          ],
           "description": "Controls the color of `TextBlock` elements."
         },
         "fontType": {
-          "$ref": "#/definitions/FontType",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FontType"
+            },
+            {
+              "type": "null"
+            }
+          ],
           "description": "Type of font to use for rendering",
           "version": "1.2"
         },
@@ -1418,7 +1467,14 @@
           "description": "Controls the horizontal text alignment."
         },
         "isSubtle": {
-          "type": "boolean",
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
           "description": "If `true`, displays text slightly toned down to appear less prominent.",
           "default": false
         },
@@ -1427,11 +1483,25 @@
           "description": "Specifies the maximum number of lines to display."
         },
         "size": {
-          "$ref": "#/definitions/FontSize",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FontSize"
+            },
+            {
+              "type": "null"
+            }
+          ],
           "description": "Controls size of text."
         },
         "weight": {
-          "$ref": "#/definitions/FontWeight",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FontWeight"
+            },
+            {
+              "type": "null"
+            }
+          ],
           "description": "Controls the weight of `TextBlock` elements."
         },
         "wrap": {
@@ -1440,9 +1510,16 @@
           "default": false
         },
         "style": {
-          "$ref": "#/definitions/TextBlockStyle",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TextBlockStyle"
+            },
+            {
+              "type": "null"
+            }
+          ],
           "description": "The style of this TextBlock for accessibility purposes.",
-          "default": "paragraph"
+          "default": "default"
         },
         "fallback": {},
         "height": {},
@@ -1698,12 +1775,12 @@
       "anyOf": [
         {
           "enum": [
-            "paragraph",
+            "default",
             "heading"
           ]
         },
         {
-          "pattern": "^([p|P][a|A][r|R][a|A][g|G][r|R][a|A][p|P][h|H])|([h|H][e|E][a|A][d|D][i|I][n|N][g|G])$"
+          "pattern": "^([d|D][e|E][f|F][a|A][u|U][l|L][t|T])|([h|H][e|E][a|A][d|D][i|I][n|N][g|G])$"
         }
       ]
     },

--- a/schemas/host-config.json
+++ b/schemas/host-config.json
@@ -156,22 +156,24 @@
 			"description": "Controls the display of `FactSet`s",
 			"properties": {
 				"title": {
-					"$ref": "#/definitions/TextBlockConfig",
+					"$ref": "#/definitions/FactSetTextConfig",
 					"default": {
 						"weight": "bolder",
 						"size": "default",
 						"color": "default",
+						"fontType": "default",
 						"isSubtle": false,
 						"wrap": true,
 						"maxWidth": 150
 					}
 				},
 				"value": {
-					"$ref": "#/definitions/TextBlockConfig",
+					"$ref": "#/definitions/FactSetTextConfig",
 					"default": {
 						"weight": "default",
 						"size": "default",
 						"color": "default",
+						"fontType": "default",
 						"isSubtle": false,
 						"wrap": true,
 						"maxWidth": 0
@@ -545,13 +547,13 @@
 				}
 			}
 		},
-		"TextBlockConfig": {
+		"FactSetTextConfig": {
 			"type": "object",
-			"description": "Parameters controlling the display of text",
+			"description": "Parameters controlling the display of text in a fact set",
 			"properties": {
 				"size": {
 					"type": "string",
-					"description": "Font size to use when a card doesn't specify",
+					"description": "Size of font for fact set text",
 					"enum": [
 						"default",
 						"small",
@@ -563,7 +565,7 @@
 				},
 				"weight": {
 					"type": "string",
-					"description": "Font weight to use when a card doesn't specify",
+					"description": "Weight of font for fact set text",
 					"enum": [
 						"normal",
 						"lighter",
@@ -573,7 +575,7 @@
 				},
 				"color": {
 					"type": "string",
-					"description": "Font color to use when a card doesn't specify",
+					"description": "Color of font for fact set text",
 					"enum": [
 						"default",
 						"dark",
@@ -585,76 +587,162 @@
 					],
 					"default": "default"
 				},
+				"fontType": {
+					"type": "string",
+					"description": "Font Type for fact set text",
+					"enum": [
+						"default",
+						"monospace"
+					],
+					"default": "default"
+				},
 				"isSubtle": {
 					"type": "boolean",
-					"description": "Should text be subtle if a card doesn't specify",
+					"description": "Indicates if fact set text should be subtle",
 					"default": false
 				},
 				"wrap": {
 					"type": "boolean",
-					"description": "Should text wrap if a card doesn't specify",
+					"description": "Indicates if fact set text should wrap",
 					"default": true
 				},
 				"maxWidth": {
 					"type": "integer",
-					"description": "Maximum width to use if a card doesn't specify",
+					"description": "Maximum width of fact set text",
 					"default": 0
 				}
 			}
-		}
-	},
-	"type": "object",
-	"properties": {
-		"supportsInteractivity": {
-			"type": "boolean",
-			"description": "Control whether interactive `Action`s are allowed to be invoke",
-			"default": true
 		},
-		"imageBaseUrl": {
-			"type": "string",
-			"format": "uri",
-			"description": "Base URL to be used when loading resources"
+		"TextStyleConfig": {
+			"type": "object",
+			"description": "Sets default properties for text of a given style",
+			"properties": {
+				"size": {
+					"type": "string",
+					"description": "Default font size for text of this style",
+					"enum": [
+						"default",
+						"small",
+						"medium",
+						"large",
+						"extraLarge"
+					],
+					"default": "default"
+				},
+				"weight": {
+					"type": "string",
+					"description": "Default font weight for text of this style",
+					"enum": [
+						"normal",
+						"lighter",
+						"bolder"
+					],
+					"default": "normal"
+				},
+				"color": {
+					"type": "string",
+					"description": "Default font color for text of this style",
+					"enum": [
+						"default",
+						"dark",
+						"light",
+						"accent",
+						"good",
+						"warning",
+						"attention"
+					],
+					"default": "default"
+				},
+				"fontType": {
+					"type": "string",
+					"description": "Default font type for text of this style",
+					"enum": [
+						"default",
+						"monospace"
+					],
+					"default": "default"
+				},
+				"isSubtle": {
+					"type": "boolean",
+					"description": "Whether text of this style should be subtle by default",
+					"default": false
+				}
+			}
 		},
-		"fontFamily": {
-			"type": "string",
-			"description": "Font face to use when rendering text",
-			"default": "Calibri"
+		"TextStylesConfig": {
+			"type": "object",
+			"description": "Configuration settings for TextBocks",
+			"properties": {
+				"heading": {
+					"$ref": "#/definitions/TextStyleConfig",
+					"default": {
+						"weight": "bolder",
+						"size": "large",
+						"color": "default",
+						"fontType": "default",
+						"isSubtle": false
+					}
+				}
+			}
 		},
-		"actions": {
-			"$ref": "#/definitions/ActionsConfig"
-		},
-		"adaptiveCard": {
-			"$ref": "#/definitions/AdaptiveCardConfig"
-		},
-		"containerStyles": {
-			"$ref": "#/definitions/ContainerStylesConfig"
-		},
-		"imageSizes": {
-			"$ref": "#/definitions/ImageSizesConfig"
-		},
-		"imageSet": {
-			"$ref": "#/definitions/ImageSetConfig"
-		},
-		"factSet": {
-			"$ref": "#/definitions/FactSetConfig"
-		},
-		"fontSizes": {
-			"$ref": "#/definitions/FontSizesConfig"
-		},
-		"fontWeights": {
-			"$ref": "#/definitions/FontWeightsConfig"
-		},
-		"spacing": {
-			"$ref": "#/definitions/SpacingsConfig"
-		},
-		"separator": {
-			"$ref": "#/definitions/SeparatorConfig"
-		},
-		"media": {
-			"$ref": "#/definitions/MediaConfig"
-		},
-		"inputs":{
-			"$ref": "#/definitions/InputsConfig"
+		"type": "object",
+		"properties": {
+			"supportsInteractivity": {
+				"type": "boolean",
+				"description": "Control whether interactive `Action`s are allowed to be invoke",
+				"default": true
+			},
+			"imageBaseUrl": {
+				"type": "string",
+				"format": "uri",
+				"description": "Base URL to be used when loading resources"
+			},
+			"fontFamily": {
+				"type": "string",
+				"description": "Font face to use when rendering text",
+				"default": "Calibri"
+			},
+			"actions": {
+				"$ref": "#/definitions/ActionsConfig"
+			},
+			"adaptiveCard": {
+				"$ref": "#/definitions/AdaptiveCardConfig"
+			},
+			"containerStyles": {
+				"$ref": "#/definitions/ContainerStylesConfig"
+			},
+			"imageSizes": {
+				"$ref": "#/definitions/ImageSizesConfig"
+			},
+			"imageSet": {
+				"$ref": "#/definitions/ImageSetConfig"
+			},
+			"factSet": {
+				"$ref": "#/definitions/FactSetConfig"
+			},
+			"fontSizes": {
+				"$ref": "#/definitions/FontSizesConfig"
+			},
+			"fontWeights": {
+				"$ref": "#/definitions/FontWeightsConfig"
+			},
+			"spacing": {
+				"$ref": "#/definitions/SpacingsConfig"
+			},
+			"separator": {
+				"$ref": "#/definitions/SeparatorConfig"
+			},
+			"media": {
+				"$ref": "#/definitions/MediaConfig"
+			},
+			"inputs": {
+				"$ref": "#/definitions/InputsConfig"
+			},
+			"textBlock": {
+				"$ref": "#/definitions/TextBlockConfig"
+			},
+			"textStyles": {
+				"$ref": "#/definitions/TextStylesConfig"
+			}
 		}
 	}
-}

--- a/schemas/src/elements/TextBlock.json
+++ b/schemas/src/elements/TextBlock.json
@@ -9,11 +9,11 @@
       "required": true
     },
     "color": {
-      "type": "Colors",
+      "type": "Colors?",
       "description": "Controls the color of `TextBlock` elements."
     },
     "fontType": {
-      "type": "FontType",
+      "type": "FontType?",
       "description": "Type of font to use for rendering",
       "version": "1.2"
     },
@@ -22,7 +22,7 @@
       "description": "Controls the horizontal text alignment."
     },
     "isSubtle": {
-      "type": "boolean",
+      "type": "boolean?",
       "description": "If `true`, displays text slightly toned down to appear less prominent.",
       "default": false
     },
@@ -31,11 +31,11 @@
       "description": "Specifies the maximum number of lines to display."
     },
     "size": {
-      "type": "FontSize",
+      "type": "FontSize?",
       "description": "Controls size of text."
     },
     "weight": {
-      "type": "FontWeight",
+      "type": "FontWeight?",
       "description": "Controls the weight of `TextBlock` elements."
     },
     "wrap": {
@@ -44,9 +44,9 @@
       "default": false
     },
     "style": {
-      "type": "TextBlockStyle",
+      "type": "TextBlockStyle?",
       "description": "The style of this TextBlock for accessibility purposes.",
-      "default": "paragraph"
+      "default": "default"
     }
   }
 }

--- a/schemas/src/elements/inlines/TextRun.json
+++ b/schemas/src/elements/inlines/TextRun.json
@@ -10,11 +10,11 @@
       "required": true
     },
     "color": {
-      "type": "Colors",
+      "type": "Colors?",
       "description": "Controls the color of the text."
     },
     "fontType": {
-      "type": "FontType",
+      "type": "FontType?",
       "description": "The type of font to use"
     },
     "highlight": {
@@ -22,7 +22,7 @@
       "description": "If `true`, displays the text highlighted."
     },
     "isSubtle": {
-      "type": "boolean",
+      "type": "boolean?",
       "description": "If `true`, displays text slightly toned down to appear less prominent.",
       "default": false
     },
@@ -35,7 +35,7 @@
       "description": "Action to invoke when this text run is clicked. Visually changes the text run into a hyperlink. `Action.ShowCard` is not supported."
     },
     "size": {
-      "type": "FontSize",
+      "type": "FontSize?",
       "description": "Controls size of text."
     },
     "strikethrough": {
@@ -48,7 +48,7 @@
       "version":"1.3"
     },
     "weight": {
-      "type": "FontWeight",
+      "type": "FontWeight?",
       "description": "Controls the weight of the text."
     }
   },

--- a/schemas/src/enums/TextBlockStyle.json
+++ b/schemas/src/enums/TextBlockStyle.json
@@ -5,12 +5,12 @@
     "version": "1.5",
     "values": [
       {
-        "value": "paragraph",
-        "description": "This is the default style. The TextBlock behaves as standard content and will be read as such by accessibility software."
+        "value": "default",
+        "description": "This is the default style which provide no special styling or behavior."
       },
       {
         "value": "heading",
-        "description": "The TextBlock behaves as a heading which impacts how accessibility software handles navigation and narration."
+        "description": "The TextBlock is a heading. This will apply the heading styling defaults and mark the text block as a heading for accessiblity."
       }
     ]
   }


### PR DESCRIPTION
# Related Issue

Fixes #5637

# Description

- Updates to Adaptive Cards schema (Adaptive cards schema is generated via a tool from source files in schemas\src)
    - TextBlock properties color, fontType, isSubtle, size, weight, and style are now nullable
    - TextBlock properties color, fontType, isSubtle, size, and weight are now nullable
   
- Update Host Config schema  
    - Rename TextBlockConfig to FactSetTextConfig
    - Add TextStyleConfig and TextStylesConfig
    - Add FontType to FactSetTextConfig (this should have already been there but was missing)



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5717)