### PR TITLE
[Chore] Fix issue template labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/app_rendering_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/app_rendering_bug_report.md
@@ -2,7 +2,7 @@
 name: Application Card Rendering Bug Report
 about: Create a bug report for problems rendering Adaptive Cards in an Application
 title: "[Rendering] Bug Title Here"
-labels: Bug Triage-Needed Area-Renderers
+labels: Bug, Triage-Needed, Area-Renderers
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/card_author_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/card_author_bug_report.md
@@ -2,7 +2,7 @@
 name: Card Author Bug Report
 about: Create a bug report for problems creating Adaptive Cards from the JSON Schema
 title: "[Authoring] Bug Title Here"
-labels: Bug Triage-Needed Area-Schema
+labels: Bug, Triage-Needed, Area-Schema
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature Request
 about: Suggest a feature you'd like to enable using AdaptiveCards
 title: "[Feature Request] Feature Title Here"
-labels: Request Triage-Needed
+labels: Request, Triage-Needed
 assignees: ''
 ---
 


### PR DESCRIPTION
# Related Issue

N/A

# Description

Github labels aren't being applied to new issues. This PR adds commas ([see docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/manually-creating-a-single-issue-template-for-your-repository)).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5747)