### PR TITLE
[Android] Calculate width for HorizontalFlowLayout

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/layout/HorizontalFlowLayout.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/layout/HorizontalFlowLayout.java
@@ -65,15 +65,28 @@ public class HorizontalFlowLayout extends RelativeLayout {
         // need to call super.onMeasure(...) otherwise we'll get some funny behaviour
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
 
-        final int width = MeasureSpec.getSize(widthMeasureSpec);
+        int width = MeasureSpec.getSize(widthMeasureSpec);
         int height = MeasureSpec.getSize(heightMeasureSpec);
 
+        final int requiredWidth = measureRequiredWidth(
+            getPaddingLeft(),
+            getPaddingRight());
+
+        if (MeasureSpec.getMode(widthMeasureSpec) == MeasureSpec.UNSPECIFIED) {
+            // set width as required since there's no height restrictions
+            width = requiredWidth;
+        } else if (MeasureSpec.getMode(widthMeasureSpec) == MeasureSpec.AT_MOST
+                && requiredWidth < width) {
+            // set width as required since it's less than the maximum allowed
+            width = requiredWidth;
+        }
+
         final int requiredHeight = measureRequiredHeight(
-                width,
-                getPaddingTop(),
-                getPaddingBottom(),
-                getPaddingLeft(),
-                getPaddingRight());
+            width,
+            getPaddingTop(),
+            getPaddingBottom(),
+            getPaddingLeft(),
+            getPaddingRight());
 
         if (MeasureSpec.getMode(heightMeasureSpec) == MeasureSpec.UNSPECIFIED) {
             // set height as required since there's no height restrictions
@@ -231,5 +244,45 @@ public class HorizontalFlowLayout extends RelativeLayout {
         ypos += line_height + paddingBottom;
 
         return ypos;
+    }
+
+    /**
+     * Measures the width required by this view
+     * by summing the width and padding of all of it's children.
+     * <p>
+     * (Package-private visibility for uint tests access.)
+     *
+     * @param paddingLeft left padding for this view.
+     * @param paddingRight right padding for this view.
+     * @return the height required by this view.
+     */
+    int measureRequiredWidth(final int paddingLeft,
+                             final int paddingRight) {
+        int requiredWidth = paddingLeft + paddingRight;
+        int childWidth, childMarginLeft, childMarginRight;
+        View child;
+        MarginLayoutParams childMarginLayoutParams;
+        // Go through the children to get the total width of the view
+        for (int i = 0; i < getChildCount(); i++) {
+            child = getChildAt(i);
+
+            if (child.getVisibility() != GONE) {
+                childWidth = child.getMeasuredWidth();
+
+                if (child.getLayoutParams() != null
+                    && child.getLayoutParams() instanceof MarginLayoutParams) {
+                    childMarginLayoutParams = (MarginLayoutParams) child.getLayoutParams();
+
+                    childMarginLeft = childMarginLayoutParams.leftMargin;
+                    childMarginRight = childMarginLayoutParams.rightMargin;
+                } else {
+                    childMarginLeft = 0;
+                    childMarginRight = 0;
+                }
+
+                requiredWidth += childMarginLeft + childWidth + childMarginRight;
+            }
+        }
+        return requiredWidth;
     }
 }

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/layout/HorizontalFlowLayout.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/layout/HorizontalFlowLayout.java
@@ -65,6 +65,7 @@ public class HorizontalFlowLayout extends RelativeLayout {
         // need to call super.onMeasure(...) otherwise we'll get some funny behaviour
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
 
+        // Width and height are initially set to be the requested size by the parent
         int width = MeasureSpec.getSize(widthMeasureSpec);
         int height = MeasureSpec.getSize(heightMeasureSpec);
 

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/layout/HorizontalFlowLayout.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/layout/HorizontalFlowLayout.java
@@ -72,13 +72,12 @@ public class HorizontalFlowLayout extends RelativeLayout {
         final int requiredWidth = measureRequiredWidth(
             getPaddingLeft(),
             getPaddingRight());
+        final int widthMode = MeasureSpec.getMode(widthMeasureSpec);
 
-        if (MeasureSpec.getMode(widthMeasureSpec) == MeasureSpec.UNSPECIFIED) {
-            // set width as required since there's no height restrictions
-            width = requiredWidth;
-        } else if (MeasureSpec.getMode(widthMeasureSpec) == MeasureSpec.AT_MOST
-                && requiredWidth < width) {
-            // set width as required since it's less than the maximum allowed
+        if ((widthMode == MeasureSpec.UNSPECIFIED)
+                || (widthMode == MeasureSpec.AT_MOST
+                && requiredWidth < width)) {
+            // set width as required since there's no height restrictions or if it's less than the maximum allowed
             width = requiredWidth;
         }
 
@@ -88,13 +87,12 @@ public class HorizontalFlowLayout extends RelativeLayout {
             getPaddingBottom(),
             getPaddingLeft(),
             getPaddingRight());
+        final int heightMode = MeasureSpec.getMode(heightMeasureSpec);
 
-        if (MeasureSpec.getMode(heightMeasureSpec) == MeasureSpec.UNSPECIFIED) {
-            // set height as required since there's no height restrictions
-            height = requiredHeight;
-        } else if (MeasureSpec.getMode(heightMeasureSpec) == MeasureSpec.AT_MOST
-                && requiredHeight < height) {
-            // set height as required since it's less than the maximum allowed
+        if ((heightMode == MeasureSpec.UNSPECIFIED)
+                || (heightMode == MeasureSpec.AT_MOST
+                && requiredHeight < height)) {
+            // set height as required since there's no height restriction or if it's less than the maximum allowed
             height = requiredHeight;
         }
 

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ImageSetRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ImageSetRenderer.java
@@ -94,11 +94,11 @@ public class ImageSetRenderer extends BaseCardElementRenderer
 
         if (imageSet.GetHeight() == HeightType.Stretch)
         {
-            viewGroup.addView(horizFlowLayout, new LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.MATCH_PARENT, 1));
+            viewGroup.addView(horizFlowLayout, new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT, 1));
         }
         else
         {
-            viewGroup.addView(horizFlowLayout, new LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT));
+            viewGroup.addView(horizFlowLayout, new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT));
         }
 
         return horizFlowLayout;

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ImageSetRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ImageSetRenderer.java
@@ -94,11 +94,11 @@ public class ImageSetRenderer extends BaseCardElementRenderer
 
         if (imageSet.GetHeight() == HeightType.Stretch)
         {
-            viewGroup.addView(horizFlowLayout, new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT, 1));
+            viewGroup.addView(horizFlowLayout, new LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.MATCH_PARENT, 1));
         }
         else
         {
-            viewGroup.addView(horizFlowLayout, new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT));
+            viewGroup.addView(horizFlowLayout, new LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT));
         }
 
         return horizFlowLayout;


### PR DESCRIPTION
# Related Issue

Fixes #7556 

# Description

Within the `onMeasure` method, we use the given `widthMeasureSpec` to get width.

I added an additional method `measureRequiredWidth` to sum the width of the view's children.
- If `MeasureSpec.getMode()` is `UNSPECIFIED`, we will use the calculated width.
- If `MeasureSpec.getMode()` is `AT_MOST`, we will use the calculated width only if it is less than the provided width.
- Otherwise, we will use the provided width.

# Sample Card

```JSON
{
    "type": "AdaptiveCard",
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
    "version": "1.2",
    "body": [
        {
            "type": "ColumnSet",
            "columns": [
                {
                    "type": "Column",
                    "width": "auto",
                    "items": [
                        {
                            "type": "ImageSet",
                            "images": [
                                {
                                    "type": "Image",
                                    "url": "https://www.webex.com/content/dam/wbx/us/images/rebrand/webex-logo.png",
                                    "width": "50px",
                                    "size": "Medium"
                                }
                            ]
                        }
                    ]
                },
                {
                    "type": "Column",
                    "width": "stretch",
                    "items": [
                        {
                            "type": "TextBlock",
                            "text": "Test Card"
                        }
                    ]
                }
            ]
        }
    ]
}
```

# How Verified

Verified manually on the Android Visualizer.

![imageSet](https://user-images.githubusercontent.com/98650930/203132155-178d5f26-b421-41be-bc30-12658957961e.gif)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8072)