### PR TITLE
[UWP Renderer]: Action/MediaEventInvoker expose a constructor that takes renderedAC

### DIFF
--- a/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
+++ b/source/uwp/Renderer/idl/AdaptiveCards.Rendering.Uwp.idl
@@ -446,6 +446,7 @@ namespace AdaptiveCards
             runtimeclass AdaptiveActionInvoker
             {
                 AdaptiveActionInvoker();
+                AdaptiveActionInvoker(RenderedAdaptiveCard renderResult);
 
                 void SendActionEvent(AdaptiveCards.ObjectModel.Uwp.IAdaptiveActionElement actionElement);
             };
@@ -453,6 +454,7 @@ namespace AdaptiveCards
             runtimeclass AdaptiveMediaEventInvoker
             {
                 AdaptiveMediaEventInvoker();
+                AdaptiveMediaEventInvoker(RenderedAdaptiveCard renderResult);
 
                 void SendMediaClickedEvent(AdaptiveCards.ObjectModel.Uwp.AdaptiveMedia mediaElement);
             };

--- a/source/uwp/Renderer/lib/AdaptiveActionInvoker.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveActionInvoker.cpp
@@ -16,10 +16,10 @@ namespace AdaptiveCards::Rendering::Uwp
 {
     HRESULT AdaptiveActionInvoker::RuntimeClassInitialize() noexcept { return S_OK; }
 
-    HRESULT AdaptiveActionInvoker::RuntimeClassInitialize(_In_ RenderedAdaptiveCard* renderResult) noexcept
+    HRESULT AdaptiveActionInvoker::RuntimeClassInitialize(_In_ IRenderedAdaptiveCard * renderResult) noexcept
     try
     {
-        ComPtr<RenderedAdaptiveCard> strongRenderResult = renderResult;
+        ComPtr<IRenderedAdaptiveCard> strongRenderResult = renderResult;
         return strongRenderResult.AsWeak(&m_weakRenderResult);
     }
     CATCH_RETURN;

--- a/source/uwp/Renderer/lib/AdaptiveActionInvoker.h
+++ b/source/uwp/Renderer/lib/AdaptiveActionInvoker.h
@@ -16,7 +16,7 @@ namespace AdaptiveCards::Rendering::Uwp
     public:
         HRESULT RuntimeClassInitialize() noexcept;
 
-        HRESULT RuntimeClassInitialize(_In_ AdaptiveCards::Rendering::Uwp::RenderedAdaptiveCard* renderResult) noexcept;
+        HRESULT RuntimeClassInitialize(_In_ ABI::AdaptiveCards::Rendering::Uwp::IRenderedAdaptiveCard* renderResult) noexcept;
 
         IFACEMETHODIMP SendActionEvent(_In_ ABI::AdaptiveCards::ObjectModel::Uwp::IAdaptiveActionElement* actionElement);
 
@@ -24,5 +24,16 @@ namespace AdaptiveCards::Rendering::Uwp
         Microsoft::WRL::WeakRef m_weakRenderResult;
     };
 
-    ActivatableClass(AdaptiveActionInvoker);
+    class AdaptiveActionInvokerFactory
+        : public Microsoft::WRL::AgileActivationFactory<ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveActionInvokerFactory>
+
+    {
+        IFACEMETHODIMP CreateInstance(ABI::AdaptiveCards::Rendering::Uwp::IRenderedAdaptiveCard* renderResult,
+                                      _COM_Outptr_ ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveActionInvoker** result) override
+        {
+            return Microsoft::WRL::Details::MakeAndInitialize<AdaptiveActionInvoker>(result, renderResult);
+        }
+    };
+
+    ActivatableClassWithFactory(AdaptiveActionInvoker, AdaptiveActionInvokerFactory);
 }

--- a/source/uwp/Renderer/lib/AdaptiveMediaEventInvoker.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveMediaEventInvoker.cpp
@@ -16,10 +16,10 @@ namespace AdaptiveCards::Rendering::Uwp
 {
     HRESULT AdaptiveMediaEventInvoker::RuntimeClassInitialize() noexcept { return S_OK; }
 
-    HRESULT AdaptiveMediaEventInvoker::RuntimeClassInitialize(_In_ RenderedAdaptiveCard* renderResult) noexcept
+    HRESULT AdaptiveMediaEventInvoker::RuntimeClassInitialize(_In_ IRenderedAdaptiveCard* renderResult) noexcept
     try
     {
-        ComPtr<RenderedAdaptiveCard> strongRenderResult = renderResult;
+        ComPtr<IRenderedAdaptiveCard> strongRenderResult = renderResult;
         return strongRenderResult.AsWeak(&m_weakRenderResult);
     }
     CATCH_RETURN;

--- a/source/uwp/Renderer/lib/AdaptiveMediaEventInvoker.h
+++ b/source/uwp/Renderer/lib/AdaptiveMediaEventInvoker.h
@@ -16,7 +16,7 @@ namespace AdaptiveCards::Rendering::Uwp
     public:
         HRESULT RuntimeClassInitialize() noexcept;
 
-        HRESULT RuntimeClassInitialize(_In_ AdaptiveCards::Rendering::Uwp::RenderedAdaptiveCard* renderResult) noexcept;
+        HRESULT RuntimeClassInitialize(_In_ ABI::AdaptiveCards::Rendering::Uwp::IRenderedAdaptiveCard* renderResult) noexcept;
 
         IFACEMETHODIMP SendMediaClickedEvent(_In_ ABI::AdaptiveCards::ObjectModel::Uwp::IAdaptiveMedia* mediaElement);
 
@@ -24,5 +24,16 @@ namespace AdaptiveCards::Rendering::Uwp
         Microsoft::WRL::WeakRef m_weakRenderResult;
     };
 
-    ActivatableClass(AdaptiveMediaEventInvoker);
+    class AdaptiveMediaEventInvokerFactory
+        : public Microsoft::WRL::AgileActivationFactory<ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveMediaEventInvokerFactory>
+
+    {
+        IFACEMETHODIMP CreateInstance(ABI::AdaptiveCards::Rendering::Uwp::IRenderedAdaptiveCard* renderResult,
+                                      _COM_Outptr_ ABI::AdaptiveCards::Rendering::Uwp::IAdaptiveMediaEventInvoker** result) override
+        {
+            return Microsoft::WRL::Details::MakeAndInitialize<AdaptiveMediaEventInvoker>(result, renderResult);
+        }
+    };
+
+    ActivatableClassWithFactory(AdaptiveMediaEventInvoker, AdaptiveActionInvokerFactory);
 }


### PR DESCRIPTION
# Related Issue

This PR fixes #6681.

# Description
The following constructors though implemented, were not exposed through `.idl` for UWP Renderer.
` AdaptiveActionInvoker(RenderedAdaptiveCard renderResult)`
` AdaptiveMediaEventInvoker(RenderedAdaptiveCard renderResult)`

I've added these constructors to the `.idl` so they can be used when Renderer is consumed by a customer.

# How Verified
Manually verified by instantiating object in C#.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/6682)