### PR TITLE
Revert "Fix help dialog's background in high contrast mode"

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/adaptivecards-designer.css
+++ b/source/nodejs/adaptivecards-designer/src/adaptivecards-designer.css
@@ -196,7 +196,7 @@
 }
 
 .acd-dialog-frame {
-    background-color: ActiveBorder;
+    background-color: white;
     display: flex;
     flex-direction: column;
     box-shadow: 0 0 50px -5px rgba(0, 0, 0, 0.4);


### PR DESCRIPTION
Reverts microsoft/AdaptiveCards#7122

Correct fix is #7497