### PR TITLE
[Designer Accessibility] Make new card dialog more keyboard accessible

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/card-designer.ts
+++ b/source/nodejs/adaptivecards-designer/src/card-designer.ts
@@ -27,6 +27,7 @@ import { TreeView } from "./tree-view";
 import { SampleCatalogue } from "./catalogue";
 import { HelpDialog } from "./help-dialog";
 import { DeviceEmulation } from "./device-emulation";
+import { Constants as ControlConstants } from "adaptivecards-controls";
 
 export class CardDesigner extends Designer.DesignContext {
     private static internalProcessMarkdown(text: string, result: Adaptive.IMarkdownProcessingResult) {
@@ -668,6 +669,12 @@ export class CardDesigner extends Designer.DesignContext {
                                 dialog.close()
                                 this.launchJsonSchemaPopup()
                             },
+                            onKeyEvent: (e: KeyboardEvent) => {
+                                if (e.key === ControlConstants.keys.enter) {
+                                    dialog.close();
+                                    this.launchJsonSchemaPopup();
+                                }
+                            },
                             cardData: {
                                 thumbnail: () => {
                                     const thumbnail = document.createElement("div");
@@ -688,6 +695,12 @@ export class CardDesigner extends Designer.DesignContext {
                                 onClick: () => {
                                     dialog.close()
                                     this.launchImagePopup()
+                                },
+                                onKeyEvent: (e: KeyboardEvent) => {
+                                    if (e.key === ControlConstants.keys.enter) {
+                                        dialog.close();
+                                        this.launchImagePopup();
+                                    }
                                 },
                                 cardData: {
                                     thumbnail: () => {

--- a/source/nodejs/adaptivecards-designer/src/open-sample-dialog.ts
+++ b/source/nodejs/adaptivecards-designer/src/open-sample-dialog.ts
@@ -47,13 +47,13 @@ class OpenSampleItem {
         element.setAttribute("role", "listitem");
         element.onclick = this.props.onClick ?? (
             (e) => {
-                this.cardSelected();
+                this.onCardSelected();
             })
 
         element.onkeyup = this.props.onKeyEvent ?? (
             (e) => {
                 if (e.key === Constants.keys.enter) {
-                    this.cardSelected();
+                    this.onCardSelected();
                 }
             })
 
@@ -104,7 +104,7 @@ class OpenSampleItem {
         return element;
     }
 
-    cardSelected() {
+    onCardSelected() {
         if (this.onComplete) {
             if (this.props.cardData instanceof Function) {
                 const cardData = this.props.cardData(this.onComplete);

--- a/source/nodejs/adaptivecards-designer/src/open-sample-dialog.ts
+++ b/source/nodejs/adaptivecards-designer/src/open-sample-dialog.ts
@@ -19,7 +19,7 @@ type CardDataProvider = (callback?: CardDataCallback) => CardData | void;
 interface OpenSampleItemProps {
     label: string,
     onClick?: (ev: MouseEvent) => any,
-	onKeyEvent?: (ev: KeyboardEvent) => any,
+    onKeyEvent?: (ev: KeyboardEvent) => any,
     cardData?: CardData | CardDataProvider,
 }
 
@@ -47,15 +47,15 @@ class OpenSampleItem {
         element.setAttribute("role", "listitem");
         element.onclick = this.props.onClick ?? (
             (e) => {
-				this.cardSelected();
+                this.cardSelected();
             })
 
-		element.onkeyup = this.props.onKeyEvent ?? (
-			(e) => {
-				if (e.key === Constants.keys.enter) {
-					this.cardSelected();
-				}
-			})
+        element.onkeyup = this.props.onKeyEvent ?? (
+            (e) => {
+                if (e.key === Constants.keys.enter) {
+                    this.cardSelected();
+                }
+            })
 
         const thumbnailHost = document.createElement("div");
         thumbnailHost.className = "acd-open-sample-item-thumbnail";
@@ -104,18 +104,18 @@ class OpenSampleItem {
         return element;
     }
 
-	cardSelected() {
-		if (this.onComplete) {
-			if (this.props.cardData instanceof Function) {
-				const cardData = this.props.cardData(this.onComplete);
-				if (cardData) {
-					this.onComplete(cardData);
-				}
-			} else if (this.props.cardData) {
-				this.onComplete(this.props.cardData);
-			}
-		}
-	}
+    cardSelected() {
+        if (this.onComplete) {
+            if (this.props.cardData instanceof Function) {
+                const cardData = this.props.cardData(this.onComplete);
+                if (cardData) {
+                    this.onComplete(cardData);
+                }
+            } else if (this.props.cardData) {
+                this.onComplete(this.props.cardData);
+            }
+        }
+    }
 }
 
 

--- a/source/nodejs/adaptivecards-designer/src/open-sample-dialog.ts
+++ b/source/nodejs/adaptivecards-designer/src/open-sample-dialog.ts
@@ -5,6 +5,7 @@ import * as ACData from "adaptivecards-templating";
 import * as Adaptive from "adaptivecards";
 import { CatalogueEntry, SampleCatalogue } from "./catalogue";
 import { Dialog } from "./dialog";
+import { Constants } from "adaptivecards-controls";
 
 export interface CardData {
     cardPayload?: string
@@ -17,7 +18,8 @@ type CardDataProvider = (callback?: CardDataCallback) => CardData | void;
 
 interface OpenSampleItemProps {
     label: string,
-    onClick?: (ev: MouseEvent) => any
+    onClick?: (ev: MouseEvent) => any,
+	onKeyEvent?: (ev: KeyboardEvent) => any,
     cardData?: CardData | CardDataProvider,
 }
 
@@ -45,17 +47,15 @@ class OpenSampleItem {
         element.setAttribute("role", "listitem");
         element.onclick = this.props.onClick ?? (
             (e) => {
-                if (this.onComplete) {
-                    if (this.props.cardData instanceof Function) {
-                        const cardData = this.props.cardData(this.onComplete);
-                        if (cardData) {
-                            this.onComplete(cardData);
-                        }
-                    } else if (this.props.cardData) {
-                        this.onComplete(this.props.cardData);
-                    }
-                }
+				this.cardSelected();
             })
+
+		element.onkeyup = this.props.onKeyEvent ?? (
+			(e) => {
+				if (e.key === Constants.keys.enter) {
+					this.cardSelected();
+				}
+			})
 
         const thumbnailHost = document.createElement("div");
         thumbnailHost.className = "acd-open-sample-item-thumbnail";
@@ -103,6 +103,19 @@ class OpenSampleItem {
 
         return element;
     }
+
+	cardSelected() {
+		if (this.onComplete) {
+			if (this.props.cardData instanceof Function) {
+				const cardData = this.props.cardData(this.onComplete);
+				if (cardData) {
+					this.onComplete(cardData);
+				}
+			} else if (this.props.cardData) {
+				this.onComplete(this.props.cardData);
+			}
+		}
+	}
 }
 
 


### PR DESCRIPTION
# Related Issue

Fixes #7687 

# Description

When creating a new card on the designer, you should be able to select a new card (blank or sample) with the enter key. We needed keyboard events in addition to the existing onClick events.

# How Verified

Verified manually on the adaptivecards-site


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7710)