### PR TITLE
[Designer] Remove border when background image is present and move logic to widget container class

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/card-designer.ts
+++ b/source/nodejs/adaptivecards-designer/src/card-designer.ts
@@ -416,6 +416,8 @@ export class CardDesigner extends Designer.DesignContext {
 
         this._designerSurface.isPreviewMode = wasInPreviewMode;
 
+        this._designerSurface.hostContainer = this.hostContainer;
+
         this.updateFullLayout();
     }
 

--- a/source/nodejs/adaptivecards-designer/src/containers/widget/widget-container-dark.css
+++ b/source/nodejs/adaptivecards-designer/src/containers/widget/widget-container-dark.css
@@ -31,6 +31,20 @@
     height: 148px;
 }
 
+.widget-large-container-no-border {
+    height: 462px !important;
+    border: 0px !important;
+}
+
+.widget-medium-container-no-border {
+    height: 304px !important;
+    border: 0px !important;
+}
+
+.widget-small-container-no-border {
+    height: 146px !important;
+    border: 0px !important;
+}
 
 /* widget-large/medium/small-container  4px(top+bottom padding+margin) widget-outer-container border*/
 

--- a/source/nodejs/adaptivecards-designer/src/containers/widget/widget-container-light.css
+++ b/source/nodejs/adaptivecards-designer/src/containers/widget/widget-container-light.css
@@ -48,6 +48,20 @@
     height: 148px;
 }
 
+.widget-large-container-no-border {
+    height: 462px !important;
+    border: 0px !important;
+}
+
+.widget-medium-container-no-border {
+    height: 304px !important;
+    border: 0px !important;
+}
+
+.widget-small-container-no-border {
+    height: 146px !important;
+    border: 0px !important;
+}
 
 /* widget-large/medium/small-container  4px(top+bottom padding+margin) widget-outer-container border*/
 

--- a/source/nodejs/adaptivecards-designer/src/containers/widget/widget-container.ts
+++ b/source/nodejs/adaptivecards-designer/src/containers/widget/widget-container.ts
@@ -13,6 +13,7 @@ export enum ContainerSize {
 
 export class WidgetContainer extends MultiThemeHostContainer {
     private _containerSize: ContainerSize;
+    private _outerFrame: HTMLDivElement;
 
     constructor(size: ContainerSize) {
         super(
@@ -40,13 +41,13 @@ export class WidgetContainer extends MultiThemeHostContainer {
             "widget-large-card"
         );
         this.cardHost.classList.add(`widget-${this._containerSize.toLowerCase()}-card`);
-        const outerFrame = document.createElement("div");
-        outerFrame.classList.add("widget-outer-container");
-        outerFrame.classList.add(`widget-${this._containerSize.toLowerCase()}-container`);
+        this._outerFrame = document.createElement("div");
+        this._outerFrame.classList.add("widget-outer-container");
+        this._outerFrame.classList.add(`widget-${this._containerSize.toLowerCase()}-container`);
 
         const header = document.createElement("div");
         header.className = "widget-header";
-        outerFrame.appendChild(header);
+        this._outerFrame.appendChild(header);
 
         const headerText = document.createElement("p");
         headerText.className = "widget-header-text";
@@ -63,8 +64,80 @@ export class WidgetContainer extends MultiThemeHostContainer {
         innerFrame.className = "widget-inner-container";
         innerFrame.appendChild(this.cardHost);
 
-        outerFrame.appendChild(innerFrame);
-        hostElement.appendChild(outerFrame);
+        this._outerFrame.appendChild(innerFrame);
+        hostElement.appendChild(this._outerFrame);
+    }
+
+    public requiresOverflowStyling(): boolean {
+        const renderedCard = document.getElementsByClassName("ac-adaptiveCard")[0] as HTMLElement;
+
+        const cardHeight = renderedCard.getBoundingClientRect().height;
+        const widgetHeight = this.cardHost.getBoundingClientRect().height;
+        
+        if (cardHeight > widgetHeight) {
+            this.applyWidgetOverflowStyling(renderedCard);
+            return true;
+        }
+        return false;
+    }
+
+    private applyWidgetOverflowStyling(renderedCard: HTMLElement) {
+        renderedCard.style.height = "100%";
+
+        const cardElementsWrapper = this.addCardElementsWrapper(renderedCard);
+        cardElementsWrapper.classList.add("no-overflow");
+
+        const carouselElements = renderedCard.getElementsByClassName("ac-carousel-container");
+
+        for (let i = 0; i < carouselElements.length; i++) {
+            const currentCarousel = carouselElements[i] as HTMLElement;
+
+            const carouselRect = currentCarousel.getBoundingClientRect();
+            const wrapperRect = cardElementsWrapper.getBoundingClientRect();
+
+            // pagination will be in the bottom 16px of a carousel
+            const paginationTop = carouselRect.bottom - 16;
+            const paginationBottom = carouselRect.bottom;
+
+            const paginationOverlapsBoundary = ((paginationBottom >= wrapperRect.bottom) && (paginationBottom < (wrapperRect.bottom + WidgetContainer.widgetPadding)) ||
+                                                (paginationTop >= wrapperRect.bottom) && (paginationTop < (wrapperRect.bottom + WidgetContainer.widgetPadding)));
+
+            if (paginationOverlapsBoundary) {
+                // Hide overflow on the cardElement instead of the wrapper since pagination dots are in the margin
+                renderedCard.classList.add("no-overflow");
+                cardElementsWrapper.classList.remove("no-overflow");
+
+                // Add the padding to the carousel if the pagination dots are in the margin
+                currentCarousel.style.marginBottom = WidgetContainer.widgetPadding + "px";
+                break;
+            }
+        }
+    }
+    
+    private addCardElementsWrapper(parentElement: Element): HTMLElement {
+        const cardElementsWrapper = document.createElement("div");
+        cardElementsWrapper.classList.add("ac-card-elements-wrapper");
+
+        Array.from(parentElement.children).forEach((child) => {
+            cardElementsWrapper.appendChild(child);
+        })
+
+        parentElement.appendChild(cardElementsWrapper);
+        return cardElementsWrapper;
+    }
+    
+    public adjustStyleForWidgetBackground() {
+        this._outerFrame.classList.remove(
+            "widget-small-container-no-border",
+            "widget-medium-container-no-border",
+            "widget-large-container-no-border"
+        );
+
+        const renderedCard = document.getElementsByClassName("ac-adaptiveCard")[0] as HTMLElement;
+        if (renderedCard.style.backgroundImage) {
+            // If there is a background image present, we should remove the border
+            this._outerFrame.classList.add(`widget-${this._containerSize.toLowerCase()}-container-no-border`);
+        }
     }
 
     get targetVersion(): Adaptive.Version {

--- a/source/nodejs/adaptivecards-designer/src/strings.ts
+++ b/source/nodejs/adaptivecards-designer/src/strings.ts
@@ -1,3 +1,5 @@
+import { WidgetContainer } from "./containers";
+
 export class Strings {
     static readonly toolboxes = {
         toolPalette: {
@@ -29,4 +31,5 @@ export class Strings {
         }
     };
     static loadingEditor = "Loading editor...";
+    static readonly widgetOverflowWarning = `[Designer] We have adjusted your card to hide overflow elements. Please ensure all card elements are contained within the proper card height per Widgets Board design guidelines. Only Carousel pagination dots can be present in the bottom ${WidgetContainer.widgetPadding}px margin of a widget.`;
 }


### PR DESCRIPTION
# Related Issue

Fixes #7958 

# Description

Removes border from Widgets Container if a background image has been set.

Also moved widget container styling changes to the WidgetContainer class.

# Sample Card

https://github.com/microsoft/AdaptiveCards/blob/2facb28c481b7a16968158b81d2669853d689497/samples/v1.0/Scenarios/WeatherLarge.json

# How Verified

Verified manually on the AdaptiveCards designer.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8022)