### PR TITLE
[Designer] Add the Carousel initialPage property to the designer

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/designer-peers.ts
+++ b/source/nodejs/adaptivecards-designer/src/designer-peers.ts
@@ -3398,6 +3398,7 @@ export class TablePeer extends TypedCardElementPeer<Adaptive.Table> {
 export class CarouselPeer extends ContainerPeer {
     // Question: What do we want the default value to be here?
     static readonly timerProperty = new CarouselTimerPropertyEditor(Adaptive.Versions.v1_6, "timer", "Timer", 5000);
+    static readonly initialPageProperty = new NumberPropertyEditor(Adaptive.Versions.v1_6, "initialPageIndex", "Initial page", 0);
 
     protected internalAddCommands(context: DesignContext, commands: Array<PeerCommand>) {
         super.internalAddCommands(context, commands);
@@ -3434,7 +3435,8 @@ export class CarouselPeer extends ContainerPeer {
 
         propertySheet.add(
             defaultCategory,
-            CarouselPeer.timerProperty);
+            CarouselPeer.timerProperty,
+            CarouselPeer.initialPageProperty);
     }
 
     canDrop(peer: DesignerPeer) {


### PR DESCRIPTION
# Related Issue

Fixes #7961

# Description

Added the `initialPage` property to the `CarouselPeer`. This addition will show the new property in the Designer's Element Properties pane.

# Sample Card

```
{
	"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
	"type": "AdaptiveCard",
	"version": "1.6",
	"body": [
		{
			"type": "Carousel",
			"initialPage": 2,
			"pages": [
				{
					"type": "CarouselPage",
					"id": "firstPage",
					"items": [
						{
							"type": "Image",
							"url": "https://picsum.photos/id/100/300/300",
							"altText": "beach"
						}
					],
					"rtl": false
				},
				{
					"type": "CarouselPage",
					"id": "secondPage",
					"items": [
						{
							"type": "Image",
							"url": "https://picsum.photos/id/110/300/300",
							"altText": "sunset"
						}
					],
					"rtl": false
				},
				{
					"type": "CarouselPage",
					"id": "thirdPage",
					"items": [
						{
							"type": "Image",
							"url": "https://picsum.photos/id/120/300/300",
							"altText": "sunset"
						}
					],
					"rtl": false
				}
			],
			"rtl": false
		},
		{
			"type": "TextBlock",
			"text": "You can choose initial carousel page by setting the value of *initialPage* property",
			"wrap": true
		}
	]
}
```

# How Verified

Verified manually on the Designer.
![image](https://user-images.githubusercontent.com/98650930/195194088-954d2d78-27be-4991-98d1-4be36613069d.png)

# Outstanding Work

Update to `serialization.ts` is needed for the desired behavior (#7963).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7962)