### PR TITLE
Fixed the hard crash at link parser

### DIFF
--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/MarkDownUnitTest.cpp
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/MarkDownUnitTest.cpp
@@ -488,6 +488,48 @@ namespace AdaptiveCardsSharedModelUnitTest
             Assert::AreEqual<std::string>("<p><em>Hello</em> <em><a href=\"*www.naver.com*\"><em>hello</em></a></em>* Hello, <a href=\"www.microsoft.com\">second</a></p>", parser.TransformToHtml());
         }
 
+        TEST_METHOD(LinkNestedParenthesisTest_1)
+        {
+            MarkDownParser parser("[empty destination]()");
+            Assert::AreEqual<std::string>("<p><a href=\"\">empty destination</a></p>", parser.TransformToHtml());
+		}
+
+        TEST_METHOD(LinkNestedParenthesisTest_2)
+        {
+            MarkDownParser parser("[Stay tuned to Know [aaa] m (aa)ore](https://aaa.bbb.com/(a)sites(Test).doc?somegar)bageValue*afterstar()");
+            Assert::AreEqual<std::string>("<p><a href=\"https://aaa.bbb.com/(a)sites(Test).doc?somegar\">Stay tuned to Know [aaa] m (aa)ore</a>bageValue*afterstar()</p>", parser.TransformToHtml());
+		}
+
+        TEST_METHOD(LinkNestedParenthesisTest_3)
+        {
+            MarkDownParser parser("[Stay tuned to Know more](https://aaa.bbb.com/(a)sites(Test).doc?somegarbageValue)*afterstar()");
+            Assert::AreEqual<std::string>("<p><a href=\"https://aaa.bbb.com/(a)sites(Test).doc?somegarbageValue\">Stay tuned to Know more</a>*afterstar()</p>", parser.TransformToHtml());
+		}
+
+        TEST_METHOD(LinkNestedParenthesisTest_4)
+        {
+            MarkDownParser parser("[Stay tuned to Know more](https://aaa.bbb.com/(a)sit(es(Test).doc?somegarbageValue)*afafafafafafa)*");
+            Assert::AreEqual<std::string>("<p><a href=\"https://aaa.bbb.com/(a)sit(es(Test).doc?somegarbageValue)*afafafafafafa\">Stay tuned to Know more</a>*</p>", parser.TransformToHtml());
+		}
+
+        TEST_METHOD(LinkNestedParenthesisTest_5)
+        {
+            MarkDownParser parser("[Stay tuned to Know more](https://aaa.bbb.com/(a)sit(es(Test).doc?somegarbageValue)*afafafafafafa)");
+            Assert::AreEqual<std::string>("<p><a href=\"https://aaa.bbb.com/(a)sit(es(Test).doc?somegarbageValue)*afafafafafafa\">Stay tuned to Know more</a></p>", parser.TransformToHtml());
+		}
+
+        TEST_METHOD(LinkNestedParenthesisTest_6)
+        {
+            MarkDownParser parser("[Stay tuned to Know)]()afafafa()");
+            Assert::AreEqual<std::string>("<p><a href=\"\">Stay tuned to Know)</a>afafafa()</p>", parser.TransformToHtml());
+		}
+
+        TEST_METHOD(LinkNestedParenthesisTest_7)
+        {
+            MarkDownParser parser("[](()");
+            Assert::AreEqual<std::string>("<p>[](()</p>", parser.TransformToHtml());
+		}
+
         TEST_METHOD(ListTest_SimpleValidListTest)
         {
             MarkDownParser parser("- hello");

--- a/source/shared/cpp/ObjectModel/MarkDownBlockParser.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownBlockParser.cpp
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#include "MarkDownBlockParser.h"
 #include "pch.h"
 #include <iostream>
+#include "MarkDownBlockParser.h"
 
 using namespace AdaptiveCards;
 

--- a/source/shared/cpp/ObjectModel/MarkDownBlockParser.cpp
+++ b/source/shared/cpp/ObjectModel/MarkDownBlockParser.cpp
@@ -468,7 +468,7 @@ bool LinkParser::MatchAtLinkDestinationStart(std::stringstream& lookahead)
     // else won't get marked
     while (lookahead.peek() != EOF && m_leftParenthesisCounts > 0)
     {
-        char token {};
+        char token{};
 
         lookahead.get(token);
 
@@ -510,7 +510,7 @@ bool LinkParser::MatchAtLinkDestinationRun(std::stringstream& lookahead)
 {
     // TODO this check is not needed; remove it in next iteration
     // validation is done in MatchAtLinkDestinationStart
-	// move parenthesis check to here
+    // move parenthesis check to here
     if (lookahead.peek() > 0 &&
         (MarkDownBlockParser::IsSpace(lookahead.peek()) || MarkDownBlockParser::IsCntrl(lookahead.peek())))
     {

--- a/source/shared/cpp/ObjectModel/MarkDownBlockParser.h
+++ b/source/shared/cpp/ObjectModel/MarkDownBlockParser.h
@@ -160,8 +160,7 @@ private:
     bool MatchAtLinkDestinationRun(std::stringstream&);
 
     int m_leftParenthesisCounts = 0;
-    int m_positionOfLinkDestinationEndToken = 0;
-    std::stringstream::pos_type m_parsingCurrentPos = 0;
+    std::streamoff m_positionOfLinkDestinationEndToken = 0;
 
     // holds intermediate result of LinkText
     MarkDownParsedResult m_linkTextParsedResult;

--- a/source/shared/cpp/ObjectModel/MarkDownBlockParser.h
+++ b/source/shared/cpp/ObjectModel/MarkDownBlockParser.h
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 #pragma once
-#include "MarkDownHtmlGenerator.h"
-#include <iomanip>
 #include "BaseCardElement.h"
+#include "MarkDownHtmlGenerator.h"
 #include "MarkDownParsedResult.h"
+#include <iomanip>
 
 namespace AdaptiveCards
 {
@@ -159,8 +159,8 @@ private:
     // Matches LinkDestination Run syntax of link
     bool MatchAtLinkDestinationRun(std::stringstream&);
 
-    int m_linkDestinationStart = 0;
-    int m_linkDestinationEnd = 0;
+    int m_leftParenthesisCounts = 0;
+    int m_positionOfLinkDestinationEndToken = 0;
     std::stringstream::pos_type m_parsingCurrentPos = 0;
 
     // holds intermediate result of LinkText

--- a/source/shared/cpp/ObjectModel/MarkDownBlockParser.h
+++ b/source/shared/cpp/ObjectModel/MarkDownBlockParser.h
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 #pragma once
-#include "BaseCardElement.h"
 #include "MarkDownHtmlGenerator.h"
-#include "MarkDownParsedResult.h"
 #include <iomanip>
+#include "BaseCardElement.h"
+#include "MarkDownParsedResult.h"
 
 namespace AdaptiveCards
 {


### PR DESCRIPTION
# Related Issue
Fixed #7812

# Description
1. parenthesis matching code didn't propagate the failure when there are more lpran than rpran.
2. removed popback() as it's not needed and caused the crash.
3. Added unit tests from #6922.
# Sample Card

N/A

# How Verified
1. added new unit tests from #6922 & added some more for testing the change.



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7817)