### PR TITLE
[Templating] Realign platforms on invalid $when behavior

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCardsTemplateResult.cs
+++ b/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCardsTemplateResult.cs
@@ -37,7 +37,7 @@ namespace AdaptiveCards.Templating
         /// <summary>
         /// Indicates that this instance captures the result of $when
         /// </summary>
-        public bool IsWhen { get; }
+        public bool IsWhen { get; set; }
         /// <summary>
         /// Predicate of $when expression
         /// </summary>

--- a/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCardsTemplateVisitor.cs
+++ b/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCardsTemplateVisitor.cs
@@ -502,7 +502,8 @@ namespace AdaptiveCards.Templating
                                 Console.WriteLine($"WARN: Could not evaluate {returnedResult} because it is not an expression or the " +
                                     $"expression is invalid. The $when condition has been set to false by default.");
                                 
-                            } else
+                            }
+                            else
                             {
                                 whenEvaluationResult = returnedResult.WhenEvaluationResult;
                             }

--- a/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCardsTemplateVisitor.cs
+++ b/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCardsTemplateVisitor.cs
@@ -495,7 +495,17 @@ namespace AdaptiveCards.Templating
 
                         if (returnedResult.IsWhen)
                         {
-                            whenEvaluationResult = returnedResult.WhenEvaluationResult;
+                            if (returnedResult.WhenEvaluationResult == AdaptiveCardsTemplateResult.EvaluationResult.NotEvaluated)
+                            {
+                                // The when expression could not be evaluated, so we are defaulting the value to false
+                                whenEvaluationResult = AdaptiveCardsTemplateResult.EvaluationResult.EvaluatedToFalse;
+                                Console.WriteLine($"WARN: Could not evaluate {returnedResult} because it is not an expression or the " +
+                                    $"expression is invalid. The $when condition has been set to false by default.");
+                                
+                            } else
+                            {
+                                whenEvaluationResult = returnedResult.WhenEvaluationResult;
+                            }
                         }
                         else
                         {
@@ -667,6 +677,15 @@ namespace AdaptiveCards.Templating
             // this node is visited only when parsing was correctly done
             // [ '{', '$when', ':', ',', 'expression'] 
             var result = Visit(context.templateExpression());
+
+            if (!result.IsWhen)
+            {
+                // We know that this result was supposed to be IsWhen since it is called from VisitTemplateWhen
+                // We create a result with `IsWhen = false` if the expression is invalid
+                // Result will now correctly follow the rest of the IsWhen logic
+                result.IsWhen = true;
+            }
+
             return result;
         }
 
@@ -728,7 +747,17 @@ namespace AdaptiveCards.Templating
             var (value, error) = new ValueExpression(Regex.Unescape(predicate)).TryGetValue(data);
             if (error == null)
             {
-                return bool.Parse(value as string);
+                try
+                {
+                    return bool.Parse(value as string);
+                }
+                catch (System.FormatException)
+                {
+                    // If the expression didn't evaluate to a boolean, we need to return false
+                    Console.WriteLine($"WARN: Could not evaluate boolean expression because it could not be found in the provided data. " +
+                                    "The condition has been set to false by default.");
+                    return false;
+                }
             }
             return true;
         }

--- a/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCardsTemplateVisitor.cs
+++ b/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCardsTemplateVisitor.cs
@@ -499,6 +499,7 @@ namespace AdaptiveCards.Templating
                             {
                                 // The when expression could not be evaluated, so we are defaulting the value to false
                                 whenEvaluationResult = AdaptiveCardsTemplateResult.EvaluationResult.EvaluatedToFalse;
+                                // TODO: Expose this warning to caller - documented in issue #7433
                                 Console.WriteLine($"WARN: Could not evaluate {returnedResult} because it is not an expression or the " +
                                     $"expression is invalid. The $when condition has been set to false by default.");
                                 
@@ -755,6 +756,7 @@ namespace AdaptiveCards.Templating
                 catch (System.FormatException)
                 {
                     // If the expression didn't evaluate to a boolean, we need to return false
+                    // TODO: Expose this warning to caller - documented in issue #7433
                     Console.WriteLine($"WARN: Could not evaluate boolean expression because it could not be found in the provided data. " +
                                     "The condition has been set to false by default.");
                     return false;

--- a/source/dotnet/Test/AdaptiveCards.Templating.Test/TestTransform.cs
+++ b/source/dotnet/Test/AdaptiveCards.Templating.Test/TestTransform.cs
@@ -13212,6 +13212,63 @@ namespace AdaptiveCards.Templating.Test
 
             Assert.AreEqual(expectedJson, st);
         }
+
+        [TestMethod]
+        public void TestWhenNotExpression()
+        {
+            string cardJson = "{\"type\": \"AdaptiveCard\", \"body\": [{\"type\": \"TextBlock\"," +
+                "\"size\": \"Medium\", \"weight\": \"Bolder\", \"text\": \"${title}\", \"$when\": \"notAnExpression\"}]," +
+                "\"$schema\": \"http://adaptivecards.io/schemas/adaptive-card.json\",\"version\": \"1.5\"}";
+
+            string expectedJson = "{\"type\":\"AdaptiveCard\",\"body\":[]," +
+                "\"$schema\":\"http://adaptivecards.io/schemas/adaptive-card.json\",\"version\":\"1.5\"}";
+
+            var context = new EvaluationContext();
+
+            var template = new AdaptiveCardTemplate(cardJson);
+            string st = template.Expand(context);
+
+            Assert.AreEqual(expectedJson, st);
+        }
+
+        [TestMethod]
+        public void TestWhenInvalidExpressionNoData()
+        {
+            string cardJson = "{\"type\": \"AdaptiveCard\", \"body\": [{\"type\": \"TextBlock\"," +
+                "\"size\": \"Medium\", \"weight\": \"Bolder\", \"text\": \"${title}\", \"$when\": \"${invalidExpression}\"}]," +
+                "\"$schema\": \"http://adaptivecards.io/schemas/adaptive-card.json\",\"version\": \"1.5\"}";
+
+            string expectedJson = "{\"type\":\"AdaptiveCard\",\"body\":[]," +
+                "\"$schema\":\"http://adaptivecards.io/schemas/adaptive-card.json\",\"version\":\"1.5\"}";
+
+            var context = new EvaluationContext();
+
+            var template = new AdaptiveCardTemplate(cardJson);
+            string st = template.Expand(context);
+
+            Assert.AreEqual(expectedJson, st);
+        }
+
+        [TestMethod]
+        public void TestWhenExpressionNotInData()
+        {
+            string cardJson = "{\"type\": \"AdaptiveCard\", \"body\": [{\"type\": \"TextBlock\"," +
+                "\"size\": \"Medium\", \"weight\": \"Bolder\", \"text\": \"${title}\", \"$when\": \"${notInData}\"}]," +
+                "\"$schema\": \"http://adaptivecards.io/schemas/adaptive-card.json\",\"version\": \"1.5\"}";
+
+            string expectedJson = "{\"type\":\"AdaptiveCard\",\"body\":[]," +
+                "\"$schema\":\"http://adaptivecards.io/schemas/adaptive-card.json\",\"version\":\"1.5\"}";
+
+            Data dt = new Data()
+            {
+                title = ""
+            };
+
+            var template = new AdaptiveCardTemplate(cardJson);
+            string st = template.Expand(dt);
+
+            Assert.AreEqual(expectedJson, st);
+        }
     }
     [TestClass]
     public sealed class TestRootKeyword

--- a/source/nodejs/adaptivecards-templating/src/template-engine.ts
+++ b/source/nodejs/adaptivecards-templating/src/template-engine.ts
@@ -416,12 +416,14 @@ export class Template {
                     
                     if (!evaluationResult.value) {
                         // Value was not found, and we should warn the client that the Expression was invalid
+                        // TODO: Expose this warning to caller - documented in issue #7433
                         console.warn(`WARN: Unable to parse the Adaptive Expression ${when}. The $when condition has been set to false by default.`);
                     }
 
                     dropObject = !whenValue;
                 } else if (when) {
                     // If $when was provided, but it is not an AEL.Expression, drop the object
+                    // TODO: Expose this warning to caller - documented in issue #7433
                     console.warn(`WARN: ${when} is not an Adaptive Expression. The $when condition has been set to false by default.`);
                     dropObject = true;
                 }

--- a/source/nodejs/adaptivecards-templating/src/template-engine.ts
+++ b/source/nodejs/adaptivecards-templating/src/template-engine.ts
@@ -413,8 +413,17 @@ export class Template {
                     if (!evaluationResult.error) {
                         whenValue = typeof evaluationResult.value === "boolean" && evaluationResult.value;
                     }
+                    
+                    if (!evaluationResult.value) {
+                        // Value was not found, and we should warn the client that the Expression was invalid
+                        console.warn(`WARN: Unable to parse the Adaptive Expression ${when}. The $when condition has been set to false by default.`);
+                    }
 
                     dropObject = !whenValue;
+                } else if (when) {
+                    // If $when was provided, but it is not an AEL.Expression, drop the object
+                    console.warn(`WARN: ${when} is not an Adaptive Expression. The $when condition has been set to false by default.`);
+                    dropObject = true;
                 }
 
                 if (!dropObject) {

--- a/source/nodejs/tests/unit-tests/src/unit-tests.test.ts
+++ b/source/nodejs/tests/unit-tests/src/unit-tests.test.ts
@@ -162,6 +162,58 @@ describe("Test Templating Library", () => {
         runTest(loadFile("template-test-resources/version-template-invalid.json"),
             loadFile("template-test-resources/version-template-fail-invalid.output.json"));
     });
+
+    it("TemplateWhenIsNotExpression", () => {
+        const templatePayload = {
+            "type": "AdaptiveCard",
+            "body": [
+                {
+                    "type": "TextBlock",
+                    "size": "Medium",
+                    "weight": "Bolder",
+                    "text": "${title}",
+                    "$when": "isNotExpression"
+                }
+            ],
+            "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+            "version": "1.5"
+        };
+
+        const expectedOutput = {
+            "type": "AdaptiveCard",
+            "body": [],
+            "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+            "version": "1.5"
+        };
+
+        runTest(templatePayload, expectedOutput, undefined, undefined);
+    });
+
+    it("TemplateWhenIsInvalidExpression", () => {
+        const templatePayload = {
+            "type": "AdaptiveCard",
+            "body": [
+                {
+                    "type": "TextBlock",
+                    "size": "Medium",
+                    "weight": "Bolder",
+                    "text": "${title}",
+                    "$when": "${invalidExpression}"
+                }
+            ],
+            "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+            "version": "1.5"
+        };
+
+        const expectedOutput = {
+            "type": "AdaptiveCard",
+            "body": [],
+            "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+            "version": "1.5"
+        };
+
+        runTest(templatePayload, expectedOutput, undefined, undefined);
+    });
 });
 
 function runTest(templatePayload: any, expectedOutput: any, data?: any, host?: any) {


### PR DESCRIPTION
# Related Issue

Fixes #6630 

# Description

Realign expected behavior for invalid boolean expressions for $when on JS and .NET Templating platforms.

Scenarios:
- If the given string is not an expression (ex: `"$when": "notAnExpression"`)
- If the given expression is invalid/not found in data (ex: `"$when": "${invalidExpression}"`)

In both scenarios, the $when condition should evaluate to `false` (drop the element) and issue a warning.

# Sample Card

## Test 1 - Not an Expression

```
{
    "type": "AdaptiveCard",
    "body": [
        {
            "type": "TextBlock",
            "size": "Medium",
            "weight": "Bolder",
            "text": "${title}",
            "$when": "NotAnExpression"
        }
    ],
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
    "version": "1.5"
}
```

## Test 2 - Invalid Expression No Data

```
{
    "type": "AdaptiveCard",
    "body": [
        {
            "type": "TextBlock",
            "size": "Medium",
            "weight": "Bolder",
            "text": "${title}",
            "$when": "${InvalidExpression}"
        }
    ],
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
    "version": "1.5"
}
```

## Test 3 - Invalid Expression with Data

Card

```
{
    "type": "AdaptiveCard",
    "body": [
        {
            "type": "TextBlock",
            "size": "Medium",
            "weight": "Bolder",
            "text": "${title}",
            "$when": "${InvalidExpression}"
        }
    ],
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
    "version": "1.5"
}
```

Data
```
{
   "test": "dummyData"
}
```

# How Verified

Verified manually with adaptivecards-site and WPF Visualizer. I also added test cases to both platforms.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7432)