### PR TITLE
bg image shouldnt be focussed if altText is not present

### DIFF
--- a/source/community/reactnative/src/components/elements/background-image.js
+++ b/source/community/reactnative/src/components/elements/background-image.js
@@ -114,7 +114,7 @@ export class BackgroundImage extends React.Component {
                     <Image
                         key="image-repeat"
                         resizeMethod={Constants.Resize}
-                        accessible={true}
+                        accessible={this.backgroundImage.altText ? true : false}
                         accessibilityLabel={this.backgroundImage.altText}
                         source={{ uri: this.backgroundImage.url }}
                         onError={() => { this.onError(onParseError) }}
@@ -128,7 +128,7 @@ export class BackgroundImage extends React.Component {
                     <Image
                         key="image-repeat-horizontal"
                         resizeMethod={Constants.Resize}
-                        accessible={true}
+                        accessible={this.backgroundImage.altText ? true : false}
                         accessibilityLabel={this.backgroundImage.altText}
                         source={{ uri: this.backgroundImage.url }}
                         onError={() => { this.onError(onParseError) }}
@@ -146,7 +146,7 @@ export class BackgroundImage extends React.Component {
                     <Image
                         key="image-repeat-vertical"
                         resizeMethod={Constants.Resize}
-                        accessible={true}
+                        accessible={this.backgroundImage.altText ? true : false}
                         accessibilityLabel={this.backgroundImage.altText}
                         source={{ uri: this.backgroundImage.url }}
                         onError={() => { this.onError(onParseError) }}
@@ -161,7 +161,7 @@ export class BackgroundImage extends React.Component {
                     <Image
                         key="image-stretch"
                         source={{ uri: this.backgroundImage.url }}
-                        accessible={true}
+                        accessible={this.backgroundImage.altText ? true : false}
                         accessibilityLabel={this.backgroundImage.altText}
                         onError={() => { this.onError(onParseError) }}
                         style={{ width: Constants.FullWidth, height: Constants.FullWidth, resizeMode: Constants.AlignStretch }}


### PR DESCRIPTION
On iOS, the background image was focussed by the screen reader even in absence of altText. This is undesirable behavior. This PR fixes that.

Verified on: Visualizer App
###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/6096)