### PR TITLE
[JS] Don't expand ShowCard inline in Popup mode

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -4831,6 +4831,7 @@ class ActionCollection {
 
     private expandShowCardAction(action: ShowCardAction, raiseEvent: boolean) {
         let afterSelectedAction = false;
+
         for (const button of this._buttons) {
             // remove actions after selected action from tabOrder, to skip focus directly to expanded card
             if (afterSelectedAction) {
@@ -4910,7 +4911,7 @@ class ActionCollection {
             if (action === this._expandedAction) {
                 this.collapseExpandedAction();
             }
-            else {
+            else if (this._owner.hostConfig.actions.showCard.actionMode === Enums.ShowCardActionMode.Inline) {
                 this.expandShowCardAction(action, true);
             }
         }


### PR DESCRIPTION
# Related Issue

Fixes https://github.com/microsoft/AdaptiveCards/issues/5450

# Description
Action.ShowCard would always expand the action's card inline even if HostConfig was configured with `"actions.showCard.mode": "popup"`. This change fixes that.

# Sample Card

The default card in the designer will do, but testing this also requires a HostConfig configured as described above.

# How Verified

Verified manually in adaptivecards-designer-app

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5861)