### PR TITLE
Fix heading levels for 'Card Payload and Data Sample Editors' and 'Keyboard shortcuts' headings in Help dialog

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/help-dialog.ts
+++ b/source/nodejs/adaptivecards-designer/src/help-dialog.ts
@@ -26,11 +26,11 @@ export class HelpDialog extends Dialog {
     protected renderContent(): HTMLElement {
         this._renderedElement = document.createElement("div");
 
-        let cardHeading = document.createElement("h1");
+        let cardHeading = document.createElement("h2");
         cardHeading.innerText = "Card Payload and Sample Data Editors";
         this._renderedElement.appendChild(cardHeading);
 
-        let keyboardHeading = document.createElement("h2");
+        let keyboardHeading = document.createElement("h3");
         keyboardHeading.innerText = "Keyboard Shortcuts";
         this._renderedElement.appendChild(keyboardHeading);
 


### PR DESCRIPTION
# Related Issue

#6276 

# Description

Use heading levels `h2` and `h3` instead of `h1` and `h2`

# How Verified

Manually verified by opening the Help dialog after making the change


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7082)