### PR TITLE
Small codefix to fix problem described in #6862

### DIFF
--- a/source/dotnet/Library/AdaptiveCards/AdaptiveRefresh.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveRefresh.cs
@@ -1,11 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 using System.Collections.Generic;
 using System.Xml.Serialization;
 
 namespace AdaptiveCards
 {
+    /// <summary>
+    /// Represents how a card can be refreshed by making a request to the target Bot
+    /// </summary>
+    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+#if !NETSTANDARD1_3
+    [XmlType(TypeName = "Refresh")]
+#endif
     public class AdaptiveRefresh
     {
         /// <summary>

--- a/source/dotnet/Library/AdaptiveCards/docs/AdaptiveCards.md
+++ b/source/dotnet/Library/AdaptiveCards/docs/AdaptiveCards.md
@@ -4095,6 +4095,10 @@ This is necessary for XML serialization. You should use the [Url](#F-Url 'Url') 
 
 AdaptiveCards
 
+##### Summary
+
+Represents how a card can be refreshed by making a request to the target Bot
+
 <a name='P-AdaptiveCards-AdaptiveRefresh-Action'></a>
 ### Action `property`
 

--- a/source/dotnet/Test/AdaptiveCards.Test/AdaptiveCardApiTests.cs
+++ b/source/dotnet/Test/AdaptiveCards.Test/AdaptiveCardApiTests.cs
@@ -81,6 +81,40 @@ namespace AdaptiveCards.Test
         }
 
         [TestMethod]
+        public void TestParsingCardWithRefreshOption()
+        {
+            string json =
+@"{
+  ""type"": ""AdaptiveCard"",
+  ""version"": ""1.4"",
+  ""body"": [
+    {
+      ""type"": ""TextBlock"",
+      ""size"": ""medium"",
+      ""weight"": ""bolder"",
+      ""text"": ""AdaptiveRefreshSerializeBug"",
+      ""wrap"": true,
+      ""style"": ""heading""
+    }
+  ],
+  ""refresh"": {
+    ""action"": {
+      ""type"": ""Action.Execute"",
+      ""verb"": ""refresh"",
+      ""title"": ""Refresh""
+    },
+    ""userIds"": [
+      ""testUser""
+    ]
+  }
+}";
+
+            AdaptiveCardParseResult adaptiveCardParseResult = AdaptiveCard.FromJson(json);
+            Assert.IsNotNull(adaptiveCardParseResult.Card);
+            Assert.AreEqual(json, adaptiveCardParseResult.Card.ToJson());
+        }
+
+        [TestMethod]
         public void TestParsingInvalidCardMissingVersion()
         {
             var json = @"{


### PR DESCRIPTION
Small codefix to fix #6862 .

Solved by setting the correct naming strategy on class AdaptiveRefresh.

Added unit test to verify fix.

All tests passing.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7107)