### PR TITLE
Adding simpler example to docs

### DIFF
--- a/samples/v1.2/Tests/Action.ToggleVisibilityExhaustive.json
+++ b/samples/v1.2/Tests/Action.ToggleVisibilityExhaustive.json
@@ -55,6 +55,21 @@
 		},
 		{
 			"type": "Action.ToggleVisibility",
+			"title": "Also Toggle!",
+			"targetElements": [
+				{
+					"elementId": "textToToggle"
+				},
+				{
+					"elementId": "imageToToggle"
+				},
+				{
+					"elementId": "imageToToggle2"
+				}
+			]
+		},
+		{
+			"type": "Action.ToggleVisibility",
 			"title": "Show!",
 			"targetElements": [
 				{
@@ -86,6 +101,42 @@
 				{
 					"elementId": "imageToToggle2",
 					"isVisible": false
+				}
+			]
+		},
+		{
+			"type": "Action.ToggleVisibility",
+			"title": "Grain!",
+			"targetElements": [
+				{
+					"elementId": "textToToggle",
+					"isVisible": true
+				},
+				{
+					"elementId": "imageToToggle",
+					"isVisible": true
+				},
+				{
+					"elementId": "imageToToggle2",
+					"isVisible": false
+				}
+			]
+		},
+		{
+			"type": "Action.ToggleVisibility",
+			"title": "Water!",
+			"targetElements": [
+				{
+					"elementId": "textToToggle",
+					"isVisible": true
+				},
+				{
+					"elementId": "imageToToggle",
+					"isVisible": false
+				},
+				{
+					"elementId": "imageToToggle2",
+					"isVisible": true
 				}
 			]
 		}


### PR DESCRIPTION
# Related Issue
Fixes #5098 

# Description

Adding simpler example to docs and moving exhaustive sample to test cases. This allows users to see the text in the buttons that was cut off in the previous example.

# How Verified

![image](https://user-images.githubusercontent.com/9759782/125660194-a588cf7c-6b7d-4442-989e-b7b67c91a4f4.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/6087)