### PR TITLE
[iOS] Fixed #5559

### DIFF
--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ViewController.m
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ViewController.m
@@ -612,7 +612,8 @@ CGFloat kFileBrowserWidth = 0;
 {
     dispatch_async(_global_queue,
                    ^{
-                       [self.chatWindow reloadRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationNone];
+                       [self.chatWindow beginUpdates];
+                       [self.chatWindow endUpdates];
                    });
 }
 @end


### PR DESCRIPTION
# Related Issue

Fixed #5559 

# Description

Sample app refreshes the row using the visible row property of a UIViewTable when input validation returns the result.
The visible row values are unreliable since the value gets cleared when the table is reloaded. Changed to begin and endUpdates calls.

# Sample Card

If appropriate, please include a link to a card in one of the samples directories that can be used to validate this change. This can be an existing card or a card added with this PR.

# How Verified

Manually verified.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5867)