### PR TITLE
Don't let focus fall on acd-designersurface

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/card-designer-surface.ts
+++ b/source/nodejs/adaptivecards-designer/src/card-designer-surface.ts
@@ -544,7 +544,7 @@ export class CardDesignerSurface {
 
         this._designerSurface = document.createElement("div");
         this._designerSurface.classList.add("acd-designersurface");
-        this._designerSurface.tabIndex = 0;
+        this._designerSurface.tabIndex = -1;
         this._designerSurface.style.position = "absolute";
         this._designerSurface.style.left = "0";
         this._designerSurface.style.top = "0";


### PR DESCRIPTION
# Related Issue

#7152 

# Description

Focus was mistakenly falling onto the `acd-designersurface`, despite there not being any purpose for it to be there (the control cannot be activated). This commit makes it so focus no longer can fall onto `acd-designersurface`, preventing focus from seemingly becoming 'lost' when navigating out of the adaptive card in designer mode.

# Sample Card

N/A

# How Verified

Manual verification, focus no longer gets lost.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7153)