### PR TITLE
Fix duplicate aria-labelledby ids in inputs

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -2484,6 +2484,10 @@ export abstract class Input extends CardElement implements IInput {
     protected getAllLabelIds(): string[] {
         let labelIds: string[] = [];
 
+        if (this.labelledBy) {
+            labelIds.push(this.labelledBy);
+        }
+
         if (this._renderedLabelElement) {
             labelIds.push(this._renderedLabelElement.id);
         }
@@ -2498,18 +2502,6 @@ export abstract class Input extends CardElement implements IInput {
     protected updateInputControlAriaLabelledBy() {
         if (this._renderedInputControlElement) {
             let labelIds: string[] = this.getAllLabelIds();
-
-            if (this.labelledBy) {
-                labelIds.push(this.labelledBy);
-            }
-
-            if (this._renderedLabelElement) {
-                labelIds.push(this._renderedLabelElement.id);
-            }
-
-            if (this._renderedErrorMessageElement) {
-                labelIds.push(this._renderedErrorMessageElement.id);
-            }
 
             if (labelIds.length > 0) {
                 this._renderedInputControlElement.setAttribute("aria-labelledby", labelIds.join(" "));


### PR DESCRIPTION
# Related Issue

Fixes https://github.com/microsoft/AdaptiveCards/issues/5686

# Description

- A previous merge caused code that had been moved from one method to another to be exist in both methods. This PR removes the duplicated code.
- This bug applied to all inputs, not just Input.ChoiceSet

# Sample Card

```json
{
    "type": "AdaptiveCard",
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
    "version": "1.3",
    "body": [
        {
            "type": "Input.Text",
            "placeholder": "Placeholder text",
            "label": "Text input label"
        },
        {
            "type": "Input.ChoiceSet",
            "choices": [
                {
                    "title": "Choice 1",
                    "value": "Choice 1"
                },
                {
                    "title": "Choice 2",
                    "value": "Choice 2"
                }
            ],
            "placeholder": "Placeholder text",
            "label": "ChoiceSet input label"
        }
    ]
}
```

# How Verified

Verified manually in adaptivecards-designer-app

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5750)