### PR TITLE
[JS] Increased hit target of pagenation bullets

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/containers/berlin/berlin-container-dark.css
+++ b/source/nodejs/adaptivecards-designer/src/containers/berlin/berlin-container-dark.css
@@ -359,6 +359,14 @@ a.ac-anchor:hover {
     height:4px !important;
     width:4px !important;
     vertical-align:middle;
+    position: relative;
+}
+
+.swiper-pagination-bullet::after {
+    content:'';
+    position: absolute;
+    top:-4px; bottom: -4px;
+    left:-4px; right:-4px;
 }
 
 .swiper-pagination-bullet:hover {

--- a/source/nodejs/adaptivecards-designer/src/containers/berlin/berlin-container-light.css
+++ b/source/nodejs/adaptivecards-designer/src/containers/berlin/berlin-container-light.css
@@ -360,6 +360,14 @@ a.ac-anchor:hover {
     height:4px !important;
     width:4px !important;
     vertical-align:middle;
+    position: relative;
+}
+
+.swiper-pagination-bullet::after {
+    content:'';
+    position: absolute;
+    top:-4px; bottom: -4px;
+    left:-4px; right:-4px;
 }
 
 .swiper-pagination-bullet:hover{


### PR DESCRIPTION
# Related Issue

https://microsoft.visualstudio.com/OS/_workitems/edit/39752320

# Description

Increased hit target.

[reference](https://front-back.com/expand-clickable-areas-for-a-better-touch-experience/)

# How Verified

Manually verified as below
Previously the hit target was exactly the size of the bullet, with the change, the hit target is increased by 4px around the bullet. The exact size is not important as actual need is different from host app to host app.
![Untitled video (1)](https://user-images.githubusercontent.com/4112696/187808282-07b72ff9-cf52-4045-9d8c-8c19bd9ac2ea.gif)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7807)