### PR TITLE
updated css

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/containers/berlin/berlin-container-dark.css
+++ b/source/nodejs/adaptivecards-designer/src/containers/berlin/berlin-container-dark.css
@@ -400,6 +400,6 @@ a.ac-anchor:hover {
 
 @media(forced-colors: active) {
     .swiper-pagination-bullet {
-        forced-color-adjust: none;
+        background-color: ButtonBorder !important;
     }
 }

--- a/source/nodejs/adaptivecards-designer/src/containers/berlin/berlin-container-dark.css
+++ b/source/nodejs/adaptivecards-designer/src/containers/berlin/berlin-container-dark.css
@@ -397,3 +397,9 @@ a.ac-anchor:hover {
     font-family: 'FabricMDL2Icons';
     content: "\E712";
 }
+
+@media(forced-colors: active) {
+    .swiper-pagination-bullet {
+        forced-color-adjust: none;
+    }
+}

--- a/source/nodejs/adaptivecards-designer/src/containers/berlin/berlin-container-light.css
+++ b/source/nodejs/adaptivecards-designer/src/containers/berlin/berlin-container-light.css
@@ -398,3 +398,10 @@ a.ac-anchor:hover {
     font-family: 'FabricMDL2Icons';
     content: "\E712";
 }
+
+@media(forced-colors: active) {
+    .swiper-pagination-bullet {
+        forced-color-adjust: none;
+        background:rgba(255, 255, 255, 0.5442) !important;
+    }
+}

--- a/source/nodejs/adaptivecards-designer/src/containers/berlin/berlin-container-light.css
+++ b/source/nodejs/adaptivecards-designer/src/containers/berlin/berlin-container-light.css
@@ -401,7 +401,6 @@ a.ac-anchor:hover {
 
 @media(forced-colors: active) {
     .swiper-pagination-bullet {
-        forced-color-adjust: none;
-        background:rgba(255, 255, 255, 0.5442) !important;
+        background-color: ButtonBorder !important;
     }
 }

--- a/source/nodejs/adaptivecards/src/scss/adaptivecards-carousel.scss
+++ b/source/nodejs/adaptivecards/src/scss/adaptivecards-carousel.scss
@@ -99,3 +99,9 @@
     --swiper-pagination-color: #007aff;
     --swiper-navigation-size: 44px;
 }
+
+@media(forced-colors: active) {
+    .swiper-pagination-bullet {
+        background-color: ButtonBorder;
+    }
+}


### PR DESCRIPTION
# Related Issue
Fixed #7659 

# Description
Carousel paginations become blended to background in high contrast mode. 
This change addresses the issue by using @media and removing the high contrast changes and sets appropriate background color for pagination.

# How Verified
Manually verified as below.

### Before Fix
Berlin dark
![Screenshot 2022-08-31 145910-dark](https://user-images.githubusercontent.com/4112696/187794382-02f5c9bf-7b6d-4964-9f1f-4864ac07542c.png)

Berlin light
![Screenshot 2022-08-31 145938-light](https://user-images.githubusercontent.com/4112696/187794394-39c5f4a2-cc29-4b52-9626-55ccdcaba27c.png)

### After Fix
![Screenshot 2022-08-31 145303](https://user-images.githubusercontent.com/4112696/187794410-5ad4bc2b-d67a-42d0-8936-c529a9007ca4.png)

![Screenshot 2022-08-31 145327](https://user-images.githubusercontent.com/4112696/187794417-54507824-1b08-4c9d-83d2-f8f7d2c62df0.png)




###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7806)