### PR TITLE
[Accessibility] Fix WeatherLarge card for accessibility

### DIFF
--- a/samples/v1.0/Scenarios/WeatherLarge.json
+++ b/samples/v1.0/Scenarios/WeatherLarge.json
@@ -29,26 +29,30 @@
 							"text": "Tue, Nov 5, 2019",
 							"weight": "bolder",
 							"size": "large",
-							"wrap": true
+							"wrap": true,
+							"color": "dark"
 						},
 						{
 							"type": "TextBlock",
 							"text": "32 / 50",
 							"size": "medium",
 							"spacing": "none",
-							"wrap": true
+							"wrap": true,
+							"color": "dark"
 						},
 						{
 							"type": "TextBlock",
 							"text": "31% chance of rain",
 							"spacing": "none",
-							"wrap": true
+							"wrap": true,
+							"color": "dark"
 						},
 						{
 							"type": "TextBlock",
 							"text": "Winds 4.4 mph SSE",
 							"spacing": "none",
-							"wrap": true
+							"wrap": true,
+							"color": "dark"
 						}
 					]
 				}
@@ -65,7 +69,8 @@
 							"type": "TextBlock",
 							"horizontalAlignment": "center",
 							"wrap": true,
-							"text": "Wednesday"
+							"text": "Wednesday",
+							"color": "dark"
 						},
 						{
 							"type": "Image",
@@ -74,18 +79,15 @@
 							"altText": "Drizzly weather"
 						},
 						{
-							"type": "FactSet",
-							"horizontalAlignment": "right",
-							"facts": [
-								{
-									"title": "High",
-									"value": "50"
-								},
-								{
-									"title": "Low",
-									"value": "32"
-								}
-							]
+							"type": "TextBlock",
+							"text": "**High**\t50",
+							"color": "dark"
+						},
+						{
+							"type": "TextBlock",
+							"text": "**Low**\t32",
+							"color": "dark",
+							"spacing": "none"
 						}
 					],
 					"selectAction": {
@@ -102,7 +104,8 @@
 							"type": "TextBlock",
 							"horizontalAlignment": "center",
 							"wrap": true,
-							"text": "Thursday"
+							"text": "Thursday",
+							"color": "dark"
 						},
 						{
 							"type": "Image",
@@ -111,17 +114,15 @@
 							"altText": "Mostly cloudy weather"
 						},
 						{
-							"type": "FactSet",
-							"facts": [
-								{
-									"title": "High",
-									"value": "50"
-								},
-								{
-									"title": "Low",
-									"value": "32"
-								}
-							]
+							"type": "TextBlock",
+							"text": "**High**\t50",
+							"color": "dark"
+						},
+						{
+							"type": "TextBlock",
+							"text": "**Low**\t32",
+							"color": "dark",
+							"spacing": "none"
 						}
 					],
 					"selectAction": {
@@ -138,7 +139,8 @@
 							"type": "TextBlock",
 							"horizontalAlignment": "center",
 							"wrap": true,
-							"text": "Friday"
+							"text": "Friday",
+							"color": "dark"
 						},
 						{
 							"type": "Image",
@@ -147,17 +149,15 @@
 							"altText": "Mostly cloudy weather"
 						},
 						{
-							"type": "FactSet",
-							"facts": [
-								{
-									"title": "High",
-									"value": "59"
-								},
-								{
-									"title": "Low",
-									"value": "32"
-								}
-							]
+							"type": "TextBlock",
+							"text": "**High**\t59",
+							"color": "dark"
+						},
+						{
+							"type": "TextBlock",
+							"text": "**Low**\t32",
+							"color": "dark",
+							"spacing": "none"
 						}
 					],
 					"selectAction": {
@@ -174,7 +174,8 @@
 							"type": "TextBlock",
 							"horizontalAlignment": "center",
 							"wrap": true,
-							"text": "Saturday"
+							"text": "Saturday",
+							"color": "dark"
 						},
 						{
 							"type": "Image",
@@ -183,17 +184,15 @@
 							"altText": "Mostly cloudy weather"
 						},
 						{
-							"type": "FactSet",
-							"facts": [
-								{
-									"title": "High",
-									"value": "50"
-								},
-								{
-									"title": "Low",
-									"value": "32"
-								}
-							]
+							"type": "TextBlock",
+							"text": "**High**\t50",
+							"color": "dark"
+						},
+						{
+							"type": "TextBlock",
+							"text": "**Low**\t32",
+							"color": "dark",
+							"spacing": "none"
 						}
 					],
 					"selectAction": {


### PR DESCRIPTION
# Related Issue

// TODO: copy bug here

# Description

Changes FactSet elements for regular TextBlocks until we get an improvement on customization for FactSet. Using a table element was tried but Table may not be usable inside of a ColumnSet

# Sample Card

WeatherCard

# How Verified

Visual verification

<img width="546" alt="Screen Shot 2022-06-13 at 10 45 51 AM" src="https://user-images.githubusercontent.com/35784165/173413446-17f8a7b5-694a-41ac-b695-c12108f0eb04.png">

