### PR TITLE
[Android] Update Input.Text rendering for stretched multilined elements

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/TextInputRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/TextInputRenderer.java
@@ -37,6 +37,7 @@ import io.adaptivecards.objectmodel.BaseInputElement;
 import io.adaptivecards.objectmodel.ContainerStyle;
 import io.adaptivecards.objectmodel.ExecuteAction;
 import io.adaptivecards.objectmodel.ForegroundColor;
+import io.adaptivecards.objectmodel.HeightType;
 import io.adaptivecards.objectmodel.HostConfig;
 import io.adaptivecards.objectmodel.SubmitAction;
 import io.adaptivecards.objectmodel.TextInput;
@@ -195,6 +196,7 @@ public class TextInputRenderer extends BaseCardElementRenderer
             boolean hasSpecificValidation)
     {
         EditText editText = null;
+        TextInput textInput = Util.tryCastTo(baseInputElement, TextInput.class);
 
         if (baseInputElement.GetIsRequired() || hasSpecificValidation)
         {
@@ -203,7 +205,13 @@ public class TextInputRenderer extends BaseCardElementRenderer
         else
         {
             editText = new EditText(context);
-            editText.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
+
+            // if the Input.Text element is multiline with height "Stretch" change height to match the parent container
+            int editTextHeight = (textInput != null && baseInputElement.GetHeight() == HeightType.Stretch && textInput.GetIsMultiline()) ?
+                ViewGroup.LayoutParams.MATCH_PARENT :
+                ViewGroup.LayoutParams.WRAP_CONTENT;
+
+            editText.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, editTextHeight));
             // editText.addTextChangedListener(new UnvalidatedTextWatcher(textInputHandler));
         }
 
@@ -243,10 +251,8 @@ public class TextInputRenderer extends BaseCardElementRenderer
 
         LinearLayout textInputViewGroup = null;
 
-        if (baseInputElement instanceof TextInput)
+        if (textInput != null)
         {
-            TextInput textInput = (TextInput) baseInputElement;
-
             BaseActionElement action = textInput.GetInlineAction();
 
             if (action != null)
@@ -393,7 +399,16 @@ public class TextInputRenderer extends BaseCardElementRenderer
 
         if (textInput.GetIsMultiline())
         {
-            editText.setLines(3);
+            // If the Input.Text has to stretch then don't limit the number of lines,
+            // otherwise default to 3 lines
+            if (textInput.GetHeight() == HeightType.Stretch)
+            {
+                editText.setMinLines(3);
+            }
+            else
+            {
+                editText.setLines(3);
+            }
 
             // Solution taken from here: https://stackoverflow.com/questions/6123973/android-edittext-vertical-scrolling-problem
             editText.setOnTouchListener(new EditTextTouchListener(editText));


### PR DESCRIPTION
# Related Issue

Fixes #5349 

# Description

Adds extra case validation for the special case of an Input.Element having the `Multiline` property set to `true` and the `Height` set to `stretch`. The changes deal with using setMinLines instead of setLines and updating the underlying LayoutParams height to match the parent container's height.

# Sample Card

Included in the bug description

# How Verified

The fix was verified by rendering the linked card in the mobile app


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/6157)