### PR TITLE
Revert full JSON round trip for arrays

### DIFF
--- a/source/nodejs/adaptivecards/src/serialization.ts
+++ b/source/nodejs/adaptivecards/src/serialization.ts
@@ -291,9 +291,7 @@ export abstract class BaseSerializationContext {
 
         if (items.length === 0) {
             if (target.hasOwnProperty(propertyName) && Array.isArray(target[propertyName])) {
-                if (!GlobalSettings.enableFullJsonRoundTrip) {
-                    delete target[propertyName];
-                }
+                delete target[propertyName];
             }
         } else {
             this.serializeValue(target, propertyName, items);


### PR DESCRIPTION
# Related Issue

Fixes #7843 

# Description

Not deleting the array property during serialization did not allow the container contents to update. We needed to delete array properties regardless of enableFullJsonRoundTrip settings.

# How Verified

Verified manually on the designer.

Before:

![containerContentsBug](https://user-images.githubusercontent.com/98650930/190006645-1909c90f-f56f-4261-9e8a-0728c0327228.gif)

After:

![containerContentsBugFix](https://user-images.githubusercontent.com/98650930/190006586-5fed3995-a9bf-45b6-9687-412c9b83efc2.gif)




###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7844)