### PR TITLE
[iOS] RichTextBlock Update

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRichTextBlockRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRichTextBlockRenderer.mm
@@ -187,8 +187,6 @@
 
     lab.translatesAutoresizingMaskIntoConstraints = NO;
 
-    [viewGroup addArrangedSubview:lab];
-
     HorizontalAlignment adaptiveAlignment = rTxtBlck->GetHorizontalAlignment().value_or(HorizontalAlignment::Left);
 
     if (adaptiveAlignment == HorizontalAlignment::Left) {
@@ -223,6 +221,8 @@
     configRtl(lab, rootView.context);
 
     configVisibility(lab, elem);
+    
+    [viewGroup addArrangedSubview:lab];
 
     return lab;
 }


### PR DESCRIPTION
# Related Issue
Fixed #6365.
Long RichTextBlock's text will get cut off unexpectedly when it's inside a column with shorter width.

# Description
This change changed the order when the compression resistance is applied. Applying compression resistance after a view is added to UIStackView does not produce the desired effect. The change applies the compression resistance first, then added to the stack iew.

# Sample Card
```json
{
    "type": "AdaptiveCard",
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
    "version": "1.3",
    "body": [
        {
            "type": "ColumnSet",
            "columns": [
                {
                    "type": "Column",
                    "width": "stretch",
                    "items": [
                        {
                            "type": "RichTextBlock",
                            "inlines": [
                                   {
                                    "type": "TextRun",
                                    "text": "Step 1\n\n",
                                    "size": "large"                                                                      
                                },        
                                {
                                    "type": "TextRun",
                                    "text": "Season the chicken with salt and pepper.  Add the carrot, celery, chicken, noodles and broth to a 6-quart Instant Pot®",
                                    "wrap": true
                                }                                
                            ]
                        }
                    ]
                },
                {
                    "type": "Column",
                    "width": "auto",
                    "items": [
                        {
                            "type": "ActionSet",
                            "actions": [
                                {
                                    "type": "Action.Submit",
                                    "title": "Action.Submit"
                                }
                            ]
                        }
                    ]
                }
            ]
        }
    ]
}


```

# How Verified
![Screen Shot 2021-09-16 at 3 41 55 PM](https://user-images.githubusercontent.com/4112696/133694908-415d5f85-7e10-4d31-8897-cffaeb9646a4.png)




###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/6368)