### PR TITLE
[JS] visibility not correctly applied to images inside an ImageSet (#3251)

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -2161,7 +2161,11 @@ export class ImageSet extends CardElementContainer {
                 let renderedImage = image.render();
 
                 if (renderedImage) {
-                    renderedImage.style.display = "inline-flex";
+
+                    if(image.isVisible){
+                        renderedImage.style.display = "inline-flex";
+                    }
+                    
                     renderedImage.style.margin = "0px";
                     renderedImage.style.marginRight = "10px";
 


### PR DESCRIPTION
# Related Issue
Fixes #3251 

# Description
It has been identified that the visibility property of images held within an ImageSet was not being properly applied when rendering the card. 

# How Verified
1) Built locally
2) Launched the designer and created a card with an ImageSet with three images
3) Tested various configurations of these images with the visibility flag checked and unchecked
4) Added a toggle visibility action and tested again with various configurations of the image visibility flag