### PR TITLE
[Accessibility] Set focus to first element in card for Action.ShowCard

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -5739,6 +5739,19 @@ class ActionCollection {
 
             raiseInlineCardExpandedEvent(action, true);
         }
+
+        if (!this._owner.isDesignMode()) {
+            for (let i = 0; i < action.card.getItemCount(); i++) {
+                const element = this.getNearestFocusableElement(action.card.getItemAt(i));
+                if (element instanceof Input) {
+                    element.focus();
+                    break;
+                } else if (element instanceof Action) {
+                    element.renderedElement?.focus();
+                    break;
+                }
+            }
+        }
     }
 
     private collapseExpandedAction() {
@@ -5791,6 +5804,30 @@ class ActionCollection {
             !(this._owner.isAtTheVeryLeft() && this._owner.isAtTheVeryRight()),
             raiseEvent
         );
+    }
+
+    getNearestFocusableElement(childElement: CardObject): CardObject | undefined {
+        if (childElement instanceof Input) {
+            return childElement;
+        }
+
+        if (childElement instanceof CardElementContainer) {
+            for (let i = 0; i < childElement.getItemCount(); i++) {
+                const element = this.getNearestFocusableElement(childElement.getItemAt(i));
+
+                if (element) {
+                    return element;
+                }
+            }
+        } else if (childElement instanceof ActionSet) {
+            for (let i = 0; i < childElement.getActionCount(); i++) {
+                if (childElement.getActionAt(i)?.isFocusable) {
+                    return childElement.getActionAt(i);
+                }
+            }
+        }
+
+        return undefined;
     }
 
     private _items: Action[] = [];


### PR DESCRIPTION
# Related Issue

Fixes #7689 

# Description

When the user show's a card, the focus remains on the ShowCard action instead of moving to the first focusable element in the now visible card.

Fixed by recursively searching for the first focusable element (input or action) within the card and focusing on it.

# How Verified

Verified manually on the adaptivecards-site.

# Outstanding Issue

How do we want this to behave with other actions? For example, if we have two actions (`ShowCard` and `OpenUrl`) in that order, selecting show card will focus on an element within the card, and `OpenUrl` will never have focus.

![ShowCardBug](https://user-images.githubusercontent.com/98650930/180863072-262ac4c4-49f8-42c3-8ce0-8fabebabaad2.gif)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7709)