### PR TITLE
added link navigation to acessibility

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRichTextBlockRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRichTextBlockRenderer.mm
@@ -49,7 +49,10 @@
         [[ACRUILabel alloc] initWithFrame:CGRectMake(0, 0, viewGroup.frame.size.width, 0)];
     lab.backgroundColor = [UIColor clearColor];
     lab.style = [viewGroup style];
-    lab.editable = NO;
+    // Apple Bug: without setting editable to YES, VO link navigation in iOS 12 and above
+    // doesn't work.
+    lab.editable = YES;
+    lab.delegate = lab;
     lab.textContainer.lineFragmentPadding = 0;
     lab.textContainerInset = UIEdgeInsetsZero;
     lab.layoutManager.usesFontLeading = false;
@@ -124,7 +127,7 @@
                                     &target)) {
                         NSRange selectActionRange = NSMakeRange(0, textRunContent.length);
 
-                        [textRunContent addAttribute:@"SelectAction"
+                        [textRunContent addAttribute:NSLinkAttributeName
                                                value:target
                                                range:selectActionRange];
 
@@ -138,7 +141,7 @@
                             hasGestureRecognizerAdded = YES;
                         }
 
-                        if (acoAction.inlineTooltip) {
+                        if (acoAction.inlineTooltip && [acoAction.inlineTooltip length]) {
                             [((ACRBaseTarget *)target) setTooltip:lab toolTipText:acoAction.inlineTooltip];
                             if (!hasLongPressGestureRecognizerAdded) {
                                 UILongPressGestureRecognizer *recognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:lab action:@selector(handleInlineAction:)];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRUILabel.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRUILabel.h
@@ -8,7 +8,7 @@
 #import "ACOBaseCardElement.h"
 #import <UIKit/UIKit.h>
 
-@interface ACRUILabel : UITextView<UITextViewDelegate>
+@interface ACRUILabel : UITextView <UITextViewDelegate>
 @property ACRContainerStyle style;
 @property CGFloat area;
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRUILabel.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRUILabel.h
@@ -8,7 +8,7 @@
 #import "ACOBaseCardElement.h"
 #import <UIKit/UIKit.h>
 
-@interface ACRUILabel : UITextView
+@interface ACRUILabel : UITextView<UITextViewDelegate>
 @property ACRContainerStyle style;
 @property CGFloat area;
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRUILabel.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRUILabel.mm
@@ -63,7 +63,7 @@
     // that link or custom attribute, SelectAction was defined
     if (!(fraction == 0.0 || fraction == 1.0) && characterIndex < self.textStorage.length) {
         if ([self.textStorage attribute:NSLinkAttributeName atIndex:characterIndex effectiveRange:NULL] ||
-            [self.textStorage attribute:@"SelectAction"
+            [self.textStorage attribute:NSLinkAttributeName
                                 atIndex:characterIndex
                          effectiveRange:NULL]) {
             return self;
@@ -99,10 +99,17 @@
 
     NSUInteger indexAtChar = [[view layoutManager] characterIndexForPoint:pt inTextContainer:view.textContainer fractionOfDistanceBetweenInsertionPoints:NULL];
     if (indexAtChar < view.textStorage.length) {
-        return [view.attributedText attribute:@"SelectAction" atIndex:indexAtChar effectiveRange:nil];
+        return [view.attributedText attribute:NSLinkAttributeName atIndex:indexAtChar effectiveRange:nil];
     }
 
     return nil;
+}
+
+// Due to Apple's VO bug, UITextView's isEditable field has to be set YES, to prevent
+// editing, implemented the delegate below.
+- (BOOL)textViewShouldBeginEditing:(UITextView *)textView
+{
+    return NO;
 }
 
 @end


### PR DESCRIPTION
# Related Issue

Fixed #6283 

# Description

Added Link Attribute for VO to detect the inline actions as links.
Added a workaround for Apple Bug where iOS12 and above fails VO unless editable is set YES.

# How Verified

1. Verified manually with relavant cards.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7553)