### PR TITLE
[ios] fixed #5206

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRFactSetRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRFactSetRenderer.mm
@@ -132,6 +132,8 @@
     NSMutableDictionary *textMap = [rootView getTextMap];
     NSInteger nValidFacts = 0;
 
+    NSMutableArray *accessibilityElements = [[NSMutableArray alloc] init];
+
     for (auto fact : factSet->GetFacts()) {
         NSString *title = [NSString stringWithCString:fact->GetTitle().c_str() encoding:NSUTF8StringEncoding];
         NSString *titleElemId = [key stringByAppendingString:[[NSNumber numberWithInt:rowFactId++] stringValue]];
@@ -152,8 +154,6 @@
         [titleLab setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisVertical];
         [titleLab setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
         [titleLab setContentHuggingPriority:UILayoutPriorityDefaultHigh forAxis:UILayoutConstraintAxisHorizontal];
-
-        titleLab.isAccessibilityElement = YES;
 
         if (factSetConfig.title.maxWidth) {
             NSLayoutConstraint *constraintForTitleLab = [NSLayoutConstraint constraintWithItem:titleLab attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationLessThanOrEqual toItem:nil attribute:NSLayoutAttributeNotAnAttribute multiplier:1.0 constant:factSetConfig.title.maxWidth];
@@ -178,17 +178,20 @@
 
 
         [valueLab setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisVertical];
-        valueLab.isAccessibilityElement = YES;
 
         if (title.length || value.length) {
             [titleStack addArrangedSubview:titleLab];
             [valueStack addArrangedSubview:valueLab];
             [NSLayoutConstraint constraintWithItem:valueLab attribute:NSLayoutAttributeHeight relatedBy:NSLayoutRelationEqual toItem:titleLab attribute:NSLayoutAttributeHeight multiplier:1.0 constant:0].active = YES;
+            [accessibilityElements addObject:titleLab];
+            [accessibilityElements addObject:valueLab];
             nValidFacts++;
         }
         configRtl(titleLab, rootView.context);
         configRtl(valueLab, rootView.context);
     }
+
+    factSetWrapperView.accessibilityElements = accessibilityElements;
 
     if (!nValidFacts) {
         return nil;


### PR DESCRIPTION
# Related Issue

Fixed #5206 

# Description

Letting VO determine the order leads to different ordering. This change sets the order so the VO will always read the title to the value.

# Sample Card

https://github.com/microsoft/AdaptiveCards/blob/main/samples/v1.0/Elements/FactSet.json

# How Verified

How you verified the fix, including one or all of the following:
1. Ran all Existing relevant unit/regression tests
2. tried different orderings and made sure they are reflected.