### PR TITLE
reverted not dropping image element with rendering error

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -2040,7 +2040,7 @@ export class Image extends CardElement {
                 if (this.renderedElement) {
                     const card = this.getRootElement() as AdaptiveCard;
 
-                    this.renderedElement;
+                    clearElement(this.renderedElement);
 
                     if (card && card.designMode) {
                         const errorElement = document.createElement("div");


### PR DESCRIPTION
# Related Issue
Fixed #7976 

# Description

Image element with rendering error have been dropped in JS, but the behavior changed. This PR fixes the issue. 

# Sample Card
```
{
    "type": "AdaptiveCard",
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
    "version": "1.5",
    "body": [
                {
                    "type": "Image",
                    "width": "72px", 
                    "height": "108px",
                    "url": "${image}",
                    "selectAction": {
                        "type": "Action.OpenUrl",
                        "tooltip": "${imageName}",
                        "url": "${games[1].pdpLink}"
                    }
                }
            ]
}
```
# How Verified

Manually verified. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/7977)