### PR TITLE
[.NET Templating] Resolve commas added in wrong place

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCardsTemplateVisitor.cs
+++ b/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCardsTemplateVisitor.cs
@@ -630,7 +630,12 @@ namespace AdaptiveCards.Templating
                     result.Append('"');
                     result.Append(value);
                     result.Append('"');
-                } else
+                }
+                else if (value is Boolean)
+                {
+                    result.Append(value.ToString().ToLower());
+                }
+                else
                 {
                     result.Append(value);
                 }

--- a/source/dotnet/Test/AdaptiveCards.Templating.Test/TestTransform.cs
+++ b/source/dotnet/Test/AdaptiveCards.Templating.Test/TestTransform.cs
@@ -13140,6 +13140,28 @@ namespace AdaptiveCards.Templating.Test
 
             AssertJsonEqual(expectedJson, st);
         }
+
+        [TestMethod]
+        public void TestBooleanProperty()
+        {
+            string cardJson = "{\"type\": \"AdaptiveCard\", \"$schema\": " +
+                "\"http://adaptivecards.io/schemas/adaptive-card.json\", \"version\": \"1.5\", " +
+                "\"body\": [{ \"type\": \"TextBlock\", \"text\": \"Hello world!\", \"wrap\": \"${title != ''}\"}]}";
+
+            string expectedJson = "{\"type\": \"AdaptiveCard\", \"$schema\": " +
+                "\"http://adaptivecards.io/schemas/adaptive-card.json\", \"version\": \"1.5\", " +
+                "\"body\": [{ \"type\": \"TextBlock\", \"text\": \"Hello world!\", \"wrap\": false}]}";
+
+            Data dt = new Data()
+            {
+                title = ""
+            };
+
+            var template = new AdaptiveCardTemplate(cardJson);
+            string st = template.Expand(dt);
+
+            AssertJsonEqual(expectedJson, st);
+        }
     }
     [TestClass]
     public sealed class TestRootKeyword

--- a/source/dotnet/Test/AdaptiveCards.Templating.Test/TestTransform.cs
+++ b/source/dotnet/Test/AdaptiveCards.Templating.Test/TestTransform.cs
@@ -13162,6 +13162,56 @@ namespace AdaptiveCards.Templating.Test
 
             AssertJsonEqual(expectedJson, st);
         }
+
+        [TestMethod]
+        public void TestAppendDelimiterDataArray()
+        {
+            string cardJson = "{\"$schema\": \"http://adaptivecards.io/schemas/adaptive-card.json\", " +
+                "\"type\": \"AdaptiveCard\", \"version\": \"1.3\", \"body\": [{\"type\": \"ColumnSet\"," +
+                "\"$data\": \"${foo}\", \"$when\": \"${$index==0}\"},{\"type\": \"Container\"," +
+                "\"$data\": \"${foo}\", \"$when\": \"${$index>0}\"}]}";
+
+            string expectedJson = "{\"$schema\":\"http://adaptivecards.io/schemas/adaptive-card.json\"," +
+                "\"type\":\"AdaptiveCard\",\"version\":\"1.3\",\"body\":[{\"type\":\"ColumnSet\"}" +
+                ",{\"type\":\"Container\"}]}";
+
+            var jsonData = @"{""foo"": [{ }, { }]}";
+
+            var context = new EvaluationContext()
+            {
+                Root = jsonData
+            };
+
+            var template = new AdaptiveCardTemplate(cardJson);
+            string st = template.Expand(context);
+
+            Assert.AreEqual(expectedJson, st);
+        }
+
+        [TestMethod]
+        public void TestAppendDelimiter()
+        {
+            string cardJson = "{\"$schema\": \"http://adaptivecards.io/schemas/adaptive-card.json\"," +
+                "\"type\": \"AdaptiveCard\", \"version\": \"1.3\", \"body\": [{\"items\": [{" +
+                "\"type\": \"Container\", \"$when\": \"${bar==1}\"}, {\"type\": \"ColumnSet\"," +
+                "\"$when\": \"${bar==2}\"}], \"$data\": \"${foo}\"}]}";
+
+            string expectedJson = "{\"$schema\":\"http://adaptivecards.io/schemas/adaptive-card.json\"," +
+                "\"type\":\"AdaptiveCard\",\"version\":\"1.3\",\"body\":[{\"items\":[{" +
+                "\"type\":\"Container\"}]}]}";
+
+            var jsonData = @"{""foo"": [{""bar"": 1}]}";
+
+            var context = new EvaluationContext()
+            {
+                Root = jsonData
+            };
+
+            var template = new AdaptiveCardTemplate(cardJson);
+            string st = template.Expand(context);
+
+            Assert.AreEqual(expectedJson, st);
+        }
     }
     [TestClass]
     public sealed class TestRootKeyword

--- a/source/dotnet/Test/AdaptiveCards.Templating.Test/TestTransform.cs
+++ b/source/dotnet/Test/AdaptiveCards.Templating.Test/TestTransform.cs
@@ -13118,6 +13118,28 @@ namespace AdaptiveCards.Templating.Test
             string st = template.Expand(dt);
             AssertJsonEqual(expectedJson, st);
         }
+
+        [TestMethod]
+        public void TestBooleanEvaluation()
+        {
+            string cardJson = "{\"type\": \"AdaptiveCard\", \"body\": [{\"type\": \"TextBlock\", " +
+                "\"size\": \"Medium\", \"text\": \"Title is ${title != ''}\"}], \"$schema\": " +
+                "\"http://adaptivecards.io/schemas/adaptive-card.json\", \"version\": \"1.5\"}";
+
+            string expectedJson = "{\"type\": \"AdaptiveCard\", \"body\": [{\"type\": \"TextBlock\", " +
+                "\"size\": \"Medium\", \"text\": \"Title is false\"}], \"$schema\": " +
+                "\"http://adaptivecards.io/schemas/adaptive-card.json\", \"version\": \"1.5\"}";
+
+            Data dt = new Data()
+            {
+                title = ""
+            };
+
+            var template = new AdaptiveCardTemplate(cardJson);
+            string st = template.Expand(dt);
+
+            AssertJsonEqual(expectedJson, st);
+        }
     }
     [TestClass]
     public sealed class TestRootKeyword


### PR DESCRIPTION
# Related Issue

Fixes #6680 

# Description

Commas were sometimes being added unnecessarily which resulted in invalid JSON. I updated `TemplateVisitor` to only add commas if there is an object prior and another object is about to be added.

# Sample Card

Card:
```
{
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
    "type": "AdaptiveCard",
    "version": "1.3",
    "body": [
      {
        "type": "ColumnSet",
        "$data": "${foo}",
        "$when": "${$index==0}"
      },
      {
        "type": "Container",
        "$data": "${foo}",
        "$when": "${$index>0}"
      }
    ]
}
```

Data:
```
{
	"foo": [{}, {}]
}
```

# How Verified

Verified manually and with the added unit tests.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7225)