### PR TITLE
[Designer] Assign names to icon buttons for Narrator

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/tool-box.ts
+++ b/source/nodejs/adaptivecards-designer/src/tool-box.ts
@@ -94,6 +94,7 @@ export class Toolbox {
 
         let headerTitleElement = document.createElement("span");
         headerTitleElement.className = "acd-toolbox-header-title";
+        headerTitleElement.id = this.title.replace(/ /g, "-");
         headerTitleElement.innerText = this.title;
 
         headerContentElement.appendChild(headerTitleElement);
@@ -130,6 +131,7 @@ export class Toolbox {
         this._expandCollapseButtonElement.tabIndex = 0;
         this._expandCollapseButtonElement.setAttribute("role", "button");
         this._expandCollapseButtonElement.setAttribute("aria-expanded", "true");
+        this._expandCollapseButtonElement.setAttribute("aria-labelledby", this.title.replace(/ /g, "-"));
 
         this._headerIconElement = document.createElement("span")
         this._headerIconElement.classList.add("acd-icon", "acd-icon-header-expanded");

--- a/source/nodejs/adaptivecards-designer/src/tool-box.ts
+++ b/source/nodejs/adaptivecards-designer/src/tool-box.ts
@@ -94,7 +94,6 @@ export class Toolbox {
 
         let headerTitleElement = document.createElement("span");
         headerTitleElement.className = "acd-toolbox-header-title";
-        headerTitleElement.id = this.title.replace(/ /g, "-");
         headerTitleElement.innerText = this.title;
 
         headerContentElement.appendChild(headerTitleElement);
@@ -131,7 +130,7 @@ export class Toolbox {
         this._expandCollapseButtonElement.tabIndex = 0;
         this._expandCollapseButtonElement.setAttribute("role", "button");
         this._expandCollapseButtonElement.setAttribute("aria-expanded", "true");
-        this._expandCollapseButtonElement.setAttribute("aria-labelledby", this.title.replace(/ /g, "-"));
+        this._expandCollapseButtonElement.setAttribute("aria-label", this.title);
 
         this._headerIconElement = document.createElement("span")
         this._headerIconElement.classList.add("acd-icon", "acd-icon-header-expanded");

--- a/source/nodejs/adaptivecards-designer/src/tool-box.ts
+++ b/source/nodejs/adaptivecards-designer/src/tool-box.ts
@@ -130,7 +130,7 @@ export class Toolbox {
         this._expandCollapseButtonElement.tabIndex = 0;
         this._expandCollapseButtonElement.setAttribute("role", "button");
         this._expandCollapseButtonElement.setAttribute("aria-expanded", "true");
-        this._expandCollapseButtonElement.setAttribute("aria-label", this.title);
+        this._expandCollapseButtonElement.ariaLabel = this.title;
 
         this._headerIconElement = document.createElement("span")
         this._headerIconElement.classList.add("acd-icon", "acd-icon-header-expanded");

--- a/source/nodejs/adaptivecards-designer/src/toolbar.ts
+++ b/source/nodejs/adaptivecards-designer/src/toolbar.ts
@@ -98,6 +98,7 @@ export class ToolbarButton extends ToolbarElement {
         if (!this.displayCaption) {
             this.renderedElement.classList.add("acd-toolbar-button-iconOnly");
             this.renderedElement.innerText = "";
+            this.renderedElement.ariaLabel = this.caption;
         }
         else {
             this.renderedElement.innerText = this.caption;


### PR DESCRIPTION
# Related Issue

Fixes #7917 

# Description

Some of the buttons in the Designer did not have an associated accessible name for Narrator.

Toolbox expand/collapse button needed to be labeled by the header text.

Toolbar buttons that only contain an icon need to specify the label.

# How Verified

Verified manually on the Adaptive Cards site.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7927)