### PR TITLE
removed wrong role assignment

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionOverflowRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionOverflowRenderer.mm
@@ -46,8 +46,6 @@
             [target setInputs:inputs superview:superview];
         }
 
-        button.accessibilityTraits |= UIAccessibilityTraitLink;
-
         [button setContentCompressionResistancePriority:UILayoutPriorityRequired
                                                 forAxis:UILayoutConstraintAxisVertical];
 


### PR DESCRIPTION
# Related Issue
Fixed #7027 

# Description
The mode button's role was wrongly assigned as a link. Removed it as the additional role isn't needed.

# How Verified

Manually verified it.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7564)