### PR TITLE
[.NET] Update to .NET 5

### DIFF
--- a/source/dotnet/Samples/AdaptiveCards.Sample.Html/AdaptiveCards.Sample.Html.csproj
+++ b/source/dotnet/Samples/AdaptiveCards.Sample.Html/AdaptiveCards.Sample.Html.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <GenerateAssemblyInfo Condition="$(Tfs_PackageVersionNumber) != ''">false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/source/dotnet/Samples/WPFVisualizer.PackageProject/AdaptiveCards.Sample.WPFVisualizer.PackageProject.wapproj
+++ b/source/dotnet/Samples/WPFVisualizer.PackageProject/AdaptiveCards.Sample.WPFVisualizer.PackageProject.wapproj
@@ -3,6 +3,9 @@
   <PropertyGroup Condition="'$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '15.0'">
     <VisualStudioVersion>15.0</VisualStudioVersion>
   </PropertyGroup>
+  <PropertyGroup>
+    <RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>
+  </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x86">
       <Configuration>Debug</Configuration>

--- a/source/dotnet/Samples/WPFVisualizer/AdaptiveCards.Sample.WPFVisualizer.csproj
+++ b/source/dotnet/Samples/WPFVisualizer/AdaptiveCards.Sample.WPFVisualizer.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>WpfVisualizer</RootNamespace>
     <AssemblyName>WpfVisualizer</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/source/dotnet/Test/AdaptiveCards.Rendering.Html.Test/AdaptiveCards.Rendering.Html.Test.csproj
+++ b/source/dotnet/Test/AdaptiveCards.Rendering.Html.Test/AdaptiveCards.Rendering.Html.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <GenerateAssemblyInfo Condition="$(Tfs_PackageVersionNumber) != ''">false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/source/dotnet/Test/AdaptiveCards.Templating.Test/AdaptiveCards.Templating.Test.csproj
+++ b/source/dotnet/Test/AdaptiveCards.Templating.Test/AdaptiveCards.Templating.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/source/dotnet/Test/AdaptiveCards.Test/AdaptiveCards.Test.csproj
+++ b/source/dotnet/Test/AdaptiveCards.Test/AdaptiveCards.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <GenerateAssemblyInfo Condition="$(Tfs_PackageVersionNumber) != ''">false</GenerateAssemblyInfo>
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
# Related Issue

Fixes #6455

# Description

This probably warrants a longer explanation, but the short of it is that the latest VS tools release breaks some Nuget tooling in some specific scenarios (that unfortunately apply to us). This appears to only have affected the `.NET Core 3.x` SDK tooling. `.NET 5` (basically the latest version of .NET Core - ask me for a .NET versioning rant sometime) is sufficiently different such that it's apparently unaffected. This change moves our .NET Core projects over to `.NET 5`. I've already updated the build pipeline to pull the `5.x` SDK. It's worth calling out that the updated projects don't impact our platform packages (just tests and the visualizer).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/6466)