### PR TITLE
[Infrastructure] Disable failing push job from js-release.yml

### DIFF
--- a/.pipelines/js-release.yml
+++ b/.pipelines/js-release.yml
@@ -59,13 +59,3 @@ steps:
         workingDir: source/nodejs/${{ target_package }}
         publishEndpoint: npmjs.com
       condition: and(succeeded(), eq(variables['Build.Reason'], 'Manual'))
-
-    - bash: |
-       git config --global user.email "adaptivecardscore@microsoft.com"
-       git config --global user.name "adaptivecards"
-       git push --tags
-      workingDirectory: source/android/adaptivecards
-      displayName: 'Push git tag'
-
-
-


### PR DESCRIPTION
Disable push job from js-release.yml to be able to continue package release

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/6563)