### PR TITLE
[UWP] Input.Text password style support

### DIFF
--- a/samples/v1.5/Elements/Input.Text.PasswordStyle.json
+++ b/samples/v1.5/Elements/Input.Text.PasswordStyle.json
@@ -6,9 +6,10 @@
 		{
 			"type": "Input.Text",
 			"id": "id0",
-			"placeholder": "password",
 			"style": "password",
-			"label": "Input.Text With Password Style"
+			"label": "Input.Text With Password Style",
+			"regex": "^.{8,20}$",
+			"errorMessage": "Password must be between 8 and 20 characters"
 		}
 	],
 	"actions": [

--- a/source/uwp/AdaptiveCardsObjectModel/idl/AdaptiveCards.ObjectModel.Uwp.idl
+++ b/source/uwp/AdaptiveCardsObjectModel/idl/AdaptiveCards.ObjectModel.Uwp.idl
@@ -17,13 +17,15 @@ namespace AdaptiveCards.ObjectModel.Uwp
         ExtraLarge
     };
 
-    enum TextWeight {
+    enum TextWeight
+    {
         Lighter = 0,
         Default,
         Bolder,
     };
 
-    enum ForegroundColor {
+    enum ForegroundColor
+    {
         Default = 0,
         Dark,
         Light,
@@ -33,26 +35,30 @@ namespace AdaptiveCards.ObjectModel.Uwp
         Attention
     };
 
-    enum HAlignment {
+    enum HAlignment
+    {
         Left = 0,
         Center,
         Right,
     };
 
-    enum VAlignment {
+    enum VAlignment
+    {
         Top = 0,
         Center,
         Bottom,
     };
 
-    enum BackgroundImageFillMode {
+    enum BackgroundImageFillMode
+    {
         Cover = 0,
         RepeatHorizontally,
         RepeatVertically,
         Repeat
     };
 
-    enum ElementType {
+    enum ElementType
+    {
         Unsupported = 0,
         AdaptiveCard,
         TextBlock,
@@ -79,7 +85,8 @@ namespace AdaptiveCards.ObjectModel.Uwp
         Table,
     };
 
-    enum ActionType {
+    enum ActionType
+    {
         Unsupported = 0,
         ShowCard,
         Submit,
@@ -89,12 +96,14 @@ namespace AdaptiveCards.ObjectModel.Uwp
         Custom
     };
 
-    enum ImageStyle {
+    enum ImageStyle
+    {
         Default = 0,
         Person,
     };
 
-    enum ImageSize {
+    enum ImageSize
+    {
         None = 0,
         Auto,
         Stretch,
@@ -103,12 +112,14 @@ namespace AdaptiveCards.ObjectModel.Uwp
         Large
     };
 
-    enum SeparatorThickness {
+    enum SeparatorThickness
+    {
         Default = 0,
         Thick,
     };
 
-    enum Spacing {
+    enum Spacing
+    {
         Default = 0,
         None,
         Small,
@@ -118,20 +129,24 @@ namespace AdaptiveCards.ObjectModel.Uwp
         Padding
     };
 
-    enum ChoiceSetStyle {
+    enum ChoiceSetStyle
+    {
         Compact = 0,
         Expanded,
         Filtered,
     };
 
-    enum TextInputStyle {
+    enum TextInputStyle
+    {
         Text = 0,
         Tel,
         Url,
         Email,
+        Password,
     };
 
-    enum ContainerStyle {
+    enum ContainerStyle
+    {
         None = 0,
         Default,
         Emphasis,
@@ -141,12 +156,14 @@ namespace AdaptiveCards.ObjectModel.Uwp
         Accent
     };
 
-    enum FontType {
+    enum FontType
+    {
         Default = 0,
         Monospace,
     };
 
-    enum ErrorStatusCode {
+    enum ErrorStatusCode
+    {
         InvalidJson = 0,
         RenderFailed,
         RequiredPropertyMissing,
@@ -155,7 +172,8 @@ namespace AdaptiveCards.ObjectModel.Uwp
         CustomError,
     };
 
-    enum WarningStatusCode {
+    enum WarningStatusCode
+    {
         UnknownElementType = 0,
         UnknownActionElementType,
         UnknownPropertyOnElement,
@@ -176,24 +194,28 @@ namespace AdaptiveCards.ObjectModel.Uwp
         RequiredPropertyMissing,
     };
 
-    enum VerticalContentAlignment {
+    enum VerticalContentAlignment
+    {
         Top = 0,
         Center,
         Bottom
     };
 
-    enum HeightType {
+    enum HeightType
+    {
         Auto = 0,
         Stretch,
     };
 
-    enum IsVisible {
+    enum IsVisible
+    {
         IsVisibleToggle = 0,
         IsVisibleTrue,
         IsVisibleFalse
     };
 
-    enum FallbackType {
+    enum FallbackType
+    {
         None = 0,
         Drop,
         Content,
@@ -208,18 +230,21 @@ namespace AdaptiveCards.ObjectModel.Uwp
         All = Left | Right | Up | Down
     };
 
-    enum AssociatedInputs {
+    enum AssociatedInputs
+    {
         Auto = 0,
         None,
     };
 
-    enum TextStyle {
+    enum TextStyle
+    {
         Default = 0,
         Heading,
         ColumnHeader,
     };
 
-    enum ActionMode {
+    enum ActionMode
+    {
         Primary = 0,
         Secondary,
     };
@@ -278,8 +303,7 @@ namespace AdaptiveCards.ObjectModel.Uwp
         Windows.Foundation.IReference<TextStyle> Style;
     };
 
-    [version(1), uuid("0AC70C29-FA90-4C28-A6D1-A6EF58126085")]
-    interface IAdaptiveInline {};
+    [version(1), uuid("0AC70C29-FA90-4C28-A6D1-A6EF58126085")] interface IAdaptiveInline {};
 
     runtimeclass AdaptiveTextRun : IAdaptiveInline, IAdaptiveTextElement
     {
@@ -706,9 +730,9 @@ namespace AdaptiveCards.ObjectModel.Uwp
     interface IAdaptiveElementParser
     {
         IAdaptiveCardElement FromJson(Windows.Data.Json.JsonObject inputJson,
-                                        AdaptiveElementParserRegistration elementParsers,
-                                        AdaptiveActionParserRegistration actionParsers,
-                                        Windows.Foundation.Collections.IVector<AdaptiveWarning> warnings);
+                                      AdaptiveElementParserRegistration elementParsers,
+                                      AdaptiveActionParserRegistration actionParsers,
+                                      Windows.Foundation.Collections.IVector<AdaptiveWarning> warnings);
     };
 
     runtimeclass AdaptiveElementParserRegistration
@@ -744,10 +768,7 @@ namespace AdaptiveCards.ObjectModel.Uwp
         String Label;
     };
 
-    [default_interface] runtimeclass AdaptiveTextBlockParser : IAdaptiveElementParser
-    {
-        AdaptiveTextBlockParser();
-    };
+    [default_interface] runtimeclass AdaptiveTextBlockParser : IAdaptiveElementParser { AdaptiveTextBlockParser(); };
 
     [default_interface] runtimeclass AdaptiveRichTextBlockParser : IAdaptiveElementParser
     {
@@ -756,64 +777,40 @@ namespace AdaptiveCards.ObjectModel.Uwp
 
     [default_interface] runtimeclass AdaptiveImageParser : IAdaptiveElementParser { AdaptiveImageParser(); };
 
-    [default_interface] runtimeclass AdaptiveImageSetParser : IAdaptiveElementParser
-    {
-        AdaptiveImageSetParser();
-    };
+    [default_interface] runtimeclass AdaptiveImageSetParser : IAdaptiveElementParser { AdaptiveImageSetParser(); };
 
-    [default_interface] runtimeclass AdaptiveContainerParser : IAdaptiveElementParser
-    {
-        AdaptiveContainerParser();
-    };
+    [default_interface] runtimeclass AdaptiveContainerParser : IAdaptiveElementParser { AdaptiveContainerParser(); };
 
     [default_interface] runtimeclass AdaptiveColumnParser : IAdaptiveElementParser { AdaptiveColumnParser(); };
 
-    [default_interface] runtimeclass AdaptiveColumnSetParser : IAdaptiveElementParser
-    {
-        AdaptiveColumnSetParser();
-    };
+    [default_interface] runtimeclass AdaptiveColumnSetParser : IAdaptiveElementParser { AdaptiveColumnSetParser(); };
 
     [default_interface] runtimeclass AdaptiveChoiceSetInputParser : IAdaptiveElementParser
     {
         AdaptiveChoiceSetInputParser();
     };
 
-    [default_interface] runtimeclass AdaptiveDateInputParser : IAdaptiveElementParser
-    {
-        AdaptiveDateInputParser();
-    };
+    [default_interface] runtimeclass AdaptiveDateInputParser : IAdaptiveElementParser { AdaptiveDateInputParser(); };
 
     [default_interface] runtimeclass AdaptiveNumberInputParser : IAdaptiveElementParser
     {
         AdaptiveNumberInputParser();
     };
 
-    [default_interface] runtimeclass AdaptiveTextInputParser : IAdaptiveElementParser
-    {
-        AdaptiveTextInputParser();
-    };
+    [default_interface] runtimeclass AdaptiveTextInputParser : IAdaptiveElementParser { AdaptiveTextInputParser(); };
 
-    [default_interface] runtimeclass AdaptiveTimeInputParser : IAdaptiveElementParser
-    {
-        AdaptiveTimeInputParser();
-    };
+    [default_interface] runtimeclass AdaptiveTimeInputParser : IAdaptiveElementParser { AdaptiveTimeInputParser(); };
 
     [default_interface] runtimeclass AdaptiveToggleInputParser : IAdaptiveElementParser
     {
         AdaptiveToggleInputParser();
     };
 
-    [default_interface] runtimeclass AdaptiveFactSetParser : IAdaptiveElementParser
-    {
-        AdaptiveFactSetParser();
-    };
+    [default_interface] runtimeclass AdaptiveFactSetParser : IAdaptiveElementParser { AdaptiveFactSetParser(); };
 
     [default_interface] runtimeclass AdaptiveMediaParser : IAdaptiveElementParser { AdaptiveMediaParser(); };
 
-    [default_interface] runtimeclass AdaptiveActionSetParser : IAdaptiveElementParser
-    {
-        AdaptiveActionSetParser();
-    };
+    [default_interface] runtimeclass AdaptiveActionSetParser : IAdaptiveElementParser { AdaptiveActionSetParser(); };
 
     [default_interface] runtimeclass AdaptiveOpenUrlActionParser : IAdaptiveActionParser
     {

--- a/source/uwp/Renderer/lib/ActionHelpers.cpp
+++ b/source/uwp/Renderer/lib/ActionHelpers.cpp
@@ -529,8 +529,9 @@ namespace AdaptiveCards::Rendering::Uwp::ActionHelpers
 
     void HandleInlineAction(_In_ IAdaptiveRenderContext* renderContext,
                             _In_ IAdaptiveRenderArgs* renderArgs,
-                            _In_ ITextBox* textBox,
+                            _In_ IUIElement* textInputUIElement,
                             _In_ IUIElement* textBoxParentContainer,
+                            bool isMultilineTextBox,
                             _In_ IAdaptiveActionElement* inlineAction,
                             _COM_Outptr_ IUIElement** textBoxWithInlineAction)
     {
@@ -688,17 +689,10 @@ namespace AdaptiveCards::Rendering::Uwp::ActionHelpers
         ComPtr<IAdaptiveActionInvoker> actionInvoker;
         THROW_IF_FAILED(renderContext->get_ActionInvoker(&actionInvoker));
 
-        boolean isMultiLine;
-        THROW_IF_FAILED(textBox->get_AcceptsReturn(&isMultiLine));
-
-        if (!isMultiLine)
+        if (!isMultilineTextBox)
         {
-            ComPtr<ITextBox> localTextBox(textBox);
-            ComPtr<IUIElement> textBoxAsUIElement;
-            THROW_IF_FAILED(localTextBox.As(&textBoxAsUIElement));
-
             EventRegistrationToken keyDownEventToken;
-            THROW_IF_FAILED(textBoxAsUIElement->add_KeyDown(
+            THROW_IF_FAILED(textInputUIElement->add_KeyDown(
                 Callback<IKeyEventHandler>(
                     [actionInvoker, localInlineAction](IInspectable* /*sender*/, IKeyRoutedEventArgs* args) -> HRESULT
                     { return HandleKeydownForInlineAction(args, actionInvoker.Get(), localInlineAction.Get()); })

--- a/source/uwp/Renderer/lib/ActionHelpers.h
+++ b/source/uwp/Renderer/lib/ActionHelpers.h
@@ -35,8 +35,9 @@ namespace AdaptiveCards::Rendering::Uwp::ActionHelpers
 
     void HandleInlineAction(_In_ ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveRenderContext* renderContext,
                             _In_ ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveRenderArgs* renderArgs,
-                            _In_ ABI::Windows::UI::Xaml::Controls::ITextBox* textBox,
+                            _In_ ABI::Windows::UI::Xaml::IUIElement* textInputUIElement,
                             _In_ ABI::Windows::UI::Xaml::IUIElement* textBoxParentContainer,
+                            bool isMultilineTextBox,
                             _In_ ABI::AdaptiveCards::ObjectModel::Uwp::IAdaptiveActionElement* inlineAction,
                             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** textBoxWithInlineAction);
 

--- a/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.cpp
@@ -25,18 +25,15 @@ namespace AdaptiveCards::Rendering::Uwp
     CATCH_RETURN;
 
     HRESULT AdaptiveTextInputRenderer::HandleLayoutAndValidation(IAdaptiveTextInput* adaptiveTextInput,
-                                                                 ITextBox* textBox,
+                                                                 IUIElement* inputUIElement,
                                                                  _In_ IAdaptiveRenderContext* renderContext,
                                                                  _In_ IAdaptiveRenderArgs* renderArgs,
-                                                                 IUIElement** textInputLayout)
+                                                                 IUIElement** textInputLayout,
+                                                                 IBorder** validationBorderOut)
     {
-        ComPtr<ITextBox> localTextBox(textBox);
-        ComPtr<IUIElement> textBoxAsUIElement;
-        localTextBox.As(&textBoxAsUIElement);
-
         // The text box may need to go into a number of parent containers to handle validation and inline actions.
         // textBoxParentContainer represents the current parent container.
-        ComPtr<IUIElement> textBoxParentContainer = textBoxAsUIElement;
+        ComPtr<IUIElement> textBoxParentContainer = inputUIElement;
 
         // If there's any validation on this input, put the input inside a border. We don't use
         // XamlHelpers::HandleInputLayoutAndValidation validation border because that would wrap any inline action as
@@ -53,7 +50,7 @@ namespace AdaptiveCards::Rendering::Uwp
         ComPtr<IBorder> validationBorder;
         if (regex.IsValid() || isRequired)
         {
-            RETURN_IF_FAILED(XamlHelpers::CreateValidationBorder(textBoxAsUIElement.Get(), renderContext, &validationBorder));
+            RETURN_IF_FAILED(XamlHelpers::CreateValidationBorder(inputUIElement, renderContext, &validationBorder));
             RETURN_IF_FAILED(validationBorder.As(&textBoxParentContainer));
         }
 
@@ -63,9 +60,17 @@ namespace AdaptiveCards::Rendering::Uwp
 
         if (inlineAction != nullptr)
         {
+            boolean isMultiline;
+            RETURN_IF_FAILED(adaptiveTextInput->get_IsMultiline(&isMultiline));
+
+            ABI::AdaptiveCards::ObjectModel::Uwp::TextInputStyle style;
+            RETURN_IF_FAILED(adaptiveTextInput->get_TextInputStyle(&style));
+
+            isMultiline &= style != (ABI::AdaptiveCards::ObjectModel::Uwp::TextInputStyle::Password);
+
             ComPtr<IUIElement> textBoxWithInlineAction;
             ActionHelpers::HandleInlineAction(
-                renderContext, renderArgs, textBox, textBoxParentContainer.Get(), inlineAction.Get(), &textBoxWithInlineAction);
+                renderContext, renderArgs, inputUIElement, textBoxParentContainer.Get(), isMultiline, inlineAction.Get(), &textBoxWithInlineAction);
             textBoxParentContainer = textBoxWithInlineAction;
         }
 
@@ -86,35 +91,16 @@ namespace AdaptiveCards::Rendering::Uwp
         RETURN_IF_FAILED(XamlHelpers::HandleInputLayoutAndValidation(
             textInputAsAdaptiveInput.Get(), textBoxParentContainer.Get(), regex.IsValid(), renderContext, &inputLayout, nullptr));
 
-        // Create the InputValue and add it to the context
-        ComPtr<TextInputValue> input;
-        RETURN_IF_FAILED(MakeAndInitialize<TextInputValue>(&input, adaptiveTextInput, textBox, validationBorder.Get()));
-        RETURN_IF_FAILED(renderContext->AddInputValue(input.Get(), renderArgs));
-
         RETURN_IF_FAILED(inputLayout.CopyTo(textInputLayout));
+        RETURN_IF_FAILED(validationBorder.CopyTo(validationBorderOut));
         return S_OK;
     }
 
-    HRESULT AdaptiveTextInputRenderer::Render(_In_ IAdaptiveCardElement* adaptiveCardElement,
-                                              _In_ IAdaptiveRenderContext* renderContext,
-                                              _In_ IAdaptiveRenderArgs* renderArgs,
-                                              _COM_Outptr_ IUIElement** textInputControl) noexcept
-    try
+    HRESULT AdaptiveTextInputRenderer::RenderTextBox(_In_ IAdaptiveTextInput* adaptiveTextInput,
+                                                     _In_ IAdaptiveRenderContext* renderContext,
+                                                     _In_ IAdaptiveRenderArgs* renderArgs,
+                                                     _COM_Outptr_ IUIElement** textInputControl)
     {
-        ComPtr<IAdaptiveHostConfig> hostConfig;
-        RETURN_IF_FAILED(renderContext->get_HostConfig(&hostConfig));
-        if (!XamlHelpers::SupportsInteractivity(hostConfig.Get()))
-        {
-            renderContext->AddWarning(
-                ABI::AdaptiveCards::ObjectModel::Uwp::WarningStatusCode::InteractivityNotSupported,
-                HStringReference(L"Text Input was stripped from card because interactivity is not supported").Get());
-            return S_OK;
-        }
-
-        ComPtr<IAdaptiveCardElement> cardElement(adaptiveCardElement);
-        ComPtr<IAdaptiveTextInput> adaptiveTextInput;
-        RETURN_IF_FAILED(cardElement.As(&adaptiveTextInput));
-
         ComPtr<ITextBox> textBox =
             XamlHelpers::CreateABIClass<ITextBox>(HStringReference(RuntimeClass_Windows_UI_Xaml_Controls_TextBox));
 
@@ -169,12 +155,98 @@ namespace AdaptiveCards::Rendering::Uwp
 
         RETURN_IF_FAILED(textBox->put_InputScope(inputScope.Get()));
 
+        ComPtr<IUIElement> textBoxAsUIElement;
+        RETURN_IF_FAILED(textBox.As(&textBoxAsUIElement));
+
+        ComPtr<IBorder> validationBorder;
+        RETURN_IF_FAILED(HandleLayoutAndValidation(
+            adaptiveTextInput, textBoxAsUIElement.Get(), renderContext, renderArgs, textInputControl, &validationBorder));
+
+        ComPtr<TextInputValue> inputValue;
+        RETURN_IF_FAILED(
+            MakeAndInitialize<TextInputValue>(&inputValue, adaptiveTextInput, textBox.Get(), validationBorder.Get()));
+        RETURN_IF_FAILED(renderContext->AddInputValue(inputValue.Get(), renderArgs));
+
         ComPtr<IFrameworkElement> textBoxAsFrameworkElement;
         RETURN_IF_FAILED(textBox.As(&textBoxAsFrameworkElement));
         RETURN_IF_FAILED(
             XamlHelpers::SetStyleFromResourceDictionary(renderContext, L"Adaptive.Input.Text", textBoxAsFrameworkElement.Get()));
 
-        RETURN_IF_FAILED(HandleLayoutAndValidation(adaptiveTextInput.Get(), textBox.Get(), renderContext, renderArgs, textInputControl));
+        return S_OK;
+    }
+
+    HRESULT AdaptiveTextInputRenderer::RenderPasswordBox(_In_ IAdaptiveTextInput* adaptiveTextInput,
+                                                         _In_ IAdaptiveRenderContext* renderContext,
+                                                         _In_ IAdaptiveRenderArgs* renderArgs,
+                                                         _COM_Outptr_ IUIElement** textInputControl)
+    {
+        ComPtr<IPasswordBox> passwordBox =
+            XamlHelpers::CreateABIClass<IPasswordBox>(HStringReference(RuntimeClass_Windows_UI_Xaml_Controls_PasswordBox));
+
+        HString textValue;
+        RETURN_IF_FAILED(adaptiveTextInput->get_Value(textValue.GetAddressOf()));
+        RETURN_IF_FAILED(passwordBox->put_Password(textValue.Get()));
+
+        UINT32 maxLength;
+        RETURN_IF_FAILED(adaptiveTextInput->get_MaxLength(&maxLength));
+        RETURN_IF_FAILED(passwordBox->put_MaxLength(maxLength));
+
+        ComPtr<IPasswordBox2> passwordBox2;
+        RETURN_IF_FAILED(passwordBox.As(&passwordBox2));
+
+        HString placeHolderText;
+        RETURN_IF_FAILED(adaptiveTextInput->get_Placeholder(placeHolderText.GetAddressOf()));
+        RETURN_IF_FAILED(passwordBox2->put_PlaceholderText(placeHolderText.Get()));
+
+        ComPtr<IUIElement> textBoxAsUIElement;
+        RETURN_IF_FAILED(passwordBox.As(&textBoxAsUIElement));
+
+        ComPtr<IBorder> validationBorder;
+        RETURN_IF_FAILED(HandleLayoutAndValidation(
+            adaptiveTextInput, textBoxAsUIElement.Get(), renderContext, renderArgs, textInputControl, &validationBorder));
+
+        ComPtr<PasswordInputValue> inputValue;
+        RETURN_IF_FAILED(
+            MakeAndInitialize<PasswordInputValue>(&inputValue, adaptiveTextInput, passwordBox.Get(), validationBorder.Get()));
+        RETURN_IF_FAILED(renderContext->AddInputValue(inputValue.Get(), renderArgs));
+
+        return S_OK;
+    }
+
+    HRESULT AdaptiveTextInputRenderer::Render(_In_ IAdaptiveCardElement* adaptiveCardElement,
+                                              _In_ IAdaptiveRenderContext* renderContext,
+                                              _In_ IAdaptiveRenderArgs* renderArgs,
+                                              _COM_Outptr_ IUIElement** textInputControl) noexcept
+    try
+    {
+        ComPtr<IAdaptiveHostConfig> hostConfig;
+        RETURN_IF_FAILED(renderContext->get_HostConfig(&hostConfig));
+        if (!XamlHelpers::SupportsInteractivity(hostConfig.Get()))
+        {
+            renderContext->AddWarning(
+                ABI::AdaptiveCards::ObjectModel::Uwp::WarningStatusCode::InteractivityNotSupported,
+                HStringReference(L"Text Input was stripped from card because interactivity is not supported").Get());
+            return S_OK;
+        }
+
+        ComPtr<IAdaptiveCardElement> cardElement(adaptiveCardElement);
+        ComPtr<IAdaptiveTextInput> adaptiveTextInput;
+        RETURN_IF_FAILED(cardElement.As(&adaptiveTextInput));
+
+        ABI::AdaptiveCards::ObjectModel::Uwp::TextInputStyle textInputStyle;
+        RETURN_IF_FAILED(adaptiveTextInput->get_TextInputStyle(&textInputStyle));
+
+        ComPtr<IUIElement> renderedTextInputControl;
+        if (textInputStyle == ABI::AdaptiveCards::ObjectModel::Uwp::TextInputStyle::Password)
+        {
+            RenderPasswordBox(adaptiveTextInput.Get(), renderContext, renderArgs, &renderedTextInputControl);
+        }
+        else
+        {
+            RenderTextBox(adaptiveTextInput.Get(), renderContext, renderArgs, &renderedTextInputControl);
+        }
+
+        RETURN_IF_FAILED(renderedTextInputControl.CopyTo(textInputControl));
 
         return S_OK;
     }

--- a/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.h
@@ -21,11 +21,22 @@ namespace AdaptiveCards::Rendering::Uwp
                               _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** result) noexcept override;
 
     private:
+        HRESULT AdaptiveTextInputRenderer::RenderTextBox(_In_ ABI::AdaptiveCards::ObjectModel::Uwp::IAdaptiveTextInput* adaptiveTextInput,
+                                                         _In_ ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveRenderContext* renderContext,
+                                                         _In_ ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveRenderArgs* renderArgs,
+                                                         _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** textInputControl);
+
+        HRESULT AdaptiveTextInputRenderer::RenderPasswordBox(_In_ ABI::AdaptiveCards::ObjectModel::Uwp::IAdaptiveTextInput* adaptiveTextInput,
+                                                             _In_ ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveRenderContext* renderContext,
+                                                             _In_ ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveRenderArgs* renderArgs,
+                                                             _COM_Outptr_ ABI::Windows::UI::Xaml::IUIElement** textInputControl);
+
         HRESULT HandleLayoutAndValidation(ABI::AdaptiveCards::ObjectModel::Uwp::IAdaptiveTextInput* adaptiveTextInput,
-                                          ABI::Windows::UI::Xaml::Controls::ITextBox* textBox,
+                                          ABI::Windows::UI::Xaml::IUIElement* textBox,
                                           ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveRenderContext* renderContext,
                                           ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveRenderArgs* renderArgs,
-                                          ABI::Windows::UI::Xaml::IUIElement** inputLayout);
+                                          ABI::Windows::UI::Xaml::IUIElement** inputLayout,
+                                          ABI::Windows::UI::Xaml::Controls::IBorder** validationBorderOut);
     };
 
     ActivatableClass(AdaptiveTextInputRenderer);

--- a/source/uwp/Renderer/lib/InputValue.h
+++ b/source/uwp/Renderer/lib/InputValue.h
@@ -35,20 +35,19 @@ namespace AdaptiveCards::Rendering::Uwp
         Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IUIElement> m_validationError;
     };
 
-    // Base class for input value types that use ITextBox (Input.Text and Input.Number)
+    // Base class for AdaptiveTextInput
     class TextInputBase : public InputValue
     {
     public:
         TextInputBase() {}
 
-        HRESULT RuntimeClassInitialize(_In_ ABI::AdaptiveCards::ObjectModel::Uwp::IAdaptiveInputElement* adaptiveInputElement,
-                                       _In_ ABI::Windows::UI::Xaml::Controls::ITextBox* uiTextBoxElement,
+        HRESULT RuntimeClassInitialize(_In_ ABI::AdaptiveCards::ObjectModel::Uwp::IAdaptiveTextInput* adaptiveTextInput,
+                                       _In_ ABI::Windows::UI::Xaml::IUIElement* uiTextInputElement,
                                        _In_ ABI::Windows::UI::Xaml::Controls::IBorder* validationBorder);
 
-        IFACEMETHODIMP get_CurrentValue(_Outptr_ HSTRING* serializedUserInput) override;
-
     protected:
-        Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::Controls::ITextBox> m_textBoxElement;
+        virtual HRESULT IsValueValid(_Out_ boolean* isInputValid) override;
+        Microsoft::WRL::ComPtr<ABI::AdaptiveCards::ObjectModel::Uwp::IAdaptiveTextInput> m_adaptiveTextInput;
     };
 
     // Input value for Input.Text
@@ -60,22 +59,38 @@ namespace AdaptiveCards::Rendering::Uwp
                                        _In_ ABI::Windows::UI::Xaml::Controls::IBorder* validationBorder);
 
     private:
-        virtual HRESULT IsValueValid(_Out_ boolean* isInputValid) override;
+        IFACEMETHODIMP get_CurrentValue(_Outptr_ HSTRING* serializedUserInput) override;
 
-        Microsoft::WRL::ComPtr<ABI::AdaptiveCards::ObjectModel::Uwp::IAdaptiveTextInput> m_adaptiveTextInput;
+        Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::Controls::ITextBox> m_textBoxElement;
+    };
+
+    class PasswordInputValue : public TextInputValue
+    {
+    public:
+        HRESULT RuntimeClassInitialize(_In_ ABI::AdaptiveCards::ObjectModel::Uwp::IAdaptiveTextInput* adaptiveTextInput,
+                                       _In_ ABI::Windows::UI::Xaml::Controls::IPasswordBox* uiPasswordElement,
+                                       _In_ ABI::Windows::UI::Xaml::Controls::IBorder* validationBorder);
+
+    private:
+        IFACEMETHODIMP get_CurrentValue(_Outptr_ HSTRING* serializedUserInput) override;
+
+    protected:
+        Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::Controls::IPasswordBox> m_passwordElement;
     };
 
     // Input value for Input.Number
-    class NumberInputValue : public TextInputBase
+    class NumberInputValue : public InputValue
     {
     public:
         HRESULT RuntimeClassInitialize(_In_ ABI::AdaptiveCards::ObjectModel::Uwp::IAdaptiveNumberInput* adaptiveNumberInput,
                                        _In_ ABI::Windows::UI::Xaml::Controls::ITextBox* uiTextBoxElement,
                                        _In_ ABI::Windows::UI::Xaml::Controls::IBorder* validationBorder);
 
+        IFACEMETHODIMP get_CurrentValue(_Outptr_ HSTRING* serializedUserInput) override;
+
     private:
         virtual HRESULT IsValueValid(_Out_ boolean* isInputValid) override;
-
+        Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::Controls::ITextBox> m_textBoxElement;
         Microsoft::WRL::ComPtr<ABI::AdaptiveCards::ObjectModel::Uwp::IAdaptiveNumberInput> m_adaptiveNumberInput;
     };
 

--- a/source/uwp/UWPUITestApp/UWPUITestApp.csproj
+++ b/source/uwp/UWPUITestApp/UWPUITestApp.csproj
@@ -191,6 +191,10 @@
       <Link>LinkedTestCards\PrimarySecondaryShowCards.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="..\..\..\samples\v1.5\Elements\Input.Text.PasswordStyle.json">
+      <Link>LinkedTestCards\Input.Text.PasswordStyle.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="UWPUITestApp_TemporaryKey.pfx" />
   </ItemGroup>
   <ItemGroup>

--- a/source/uwp/UWPUITests/UITest.cs
+++ b/source/uwp/UWPUITests/UITest.cs
@@ -145,6 +145,54 @@ namespace UWPUITests
             Assert.ThrowsException<Microsoft.Windows.Apps.Test.Foundation.UIObjectNotFoundException>(delegate () { TestHelpers.FindElementByName("Secondary Show Card"); });
         }
 
+        [TestMethod]
+        public void PasswordTest()
+        {
+            TestHelpers.GoToTestCase("Input.Text.PasswordStyle");
+
+            var passwordBox = TestHelpers.CastTo<Edit>(TestHelpers.FindByMultiple(
+                "Name", "Input.Text With Password Style\r\n",
+                "ClassName", "PasswordBox"));
+
+            Assert.IsTrue(passwordBox.IsPassword);
+
+            passwordBox.SendKeys("aNewPassword123!");
+            Assert.AreEqual("●●●●●●●●●●●●●●●●", passwordBox.Value);
+
+            // Submit data
+            TestHelpers.FindElementByName("OK").Click();
+
+            // Verify submitted data
+            Assert.AreEqual("aNewPassword123!", TestHelpers.GetInputValue("id0"));
+        }
+
+        [TestMethod]
+        public void PasswordRegexTest()
+        {
+            TestHelpers.GoToTestCase("Input.Text.PasswordStyle");
+
+            var passwordBox = TestHelpers.CastTo<Edit>(TestHelpers.FindByMultiple(
+                "Name", "Input.Text With Password Style\r\n",
+                "ClassName", "PasswordBox"));
+
+            Assert.IsTrue(passwordBox.IsPassword);
+
+            passwordBox.SendKeys("short");
+
+            // Submit data
+            TestHelpers.FindElementByName("OK").Click();
+
+            var errorMessage = TestHelpers.FindElementByName("Password must be between 8 and 20 characters");
+            Assert.IsNotNull(errorMessage);
+
+            passwordBox.SendKeys("LONGER!");
+
+            TestHelpers.FindElementByName("OK").Click();
+
+            // Verify submitted data
+            Assert.AreEqual("shortLONGER!", TestHelpers.GetInputValue("id0"));
+        }
+
         [ClassCleanup]
         public static void TearDown()
         {


### PR DESCRIPTION
# Related Issue
Fixes #6334 

# Description
Adds handling of Input.Text password style using Xaml's PasswordBox. Some refactoring to account for the fact that in Xaml a PasswordBox is not the same type as a normal TextBox. Specifically, a new InputValue type is added to support getting values out of a PasswordBox while sharing the validation logic with other styles of Input.Text.

# Sample Card
\samples\v.15\Elements\Input.Text.PasswordStyle.json

# How Verified
UWP unit tests including new tests to validate password scenarios.
