### PR TITLE
[cad-designer: viva connections] Set cursor to pointer for clickable quick view ColumnSets

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/containers/viva-connections/viva-connections-container.css
+++ b/source/nodejs/adaptivecards-designer/src/containers/viva-connections/viva-connections-container.css
@@ -88,7 +88,7 @@
 .ac-container {
   border: none !important;
 }
-.ac-image.ac-selectable, .ac-container.ac-selectable {
+.ac-image.ac-selectable, .ac-container.ac-selectable, .ac-columnSet.ac-selectable {
   cursor: pointer;
 }
 .ac-container iframe {


### PR DESCRIPTION
# Description

This PR sets the cursor to pointer when hovering over `ColumnSet`s that are clickable (when `selectAction` is set to `Action.OpenUrl`), in Viva Connections cards in the card designer. This is in sync with changes to Viva Connections itself. This is a very minor one-line change.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7042)