### PR TITLE
[JS Renderer] Search card actions in findDOMNodeOwner

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -2353,7 +2353,16 @@ export abstract class CardElementContainer extends CardElement {
             }
         }
 
-        // if not found in children, defer to parent implementation
+        // If not found in children, check the actions
+        for (let i = 0; i < this.getActionCount(); i++) {
+            target = this.getActionAt(i)?.findDOMNodeOwner(node);
+
+            if (target) {
+                return target;
+            }
+        }
+
+        // if not found in children or actions, defer to parent implementation
         return super.findDOMNodeOwner(node);
     }
 }


### PR DESCRIPTION
# Related Issue

Fixes #7606 

# Description

When searching the card children for DOM node owner, we did not look in the actions.

Updated the method so that if it is not found in the child elements, we search the card actions before returning the card itself.

# Sample Card

```
const card = new AdaptiveCard();

card.parse({
  type: 'AdaptiveCard',
  body: [
    {
      type: 'ActionSet',
      actions: [
        {
          type: 'Action.OpenUrl',
          title: 'Aloha!',
          url: 'https://bing.com/'
        }
      ]
    }
  ],
  actions: [
    {
      type: 'Action.OpenUrl',
      title: 'Hello, World!',
      url: 'https://bing.com/'
    }
  ],
  $schema: 'http://adaptivecards.io/schemas/adaptive-card.json',
  version: '1.5'
});

const [firstButton, secondButton] = card.render().querySelectorAll('.ac-pushButton');

expect(firstButton.innerText).toBe('Aloha!');
expect(secondButton.innerText).toBe('Hello, World!');

const firstCardObject = card.findDOMNodeOwner(firstButton);
const secondCardObject = card.findDOMNodeOwner(secondButton);

expect(firstCardObject.toJSON()).toHaveProperty('type', 'Action.OpenUrl');
expect(secondCardObject.toJSON()).toHaveProperty('type', 'Action.OpenUrl'); // This line failed, the "type" expected to be "Action.OpenUrl", however, actual is "AdaptiveCard".
```

# How Verified

Verified manually on the AdaptiveCard UI Test App


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7726)