### PR TITLE
Moving resource bundle to core

### DIFF
--- a/source/ios/tools/AdaptiveCards.podspec
+++ b/source/ios/tools/AdaptiveCards.podspec
@@ -17,6 +17,7 @@ Pod::Spec.new do |spec|
 
   spec.subspec 'AdaptiveCardsCore' do | sspec |
     sspec.source_files = 'source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/*.{h,m,mm}'
+    sspec.resource_bundles = {'AdaptiveCards' => ['source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/Resources/**/*']}
     sspec.dependency 'AdaptiveCards/AdaptiveCardsPrivate'
     sspec.dependency 'AdaptiveCards/ObjectModel'
   end
@@ -45,8 +46,6 @@ Pod::Spec.new do |spec|
   spec.platform         = :ios, '14'
 
   spec.frameworks = 'AVFoundation', 'AVKit', 'CoreGraphics', 'QuartzCore', 'UIKit'
-  
-  spec.resource_bundles = {'AdaptiveCards' => ['source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/Resources/**/*']}
 
   spec.exclude_files = 'source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/include/**/*'
 


### PR DESCRIPTION
# Related Issue

Host application is not able to find the AdaptiveCards.bundle when SDK is consumed without `UIProvider`

# Description

This fix moves the resource bundle from root spec to `AdaptiveCardsCore` spec. 

# How Verified
Build the product and verify that `AdaptiveCards.bundle` is present in the build directory. The consumption is done adding the pod to a podfile

pod 'AdaptiveCards' ~> 'x.x.x'
AND
pod 'AdaptiveCards/AdaptiveCardsCore' ~> 'x.x.x'
pod 'AdaptiveCards/AdaptiveCardsPrivate' ~> 'x.x.x'
pod 'AdaptiveCards/ObjectModel' ~> 'x.x.x'

![image](https://user-images.githubusercontent.com/86079148/146460632-a85344c4-23e2-4f5c-8579-cc57196c89be.png)






###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/6853)