### PR TITLE
Add null check to parentCarousel

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/designer-peers.ts
+++ b/source/nodejs/adaptivecards-designer/src/designer-peers.ts
@@ -3469,7 +3469,7 @@ export class CarouselPagePeer extends ContainerPeer {
     isVisible(): boolean {
         const parentCarousel = this.parent as CarouselPeer;
 
-        return this === parentCarousel.children[(parentCarousel.cardElement as Adaptive.Carousel).currentPageIndex];
+        return this === parentCarousel?.children[(parentCarousel.cardElement as Adaptive.Carousel).currentPageIndex];
     }
 
     bringCardElementIntoView(): boolean {


### PR DESCRIPTION
# Related Issue

Fixes #7835 

# Description

When adding new pages to a carousel, we would sometimes call isVisible on a CarouselPage when it is not yet assigned to a Carousel. We needed to add a null check.

# How Verified

Verified manually on the designer


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7845)