### PR TITLE
Accessibility fix for inline-actions on inputs

### DIFF
--- a/source/community/reactnative/src/components/containers/factset.js
+++ b/source/community/reactnative/src/components/containers/factset.js
@@ -95,7 +95,7 @@ export class FactSet extends React.Component {
 		let valueConfig = this.hostConfig.factSet.value;
 		factSetJson.facts.map((element, index) => {
 			renderedElement.push(
-				<View style={[styles.textContainer]} key={`FACT-${element.title}-${index}`}>
+				<View style={[styles.textContainer]} key={`FACT-${element.title}-${index}`} accessible={true}>
 					<Label
 						text={element.title}
 						size={titleConfig.size}

--- a/source/community/reactnative/src/components/inputs/input-label.js
+++ b/source/community/reactnative/src/components/inputs/input-label.js
@@ -45,7 +45,7 @@ export default class InputLabel extends React.Component {
 		}
 		if (inputLabel) {
 			return (
-				<View style={styles.container}>
+				<View style={styles.container} accessible={typeof label == Constants.TypeString ? true: undefined}>
 					<View>{inputLabel}</View>
 					{this.isRequired && this.getRedAsterisk()}
 				</View>

--- a/source/community/reactnative/src/components/inputs/input.js
+++ b/source/community/reactnative/src/components/inputs/input.js
@@ -240,7 +240,12 @@ export class Input extends React.Component {
 						<TouchableOpacity
 							disabled={inlineAction.isEnabled == undefined ? false : !inlineAction.isEnabled} //isEnabled defaults to true
 							opacity={inlineAction.isEnabled == undefined ? 1.0 : inlineAction.isEnabled ? 1.0 : 0.5}
-							onPress={() => { this.onClickHandle(onExecuteAction, Constants.InlineAction) }}>
+							onPress={() => { this.onClickHandle(onExecuteAction, Constants.InlineAction) }}
+							accessible={true}
+							accessibilityLabel={inlineAction.title}
+							accessibilityState={{disabled: inlineAction.isEnabled == undefined ? false : !inlineAction.isEnabled}}
+							accessibilityRole={'button'}
+							>
 							{Utils.isNullOrEmpty(inlineAction.iconUrl) ?
 								<Text style={[styles.inlineActionText, opacityStyle]}>{inlineAction.title}</Text> :
 								<Image


### PR DESCRIPTION
The inline-action buttons had no role or name assigned previously. This PR adds the name, role and disabled state.
Also concatenates the Label and Asterisk in a single narration.

Also concatenate the fact set label and value into a single announcement.
###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/6060)