### PR TITLE
Adjust contrast on designer peer buttons

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/adaptivecards-designer.css
+++ b/source/nodejs/adaptivecards-designer/src/adaptivecards-designer.css
@@ -748,8 +748,8 @@
 
 .acd-peerButton {
     font-size: 14px;
-    border: 1px solid steelblue;
-    color: steelblue;
+    border: 1px solid #2D7BB7;
+    color: #2D7BB7;
     background-color: white;
     cursor: default;
     user-select: none;
@@ -787,7 +787,7 @@
 }
 
 .acd-peerButton:hover {
-    background-color: steelblue;
+    background-color: #2D7BB7;
     color: white;
 }
 


### PR DESCRIPTION
# Related Issue

Closes #7109

# Description

Adjusts the color of the designer's peer buttons (i.e. bind, close, drag) to match that of the warning/error message. This makes the color contrast 4.537:1, which is acceptable for regular text and graphical UI controls.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7110)