### PR TITLE
Prevent multiple actions from executing

### DIFF
--- a/source/nodejs/adaptivecards-react/src/adaptive-card.tsx
+++ b/source/nodejs/adaptivecards-react/src/adaptive-card.tsx
@@ -97,11 +97,12 @@ export const AdaptiveCard = ({
                     }
                     break;
                 }
-            }
-            // TODO: Why is there a global action handler when we have specific
-            // handlers for the above cases? Can we simplify to one approach?
-            if (onExecuteAction) {
-                onExecuteAction(a);
+                case AdaptiveCards.ExecuteAction.JsonTypeName: {
+                    if (onExecuteAction) {
+                        onExecuteAction(a);
+                    }
+                    break;
+                }
             }
         },
         [onActionOpenUrl, onActionShowCard, onActionSubmit, onExecuteAction]


### PR DESCRIPTION
# Description

With the current code in `adaptivecards-react`, both `submitAction` and `executeAction` will be executed if both callbacks are passed and a submit action is triggered. This is unexpected behaviour.

This seems to be a bug that slipped in as indicated by the old comment and running `executeAction` in the switch/case same as the rest of the handlers solves the issue.

# Sample App

```
import React from "react";
import { AdaptiveCard } from "adaptivecards-react";

const payload = {
    "type": "AdaptiveCard",
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
    "version": "1.5",
    "body": [
        {
            "type": "ActionSet",
            "actions": [
                {
                    "type": "Action.Execute",
                    "title": "Action.Execute"
                },
                {
                    "type": "Action.Submit",
                    "title": "Action.Submit"
                }
            ]
        }
    ]
}

const App = () => {
  // onExecute Handler
  const onExecuteAction = (e) => {
    console.log("Running ExecuteAction");
  };
  // onSubmit Handler
  const onActionSubmit = (e) => {
    console.log("Running onActionSubmit");
  };

  return <AdaptiveCard payload={payload} onExecuteAction={onExecuteAction} onActionSubmit={onActionSubmit}/>;
};

export default App;
```

Expected behaviour:
- Clicking on Action.Execute should only execute the onExecuteAction
- Clicking on Action.Submit should only execute the onActionSubmit

Actual behaviour:
- Clicking on Action.Execute executes the onExecuteAction
- Clicking on Action.Submit executes the onActionSubmit and onExecuteAction
