### PR TITLE
[ReactNative] fix ColumnSet use Column directly, it will cause cannot register custom Column

### DIFF
--- a/source/community/reactnative/src/components/containers/columnset.js
+++ b/source/community/reactnative/src/components/containers/columnset.js
@@ -11,9 +11,9 @@ import {
 
 import { SelectAction } from '../actions';
 import ElementWrapper from '../elements/element-wrapper';
-import { Column } from "./column";
 import * as Constants from '../../utils/constants';
 import { ContainerWrapper } from './';
+import { Registry } from '../registration/registry';
 
 export class ColumnSet extends React.PureComponent {
 
@@ -32,11 +32,12 @@ export class ColumnSet extends React.PureComponent {
 		const children = [];
 		if (!this.payload)
 			return children;
-
+    //get Column element from Registry
+    const ColumnElement = Registry.getManager().getComponentOfType("Column");
 		// parse elements
 		payload.columns.map((element, index) => {
 			children.push(
-				<Column json={element}
+				<ColumnElement json={element}
 					columns={payload.columns}
 					configManager={this.props.configManager}
 					hasBackgroundImage={payload.parent.backgroundImage}


### PR DESCRIPTION


# Related Issue
[#7479 ]

# Description

in ColumnSet, it use Column directly , if we have registered custom Column, it will not work

# Sample Card



# How Verified
1. open ReactNative column


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7482)