### PR TITLE
[JS] More reasonable HostConfig label defaults

### DIFF
--- a/source/nodejs/adaptivecards/src/host-config.ts
+++ b/source/nodejs/adaptivecards/src/host-config.ts
@@ -1050,23 +1050,16 @@ export const defaultHostConfig: HostConfig = new HostConfig(
         inputs: {
             label: {
                 requiredInputs: {
-                    color: Enums.TextColor.Accent,
-                    size: Enums.TextSize.ExtraLarge,
                     weight: Enums.TextWeight.Bolder,
-                    isSubtle: true,
-                    suffix: " (required)",
-                    suffixColor: Enums.TextColor.Good
+                    suffix: " *",
+                    suffixColor: Enums.TextColor.Attention
                 },
                 optionalInputs: {
-                    color: Enums.TextColor.Warning,
-                    size: Enums.TextSize.Medium,
-                    weight: Enums.TextWeight.Lighter,
-                    isSubtle: false
+                    weight: Enums.TextWeight.Bolder
                 }
             },
             errorMessage: {
-                color: Enums.TextColor.Accent,
-                size: Enums.TextSize.Small,
+                color: Enums.TextColor.Attention,
                 weight: Enums.TextWeight.Bolder
             }
         },


### PR DESCRIPTION
# Related Issue

Fixes #6613

# Description

I think that the defaults for Javascript's default HostConfig for Labels and ErrorMessage were chosen in order to make it easy to test to make sure that they were being applied correctly during development. However, they don't really make for an appealing default experience, so we're changing them to be more in line with what we'd expect most hosts want.

One place you can see the defaults in action is inside the Designer's `New Card` dialog:

<details>
<summary>Before</summary>

![image](https://user-images.githubusercontent.com/16614499/139166973-b5050a8c-80db-4692-b813-f9276a0b0765.png)

</details>

<details>
<summary>After</summary>

![image](https://user-images.githubusercontent.com/16614499/139167040-8ee86746-063f-47a2-95b3-35b1c74bab5e.png)


</details>

# How Verified

* local build and devtools

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/6662)