### PR TITLE
Allow footer hyperlinks to wrap

### DIFF
--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/source/css/style.css
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/source/css/style.css
@@ -674,7 +674,7 @@ button .fa-check {
   color: #5a5a5a;
   font-size: 14px;
   font-weight: 600;
-  white-space: nowrap;
+  white-space: break-word;
 }
 
 .ac-footer a:hover {


### PR DESCRIPTION
# Related Issue

Closes #7143 

# Description

The horizontal scroll bar is appearing sometimes because the blog post titles are too long! This causes the hyperlinks in the footer to overflow and introduces a horizontal scrollbar. The fix here is to allow the hyperlinks to wrap. So if we update the `white-space` styling to `break-word`, we get it to wrap.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7147)