### PR TITLE
[Designer] Update carousel styling for berlin containers

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/containers/berlin/berlin-container-dark.css
+++ b/source/nodejs/adaptivecards-designer/src/containers/berlin/berlin-container-dark.css
@@ -311,6 +311,9 @@ a.ac-anchor:hover {
 
 .ac-carousel-container {
 	padding: 0px 16px 16px 16px !important;
+}
+
+.ac-carousel-card-level-container {
 	margin: 0px -16px -16px -16px !important;
 }
 

--- a/source/nodejs/adaptivecards-designer/src/containers/berlin/berlin-container-light.css
+++ b/source/nodejs/adaptivecards-designer/src/containers/berlin/berlin-container-light.css
@@ -310,6 +310,9 @@ a.ac-anchor:hover {
 
 .ac-carousel-container {
 	padding: 0px 16px 16px 16px !important;
+}
+
+.ac-carousel-card-level-container {
 	margin: 0px -16px -16px -16px !important;
 }
 

--- a/source/nodejs/adaptivecards/src/carousel.ts
+++ b/source/nodejs/adaptivecards/src/carousel.ts
@@ -270,6 +270,7 @@ export class Carousel extends Container {
         }
 
         const cardLevelContainer: HTMLElement = document.createElement("div");
+        cardLevelContainer.className = this.hostConfig.makeCssClassName("ac-carousel-card-level-container");
 
         const carouselContainer: HTMLElement = document.createElement("div");
         carouselContainer.className = this.hostConfig.makeCssClassName("swiper", "ac-carousel");


### PR DESCRIPTION
# Description

Because of the custom margins and padding on the carousel control in berlin containers, the carousel peer locations were not being calculated correctly.

The negative margins needed to be moved a level up in the DOM tree.

# How Verified

Verified manually in the Adaptive Cards designer.

## Before
![CarouselError](https://user-images.githubusercontent.com/98650930/183988947-d15c6e46-91bc-492d-b919-a99609c0c740.gif)

## After
![CarouselErrorFix](https://user-images.githubusercontent.com/98650930/183991973-fc53a712-8ccd-4554-8a4f-e0be8b9c92cc.gif)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7755)