### PR TITLE
Change the color of the 'redo' button so that it is able to adopt the high contrast theme color

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/adaptivecards-designer.css
+++ b/source/nodejs/adaptivecards-designer/src/adaptivecards-designer.css
@@ -948,7 +948,7 @@
 }
 
 .acd-toolbar-button.acd-toolbar-button-disabled {
-    color: lightgray;
+    color: InactiveCaptionText;
     background-color: transparent;
     cursor: default;
 }


### PR DESCRIPTION
# Related Issue

#7013 

# Description

Use a resource color (`InactiveCaptionText`) for setting the color of the 'redo' button instead of hard coding `lightgray`. 

# How Verified

Manually verified by setting a high contrast theme and observing the color of the inactive redo button.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7091)