### PR TITLE
implemented carousel telemetry feature

### DIFF
--- a/source/nodejs/adaptivecards/package-lock.json
+++ b/source/nodejs/adaptivecards/package-lock.json
@@ -19,7 +19,7 @@
 				"typedoc-plugin-markdown": "^3.11.2"
 			},
 			"peerDependencies": {
-				"swiper": "^7.2.0"
+				"swiper": "^8.2.6"
 			}
 		},
 		"node_modules/@babel/compat-data": {
@@ -1853,9 +1853,9 @@
 			}
 		},
 		"node_modules/dom7": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/dom7/-/dom7-4.0.1.tgz",
-			"integrity": "sha512-y/RWjw3gK3qQnZz6IqDaIoqH6+xBhcB3Wsh5HFwl0abwuO/NAgbSB31ZbxtBDcuDe8jAX5NYUNDLTx4Ul48sIw==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/dom7/-/dom7-4.0.4.tgz",
+			"integrity": "sha512-DSSgBzQ4rJWQp1u6o+3FVwMNnT5bzQbMb+o31TjYYeRi05uAcpF8koxdfzeoe5ElzPmua7W7N28YJhF7iEKqIw==",
 			"peer": true,
 			"dependencies": {
 				"ssr-window": "^4.0.0"
@@ -4311,9 +4311,9 @@
 			"dev": true
 		},
 		"node_modules/ssr-window": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.1.tgz",
-			"integrity": "sha512-5q936lkCk5Lg5hM6tG8Nutdym4vNiuFSWorslTzOn71PWb3Wnx44q/k2Ryn1LWA1G4FtxMzjywUFOiOxPkVGrA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.2.tgz",
+			"integrity": "sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ==",
 			"peer": true
 		},
 		"node_modules/stack-utils": {
@@ -4441,9 +4441,9 @@
 			}
 		},
 		"node_modules/swiper": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/swiper/-/swiper-7.2.0.tgz",
-			"integrity": "sha512-CUL6Nvzcf3fU0b8dHaraYphgBT7l44PY1B6T8b+E12pim4DEcwFZDy/KZoIKrAnn+rfbayCmcksYmSDIP5nDHg==",
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/swiper/-/swiper-8.3.0.tgz",
+			"integrity": "sha512-pdrENUco8MVyJ/cTZMQ5c9AqZDRYGJChd+5lcDsoGpKhgOloSzS7hMvgH+ipvTVCaNOCTlSaf5ZYm1Jz5TqKDQ==",
 			"funding": [
 				{
 					"type": "patreon",
@@ -4457,8 +4457,8 @@
 			"hasInstallScript": true,
 			"peer": true,
 			"dependencies": {
-				"dom7": "^4.0.1",
-				"ssr-window": "^4.0.1"
+				"dom7": "^4.0.4",
+				"ssr-window": "^4.0.2"
 			},
 			"engines": {
 				"node": ">= 4.7.0"
@@ -6453,9 +6453,9 @@
 			"dev": true
 		},
 		"dom7": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/dom7/-/dom7-4.0.1.tgz",
-			"integrity": "sha512-y/RWjw3gK3qQnZz6IqDaIoqH6+xBhcB3Wsh5HFwl0abwuO/NAgbSB31ZbxtBDcuDe8jAX5NYUNDLTx4Ul48sIw==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/dom7/-/dom7-4.0.4.tgz",
+			"integrity": "sha512-DSSgBzQ4rJWQp1u6o+3FVwMNnT5bzQbMb+o31TjYYeRi05uAcpF8koxdfzeoe5ElzPmua7W7N28YJhF7iEKqIw==",
 			"peer": true,
 			"requires": {
 				"ssr-window": "^4.0.0"
@@ -8367,9 +8367,9 @@
 			"dev": true
 		},
 		"ssr-window": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.1.tgz",
-			"integrity": "sha512-5q936lkCk5Lg5hM6tG8Nutdym4vNiuFSWorslTzOn71PWb3Wnx44q/k2Ryn1LWA1G4FtxMzjywUFOiOxPkVGrA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.2.tgz",
+			"integrity": "sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ==",
 			"peer": true
 		},
 		"stack-utils": {
@@ -8470,13 +8470,13 @@
 			}
 		},
 		"swiper": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/swiper/-/swiper-7.2.0.tgz",
-			"integrity": "sha512-CUL6Nvzcf3fU0b8dHaraYphgBT7l44PY1B6T8b+E12pim4DEcwFZDy/KZoIKrAnn+rfbayCmcksYmSDIP5nDHg==",
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/swiper/-/swiper-8.3.0.tgz",
+			"integrity": "sha512-pdrENUco8MVyJ/cTZMQ5c9AqZDRYGJChd+5lcDsoGpKhgOloSzS7hMvgH+ipvTVCaNOCTlSaf5ZYm1Jz5TqKDQ==",
 			"peer": true,
 			"requires": {
-				"dom7": "^4.0.1",
-				"ssr-window": "^4.0.1"
+				"dom7": "^4.0.4",
+				"ssr-window": "^4.0.2"
 			}
 		},
 		"symbol-tree": {

--- a/source/nodejs/adaptivecards/package.json
+++ b/source/nodejs/adaptivecards/package.json
@@ -49,7 +49,7 @@
 		"typedoc-plugin-markdown": "^3.11.2"
 	},
 	"peerDependencies": {
-		"swiper": "^7.2.0"
+		"swiper": "^8.2.6"
 	},
 	"jest": {
 		"verbose": true,

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as Enums from "./enums";
+import { Carousel, CarouselEvent } from "./carousel";
 import {
     PaddingDefinition,
     GlobalSettings,
@@ -11,7 +12,7 @@ import {
     StringWithSubstitutions,
     ContentTypes,
     IInput,
-    IResourceInformation
+    IResourceInformation,
 } from "./shared";
 import * as Utils from "./utils";
 import {
@@ -8143,6 +8144,7 @@ export class AdaptiveCard extends ContainerWithActions {
     static onImageLoaded?: (image: Image) => void;
     static onInlineCardExpanded?: (action: ShowCardAction, isExpanded: boolean) => void;
     static onInputValueChanged?: (input: Input) => void;
+    static onCarouselEvent?: (carouselEvent: CarouselEvent) => void;
     static onProcessMarkdown?: (text: string, result: IMarkdownProcessingResult) => void;
     static onDisplayOverflowActionMenu?: (
         actions: readonly Action[],
@@ -8288,6 +8290,7 @@ export class AdaptiveCard extends ContainerWithActions {
     onImageLoaded?: (image: Image) => void;
     onInlineCardExpanded?: (action: ShowCardAction, isExpanded: boolean) => void;
     onInputValueChanged?: (input: Input) => void;
+    onCarouselEvent?: (carouselEvent: CarouselEvent) => void;
     onDisplayOverflowActionMenu?: (actions: readonly Action[], target?: HTMLElement) => boolean;
     onRenderOverflowActions?: (actions: readonly Action[], isRootLevelActions: boolean) => boolean;
 

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as Enums from "./enums";
-import { Carousel, CarouselEvent } from "./carousel";
+import { CarouselEvent } from "./carousel";
 import {
     PaddingDefinition,
     GlobalSettings,

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -8309,7 +8309,6 @@ export class AdaptiveCard extends ContainerWithActions {
     onImageLoaded?: (image: Image) => void;
     onInlineCardExpanded?: (action: ShowCardAction, isExpanded: boolean) => void;
     onInputValueChanged?: (input: Input) => void;
-    onCarouselEvent?: (carouselEvent: CarouselEvent) => void;
     onDisplayOverflowActionMenu?: (actions: readonly Action[], target?: HTMLElement) => boolean;
     onRenderOverflowActions?: (actions: readonly Action[], isRootLevelActions: boolean) => boolean;
 

--- a/source/nodejs/adaptivecards/src/carousel.ts
+++ b/source/nodejs/adaptivecards/src/carousel.ts
@@ -117,17 +117,17 @@ export class Carousel extends Container {
 
     //#endregion
 
-    get currentEventType(): Enums.CarouselEventType {
+    get currentEventType(): Enums.CarouselInteractionEvent {
         return this._currentEventType;
     }
 
-    set currentEventType(eventType: Enums.CarouselEventType) {
+    set currentEventType(eventType: Enums.CarouselInteractionEvent) {
         this._currentEventType = eventType;
     }
 
     private _pages: CarouselPage[] = [];
     private _renderedPages: CarouselPage[];
-    private _currentEventType: Enums.CarouselEventType;
+    private _currentEventType: Enums.CarouselInteractionEvent;
 
     protected forbiddenChildElements(): string[] {
         return [
@@ -200,7 +200,7 @@ export class Carousel extends Container {
     }
 
     get currentPageIndex(): number | undefined {
-        if (this._carousel?.slides?.length) {
+        if (this._carousel) {
             return this._carousel.realIndex;
         }
         return undefined;
@@ -411,19 +411,19 @@ export class Carousel extends Container {
         });
 
         carousel.on('navigationNext',  () => {
-            raiseCarouselEvent(this, Enums.CarouselEventType.NextNavigationInteractionType);
+            raiseCarouselEvent(this, Enums.CarouselInteractionEvent.NavigationNext);
         });
 
         carousel.on('navigationPrev',  () => {
-            raiseCarouselEvent(this, Enums.CarouselEventType.PreviousNavigationInteractionType);
+            raiseCarouselEvent(this, Enums.CarouselInteractionEvent.NavigationPrevious);
         });
 
         carousel.on('slideChangeTransitionEnd',  () => {
-            raiseCarouselEvent(this, Enums.CarouselEventType.PaginationInteractionType);
+            raiseCarouselEvent(this, Enums.CarouselInteractionEvent.Pagination);
         });
 
         carousel.on('autoplay',  () => {
-            raiseCarouselEvent(this, Enums.CarouselEventType.AutoplayType);
+            raiseCarouselEvent(this, Enums.CarouselInteractionEvent.Autoplay);
         });
 
         this._carousel = carousel;
@@ -453,7 +453,7 @@ export class Carousel extends Container {
 }
 
 export class CarouselEvent {
-    type : Enums.CarouselEventType;
+    type : Enums.CarouselInteractionEvent;
     carouselId : string | undefined;
     activeCarouselPageId : string | undefined;
     activeCarouselPageIndex : number | undefined;
@@ -465,14 +465,14 @@ export class CarouselEvent {
     }
 }
 
-function raiseCarouselEvent(carousel: Carousel, eventType : Enums.CarouselEventType) {
+function raiseCarouselEvent(carousel: Carousel, eventType : Enums.CarouselInteractionEvent) {
     const card = carousel.getRootElement() as AdaptiveCard;
     const onCarouselEventHandler =
         card && card.onCarouselEvent
             ? card.onCarouselEvent
             : AdaptiveCard.onCarouselEvent;
 
-    if (onCarouselEventHandler && eventType == Enums.CarouselEventType.PaginationInteractionType) {
+    if (onCarouselEventHandler && eventType == Enums.CarouselInteractionEvent.Pagination) {
         onCarouselEventHandler(new CarouselEvent(carousel));
     }
     carousel.currentEventType = eventType;

--- a/source/nodejs/adaptivecards/src/carousel.ts
+++ b/source/nodejs/adaptivecards/src/carousel.ts
@@ -466,12 +466,7 @@ export class CarouselEvent {
 }
 
 function raiseCarouselEvent(carousel: Carousel, eventType : Enums.CarouselInteractionEvent) {
-    const card = carousel.getRootElement() as AdaptiveCard;
-    const onCarouselEventHandler =
-        card && card.onCarouselEvent
-            ? card.onCarouselEvent
-            : AdaptiveCard.onCarouselEvent;
-
+    const onCarouselEventHandler = AdaptiveCard.onCarouselEvent;
     if (onCarouselEventHandler && eventType == Enums.CarouselInteractionEvent.Pagination) {
         onCarouselEventHandler(new CarouselEvent(carousel));
     }

--- a/source/nodejs/adaptivecards/src/carousel.ts
+++ b/source/nodejs/adaptivecards/src/carousel.ts
@@ -411,19 +411,19 @@ export class Carousel extends Container {
         });
 
         carousel.on('navigationNext',  () => {
-            raiseCarouselEvent(this, Enums.CarouselInteractionEvent.NavigationNext);
+            this.raiseCarouselEvent(Enums.CarouselInteractionEvent.NavigationNext);
         });
 
         carousel.on('navigationPrev',  () => {
-            raiseCarouselEvent(this, Enums.CarouselInteractionEvent.NavigationPrevious);
+            this.raiseCarouselEvent(Enums.CarouselInteractionEvent.NavigationPrevious);
         });
 
         carousel.on('slideChangeTransitionEnd',  () => {
-            raiseCarouselEvent(this, Enums.CarouselInteractionEvent.Pagination);
+            this.raiseCarouselEvent(Enums.CarouselInteractionEvent.Pagination);
         });
 
         carousel.on('autoplay',  () => {
-            raiseCarouselEvent(this, Enums.CarouselInteractionEvent.Autoplay);
+            this.raiseCarouselEvent(Enums.CarouselInteractionEvent.Autoplay);
         });
 
         this._carousel = carousel;
@@ -450,6 +450,23 @@ export class Carousel extends Container {
             }
         );
     }
+
+    private createCarouselEvent (type : Enums.CarouselInteractionEvent): CarouselEvent
+    {
+        let currentPageId : string | undefined;
+        if (this.currentPageIndex != undefined) {
+            currentPageId = this.getItemAt(this.currentPageIndex).id;
+        }
+        return new CarouselEvent(type, this.id, currentPageId, this.currentPageIndex);   
+    }
+
+    private raiseCarouselEvent(eventType : Enums.CarouselInteractionEvent) {
+        const onCarouselEventHandler = AdaptiveCard.onCarouselEvent;
+        if (onCarouselEventHandler && eventType == Enums.CarouselInteractionEvent.Pagination) {
+            onCarouselEventHandler(this.createCarouselEvent(this.currentEventType));
+        }
+        this.currentEventType = eventType;
+    }
 }
 
 export class CarouselEvent {
@@ -457,20 +474,17 @@ export class CarouselEvent {
     carouselId : string | undefined;
     activeCarouselPageId : string | undefined;
     activeCarouselPageIndex : number | undefined;
-    constructor(carousel : Carousel) {
-        this.carouselId = carousel.id;
-        this.activeCarouselPageIndex = carousel.currentPageIndex;
-        this.activeCarouselPageId = (this.activeCarouselPageIndex != undefined) ? carousel.getItemAt(this.activeCarouselPageIndex).id : undefined; 
-        this.type = carousel.currentEventType;
-    }
-}
 
-function raiseCarouselEvent(carousel: Carousel, eventType : Enums.CarouselInteractionEvent) {
-    const onCarouselEventHandler = AdaptiveCard.onCarouselEvent;
-    if (onCarouselEventHandler && eventType == Enums.CarouselInteractionEvent.Pagination) {
-        onCarouselEventHandler(new CarouselEvent(carousel));
+    constructor(type : Enums.CarouselInteractionEvent,
+        carouselId : string | undefined,
+        activeCarouselPageId : string | undefined,
+        activeCarouselPageIndex : number | undefined)
+    {
+        this.carouselId = carouselId;
+        this.activeCarouselPageIndex = activeCarouselPageIndex;
+        this.activeCarouselPageId = activeCarouselPageId;
+        this.type = type;
     }
-    carousel.currentEventType = eventType;
 }
 
 GlobalRegistry.defaultElements.register(

--- a/source/nodejs/adaptivecards/src/carousel.ts
+++ b/source/nodejs/adaptivecards/src/carousel.ts
@@ -117,17 +117,17 @@ export class Carousel extends Container {
 
     //#endregion
 
-    get currentEventType(): Enums.CarouselInteractionEvent {
-        return this._currentEventType;
+    get previousEventType(): Enums.CarouselInteractionEvent {
+        return this._previousEventType;
     }
 
-    set currentEventType(eventType: Enums.CarouselInteractionEvent) {
-        this._currentEventType = eventType;
+    set previousEventType(eventType: Enums.CarouselInteractionEvent) {
+        this._previousEventType = eventType;
     }
 
     private _pages: CarouselPage[] = [];
     private _renderedPages: CarouselPage[];
-    private _currentEventType: Enums.CarouselInteractionEvent;
+    private _previousEventType: Enums.CarouselInteractionEvent = Enums.CarouselInteractionEvent.Pagination;
 
     protected forbiddenChildElements(): string[] {
         return [
@@ -200,10 +200,7 @@ export class Carousel extends Container {
     }
 
     get currentPageIndex(): number | undefined {
-        if (this._carousel) {
-            return this._carousel.realIndex;
-        }
-        return undefined;
+        return this._carousel?.realIndex;
     }
 
     protected internalParse(source: any, context: SerializationContext) {
@@ -462,29 +459,20 @@ export class Carousel extends Container {
 
     private raiseCarouselEvent(eventType : Enums.CarouselInteractionEvent) {
         const onCarouselEventHandler = AdaptiveCard.onCarouselEvent;
+        // pagination event is triggered on slide transition end event 
         if (onCarouselEventHandler && eventType == Enums.CarouselInteractionEvent.Pagination) {
-            onCarouselEventHandler(this.createCarouselEvent(this.currentEventType));
+	    // returns the event type that causes slide transition
+            onCarouselEventHandler(this.createCarouselEvent(this.previousEventType));
         }
-        this.currentEventType = eventType;
+        this.previousEventType = eventType;
     }
 }
 
 export class CarouselEvent {
-    type : Enums.CarouselInteractionEvent;
-    carouselId : string | undefined;
-    activeCarouselPageId : string | undefined;
-    activeCarouselPageIndex : number | undefined;
-
-    constructor(type : Enums.CarouselInteractionEvent,
-        carouselId : string | undefined,
-        activeCarouselPageId : string | undefined,
-        activeCarouselPageIndex : number | undefined)
-    {
-        this.carouselId = carouselId;
-        this.activeCarouselPageIndex = activeCarouselPageIndex;
-        this.activeCarouselPageId = activeCarouselPageId;
-        this.type = type;
-    }
+    constructor(public type : Enums.CarouselInteractionEvent,
+        public carouselId : string | undefined,
+        public activeCarouselPageId : string | undefined,
+        public activeCarouselPageIndex : number | undefined) {}
 }
 
 GlobalRegistry.defaultElements.register(

--- a/source/nodejs/adaptivecards/src/enums.ts
+++ b/source/nodejs/adaptivecards/src/enums.ts
@@ -201,3 +201,10 @@ export enum LogLevel {
     Warning,
     Error
 }
+
+export enum CarouselEventType {
+    NextNavigationInteractionType,
+    PreviousNavigationInteractionType,
+    PaginationInteractionType,
+    AutoplayType
+}

--- a/source/nodejs/adaptivecards/src/enums.ts
+++ b/source/nodejs/adaptivecards/src/enums.ts
@@ -202,9 +202,9 @@ export enum LogLevel {
     Error
 }
 
-export enum CarouselEventType {
-    NextNavigationInteractionType,
-    PreviousNavigationInteractionType,
-    PaginationInteractionType,
-    AutoplayType
+export enum CarouselInteractionEvent {
+    NavigationNext,
+    NavigationPrevious,
+    Pagination,
+    Autoplay
 }


### PR DESCRIPTION
# Related Issue

Fixed #7512 

# Description

* generate events of carousel page transitions initiated by clicking next navi button and prev navi button, for autoplay, and for pagenation.
* Updated swiper version to be able to listen on navi button click events.
* added the event handler hook.

| Capability      | Priority | Status |
| ----------- | ----------- | -- |
| Event for when user clicks the next arrow on the carousel | Must | Implemented |
| Event for when a user clicks the previous arrow on the carousel | Must | Implemented |
| Event for when a user navigates the carousel with the bottom dots | Must | Implemented |
| Which carousel pages did the user see vs not see | Must | Tools are provided and users to implement |
| How much time a user spent on a carousel and which page | Must | Tools are provided and users to implement |
| How long did the user hover over the page | Could | Not Implemented |
| Event for when user clicks on something in the carousel that might not be an action (i.e. highlighting text) | Could | Not Implemented |

We will make private drop and will gather their feedback.

# How Verified

Tested manually with samples

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7656)