### PR TITLE
Update role of 'Select Host App' combobox

### DIFF
--- a/source/nodejs/adaptivecards-controls/src/dropdown.ts
+++ b/source/nodejs/adaptivecards-controls/src/dropdown.ts
@@ -239,7 +239,7 @@ export class DropDown extends InputWithPopup<DropDownPopupControl, DropDownItem>
             this.rootElement.setAttribute("aria-labelledby", ariaLabelledByIds.join(" "));
         }
 
-        this.rootElement.setAttribute("role", "button");
+        this.rootElement.setAttribute("role", "combobox");
         this.rootElement.setAttribute("aria-haspopup", "menu");
     }
 


### PR DESCRIPTION
# Related Issue

Close #7117 

# Description

Updates the role of the `Select Host App` combo box in the designer from `button` to `combobox`

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7118)