### PR TITLE
Add underline styling to hyperlinks

### DIFF
--- a/source/nodejs/adaptivecards-site/pages/_data/samples.yml
+++ b/source/nodejs/adaptivecards-site/pages/_data/samples.yml
@@ -4,7 +4,7 @@ en:
   intro: These samples are <em>just a teaser</em> of the type of cards you can create. Go ahead and tweak them to make any scenario possible!
   accwarning: |
     <strong>Important note about accessibility:</strong> 
-    In version 1.3 of the schema we introduced a <a href="https://docs.microsoft.com/en-us/adaptive-cards/authoring-cards/input-validation#labels"><strong>label</strong></a> property on Inputs to improve accessibility. If the <a href="https://docs.microsoft.com/en-us/adaptive-cards/resources/partners">Host app you are targeting</a> supports v1.3 you should use <strong>label</strong> instead of a <strong>TextBlock</strong> as seen in some samples below. Once most Host apps have updated to the latest version we will update the samples accordingly.</a>
+    In version 1.3 of the schema we introduced a <a href="https://docs.microsoft.com/en-us/adaptive-cards/authoring-cards/input-validation#labels" style="text-decoration:underline;"><strong>label</strong></a> property on Inputs to improve accessibility. If the <a href="https://docs.microsoft.com/en-us/adaptive-cards/resources/partners" style="text-decoration:underline;">Host app you are targeting</a> supports v1.3 you should use <strong>label</strong> instead of a <strong>TextBlock</strong> as seen in some samples below. Once most Host apps have updated to the latest version we will update the samples accordingly.</a>
   choose_sample: "Choose Sample:"
   use_templating: Use Adaptive Card Templating <span class="w3-tag w3-medium w3-round ac-blue">Updated May 2020</span>
   templating_info: |

--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/explorer.ejs
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/explorer.ejs
@@ -20,7 +20,7 @@
 	</nav>
 
 	<div class="w3-main" style="margin-left: 200px">
-		<div class="w3-container">
+		<div class="w3-container schema-content">
 			<h1><%= page.title %></h1>
 
 			<!-- mobile nav -->

--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/source/css/style.css
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/source/css/style.css
@@ -653,6 +653,11 @@ button .fa-check {
   color: blue;
 }
 
+.schema-content a:link,
+.schema-content a:visited {
+	text-decoration: underline;
+}
+
 /* .fa-chevron-right {
   font-size: 11px;
   font-weight: lighter;


### PR DESCRIPTION
# Related Issue

Close #7138 

# Description

Provides an underline styling for the hyperlinks in (1) the schema explorer and (2) the accessibility note written in some pages. (1) was accomplished by adding a new class to the content div of the schema explorer (then styling that class). (2) was accomplished by adding the styling directly to that note.

Thought the styling is redundant for the accessibility note in the schema explorer, CSS gracefully cascades the styling sheets and only applies the styling once.