### PR TITLE
[UWP Renderer] Check radio buttons when they receive focus

### DIFF
--- a/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.cpp
@@ -171,22 +171,22 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
                 }
 
                 radioButton.PreviewKeyDown(
-                    [this, stackPanel](winrt::IInspectable const& sender, winrt::KeyRoutedEventArgs const& args) -> void
+                    [stackPanel, radioButton](winrt::IInspectable const& /*sender*/, winrt::KeyRoutedEventArgs const& args) -> void
                     {
-                        std::uint32_t currentIndex;
+                        std::uint32_t currentButtonIndex;
                         auto children = stackPanel.Children();
                         auto size = children.Size();
-                        if (const auto isButtonFound = children.IndexOf(sender.as<winrt::RadioButton>(), currentIndex))
+                        if (const auto isButtonFound = children.IndexOf(radioButton, currentButtonIndex))
                         {
                             if (args.Key() == winrt::VirtualKey::Down)
                             {
-                                currentIndex = (currentIndex + 1) % size;
-                                children.GetAt(currentIndex).as<winrt::RadioButton>().IsChecked(true);
+                                auto newButtonIndex = (currentButtonIndex + 1) % size;
+                                children.GetAt(newButtonIndex).as<winrt::RadioButton>().IsChecked(true);
                             }
                             else if (args.Key() == winrt::VirtualKey::Up)
                             {
-                                currentIndex = (currentIndex + size - 1) % size;
-                                children.GetAt(currentIndex).as<winrt::RadioButton>().IsChecked(true);
+                                auto newButtonIndex = (currentButtonIndex + size - 1) % size;
+                                children.GetAt(newButtonIndex).as<winrt::RadioButton>().IsChecked(true);
                             }
                         }
                     });

--- a/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.cpp
@@ -169,6 +169,53 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
                     // Otherwise, leave all options unset
                     radioButton.IsChecked(IsChoiceSelected(values, input));
                 }
+
+                radioButton.PreviewKeyDown(
+                    [this, radioButton, stackPanel](winrt::IInspectable const& /*sender*/, winrt::KeyRoutedEventArgs const& args) -> void
+                    {
+                        if (args.Key() == winrt::VirtualKey::Down)
+                        {
+                            std::uint32_t index;
+                            auto children = stackPanel.Children();
+                            auto buttonFound = children.IndexOf(radioButton, index);
+
+                            if (buttonFound)
+                            {
+                                winrt::RadioButton nextButton;
+                                if (index < children.Size() - 1)
+                                {
+                                    nextButton = children.GetAt(index + 1).as<winrt::RadioButton>();
+                                }
+                                else
+                                {
+                                    nextButton = children.GetAt(0).as<winrt::RadioButton>();
+
+                                }
+                                nextButton.IsChecked(true);
+                            }
+                        }
+                        else if (args.Key() == winrt::VirtualKey::Up)
+                        {
+                            std::uint32_t index;
+                            auto children = stackPanel.Children();
+                            auto buttonFound = children.IndexOf(radioButton, index);
+
+                            if (buttonFound)
+                            {
+                                winrt::RadioButton nextButton;
+                                if (index == 0)
+                                {
+                                    nextButton = children.GetAt(children.Size() - 1).as<winrt::RadioButton>();
+                                }
+                                else
+                                {
+                                    nextButton = children.GetAt(index - 1).as<winrt::RadioButton>();
+                                }
+                                nextButton.IsChecked(true);
+                            }
+                        }
+                    });
+
                 choiceItem = radioButton;
             }
             winrt::hstring title = input.Title();

--- a/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.cpp
@@ -171,47 +171,22 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
                 }
 
                 radioButton.PreviewKeyDown(
-                    [this, radioButton, stackPanel](winrt::IInspectable const& /*sender*/, winrt::KeyRoutedEventArgs const& args) -> void
+                    [this, stackPanel](winrt::IInspectable const& sender, winrt::KeyRoutedEventArgs const& args) -> void
                     {
-                        if (args.Key() == winrt::VirtualKey::Down)
+                        std::uint32_t currentIndex;
+                        auto children = stackPanel.Children();
+                        auto size = children.Size();
+                        if (const auto isButtonFound = children.IndexOf(sender.as<winrt::RadioButton>(), currentIndex))
                         {
-                            std::uint32_t index;
-                            auto children = stackPanel.Children();
-                            auto buttonFound = children.IndexOf(radioButton, index);
-
-                            if (buttonFound)
+                            if (args.Key() == winrt::VirtualKey::Down)
                             {
-                                winrt::RadioButton nextButton;
-                                if (index < children.Size() - 1)
-                                {
-                                    nextButton = children.GetAt(index + 1).as<winrt::RadioButton>();
-                                }
-                                else
-                                {
-                                    nextButton = children.GetAt(0).as<winrt::RadioButton>();
-
-                                }
-                                nextButton.IsChecked(true);
+                                currentIndex = (currentIndex + 1) % size;
+                                children.GetAt(currentIndex).as<winrt::RadioButton>().IsChecked(true);
                             }
-                        }
-                        else if (args.Key() == winrt::VirtualKey::Up)
-                        {
-                            std::uint32_t index;
-                            auto children = stackPanel.Children();
-                            auto buttonFound = children.IndexOf(radioButton, index);
-
-                            if (buttonFound)
+                            else if (args.Key() == winrt::VirtualKey::Up)
                             {
-                                winrt::RadioButton nextButton;
-                                if (index == 0)
-                                {
-                                    nextButton = children.GetAt(children.Size() - 1).as<winrt::RadioButton>();
-                                }
-                                else
-                                {
-                                    nextButton = children.GetAt(index - 1).as<winrt::RadioButton>();
-                                }
-                                nextButton.IsChecked(true);
+                                currentIndex = (currentIndex + size - 1) % size;
+                                children.GetAt(currentIndex).as<winrt::RadioButton>().IsChecked(true);
                             }
                         }
                     });


### PR DESCRIPTION
# Related Issue

Fixes #7630 

# Description

When receiving focus via arrow keys, Radio Buttons should also be checked.

I added logic to the `PreviewKeyDown` event for Radio Buttons that:
- Checks if the up or down arrow was pressed
- Determines which radio button will receive focus next
- Set `IsChecked(true)` for that button

# Sample Card

Can be tested with https://github.com/microsoft/AdaptiveCards/blob/45caa275735e210f27449570524d4f51a4aff40a/samples/v1.5/Scenarios/InputsWithValidation.json

# How Verified

Verified manually on the UWP Visualizer.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8049)