### PR TITLE
Updated app push to use pre-existing yml templates

### DIFF
--- a/.pipelines/ios-app-push.yml
+++ b/.pipelines/ios-app-push.yml
@@ -22,8 +22,8 @@ pool:
 
 steps:
   - bash: | 
-     echo "Adaptive Version ${{appVersion}}.$BUILD_NUMBER"
-     xcrun agvtool new-version -all ${{appVersion}}.$BUILD_NUMBER
+     echo "Adaptive Version ${{ parameters.appVersion }}.$BUILD_NUMBER"
+     xcrun agvtool new-version -all ${{ parameters.appVersion }}.$BUILD_NUMBER
     workingDirectory: source/ios/AdaptiveCards/ADCIOSVisualizer
     displayName: 'Bash - update sample app version'
     env:

--- a/.pipelines/ios-app-push.yml
+++ b/.pipelines/ios-app-push.yml
@@ -1,0 +1,42 @@
+parameters:
+  - name: appVersion
+    displayName: Update version of app
+    type: string
+    default: 2.4.0-beta
+    values:
+      - 2.4.0-beta
+
+name: $(Year:yy).$(Month).$(DayOfMonth).$(rev:r)
+
+pr: none
+trigger: none
+
+schedules:
+  - cron: "1 7 1,15 * *"
+    displayName: Send Heartbeat 
+    branches:
+      include:
+        - main
+pool:
+  vmImage: 'macos-latest'
+
+steps:
+  - bash: | 
+     echo "Adaptive Version ${{appVersion}}.$BUILD_NUMBER"
+     xcrun agvtool new-version -all ${ACIOSVERSION}.$BUILD_NUMBER
+    workingDirectory: source/ios/AdaptiveCards/ADCIOSVisualizer
+    displayName: 'Bash - update sample app version'
+    env:
+      BUILD_NUMBER: $(BUILD_BUILDNUMBER)
+  - template: templates/ios-install-cert-template.yml
+  - template: templates/ios-spec-lint-template.yml
+  - task: AppCenterDistribute@3
+    inputs:
+      serverEndpoint: 'Microsoft App Center'
+      appSlug: 'Adaptive-Cards/Adaptive-Cards-iOS-Visualizer'
+      appFile: '**/*.ipa'
+      symbolsDsymFiles: '**/*.dSYM'
+      symbolsIncludeParentDirectory: true
+      releaseNotesOption: 'input'
+      releaseNotesInput: 'Nightly Build from main'
+      destinationType: 'groups'

--- a/.pipelines/ios-app-push.yml
+++ b/.pipelines/ios-app-push.yml
@@ -23,7 +23,7 @@ pool:
 steps:
   - bash: | 
      echo "Adaptive Version ${{appVersion}}.$BUILD_NUMBER"
-     xcrun agvtool new-version -all ${ACIOSVERSION}.$BUILD_NUMBER
+     xcrun agvtool new-version -all ${appVersion}.$BUILD_NUMBER
     workingDirectory: source/ios/AdaptiveCards/ADCIOSVisualizer
     displayName: 'Bash - update sample app version'
     env:

--- a/.pipelines/ios-app-push.yml
+++ b/.pipelines/ios-app-push.yml
@@ -12,8 +12,8 @@ pr: none
 trigger: none
 
 schedules:
-  - cron: "1 7 1,15 * *"
-    displayName: Send Heartbeat 
+  - cron: "0 3 * * 1"
+    displayName: Publish iOS App
     branches:
       include:
         - main

--- a/.pipelines/ios-app-push.yml
+++ b/.pipelines/ios-app-push.yml
@@ -29,7 +29,6 @@ steps:
     env:
       BUILD_NUMBER: $(Build.BuildNumber)
   - template: templates/ios-install-cert-template.yml
-  - template: templates/ios-spec-lint-template.yml
   - task: AppCenterDistribute@3
     inputs:
       serverEndpoint: 'Microsoft App Center'

--- a/.pipelines/ios-app-push.yml
+++ b/.pipelines/ios-app-push.yml
@@ -27,7 +27,7 @@ steps:
     workingDirectory: source/ios/AdaptiveCards/ADCIOSVisualizer
     displayName: 'Bash - update sample app version'
     env:
-      BUILD_NUMBER: $(BUILD_BUILDNUMBER)
+      BUILD_NUMBER: $(Build.BuildNumber)
   - template: templates/ios-install-cert-template.yml
   - template: templates/ios-spec-lint-template.yml
   - task: AppCenterDistribute@3

--- a/.pipelines/ios-app-push.yml
+++ b/.pipelines/ios-app-push.yml
@@ -23,7 +23,7 @@ pool:
 steps:
   - bash: | 
      echo "Adaptive Version ${{appVersion}}.$BUILD_NUMBER"
-     xcrun agvtool new-version -all ${appVersion}.$BUILD_NUMBER
+     xcrun agvtool new-version -all ${{appVersion}}.$BUILD_NUMBER
     workingDirectory: source/ios/AdaptiveCards/ADCIOSVisualizer
     displayName: 'Bash - update sample app version'
     env:

--- a/.pipelines/templates/ios-install-cert-template.yml
+++ b/.pipelines/templates/ios-install-cert-template.yml
@@ -10,7 +10,7 @@ steps:
   displayName: 'Install Provisioning Profile'
   inputs:
     provisioningProfileLocation: 'secureFiles'
-    provProfileSecureFile: 'iOS_Team_Provisioning_Profile.mobileprovision'
+    provProfileSecureFile: '025544d3-4a64-49d0-8e76-29f3ddd185ae.mobileprovision'
 
 - template: ios-build-template.yml
   parameters:

--- a/.pipelines/templates/ios-install-cert-template.yml
+++ b/.pipelines/templates/ios-install-cert-template.yml
@@ -2,7 +2,7 @@ steps:
 - task: InstallAppleCertificate@2
   displayName: 'Install Certificates'
   inputs:
-    certSecureFile: 'Certificates_Nov_19_B.p12' 
+    certSecureFile: 'Certificates.p12' 
     certPwd: '$(P12password)'
     keychain: 'temp'
 
@@ -10,7 +10,7 @@ steps:
   displayName: 'Install Provisioning Profile'
   inputs:
     provisioningProfileLocation: 'secureFiles'
-    provProfileSecureFile: '025544d3-4a64-49d0-8e76-29f3ddd185ae.mobileprovision'
+    provProfileSecureFile: 'iOS_Team_Provisioning_Profile.mobileprovision'
 
 - template: ios-build-template.yml
   parameters:


### PR DESCRIPTION
# Related Issue
Fixed #7551 

# Description
* added a new pipeline that uses yml to publish ios app
* updated templates to use common variable name for cert.

# How Verified

verified that it can build & publish to appcenter.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7763)