### PR TITLE
Add a 1px left margin to the Documentation item in the header

### DIFF
--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/_partial/header.ejs
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/_partial/header.ejs
@@ -54,7 +54,7 @@
                                             <a class="c-uhf-nav-link" href="<%- url_for('/') %>" data-m="{&quot;cN&quot;:&quot;CatNav_Home_nav&quot;,&quot;id&quot;:&quot;n1c8c2m1r1a1&quot;,&quot;sN&quot;:1,&quot;aN&quot;:&quot;c8c2m1r1a1&quot;}"><%= site.data.banner.en.home %></a>
                                         </li>
                                         <li class="single-link js-nav-menu">
-                                            <a id="c-shellmenu_0" class="c-uhf-nav-link" href="https://docs.microsoft.com/en-us/adaptive-cards"
+                                            <a id="c-shellmenu_0" class="c-uhf-nav-link" style="margin-left:1px;" href="https://docs.microsoft.com/en-us/adaptive-cards"
                                                 data-m="{&quot;cN&quot;:&quot;CatNav_Documentation_nav&quot;,&quot;id&quot;:&quot;n2c8c2m1r1a1&quot;,&quot;sN&quot;:2,&quot;aN&quot;:&quot;c8c2m1r1a1&quot;}"><%= site.data.banner.en.documentation %></a>
                                         </li>
                                         <li class="single-link js-nav-menu">


### PR DESCRIPTION
# Related Issue

#7137 

# Description

Add a 1px left margin to the documentation item in the header so the focus indicator does not get cut off when the page is resized to 200%.

# Sample Card

N/A

# How Verified

Manual verification, cannot repro the bug anymore

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7142)