### PR TITLE
[Android] Fix isVisible: false when height is Stretch

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/BaseCardElementRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/BaseCardElementRenderer.java
@@ -179,6 +179,8 @@ public abstract class BaseCardElementRenderer implements IBaseCardElementRendere
         View separator = null;
         TagContent tagContent = getTagContent(elementView);
 
+        int visibility = isVisible ? View.VISIBLE : View.GONE;
+
         if (tagContent != null)
         {
             separator = tagContent.GetSeparator();
@@ -188,19 +190,17 @@ public abstract class BaseCardElementRenderer implements IBaseCardElementRendere
             {
                 viewGroupsToUpdate.add(viewGroup);
             }
-        }
 
-        int visibility = isVisible ? View.VISIBLE : View.GONE;
+            View stretchContainer = tagContent.GetStretchContainer();
+            if (stretchContainer != null)
+            {
+                stretchContainer.setVisibility(visibility);
+            }
+        }
 
         if (separator != null)
         {
             separator.setVisibility(visibility);
-        }
-
-        View stretchContainer = tagContent.GetStretchContainer();
-        if (stretchContainer != null)
-        {
-            stretchContainer.setVisibility(visibility);
         }
 
         elementView.setVisibility(visibility);

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/registration/CardRendererRegistration.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/registration/CardRendererRegistration.java
@@ -574,7 +574,7 @@ public class CardRendererRegistration
             Util.MoveChildrenViews(mockLayout, stretchElementLayout);
             container.addView(stretchElementLayout);
 
-            tagContent.SetStretchContainer(container);
+            tagContent.SetStretchContainer(stretchElementLayout);
         }
         else
         {


### PR DESCRIPTION
# Related Issue

Fixes #5464 

# Description

The wrong view was being assigned to tagContent's stretchContainer. Additionally, isVisiblity did not include a null-check before accessing stretchContainer. Fixed, so isVisibility: false doesn't cause the renderer to fail when height is Stretch.

# Sample Card

Sample card in issue.

# How Verified

Manually verified sample card works as expected.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5883)