### PR TITLE
[Shared] Only validate non-empty locales

### DIFF
--- a/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
+++ b/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
@@ -147,7 +147,11 @@ void AdaptiveCard::_ValidateLanguage(const std::string& language, std::vector<st
 {
     try
     {
-        if (language.empty() || language.length() == 2 || language.length() == 3)
+        if (language.empty())
+        {
+            // no need to validate locale
+        }
+        else if (language.length() == 2)
         {
             auto locale = std::locale(language.c_str());
         }


### PR DESCRIPTION
# Description

`std::locale::locale` was showing up as the top hot path during some perf measuring I was doing. The intent of the code in question is to validate the language identifier supplied in the `AdaptiveCard` `lang` property, which accepts 2-letter language codes according to [our docs](https://adaptivecards.io/explorer/AdaptiveCard.html). Since the `lang` property isn't super common, we should avoid instantiating `std::locale` unless a language was actually supplied.

# How Verified

* local build/unit tests

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5969)