### PR TITLE
skip npx lint-staged on the hook

### DIFF
--- a/source/nodejs/.husky/pre-commit
+++ b/source/nodejs/.husky/pre-commit
@@ -4,8 +4,9 @@ if [ -f $HUSKY_SH ]; then
     . $HUSKY_SH
     cd source/nodejs
     NODEJS_FILES_CHANGED=`git status . --short | wc -l`
-    if [ $NODEJS_FILES_CHANGED != "0" ]; then
-        npx lint-staged
-    fi
+    # npx lint-staged is disabled because of https://github.com/microsoft/AdaptiveCards/issues/6895
+    #if [ $NODEJS_FILES_CHANGED != "0" ]; then
+    #    npx lint-staged
+    #fi
 fi
 


### PR DESCRIPTION
Because of #6895, skip the lint-staged
This need to be re-enabled after this issue is resolved.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/6898)