### PR TITLE
[Designer] Add right to left support to designer

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/designer-peers.ts
+++ b/source/nodejs/adaptivecards-designer/src/designer-peers.ts
@@ -2122,7 +2122,8 @@ export class AdaptiveCardPeer extends TypedCardElementPeer<Adaptive.AdaptiveCard
         propertySheet.add(
             PropertySheetCategory.LayoutCategory,
             ContainerPeer.minHeightProperty,
-            ContainerPeer.verticalContentAlignmentProperty);
+            ContainerPeer.verticalContentAlignmentProperty,
+            ContainerPeer.rtlProperty);
 
         propertySheet.add(
             "Background image",
@@ -2210,7 +2211,8 @@ export class ColumnPeer extends TypedCardElementPeer<Adaptive.Column> {
         propertySheet.add(
             PropertySheetCategory.LayoutCategory,
             ContainerPeer.minHeightProperty,
-            ContainerPeer.verticalContentAlignmentProperty);
+            ContainerPeer.verticalContentAlignmentProperty,
+            ContainerPeer.rtlProperty);
 
         propertySheet.add(
             PropertySheetCategory.StyleCategory,
@@ -2317,6 +2319,7 @@ export class ContainerPeer extends TypedCardElementPeer<Adaptive.Container> {
             new EnumPropertyEditor(Adaptive.Versions.v1_2, "verticalAlignment", "Vertical alignment", Adaptive.VerticalAlignment)
         ]
     );
+    static readonly rtlProperty = new BooleanPropertyEditor(Adaptive.Versions.v1_5, "rtl", "Present right to left");
 
     protected isContainer(): boolean {
         return true;
@@ -2328,7 +2331,8 @@ export class ContainerPeer extends TypedCardElementPeer<Adaptive.Container> {
         propertySheet.add(
             PropertySheetCategory.LayoutCategory,
             ContainerPeer.minHeightProperty,
-            ContainerPeer.verticalContentAlignmentProperty);
+            ContainerPeer.verticalContentAlignmentProperty,
+            ContainerPeer.rtlProperty);
 
         propertySheet.add(
             PropertySheetCategory.StyleCategory,


### PR DESCRIPTION
# Description

We needed to add `rtl` support to the designer for the following elements: `AdaptiveCard`, `Container`, `Column`, and `TableCell`.

The cards already supported `rtl`, but we needed a way to enable/disable the feature from the `Element Properties` pane.

# Sample Card

You can now enable/disable `rtl` within the designer for the expected properties as shown below:

![RtlSupport](https://user-images.githubusercontent.com/98650930/176267730-388af460-895e-4d22-ba39-add907b17cf7.gif)

# How Verified

Verified manually in the designer.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7579)