### PR TITLE
Update supported version for teams and appropriate warning message

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/card-designer.ts
+++ b/source/nodejs/adaptivecards-designer/src/card-designer.ts
@@ -342,7 +342,10 @@ export class CardDesigner extends Designer.DesignContext {
 
             let errorPane = document.getElementById("errorPane");
             errorPane.innerHTML = "";
-
+			
+			if(this.hostContainer.name == "Microsoft Teams - Dark" || this.hostContainer.name == "Microsoft Teams - Light"){
+				errorPane.appendChild(this.renderErrorPaneElement("[Warning] The selected Target Version (" + this.targetVersion.toString() + ") is only supported by bot sent card. For user sent cards please use version 1.3"));
+			}
             if (this.targetVersion.compareTo(this.hostContainer.targetVersion) > 0 && Shared.GlobalSettings.showTargetVersionMismatchWarning) {
                 errorPane.appendChild(this.renderErrorPaneElement("[Warning] The selected Target Version (" + this.targetVersion.toString() + ") is greater than the version supported by " + this.hostContainer.name + " (" + this.hostContainer.targetVersion.toString() + ")"));
             }

--- a/source/nodejs/adaptivecards-designer/src/containers/teams/teams-container.ts
+++ b/source/nodejs/adaptivecards-designer/src/containers/teams/teams-container.ts
@@ -43,7 +43,7 @@ abstract class BaseTeamsContainer extends HostContainer {
     }
 
     get targetVersion(): Adaptive.Version {
-        return Adaptive.Versions.v1_2;
+        return Adaptive.Versions.v1_4;
     }
 }
 


### PR DESCRIPTION
This addresses #6314.

The designer is now updated to show an appropriate warning with teams containers to indicate support only for bot sent cards.