### PR TITLE
[a11y] Update SportingEvent sample

### DIFF
--- a/samples/v1.0/Scenarios/SportingEvent.json
+++ b/samples/v1.0/Scenarios/SportingEvent.json
@@ -17,7 +17,7 @@
 								{
 									"type": "Image",
 									"url": "https://adaptivecards.io/content/cats/3.png",
-									"size": "medium",
+									"size": "small",
 									"altText": "Shades cat team emblem"
 								},
 									{
@@ -66,7 +66,7 @@
 								{
 									"type": "Image",
 									"url": "https://adaptivecards.io/content/cats/2.png",
-									"size": "medium",
+									"size": "small",
 									"horizontalAlignment": "center",
 									"altText": "Skins cat team emblem"
 								},


### PR DESCRIPTION
# Related Issue

Fixes https://github.com/microsoft/AdaptiveCards/issues/7033

# Description

Android supports a large set of devices, each with a different screen resolution and other display differences, as such, usually apps can pick smaller images for phones with smaller screens, AC doesn't support that, as such, even when a card is good in one phone it isn't in other phones, in the case of the sporting event card it's good in phones with better display resolutions but not accessible on small resolution phones. 

The fix is changing the size of the images in the SportingEvent card, the code accurately resizes the images shown so it's not a code issue but some screens are narrower than others so the only viable fix is updating the card.

# Visuals 
![Screenshot_1655935538](https://user-images.githubusercontent.com/35784165/175160459-d4d9d5fe-1f9e-48a5-b85c-f9db0de7f074.png)

![Screenshot_1655935620](https://user-images.githubusercontent.com/35784165/175160553-4a675db4-4b06-4106-8ada-3418b8c7b5b8.png)



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7561)