### PR TITLE
fixed unit tests

### DIFF
--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizerUITests/ADCIOSVisualizerUITests.mm
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizerUITests/ADCIOSVisualizerUITests.mm
@@ -249,7 +249,9 @@
     [chatWindow /*@START_MENU_TOKEN@*/.buttons[@"myColor"] /*[[".cells.buttons[@\"myColor\"]",".buttons[@\"myColor\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/ tap];
 
     XCUIElementQuery *tablesQuery = testApp.tables;
-    [tablesQuery.cells[@"(null), Blue"].staticTexts[@"Blue"] tap];
+    [tablesQuery.cells[@"myColor, Blue"].staticTexts[@"Blue"] tap];
+
+    [chatWindow swipeUp];
 
     XCUIElementQuery *buttons = testApp.buttons;
     [buttons[@"OK"] tap];
@@ -273,6 +275,9 @@
     [chatWindow.tables[@"myColor2"].staticTexts[@"myColor2, Green"] tap];
     [chatWindow /*@START_MENU_TOKEN@*/.tables[@"myColor3"].staticTexts[@"myColor3, Red"] /*[[".cells.tables[@\"myColor3\"]",".cells[@\"Empty list, Red\"]",".staticTexts[@\"Red\"]",".staticTexts[@\"myColor3, Red\"]",".tables[@\"myColor3\"]"],[[[-1,4,1],[-1,0,1]],[[-1,3],[-1,2],[-1,1,2]],[[-1,3],[-1,2]]],[0,0]]@END_MENU_TOKEN@*/ tap];
 
+    [chatWindow swipeUp];
+
+    // Execute a drag from the 4th element to the 2nd element
     XCUIElementQuery *buttons = testApp.buttons;
     [buttons[@"OK"] tap];
 
@@ -293,6 +298,8 @@
     XCUIElement *chatWindow = testApp.tables[@"ChatWindow"];
     [chatWindow.tables[@"myColor3"].staticTexts[@"myColor3, Blue"] tap];
     [chatWindow /*@START_MENU_TOKEN@*/.tables[@"myColor3"].staticTexts[@"myColor3, Red"] /*[[".cells.tables[@\"myColor3\"]",".cells[@\"Empty list, Red\"]",".staticTexts[@\"Red\"]",".staticTexts[@\"myColor3, Red\"]",".tables[@\"myColor3\"]"],[[[-1,4,1],[-1,0,1]],[[-1,3],[-1,2],[-1,1,2]],[[-1,3],[-1,2]]],[0,0]]@END_MENU_TOKEN@*/ tap];
+
+    [chatWindow swipeUp];
 
     XCUIElementQuery *buttons = testApp.buttons;
     [buttons[@"OK"] tap];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetCompactStyleView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetCompactStyleView.mm
@@ -77,6 +77,8 @@ using namespace AdaptiveCards;
         _listView = [[UITableView alloc] init];
         _listView.dataSource = self;
         _listView.delegate = self;
+        _listView.accessibilityIdentifier = [NSString stringWithUTF8String:choiceSet->GetId().c_str()];
+
         self.filteredListView = _listView;
 
         _view = [[UIView alloc] init];
@@ -343,6 +345,7 @@ using namespace AdaptiveCards;
     cell.textLabel.text = [_filteredDataSource getItemAt:indexPath.row];
     cell.textLabel.numberOfLines = _wrapLines;
     cell.accessibilityLabel = [NSString stringWithFormat:@"%@, %@", _inputLabel, cell.textLabel.text];
+    cell.accessibilityIdentifier = [NSString stringWithFormat:@"%@, %@", self.id, cell.textLabel.text];
     cell.accessibilityTraits = UIAccessibilityTraitButton;
     return cell;
 }


### PR DESCRIPTION
# Related Issue

Fixes issues where ui unit test failures.

# Open bugs

#7114 - Bug opened to track improvement on swipe calls

# Description

https://github.com/microsoft/AdaptiveCards/pull/7100
* with input added, texts got wrapped and made the card longer.
* 'ok' button is pushed down and became hidden.
* added `swipe up` motion to the unit tests to bring up the ok button.
* added accessibility label to filtered list input.
* 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7113)