### PR TITLE
[Android] Fix CI build break

### DIFF
--- a/source/android/build.gradle
+++ b/source/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/source/android/constants.gradle
+++ b/source/android/constants.gradle
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 project.ext {
     compileSdkVersion = 32
-    minSdkVersion = 19
+    minSdkVersion = 21
     // From sdk version 21 multidex is enabled by default
     uiTestAppMinSdkVersion = 21
     targetSdkVersion = 30


### PR DESCRIPTION
# Description

Due to an update in the virtual environments, the default ndk version was removed making the default version used by gradle to be used (https://developer.android.com/studio/projects/install-ndk#apply-specific-version) which is a version not installed in the vm Image we use. For such reason gradle had to be updated to version 4.1.3.




###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7733)