### PR TITLE
Tab focus can no longer land on disabled 'undo'/'redo' buttons

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/toolbar.ts
+++ b/source/nodejs/adaptivecards-designer/src/toolbar.ts
@@ -72,10 +72,12 @@ export class ToolbarButton extends ToolbarElement {
         if(!this.isEnabled) {
             this.renderedElement.classList.add("acd-toolbar-button-disabled");
             this.renderedElement.setAttribute("aria-disabled", "true");
+            this.renderedElement.tabIndex = -1;
         }
         else {
             this.renderedElement.classList.remove("acd-toolbar-button-disabled");
             this.renderedElement.removeAttribute("aria-disabled");
+            this.renderedElement.tabIndex = 0;
         }
 
         if (this.isToggled) {


### PR DESCRIPTION
# Related Issue

#7116 

# Description

For toolbar buttons, we now set the tab index to be -1 if it is disabled or 0 if it is enabled (so it is no longer possible to tab to it when it is disabled, but it is still possible to tab to it when it is enabled).

# Sample Card

N/A

# How Verified

Manual verification

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7119)