### PR TITLE
[Designer Accessibility] Remove tabIndex from pickerContainerElement

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/toolbar.ts
+++ b/source/nodejs/adaptivecards-designer/src/toolbar.ts
@@ -271,12 +271,10 @@ export class ToolbarChoicePicker extends ToolbarElement {
         if (!this.isEnabled) {
             this.renderedElement.classList.add("acd-toolbar-picker-disabled");
             this.renderedElement.setAttribute("aria-disabled", "true");
-            this.renderedElement.tabIndex = -1;
             this._dropDown.isEnabled = false;
         } else {
             this.renderedElement.classList.remove("acd-toolbar-picker-disabled");
             this.renderedElement.removeAttribute("aria-disabled");
-            this.renderedElement.tabIndex = 0;
             this._dropDown.isEnabled = true;
         }
 


### PR DESCRIPTION
# Related Issue

Fixes #7931

# Description

For the designer's toolbar choicePicker, we were setting the picker container (holds the title and the picker) and the picker to be focusable. Only the picker needs to be focusable, so we can remove the tabIndex handling on the container.

This resolves the issue of focus being given to non-interactable elements via keyboard navigation and voice access.

# How Verified

Verified manually on the Adaptive Cards site.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7972)