### PR TITLE
[React-Native] Screen reader accessibility fixes

### DIFF
--- a/source/community/reactnative/src/components/elements/image.js
+++ b/source/community/reactnative/src/components/elements/image.js
@@ -290,7 +290,7 @@ export class Img extends React.Component {
 					onPageLayout={this.onPageLayoutHandler}>
 
 					<Image style={imageComputedStyle}
-						accessible={true}
+						accessible={this.payload.altText ? true : false}
 						accessibilityLabel={this.payload.altText}
 						source={{ uri: imageUrl }} />
 				</ElementWrapper>

--- a/source/community/reactnative/src/components/inputs/choice-set/check-box.js
+++ b/source/community/reactnative/src/components/inputs/choice-set/check-box.js
@@ -123,7 +123,10 @@ class CheckBox extends React.PureComponent {
 		return (
 			<TouchableOpacity activeOpacity={1}
 				onPress={this.onChange.bind(this)}
-				style={style}>
+				style={style}
+				accessibilityRole={this.props.isRadioButtonType ? 'radio' : 'checkbox'}
+				accessibilityState={{checked: this.state.checked}}
+				>
 				{this.renderContent()}
 			</TouchableOpacity>
 		)

--- a/source/community/reactnative/src/components/inputs/choice-set/choice-set-input.js
+++ b/source/community/reactnative/src/components/inputs/choice-set/choice-set-input.js
@@ -164,7 +164,7 @@ export class ChoiceSetInput extends React.Component {
 					activeOpacity={1}
 					onPress={onPress}
 					accessible={true}
-					accessibilityRole={'combobox'}
+					accessibilityRole={'button'}
 					accessibilityState={{expanded: this.state.isPickerSelected}}
 					>
 					<View style={this.styleConfig.dropdown}>

--- a/source/community/reactnative/src/components/inputs/choice-set/choice-set-input.js
+++ b/source/community/reactnative/src/components/inputs/choice-set/choice-set-input.js
@@ -162,7 +162,11 @@ export class ChoiceSetInput extends React.Component {
 			<View style={styles.containerView}>
 				{(Platform.OS === Constants.PlatformIOS) && <TouchableOpacity
 					activeOpacity={1}
-					onPress={onPress}>
+					onPress={onPress}
+					accessible={true}
+					accessibilityRole={'combobox'}
+					accessibilityState={{expanded: this.state.isPickerSelected}}
+					>
 					<View style={this.styleConfig.dropdown}>
 						<Text
 							style={[this.styleConfig.dropdownText, this.styleConfig.defaultFontConfig]}
@@ -298,7 +302,7 @@ export class ChoiceSetInput extends React.Component {
 					<ElementWrapper configManager={this.props.configManager} json={this.payload} style={styles.containerView} isError={this.state.isError} isFirst={this.props.isFirst}>
 						<InputLabel configManager={this.props.configManager} isRequired={this.isRequired} label={label} />
 						<View
-							accessible={true}
+							accessible={false}
 							accessibilityLabel={this.payload.altText}
 							style={styles.choiceSetView}>
 							{!isMultiSelect ?

--- a/source/community/reactnative/src/components/inputs/input-label.js
+++ b/source/community/reactnative/src/components/inputs/input-label.js
@@ -19,6 +19,7 @@ export default class InputLabel extends React.Component {
 		this.style = props.style || {};
 		this.isRequired = props.isRequired || false;
 		this.hostConfig = props.configManager.hostConfig;
+		this.altText = props.altText;
 	}
 
 	render() {
@@ -31,7 +32,8 @@ export default class InputLabel extends React.Component {
 						text={label}
 						style={[this.props.configManager.styleConfig.defaultFontConfig, style]}
 						configManager={this.props.configManager}
-						wrap={wrap} />
+						wrap={wrap}
+						altText={this.props.altText} />
 				);
 			} else if (typeof label == Constants.TypeObject && this.isValidLabelType(label.type)) {
 				let element = [];

--- a/source/community/reactnative/src/components/inputs/picker-input.js
+++ b/source/community/reactnative/src/components/inputs/picker-input.js
@@ -83,7 +83,8 @@ export class PickerInput extends React.Component {
 				{({ addInputItem, showErrors }) => (
 					<ElementWrapper configManager={this.props.configManager} style={styles.elementWrapper} json={this.payload} isError={this.state.isError} isFirst={this.props.isFirst}>
 						<InputLabel configManager={this.props.configManager} isRequired={this.isRequired} label={label} />
-						<TouchableOpacity style={styles.inputWrapper} onPress={this.props.showPicker}>
+						<TouchableOpacity style={styles.inputWrapper} onPress={this.props.showPicker}
+						accessibilityRole='button'>
 							{/* added extra view to fix touch event in ios . */}
 							<View
 								accessible={true}

--- a/source/community/reactnative/src/components/inputs/toggle-input.js
+++ b/source/community/reactnative/src/components/inputs/toggle-input.js
@@ -68,15 +68,23 @@ export class ToggleInput extends React.Component {
 						}
 						return (
 							<View
-								accessible={Platform.OS===Constants.PlatformIOS ? true : undefined}
-								accessibilityLabel={Platform.OS===Constants.PlatformIOS ? this.altText : undefined}
+								accessible={true}
+								accessibilityLabel={this.altText}
 								style={styles.toggleView}
-								accessibilityRole={Platform.OS === Constants.PlatformIOS ? 'switch' : undefined}
-								onAccessibilityTap={
-									() => {Platform.OS === Constants.PlatformIOS && this.toggleValueChanged(!this.state.toggleValue, addInputItem)}
+								accessibilityRole={'switch'}
+								onAccessibilityAction={
+									(event) => {
+										if (event.nativeEvent.actionName === 'activate') {
+											this.toggleValueChanged(!this.state.toggleValue, addInputItem);
+										}
+									}
 								}
-								accessibilityState={Platform.OS === Constants.PlatformIOS ? {checked: this.state.toggleValue} : undefined}>
+								accessibilityActions={[{name: 'activate'}]}
+								accessibilityState={{checked: this.state.toggleValue}}
+							>
 								<Switch
+									accessible={false}
+									importantForAccessibility='no-hide-descendants'
 									style={styles.switch}
 									value={toggleValue}
 									onValueChange={toggleValue => {
@@ -84,7 +92,7 @@ export class ToggleInput extends React.Component {
 									}}>
 								</Switch>
 								<View style={styles.titleContainer}>
-									<InputLabel configManager={this.props.configManager} isRequired={this.isRequired} wrap={this.wrapText} style={styles.title} label={this.title} altText={this.altText}/>
+									<InputLabel configManager={this.props.configManager} isRequired={this.isRequired} wrap={this.wrapText} style={styles.title} label={this.title}/>
 								</View>
 							</View>
 						)

--- a/source/community/reactnative/src/components/inputs/toggle-input.js
+++ b/source/community/reactnative/src/components/inputs/toggle-input.js
@@ -8,7 +8,8 @@ import React from 'react';
 import {
 	Switch,
 	StyleSheet,
-	View
+	View,
+	Platform
 } from 'react-native';
 
 import { InputContextConsumer } from '../../utils/context';
@@ -67,9 +68,14 @@ export class ToggleInput extends React.Component {
 						}
 						return (
 							<View
-								accessible={true}
-								accessibilityLabel={this.altText}
-								style={styles.toggleView}>
+								accessible={Platform.OS===Constants.PlatformIOS ? true : undefined}
+								accessibilityLabel={Platform.OS===Constants.PlatformIOS ? this.altText : undefined}
+								style={styles.toggleView}
+								accessibilityRole={Platform.OS === Constants.PlatformIOS ? 'switch' : undefined}
+								onAccessibilityTap={
+									() => {Platform.OS === Constants.PlatformIOS && this.toggleValueChanged(!this.state.toggleValue, addInputItem)}
+								}
+								accessibilityState={Platform.OS === Constants.PlatformIOS ? {checked: this.state.toggleValue} : undefined}>
 								<Switch
 									style={styles.switch}
 									value={toggleValue}
@@ -78,7 +84,7 @@ export class ToggleInput extends React.Component {
 									}}>
 								</Switch>
 								<View style={styles.titleContainer}>
-									<InputLabel configManager={this.props.configManager} isRequired={this.isRequired} wrap={this.wrapText} style={styles.title} label={this.title} />
+									<InputLabel configManager={this.props.configManager} isRequired={this.isRequired} wrap={this.wrapText} style={styles.title} label={this.title} altText={this.altText}/>
 								</View>
 							</View>
 						)


### PR DESCRIPTION
# Description

## Fixing issues due to which Input controls were not usable via VoiceOver on iOS
Input controls were not usable on iOS - user was blocked from selecting radio buttons, checkboxes, and switches.

## Issues observed in both iOS and Android
Checked/unchecked state not defined for radio button and checkbox.
# How Verified

Validated using the cards in Visualizer app.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/5982)