### PR TITLE
Update handling of Actions for designer peer ordering

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/card-designer-surface.ts
+++ b/source/nodejs/adaptivecards-designer/src/card-designer-surface.ts
@@ -487,7 +487,6 @@ export class CardDesignerSurface {
         return null;
     }
 
-    // Question: does showCard always add to the end?
     private inlineCardExpanded(action: Adaptive.ShowCardAction, isExpanded: boolean) {
         let peer = this.findCardElementPeer(action.card);
 
@@ -496,6 +495,7 @@ export class CardDesignerSurface {
                 let registration = CardDesignerSurface.cardElementPeerRegistry.findTypeRegistration(Adaptive.AdaptiveCard);
 
                 peer = new registration.peerType(peer, this, registration, action.card);
+                peer.insertAfterNeighbor = true;
 
                 let parentPeer = this.findActionPeer(action);
 
@@ -507,7 +507,7 @@ export class CardDesignerSurface {
                 }
             }
             else {
-                peer.addElementsToDesignerSurface(this._designerSurface);
+                peer.addElementsToDesignerSurface(this._designerSurface, this.getPeerDOMNeighbor(peer));
             }
         }
         else {
@@ -860,7 +860,20 @@ export class CardDesignerSurface {
     getPeerDOMNeighbor(peer: DesignerPeers.DesignerPeer): HTMLElement {
         if (peer.parent) {
             let neighboringPeer = peer.parent;
-            if (peer instanceof DesignerPeers.CardElementPeer) {
+            if (neighboringPeer instanceof DesignerPeers.ActionSetPeer) {
+                // A new action is being added to an ActionSet, so we can add the ActionPeer as the last child element
+                const childCount = neighboringPeer.getChildCount();
+                if (childCount > 1) {
+                    // Subtract 2 because the child count already includes the action being currently added
+                    neighboringPeer = neighboringPeer.getChildAt(childCount - 2);
+                }
+
+            } else if (neighboringPeer instanceof DesignerPeers.ActionPeer) {
+                // neighboringPeer should be the parent so we can get the last element in the actionSet
+                neighboringPeer = neighboringPeer.parent;
+                neighboringPeer = neighboringPeer.getChildAt(neighboringPeer.getChildCount() - 1);
+
+            }else if (peer instanceof DesignerPeers.CardElementPeer) {
 
                 // Get the index of the peer within its container
                 const peerIndex = peer.cardElement.index;
@@ -875,13 +888,6 @@ export class CardDesignerSurface {
                     }
                 }
                 
-            } else if (peer instanceof DesignerPeers.ActionPeer) {
-
-                // peer.parent should be an ActionSet, so we know that we can add the ActionPeer as the last child element
-                const childCount = neighboringPeer.getChildCount();
-                if (childCount > 1) {
-                    neighboringPeer = neighboringPeer.getChildAt(childCount - 2);
-                }
             }
 
             return neighboringPeer.renderedElement;

--- a/source/nodejs/adaptivecards-designer/src/card-designer-surface.ts
+++ b/source/nodejs/adaptivecards-designer/src/card-designer-surface.ts
@@ -873,7 +873,7 @@ export class CardDesignerSurface {
                 neighboringPeer = neighboringPeer.parent;
                 neighboringPeer = neighboringPeer.getChildAt(neighboringPeer.getChildCount() - 1);
 
-            }else if (peer instanceof DesignerPeers.CardElementPeer) {
+            } else if (peer instanceof DesignerPeers.CardElementPeer) {
 
                 // Get the index of the peer within its container
                 const peerIndex = peer.cardElement.index;


### PR DESCRIPTION
# Related Issue

Fixes #7705 

# Description

Designer peers were not being added in the correct location when selecting `ShowCard` actions.

# How Verified

Verified manually on the adaptive cards site
![ShowCard-1](https://user-images.githubusercontent.com/98650930/180496388-ced8e15c-a3bb-4d79-a208-ff8d73be09c7.gif)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7704)