### PR TITLE
[JS] Fix regressions causing GlobalRegistry not to be initialized

### DIFF
--- a/source/nodejs/adaptivecards/src/registry.ts
+++ b/source/nodejs/adaptivecards/src/registry.ts
@@ -67,6 +67,9 @@ export class CardObjectRegistry<T extends SerializableObject> {
 }
 
 export class GlobalRegistry {
+    private static _elements?: CardObjectRegistry<CardElement>;
+    private static _actions?: CardObjectRegistry<Action>;
+
     static populateWithDefaultElements(registry: CardObjectRegistry<CardElement>) {
         registry.clear();
 
@@ -82,11 +85,26 @@ export class GlobalRegistry {
     static readonly defaultElements = new CardObjectRegistry<CardElement>();
     static readonly defaultActions = new CardObjectRegistry<Action>();
 
-    static readonly elements = new CardObjectRegistry<CardElement>();
-    static readonly actions = new CardObjectRegistry<Action>();
+    static get elements(): CardObjectRegistry<CardElement> {
+        if (!GlobalRegistry._elements) {
+            GlobalRegistry._elements = new CardObjectRegistry<CardElement>();
+            GlobalRegistry.populateWithDefaultElements(GlobalRegistry._elements);
+        }
+
+        return GlobalRegistry._elements;
+    }
+
+    static get actions(): CardObjectRegistry<Action> {
+        if (!GlobalRegistry._actions) {
+            GlobalRegistry._actions = new CardObjectRegistry<Action>();
+            GlobalRegistry.populateWithDefaultActions(GlobalRegistry._actions);
+        }
+
+        return GlobalRegistry._actions;
+    }
 
     static reset() {
-        GlobalRegistry.populateWithDefaultElements(GlobalRegistry.elements);
-        GlobalRegistry.populateWithDefaultActions(GlobalRegistry.actions);
+        GlobalRegistry._elements = undefined;
+        GlobalRegistry._actions = undefined;
     }
 }


### PR DESCRIPTION
# Related Issue

Fixes https://github.com/microsoft/AdaptiveCards/issues/5863

Note this issue has not been shipped, so it isn't an actual problem (unless of course it isn't fixed before we ship)

# Description

The Table work introduced a change in how (or more accurately "when") built-in elements and actions are registered. Namely, the model is now that code files that declare an element or action are also responsible for registering them into the GlobalRegistry instead of the GlobalRegistry registering all built-in components itself. This change was made in order to remove a circular reference between `card-elements.ts` and `registry.ts` and allow the Table implementation to be segregated into its own code file, `table.ts`. The change will also facilitate a future reorganization of the code where the code for other elements and actions will also be moved to separate files.

Unfortunately the change caused the `GlobalRegistry.elements` and `GlobalRegistry.actions` registries not to be initialized anymore and therefore being empty. This breaks applications that rely on these registries (the designer does not, which is why the issue wasn't caught at the time Table was implemented.)

This PR delays the instantiation and initialization of `GlobalRegistry.elements` and `GlobalRegistry.actions` to the moment they are first needed, which ensures they are populated correctly.

# How Verified

Verified manually.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5864)