### PR TITLE
Fix luminosity ratio of links in footer of website

### DIFF
--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/source/css/style.css
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/source/css/style.css
@@ -682,7 +682,7 @@ button .fa-check {
 }
 
 .ac-footer-link-no-chevron{
-  color: #0b78d0!important;  
+  color: #0c70c3!important;  
 }
 
 .ac-footer .post-subtitle {


### PR DESCRIPTION
# Related Issue

#6420 

# Description

Change the colorr of the links to be a darker blue so that the contrast ratio is now 4.5:1

# How Verified

Using accessibility insights on the new colour and verified that the contrast ratio is now 4.5:1


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7081)