### PR TITLE
[.NET] Unpin Newtonsoft.JSON version

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Rendering.Html/AdaptiveCards.Rendering.Html.csproj
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Html/AdaptiveCards.Rendering.Html.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="[11.0.2, 12.0.3]" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Reflection" Version="4.3.*" />
   </ItemGroup>
 

--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveCards.Rendering.Wpf.csproj
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveCards.Rendering.Wpf.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="[11.0.2, 12.0.3]" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCards.Templating.csproj
+++ b/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCards.Templating.csproj
@@ -54,7 +54,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="[11.0.2, 12.0.3]" NoWarn="NU1605" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" NoWarn="NU1605" />
     <PackageReference Include="Vsxmd" Version="1.4.*">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/dotnet/Library/AdaptiveCards/AdaptiveCards.csproj
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveCards.csproj
@@ -55,7 +55,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="[11.0.2, 12.0.3]" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.*" />
     <PackageReference Include="System.Net.Http" Version="4.3.*" />
     <PackageReference Include="Vsxmd" Version="1.4.*">

--- a/source/dotnet/Test/AdaptiveCards.Rendering.Html.Test/AdaptiveCards.Rendering.Html.Test.csproj
+++ b/source/dotnet/Test/AdaptiveCards.Rendering.Html.Test/AdaptiveCards.Rendering.Html.Test.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.*" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.*" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.*" />
-    <PackageReference Include="Newtonsoft.Json" Version="[11.0.2, 12.0.3]" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/dotnet/Test/AdaptiveCards.Templating.Test/AdaptiveCards.Templating.Test.csproj
+++ b/source/dotnet/Test/AdaptiveCards.Templating.Test/AdaptiveCards.Templating.Test.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.*" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.*" />
     <PackageReference Include="coverlet.collector" Version="1.3.*" />
-    <PackageReference Include="Newtonsoft.Json" Version="[11.0.2, 12.0.3]" NoWarn="NU1605" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" NoWarn="NU1605" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/dotnet/Test/AdaptiveCards.Test/AdaptiveCards.Test.csproj
+++ b/source/dotnet/Test/AdaptiveCards.Test/AdaptiveCards.Test.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.*" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.*" />
     <PackageReference Include="System.Net.Http" Version="4.3.*" />
-    <PackageReference Include="Newtonsoft.Json" Version="[11.0.2, 12.0.3]" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Related Issue

Fixes #5575

# Description

With the current versioning regime, clients of our .NET libraries aren't allowed to use [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json/) `13.x`.

# How Verified

* local build, manual smoke test