### PR TITLE
[Android] Escape character not removed from TextBlock

### DIFF
--- a/source/shared/cpp/ObjectModel/MarkDownBlockParser.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownBlockParser.cpp
@@ -138,7 +138,7 @@ EmphasisParser::EmphasisState EmphasisParser::MatchText(EmphasisParser& parser, 
     }
     else
     {
-        if (isEmphasisToken && parser.m_lookBehind == DelimiterType::Escape)
+        if (parser.m_lookBehind == DelimiterType::Escape)
         {
             // remove escape char from stream
             token.pop_back();


### PR DESCRIPTION

# Description

Escape character is not removed from TextBlock. 

For e.g : \\*text\\* should be displayed as *text* but displayed as  \*text\* in Mobile


# Sample Card

```
{
  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
  "type": "AdaptiveCard",
  "version": "1.2",

  "body": [

	{

	  "type": "TextBlock",

	  "text": "Text with stars to make it italic: \\*text\\*",

	  "wrap": true

	}
  ],

  "actions": [],

  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",

  "version": "1.4"


}
```

# How Verified

before           |  after
:-------------------------:|:-------------------------:
![screenshot-1653330462137](https://user-images.githubusercontent.com/80986038/169884345-4064e493-f864-4bbb-9e60-5373fbc54209.png)  |  ![screenshot-1653330348771](https://user-images.githubusercontent.com/80986038/169884415-d895b771-44ae-49de-b596-925a72192968.png)



