### PR TITLE
Add (typeof window === 'undefined') check for trustedType

### DIFF
--- a/source/nodejs/ac-typed-schema/package-lock.json
+++ b/source/nodejs/ac-typed-schema/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@microsoft/ac-typed-schema",
-	"version": "0.7.0",
+	"version": "0.7.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@microsoft/ac-typed-schema",
-			"version": "0.7.0",
+			"version": "0.7.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/i18n": "^0.13.0",

--- a/source/nodejs/ac-typed-schema/package.json
+++ b/source/nodejs/ac-typed-schema/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/ac-typed-schema",
-	"version": "0.7.0",
+	"version": "0.7.1",
 	"private": true,
 	"description": "Generates the element/property tables for our specs based on the schema file.",
 	"author": "AdaptiveCards",

--- a/source/nodejs/adaptivecards-aaf-testapp/package-lock.json
+++ b/source/nodejs/adaptivecards-aaf-testapp/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@microsoft/adaptivecards-aaf-testapp",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@microsoft/adaptivecards-aaf-testapp",
-			"version": "0.2.0-alpha.0",
+			"version": "0.2.1",
 			"license": "MIT",
 			"devDependencies": {}
 		}

--- a/source/nodejs/adaptivecards-aaf-testapp/package.json
+++ b/source/nodejs/adaptivecards-aaf-testapp/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/adaptivecards-aaf-testapp",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"description": "AAF JavaScript Runtime test application",
 	"author": "AdaptiveCards",
 	"license": "MIT",
@@ -12,6 +12,6 @@
 		"release": "npm run build"
 	},
 	"dependencies": {
-		"adaptivecards": "^2.11.0"
+		"adaptivecards": "^2.11.1"
 	}
 }

--- a/source/nodejs/adaptivecards-controls/package-lock.json
+++ b/source/nodejs/adaptivecards-controls/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "adaptivecards-controls",
-	"version": "0.10.0",
+	"version": "0.10.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "adaptivecards-controls",
-			"version": "0.10.0-alpha.0",
+			"version": "0.10.1",
 			"license": "MIT",
 			"devDependencies": {}
 		}

--- a/source/nodejs/adaptivecards-controls/package.json
+++ b/source/nodejs/adaptivecards-controls/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "adaptivecards-controls",
-	"version": "0.10.0",
+	"version": "0.10.1",
 	"description": "A library of pure JS/HTML controls designed for use with Adaptive Cards.",
 	"author": "Microsoft",
 	"license": "MIT",

--- a/source/nodejs/adaptivecards-controls/src/utils.ts
+++ b/source/nodejs/adaptivecards-controls/src/utils.ts
@@ -140,6 +140,6 @@ export function getAttributeValueAsInt(element: HTMLElement, attributeName: stri
 }
 
 export function clearElement(element: HTMLElement) : void {
-    const trustedHtml = window.trustedTypes?.emptyHTML ?? "";
+    const trustedHtml = (typeof window === 'undefined') ? "" : (window.trustedTypes?.emptyHTML ?? "");
     element.innerHTML = trustedHtml as string;
 }

--- a/source/nodejs/adaptivecards-designer-app/package-lock.json
+++ b/source/nodejs/adaptivecards-designer-app/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@microsoft/adaptivecards-designer-app",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@microsoft/adaptivecards-designer-app",
-			"version": "0.6.0",
+			"version": "0.6.1",
 			"license": "MIT",
 			"dependencies": {
 				"monaco-editor": "^0.29.1"

--- a/source/nodejs/adaptivecards-designer-app/package.json
+++ b/source/nodejs/adaptivecards-designer-app/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/adaptivecards-designer-app",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"description": "Adaptive Card designer app",
 	"author": "AdaptiveCards",
 	"license": "MIT",
@@ -18,9 +18,9 @@
 		"monaco-editor-webpack-plugin": "^5.0.0"
 	},
 	"dependencies": {
-		"adaptivecards": "^2.11.0",
-		"adaptivecards-designer": "^2.4.0",
-		"adaptivecards-templating": "^2.3.0",
+		"adaptivecards": "^2.11.1",
+		"adaptivecards-designer": "^2.4.1",
+		"adaptivecards-templating": "^2.3.1",
 		"monaco-editor": "^0.29.1"
 	}
 }

--- a/source/nodejs/adaptivecards-designer/package-lock.json
+++ b/source/nodejs/adaptivecards-designer/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "adaptivecards-designer",
-	"version": "2.4.0",
+	"version": "2.4.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "adaptivecards-designer",
-			"version": "2.4.0",
+			"version": "2.4.1",
 			"license": "MIT",
 			"dependencies": {
 				"clipboard": "^2.0.1"

--- a/source/nodejs/adaptivecards-designer/package.json
+++ b/source/nodejs/adaptivecards-designer/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "adaptivecards-designer",
-	"version": "2.4.0",
+	"version": "2.4.1",
 	"description": "Adaptive Card designer embeddable control",
 	"author": "AdaptiveCards",
 	"license": "MIT",
@@ -35,7 +35,7 @@
 		"release-deps": "npx lerna run --scope adaptivecards-designer --include-dependencies release --stream"
 	},
 	"dependencies": {
-		"adaptivecards-controls": "^0.10.0",
+		"adaptivecards-controls": "^0.10.1",
 		"clipboard": "^2.0.1"
 	},
 	"peerDependencies": {
@@ -46,8 +46,8 @@
 	},
 	"devDependencies": {
 		"adaptive-expressions": "^4.11.0",
-		"adaptivecards": "^2.11.0",
-		"adaptivecards-templating": "^2.3.0",
+		"adaptivecards": "^2.11.1",
+		"adaptivecards-templating": "^2.3.1",
 		"cpy-cli": "^4.1.0",
 		"dotenv-webpack": "^7.0.3",
 		"monaco-editor": "^0.29.1",

--- a/source/nodejs/adaptivecards-extras-designer/package-lock.json
+++ b/source/nodejs/adaptivecards-extras-designer/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@microsoft/adaptivecards-extras-designer",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@microsoft/adaptivecards-extras-designer",
-			"version": "0.2.0-alpha.0",
+			"version": "0.2.1",
 			"license": "MIT",
 			"devDependencies": {}
 		}

--- a/source/nodejs/adaptivecards-extras-designer/package.json
+++ b/source/nodejs/adaptivecards-extras-designer/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/adaptivecards-extras-designer",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"description": "Designer support for Adaptive Card Extras",
 	"author": "AdaptiveCards",
 	"license": "MIT",
@@ -28,8 +28,8 @@
 		"release": "npm run build && webpack --mode=production && npm run dts"
 	},
 	"dependencies": {
-		"@microsoft/adaptivecards-extras": "^0.2.0",
-		"adaptivecards": "^2.11.0",
-		"adaptivecards-designer": "^2.4.0"
+		"@microsoft/adaptivecards-extras": "^0.2.1",
+		"adaptivecards": "^2.11.1",
+		"adaptivecards-designer": "^2.4.1"
 	}
 }

--- a/source/nodejs/adaptivecards-extras/package-lock.json
+++ b/source/nodejs/adaptivecards-extras/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@microsoft/adaptivecards-extras",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@microsoft/adaptivecards-extras",
-			"version": "0.2.0-alpha.0",
+			"version": "0.2.1",
 			"license": "MIT",
 			"devDependencies": {}
 		}

--- a/source/nodejs/adaptivecards-extras/package.json
+++ b/source/nodejs/adaptivecards-extras/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/adaptivecards-extras",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"description": "Adaptive Card Extras",
 	"author": "AdaptiveCards",
 	"license": "MIT",
@@ -28,6 +28,6 @@
 		"release": "npm run build && webpack --mode=production && npm run dts"
 	},
 	"dependencies": {
-		"adaptivecards": "^2.11.0"
+		"adaptivecards": "^2.11.1"
 	}
 }

--- a/source/nodejs/adaptivecards-react-testapp/package-lock.json
+++ b/source/nodejs/adaptivecards-react-testapp/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@microsoft/adaptivecards-react-testapp",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@microsoft/adaptivecards-react-testapp",
-			"version": "0.1.1",
+			"version": "0.1.2",
 			"license": "MIT",
 			"dependencies": {
 				"@testing-library/jest-dom": "^5.11.4",

--- a/source/nodejs/adaptivecards-react-testapp/package.json
+++ b/source/nodejs/adaptivecards-react-testapp/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/adaptivecards-react-testapp",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"description": "JavaScript Runtime test application for adaptivecards-react",
 	"private": true,
 	"author": "AdaptiveCards",
@@ -27,7 +27,7 @@
 		"@types/node": "^12.0.0",
 		"@types/react": "^17.0.0",
 		"@types/react-dom": "^17.0.0",
-		"adaptivecards-react": "^1.1.0",
+		"adaptivecards-react": "^1.1.1",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",
 		"typescript": "^4.1.2",

--- a/source/nodejs/adaptivecards-react/package-lock.json
+++ b/source/nodejs/adaptivecards-react/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "adaptivecards-react",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "adaptivecards-react",
-			"version": "1.1.0",
+			"version": "1.1.1",
 			"license": "MIT",
 			"dependencies": {
 				"markdown-it": "^12.2.0"

--- a/source/nodejs/adaptivecards-react/package.json
+++ b/source/nodejs/adaptivecards-react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "adaptivecards-react",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "React.js Adaptive Cards Javascript library for HTML Clients",
 	"author": "AdaptiveCards",
 	"license": "MIT",
@@ -39,7 +39,7 @@
 		"react": "^17.0.2"
 	},
 	"dependencies": {
-		"adaptivecards": "^2.11.0",
+		"adaptivecards": "^2.11.1",
 		"markdown-it": "^12.2.0"
 	}
 }

--- a/source/nodejs/adaptivecards-react/src/adaptive-card.tsx
+++ b/source/nodejs/adaptivecards-react/src/adaptive-card.tsx
@@ -124,7 +124,7 @@ export const AdaptiveCard = ({
         try {
             card.parse(payload);
             const result = card.render() as HTMLElement;
-            const trustedHtml = window.trustedTypes?.emptyHTML ?? "";
+            const trustedHtml = (typeof window === 'undefined') ? "" : (window.trustedTypes?.emptyHTML ?? "");
             targetRef.current.innerHTML = trustedHtml as string;
             targetRef.current.appendChild(result);
         } catch (cardRenderError) {

--- a/source/nodejs/adaptivecards-site/package-lock.json
+++ b/source/nodejs/adaptivecards-site/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@microsoft/adaptivecards-site",
-	"version": "0.8.0",
+	"version": "0.8.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@microsoft/adaptivecards-site",
-			"version": "0.8.0",
+			"version": "0.8.1",
 			"devDependencies": {
 				"@fortawesome/fontawesome-free": "^6.2.0",
 				"adaptive-expressions": "^4.11.0",

--- a/source/nodejs/adaptivecards-site/package.json
+++ b/source/nodejs/adaptivecards-site/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/adaptivecards-site",
-	"version": "0.8.0",
+	"version": "0.8.1",
 	"private": true,
 	"scripts": {
 		"clean": "hexo clean",
@@ -17,12 +17,12 @@
 	},
 	"devDependencies": {
 		"@fortawesome/fontawesome-free": "^6.2.0",
-		"@microsoft/ac-typed-schema": "^0.7.0",
-		"@microsoft/marked-schema": "^0.2.0",
+		"@microsoft/ac-typed-schema": "^0.7.1",
+		"@microsoft/marked-schema": "^0.2.1",
 		"adaptive-expressions": "^4.11.0",
-		"adaptivecards": "^2.11.0",
-		"adaptivecards-designer": "^2.4.0",
-		"adaptivecards-templating": "^2.3.0",
+		"adaptivecards": "^2.11.1",
+		"adaptivecards-designer": "^2.4.1",
+		"adaptivecards-templating": "^2.3.1",
 		"change-case": "^4.1.2",
 		"cheerio": "^1.0.0-rc.12",
 		"glob": "^8.0.3",

--- a/source/nodejs/adaptivecards-templating/package-lock.json
+++ b/source/nodejs/adaptivecards-templating/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "adaptivecards-templating",
-	"version": "2.3.0",
+	"version": "2.3.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "adaptivecards-templating",
-			"version": "2.3.0",
+			"version": "2.3.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/json-schema": "^7.0.8",

--- a/source/nodejs/adaptivecards-templating/package.json
+++ b/source/nodejs/adaptivecards-templating/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "adaptivecards-templating",
-	"version": "2.3.0",
+	"version": "2.3.1",
 	"description": "Adaptive Card data binding and templating engine for JavaScript",
 	"author": "AdaptiveCards",
 	"license": "MIT",
@@ -38,7 +38,7 @@
 	"devDependencies": {
 		"@types/json-schema": "^7.0.8",
 		"adaptive-expressions": "^4.11.0",
-		"adaptivecards": "^2.11.0",
+		"adaptivecards": "^2.11.1",
 		"typedoc": "^0.22.5",
 		"typedoc-plugin-markdown": "^3.11.2"
 	},

--- a/source/nodejs/adaptivecards-ui-testapp/package-lock.json
+++ b/source/nodejs/adaptivecards-ui-testapp/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@microsoft/adaptivecards-ui-testapp",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@microsoft/adaptivecards-ui-testapp",
-			"version": "1.1.0",
+			"version": "1.1.1",
 			"license": "MIT",
 			"dependencies": {
 				"remarkable": "^2.0.1"

--- a/source/nodejs/adaptivecards-ui-testapp/package.json
+++ b/source/nodejs/adaptivecards-ui-testapp/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/adaptivecards-ui-testapp",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "Harness for UI testing for the Adaptive Cards rendering library",
 	"author": "AdaptiveCards",
 	"license": "MIT",
@@ -29,14 +29,14 @@
 		"release": "npm run clean && webpack --mode=production"
 	},
 	"dependencies": {
-		"adaptivecards-controls": "^0.10.0",
+		"adaptivecards-controls": "^0.10.1",
 		"remarkable": "^2.0.1"
 	},
 	"devDependencies": {
 		"adaptive-expressions": "^4.11.0",
-		"adaptivecards": "^2.11.0",
+		"adaptivecards": "^2.11.1",
 		"adaptivecards-controls": "^0.9.0",
-		"adaptivecards-templating": "^2.3.0"
+		"adaptivecards-templating": "^2.3.1"
 	},
 	"nx": {
 		"implicitDependencies": [

--- a/source/nodejs/adaptivecards-ui-testapp/src/rendering-utils.ts
+++ b/source/nodejs/adaptivecards-ui-testapp/src/rendering-utils.ts
@@ -4,7 +4,7 @@ import { getTestCasesList } from "./file-retriever-utils";
 import { Action, AdaptiveCard, ExecuteAction, HostConfig, IMarkdownProcessingResult, Input, OpenUrlAction, PropertyBag, SerializationContext, SubmitAction, Version, Versions } from "adaptivecards";
 import * as Remarkable from "remarkable";
 
-const ttPolicy = (typeof window === 'undefined') ? undefined: window.trustedTypes?.createPolicy('adaptivecards-ui-testapp', {
+const ttPolicy = (typeof window === 'undefined') ? undefined : window.trustedTypes?.createPolicy('adaptivecards-ui-testapp', {
     createHTML: value => value,
 });
 

--- a/source/nodejs/adaptivecards-ui-testapp/src/rendering-utils.ts
+++ b/source/nodejs/adaptivecards-ui-testapp/src/rendering-utils.ts
@@ -4,7 +4,7 @@ import { getTestCasesList } from "./file-retriever-utils";
 import { Action, AdaptiveCard, ExecuteAction, HostConfig, IMarkdownProcessingResult, Input, OpenUrlAction, PropertyBag, SerializationContext, SubmitAction, Version, Versions } from "adaptivecards";
 import * as Remarkable from "remarkable";
 
-const ttPolicy = window.trustedTypes?.createPolicy('adaptivecards-ui-testapp', {
+const ttPolicy = (typeof window === 'undefined') ? undefined: window.trustedTypes?.createPolicy('adaptivecards-ui-testapp', {
     createHTML: value => value,
 });
 
@@ -135,7 +135,7 @@ export function renderCard(cardJson: any, callbackFunction: Function): void {
 
 export function cardRenderedCallback(renderedCard: HTMLElement) {
     const renderedCardDiv = document.getElementById("renderedCardSpace");
-    const trustedHtml = window.trustedTypes?.emptyHTML ?? "";
+    const trustedHtml = (typeof window === 'undefined') ? "" : (window.trustedTypes?.emptyHTML ?? "");
     renderedCardDiv.innerHTML = trustedHtml as string;
     renderedCardDiv.appendChild(renderedCard);
     renderedCardDiv.style.visibility = "visible";

--- a/source/nodejs/adaptivecards/package-lock.json
+++ b/source/nodejs/adaptivecards/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "adaptivecards",
-	"version": "2.11.0",
+	"version": "2.11.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "adaptivecards",
-			"version": "2.11.0",
+			"version": "2.11.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/jest": "^27.0.2",

--- a/source/nodejs/adaptivecards/package.json
+++ b/source/nodejs/adaptivecards/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "adaptivecards",
-	"version": "2.11.0",
+	"version": "2.11.1",
 	"description": "Adaptive Cards Javascript library for HTML Clients",
 	"author": "AdaptiveCards",
 	"license": "MIT",

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -50,8 +50,9 @@ import { CardObjectRegistry, GlobalRegistry, ElementSingletonBehavior } from "./
 import { Strings } from "./strings";
 import { MenuItem, PopupMenu } from "./controls";
 
+
 function clearElement(element: HTMLElement) : void {
-    const trustedHtml = window.trustedTypes?.emptyHTML ?? "";
+    const trustedHtml = (typeof window === 'undefined') ? "" : (window.trustedTypes?.emptyHTML ?? "");
     element.innerHTML = trustedHtml as string;
 }
 
@@ -1107,7 +1108,7 @@ export class TextBlock extends BaseTextBlock {
 
     // Markdown processing is handled outside of Adaptive Cards. It's up to the host to ensure that markdown is safely
     // processed.
-    private static readonly _ttMarkdownPolicy = window.trustedTypes?.createPolicy(
+    private static readonly _ttMarkdownPolicy = (typeof window === 'undefined') ? undefined: window.trustedTypes?.createPolicy(
         "adaptivecards#markdownPassthroughPolicy",
         { createHTML: (value) => value }
     );
@@ -1116,7 +1117,7 @@ export class TextBlock extends BaseTextBlock {
     // GlobalSettings.useAdvancedTextBlockTruncation), we store the original pre-truncation content in
     // _originalInnerHtml so that we can restore/recalculate truncation later if space availability has changed (see
     // TextBlock.restoreOriginalContent())
-    private static readonly _ttRoundtripPolicy = window.trustedTypes?.createPolicy(
+    private static readonly _ttRoundtripPolicy = (typeof window === 'undefined') ? undefined: window.trustedTypes?.createPolicy(
         "adaptivecards#restoreContentsPolicy",
         { createHTML: (value) => value }
     );

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -1108,7 +1108,7 @@ export class TextBlock extends BaseTextBlock {
 
     // Markdown processing is handled outside of Adaptive Cards. It's up to the host to ensure that markdown is safely
     // processed.
-    private static readonly _ttMarkdownPolicy = (typeof window === 'undefined') ? undefined: window.trustedTypes?.createPolicy(
+    private static readonly _ttMarkdownPolicy = (typeof window === 'undefined') ? undefined : window.trustedTypes?.createPolicy(
         "adaptivecards#markdownPassthroughPolicy",
         { createHTML: (value) => value }
     );
@@ -1117,7 +1117,7 @@ export class TextBlock extends BaseTextBlock {
     // GlobalSettings.useAdvancedTextBlockTruncation), we store the original pre-truncation content in
     // _originalInnerHtml so that we can restore/recalculate truncation later if space availability has changed (see
     // TextBlock.restoreOriginalContent())
-    private static readonly _ttRoundtripPolicy = (typeof window === 'undefined') ? undefined: window.trustedTypes?.createPolicy(
+    private static readonly _ttRoundtripPolicy = (typeof window === 'undefined') ? undefined : window.trustedTypes?.createPolicy(
         "adaptivecards#restoreContentsPolicy",
         { createHTML: (value) => value }
     );

--- a/source/nodejs/adaptivecards/src/utils.ts
+++ b/source/nodejs/adaptivecards/src/utils.ts
@@ -190,7 +190,7 @@ export function truncateText(element: HTMLElement, maxHeight: number, lineHeight
  * TextBlock.truncateIfSupported}), but had a bug where it might actually pass through an element
  * for which innerHTML yielded actual HTML (since fixed).
  */
-const ttDeprecatedPolicy = (typeof window === 'undefined') ? null : window.trustedTypes?.createPolicy("adaptivecards#deprecatedExportedFunctionPolicy", {
+const ttDeprecatedPolicy = window.trustedTypes?.createPolicy("adaptivecards#deprecatedExportedFunctionPolicy", {
     createHTML: (value) => value
 });
 

--- a/source/nodejs/adaptivecards/src/utils.ts
+++ b/source/nodejs/adaptivecards/src/utils.ts
@@ -190,7 +190,7 @@ export function truncateText(element: HTMLElement, maxHeight: number, lineHeight
  * TextBlock.truncateIfSupported}), but had a bug where it might actually pass through an element
  * for which innerHTML yielded actual HTML (since fixed).
  */
-const ttDeprecatedPolicy = window.trustedTypes?.createPolicy("adaptivecards#deprecatedExportedFunctionPolicy", {
+const ttDeprecatedPolicy = (typeof window === 'undefined') ? undefined : window.trustedTypes?.createPolicy("adaptivecards#deprecatedExportedFunctionPolicy", {
     createHTML: (value) => value
 });
 

--- a/source/nodejs/adaptivecards/src/utils.ts
+++ b/source/nodejs/adaptivecards/src/utils.ts
@@ -190,7 +190,7 @@ export function truncateText(element: HTMLElement, maxHeight: number, lineHeight
  * TextBlock.truncateIfSupported}), but had a bug where it might actually pass through an element
  * for which innerHTML yielded actual HTML (since fixed).
  */
-const ttDeprecatedPolicy = window.trustedTypes?.createPolicy("adaptivecards#deprecatedExportedFunctionPolicy", {
+const ttDeprecatedPolicy = (typeof window === 'undefined') ? null : window.trustedTypes?.createPolicy("adaptivecards#deprecatedExportedFunctionPolicy", {
     createHTML: (value) => value
 });
 

--- a/source/nodejs/marked-schema/package-lock.json
+++ b/source/nodejs/marked-schema/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@microsoft/marked-schema",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@microsoft/marked-schema",
-			"version": "0.2.0",
+			"version": "0.2.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"json-schema-ref-parser": "^9.0.9",

--- a/source/nodejs/marked-schema/package.json
+++ b/source/nodejs/marked-schema/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/marked-schema",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"description": "Create markdown documentations from a JSON-schema file",
 	"main": "lib/index.js",
 	"scripts": {

--- a/source/nodejs/spec-generator/package-lock.json
+++ b/source/nodejs/spec-generator/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@microsoft/spec-generator",
-	"version": "0.7.0",
+	"version": "0.7.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@microsoft/spec-generator",
-			"version": "0.7.0",
+			"version": "0.7.1",
 			"license": "MIT",
 			"devDependencies": {
 				"p-iteration": "^1.1.8"

--- a/source/nodejs/spec-generator/package.json
+++ b/source/nodejs/spec-generator/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/spec-generator",
-	"version": "0.7.0",
+	"version": "0.7.1",
 	"private": true,
 	"description": "Generates the element/property tables for our specs based on the schema file.",
 	"author": "AdaptiveCards",
@@ -22,8 +22,8 @@
 		"build-all-and-run": "npm run build-all && npm run run"
 	},
 	"devDependencies": {
-		"@microsoft/ac-typed-schema": "^0.7.0",
-		"@microsoft/marked-schema": "^0.2.0",
+		"@microsoft/ac-typed-schema": "^0.7.1",
+		"@microsoft/marked-schema": "^0.2.1",
 		"p-iteration": "^1.1.8"
 	}
 }

--- a/source/nodejs/tests/unit-tests/jest.config.js
+++ b/source/nodejs/tests/unit-tests/jest.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   preset: 'ts-jest',
-  testEnvironment: 'jsdom',
+  testEnvironment: 'node',
 };

--- a/source/nodejs/tests/unit-tests/package-lock.json
+++ b/source/nodejs/tests/unit-tests/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@microsoft/ac-unit-tests",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@microsoft/ac-unit-tests",
-			"version": "0.1.1",
+			"version": "0.1.2",
 			"license": "MIT",
 			"devDependencies": {
 				"monaco-editor": "^0.29.1",

--- a/source/nodejs/tests/unit-tests/package.json
+++ b/source/nodejs/tests/unit-tests/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/ac-unit-tests",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"description": "Builds the unit tests.",
 	"author": "AdaptiveCards",
 	"license": "MIT",
@@ -17,8 +17,8 @@
 		"build-and-test": "npm run build && npm run test"
 	},
 	"devDependencies": {
-		"adaptivecards": "^2.10.0",
-		"adaptivecards-templating": "^2.3.0",
+		"adaptivecards": "^2.11.1",
+		"adaptivecards-templating": "^2.3.1",
 		"monaco-editor": "^0.29.1",
 		"vkbeautify": "^0.99.3"
 	}


### PR DESCRIPTION
Fix #7904 
1. add (typeof window === 'undefined') for everywhere use trustedTypes
2. make unit test to use node environment instead of jsdom which will not have window object
3. bump up version with `npx lerna version --force-publish --no-push --no-git-tag-version` to make min version change

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7910)