### PR TITLE
[Shared] Add table section to hostconfig

### DIFF
--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/AdaptiveCardsSharedModelUnitTest.vcxproj
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/AdaptiveCardsSharedModelUnitTest.vcxproj
@@ -250,6 +250,7 @@
     <ClCompile Include="ContainerStyleTest.cpp" />
     <ClCompile Include="ElementTest.cpp" />
     <ClCompile Include="FallbackTests.cpp" />
+    <ClCompile Include="HostConfigTest.cpp" />
     <ClCompile Include="TableTests.cpp" />
     <ClCompile Include="TextParsingTest.cpp" />
     <ClCompile Include="UnsupportedtypesParsingTest.cpp" />

--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/AdaptiveCardsSharedModelUnitTest.vcxproj.filters
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/AdaptiveCardsSharedModelUnitTest.vcxproj.filters
@@ -95,6 +95,9 @@
     <ClCompile Include="TableTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="HostConfigTest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="EverythingBagel.json">

--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/HostConfigTest.cpp
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/HostConfigTest.cpp
@@ -1,0 +1,33 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#include "stdafx.h"
+#include "HostConfig.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace AdaptiveCards;
+
+namespace AdaptiveCardsSharedModelUnitTest
+{
+    TEST_CLASS(HostConfigTest)
+    {
+    public:
+        TEST_METHOD(DeserializeTableTest)
+        {
+            const std::string tableConfigJson = R"({
+   "table": {
+       "cellSpacing": 11
+   }
+})";
+
+            const auto hostConfig = HostConfig::DeserializeFromString(tableConfigJson);
+            const auto tableConfig = hostConfig.GetTable();
+            Assert::AreEqual(11ui32, tableConfig.cellSpacing);
+        }
+
+        TEST_METHOD(DeserializeDefaultTableTest)
+        {
+            const auto hostConfig = HostConfig::DeserializeFromString("{}");
+            Assert::AreEqual(8ui32, hostConfig.GetTable().cellSpacing);
+        }
+    };
+}

--- a/source/shared/cpp/ObjectModel/Enums.cpp
+++ b/source/shared/cpp/ObjectModel/Enums.cpp
@@ -36,6 +36,7 @@ namespace AdaptiveCards
             {AdaptiveCardSchemaKey::ButtonSpacing, "buttonSpacing"},
             {AdaptiveCardSchemaKey::Buttons, "buttons"},
             {AdaptiveCardSchemaKey::Card, "card"},
+            {AdaptiveCardSchemaKey::CellSpacing, "cellSpacing"},
             {AdaptiveCardSchemaKey::Cells, "cells"},
             {AdaptiveCardSchemaKey::Center, "center"},
             {AdaptiveCardSchemaKey::ChoiceSet, "choiceSet"},

--- a/source/shared/cpp/ObjectModel/Enums.h
+++ b/source/shared/cpp/ObjectModel/Enums.h
@@ -38,6 +38,7 @@ namespace AdaptiveCards
         ButtonSpacing,
         Buttons,
         Card,
+        CellSpacing,
         Cells,
         Center,
         ChoiceSet,

--- a/source/shared/cpp/ObjectModel/HostConfig.cpp
+++ b/source/shared/cpp/ObjectModel/HostConfig.cpp
@@ -14,13 +14,13 @@ HostConfig HostConfig::DeserializeFromString(const std::string& jsonString)
 HostConfig HostConfig::Deserialize(const Json::Value& json)
 {
     HostConfig result;
-    std::string fontFamily = ParseUtil::GetString(json, AdaptiveCardSchemaKey::FontFamily);
+    std::string fontFamily = ParseUtil::TryGetString(json, AdaptiveCardSchemaKey::FontFamily);
     result._fontFamily = fontFamily != "" ? fontFamily : result._fontFamily;
 
     result._supportsInteractivity =
-        ParseUtil::GetBool(json, AdaptiveCardSchemaKey::SupportsInteractivity, result._supportsInteractivity);
+        ParseUtil::GetOptionalBool(json, AdaptiveCardSchemaKey::SupportsInteractivity, false).value_or(result._supportsInteractivity);
 
-    result._imageBaseUrl = ParseUtil::GetString(json, AdaptiveCardSchemaKey::ImageBaseUrl);
+    result._imageBaseUrl = ParseUtil::TryGetString(json, AdaptiveCardSchemaKey::ImageBaseUrl);
 
     result._factSet = ParseUtil::ExtractJsonValueAndMergeWithDefault<FactSetConfig>(json,
                                                                                     AdaptiveCardSchemaKey::FactSet,
@@ -84,6 +84,9 @@ HostConfig HostConfig::Deserialize(const Json::Value& json)
                                                                                       AdaptiveCardSchemaKey::Headings,
                                                                                       result._headings,
                                                                                       HeadingsConfig::Deserialize);
+
+    result._table =
+        ParseUtil::ExtractJsonValueAndMergeWithDefault<TableConfig>(json, AdaptiveCardSchemaKey::Table, result._table, TableConfig::Deserialize);
 
     return result;
 }
@@ -488,6 +491,15 @@ HeadingsConfig HeadingsConfig::Deserialize(const Json::Value& json, const Headin
     HeadingsConfig result;
 
     result.level = ParseUtil::GetInt(json, AdaptiveCardSchemaKey::Level, defaultValue.level);
+
+    return result;
+}
+
+TableConfig TableConfig::Deserialize(const Json::Value& json, const TableConfig& defaultValue)
+{
+    TableConfig result;
+
+    result.cellSpacing = ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::CellSpacing, defaultValue.cellSpacing);
 
     return result;
 }
@@ -926,4 +938,14 @@ HeadingsConfig HostConfig::GetHeadings() const
 void HostConfig::SetHeadings(const HeadingsConfig value)
 {
     _headings = value;
+}
+
+TableConfig HostConfig::GetTable() const
+{
+    return _table;
+}
+
+void HostConfig::SetTable(const TableConfig value)
+{
+    _table = value;
 }

--- a/source/shared/cpp/ObjectModel/HostConfig.h
+++ b/source/shared/cpp/ObjectModel/HostConfig.h
@@ -350,6 +350,12 @@ namespace AdaptiveCards
         static HeadingsConfig Deserialize(const Json::Value& json, const HeadingsConfig& defaultValue);
     };
 
+    struct TableConfig
+    {
+        unsigned int cellSpacing = 8;
+        static TableConfig Deserialize(const Json::Value& json, const TableConfig& defaultValue);
+    };
+
     class HostConfig
     {
     public:
@@ -422,6 +428,9 @@ namespace AdaptiveCards
         HeadingsConfig GetHeadings() const;
         void SetHeadings(const HeadingsConfig value);
 
+        TableConfig GetTable() const;
+        void SetTable(const TableConfig value);
+
     private:
         const ContainerStyleDefinition& GetContainerStyle(ContainerStyle style) const;
         const ColorConfig& GetContainerColorConfig(const ColorsConfig& colors, ForegroundColor color) const;
@@ -444,5 +453,6 @@ namespace AdaptiveCards
         MediaConfig _media;
         InputsConfig _inputs;
         HeadingsConfig _headings;
+        TableConfig _table;
     };
 }

--- a/source/shared/cpp/ObjectModel/ParseUtil.cpp
+++ b/source/shared/cpp/ObjectModel/ParseUtil.cpp
@@ -73,15 +73,13 @@ namespace AdaptiveCards
 
     std::string ParseUtil::TryGetString(const Json::Value& json, AdaptiveCardSchemaKey key)
     {
-        const std::string& propertyName = AdaptiveCardSchemaKeyToString(key);
-        auto propertyValue = json.get(propertyName, Json::Value());
-        if (propertyValue.empty() || !propertyValue.isString())
+        try
+        {
+            return GetString(json, key);
+        }
+        catch (Json::Exception&)
         {
             return "";
-        }
-        else
-        {
-            return propertyValue.asString();
         }
     }
 

--- a/source/shared/cpp/ObjectModel/ParseUtil.h
+++ b/source/shared/cpp/ObjectModel/ParseUtil.h
@@ -245,8 +245,20 @@ namespace AdaptiveCards
                                                      const T& defaultValue,
                                                      const std::function<T(const Json::Value&, const T&)>& deserializer)
     {
-        auto jsonObject = ParseUtil::ExtractJsonValue(rootJson, key);
-        T result = jsonObject.empty() ? defaultValue : deserializer(jsonObject, defaultValue);
+        T result = defaultValue;
+        try
+        {
+            auto jsonObject = ParseUtil::ExtractJsonValue(rootJson, key);
+            if (!jsonObject.empty())
+            {
+                result = deserializer(jsonObject, defaultValue);
+            }
+        }
+        catch (Json::Exception&)
+        {
+            // value missing
+        }
+
         return result;
     }
 


### PR DESCRIPTION
# Related Issue

Fixes #5846

# Description

Add missing `table` section (with `cellSpacing` option) to `HostConfig`. Note that in order to get this under test, I relaxed `HostConfig::Deserialize` to allow for sparse parsing of the JSON document. Before this, host configs had to have every section defined in order to pass parsing, which isn't really what we want.

# How Verified

* new unit tests
