### PR TITLE
Release/website updates 03 2022

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -41,7 +41,7 @@ A bug must have an issue tracking it in the issue tracker that has been approved
 ## Contributing features
 
 Thank you for wanting to contribute to Adaptive Cards. If you are planning to make changes to the Core SDK, please make sure these changes align with our [Core Design Principles](https://docs.microsoft.com/en-us/adaptive-cards/#core-design-principles). Prior to writing any code that affects rendering, please make sure you follow the following steps:
-1.	Open a "Feature Request" issue to start the discussion on the feature you wish to see in the product. Please make sure you search our planned work to see if your feature is already planned. Please make sure you search our [planned work](https://portal.productboard.com/adaptivecards/1-adaptive-cards-features/tabs/6-planned) to see if your feature is already planned.
+1.	Open a "Feature Request" issue to start the discussion on the feature you wish to see in the product. Please make sure you search our planned work to see if your feature is already planned. Please make sure you search our [planned work](https://github.com/microsoft/AdaptiveCards/projects/32) to see if your feature is already planned.
 2.	Open a PR with a .MD file to the [following directory](https://github.com/microsoft/AdaptiveCards/tree/main/specs/elements) with a spec that clearly outlines the feature you are implementing. **Include as much detail on the feature as possible**.
     1.	At a bare minimum you must answer the following questions:
         1.	Why do you need this feature and what will the feature do?

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Dive in
 
 * [Documentation](https://adaptivecards.io/documentation/)
-* [Roadmap](https://portal.productboard.com/adaptivecards/1-adaptive-cards-features/tabs/5-launched)
+* [Roadmap](https://github.com/microsoft/AdaptiveCards/projects/32)
 * [Schema Explorer](https://adaptivecards.io/explorer/)
 * [Sample Cards](https://adaptivecards.io/samples/)
 * [Designer](https://adaptivecards.io/designer/)

--- a/samples/Templates/Scenarios/ApplicationLogin.data.json
+++ b/samples/Templates/Scenarios/ApplicationLogin.data.json
@@ -1,0 +1,5 @@
+{
+    "ApplicationInfo": {
+        "title": "Application Login"
+    }
+}

--- a/samples/Templates/Scenarios/ApplicationLogin.template.json
+++ b/samples/Templates/Scenarios/ApplicationLogin.template.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "type": "AdaptiveCard",
+    "version": "1.5",
+    "body": [
+        {
+            "type": "TextBlock",
+            "size": "Medium",
+            "weight": "Bolder",
+            "text": " ${ApplicationInfo.title}",
+            "horizontalAlignment": "Center",
+            "wrap": true,
+            "style": "heading"
+        },
+        {
+            "type": "TextBlock",
+            "text": "Username",
+            "wrap": true
+        },
+        {
+            "type": "Input.Text",
+            "style": "text",
+            "id": "UserVal",
+            "isRequired": true
+        },
+        {
+            "type": "TextBlock",
+            "text": "Password",
+            "wrap": true
+        },
+        {
+            "type": "Input.Text",
+            "id": "PassVal",
+            "style": "password",
+            "isRequired": true
+        }
+    ],
+    "actions": [
+        {
+            "type": "Action.Submit",
+            "title": "Login",
+            "data": {
+                "id": "LoginVal"
+            }
+        }
+    ]
+}

--- a/samples/Templates/Scenarios/FlightUpdateTable.data.json
+++ b/samples/Templates/Scenarios/FlightUpdateTable.data.json
@@ -1,0 +1,40 @@
+{
+	"@context": "http://schema.org",
+	"@type": "FlightReservation",
+	"reservationId": "RXJ34P",
+	"reservationStatus": "http://schema.org/ReservationConfirmed",
+	"passengerPriorityStatus": "Fast Track",
+	"passengerSequenceNumber": "ABC123",
+	"securityScreening": "TSA PreCheck",
+	"underName": {
+	  "@type": "Person",
+	  "name": "Sarah Hum"
+	},
+	"reservationFor": {
+	  "@type": "Flight",
+	  "flightNumber": "KL605",
+	  "provider": {
+		"@type": "Airline",
+		"name": "KLM",
+		"iataCode": "KL",
+		"boardingPolicy": "http://schema.org/ZoneBoardingPolicy"
+	  },
+	  "seller": {
+		"@type": "Airline",
+		"name": "KLM",
+		"iataCode": "KL"
+	  },
+	  "departureAirport": {
+		"@type": "Airport",
+		"name": "Amsterdam Airport",
+		"iataCode": "AMS"
+	  },
+	  "departureTime": "2017-03-04T09:20:00-01:00",
+	  "arrivalAirport": {
+		"@type": "Airport",
+		"name": "San Francisco Airport",
+		"iataCode": "SFO"
+	  },
+	  "arrivalTime": "2017-03-05T08:20:00+04:00"
+	}
+  }

--- a/samples/Templates/Scenarios/FlightUpdateTable.template.json
+++ b/samples/Templates/Scenarios/FlightUpdateTable.template.json
@@ -1,0 +1,261 @@
+{ 
+    "type": "AdaptiveCard",
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.5",
+    "body": [
+        {
+            "type": "Table",
+            "columns": [
+                {
+                    "width": 1
+                },
+                {
+                    "width": 1
+                },
+                {
+                    "width": 1
+                }
+            ],
+            "rows": [
+                {
+                    "type": "TableRow",
+                    "cells": [
+                        {
+                            "type": "TableCell",
+                            "items": [
+                                {
+                                    "type": "Image",
+                                    "size": "Small",
+                                    "url": "https://adaptivecards.io/content/airplane.png"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "TableCell"
+                        },
+                        {
+                            "type": "TableCell",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Flight Status",
+                                    "horizontalAlignment": "Right",
+                                    "isSubtle": true,
+                                    "wrap": true
+                                },
+                                {
+                                    "type": "TextBlock",
+                                    "text": "DELAYED",
+                                    "horizontalAlignment": "Right",
+                                    "spacing": "None",
+                                    "size": "Large",
+                                    "color": "Attention",
+                                    "wrap": true
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "TableRow",
+                    "cells": [
+                        {
+                            "type": "TableCell",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Passengers",
+                                    "isSubtle": true,
+                                    "weight": "Bolder",
+                                    "wrap": true,
+                                    "spacing": "None"
+                                },
+                                {
+                                    "type": "TextBlock",
+                                    "text": "${underName.name}",
+                                    "spacing": "Small",
+                                    "wrap": true
+                                },
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Jeremy Goldberg",
+                                    "spacing": "Small",
+                                    "wrap": true
+                                },
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Evan Litvak",
+                                    "spacing": "Small",
+                                    "wrap": true
+                                }
+                            ]
+                        },
+                        {
+                            "type": "TableCell"
+                        },
+                        {
+                            "type": "TableCell",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Seat",
+                                    "horizontalAlignment": "Right",
+                                    "isSubtle": true,
+                                    "weight": "Bolder",
+                                    "wrap": true
+                                },
+                                {
+                                    "type": "TextBlock",
+                                    "text": "14A",
+                                    "horizontalAlignment": "Right",
+                                    "spacing": "Small",
+                                    "wrap": true
+                                },
+                                {
+                                    "type": "TextBlock",
+                                    "text": "14B",
+                                    "horizontalAlignment": "Right",
+                                    "spacing": "Small",
+                                    "wrap": true
+                                },
+                                {
+                                    "type": "TextBlock",
+                                    "text": "14C",
+                                    "horizontalAlignment": "Right",
+                                    "spacing": "Small",
+                                    "wrap": true
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "TableRow",
+                    "cells": [
+                        {
+                            "type": "TableCell",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Flight",
+                                    "isSubtle": true,
+                                    "weight": "Bolder",
+                                    "wrap": true
+                                },
+                                {
+                                    "type": "TextBlock",
+                                    "text": "${reservationFor.flightNumber}",
+                                    "spacing": "Small",
+                                    "wrap": true
+                                }
+                            ]
+                        },
+                        {
+                            "type": "TableCell",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Departs",
+                                    "isSubtle": true,
+                                    "horizontalAlignment": "Center",
+                                    "weight": "Bolder",
+                                    "wrap": true
+                                },
+                                {
+                                    "type": "TextBlock",
+                                    "text": "{{TIME(${string(reservationFor.departureTime)})}}",
+                                    "color": "Attention",
+                                    "weight": "Bolder",
+                                    "horizontalAlignment": "Center",
+                                    "spacing": "Small",
+                                    "wrap": true
+                                }
+                            ]
+                        },
+                        {
+                            "type": "TableCell",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Arrives",
+                                    "isSubtle": true,
+                                    "horizontalAlignment": "Right",
+                                    "weight": "Bolder",
+                                    "wrap": true
+                                },
+                                {
+                                    "type": "TextBlock",
+                                    "text": "{{TIME(${string(reservationFor.arrivalTime)})}}",
+                                    "color": "Attention",
+                                    "horizontalAlignment": "Right",
+                                    "weight": "Bolder",
+                                    "spacing": "Small",
+                                    "wrap": true
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "TableRow",
+                    "cells": [
+                        {
+                            "type": "TableCell",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "${reservationFor.departureAirport.name}",
+                                    "isSubtle": true,
+                                    "wrap": true
+                                },
+                                {
+                                    "type": "TextBlock",
+                                    "text": "${reservationFor.departureAirport.iataCode}",
+                                    "size": "ExtraLarge",
+                                    "color": "Accent",
+                                    "spacing": "None",
+                                    "wrap": true
+                                }
+                            ]
+                        },
+                        {
+                            "type": "TableCell",
+                            "items": [
+                                {
+                                    "type": "Image",
+                                    "url": "https://adaptivecards.io/content/airplane.png",
+                                    "horizontalAlignment": "Center",
+                                    "size": "Small"
+                                }
+                            ],
+                            "verticalContentAlignment": "Center"
+                        },
+                        {
+                            "type": "TableCell",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "${reservationFor.arrivalAirport.name}",
+                                    "isSubtle": true,
+                                    "horizontalAlignment": "Right",
+                                    "wrap": true
+                                },
+                                {
+                                    "type": "TextBlock",
+                                    "text": "${reservationFor.arrivalAirport.iataCode}",
+                                    "horizontalAlignment": "Right",
+                                    "size": "ExtraLarge",
+                                    "color": "Accent",
+                                    "spacing": "None",
+                                    "wrap": true
+                                }
+                            ]
+                        }
+                    ],
+                    "spacing": "None"
+                }
+            ],
+            "showGridLines": false
+        }
+    ]
+}

--- a/samples/Templates/Scenarios/InputFormWithRTL.data.json
+++ b/samples/Templates/Scenarios/InputFormWithRTL.data.json
@@ -1,0 +1,6 @@
+{ 
+    "FormInfo":{
+        "titleENG":"Registration Form",
+        "titleARA":"إستمارة تسجيل"
+    }
+}

--- a/samples/Templates/Scenarios/InputFormWithRTL.template.json
+++ b/samples/Templates/Scenarios/InputFormWithRTL.template.json
@@ -1,0 +1,116 @@
+{
+	"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+	"type": "AdaptiveCard",
+	"version": "1.5",
+	"body": [
+	  {
+		"type": "TextBlock",
+		"text": "Please select your language:"
+	  }
+	],
+	"actions": [
+	  {
+		"type": "Action.ShowCard",
+		"title": "English",
+		"card": {
+		  "type": "AdaptiveCard",
+		  "body": [
+			{
+			  "type": "TextBlock",
+			  "size": "medium",
+			  "weight": "bolder",
+			  "text": " ${FormInfo.titleENG}",
+			  "horizontalAlignment": "center",
+			  "wrap": true,
+			  "style": "heading"
+			},
+			{
+			  "type": "Input.Text",
+			  "label": "Name",
+			  "style": "text",
+			  "id": "SimpleValENG",
+			  "isRequired": true,
+			  "errorMessage": "Name is required"
+			},
+			{
+			  "type": "Input.Text",
+			  "label": "Email",
+			  "style": "email",
+			  "id": "EmailValENG"
+			},
+			{
+			  "type": "Input.Text",
+			  "label": "Phone",
+			  "style": "tel",
+			  "id": "TelValENG"
+			},
+			{
+			  "type": "Input.Text",
+			  "label": "Comments",
+			  "style": "text",
+			  "isMultiline": true,
+			  "id": "MultiLineValENG"
+			}
+		  ],
+		  "actions": [
+			{
+			  "type": "Action.Submit",
+			  "title": "Submit"
+			}
+		  ]
+		}
+	  },
+	  {
+		"type": "Action.ShowCard",
+		"title": "عربي",
+		"card": {
+		  "type": "AdaptiveCard",
+		  "rtl": true,
+		  "body": [
+			{
+			  "type": "TextBlock",
+			  "size": "medium",
+			  "weight": "bolder",
+			  "text": " ${FormInfo.titleARA}",
+			  "horizontalAlignment": "center",
+			  "wrap": true,
+			  "style": "heading"
+			},
+			{
+			  "type": "Input.Text",
+			  "label": "اسم",
+			  "style": "text",
+			  "id": "SimpleValARA",
+			  "isRequired": true,
+			  "errorMessage": "مطلوب اسم"
+			},
+			{
+			  "type": "Input.Text",
+			  "label": "بريد الالكتروني",
+			  "style": "email",
+			  "id": "EmailValARA"
+			},
+			{
+			  "type": "Input.Text",
+			  "label": "هاتف",
+			  "style": "tel",
+			  "id": "TelValARA"
+			},
+			{
+			  "type": "Input.Text",
+			  "label": "تعليقات",
+			  "style": "text",
+			  "isMultiline": true,
+			  "id": "MultiLineValARA"
+			}
+		  ],
+		  "actions": [
+			{
+			  "type": "Action.Submit",
+			  "title": "يقدم"
+			}
+		  ]
+		}
+	  }
+	]
+}

--- a/samples/Templates/Scenarios/OrderConfirmation.data.json
+++ b/samples/Templates/Scenarios/OrderConfirmation.data.json
@@ -1,0 +1,9 @@
+{
+    "title": "Please confirm your order:",
+    "customer": [{
+        "firstName": "John",
+        "lastName": "Smith",
+        "phone": "(555) 555-5555"
+    }
+    ]
+}

--- a/samples/Templates/Scenarios/OrderConfirmation.template.json
+++ b/samples/Templates/Scenarios/OrderConfirmation.template.json
@@ -1,0 +1,68 @@
+{ 
+    "type": "AdaptiveCard",
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.5",
+    "body": [
+        {
+            "type": "TextBlock",
+            "text": "${title}",
+            "wrap": true,
+            "style": "heading"
+        },
+        {
+            "type": "FactSet",
+            "facts": [
+                {
+                    "title": "Name",
+                    "value": "${customer[0].firstName} ${customer[0].lastName}"
+                },
+                {
+                    "title": "Phone number",
+                    "value": "${customer[0].phone}"
+                }
+            ]
+        },
+        {
+            "type": "Container",
+            "items": [
+                {
+                    "type": "FactSet",
+                    "facts": [
+                        {
+                            "title": "1x",
+                            "value": "Steak"
+                        },
+                        {
+                            "title": "2x",
+                            "value": "Side Rice"
+                        },
+                        {
+                            "title": "1x",
+                            "value": "Soft Drink"
+                        }
+                    ],
+                    "spacing": "Small"
+                }
+            ],
+            "spacing": "Small"
+        }
+    ],
+    "actions": [
+        {
+            "type": "Action.Execute",
+            "title": "Place Order"
+        },
+        {
+            "type": "Action.Execute",
+            "title": "Edit Order",
+            "data": "edit",
+            "mode": "secondary"
+        },
+        {
+            "type": "Action.Execute",
+            "title": "Save Order",
+            "data": "save",
+            "mode": "secondary"
+        }
+    ]
+}

--- a/samples/Templates/Scenarios/OrderDelivery.data.json
+++ b/samples/Templates/Scenarios/OrderDelivery.data.json
@@ -1,0 +1,18 @@
+{
+	"name": "Malt \u0026 Vine",
+	"address": {
+		"addressLocality": "Redmond",
+		"addressRegion": "WA",
+		"streetAddress": "16851 Redmond Way",
+		"postalCode": "98052",
+		"addressCountry": "US"
+	},
+	"review": [{
+		"reviewRating": {
+		  "ratingValue": 4
+		},
+		"datePublished": "2014-11-28",
+		"description": "Great concept and a wide selection of beers both on tap and bottled! Smaller wine selection than I wanted, but the variety of beers certainly made up for that. Although I didn't order anything, my boyfriend got a beer and he loved it. Their prices are fair too. \n\nThe concept is really awesome. It's a bar/store that you can bring outside food into. The place was pretty packed tonight. I wish we had stayed for more than one drink. I would have loved to sample everything!",
+		"author": "Blaire S."
+	}]
+}

--- a/samples/Templates/Scenarios/OrderDelivery.template.json
+++ b/samples/Templates/Scenarios/OrderDelivery.template.json
@@ -1,0 +1,70 @@
+{ 
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "type": "AdaptiveCard",
+    "version": "1.5",
+    "body": [
+        {
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "width": 2,
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "${address.addressLocality}, ${address.addressRegion}",
+                            "wrap": true
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "${name}",
+                            "weight": "bolder",
+                            "size": "extraLarge",
+                            "spacing": "none",
+                            "wrap": true
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "4.5 stars (176 reviews) · mid-priced",
+                            "isSubtle": true,
+                            "spacing": "none",
+                            "wrap": true
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "**${review[0].author}** said \"${review[0].description}\"",
+                            "size": "small",
+                            "wrap": true,
+                            "maxLines": 3
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": 1,
+                    "items": [
+                        {
+                            "type": "Image",
+                            "url": "https://picsum.photos/300?image=882",
+                            "size": "auto",
+                            "altText": "Seated guest drinking a cup of coffee"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "type": "Action.Submit",
+            "title": "Pickup",
+            "tooltip": "Schedule order for pickup"
+        },
+        {
+            "type": "Action.Submit",
+            "title": "Delivery",
+            "isEnabled": false,
+            "tooltip": "Your location is too far for delivery"
+        }
+    ]
+}

--- a/samples/Templates/Scenarios/RestaurantOrder.data.json
+++ b/samples/Templates/Scenarios/RestaurantOrder.data.json
@@ -1,0 +1,76 @@
+{ 
+    "FormInfo": {
+        "title": "Malt & Vine Order Form"
+    },
+    "Order": {
+        "questions": [
+            {
+                "question": "Which entree would you like?",
+                "items": [
+                    {
+                        "choice": "Steak",
+                        "value": "1"
+                    },
+                    {
+                        "choice": "Chicken",
+                        "value": "2"
+                    },
+                    {
+                        "choice": "Tofu",
+                        "value": "3"
+                    }
+                ]
+            },
+            {
+                "question": "Which side would you like?",
+                "items": [
+                    {
+                        "choice": "Baked Potato",
+                        "value": "1"
+                    },
+                    {
+                        "choice": "Rice",
+                        "value": "2"
+                    },
+                    {
+                        "choice": "Vegetables",
+                        "value": "3"
+                    },
+                    {
+                        "choice": "Noodles",
+                        "value": "4"
+                    },
+                    {
+                        "choice": "No Side",
+                        "value": "5"
+                    }
+                ]
+            },
+            {
+                "question": "Which drink would you like?",
+                "items": [
+                    {
+                        "choice": "Water",
+                        "value": "1"
+                    },
+                    {
+                        "choice": "Soft Drink",
+                        "value": "2"
+                    },
+                    {
+                        "choice": "Coffee",
+                        "value": "3"
+                    },
+                    {
+                        "choice": "Natural Juice",
+                        "value": "4"
+                    },
+                    {
+                        "choice": "No Drink",
+                        "value": "5"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/samples/Templates/Scenarios/RestaurantOrder.template.json
+++ b/samples/Templates/Scenarios/RestaurantOrder.template.json
@@ -1,0 +1,68 @@
+{ 
+    "type": "AdaptiveCard",
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.5",
+    "body": [
+        {
+            "type": "TextBlock",
+            "text": "${FormInfo.title}",
+            "size": "Large",
+            "wrap": true,
+            "weight": "Bolder"
+        },
+        {
+            "type": "Input.ChoiceSet",
+            "id": "EntreeSelectVal",
+            "label": "${Order.questions[0].question}",
+            "style": "filtered",
+            "isRequired": true,
+            "errorMessage": "This is a required input",
+            "placeholder": "Please choose",
+            "choices": [
+                {
+                    "$data": "${Order.questions[0].items}",
+                    "title": "${choice}",
+                    "value": "${value}"
+                }
+            ]
+        },
+        {
+            "type": "Input.ChoiceSet",
+            "id": "SideVal",
+            "label": "${Order.questions[1].question}",
+            "style": "filtered",
+            "isRequired": true,
+            "errorMessage": "This is a required input",
+            "placeholder": "Please choose",
+            "choices": [
+                {
+                    "$data": "${Order.questions[1].items}",
+                    "title": "${choice}",
+                    "value": "${value}"
+                }
+            ]
+        },
+        {
+            "type": "Input.ChoiceSet",
+            "id": "DrinkVal",
+            "label": "${Order.questions[2].question}",
+            "style": "filtered",
+            "isRequired": true,
+            "errorMessage": "This is a required input",
+            "placeholder": "Please choose",
+            "choices": [
+                {
+                    "$data": "${Order.questions[2].items}",
+                    "title": "${choice}",
+                    "value": "${value}"
+                }
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "type": "Action.Submit",
+            "title": "Place Order"
+        }
+    ]
+}

--- a/samples/v1.5/Scenarios/ApplicationLogin.json
+++ b/samples/v1.5/Scenarios/ApplicationLogin.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "type": "AdaptiveCard",
+    "version": "1.5",
+    "body": [
+        {
+            "type": "TextBlock",
+            "size": "Medium",
+            "weight": "Bolder",
+            "text": "Application Login",
+            "horizontalAlignment": "Center",
+            "wrap": true,
+            "style": "heading"
+        },
+        {
+            "type": "TextBlock",
+            "text": "Username",
+            "wrap": true
+        },
+        {
+            "type": "Input.Text",
+            "style": "text",
+            "id": "UserVal",
+            "isRequired": true
+        },
+        {
+            "type": "TextBlock",
+            "text": "Password",
+            "wrap": true
+        },
+        {
+            "type": "Input.Text",
+            "id": "PassVal",
+            "style": "password",
+            "isRequired": true
+        }
+    ],
+    "actions": [
+        {
+            "type": "Action.Submit",
+            "title": "Login",
+            "data": {
+                "id": "LoginVal"
+            }
+        }
+    ]
+}

--- a/samples/v1.5/Scenarios/FlightUpdateTable.json
+++ b/samples/v1.5/Scenarios/FlightUpdateTable.json
@@ -1,0 +1,261 @@
+{ 
+    "type": "AdaptiveCard",
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.5",
+    "body": [
+        {
+            "type": "Table",
+            "columns": [
+                {
+                    "width": 1
+                },
+                {
+                    "width": 1
+                },
+                {
+                    "width": 1
+                }
+            ],
+            "rows": [
+                {
+                    "type": "TableRow",
+                    "cells": [
+                        {
+                            "type": "TableCell",
+                            "items": [
+                                {
+                                    "type": "Image",
+                                    "size": "Small",
+                                    "url": "https://adaptivecards.io/content/airplane.png"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "TableCell"
+                        },
+                        {
+                            "type": "TableCell",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Flight Status",
+                                    "horizontalAlignment": "Right",
+                                    "isSubtle": true,
+                                    "wrap": true
+                                },
+                                {
+                                    "type": "TextBlock",
+                                    "text": "DELAYED",
+                                    "horizontalAlignment": "Right",
+                                    "spacing": "None",
+                                    "size": "Large",
+                                    "color": "Attention",
+                                    "wrap": true
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "TableRow",
+                    "cells": [
+                        {
+                            "type": "TableCell",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Passengers",
+                                    "isSubtle": true,
+                                    "weight": "Bolder",
+                                    "wrap": true,
+                                    "spacing": "None"
+                                },
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Sarah Hum",
+                                    "spacing": "Small",
+                                    "wrap": true
+                                },
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Jeremy Goldberg",
+                                    "spacing": "Small",
+                                    "wrap": true
+                                },
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Evan Litvak",
+                                    "spacing": "Small",
+                                    "wrap": true
+                                }
+                            ]
+                        },
+                        {
+                            "type": "TableCell"
+                        },
+                        {
+                            "type": "TableCell",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Seat",
+                                    "horizontalAlignment": "Right",
+                                    "isSubtle": true,
+                                    "weight": "Bolder",
+                                    "wrap": true
+                                },
+                                {
+                                    "type": "TextBlock",
+                                    "text": "14A",
+                                    "horizontalAlignment": "Right",
+                                    "spacing": "Small",
+                                    "wrap": true
+                                },
+                                {
+                                    "type": "TextBlock",
+                                    "text": "14B",
+                                    "horizontalAlignment": "Right",
+                                    "spacing": "Small",
+                                    "wrap": true
+                                },
+                                {
+                                    "type": "TextBlock",
+                                    "text": "14C",
+                                    "horizontalAlignment": "Right",
+                                    "spacing": "Small",
+                                    "wrap": true
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "TableRow",
+                    "cells": [
+                        {
+                            "type": "TableCell",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Flight",
+                                    "isSubtle": true,
+                                    "weight": "Bolder",
+                                    "wrap": true
+                                },
+                                {
+                                    "type": "TextBlock",
+                                    "text": "KL605",
+                                    "spacing": "Small",
+                                    "wrap": true
+                                }
+                            ]
+                        },
+                        {
+                            "type": "TableCell",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Departs",
+                                    "isSubtle": true,
+                                    "horizontalAlignment": "Center",
+                                    "weight": "Bolder",
+                                    "wrap": true
+                                },
+                                {
+                                    "type": "TextBlock",
+                                    "text": "2:20 AM",
+                                    "color": "Attention",
+                                    "weight": "Bolder",
+                                    "horizontalAlignment": "Center",
+                                    "spacing": "Small",
+                                    "wrap": true
+                                }
+                            ]
+                        },
+                        {
+                            "type": "TableCell",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Arrives",
+                                    "isSubtle": true,
+                                    "horizontalAlignment": "Right",
+                                    "weight": "Bolder",
+                                    "wrap": true
+                                },
+                                {
+                                    "type": "TextBlock",
+                                    "text": "8:20 PM",
+                                    "color": "Attention",
+                                    "horizontalAlignment": "Right",
+                                    "weight": "Bolder",
+                                    "spacing": "Small",
+                                    "wrap": true
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "TableRow",
+                    "cells": [
+                        {
+                            "type": "TableCell",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Amsterdam Airport",
+                                    "isSubtle": true,
+                                    "wrap": true
+                                },
+                                {
+                                    "type": "TextBlock",
+                                    "text": "AMS",
+                                    "size": "ExtraLarge",
+                                    "color": "Accent",
+                                    "spacing": "None",
+                                    "wrap": true
+                                }
+                            ]
+                        },
+                        {
+                            "type": "TableCell",
+                            "items": [
+                                {
+                                    "type": "Image",
+                                    "url": "https://adaptivecards.io/content/airplane.png",
+                                    "horizontalAlignment": "Center",
+                                    "size": "Small"
+                                }
+                            ],
+                            "verticalContentAlignment": "Center"
+                        },
+                        {
+                            "type": "TableCell",
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "San Francisco Airport",
+                                    "isSubtle": true,
+                                    "horizontalAlignment": "Right",
+                                    "wrap": true
+                                },
+                                {
+                                    "type": "TextBlock",
+                                    "text": "SFO",
+                                    "horizontalAlignment": "Right",
+                                    "size": "ExtraLarge",
+                                    "color": "Accent",
+                                    "spacing": "None",
+                                    "wrap": true
+                                }
+                            ]
+                        }
+                    ],
+                    "spacing": "None"
+                }
+            ],
+            "showGridLines": false
+        }
+    ]
+}

--- a/samples/v1.5/Scenarios/InputFormWithRTL.json
+++ b/samples/v1.5/Scenarios/InputFormWithRTL.json
@@ -1,0 +1,116 @@
+{
+	"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+	"type": "AdaptiveCard",
+	"version": "1.5",
+	"body": [
+	  {
+		"type": "TextBlock",
+		"text": "Please select your language:"
+	  }
+	],
+	"actions": [
+	  {
+		"type": "Action.ShowCard",
+		"title": "English",
+		"card": {
+		  "type": "AdaptiveCard",
+		  "body": [
+			{
+			  "type": "TextBlock",
+			  "size": "medium",
+			  "weight": "bolder",
+			  "text": "Registration Form",
+			  "horizontalAlignment": "center",
+			  "wrap": true,
+			  "style": "heading"
+			},
+			{
+			  "type": "Input.Text",
+			  "label": "Name",
+			  "style": "text",
+			  "id": "SimpleValENG",
+			  "isRequired": true,
+			  "errorMessage": "Name is required"
+			},
+			{
+			  "type": "Input.Text",
+			  "label": "Email",
+			  "style": "email",
+			  "id": "EmailValENG"
+			},
+			{
+			  "type": "Input.Text",
+			  "label": "Phone",
+			  "style": "tel",
+			  "id": "TelValENG"
+			},
+			{
+			  "type": "Input.Text",
+			  "label": "Comments",
+			  "style": "text",
+			  "isMultiline": true,
+			  "id": "MultiLineValENG"
+			}
+		  ],
+		  "actions": [
+			{
+			  "type": "Action.Submit",
+			  "title": "Submit"
+			}
+		  ]
+		}
+	  },
+	  {
+		"type": "Action.ShowCard",
+		"title": "عربي",
+		"card": {
+		  "type": "AdaptiveCard",
+		  "rtl": true,
+		  "body": [
+			{
+			  "type": "TextBlock",
+			  "size": "medium",
+			  "weight": "bolder",
+			  "text": "إستمارة تسجيل",
+			  "horizontalAlignment": "center",
+			  "wrap": true,
+			  "style": "heading"
+			},
+			{
+			  "type": "Input.Text",
+			  "label": "اسم",
+			  "style": "text",
+			  "id": "SimpleValARA",
+			  "isRequired": true,
+			  "errorMessage": "مطلوب اسم"
+			},
+			{
+			  "type": "Input.Text",
+			  "label": "بريد الالكتروني",
+			  "style": "email",
+			  "id": "EmailValARA"
+			},
+			{
+			  "type": "Input.Text",
+			  "label": "هاتف",
+			  "style": "tel",
+			  "id": "TelValARA"
+			},
+			{
+			  "type": "Input.Text",
+			  "label": "تعليقات",
+			  "style": "text",
+			  "isMultiline": true,
+			  "id": "MultiLineValARA"
+			}
+		  ],
+		  "actions": [
+			{
+			  "type": "Action.Submit",
+			  "title": "يقدم"
+			}
+		  ]
+		}
+	  }
+	]
+}

--- a/samples/v1.5/Scenarios/OrderConfirmation.json
+++ b/samples/v1.5/Scenarios/OrderConfirmation.json
@@ -1,0 +1,68 @@
+{ 
+    "type": "AdaptiveCard",
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.5",
+    "body": [
+        {
+            "type": "TextBlock",
+            "text": "Please confirm your order:",
+            "wrap": true,
+            "style": "heading"
+        },
+        {
+            "type": "FactSet",
+            "facts": [
+                {
+                    "title": "Name",
+                    "value": "John Smith"
+                },
+                {
+                    "title": "Phone number",
+                    "value": "(555) 555-5555"
+                }
+            ]
+        },
+        {
+            "type": "Container",
+            "items": [
+                {
+                    "type": "FactSet",
+                    "facts": [
+                        {
+                            "title": "1x",
+                            "value": "Steak"
+                        },
+                        {
+                            "title": "2x",
+                            "value": "Side Rice"
+                        },
+                        {
+                            "title": "1x",
+                            "value": "Soft Drink"
+                        }
+                    ],
+                    "spacing": "Small"
+                }
+            ],
+            "spacing": "Small"
+        }
+    ],
+    "actions": [
+        {
+            "type": "Action.Execute",
+            "title": "Place Order"
+        },
+        {
+            "type": "Action.Execute",
+            "title": "Edit Order",
+            "data": "edit",
+            "mode": "secondary"
+        },
+        {
+            "type": "Action.Execute",
+            "title": "Save Order",
+            "data": "save",
+            "mode": "secondary"
+        }
+    ]
+}

--- a/samples/v1.5/Scenarios/OrderDelivery.json
+++ b/samples/v1.5/Scenarios/OrderDelivery.json
@@ -1,0 +1,70 @@
+{ 
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "type": "AdaptiveCard",
+    "version": "1.5",
+    "body": [
+        {
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "width": 2,
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Redmond, WA",
+                            "wrap": true
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "Malt & Vine",
+                            "weight": "bolder",
+                            "size": "extraLarge",
+                            "spacing": "none",
+                            "wrap": true
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "4.5 stars (176 reviews) · mid-priced",
+                            "isSubtle": true,
+                            "spacing": "none",
+                            "wrap": true
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": "**Blaire S.** said \"Great concept and a wide selection of beers both on tap and bottled! Smaller wine selection than I wanted, but the variety of beers certainly made up for that. Although I didn't order anything, my boyfriend got a beer and he loved it. Their prices are fair too. \n\nThe concept is really awesome. It's a bar/store that you can bring outside food into. The place was pretty packed tonight. I wish we had stayed for more than one drink. I would have loved to sample everything!\"",
+                            "size": "small",
+                            "wrap": true,
+                            "maxLines": 3
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": 1,
+                    "items": [
+                        {
+                            "type": "Image",
+                            "url": "https://picsum.photos/300?image=882",
+                            "size": "auto",
+                            "altText": "Seated guest drinking a cup of coffee"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "type": "Action.Submit",
+            "title": "Pickup",
+            "tooltip": "Schedule order for pickup"
+        },
+        {
+            "type": "Action.Submit",
+            "title": "Delivery",
+            "isEnabled": false,
+            "tooltip": "Your location is too far for delivery"
+        }
+    ]
+}

--- a/samples/v1.5/Scenarios/RestaurantOrder.json
+++ b/samples/v1.5/Scenarios/RestaurantOrder.json
@@ -1,0 +1,105 @@
+{ 
+    "type": "AdaptiveCard",
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.5",
+    "body": [
+        {
+            "type": "TextBlock",
+            "text": "Malt & Vine Order Form",
+            "size": "Large",
+            "wrap": true,
+            "weight": "Bolder"
+        },
+        {
+            "type": "Input.ChoiceSet",
+            "id": "EntreeSelectVal",
+            "label": "Which entree would you like?",
+            "style": "filtered",
+            "isRequired": true,
+            "errorMessage": "This is a required input",
+            "placeholder": "Please choose",
+            "choices": [
+                {
+                    "title": "Steak",
+                    "value": "1"
+                },
+                {
+                    "title": "Chicken",
+                    "value": "2"
+                },
+                {
+                    "title": "Tofu",
+                    "value": "3"
+                }
+            ]
+        },
+        {
+            "type": "Input.ChoiceSet",
+            "id": "SideVal",
+            "label": "Which side would you like?",
+            "style": "filtered",
+            "isRequired": true,
+            "errorMessage": "This is a required input",
+            "placeholder": "Please choose",
+            "choices": [
+                {
+                    "title": "Baked Potato",
+                    "value": "1"
+                },
+                {
+                    "title": "Rice",
+                    "value": "2"
+                },
+                {
+                    "title": "Vegetables",
+                    "value": "3"
+                },
+                {
+                    "title": "Noodles",
+                    "value": "4"
+                },
+                {
+                    "title": "No Side",
+                    "value": "5"
+                }
+            ]
+        },
+        {
+            "type": "Input.ChoiceSet",
+            "id": "DrinkVal",
+            "label": "Which drink would you like?",
+            "style": "filtered",
+            "isRequired": true,
+            "errorMessage": "This is a required input",
+            "placeholder": "Please choose",
+            "choices": [
+                {
+                    "title": "Water",
+                    "value": "1"
+                },
+                {
+                    "title": "Soft Drink",
+                    "value": "2"
+                },
+                {
+                    "title": "Coffee",
+                    "value": "3"
+                },
+                {
+                    "title": "Natural Juice",
+                    "value": "4"
+                },
+                {
+                    "title": "No Drink",
+                    "value": "5"
+                }
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "type": "Action.Submit",
+            "title": "Place Order"
+        }
+    ]
+}

--- a/source/dotnet/Test/AdaptiveCards.Test/XmlSerializationTests.cs
+++ b/source/dotnet/Test/AdaptiveCards.Test/XmlSerializationTests.cs
@@ -36,7 +36,8 @@ namespace AdaptiveCards.Test
             // After changing the default value of the TextBlock Text property this test doesn't succeed as xml can't
             // read a single space (even with xml:space=preserve), hence we skip this file(s) to avoid test failures.
             // The generated xml actually contains the empty space
-            string[] cardsToIgnore = { "FlightUpdate.json" };
+			// v1.5 features are not implemented for .NET, therefore need to add the 1.5 scenario cards that are failing here
+            string[] cardsToIgnore = { "FlightUpdate.json", "FlightUpdateTable.json", "RestaurantOrder.json" };
          
             XmlSerializer serializer = new XmlSerializer(typeof(AdaptiveCard));
             foreach (var version in Directory.EnumerateDirectories(@"..\..\..\..\..\..\..\samples\", "v*"))

--- a/source/nodejs/adaptivecards-designer-app/src/app.ts
+++ b/source/nodejs/adaptivecards-designer-app/src/app.ts
@@ -61,7 +61,11 @@ window.onload = function () {
     }
     */
 
-    let designer = new ACDesigner.CardDesigner(ACDesigner.defaultMicrosoftHosts);
+    let designer = new ACDesigner.CardDesigner(
+      ACDesigner.defaultMicrosoftHosts,
+      ACDesigner.defaultMicrosoftDeviceEmulations
+    );
+
     designer.sampleCatalogueUrl = window.location.origin + "/sample-catalogue.json";
     designer.attachTo(document.getElementById("designerRootHost"));
 

--- a/source/nodejs/adaptivecards-designer-app/src/app.ts
+++ b/source/nodejs/adaptivecards-designer-app/src/app.ts
@@ -10,7 +10,7 @@ import "./app.css";
 // Uncomment below if you plan to use an empty hostContainers array
 // import "adaptivecards-designer/dist/adaptivecards-defaulthost.css";
 
-window.onload = function() {
+window.onload = function () {
     ACTemplating.GlobalSettings.getUndefinedFieldValueSubstitutionString = (path: string) => { return "<" + path + " is undefined>" };
 
     ACDesigner.GlobalSettings.showVersionPicker = true;
@@ -28,9 +28,9 @@ window.onload = function() {
     ACDesigner.Strings.toolboxes.toolPalette.title = "Custom title";
     */
 
-	// Uncomment to configure pic2card service
-	/*
-	ACDesigner.Pic2Card.pic2cardService = "https://<<your-pic2Card-service-endpoint>>";
+    // Uncomment to configure pic2card service
+    /*
+    ACDesigner.Pic2Card.pic2cardService = "https://<<your-pic2Card-service-endpoint>>";
     */
 
     // To Configure path for pic2card image usage policy
@@ -38,13 +38,13 @@ window.onload = function() {
     ACDesigner.Pic2Card.privacyLink = "../myPath/privacy";
     */
 
-	ACDesigner.CardDesigner.onProcessMarkdown = (text: string, result: { didProcess: boolean, outputHtml: string }) => {
-		result.outputHtml = new markdownit().render(text);
-		result.didProcess = true;
-	}
+    ACDesigner.CardDesigner.onProcessMarkdown = (text: string, result: { didProcess: boolean, outputHtml: string }) => {
+        result.outputHtml = new markdownit().render(text);
+        result.didProcess = true;
+    }
 
-	if (!ACDesigner.SettingsManager.isLocalStorageAvailable) {
-		console.log("Local storage is not available.");
+    if (!ACDesigner.SettingsManager.isLocalStorageAvailable) {
+        console.log("Local storage is not available.");
     }
 
     // Uncomment to disable (de)serialization of a specific property
@@ -61,9 +61,9 @@ window.onload = function() {
     }
     */
 
-	let designer = new ACDesigner.CardDesigner(ACDesigner.defaultMicrosoftHosts);
-	designer.sampleCatalogueUrl = window.location.origin + "/sample-catalogue.json";
-	designer.attachTo(document.getElementById("designerRootHost"));
+    let designer = new ACDesigner.CardDesigner(ACDesigner.defaultMicrosoftHosts);
+    designer.sampleCatalogueUrl = window.location.origin + "/sample-catalogue.json";
+    designer.attachTo(document.getElementById("designerRootHost"));
 
     /* Uncomment to test a custom palette item example
     let exampleSnippet = new ACDesigner.SnippetPaletteItem("Custom", "Example");
@@ -195,29 +195,29 @@ window.onload = function() {
     };
 
     /*
-	let sampleData = {
-		firstName: "John",
-		lastName: "Doe",
-		age: 45,
-		isMarried: true,
-		address: {
-			street: "1234 555th Ave NE",
-			city: "Redmond",
-			state: "WA",
-			countryOrRegion: "USA"
-		},
-		children: [
-			{
-				firstName: "Jennifer",
-				lastName: "Doe",
-				age: 9
-			},
-			{
-				firstName: "James",
-				lastName: "Doe",
-				age: 13
-			}
-		]
+    let sampleData = {
+        firstName: "John",
+        lastName: "Doe",
+        age: 45,
+        isMarried: true,
+        address: {
+            street: "1234 555th Ave NE",
+            city: "Redmond",
+            state: "WA",
+            countryOrRegion: "USA"
+        },
+        children: [
+            {
+                firstName: "Jennifer",
+                lastName: "Doe",
+                age: 9
+            },
+            {
+                firstName: "James",
+                lastName: "Doe",
+                age: 13
+            }
+        ]
     };
 
     let sampleDataStructure: ACDesigner.IData = {
@@ -310,7 +310,7 @@ window.onload = function() {
     };
     */
 
-	designer.dataStructure = ACDesigner.FieldDefinition.parse(sampleDataStructure);
+    designer.dataStructure = ACDesigner.FieldDefinition.parse(sampleDataStructure);
     // designer.lockDataStructure = true;
     designer.sampleData = sampleData;
     designer.bindingPreviewMode = ACDesigner.BindingPreviewMode.SampleData;

--- a/source/nodejs/adaptivecards-designer/src/adaptivecards-designer.css
+++ b/source/nodejs/adaptivecards-designer/src/adaptivecards-designer.css
@@ -35,7 +35,8 @@
 }
 
 .acd-designer-host {
-    margin: 20px 40px 20px 20px;
+    margin: 20px 0;
+    padding: 0 40px 0 20px;
 }
 
 .acd-designer-card-header {
@@ -902,6 +903,10 @@
     align-items: center;
     flex: 0 0 auto;
     margin: 0px 8px 0px 8px;
+}
+
+.acd-toolbar-picker-disabled[aria-disabled="true"], .acd-toolbar-picker-disabled + .acd-toolbar-separator {
+    display: none;
 }
 
 @media all and (min-width: 651px) {

--- a/source/nodejs/adaptivecards-designer/src/adaptivecards-designer.ts
+++ b/source/nodejs/adaptivecards-designer/src/adaptivecards-designer.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as containers from "./containers";
+import { DeviceEmulation } from "./device-emulation";
 
 export * from "./adaptivecards-designer-standalone";
 export * from "./containers/index";
@@ -15,5 +16,13 @@ export const defaultMicrosoftHosts: containers.HostContainer[] = [
 	new containers.LightCortanaContainer("Cortana Skills - Light", "containers/cortana-container-light.css"),
 	new containers.BotFrameworkContainer("Bot Framework Other Channels (Image render)", "containers/bf-image-container.css"),
 	new containers.CortanaClassicContainer("Cortana Skills (Classic)", "containers/cortana-classic-container.css"),
-	new containers.FederatedSearchContainer("Federated Search","containers/federated-search-container.css")
-]
+	new containers.FederatedSearchContainer("Federated Search","containers/federated-search-container.css"),
+];
+
+export const defaultMicrosoftDeviceEmulations: DeviceEmulation[] = [
+  { name: "Desktop (unconstrained)", maxWidth: undefined },
+  { name: "Small mobile (320px)", maxWidth: "320px" },
+  { name: "Large mobile (414px)", maxWidth: "414px" },
+  { name: "Small tablet (768px)", maxWidth: "768px" },
+  { name: "Large tablet (1024px)", maxWidth: "1024px" },
+];

--- a/source/nodejs/adaptivecards-designer/src/adaptivecards-designer.ts
+++ b/source/nodejs/adaptivecards-designer/src/adaptivecards-designer.ts
@@ -15,4 +15,5 @@ export const defaultMicrosoftHosts: containers.HostContainer[] = [
 	new containers.LightCortanaContainer("Cortana Skills - Light", "containers/cortana-container-light.css"),
 	new containers.BotFrameworkContainer("Bot Framework Other Channels (Image render)", "containers/bf-image-container.css"),
 	new containers.CortanaClassicContainer("Cortana Skills (Classic)", "containers/cortana-classic-container.css"),
+	new containers.FederatedSearchContainer("Federated Search","containers/federated-search-container.css")
 ]

--- a/source/nodejs/adaptivecards-designer/src/containers/bf-image/bf-image-container.ts
+++ b/source/nodejs/adaptivecards-designer/src/containers/bf-image/bf-image-container.ts
@@ -15,7 +15,11 @@ export class BotFrameworkContainer extends HostContainer {
 		hostElement.appendChild(frame);
 	}
 
-    public getHostConfig(): Adaptive.HostConfig {
-        return new Adaptive.HostConfig(hostConfig);
-    }
+	public getHostConfig(): Adaptive.HostConfig {
+		return new Adaptive.HostConfig(hostConfig);
+	}
+
+	get enableDeviceEmulation(): boolean {
+		return true;
+	}
 }

--- a/source/nodejs/adaptivecards-designer/src/containers/cortana/cortana-container.ts
+++ b/source/nodejs/adaptivecards-designer/src/containers/cortana/cortana-container.ts
@@ -17,6 +17,10 @@ abstract class BaseCortanaContainer extends HostContainer {
     get targetVersion(): Adaptive.Version {
         return Adaptive.Versions.v1_2;
     }
+
+    get enableDeviceEmulation(): boolean {
+        return true;
+    }
 }
 
 export class LightCortanaContainer extends BaseCortanaContainer {

--- a/source/nodejs/adaptivecards-designer/src/containers/federated-search/federated-search-container.css
+++ b/source/nodejs/adaptivecards-designer/src/containers/federated-search/federated-search-container.css
@@ -1,0 +1,80 @@
+a.ac-anchor:hover {
+  text-decoration: underline;
+}
+a.ac-anchor {
+  text-decoration: none;
+}
+a.ac-anchor:link {
+  color: inherit;
+}
+a.ac-anchor:visited {
+  color: inherit;
+  text-decoration: none;
+}
+.ac-textBlock p {
+  margin-top: 1px !important;
+}
+.ac-adaptiveCard {
+  background-color: inherit !important;
+}
+.ac-textBlock > p {
+  font-size: inherit;
+  font-family: inherit;
+  line-height: inherit;
+  font-weight: inherit;
+}
+
+.fedsearch-card {
+  border: 2px solid #f1f0ef;
+  border-top-color: #bfc6ceaf;
+  border-bottom-color: #bfc6ceaf;
+  border-radius: 4px;
+}
+
+.ac-container.ac-adaptiveCard {
+  border: none !important;
+}
+.aaf-spinner {
+  border-color: #6264a7;
+}
+.ac-pushButton {
+  background-color: inherit !important;
+  color: #6264a7;
+  border: 0px;
+  padding: 0px;
+  cursor: pointer;
+}
+.ac-choiceSetInput-expanded div {
+  margin-top: 6px;
+}
+.ac-pushButton.ac-pushButton.expanded:hover {
+  background-color: inherit !important;
+  border: 0px;
+  color: #6264a7;
+}
+
+.ac-pushButton.ac-actionSet .ac-pushButton.style-default.expandable:after {
+  content: "";
+}
+.aaf-progress-overlay {
+  background-color: inherit;
+}
+.ac-input input:checked {
+  appearance: none;
+}
+.ac-input input:checked::after {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  top: 2px;
+  position: relative;
+  content: " ";
+  display: inline-block;
+  visibility: visible;
+  border: 2px solid #6264a7;
+  background: radial-gradient(+ #6264a7 #6264a7 + 40% transparent 50% transparent);
+}
+.ac-input:focus {
+  border: 1px solid #6264a7;
+  outline: none;
+}

--- a/source/nodejs/adaptivecards-designer/src/containers/federated-search/federated-search-container.ts
+++ b/source/nodejs/adaptivecards-designer/src/containers/federated-search/federated-search-container.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as Adaptive from "adaptivecards";
+import { HostContainer } from "../host-container";
+import * as hostConfig from "../../hostConfigs/federated-search.json";
+
+export class FederatedSearchContainer extends HostContainer {
+  constructor(name: string, styleSheet: string) {
+    super(name, styleSheet);
+
+    this.actionsRegistry.unregister("Action.Submit");
+    this.elementsRegistry.unregister("Input.Text");
+    this.elementsRegistry.unregister("Input.Date");
+    this.elementsRegistry.unregister("Input.Time");
+    this.elementsRegistry.unregister("Input.Toggle");
+    this.elementsRegistry.unregister("Input.ChoiceSet");
+    this.elementsRegistry.unregister("Input.Number");    
+    
+  }
+
+  public renderTo(hostElement: HTMLElement) {
+    hostElement.classList.add("fedsearch-card");
+    hostElement.appendChild(this.cardHost);
+  }
+
+  public initialize() {
+    super.initialize();
+
+  }
+
+  public getHostConfig(): Adaptive.HostConfig {
+    return new Adaptive.HostConfig(hostConfig);
+  }
+
+  get targetVersion(): Adaptive.Version {
+    return Adaptive.Versions.v1_4;
+  }
+}

--- a/source/nodejs/adaptivecards-designer/src/containers/federated-search/federated-search-container.ts
+++ b/source/nodejs/adaptivecards-designer/src/containers/federated-search/federated-search-container.ts
@@ -19,7 +19,7 @@ export class FederatedSearchContainer extends HostContainer {
   }
 
   public renderTo(hostElement: HTMLElement) {
-    hostElement.classList.add("fedsearch-card");
+    this.cardHost.classList.add("fedsearch-card");
     hostElement.appendChild(this.cardHost);
   }
 
@@ -34,5 +34,9 @@ export class FederatedSearchContainer extends HostContainer {
 
   get targetVersion(): Adaptive.Version {
     return Adaptive.Versions.v1_4;
+  }
+
+  get enableDeviceEmulation(): boolean {
+    return true;
   }
 }

--- a/source/nodejs/adaptivecards-designer/src/containers/host-container.ts
+++ b/source/nodejs/adaptivecards-designer/src/containers/host-container.ts
@@ -76,4 +76,8 @@ export abstract class HostContainer {
     get targetVersion(): Version {
         return Versions.v1_0;
     }
+
+    get enableDeviceEmulation(): boolean {
+        return false;
+    }
 }

--- a/source/nodejs/adaptivecards-designer/src/containers/index.ts
+++ b/source/nodejs/adaptivecards-designer/src/containers/index.ts
@@ -12,3 +12,4 @@ export * from "./teams/teams-container";
 export * from "./timeline/timeline-container";
 export * from "./webchat/webchat-container";
 export * from "./viva-connections/viva-connections-container";
+export * from "./federated-search/federated-search-container";

--- a/source/nodejs/adaptivecards-designer/src/containers/outlook/outlook-container.ts
+++ b/source/nodejs/adaptivecards-designer/src/containers/outlook/outlook-container.ts
@@ -13,7 +13,7 @@ export class OutlookContainer extends HostContainer {
     }
 
     public renderTo(hostElement: HTMLElement) {
-        hostElement.classList.add("outlook-frame");
+        this.cardHost.classList.add("outlook-frame");
         hostElement.appendChild(this.cardHost);
     }
 
@@ -124,5 +124,9 @@ export class OutlookContainer extends HostContainer {
 
     get targetVersion(): Adaptive.Version {
         return Adaptive.Versions.v1_4;
+    }
+
+    get enableDeviceEmulation(): boolean {
+        return true;
     }
 }

--- a/source/nodejs/adaptivecards-designer/src/containers/teams/teams-container.ts
+++ b/source/nodejs/adaptivecards-designer/src/containers/teams/teams-container.ts
@@ -45,6 +45,10 @@ abstract class BaseTeamsContainer extends HostContainer {
     get targetVersion(): Adaptive.Version {
         return Adaptive.Versions.v1_4;
     }
+
+    get enableDeviceEmulation(): boolean {
+        return true;
+    }
 }
 
 export class LightTeamsContainer extends BaseTeamsContainer {

--- a/source/nodejs/adaptivecards-designer/src/device-emulation.ts
+++ b/source/nodejs/adaptivecards-designer/src/device-emulation.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export abstract class DeviceEmulation {
+  readonly name: string;
+  readonly maxWidth: string | undefined;
+
+  constructor(name: string, maxWidth: string | undefined) {
+    this.name = name;
+    this.maxWidth = maxWidth;
+  }
+}

--- a/source/nodejs/adaptivecards-designer/src/hostConfigs/federated-search.json
+++ b/source/nodejs/adaptivecards-designer/src/hostConfigs/federated-search.json
@@ -1,0 +1,308 @@
+{
+	"choiceSetInputValueSeparator": ",",
+	"supportsInteractivity": true,
+	"spacing": {
+		"small": 8,
+		"default": 12,
+		"medium": 16,
+		"large": 20,
+		"extraLarge": 24,
+		"padding": 16
+	},
+	"separator": {
+		"lineThickness": 1,
+		"lineColor": "#EEEEEE"
+	},
+	"imageSizes": {
+		"small": 32,
+		"medium": 52,
+		"large": 100
+	},
+	"fontTypes": {
+		"default": {
+			"fontFamily": "'Segoe UI', Tahoma, Geneva, Verdana, sans-serif",
+			"fontSizes": {
+				"small": 12,
+				"default": 14,
+				"medium": 14,
+				"large": 18,
+				"extraLarge": 24
+			},
+			"fontWeights": {
+				"lighter": 200,
+				"default": 400,
+				"bolder": 600
+			}
+		},
+		"monospace": {
+			"fontFamily": "'Courier New', Courier, monospace",
+			"fontSizes": {
+				"small": 12,
+				"default": 14,
+				"medium": 14,
+				"large": 18,
+				"extraLarge": 24
+			},
+			"fontWeights": {
+				"lighter": 200,
+				"default": 400,
+				"bolder": 600
+			}
+		}
+	},
+	"textStyles": {
+		"heading": {
+			"fontType": "default",
+			"size": "large",
+			"weight": "bolder",
+			"color": "default",
+			"isSubtle": false
+		}
+	},
+	"textBlock": {
+		"headingLevel": 2
+	},
+	"containerStyles": {
+		"default": {
+			"foregroundColors": {
+				"default": {
+					"default": "#ff252424",
+					"subtle": "#bf252424"
+				},
+				"dark": {
+					"default": "#252424",
+					"subtle": "#bf252424"
+				},
+				"light": {
+					"default": "#ffffff",
+					"subtle": "#fff3f2f1"
+				},
+				"accent": {
+					"default": "#6264a7",
+					"subtle": "#8b8cc7"
+				},
+				"good": {
+					"default": "#92c353",
+					"subtle": "#e592c353"
+				},
+				"warning": {
+					"default": "#f8d22a",
+					"subtle": "#e5f8d22a"
+				},
+				"attention": {
+					"default": "#c4314b",
+					"subtle": "#e5c4314b"
+				}
+			},
+			"borderColor": "#CCCCCC",
+			"backgroundColor": "#ffffff"
+		},
+		"emphasis": {
+			"foregroundColors": {
+				"default": {
+					"default": "#ff252424",
+					"subtle": "#bf252424"
+				},
+				"dark": {
+					"default": "#252424",
+					"subtle": "#bf252424"
+				},
+				"light": {
+					"default": "#ffffff",
+					"subtle": "#fff3f2f1"
+				},
+				"accent": {
+					"default": "#6264a7",
+					"subtle": "#8b8cc7"
+				},
+				"good": {
+					"default": "#92c353",
+					"subtle": "#e592c353"
+				},
+				"warning": {
+					"default": "#f8d22a",
+					"subtle": "#e5f8d22a"
+				},
+				"attention": {
+					"default": "#c4314b",
+					"subtle": "#e5c4314b"
+				}
+			},
+			"borderColor": "#666666",
+			"backgroundColor": "#fff9f8f7"
+		},
+		"accent": {
+			"borderColor": "#62A8F7",
+			"backgroundColor": "#C7DEF9",
+			"foregroundColors": {
+				"default": {
+					"default": "#ff252424",
+					"subtle": "#bf252424"
+				},
+				"dark": {
+					"default": "#252424",
+					"subtle": "#bf252424"
+				},
+				"light": {
+					"default": "#ffffff",
+					"subtle": "#fff3f2f1"
+				},
+				"accent": {
+					"default": "#6264a7",
+					"subtle": "#8b8cc7"
+				},
+				"good": {
+					"default": "#92c353",
+					"subtle": "#e592c353"
+				},
+				"warning": {
+					"default": "#f8d22a",
+					"subtle": "#e5f8d22a"
+				},
+				"attention": {
+					"default": "#c4314b",
+					"subtle": "#e5c4314b"
+				}
+			}
+		},
+		"good": {
+			"borderColor": "#69E569",
+			"backgroundColor": "#CCFFCC",
+			"foregroundColors": {
+				"default": {
+					"default": "#ff252424",
+					"subtle": "#bf252424"
+				},
+				"dark": {
+					"default": "#252424",
+					"subtle": "#bf252424"
+				},
+				"light": {
+					"default": "#ffffff",
+					"subtle": "#fff3f2f1"
+				},
+				"accent": {
+					"default": "#6264a7",
+					"subtle": "#8b8cc7"
+				},
+				"good": {
+					"default": "#92c353",
+					"subtle": "#e592c353"
+				},
+				"warning": {
+					"default": "#f8d22a",
+					"subtle": "#e5f8d22a"
+				},
+				"attention": {
+					"default": "#c4314b",
+					"subtle": "#e5c4314b"
+				}
+			}
+		},
+		"attention": {
+			"borderColor": "#FF764C",
+			"backgroundColor": "#FFC5B2",
+			"foregroundColors": {
+				"default": {
+					"default": "#ff252424",
+					"subtle": "#bf252424"
+				},
+				"dark": {
+					"default": "#252424",
+					"subtle": "#bf252424"
+				},
+				"light": {
+					"default": "#ffffff",
+					"subtle": "#fff3f2f1"
+				},
+				"accent": {
+					"default": "#6264a7",
+					"subtle": "#8b8cc7"
+				},
+				"good": {
+					"default": "#92c353",
+					"subtle": "#e592c353"
+				},
+				"warning": {
+					"default": "#f8d22a",
+					"subtle": "#e5f8d22a"
+				},
+				"attention": {
+					"default": "#c4314b",
+					"subtle": "#e5c4314b"
+				}
+			}
+		},
+		"warning": {
+			"borderColor": "#FFBC51",
+			"backgroundColor": "#FFE2B2",
+			"foregroundColors": {
+				"default": {
+					"default": "#ff252424",
+					"subtle": "#bf252424"
+				},
+				"dark": {
+					"default": "#252424",
+					"subtle": "#bf252424"
+				},
+				"light": {
+					"default": "#ffffff",
+					"subtle": "#fff3f2f1"
+				},
+				"accent": {
+					"default": "#6264a7",
+					"subtle": "#8b8cc7"
+				},
+				"good": {
+					"default": "#92c353",
+					"subtle": "#e592c353"
+				},
+				"warning": {
+					"default": "#f8d22a",
+					"subtle": "#e5f8d22a"
+				},
+				"attention": {
+					"default": "#c4314b",
+					"subtle": "#e5c4314b"
+				}
+			}
+		}
+	},
+	"actions": {
+		"maxActions": 6,
+		"spacing": "Default",
+		"buttonSpacing": 8,
+		"showCard": {
+			"actionMode": "Inline",
+			"inlineTopMargin": 16,
+			"style": "emphasis"
+		},
+		"preExpandSingleShowCardAction": false,
+		"actionsOrientation": "Horizontal",
+		"actionAlignment": "Left"
+	},
+	"adaptiveCard": {
+		"allowCustomStyle": false
+	},
+	"imageSet": {
+		"imageSize": "Medium",
+		"maxImageHeight": 100
+	},
+	"factSet": {
+		"title": {
+			"size": "Default",
+			"color": "Default",
+			"isSubtle": false,
+			"weight": "Bolder",
+			"warp": true
+		},
+		"value": {
+			"size": "Default",
+			"color": "Default",
+			"isSubtle": false,
+			"weight": "Default",
+			"warp": true
+		},
+		"spacing": 16
+	}
+}

--- a/source/nodejs/adaptivecards-designer/src/toolbar.ts
+++ b/source/nodejs/adaptivecards-designer/src/toolbar.ts
@@ -214,6 +214,7 @@ export interface IChoicePickerItem {
 export class ToolbarChoicePicker extends ToolbarElement {
     private _dropDown: DropDown;
     private _labelledById: string; // id to use for our label element
+    private _isEnabled: boolean = true;
 
     protected internalRender(): HTMLElement {
         this._dropDown = new DropDown();
@@ -262,6 +263,16 @@ export class ToolbarChoicePicker extends ToolbarElement {
         return pickerContainerElement;
     }
 
+    protected internalUpdateLayout() {
+        if (!this.isEnabled) {
+            this.renderedElement.classList.add("acd-toolbar-picker-disabled");
+            this.renderedElement.setAttribute("aria-disabled", "true");
+        } else {
+            this.renderedElement.classList.remove("acd-toolbar-picker-disabled");
+            this.renderedElement.removeAttribute("aria-disabled");
+        }
+    }
+
     onChanged: (sender: ToolbarChoicePicker) => void;
 
     label: string = null;
@@ -278,6 +289,15 @@ export class ToolbarChoicePicker extends ToolbarElement {
 
     set selectedIndex(value: number) {
         this._dropDown.selectedIndex = value;
+    }
+
+    get isEnabled(): boolean {
+        return this._isEnabled;
+    }
+
+    set isEnabled(value: boolean) {
+        this._isEnabled = value;
+        this.updateLayout();
     }
 }
 

--- a/source/nodejs/adaptivecards-site/pages/_data/home.yml
+++ b/source/nodejs/adaptivecards-site/pages/_data/home.yml
@@ -34,7 +34,7 @@ en:
       tag: 
       tag_class: ac-blue
     - title: Roadmap
-      href: https://portal.productboard.com/adaptivecards/1-adaptive-cards-features/tabs/5-roadmap
+      href: https://github.com/microsoft/AdaptiveCards/projects/32
       fa: far fa-calendar-alt
       tag: 
       tag_class: w3-light-gray

--- a/source/nodejs/adaptivecards-site/pages/_posts/2021/Community-Call-November.md
+++ b/source/nodejs/adaptivecards-site/pages/_posts/2021/Community-Call-November.md
@@ -1,0 +1,48 @@
+---
+title: 📣 Community Call - November, 2021
+subtitle: Viva Connections Dashboard, Quick View Cards
+date: 2021-11-11
+featured_image: https://techcommunity.microsoft.com/t5/image/serverpage/image-id/328056i9FC2616DE8DC2E07/image-size/large?v=v2&px=999
+github_username: JeanRoca
+twitter: jpthepm
+---
+
+The following topics are covered in this month’s community call: **Viva Connections + Adaptive Cards** (Dashboard overview, 6 different Quick View card layouts, and comparing card renderings from Designer and Dashboard) Emily Lynam (Microsoft), Max Kulakov (Microsoft), and Siddharth Gulati (Microsoft), **v1.5 Blog Post + Website Changes** (feature details in latest blog post and v1.5 features added to Designer) - J.P. Roca (Microsoft) and **Q&A** – members of the Developer and PM teams fielded questions on a host of topics for the last 25 minutes on this call.   Questions on Power Apps, Viva Connections, Adaptive Cards, AC in Azure Logic Apps, Adaptive Components, AC Designer, Universal Actions, Teams, Outlook integration…  This call was hosted by [J.P. Roca](http://twitter.com/jpthepm) (Microsoft) | @jpthepm.  Recorded on November 11, 2021.
+
+### Watch the call here
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/_qDFDMUouxE" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+### Agenda:
+- **Viva Connections + Adaptive Cards** 🤝 - Emily Lynam (Microsoft), Max Kulakov (Microsoft), and [Siddharth Gulati](http://twitter.com/sidvaani) (Microsoft) | @sidvaani –[00:45](https://youtu.be/_qDFDMUouxE?t=45)
+- **v1.5 Blog Post + Website Changes** 📢 - [J.P. Roca](http://twitter.com/jpthepm) (Microsoft) | @jpthepm – [13:53](https://youtu.be/_qDFDMUouxE?t=833)
+- **Q&A** :white_question_mark: - with members of Microsoft Developer and PM teams – [14:53](https://youtu.be/_qDFDMUouxE?t=873)
+
+### Demo:
+**Viva Connections + Adaptive Cards** - overview Viva Connections Dashboard, elements of Dashboard, card layouts, information flow, rendering differences between web and mobile.  Viva Connections has 3 pillars – Dashboard, Applications and Feeds.  Deep dive into Authoring a Quick View card in both Dashboard and in Adaptive Cards Designer – note same JSON, renders similar card, due to same Fluent UI/React behind scenes.  Step through 6 different Quick View card layouts.      
+
+### Referenced in this call:
+- Blog - [Announcing Adaptive Cards 1.5](https://adaptivecards.io/blog/)
+- Blog - [Guidance on implementing partner offerings for Viva Connections with ACEs and custom APIs](https://devblogs.microsoft.com/microsoft365dev/guidance-on-implementing-partner-offerings-for-viva-connections-with-aces-and-custom-apis/)
+- Blog - [Viva Connections mobile and new partner integrations are now generally available](https://techcommunity.microsoft.com/t5/microsoft-viva-blog/viva-connections-mobile-and-new-partner-integrations-are-now/ba-p/2932217)
+
+
+Next month's call will be held on **Thursday, January 13, 2022 at 9:00am PST.** We look forward to talking to you then! Download a recurring calendar invite here at <https://aka.ms/adaptivecardscommunitycall>.
+
+Check out the previous month's call recording on our [Office Development YouTube Channel](https://www.youtube.com/channel/UCV_6HOhwxYLXAGd-JOqKPoQ)
+
+### Resources in General: 
+- Let us know the features you need    https://aka.ms/ACRoadmap
+- Schema Explorer - https://adaptivecards.io/explorer/Action.Execute.html
+- Designer - https://adaptivecards.io/designer/ 
+- Get started with Templating - https://aka.ms/ACTemplating
+- Browse the Adaptive Cards Code - https://aka.ms/ACRepo
+- Find tools, sample cards and more - https://www.madewithcards.io
+- Contribution Guidelines – https://aka.ms/ACRepo 
+
+### Adaptive Cards feedback channels
+
+-   [Issues and feature requests](https://github.com/Microsoft/AdaptiveCards/issues)
+-   [Technical questions](https://stackoverflow.com/questions/tagged/adaptive-cards)
+
+The Adaptive Cards developer community call is on the 2nd Thursday of each month. We will provide you with the opportunity to learn about Adaptive Cards in general, how they could be a great tool in your applications and contribute to the evolution of the format and SDKs. Each month, we'll discuss new features we are bringing to the platform, our roadmap, and listen to your feedback and suggestions.

--- a/source/nodejs/adaptivecards-site/pages/_posts/2021/Community-Call-October.md
+++ b/source/nodejs/adaptivecards-site/pages/_posts/2021/Community-Call-October.md
@@ -1,0 +1,47 @@
+---
+title: 📣 Community Call - October, 2021
+subtitle: FactSet + Adaptive Cards, v1.5 Release
+date: 2021-10-14
+featured_image: https://techcommunity.microsoft.com/t5/image/serverpage/image-id/324683iE137929D200330F1/image-size/large?v=v2&px=999
+github_username: JeanRoca
+twitter: jpthepm
+---
+
+The following topics are covered in this month’s community call: **FactSet + Adaptive Cards** (rendering Adaptive Cards in their products) Matt Pineau (FactSet) and Andrew Curtice (FactSet), **v1.5 Release** (shipped v1.5 of our schema!  New features include: RTL support, Input.Text masking, ActionSet overflow, Tooltip for Actions, Table element, Static filtered choicesets and Action.isEnabled) - J.P. Roca (Microsoft) and finally **Q&A –** members of the Developer and PM teams fielded questions on a host of topics for the last 20 minutes on this call.   This call was hosted by [J.P. Roca](http://twitter.com/jpthepm) (Microsoft) | @jpthepm.  Recorded on October 14, 2021.
+
+### Watch the call here
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/zr8TiZZB5_k" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+### Agenda:
+- FactSet + Adaptive Cards 🤝- Matt Pineau (FactSet) and Andrew Curtice (FactSet) – [00:29](https://youtu.be/zr8TiZZB5_k?t=29)
+- v1.5 Release 📢 - [J.P. Roca](http://twitter.com/jpthepm) (Microsoft) | @jpthepm – [23:42](https://youtu.be/zr8TiZZB5_k?t=1422)
+- Q&A :white_question_mark: - with members of Microsoft Developer and PM teams – [26:58](https://youtu.be/zr8TiZZB5_k?t=1618)
+
+### Demo:
+**FactSet + Adaptive Cards**   FactSet - a financial services company, utilizes and has extended Adaptive Cards in their Signals product to proactively deliver brief and atomic information to customers.  Adaptive Cards are integrated through Power Automate into Microsoft Teams and Outlook.  FactSet’s WorkStation product uses the Extensibility feature of Adaptive Cards in its Fusion UI renderer to deliver responsiveness across platforms with little code.  Q&A throughout.       
+
+### Referenced in this call:
+- API - signals-api | https://developer.factset.com/api-catalog/signals-api (includes the /events/adaptive-cards URL endpoints AND a document **Client Workflow and Triggers for each Signal**, that shows example adaptive cards.
+- General website - FactSet.com | http://factset.com
+
+
+Next month's call will be held on **Thursday, November 11, 2021 at 9:00am PST.** We look forward to talking to you then! Download a recurring calendar invite here at <https://aka.ms/adaptivecardscommunitycall>.
+
+Check out the previous month's call recording on our [Office Development YouTube Channel](https://www.youtube.com/channel/UCV_6HOhwxYLXAGd-JOqKPoQ)
+
+### Resources in General: 
+- Let us know the features you need    https://aka.ms/ACRoadmap
+- Schema Explorer - https://adaptivecards.io/explorer/Action.Execute.html
+- Designer - https://adaptivecards.io/designer/ 
+- Get started with Templating - https://aka.ms/ACTemplating
+- Browse the Adaptive Cards Code - https://aka.ms/ACRepo
+- Find tools, sample cards and more - https://www.madewithcards.io
+- Contribution Guidelines – https://aka.ms/ACRepo 
+
+### Adaptive Cards feedback channels
+
+-   [Issues and feature requests](https://github.com/Microsoft/AdaptiveCards/issues)
+-   [Technical questions](https://stackoverflow.com/questions/tagged/adaptive-cards)
+
+The Adaptive Cards developer community call is on the 2nd Thursday of each month. We will provide you with the opportunity to learn about Adaptive Cards in general, how they could be a great tool in your applications and contribute to the evolution of the format and SDKs. Each month, we'll discuss new features we are bringing to the platform, our roadmap, and listen to your feedback and suggestions.

--- a/source/nodejs/adaptivecards-site/pages/_posts/2022/Community-Call-February.md
+++ b/source/nodejs/adaptivecards-site/pages/_posts/2022/Community-Call-February.md
@@ -11,7 +11,7 @@ The following topics are covered in this month’s community call. Demo: **Adapt
 
 ### Watch the call here
 
-<iframe width="680" height="383" src="https://www.youtube.com/embed/-Y7_nNwC20w" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="680" height="383" src="https://www.youtube.com/embed/-Y7_nNwC20w" title="Community Call February 2022 video" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ### Agenda:
 - Adaptive Cards Video Player Bot on Teams - [Alexis Kinzelin](https://www.linkedin.com/in/alexis-kinzelin-214b6b20/) (Microsoft) – [00:28](https://youtu.be/-Y7_nNwC20w?t=28)

--- a/source/nodejs/adaptivecards-site/pages/_posts/2022/Community-Call-February.md
+++ b/source/nodejs/adaptivecards-site/pages/_posts/2022/Community-Call-February.md
@@ -1,0 +1,48 @@
+---
+title: 📣 Community Call - February, 2022
+subtitle: Adaptive Cards Video Player Bot on Teams
+date: 2022-02-10
+featured_image: https://techcommunity.microsoft.com/t5/image/serverpage/image-id/347408iAF616545D5ED026B/image-size/large?v=v2&px=999
+github_username: JeanRoca
+twitter: jpthepm
+---
+
+The following topics are covered in this month’s community call. Demo: **Adaptive Cards Video Player Bot on Teams** (set up an Adaptive Card that plays video content within Teams environment, complete sample code) - [Alexis Kinzelin](https://www.linkedin.com/in/alexis-kinzelin-214b6b20/) (Microsoft), and **Q&A** – [J.P. Roca](http://twitter.com/jpthepm) (Microsoft) and [Alexis Kinzelin](https://www.linkedin.com/in/alexis-kinzelin-214b6b20/) (Microsoft) field general and demo related questions. This call was hosted by [J.P. Roca](http://twitter.com/jpthepm) (Microsoft) | @jpthepm. Recorded on February 10, 2022.
+
+### Watch the call here
+
+<iframe width="680" height="383" src="https://www.youtube.com/embed/-Y7_nNwC20w" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+### Agenda:
+- Adaptive Cards Video Player Bot on Teams - [Alexis Kinzelin](https://www.linkedin.com/in/alexis-kinzelin-214b6b20/) (Microsoft) – [00:28](https://youtu.be/-Y7_nNwC20w?t=28)
+- Q&A [J.P. Roca](http://twitter.com/jpthepm) (Microsoft) | @jpthepm and Team – [22:06](https://youtu.be/-Y7_nNwC20w?t=1326)
+
+### Demo:
+**Adaptive Cards Video Player Bot on Teams** – set up an Adaptive Card that plays video content within Teams. Extends “Company Communicator” app and uses SSO authentication, Microsoft Teams “stage view” and deep linking to play full screen video, no redirection to a web-browser. For videos hosted on SPO or public hosted. Video owner configures Adaptive card via personal bot that generates an Adaptive Card with deeplink to send to users. Recipients with permissions to SharePoint site hosting video, open video without having to authenticate. Sample code and Q&A. 
+
+### Referenced in this call:
+- Repo - [Teams Video Player Bot](https://github.com/officedev/Teams-Video-Player-Bot) 
+- Documentation - [Tabs link unfurling and Stage View](https://docs.microsoft.com/microsoftteams/platform/tabs/tabs-link-unfurling) 
+- Teams template - [Company Communicator App Template](https://github.com/OfficeDev/microsoft-teams-apps-company-communicator) 
+- Documentation – [Invoke Stage View through deep link](https://docs.microsoft.com/microsoftteams/platform/tabs/tabs-link-unfurling#invoke-stage-view-through-deep-link) 
+- Repo - [Tabs link unfurling and Stage View](https://github.com/MicrosoftDocs/msteams-docs/blob/main/msteams-platform/tabs/tabs-link-unfurling.md) 
+- Documentation - [List apps installed for user](https://docs.microsoft.com/graph/api/userteamwork-list-installedapps?view=graph-rest-1.0&tabs=http) 
+
+Next month's call will be held on **Thursday, March 10, 2022 at 9:00am PST.** We look forward to talking to you then! Download a recurring calendar invite here at <https://aka.ms/adaptivecardscommunitycall>.
+
+Check out the previous month's call recording on our [Office Development YouTube Channel](https://www.youtube.com/channel/UCV_6HOhwxYLXAGd-JOqKPoQ)
+
+### Resources in General: 
+- Let us know the features you need    https://aka.ms/ACRoadmap
+- Schema Explorer - https://adaptivecards.io/explorer/Action.Execute.html
+- Designer - https://adaptivecards.io/designer/ 
+- Get started with Templating - https://aka.ms/ACTemplating
+- Browse the Adaptive Cards Code - https://aka.ms/ACRepo
+- Find tools, sample cards and more - https://www.madewithcards.io
+- Contribution Guidelines – https://aka.ms/ACRepo 
+
+### Adaptive Cards feedback channels
+-   [Issues and feature requests](https://github.com/Microsoft/AdaptiveCards/issues)
+-   [Technical questions](https://stackoverflow.com/questions/tagged/adaptive-cards)
+
+The Adaptive Cards developer community call is on the 2nd Thursday of each month. We will provide you with the opportunity to learn about Adaptive Cards in general, how they could be a great tool in your applications and contribute to the evolution of the format and SDKs. Each month, we'll discuss new features we are bringing to the platform, our roadmap, and listen to your feedback and suggestions.

--- a/source/nodejs/adaptivecards-site/pages/_posts/2022/Community-Call-January.md
+++ b/source/nodejs/adaptivecards-site/pages/_posts/2022/Community-Call-January.md
@@ -11,7 +11,7 @@ The following topics are covered in this month’s community call: **Adaptive Ca
 
 ### Watch the call here
 
-<iframe width="680" height="383" src="https://www.youtube.com/embed/1IOr7naHqYA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="680" height="383" src="https://www.youtube.com/embed/1IOr7naHqYA" title="Community Call January 2022 video" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ### Agenda:
 - Adaptive Cards and the Power Platform to solve captchas - [Tomasz Poszytek](http://twitter.com/TomaszPoszytek) (MVP) | – [00:25](https://youtu.be/1IOr7naHqYA?t=25)

--- a/source/nodejs/adaptivecards-site/pages/_posts/2022/Community-Call-January.md
+++ b/source/nodejs/adaptivecards-site/pages/_posts/2022/Community-Call-January.md
@@ -1,0 +1,46 @@
+---
+title: 📣 Community Call - January, 2022
+subtitle: Adaptive Cards and the Power Platform to Solve Captchas
+date: 2022-01-13
+featured_image: https://techcommunity.microsoft.com/t5/image/serverpage/image-id/342854i897959EDC41B991B/image-size/large?v=v2&px=999
+github_username: JeanRoca
+twitter: jpthepm
+---
+
+The following topics are covered in this month’s community call: **Adaptive Cards and the Power Platform to solve captchas** (Use RPA, Adaptive Cards actionable messaging and Power Automate to resolve captcha challenges remotely on desktop or mobile) - [Tomasz Poszytek](http://twitter.com/TomaszPoszytek) (MVP), **Website Updates** (Blog posts for previous community calls, new samples for all 1.5 features!) - [J.P. Roca](http://twitter.com/jpthepm) (Microsoft) and **Q&A** – members of the Developer and PM teams fielded questions on a host of topics for the last 15 minutes on this call. This call was hosted by [J.P. Roca](http://twitter.com/jpthepm) (Microsoft) | @jpthepm. Recorded on January 13, 2022.
+
+### Watch the call here
+
+<iframe width="680" height="383" src="https://www.youtube.com/embed/1IOr7naHqYA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+### Agenda:
+- Adaptive Cards and the Power Platform to solve captchas - [Tomasz Poszytek](http://twitter.com/TomaszPoszytek) (MVP) | – [00:25](https://youtu.be/1IOr7naHqYA?t=25)
+- Website Updates - [J.P. Roca](http://twitter.com/jpthepm) (Microsoft) | @jpthepm – [25:15](https://youtu.be/1IOr7naHqYA?t=1515)
+- Q&A - with members of Microsoft Developer and PM teams – [27:11](https://youtu.be/1IOr7naHqYA?t=1631)
+
+### Referenced in this call:
+- Demo - [Solving reCaptcha v2 challenge with Power Automate Desktop](https://youtu.be/9pgC02Co2rQ) 
+- Demo - [Actionable Messages using Adaptive Cards - ultimate guide](https://youtu.be/x5IXd-g8OXw) 
+- YouTube Channel - [Tomasz Poszytek](https://www.youtube.com/c/TomaszPoszytek) 
+- Blog post – [Get started with Adaptive Cards](https://techcommunity.microsoft.com/t5/microsoft-365-pnp-blog/get-started-with-adaptive-cards/ba-p/2048786) 
+- November Adaptive Cards Community call demo - Viva Connections + Adaptive Cards - Emily Lynam (Microsoft), Max Kulakov (Microsoft), and Siddharth Gulati (Microsoft) | @sidvaani – [00:45](https://youtu.be/_qDFDMUouxE?t=45)
+
+Next month's call will be held on **Thursday, February 10, 2022 at 9:00am PST.** We look forward to talking to you then! Download a recurring calendar invite here at <https://aka.ms/adaptivecardscommunitycall>.
+
+Check out the previous month's call recording on our [Office Development YouTube Channel](https://www.youtube.com/channel/UCV_6HOhwxYLXAGd-JOqKPoQ)
+
+### Resources in General: 
+- Let us know the features you need    https://aka.ms/ACRoadmap
+- Schema Explorer - https://adaptivecards.io/explorer/Action.Execute.html
+- Designer - https://adaptivecards.io/designer/ 
+- Get started with Templating - https://aka.ms/ACTemplating
+- Browse the Adaptive Cards Code - https://aka.ms/ACRepo
+- Find tools, sample cards and more - https://www.madewithcards.io
+- Contribution Guidelines – https://aka.ms/ACRepo 
+
+### Adaptive Cards feedback channels
+
+-   [Issues and feature requests](https://github.com/Microsoft/AdaptiveCards/issues)
+-   [Technical questions](https://stackoverflow.com/questions/tagged/adaptive-cards)
+
+The Adaptive Cards developer community call is on the 2nd Thursday of each month. We will provide you with the opportunity to learn about Adaptive Cards in general, how they could be a great tool in your applications and contribute to the evolution of the format and SDKs. Each month, we'll discuss new features we are bringing to the platform, our roadmap, and listen to your feedback and suggestions.

--- a/source/nodejs/adaptivecards-site/pages/_posts/2022/Community-Call-March.md
+++ b/source/nodejs/adaptivecards-site/pages/_posts/2022/Community-Call-March.md
@@ -11,7 +11,7 @@ The following topics are covered in this month’s community call. Demo: **Adapt
 
 ### Watch the call here
 
-<iframe width="680" height="383" src="https://www.youtube.com/embed/k5kNBgevDBM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="680" height="383" src="https://www.youtube.com/embed/k5kNBgevDBM" title="Community Call March 2022 video" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ### Agenda:
 - Adaptive Cards Host Control in Microsoft PnP Library – [Fabio Franzini](http://twitter.com/franzinifabio) (Apvee Solutions) | @franzinifabio – [00:38](https://youtu.be/k5kNBgevDBM?t=38)

--- a/source/nodejs/adaptivecards-site/pages/_posts/2022/Community-Call-March.md
+++ b/source/nodejs/adaptivecards-site/pages/_posts/2022/Community-Call-March.md
@@ -1,0 +1,51 @@
+---
+title: 📣 Community Call - March, 2022
+subtitle: Adaptive Cards Host Control in Microsoft PnP Library
+date: 2022-03-10
+featured_image: https://techcommunity.microsoft.com/t5/image/serverpage/image-id/356326i03254E96BDFD72C2/image-size/large?v=v2&px=999
+github_username: JeanRoca
+twitter: jpthepm
+---
+
+The following topics are covered in this month’s community call. Demo: **Adaptive Cards Host Control in Microsoft PnP Library** (use an Adaptive Card in an SPFx solution that allows UI changes at runtime) – [Fabio Franzini](http://twitter.com/franzinifabio) (Apvee Solutions), **Designer Device Emulator** (quick way to see Adaptive Card layout at various selected screen resolutions) – Will Shown (Microsoft), and 15 minute live **Q&A** – host and demo presenters answer questions about their demos and on **building Teams apps with React; which React library to use - React Northstar, React Teams or Fluent UI?** This call was hosted by [J.P. Roca](http://twitter.com/jpthepm) (Microsoft) | @jpthepm. Recorded on March 10, 2022.
+
+### Watch the call here
+
+<iframe width="680" height="383" src="https://www.youtube.com/embed/k5kNBgevDBM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+### Agenda:
+- Adaptive Cards Host Control in Microsoft PnP Library – [Fabio Franzini](http://twitter.com/franzinifabio) (Apvee Solutions) | @franzinifabio – [00:38](https://youtu.be/k5kNBgevDBM?t=38)
+- Designer Device Emulator – Will Shown (Microsoft) – [20:20](https://youtu.be/k5kNBgevDBM?t=1220)
+- Q&A – [J.P. Roca](http://twitter.com/jpthepm) (Microsoft) | @jpthepm & demo presenters – [23:49](https://youtu.be/k5kNBgevDBM?t=1429)
+
+### Demo:
+**Demo 1: Adaptive Cards Host Control in Microsoft PnP Library –** customers want same functionality, different UI. Needed a way to change UI at runtime (no recompiling required). This SPFx solution contains a web part that hosts an AdaptiveCardhost control. Same web part can be used in a SharePoint page, Teams tab and Teams personal app. Hear the rationale behind this React control, why use the Adaptive Cards SDK, Fluent UI, and how control is implemented.
+
+**Demo 2: Designer Device Emulator** - created by the Teams Platform group, this emulator shows Adaptive Card layouts for selected screen widths/resolutions. Desktop (unconstrained), small mobile (320px), large mobile (414px), small tablet (768px), large tablet (1024px). If you host your own Designer, then you can add additional resolution options. Great for mobile projects. Emulator will show up on AdaptiveCards.io shortly.
+
+### Referenced in this call:
+- **D1**:  SPFx Controls - [Adaptive Card Host](https://pnp.github.io/sp-dev-fx-controls-react/controls/AdaptiveCardHost/) 
+- **D1**:  SPFx Samples - [SharePoint Framework Client-Side Web Part Samples](https://pnp.github.io/sp-dev-fx-webparts/) (Demo will be posted here when complete) 
+- **D2**:  [Nightly build for Adaptive Cards Designer with Device Emulator](https://adaptivecardsci.z5.web.core.windows.net/designer) 
+- Power Automate for Desktop Announcement - [https://powerautomate.microsoft.com/en-us/blog/power-automate-for-desktop-february-2022-update/](https://powerautomate.microsoft.com/en-us/blog/power-automate-for-desktop-february-2022-update/)
+- The latest Fluent React v9 here - [fluentui/packages/react-components at master · microsoft/fluentui (github.com)](https://github.com/microsoft/fluentui/tree/master/packages/react-components#readme)
+
+Next month's call will be held on **Thursday, April 14, 2022 at 9:00am PST.** We look forward to talking to you then! Download a recurring calendar invite here at <https://aka.ms/adaptivecardscommunitycall>.
+
+Check out the previous month's call recording on our [Office Development YouTube Channel](https://www.youtube.com/channel/UCV_6HOhwxYLXAGd-JOqKPoQ)
+
+### Resources in General: 
+- Let us know the features you need    https://aka.ms/ACRoadmap
+- Schema Explorer - https://adaptivecards.io/explorer/Action.Execute.html
+- Designer - https://adaptivecards.io/designer/ 
+- Get started with Templating - https://aka.ms/ACTemplating
+- Browse the Adaptive Cards Code - https://aka.ms/ACRepo
+- Find tools, sample cards and more - https://www.madewithcards.io
+- Contribution Guidelines – https://aka.ms/ACRepo 
+
+### Adaptive Cards feedback channels
+
+-   [Issues and feature requests](https://github.com/Microsoft/AdaptiveCards/issues)
+-   [Technical questions](https://stackoverflow.com/questions/tagged/adaptive-cards)
+
+The Adaptive Cards developer community call is on the 2nd Thursday of each month. We will provide you with the opportunity to learn about Adaptive Cards in general, how they could be a great tool in your applications and contribute to the evolution of the format and SDKs. Each month, we'll discuss new features we are bringing to the platform, our roadmap, and listen to your feedback and suggestions.

--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/designer.ejs
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/designer.ejs
@@ -69,7 +69,7 @@
 		}
 
 		function initializeDesigner() {
-			let designer = new ACDesigner.CardDesigner(ACDesigner.defaultMicrosoftHosts);
+			let designer = new ACDesigner.CardDesigner(ACDesigner.defaultMicrosoftHosts, ACDesigner.defaultMicrosoftDeviceEmulations);
 			designer.assetPath = "<%- config.root %>node_modules/adaptivecards-designer/dist/";
 			designer.sampleCatalogueUrl = "<%- config.root %>designer/sample-catalogue.json";
 			designer.bindingPreviewMode = ACDesigner.BindingPreviewMode.SampleData;

--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/source/css/style.css
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/source/css/style.css
@@ -320,7 +320,7 @@ ul.action-list {
 
 .toc-todo li,
 .toc-todo a {
-  padding-left: 30px;
+  padding-left: 15px;
   padding-top: 3px;
   padding-bottom: 3px;
   margin: 0;


### PR DESCRIPTION
We have some content on the current CI build of the website that should not be displayed on our GA production site due to it still being in preview. I went ahead and cherry-picked the changes that should be in this website release and am merging those into the latest build of the GA website. These changes are:

- Added Scenario cards for all 1.5 features + Bug fix for indentation on schema explorer
    - https://github.com/microsoft/AdaptiveCards/pull/6733
- Added blog posts for October and November
    - Added blog posts for oct and nov by JeanRoca · Pull Request #6873 · microsoft/AdaptiveCards (github.com)
- Added blog posts for jan feb and march
    - Website updates by JeanRoca · Pull Request #7163 · microsoft/AdaptiveCards (github.com)
- Federated search for designer
    - Adaptive Card Designer - Host App for Federated Search Channel by naramaka · Pull Request #7061 · microsoft/AdaptiveCards (github.com)
- Designer emulator
    - Add rudimentary device emulation to Adaptive Cards Designer by thure · Pull Request #7051 · microsoft/AdaptiveCards (github.com)

I don't have permissions to do so, but it would be great if we could have a new branch based off release/schema-1.5-website and I target that for the PR that way release/schema-1.5-website remains the same.
