### PR TITLE
[Designer] Fix contrast ratios for button borders

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/adaptivecards-designer.css
+++ b/source/nodejs/adaptivecards-designer/src/adaptivecards-designer.css
@@ -932,18 +932,18 @@ a.default-ac-anchor:visited:active {
     height: 31px;
     background-color: #EEEEEE;
     color: black;
-    border: 1px solid #CCCCCC;
+    border: 1px solid #666666;
     border-radius: 2px;
 }
 
 .default-ac-pushButton:hover, .acd-dialog-button:hover {
     /* background-color: #DDDDDD; */
-    border: 1px solid #BBBBBB;
+    border: 1px solid #555555;
 }
 
 .default-ac-pushButton:active, .acd-dialog-button:active {
     /* background-color: #CCCCCC; */
-    border: 1px solid #BBBBBB;
+    border: 1px solid #555555;
 }
 
 .default-ac-pushButton.subdued {


### PR DESCRIPTION
# Related Issue

Fixes ADO [30642435](https://microsoft.visualstudio.com/OS/_queries/edit/30642435/) and [30926378](https://microsoft.visualstudio.com/OS/_queries/edit/30926378/)

# Description

Darken the border of buttons in order to meet accessibility contrast ratio requirements. Contrast ratio between background and button border is now 5.453:1

# How Verified

Confirmed contrast ratio of buttons in the designer using accessibility insights.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/6006)