### PR TITLE
Fix uwp-ci test failure on ActivityUpdateSmokeTest

### DIFF
--- a/source/uwp/UWPUITests/TestHelpers.cs
+++ b/source/uwp/UWPUITests/TestHelpers.cs
@@ -132,7 +132,7 @@ namespace UWPUITests
             // return inputTextBlock?.DocumentText;
         }
 
-        public static void SetDateToUIElement(int year, int month, int day)
+        public static void SetDateToUIElement(int month, int day)
         {
             // Retrieve the date input and click on it
             // TODO: Fix UWP implementation to assign name/id to the CalendarDatePicker control
@@ -151,7 +151,7 @@ namespace UWPUITests
             MoveToMonth(currentMonth, month, calendarView);
 
             // Click on the day "16" button which in turn closes the popup
-            FindElementByName("16", calendarView).Click();
+            FindElementByName(day.ToString(), calendarView).Click();
         }
 
         private static void MoveToMonth(int currentMonth, int expectedMonth, UIObject calendarView)

--- a/source/uwp/UWPUITests/UITest.cs
+++ b/source/uwp/UWPUITests/UITest.cs
@@ -27,7 +27,7 @@ namespace UWPUITests
             showCardButton.Click();
 
             // Set the date on the Date control
-            TestHelpers.SetDateToUIElement(2021, 07, 16);
+            TestHelpers.SetDateToUIElement(7, 16);
 
             // Retrieve the "Add a comment" Input.Text and fill it with information
             var commentTextBox = TestHelpers.CastTo<Edit>(TestHelpers.FindElementByName("Add a comment"));
@@ -38,7 +38,7 @@ namespace UWPUITests
 
             // Verify submitted data
             Assert.AreEqual("A comment", TestHelpers.GetInputValue("comment"), "Values for input comment differ");
-            Assert.AreEqual("2021-07-16", TestHelpers.GetInputValue("dueDate"), "Values for input dueDate differ");
+            Assert.AreEqual(System.DateTime.Now.Year.ToString() + "-07-16", TestHelpers.GetInputValue("dueDate"), "Values for input dueDate differ");
         }
 
         [TestMethod]


### PR DESCRIPTION
Fix 2022 year issue: `Assert.AreEqual failed. Expected:<2021-07-16>. Actual:<2022-07-16>. Values for input dueDate differ`


SetDateToUIElement didn't take year and day. So remove the year from the function.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/6864)