### PR TITLE
Provide name and tooltip for collapsed/expanded arrows under 'Amount' in the 'Expense approval card'

### DIFF
--- a/source/uwp/Renderer/lib/ActionHelpers.cpp
+++ b/source/uwp/Renderer/lib/ActionHelpers.cpp
@@ -586,6 +586,8 @@ namespace AdaptiveCards::Rendering::Uwp::ActionHelpers
         {
             if (action.Title().empty() && action.Tooltip().empty())
             {
+                // We are in the same edge case mentioned above (column being used as a toggle button)
+                // so we need to ensure that we update our title/tooltip when our items swap visibilities
                 const auto callback = [adaptiveCardElement, button, description]()
                 {
                     if (const auto col = adaptiveCardElement.try_as<winrt::AdaptiveColumn>())

--- a/source/uwp/Renderer/lib/ActionHelpers.h
+++ b/source/uwp/Renderer/lib/ActionHelpers.h
@@ -50,7 +50,8 @@ namespace AdaptiveCards::Rendering::Uwp::ActionHelpers
 
     void WireButtonClickToAction(winrt::Button const& button,
                                  winrt::IAdaptiveActionElement const& action,
-                                 winrt::AdaptiveRenderContext const& renderContext);
+                                 winrt::AdaptiveRenderContext const& renderContext,
+                                 std::function<void()> callback = nullptr);
 
     winrt::UIElement WrapInTouchTarget(winrt::IAdaptiveCardElement const& adaptiveCardElement,
                                                           winrt::UIElement const& elementToWrap,


### PR DESCRIPTION
# Related Issue
Fixes #6274, #7012

# Description

The issues were regarding an edge case where we use a `Column` as a toggle button, i.e. the column contains 2 items, one visible and one invisible, and clicking the column swaps the visibilities between the items. In this case, the column itself does not have a title or a tooltip, and we need to reach into the visible item to get the `AltText`. 

The fix has 2 parts - 

1. When we first try to set the column's title/tooltip, we reach into the only visible item and use its `AltText`
2. Whenever the column is clicked, we invoke a callback function that updates the column's title/tooltip based on which item is now visible

# Sample Card

Expense report

# How Verified

Manual verification, can no longer reproduce the bugs listed above

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7066)