### PR TITLE
Dotnet 1.5 Input.Text Password stye

### DIFF
--- a/source/dotnet/Library/AdaptiveCards/AdaptiveTextInputStyle.cs
+++ b/source/dotnet/Library/AdaptiveCards/AdaptiveTextInputStyle.cs
@@ -30,6 +30,11 @@ namespace AdaptiveCards
         /// <summary>
         /// Input is an email address. The client may use this information to provide optimized keyboard input for the user.
         /// </summary>
-        Email
+        Email,
+
+        /// <summary>
+        /// Display input text with password masking
+        /// </summary>
+        Password,
     }
 }

--- a/source/dotnet/Library/AdaptiveCards/docs/AdaptiveCards.md
+++ b/source/dotnet/Library/AdaptiveCards/docs/AdaptiveCards.md
@@ -476,6 +476,7 @@
   - [GetNonInteractiveValue()](#M-AdaptiveCards-AdaptiveTextInput-GetNonInteractiveValue 'AdaptiveCards.AdaptiveTextInput.GetNonInteractiveValue')
 - [AdaptiveTextInputStyle](#T-AdaptiveCards-AdaptiveTextInputStyle 'AdaptiveCards.AdaptiveTextInputStyle')
   - [Email](#F-AdaptiveCards-AdaptiveTextInputStyle-Email 'AdaptiveCards.AdaptiveTextInputStyle.Email')
+  - [Password](#F-AdaptiveCards-AdaptiveTextInputStyle-Password 'AdaptiveCards.AdaptiveTextInputStyle.Password')
   - [Tel](#F-AdaptiveCards-AdaptiveTextInputStyle-Tel 'AdaptiveCards.AdaptiveTextInputStyle.Tel')
   - [Text](#F-AdaptiveCards-AdaptiveTextInputStyle-Text 'AdaptiveCards.AdaptiveTextInputStyle.Text')
   - [Url](#F-AdaptiveCards-AdaptiveTextInputStyle-Url 'AdaptiveCards.AdaptiveTextInputStyle.Url')
@@ -5023,6 +5024,13 @@ Style of text input.
 ##### Summary
 
 Input is an email address. The client may use this information to provide optimized keyboard input for the user.
+
+<a name='F-AdaptiveCards-AdaptiveTextInputStyle-Password'></a>
+### Password `constants`
+
+##### Summary
+
+Display input text with password masking
 
 <a name='F-AdaptiveCards-AdaptiveTextInputStyle-Tel'></a>
 ### Tel `constants`

--- a/source/dotnet/Test/AdaptiveCards.Test/AdaptiveInputTests.cs
+++ b/source/dotnet/Test/AdaptiveCards.Test/AdaptiveInputTests.cs
@@ -31,5 +31,18 @@ namespace AdaptiveCards.Test
 
             StringAssert.Contains(ex.Message, "'id'");
         }
+
+        [TestMethod]
+        public void TesPassWordInputStyle()
+        {
+            var card = Utilities.BuildASimpleTestCard();
+            var passwordStyleMockUpString  = new SerializableDictionary<string, object>() { ["style"] = "Password"};
+            var expectedJSON = Utilities.SerializeAfterManuallyWritingTestValueToAdaptiveElementWithTheGivenId(card, "textInput", passwordStyleMockUpString);
+            var testCard = AdaptiveCard.FromJson(expectedJSON);
+            Assert.IsTrue(testCard.Warnings.Count == 0);
+            AdaptiveTextInput textInput = Utilities.GetAdaptiveElementWithId(testCard.Card, "textInput") as AdaptiveTextInput;
+            Assert.IsNotNull(textInput);
+            Assert.AreEqual(AdaptiveTextInputStyle.Password, textInput.Style);
+        }
     }
 }

--- a/source/dotnet/Test/AdaptiveCards.Test/Utilities.cs
+++ b/source/dotnet/Test/AdaptiveCards.Test/Utilities.cs
@@ -82,6 +82,13 @@ namespace AdaptiveCards.Test
 
             card.Body.Add(textBlock);
 
+            AdaptiveTextInput textInput = new AdaptiveTextInput
+            {
+                Id = "textInput"
+            };
+
+            card.Body.Add(textInput);
+
             AdaptiveSubmitAction submitAction = new AdaptiveSubmitAction
             {
                 Id = "submitAction",


### PR DESCRIPTION
# Related Issue
https://microsoft.visualstudio.com/OS/_workitems/edit/41839375

# Description

* Added password style to Input.Text

# Sample Card

https://github.com/microsoft/AdaptiveCards/blob/main/samples/v1.5/Elements/Input.Text.PasswordStyle.json

# How Verified

1. New unit tests that were added.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8002)