### PR TITLE
Add aria label to close video button

### DIFF
--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/index.ejs
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/index.ejs
@@ -6,7 +6,7 @@
 				<source src="https://adaptivecardsblob.blob.core.windows.net/assets/AdaptiveCardsOverviewVideo.mp4"
 					type="video/mp4" />
 			</video>
-			<span id="closeVideo" tabIndex="0" class="w3-button w3-xlarge w3-transparent w3-display-topright"
+			<span id="closeVideo" tabIndex="0" aria-label="Close video" class="w3-button w3-xlarge w3-transparent w3-display-topright"
 				title="Close video">×</span>
 		</div>
 	</div>


### PR DESCRIPTION
# Related Issue

#6422

# Description

The screen reader was not reading out the correct thing for the close video button. Adding an aria label fixes that.

# How Verified

Screen reader now says 'close video group' for the close video button

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7090)