### PR TITLE
[ReactNative] fix Markdown link text render error

### DIFF
--- a/source/community/reactnative/src/utils/markdown-formatter.js
+++ b/source/community/reactnative/src/utils/markdown-formatter.js
@@ -136,8 +136,7 @@ export default class MarkdownFormatter extends React.PureComponent {
 						let middleIndex = group.length / 2;
 						let firstHalf = group.substring(0, middleIndex);
 						let secondHalf = group.substring(middleIndex, group.length);
-						let middle = (j < middleIndex) ? group.substring(0, middleIndex) : group.substring(middleIndex, group.length);
-						regex = regex + firstHalf + '([^' + middle + ']+)' + secondHalf;
+						regex = regex + firstHalf + '(.*?)' + secondHalf;
 					}
 					pattern = regex;
 					break;

--- a/source/community/reactnative/src/visualizer/payloads/payloads/TextBlock.Markdown.json
+++ b/source/community/reactnative/src/visualizer/payloads/payloads/TextBlock.Markdown.json
@@ -26,7 +26,7 @@
 		},
 		{
 			"type": "TextBlock",
-			"text": "Check out [Adaptive Cards](http://adaptivecards.io)",
+			"text": "Check out [test [Adaptive] Cards](http://adaptivecards.io)",
 			"spacing": "medium"
 		}
 	]


### PR DESCRIPTION
# Related Issue
[#7478 ]

# Description
The markdown link pattern [([^[].*?)] cannot handle the link text which contains '[', it will render error
The markdown link pattern should be [(.*?)]((.*?))


# Sample Card

{
	"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
	"type": "AdaptiveCard",
	"version": "1.0",
	"body": [
		{
			"type": "TextBlock",
			"text": "This is some **bold** text"
		},
		{
			"type": "TextBlock",
			"text": "This is some _italic_ text",
			"spacing": "medium"
		},
		{
			"type": "TextBlock",
			"text": "- Bullet \r- List \r",
			"wrap": true,
			"spacing": "medium"
		},
		{
			"type": "TextBlock",
			"text": "1. Numbered\r2. List\r",
			"wrap": true,
			"spacing": "medium"
		},
		{
			"type": "TextBlock",
			"text": "Check out [test [Adaptive] Cards](http://adaptivecards.io)",
			"spacing": "medium"
		}
	]
}

# How Verified

1. open ReactNative TextBlock.MarkDown
before
<img width="460" alt="image" src="https://user-images.githubusercontent.com/20136688/170203434-c814f6f5-5bba-4994-8f28-1734cc1b6d90.png">
fixed
<img width="447" alt="image" src="https://user-images.githubusercontent.com/20136688/170203498-02d4246a-3675-48ad-9922-a8fc5ffc6a3b.png">



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7481)