### PR TITLE
[UWP Renderer] Set accessible name for Inputs

### DIFF
--- a/source/uwp/Renderer/lib/XamlHelpers.cpp
+++ b/source/uwp/Renderer/lib/XamlHelpers.cpp
@@ -745,10 +745,6 @@ namespace AdaptiveCards::Rendering::Uwp::XamlHelpers
         if (label)
         {
             winrt::AutomationProperties::SetLabeledBy(actualUIElement, label);
-        }
-
-        if (!adaptiveInput.Label().empty())
-        {
             winrt::AutomationProperties::SetName(actualUIElement, adaptiveInput.Label());
         }
 

--- a/source/uwp/Renderer/lib/XamlHelpers.cpp
+++ b/source/uwp/Renderer/lib/XamlHelpers.cpp
@@ -745,11 +745,11 @@ namespace AdaptiveCards::Rendering::Uwp::XamlHelpers
         if (label)
         {
             winrt::AutomationProperties::SetLabeledBy(actualUIElement, label);
+        }
 
-            if (!adaptiveInput.Label().empty())
-            {
-                winrt::AutomationProperties::SetName(actualUIElement, adaptiveInput.Label());
-            }
+        if (!adaptiveInput.Label().empty())
+        {
+            winrt::AutomationProperties::SetName(actualUIElement, adaptiveInput.Label());
         }
 
         return inputStackPanel;

--- a/source/uwp/Renderer/lib/XamlHelpers.cpp
+++ b/source/uwp/Renderer/lib/XamlHelpers.cpp
@@ -745,6 +745,11 @@ namespace AdaptiveCards::Rendering::Uwp::XamlHelpers
         if (label)
         {
             winrt::AutomationProperties::SetLabeledBy(actualUIElement, label);
+
+            if (!adaptiveInput.Label().empty())
+            {
+                winrt::AutomationProperties::SetName(actualUIElement, adaptiveInput.Label());
+            }
         }
 
         return inputStackPanel;


### PR DESCRIPTION
# Related Issue

Fixes #7521

# Description

Updating input elements to set the accessible name in addition to the `labeledBy` property.

# Sample Card

https://github.com/microsoft/AdaptiveCards/blob/5d4eab82c9dad4d49b45e17b8d86f62a48946627/samples/v1.3/Scenarios/InputsWithValidation.json

# How Verified

Verified on the UWP Visualizer.

Name now includes "Start time"
![Screenshot (12)](https://user-images.githubusercontent.com/98650930/200947377-ae52d9b6-546b-4c54-b9cc-31d079d648b9.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8032)