### PR TITLE
Adding an issue template for the designer

### DIFF
--- a/.github/ISSUE_TEMPLATE/designer_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/designer_bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Designer Bug Report
+about: Create a bug report for problems in the Adaptive Cards designer
+title: "[Designer] Bug Title Here"
+labels: Bug, Triage-Needed, Designer
+assignees: ''
+---
+
+# Host Application
+
+Please provide the name of the application that is rendering the card (ex: Bot Framework, Outlook, Teams, etc)
+
+# Target Version
+
+Please provide the Adaptive Cards SDK version (ex: 1.3, 1.4)
+
+# Problem Description
+
+Please enter a description of the issue. If you just have a question, please post [on StackOverflow instead](https://stackoverflow.com/questions/tagged/adaptive-cards)
+
+# Screenshot
+
+Please provide a screenshot of the problem (if possible)
+
+# Card JSON
+
+Please provide the JSON of the Card that is being rendered


### PR DESCRIPTION
# Related Issue

A Pull Request should close a **single** issue; multiple issues can be closed when the issues are **small and related**, but that should be an exception not the rule. Please keep Pull Requests small and targeted; large 'code drops' with dozens of files will be closed and asked to split into reviewable pieces. Reviews that need to be large due to dependencies will be
reviewed on a case-by-case basis.

Please use one of the well-known [github fixes keywords](https://help.github.com/en/articles/closing-issues-using-keywords) to reference
the issue fixed with this PR (eg Fixes #<github issue number>). If an issue doesn't yet exist please create one to aid
in issue tracking.

**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

# Description

Adding an issue template for designer bugs

# Sample Card

N/A

# How Verified

N/A


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5975)