### PR TITLE
[JS Website] Disable headerIds for the markdown renderer

### DIFF
--- a/source/nodejs/adaptivecards-site/_config.yml
+++ b/source/nodejs/adaptivecards-site/_config.yml
@@ -122,3 +122,7 @@ css_minifier:
   silent: false
   exclude: 
     - '*.min.css'
+
+# hexo-renderer-marked
+marked:
+  headerIds: false


### PR DESCRIPTION
# Related Issue

Fixes #7643 

# Description

We generate html for the website using `ejs` files and by converting `md` files using `hexo-renderer-marked`. Therefore, the headings throughout the site were inconsistent.

All of the headings generated with `hexo-renderer-marked` contain a `headerlink`. See https://github.com/hexojs/hexo-renderer-marked/blob/a93ebeb1e8cc11e754630c0a1506da9a1489b2b0/lib/renderer.js#L21-L38.

Disabling `headerIds` fixes the discrepancy, and none of the headers contain links.

# How Verified

Verified manually on the Adaptive Cards site.

# Future Work

If we want to utilize header ids in the future, we can override the behavior `hexo-renderer-marked` (See https://github.com/hexojs/hexo-renderer-marked#extensibility). We would also need to update our `ejs` files so that all headers are consistent.
