### PR TITLE
[Shared] Add columnHeader HostConfig object

### DIFF
--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/HostConfigTest.cpp
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/HostConfigTest.cpp
@@ -14,10 +14,10 @@ namespace AdaptiveCardsSharedModelUnitTest
         TEST_METHOD(DeserializeTableTest)
         {
             const std::string tableConfigJson = R"({
-   "table": {
-       "cellSpacing": 11
-   }
-})";
+               "table": {
+                   "cellSpacing": 11
+               }
+            })";
 
             const auto hostConfig = HostConfig::DeserializeFromString(tableConfigJson);
             const auto tableConfig = hostConfig.GetTable();
@@ -29,5 +29,43 @@ namespace AdaptiveCardsSharedModelUnitTest
             const auto hostConfig = HostConfig::DeserializeFromString("{}");
             Assert::AreEqual(8ui32, hostConfig.GetTable().cellSpacing);
         }
+
+        TEST_METHOD(DeserializeColumnHeaderTest)
+        {
+            const std::string columnHeaderJson = R"({
+                "textStyles": {
+                    "columnHeader": {
+                        "size": "small",
+                        "weight": "normal",
+                        "color": "accent",
+                        "isSubtle": true,
+                        "fontType": "monospace"
+                    }
+                }
+            })";
+
+            const auto hostConfig = HostConfig::DeserializeFromString(columnHeaderJson);
+            const auto columnConfig = hostConfig.GetTextStyles().columnHeader;
+
+            Assert::IsTrue(columnConfig.weight == TextWeight::Default);
+            Assert::IsTrue(columnConfig.size == TextSize::Small);
+            Assert::IsTrue(columnConfig.isSubtle);
+            Assert::IsTrue(columnConfig.color == ForegroundColor::Accent);
+            Assert::IsTrue(columnConfig.fontType == FontType::Monospace);
+        }
+
+        TEST_METHOD(DeserializeDefaultColumnHeaderTest)
+        {
+            const auto hostConfig = HostConfig::DeserializeFromString("{}");
+            const auto actualConfig = hostConfig.GetTextStyles().columnHeader;
+            const TextStyleConfig expectedConfig{TextWeight::Bolder, TextSize::Default, false, ForegroundColor::Default, FontType::Default};
+
+            Assert::IsTrue(expectedConfig.weight == actualConfig.weight);
+            Assert::IsTrue(expectedConfig.size == actualConfig.size);
+            Assert::IsTrue(expectedConfig.isSubtle == actualConfig.isSubtle);
+            Assert::IsTrue(expectedConfig.color == actualConfig.color);
+            Assert::IsTrue(expectedConfig.fontType == actualConfig.fontType);
+        }
+
     };
 }

--- a/source/shared/cpp/ObjectModel/Enums.cpp
+++ b/source/shared/cpp/ObjectModel/Enums.cpp
@@ -44,6 +44,7 @@ namespace AdaptiveCards
             {AdaptiveCardSchemaKey::Color, "color"},
             {AdaptiveCardSchemaKey::ColorConfig, "colorConfig"},
             {AdaptiveCardSchemaKey::Column, "column"},
+            {AdaptiveCardSchemaKey::ColumnHeader, "columnHeader"},
             {AdaptiveCardSchemaKey::ColumnSet, "columnSet"},
             {AdaptiveCardSchemaKey::Columns, "columns"},
             {AdaptiveCardSchemaKey::ConnectionName, "connectionName"},

--- a/source/shared/cpp/ObjectModel/Enums.h
+++ b/source/shared/cpp/ObjectModel/Enums.h
@@ -46,6 +46,7 @@ namespace AdaptiveCards
         Color,
         ColorConfig,
         Column,
+        ColumnHeader,
         ColumnSet,
         Columns,
         ConnectionName,

--- a/source/shared/cpp/ObjectModel/HostConfig.cpp
+++ b/source/shared/cpp/ObjectModel/HostConfig.cpp
@@ -240,6 +240,12 @@ TextStylesConfig TextStylesConfig::Deserialize(const Json::Value& json, const Te
                                                                                      AdaptiveCardSchemaKey::Heading,
                                                                                      defaultValue.heading,
                                                                                      TextStyleConfig::Deserialize);
+
+    result.columnHeader = ParseUtil::ExtractJsonValueAndMergeWithDefault<TextStyleConfig>(json,
+                                                                                          AdaptiveCardSchemaKey::ColumnHeader,
+                                                                                          defaultValue.columnHeader,
+                                                                                          TextStyleConfig::Deserialize);
+
     return result;
 }
 

--- a/source/shared/cpp/ObjectModel/HostConfig.h
+++ b/source/shared/cpp/ObjectModel/HostConfig.h
@@ -127,6 +127,7 @@ namespace AdaptiveCards
     struct TextStylesConfig
     {
         TextStyleConfig heading = {TextWeight::Bolder, TextSize::Large, false, ForegroundColor::Default, FontType::Default};
+        TextStyleConfig columnHeader = {TextWeight::Bolder, TextSize::Default, false, ForegroundColor::Default, FontType::Default};
 
         static TextStylesConfig Deserialize(const Json::Value& json, const TextStylesConfig& defaultValue);
     };


### PR DESCRIPTION
# Related Issue

Fixes #5854

# Description

Now that the heading styles HostConfig changes are in, we can get `columnHeader` in.

# How Verified

* new unit tests

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5862)