### PR TITLE
[Web Accessibility] Add textBlock to hostConfig for schema explorer

### DIFF
--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/source/js/script.js
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/source/js/script.js
@@ -313,6 +313,9 @@ $(function () {
 				"wrap": true
 			},
 			"spacing": 8
+		},
+		"textBlock": {
+			"headingLevel": 2
 		}
 	}
 


### PR DESCRIPTION
# Related Issue

Fixes #7870 
Fixes #7905 

# Description

Needed to add `textBlock.headingLevel` to the schema explorer host config so that `aria-level` will be properly added to headings.

# How Verified

Verified manually on the Adaptive Cards site.
