### PR TITLE
Fixing adaptivecards-react readme typo

### DIFF
--- a/source/nodejs/adaptivecards-react/README.md
+++ b/source/nodejs/adaptivecards-react/README.md
@@ -5,15 +5,15 @@
 ### Node
 
 ```console
-npm install react react-adaptivecards --save
+npm install react adaptivecards-react --save
 ```
 
 ```js
 // Import the module:
-import * as AdaptiveCard from "react-adaptivecards";
+import * as AdaptiveCard from "adaptivecards-react";
 
 // OR require it:
-var AdaptiveCard = require("react-adaptivecards");
+var AdaptiveCard = require("adaptivecards-react");
 ```
 
 ### Usage

--- a/source/nodejs/adaptivecards-react/package.json
+++ b/source/nodejs/adaptivecards-react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "adaptivecards-react",
-	"version": "1.0.0-beta.1",
+	"version": "1.0.0-beta.2",
 	"description": "React.js Adaptive Cards Javascript library for HTML Clients",
 	"author": "AdaptiveCards",
 	"license": "MIT",


### PR DESCRIPTION
Fixing a small typo in the adaptivecards-react readme that referenced the wrong npm package

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/6242)