### PR TITLE
[Android] Bump gradle 6.1 to 6.7

### DIFF
--- a/source/android/gradle/wrapper/gradle-wrapper.properties
+++ b/source/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip


### PR DESCRIPTION
# Related Issue

Failing Android pipelines

# Description

Bump gradle version to fix unreliable downloading of dependencies in CI.

# Sample Card

N/A

# How Verified

Verified with CI runs

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/6002)