### PR TITLE
[JS] Remove `role='menubar'` from `ActionCollection`

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -5007,7 +5007,6 @@ class ActionCollection {
             let buttonStrip = document.createElement("div");
             buttonStrip.className = hostConfig.makeCssClassName("ac-actionSet");
             buttonStrip.style.display = "flex";
-            buttonStrip.setAttribute("role", "menubar");
 
             if (orientation == Enums.Orientation.Horizontal) {
                 buttonStrip.style.flexDirection = "row";
@@ -5114,12 +5113,6 @@ class ActionCollection {
                 action.render();
 
                 if (action.renderedElement) {
-                    if (primaryActions.length > 1) {
-                        action.renderedElement.setAttribute("aria-posinset", (i + 1).toString());
-                        action.renderedElement.setAttribute("aria-setsize", primaryActions.length.toString());
-                        action.renderedElement.setAttribute("role", "menuitem");
-                    }
-
                     if (hostConfig.actions.actionsOrientation == Enums.Orientation.Horizontal && hostConfig.actions.actionAlignment == Enums.ActionAlignment.Stretch) {
                         action.renderedElement.style.flex = "0 1 100%";
                     }


### PR DESCRIPTION
# Related Issue

Fixes #6425
Fixes #6019

# Description

Remove the `menubar` role from `ActionCollection` (as well as `aria-posinset`, `aria-setsize`, and `role='menuitem'` from children).  This was originally part of a fix to expose actions in a set to address a different accessibility concern (see #4184) -- namely that actions in an `ActionSet` should be presented in such a way that AT can tell the user how many actions there are. The way you do that is via `aria-posinset` and `aria-setsize`, which are only applicable to a limited number of roles (`button` and `link` [not being among them](https://www.w3.org/TR/wai-aria/#aria-posinset)). There can, of course, only be one `role` applied to an element, so we must unfortunately choose to stick with `button` or `link` and remove the other attributes.

# How Verified

* local build, devtools, narrator

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/6763)