### PR TITLE
[.NET Templating] Update Boolean expression evaluation

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCardsTemplateVisitor.cs
+++ b/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCardsTemplateVisitor.cs
@@ -630,7 +630,12 @@ namespace AdaptiveCards.Templating
                     result.Append('"');
                     result.Append(value);
                     result.Append('"');
-                } else
+                }
+                else if (value is Boolean)
+                {
+                    result.Append(value.ToString().ToLower());
+                }
+                else
                 {
                     result.Append(value);
                 }

--- a/source/dotnet/Test/AdaptiveCards.Templating.Test/TestTransform.cs
+++ b/source/dotnet/Test/AdaptiveCards.Templating.Test/TestTransform.cs
@@ -13140,6 +13140,28 @@ namespace AdaptiveCards.Templating.Test
 
             AssertJsonEqual(expectedJson, st);
         }
+
+        [TestMethod]
+        public void TestBooleanProperty()
+        {
+            string cardJson = "{\"type\": \"AdaptiveCard\", \"$schema\": " +
+                "\"http://adaptivecards.io/schemas/adaptive-card.json\", \"version\": \"1.5\", " +
+                "\"body\": [{ \"type\": \"TextBlock\", \"text\": \"Hello world!\", \"wrap\": \"${title != ''}\"}]}";
+
+            string expectedJson = "{\"type\": \"AdaptiveCard\", \"$schema\": " +
+                "\"http://adaptivecards.io/schemas/adaptive-card.json\", \"version\": \"1.5\", " +
+                "\"body\": [{ \"type\": \"TextBlock\", \"text\": \"Hello world!\", \"wrap\": false}]}";
+
+            Data dt = new Data()
+            {
+                title = ""
+            };
+
+            var template = new AdaptiveCardTemplate(cardJson);
+            string st = template.Expand(dt);
+
+            AssertJsonEqual(expectedJson, st);
+        }
     }
     [TestClass]
     public sealed class TestRootKeyword

--- a/source/dotnet/Test/AdaptiveCards.Templating.Test/TestTransform.cs
+++ b/source/dotnet/Test/AdaptiveCards.Templating.Test/TestTransform.cs
@@ -13118,6 +13118,28 @@ namespace AdaptiveCards.Templating.Test
             string st = template.Expand(dt);
             AssertJsonEqual(expectedJson, st);
         }
+
+        [TestMethod]
+        public void TestBooleanEvaluation()
+        {
+            string cardJson = "{\"type\": \"AdaptiveCard\", \"body\": [{\"type\": \"TextBlock\", " +
+                "\"size\": \"Medium\", \"text\": \"Title is ${title != ''}\"}], \"$schema\": " +
+                "\"http://adaptivecards.io/schemas/adaptive-card.json\", \"version\": \"1.5\"}";
+
+            string expectedJson = "{\"type\": \"AdaptiveCard\", \"body\": [{\"type\": \"TextBlock\", " +
+                "\"size\": \"Medium\", \"text\": \"Title is false\"}], \"$schema\": " +
+                "\"http://adaptivecards.io/schemas/adaptive-card.json\", \"version\": \"1.5\"}";
+
+            Data dt = new Data()
+            {
+                title = ""
+            };
+
+            var template = new AdaptiveCardTemplate(cardJson);
+            string st = template.Expand(dt);
+
+            AssertJsonEqual(expectedJson, st);
+        }
     }
     [TestClass]
     public sealed class TestRootKeyword


### PR DESCRIPTION
# Related Issue

Fixes #6854 

# Description

Boolean expressions were evaluating to `True`/`False` instead of `true`/`false`.  Boolean.ToString() capitalizes the string value, so we must convert to lowercase before appending to result.

# Sample Card

Sample template:
```
{
    "type": "AdaptiveCard",
    "body": [
        {
            "type": "TextBlock",
            "size": "Medium",
            "text": "Title is ${title != ''}"
        }
    ],
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
    "version": "1.5"
}
```

Sample Data:
```
{
    "title": ""
}
```

Output should be "Title is false"

# How Verified

Verified on WPF Visualizer


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7223)