### PR TITLE
[JS] Fix #6810: onAnchorClicked() should pass the anchor element itself

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -1205,13 +1205,13 @@ export class TextBlock extends BaseTextBlock {
                 anchor.classList.add(hostConfig.makeCssClassName("ac-anchor"));
                 anchor.target = "_blank";
                 anchor.onclick = (e: MouseEvent) => {
-                    if (raiseAnchorClickedEvent(this, e.target as HTMLAnchorElement, e)) {
+                    if (raiseAnchorClickedEvent(this, anchor, e)) {
                         e.preventDefault();
                         e.cancelBubble = true;
                     }
                 };
                 anchor.oncontextmenu = (e: MouseEvent) => {
-                    if (raiseAnchorClickedEvent(this, e.target as HTMLAnchorElement, e)) {
+                    if (raiseAnchorClickedEvent(this, anchor, e)) {
                         e.preventDefault();
                         e.cancelBubble = true;
 


### PR DESCRIPTION
# Related Issue

#6810 

# Description

See #6810 for details

# Sample Card

```JSON
{
  "$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
  "type": "AdaptiveCard",
  "version": "1.0",
  "body": [
    {
      "type": "TextBlock",
      "text": "[**hyperlink strong**](https://microsoft.com)"
    }
  ]
}
```

# How Verified

How you verified the fix, including one or all of the following:
1. Register `onAnchorClicked()` callback to SDK
2. Send a card as above
3. Expect `onAnchorClicked()` with target of `<a>` tag with `href` rather than `<strong>` tag

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/6837)