### PR TITLE
Convey Ctrl+M shortcut key to move out of code editor

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/card-designer.ts
+++ b/source/nodejs/adaptivecards-designer/src/card-designer.ts
@@ -1034,7 +1034,7 @@ export class CardDesigner extends Designer.DesignContext {
         // Setup card JSON editor
         this._cardEditorToolbox.content = document.createElement("div");
         this._cardEditorToolbox.content.setAttribute("role", "region");
-        this._cardEditorToolbox.content.setAttribute("aria-label", "card payload editor, press Ctrl+M to toggle tab behavior");
+        this._cardEditorToolbox.content.setAttribute("aria-label", "card payload editor, press Ctrl+M to toggle behavior of the TAB key");
         this._cardEditorToolbox.content.classList.add("acd-code-editor");
 
         this._cardEditor = monaco.editor.create(

--- a/source/nodejs/adaptivecards-designer/src/card-designer.ts
+++ b/source/nodejs/adaptivecards-designer/src/card-designer.ts
@@ -1034,7 +1034,7 @@ export class CardDesigner extends Designer.DesignContext {
         // Setup card JSON editor
         this._cardEditorToolbox.content = document.createElement("div");
         this._cardEditorToolbox.content.setAttribute("role", "region");
-        this._cardEditorToolbox.content.setAttribute("aria-label", "card payload editor");
+        this._cardEditorToolbox.content.setAttribute("aria-label", "card payload editor, press Ctrl+M to toggle tab behavior");
         this._cardEditorToolbox.content.classList.add("acd-code-editor");
 
         this._cardEditor = monaco.editor.create(


### PR DESCRIPTION
# Related Issue

#7015 

# Description

We add the hint about `ctrl+m` toggling the tab behavior to the label of the card editor.

# How Verified

Tested using narrator, the new label gets announced


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7072)