### PR TITLE
Enable data binding for the designer

### DIFF
--- a/source/nodejs/adaptivecards/src/serialization.ts
+++ b/source/nodejs/adaptivecards/src/serialization.ts
@@ -197,7 +197,9 @@ export abstract class BaseSerializationContext {
             propertyValue === undefined ||
             propertyValue === defaultValue
         ) {
-            delete target[propertyName];
+            if (!GlobalSettings.enableFullJsonRoundTrip) {
+                delete target[propertyName];
+            }
         } else {
             target[propertyName] = propertyValue;
         }
@@ -214,7 +216,9 @@ export abstract class BaseSerializationContext {
             propertyValue === undefined ||
             propertyValue === defaultValue
         ) {
-            delete target[propertyName];
+            if (!GlobalSettings.enableFullJsonRoundTrip) {
+                delete target[propertyName];
+            }
         } else {
             target[propertyName] = propertyValue;
         }
@@ -232,7 +236,9 @@ export abstract class BaseSerializationContext {
             propertyValue === defaultValue ||
             isNaN(propertyValue)
         ) {
-            delete target[propertyName];
+            if (!GlobalSettings.enableFullJsonRoundTrip) {
+                delete target[propertyName];
+            }
         } else {
             target[propertyName] = propertyValue;
         }
@@ -250,7 +256,9 @@ export abstract class BaseSerializationContext {
             propertyValue === undefined ||
             propertyValue === defaultValue
         ) {
-            delete target[propertyName];
+            if (!GlobalSettings.enableFullJsonRoundTrip) {
+                delete target[propertyName];
+            }
         } else {
             target[propertyName] = enumType[propertyValue];
         }
@@ -283,7 +291,9 @@ export abstract class BaseSerializationContext {
 
         if (items.length === 0) {
             if (target.hasOwnProperty(propertyName) && Array.isArray(target[propertyName])) {
-                delete target[propertyName];
+                if (!GlobalSettings.enableFullJsonRoundTrip) {
+                    delete target[propertyName];
+                }
             }
         } else {
             this.serializeValue(target, propertyName, items);
@@ -1093,7 +1103,7 @@ export abstract class SerializableObject {
     }
 
     protected setValue(prop: PropertyDefinition, value: any) {
-        if (value === undefined || value === null) {
+        if ((value === undefined || value === null) && (!GlobalSettings.enableFullJsonRoundTrip || !this._rawProperties.hasOwnProperty(prop.getInternalName()))) {
             delete this._propertyBag[prop.getInternalName()];
         } else {
             this._propertyBag[prop.getInternalName()] = value;

--- a/source/nodejs/adaptivecards/src/serialization.ts
+++ b/source/nodejs/adaptivecards/src/serialization.ts
@@ -1103,7 +1103,7 @@ export abstract class SerializableObject {
     }
 
     protected setValue(prop: PropertyDefinition, value: any) {
-        if ((value === undefined || value === null) && (!GlobalSettings.enableFullJsonRoundTrip || !this._rawProperties.hasOwnProperty(prop.getInternalName()))) {
+        if (value === undefined || value === null) {
             delete this._propertyBag[prop.getInternalName()];
         } else {
             this._propertyBag[prop.getInternalName()] = value;


### PR DESCRIPTION
# Related Issue
Fixes https://github.com/microsoft/AdaptiveCards/issues/6631

# Description
Updated `setValue` and serialization methods so that values are not deleted from the `propertyBag` if `GlobalSettings.enableFullJsonRoundTrip === true`.

Note: Data binding will only work while in preview mode.

# Sample Card

```
{
    "type": "AdaptiveCard",
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
    "version": "1.5",
    "body": [
        {
            "type": "TextBlock",
            "text": "Image test:",
            "wrap": true
        },
        {
            "type": "Image",
            "url": "https://pbs.twimg.com/profile_images/3647943215/d7f12830b3c17a5a9e4afcc370e3a37e_400x400.jpeg",
            "width": "${imageSize}",
            "height": "${imageSize}"
        }
    ]
}
```
# Data JSON

```
{
    "imageSize": "100px"
}
```
# How Verified
Verified manually on the AdaptiveCards site

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7774)