### PR TITLE
Rich text block schema as per Adaptive Card designer

### DIFF
--- a/source/community/reactnative/src/components/elements/rich-text-block.js
+++ b/source/community/reactnative/src/components/elements/rich-text-block.js
@@ -125,6 +125,10 @@ export class RichTextBlock extends React.Component {
     }
 
     render() {
+        if (!this.payload.paragraphs) {
+            this.payload.paragraphs = [{"inlines": this.payload.inlines}];
+        }
+
         return (<InputContextConsumer>
             {({ onExecuteAction }) => {
                 this.onExecuteAction = onExecuteAction;


### PR DESCRIPTION
As per adaptive card designer, rich text block does not expect "paragraphs" to be the first JSON key. However, RN sdk is expecting it to be.
This PR ensures that both cases - with or without paragraph work, by synthetically injecting a paragraph as the parent of all inlines in case a paragraph is not present

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/6151)