### PR TITLE
Jwoo/feature/carousel 4

### DIFF
--- a/source/nodejs/adaptivecards/src/carousel.ts
+++ b/source/nodejs/adaptivecards/src/carousel.ts
@@ -270,23 +270,25 @@ export class Carousel extends Container {
 
         swiperContainer.appendChild(swiperWrapper as HTMLElement);
 
+        swiperContainer.tabIndex = 0;
+
         containerForAdorners.appendChild(swiperContainer);
 
         this.initializeCarouselControl(swiperContainer, nextElementDiv, prevElementDiv, pagination);
 
-        cardLevelContainer.addEventListener("focusin", (event) => {
-            if (!this._isSwiperInitialized) {
-                this._isSwiperInitialized = true;
-                this._swiper?.destroy();
-                this.initializeCarouselControl(swiperContainer, nextElementDiv, prevElementDiv, pagination);
-            }
-        });
+        cardLevelContainer.addEventListener("keydown", (event) => {
+            // we don't need to check which key was pressed, we only need to reinit swiper once, then remove this event listener
+           let activeIndex = this._swiper?.activeIndex;
+           this.initializeCarouselControl(swiperContainer, nextElementDiv, prevElementDiv, pagination);
+           if (activeIndex) { 
+               this._swiper?.slideTo(activeIndex);
+           }
+        }, {once : true});
 
         return this._renderedPages.length > 0 ? cardLevelContainer : undefined;
     }
 
     private _swiper?: Swiper;
-    private _isSwiperInitialized = false;
 
     private initializeCarouselControl(swiperContainer: HTMLElement, nextElement: HTMLElement, prevElement: HTMLElement, paginationElement: HTMLElement): void {
         const swiperOptions: SwiperOptions = {

--- a/source/nodejs/tests/ui-tests/src/ui-tests.test.ts
+++ b/source/nodejs/tests/ui-tests/src/ui-tests.test.ts
@@ -13,6 +13,7 @@ describe("Mock function", function() {
     // the input value. Only use this if you see some test flakiness. Value is given in ms
     const delayForInputRetrieval: number = 500;
     const delayForCarouselArrows: number = 1000;
+    const delayForCarouselTimer: number = 5500;
 
     // Timeout of 10 minutes for the dev server to start up in the CI jobs, the dev-server
     // usually takes between 1 to 2 minutes but we have no way to determine when the server
@@ -156,5 +157,33 @@ describe("Mock function", function() {
         const secondCarouselPageVisibility: string =
             await testUtils.getCssPropertyValueForElementWithId("theSecondCarouselPage", "visibility");
         Assert.strictEqual("visible", secondCarouselPageVisibility);
+    }), 9000);
+
+    test("Test click on navigation does not cause sudden jump", (async() => {
+        await testUtils.goToTestCase("v1.6/Carousel");
+
+        let firstCarouselPageVisibility: string = await testUtils.getCssPropertyValueForElementWithId("firstCarouselPage", "visibility");
+
+        Assert.strictEqual("visible", firstCarouselPageVisibility);
+
+        // wait for 3 pages to turn
+        await testUtils.delay(delayForCarouselTimer * 3);
+
+        firstCarouselPageVisibility = await testUtils.getCssPropertyValueForElementWithId("firstCarouselPage", "visibility");
+        Assert.strictEqual("hidden", firstCarouselPageVisibility);
+
+        const thirdCarouselPageVisibility: string =
+            await testUtils.getCssPropertyValueForElementWithId("theThirdCarouselPage", "visibility");
+        Assert.strictEqual("visible", thirdCarouselPageVisibility);
+
+        // cause the page to go the 2nd page
+        const leftArrow = await testUtils.driver.findElement(Webdriver.By.className("ac-carousel-left"));
+        await leftArrow.click();
+        await testUtils.delay(delayForCarouselArrows);
+
+        // make sure firstCarouselPage is hidden
+        firstCarouselPageVisibility = await testUtils.getCssPropertyValueForElementWithId("firstCarouselPage", "visibility");
+        Assert.strictEqual("hidden", firstCarouselPageVisibility);
+
     }), 9000);
 });


### PR DESCRIPTION
# Description
* re-initializing swiper; swiper needs to be re-initialized because it won't configure pagination bullets for a11y.
* Fixed the issue where it resets the active page and swiper wrapper's attributes. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/6720)