### PR TITLE
[Templating] Expose warnings/errors to callers

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCardTemplate.cs
+++ b/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCardTemplate.cs
@@ -75,8 +75,8 @@ namespace AdaptiveCards.Templating
         /// <returns>json as string</returns>
         public string Expand(EvaluationContext context, Func<string, object> nullSubstitutionOption = null)
         {
-            ArrayList<string> log;
-            return Expand(context, out log, nullSubstitutionOption);
+            ArrayList<string> errorLog;
+            return Expand(context, out errorLog, nullSubstitutionOption);
         }
 
         /// <summary>
@@ -90,7 +90,7 @@ namespace AdaptiveCards.Templating
         /// <para> Default behavior is leaving templated string unchanged</para>
         /// </remarks>
         /// <param name="context">provides data context</param>
-        /// <param name="log">stores the outputed log statements from parsing the template</param>
+        /// <param name="errorLog">stores the outputed log statements from parsing the template</param>
         /// <param name="nullSubstitutionOption">defines behavior when no suitable data is found for a template entry</param>
         /// <example>
         /// <code>
@@ -101,13 +101,13 @@ namespace AdaptiveCards.Templating
         /// </example>
         /// <seealso cref="EvaluationContext"/>
         /// <returns>json as string</returns>
-        public string Expand(EvaluationContext context, out ArrayList<string> log, Func<string, object> nullSubstitutionOption = null)
+        public string Expand(EvaluationContext context, out ArrayList<string> errorLog, Func<string, object> nullSubstitutionOption = null)
         {
         
             if (parseTree == null)
             {
                 // Create empty array list so that `out` parameter has a value
-                log = new ArrayList<string>();
+                errorLog = new ArrayList<string>();
                 return jsonTemplateString;
             }
 
@@ -129,9 +129,21 @@ namespace AdaptiveCards.Templating
 
             AdaptiveCardsTemplateResult result = eval.Visit(parseTree);
 
-            log = eval.getTemplateLog();
+            errorLog = eval.getTemplateLog();
 
             return result.ToString();
+        }
+
+        /// <summary>
+        /// Wrapper method to maintain functionality if caller decides not to use log files
+        /// </summary>
+        /// <param name="rootData">Serializable object or a string in valid json format that will be used as data context</param>
+        /// <param name="nullSubstitutionOption">Defines behavior when no suitable data is found for a template entry</param>
+        /// <returns></returns>
+        public string Expand(object rootData, Func<string, object> nullSubstitutionOption = null)
+        {
+            ArrayList<string> errorLog = new ArrayList<string>();
+            return Expand(rootData, out errorLog, nullSubstitutionOption);
         }
 
         /// <summary>
@@ -145,6 +157,7 @@ namespace AdaptiveCards.Templating
         /// <para> Default behavior is leaving templated string unchanged</para>
         /// </remarks>
         /// <param name="rootData">Serializable object or a string in valid json format that will be used as data context</param>
+        /// <param name="errorLog">stores the outputed log statements from parsing the template</param>
         /// <param name="nullSubstitutionOption">Defines behavior when no suitable data is found for a template entry</param>
         /// <example>
         /// <code>
@@ -154,13 +167,15 @@ namespace AdaptiveCards.Templating
         /// </example>
         /// <seealso cref="EvaluationContext"/>
         /// <returns>json as string</returns>
-        public string Expand(object rootData, Func<string, object> nullSubstitutionOption = null)
+        public string Expand(object rootData, out ArrayList<string> errorLog, Func<string, object> nullSubstitutionOption = null)
         {
-            // TODO: need to add error logging here - not so much in the template visitor??
-            // Caller will call AdaptiveCardTemplate.Expand - NOT from AdaptiveCardsTemplateVisitor
             var context = new EvaluationContext(rootData);
 
-            return Expand(context, nullSubstitutionOption);
+            errorLog = new ArrayList<string>();
+
+            string expand = Expand(context, out errorLog, nullSubstitutionOption);
+
+            return expand;
         }
     }
 }

--- a/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCardsTemplateVisitor.cs
+++ b/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCardsTemplateVisitor.cs
@@ -23,6 +23,7 @@ namespace AdaptiveCards.Templating
         private Stack<DataContext> dataContext = new Stack<DataContext>();
         private readonly JToken root;
         private readonly Options options;
+        private ArrayList<string> templateLog;
 
         /// <summary>
         /// maintains data context
@@ -126,6 +127,8 @@ namespace AdaptiveCards.Templating
             {
                 NullSubstitution = nullSubstitutionOption != null? nullSubstitutionOption : (path) => $"${{{path}}}"
             };
+
+            templateLog = new ArrayList<string>();
         }
 
         /// <summary>
@@ -196,6 +199,11 @@ namespace AdaptiveCards.Templating
         private bool HasDataContext()
         {
             return dataContext.Count != 0;
+        }
+
+        public ArrayList<string> getTemplateLog()
+        {
+            return templateLog;
         }
 
         /// <summary>

--- a/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCardsTemplateVisitor.cs
+++ b/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCardsTemplateVisitor.cs
@@ -344,8 +344,20 @@ namespace AdaptiveCards.Templating
                 return result;
             }
 
+            bool isTrue = false;
+
+            try
+            {
+                isTrue = IsTrue(result.Predicate, dataContext.token);
+            }
+            catch (System.FormatException)
+            {
+                templateLog.Add($"WARN: Could not evaluate boolean expression because it could not be found in the provided data. " +
+                                    "The condition has been set to false by default.");
+            }
+
             // evaluate $when
-            result.WhenEvaluationResult = IsTrue(result.Predicate, dataContext.token) ?
+            result.WhenEvaluationResult = isTrue ?
                 AdaptiveCardsTemplateResult.EvaluationResult.EvaluatedToTrue :
                 AdaptiveCardsTemplateResult.EvaluationResult.EvaluatedToFalse;
 
@@ -507,8 +519,8 @@ namespace AdaptiveCards.Templating
                             {
                                 // The when expression could not be evaluated, so we are defaulting the value to false
                                 whenEvaluationResult = AdaptiveCardsTemplateResult.EvaluationResult.EvaluatedToFalse;
-                                // TODO: Expose this warning to caller - documented in issue #7433
-                                Console.WriteLine($"WARN: Could not evaluate {returnedResult} because it is not an expression or the " +
+
+                                templateLog.Add($"WARN: Could not evaluate {returnedResult} because it is not an expression or the " +
                                     $"expression is invalid. The $when condition has been set to false by default.");
                                 
                             }
@@ -757,18 +769,7 @@ namespace AdaptiveCards.Templating
             var (value, error) = new ValueExpression(Regex.Unescape(predicate)).TryGetValue(data);
             if (error == null)
             {
-                try
-                {
-                    return bool.Parse(value as string);
-                }
-                catch (System.FormatException)
-                {
-                    // If the expression didn't evaluate to a boolean, we need to return false
-                    // TODO: Expose this warning to caller - documented in issue #7433
-                    Console.WriteLine($"WARN: Could not evaluate boolean expression because it could not be found in the provided data. " +
-                                    "The condition has been set to false by default.");
-                    return false;
-                }
+                return bool.Parse(value as string);
             }
             return true;
         }

--- a/source/dotnet/Test/AdaptiveCards.Templating.Test/AdaptiveCards.Templating.Test.csproj
+++ b/source/dotnet/Test/AdaptiveCards.Templating.Test/AdaptiveCards.Templating.Test.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="AdaptiveExpressions" Version="4.11.*" />
-    <PackageReference Include="Antlr4.Runtime.Standard" Version="4.9.1" />
+    <PackageReference Include="Antlr4.Runtime.Standard" Version="4.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.*" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.*" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.*" />

--- a/source/dotnet/Test/AdaptiveCards.Templating.Test/TestTransform.cs
+++ b/source/dotnet/Test/AdaptiveCards.Templating.Test/TestTransform.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System;
 using AdaptiveExpressions.Memory;
 using System.Collections.Generic;
+using Antlr4.Runtime.Misc;
 
 namespace AdaptiveCards.Templating.Test
 {
@@ -13268,6 +13269,84 @@ namespace AdaptiveCards.Templating.Test
             string st = template.Expand(dt);
 
             Assert.AreEqual(expectedJson, st);
+        }
+
+        [TestMethod]
+        public void TestWhenNotExpressionWithLog()
+        {
+            string cardJson = "{\"type\": \"AdaptiveCard\", \"body\": [{\"type\": \"TextBlock\"," +
+                "\"size\": \"Medium\", \"weight\": \"Bolder\", \"text\": \"${title}\", \"$when\": \"notAnExpression\"}]," +
+                "\"$schema\": \"http://adaptivecards.io/schemas/adaptive-card.json\",\"version\": \"1.5\"}";
+
+            string expectedJson = "{\"type\":\"AdaptiveCard\",\"body\":[]," +
+                "\"$schema\":\"http://adaptivecards.io/schemas/adaptive-card.json\",\"version\":\"1.5\"}";
+
+            var context = new EvaluationContext();
+
+            var template = new AdaptiveCardTemplate(cardJson);
+
+            ArrayList<string> log;
+            string st = template.Expand(context, out log);
+
+            Assert.AreEqual(expectedJson, st);
+
+            string expectedWarning = "WARN: Could not evaluate \"notAnExpression\" because it is not " +
+                "an expression or the expression is invalid. The $when condition has been set to false by default.";
+
+            Assert.AreEqual(expectedWarning, log[0]);
+        }
+
+        [TestMethod]
+        public void TestWhenInvalidExpressionNoDataWithLog()
+        {
+            string cardJson = "{\"type\": \"AdaptiveCard\", \"body\": [{\"type\": \"TextBlock\"," +
+                "\"size\": \"Medium\", \"weight\": \"Bolder\", \"text\": \"${title}\", \"$when\": \"${invalidExpression}\"}]," +
+                "\"$schema\": \"http://adaptivecards.io/schemas/adaptive-card.json\",\"version\": \"1.5\"}";
+
+            string expectedJson = "{\"type\":\"AdaptiveCard\",\"body\":[]," +
+                "\"$schema\":\"http://adaptivecards.io/schemas/adaptive-card.json\",\"version\":\"1.5\"}";
+
+            var context = new EvaluationContext();
+
+            var template = new AdaptiveCardTemplate(cardJson);
+
+            ArrayList<string> log;
+            string st = template.Expand(context, out log);
+
+            Assert.AreEqual(expectedJson, st);
+
+            string expectedWarning = "WARN: Could not evaluate \"${invalidExpression}\" because it is not " +
+                "an expression or the expression is invalid. The $when condition has been set to false by default.";
+
+            Assert.AreEqual(expectedWarning, log[0]);
+        }
+
+        [TestMethod]
+        public void TestWhenExpressionNotInDataWithLog()
+        {
+            string cardJson = "{\"type\": \"AdaptiveCard\", \"body\": [{\"type\": \"TextBlock\"," +
+                "\"size\": \"Medium\", \"weight\": \"Bolder\", \"text\": \"${title}\", \"$when\": \"${notInData}\"}]," +
+                "\"$schema\": \"http://adaptivecards.io/schemas/adaptive-card.json\",\"version\": \"1.5\"}";
+
+            string expectedJson = "{\"type\":\"AdaptiveCard\",\"body\":[]," +
+                "\"$schema\":\"http://adaptivecards.io/schemas/adaptive-card.json\",\"version\":\"1.5\"}";
+
+            Data dt = new Data()
+            {
+                title = ""
+            };
+
+            var template = new AdaptiveCardTemplate(cardJson);
+
+            ArrayList<string> log;
+            string st = template.Expand(dt, out log);
+
+            Assert.AreEqual(expectedJson, st);
+
+            string expectedWarning = "WARN: Could not evaluate boolean expression " +
+                "because it could not be found in the provided data. The condition has been set to false by default.";
+
+            Assert.AreEqual(expectedWarning, log[0]);
         }
     }
     [TestClass]

--- a/source/nodejs/adaptivecards-templating/src/template-engine.ts
+++ b/source/nodejs/adaptivecards-templating/src/template-engine.ts
@@ -154,6 +154,10 @@ export interface IEvaluationContext {
  * Represents a template that can be bound to data.
  */
 export class Template {
+
+    // TODO: The template class can probably store the array of warnings :)
+    private templateLog;
+
     private static prepare(node: any): any {
         if (typeof node === "string") {
             return Template.parseInterpolatedString(node);
@@ -520,9 +524,17 @@ export class Template {
      * @returns A value representing the expanded template. The type of that value
      *   is dependent on the type of the original template payload passed to the constructor.
      */
-    expand(context: IEvaluationContext): any {
+    // TODO: this method needs an `out` parameter for storing errors - look at implementation in base adaptivecards repo!
+    expand(context: IEvaluationContext, log?: Array<String>): any {
+        this.templateLog = log;
         this._context = new EvaluationContext(context);
 
-        return this.internalExpand(this._preparedPayload);
+        if (log) {
+            // Only return error/warning log if we were given an array to store the data
+            return this.internalExpand(this._preparedPayload), this.templateLog;
+        }
+        else {
+            return this.internalExpand(this._preparedPayload);
+        }
     }
 }

--- a/source/nodejs/tests/unit-tests/src/unit-tests.test.ts
+++ b/source/nodejs/tests/unit-tests/src/unit-tests.test.ts
@@ -214,6 +214,83 @@ describe("Test Templating Library", () => {
 
         runTest(templatePayload, expectedOutput, undefined, undefined);
     });
+
+    it("TemplateWhenIsNotExpressionWithLog", () => {
+        const templatePayload = {
+            "type": "AdaptiveCard",
+            "body": [
+                {
+                    "type": "TextBlock",
+                    "size": "Medium",
+                    "weight": "Bolder",
+                    "text": "${title}",
+                    "$when": "isNotExpression"
+                }
+            ],
+            "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+            "version": "1.5"
+        };
+
+        const expectedOutput = {
+            "type": "AdaptiveCard",
+            "body": [],
+            "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+            "version": "1.5"
+        };
+
+        let template = new ACData.Template(templatePayload);
+
+        let context = {
+            $root: undefined
+        };
+
+        let [card, errorLog] = template.expand(context, []);
+
+        console.log(template.expand(context, []));
+
+        expect(card).toStrictEqual(expectedOutput);
+
+        let expectedWarning = "WARN: isNotExpression is not an Adaptive Expression. The $when condition has been set to false by default.";
+
+        expect(errorLog[0]).toStrictEqual(expectedWarning);
+    });
+
+    it("TemplateWhenIsInvalidExpressionWithLog", () => {
+        const templatePayload = {
+            "type": "AdaptiveCard",
+            "body": [
+                {
+                    "type": "TextBlock",
+                    "size": "Medium",
+                    "weight": "Bolder",
+                    "text": "${title}",
+                    "$when": "${invalidExpression}"
+                }
+            ],
+            "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+            "version": "1.5"
+        };
+
+        const expectedOutput = {
+            "type": "AdaptiveCard",
+            "body": [],
+            "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+            "version": "1.5"
+        };
+
+        let template = new ACData.Template(templatePayload);
+
+        let context = {
+            $root: undefined
+        };
+
+        let [card, errorLog] = template.expand(context, []);
+
+        expect(card).toStrictEqual(expectedOutput);
+
+        let expectedWarning = "WARN: Unable to parse the Adaptive Expression invalidExpression. The $when condition has been set to false by default.";
+        expect(errorLog[0]).toStrictEqual(expectedWarning);
+    });
 });
 
 function runTest(templatePayload: any, expectedOutput: any, data?: any, host?: any) {


### PR DESCRIPTION
# Related Issue

Fixes #7433 

# Description

Warnings need to be exposed to the caller instead of logged in the console.

I added an optional parameter for an array of warning/error strings to the expand method of the JS library.

For the .NET library, I added an out parameter for the warning/error string array to the Expand methods. I also added an additional wrapper methods, that call the updated Expand methods to ensure this isn't a breaking change.

# Sample Card

These cards should produce warning strings if the proper expand method is called.

## Test 1 - Not an Expression

```
{
    "type": "AdaptiveCard",
    "body": [
        {
            "type": "TextBlock",
            "size": "Medium",
            "weight": "Bolder",
            "text": "${title}",
            "$when": "NotAnExpression"
        }
    ],
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
    "version": "1.5"
}
```

## Test 2 - Invalid Expression No Data

```
{
    "type": "AdaptiveCard",
    "body": [
        {
            "type": "TextBlock",
            "size": "Medium",
            "weight": "Bolder",
            "text": "${title}",
            "$when": "${InvalidExpression}"
        }
    ],
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
    "version": "1.5"
}
```

## Test 3 - Invalid Expression with Data

Card

```
{
    "type": "AdaptiveCard",
    "body": [
        {
            "type": "TextBlock",
            "size": "Medium",
            "weight": "Bolder",
            "text": "${title}",
            "$when": "${InvalidExpression}"
        }
    ],
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
    "version": "1.5"
}
```

Data
```
{
   "test": "dummyData"
}
```

# How Verified

Verified with the unit tests added with this PR.
