### PR TITLE
prefix adaptivecards#  for ttpolicy

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -1109,7 +1109,7 @@ export class TextBlock extends BaseTextBlock {
     // Markdown processing is handled outside of Adaptive Cards. It's up to the host to ensure that markdown is safely
     // processed.
     private static readonly _ttMarkdownPolicy = window.trustedTypes?.createPolicy(
-        "markdownPassthroughPolicy",
+        "adaptivecards#markdownPassthroughPolicy",
         { createHTML: (value) => value }
     );
 
@@ -1118,7 +1118,7 @@ export class TextBlock extends BaseTextBlock {
     // _originalInnerHtml so that we can restore/recalculate truncation later if space availability has changed (see
     // TextBlock.restoreOriginalContent())
     private static readonly _ttRoundtripPolicy = window.trustedTypes?.createPolicy(
-        "restoreContentsPolicy",
+        "adaptivecards#restoreContentsPolicy",
         { createHTML: (value) => value }
     );
 

--- a/source/nodejs/adaptivecards/src/utils.ts
+++ b/source/nodejs/adaptivecards/src/utils.ts
@@ -190,7 +190,7 @@ export function truncateText(element: HTMLElement, maxHeight: number, lineHeight
  * TextBlock.truncateIfSupported}), but had a bug where it might actually pass through an element
  * for which innerHTML yielded actual HTML (since fixed).
  */
-const ttDeprecatedPolicy = window.trustedTypes?.createPolicy("deprecatedExportedFunctionPolicy", {
+const ttDeprecatedPolicy = window.trustedTypes?.createPolicy("adaptivecards#deprecatedExportedFunctionPolicy", {
     createHTML: (value) => value
 });
 


### PR DESCRIPTION
ttpolicy prefixed with package name

adaptivecards#markdownPassthrough
adaptivecards#restoreContents
adaptivecards#deprecatedExportedFunction

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7860)