### PR TITLE
Update js-release.yml to use npm 8.11.0

### DIFF
--- a/.pipelines/js-release.yml
+++ b/.pipelines/js-release.yml
@@ -45,7 +45,7 @@ steps:
 - bash: |
    npx lerna bootstrap --ci
   workingDirectory: source/nodejs
-  displayName: 'Bash - npx lerna bootstrap --ci
+  displayName: 'Bash - npx lerna bootstrap --ci'
 '
 - bash: |
    npx lerna run release

--- a/.pipelines/js-release.yml
+++ b/.pipelines/js-release.yml
@@ -33,11 +33,24 @@ steps:
     versionSpec: 14.x
 
 - bash: |
+   npm install -g npm@8.11.0
+  workingDirectory: source/nodejs
+  displayName: 'Bash - npm install -g npm 8.11.0'
+
+- bash: |
    npm ci 
+  workingDirectory: source/nodejs
+  displayName: 'Bash - npm ci'
+
+- bash: |
    npx lerna bootstrap --ci
+  workingDirectory: source/nodejs
+  displayName: 'Bash - npx lerna bootstrap --ci
+'
+- bash: |
    npx lerna run release
   workingDirectory: source/nodejs
-  displayName: 'Bash - lerna bootstrap'
+  displayName: 'Bash - npx lerna run release'
 
 - bash: |
    npm run audit-all -- --no-fix

--- a/.pipelines/js-release.yml
+++ b/.pipelines/js-release.yml
@@ -46,6 +46,7 @@ steps:
    npx lerna bootstrap --ci
   workingDirectory: source/nodejs
   displayName: 'Bash - npx lerna bootstrap --ci'
+
 - bash: |
    npx lerna run release
   workingDirectory: source/nodejs

--- a/.pipelines/js-release.yml
+++ b/.pipelines/js-release.yml
@@ -46,7 +46,6 @@ steps:
    npx lerna bootstrap --ci
   workingDirectory: source/nodejs
   displayName: 'Bash - npx lerna bootstrap --ci'
-'
 - bash: |
    npx lerna run release
   workingDirectory: source/nodejs


### PR DESCRIPTION
1. use npm 8.11.0. Look like the lerna requires newer npm version
2. it's not readable when error happens in bash, split it into multiple lines.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7900)