### PR TITLE
[Chore] Mark SWIG files as generated

### DIFF
--- a/source/android/adaptivecards/src/main/cpp/.gitattributes
+++ b/source/android/adaptivecards/src/main/cpp/.gitattributes
@@ -1,0 +1,8 @@
+###############################################################################
+# Configure Github language/diffs (see github/linguist)
+#
+# Mark SWIG-generated files appropriately
+###############################################################################
+
+/objectmodel_wrap.cpp linguist-generated
+/objectmodel_wrap.h linguist-generated

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/.gitattributes
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/.gitattributes
@@ -1,0 +1,7 @@
+###############################################################################
+# Configure Github language/diffs (see github/linguist)
+#
+# Mark SWIG-generated files appropriately
+###############################################################################
+
+/objectmodel/* linguist-generated


### PR DESCRIPTION
# Related Issue

N/A

# Description

SWIG-generated files aren't useful in PR diffs, so this tells Github to auto-hide them during reviews (additionally, removes them from repo language statistics). See: [linguist-generated](https://github.com/github/linguist/blob/master/docs/overrides.md#generated-code).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5756)