### PR TITLE
[JS] Pin newer `jest` and `ts-jest` dependencies for `adaptivecards`

### DIFF
--- a/source/nodejs/adaptivecards/package.json
+++ b/source/nodejs/adaptivecards/package.json
@@ -44,7 +44,7 @@
 		"dts-generator": "^3.0.0",
 		"eslint": "^7.3.1",
 		"html-webpack-plugin": "^5.3.2",
-		"jest": "^27.0.0-next.9",
+		"jest": "^27.3.1",
 		"rimraf": "^3.0.2",
 		"swiper": "^7.2.0",
 		"ts-jest": "^27.0.0-next.12",

--- a/source/nodejs/adaptivecards/package.json
+++ b/source/nodejs/adaptivecards/package.json
@@ -47,7 +47,7 @@
 		"jest": "^27.3.1",
 		"rimraf": "^3.0.2",
 		"swiper": "^7.2.0",
-		"ts-jest": "^27.0.0-next.12",
+		"ts-jest": "^27.0.7",
 		"typedoc": "^0.22.5",
 		"typedoc-plugin-markdown": "^3.11.2",
 		"typescript": "^4.2.3",


### PR DESCRIPTION
# Description

Just a minor oversight - the version of `jest` I saw recommended to fix our problems consuming the `swiper` module ended
up being a pre-release version. `jest@^27` and `ts-jest@^27` have since had full releases, so I just wanted to make sure we were requiring them specifically. For what it's worth, we weren't actually *using* the prerelease versions (see below), but all the same it's better to declare our dependency against a full-fledged release.

https://github.com/microsoft/AdaptiveCards/blob/2c3f8530556213a1a1f5ed742b62c28f24a4c24d/source/nodejs/adaptivecards/package-lock.json#L4485-L4486

# How Verified

* verified unit tests still pass

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/6702)