### PR TITLE
fixed media control a11y issue

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRMediaRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRMediaRenderer.mm
@@ -146,12 +146,12 @@
         [view addGestureRecognizer:recognizer];
         view.userInteractionEnabled = YES;
 
-        contentholdingview.isAccessibilityElement = NO;
-        view.isAccessibilityElement = YES;
-        view.accessibilityTraits = UIAccessibilityTraitStartsMediaSession | UIAccessibilityTraitButton;
+        contentholdingview.isAccessibilityElement = YES;
+        view.isAccessibilityElement = NO;
+        contentholdingview.accessibilityTraits = UIAccessibilityTraitStartsMediaSession | UIAccessibilityTraitButton;
         NSString *stringForAccessibilityLabel = [NSString stringWithCString:mediaElem->GetAltText().c_str() encoding:NSUTF8StringEncoding];
         if (stringForAccessibilityLabel.length) {
-            view.accessibilityLabel = stringForAccessibilityLabel;
+            contentholdingview.accessibilityLabel = stringForAccessibilityLabel;
         }
     }
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRMediaTarget.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRMediaTarget.mm
@@ -251,6 +251,9 @@ const int posterTag = 0x504F5354;
     [self->_containingview addSubview:mediaView];
     [NSLayoutConstraint constraintWithItem:mediaView attribute:NSLayoutAttributeCenterX relatedBy:NSLayoutRelationEqual toItem:self->_containingview attribute:NSLayoutAttributeCenterX multiplier:1.0 constant:0].active = YES;
     [NSLayoutConstraint constraintWithItem:mediaView attribute:NSLayoutAttributeCenterY relatedBy:NSLayoutRelationEqual toItem:self->_containingview attribute:NSLayoutAttributeCenterY multiplier:1.0 constant:0].active = YES;
+    
+    self->_containingview.isAccessibilityElement = NO;
+    UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, self->_mediaViewController.view);
 
     [player play];
 }

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRMediaTarget.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRMediaTarget.mm
@@ -251,7 +251,7 @@ const int posterTag = 0x504F5354;
     [self->_containingview addSubview:mediaView];
     [NSLayoutConstraint constraintWithItem:mediaView attribute:NSLayoutAttributeCenterX relatedBy:NSLayoutRelationEqual toItem:self->_containingview attribute:NSLayoutAttributeCenterX multiplier:1.0 constant:0].active = YES;
     [NSLayoutConstraint constraintWithItem:mediaView attribute:NSLayoutAttributeCenterY relatedBy:NSLayoutRelationEqual toItem:self->_containingview attribute:NSLayoutAttributeCenterY multiplier:1.0 constant:0].active = YES;
-    
+
     self->_containingview.isAccessibilityElement = NO;
     UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, self->_mediaViewController.view);
 


### PR DESCRIPTION
# Related Issue
Fixed #7021 

# Description

* poster is used for activating the media, so it is an accessibility item; however with this arrangement, it makes its child elements such as media control inaccessible.
* made its parent view accessible and toggle off its a11y when media control appears, and notifies vo of view change to shift vo focus to the player control

# Sample Card

https://github.com/microsoft/AdaptiveCards/blob/main/samples/v1.1/Scenarios/ProductVideo.json

# How Verified

How you verified the fix, including one or all of the following:
3. Manually verified using the sample above.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7938)