### PR TITLE
Fixed column rendering in places other than columnset

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRColumnRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRColumnRenderer.mm
@@ -34,6 +34,10 @@
     baseCardElement:(ACOBaseCardElement *)acoElem
          hostConfig:(ACOHostConfig *)acoConfig;
 {
+    if (![viewGroup isKindOfClass:[ACRColumnSetView class]]) {
+        return nil;
+    }
+
     std::shared_ptr<BaseCardElement> elem = [acoElem element];
     std::shared_ptr<Column> columnElem = std::dynamic_pointer_cast<Column>(elem);
 


### PR DESCRIPTION
# Related Issue

Fixed #7903 

# Description

Added simple check that checks if a parent view of column is columnset.

How you verified the fix, including one or all of the following:
verified manually with samples.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8093)