### PR TITLE
[UWP Renderer]: Make references to the ::winrt::AdaptiveCards::Rendering::Uwp namespace consistent

### DIFF
--- a/source/uwp/Renderer/dll/CppWinRTIncludes.h
+++ b/source/uwp/Renderer/dll/CppWinRTIncludes.h
@@ -54,6 +54,7 @@ namespace winrt
     // In order to avoid "namespace not defined" errors we have to define the namespace here too.
     namespace AdaptiveCards::Rendering::Uwp{}
     using namespace ::winrt::AdaptiveCards::Rendering::Uwp;
+    namespace render_xaml = ::winrt::AdaptiveCards::Rendering::Uwp;
 
     namespace AdaptiveCards::Rendering::Uwp::implementation{}
     namespace implementation

--- a/source/uwp/Renderer/dll/CppWinRTIncludes.h
+++ b/source/uwp/Renderer/dll/CppWinRTIncludes.h
@@ -54,6 +54,9 @@ namespace winrt
     // In order to avoid "namespace not defined" errors we have to define the namespace here too.
     namespace AdaptiveCards::Rendering::Uwp{}
     using namespace ::winrt::AdaptiveCards::Rendering::Uwp;
+
+    // render_xaml namespace alias used to differentiate in cases where a type exists in both
+    // the renderer and the object model (ie. ActionMode)
     namespace render_xaml = ::winrt::AdaptiveCards::Rendering::Uwp;
 
     namespace AdaptiveCards::Rendering::Uwp::implementation{}

--- a/source/uwp/Renderer/lib/ActionHelpers.cpp
+++ b/source/uwp/Renderer/lib/ActionHelpers.cpp
@@ -691,7 +691,7 @@ namespace AdaptiveCards::Rendering::Uwp::ActionHelpers
         auto showCardActionConfig = actionsConfig.ShowCard();
         auto showCardActionMode = showCardActionConfig.ActionMode();
         // ActionMode enum exists both in Rendering in ObjectModel namespaces. When the time permits, fix it.
-        if (showCardActionMode == winrt::AdaptiveCards::Rendering::Uwp::ActionMode::Inline)
+        if (showCardActionMode == winrt::render_xaml::ActionMode::Inline)
         {
             // Get the card to be shown
             auto actionAsShowCardAction = action.as<winrt::AdaptiveShowCardAction>();

--- a/source/uwp/Renderer/lib/AdaptiveActionRendererRegistration.h
+++ b/source/uwp/Renderer/lib/AdaptiveActionRendererRegistration.h
@@ -13,7 +13,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
 
         AdaptiveActionRendererRegistration() = default;
 
-        Uwp::IAdaptiveActionRenderer Get(winrt::hstring const& type);
+        winrt::IAdaptiveActionRenderer Get(winrt::hstring const& type);
         void Set(winrt::hstring const& type, winrt::IAdaptiveActionRenderer const& renderer);
         void Remove(winrt::hstring const& type);
 

--- a/source/uwp/Renderer/lib/AdaptiveActionSetRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveActionSetRenderer.h
@@ -12,8 +12,8 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         AdaptiveActionSetRenderer() = default;
 
         winrt::UIElement Render(winrt::IAdaptiveCardElement const& cardElement,
-                                                   Uwp::AdaptiveRenderContext const& renderContext,
-                                                   Uwp::AdaptiveRenderArgs const& renderArgs);
+                                winrt::AdaptiveRenderContext const& renderContext,
+                                winrt::AdaptiveRenderArgs const& renderArgs);
     };
 }
 namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation

--- a/source/uwp/Renderer/lib/AdaptiveCardRendererComponent.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveCardRendererComponent.cpp
@@ -54,7 +54,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         UpdateActionSentimentResourceDictionary();
     }
 
-    Uwp::AdaptiveFeatureRegistration AdaptiveCardRenderer::FeatureRegistration()
+    winrt::AdaptiveFeatureRegistration AdaptiveCardRenderer::FeatureRegistration()
     {
         if (!m_featureRegistration)
         {
@@ -70,14 +70,17 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         m_desiredHeight = desiredHeight;
     }
 
-    bool AdaptiveCardRenderer::OverflowMaxActions() { return GetHostConfig()->OverflowMaxActions; }
+    bool AdaptiveCardRenderer::OverflowMaxActions()
+    {
+        return GetHostConfig()->OverflowMaxActions;
+    }
 
     void AdaptiveCardRenderer::OverflowMaxActions(bool overflowMaxActions)
     {
         GetHostConfig()->OverflowMaxActions = overflowMaxActions;
     }
 
-    Uwp::RenderedAdaptiveCard AdaptiveCardRenderer::RenderAdaptiveCard(winrt::AdaptiveCard const& adaptiveCard)
+    winrt::RenderedAdaptiveCard AdaptiveCardRenderer::RenderAdaptiveCard(winrt::AdaptiveCard const& adaptiveCard)
     {
         auto renderedCard = winrt::make_self<implementation::RenderedAdaptiveCard>();
         renderedCard->SetOriginatingCard(adaptiveCard);
@@ -120,7 +123,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         return *renderedCard;
     }
 
-    Uwp::RenderedAdaptiveCard AdaptiveCardRenderer::RenderAdaptiveCardFromJsonString(hstring const& adaptiveJson)
+    winrt::RenderedAdaptiveCard AdaptiveCardRenderer::RenderAdaptiveCardFromJsonString(hstring const& adaptiveJson)
     {
         auto adaptiveCardParseResult = winrt::AdaptiveCard::FromJsonString(adaptiveJson);
         if (auto parsedCard = adaptiveCardParseResult.AdaptiveCard())
@@ -141,7 +144,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         }
     }
 
-    Uwp::RenderedAdaptiveCard AdaptiveCardRenderer::RenderAdaptiveCardFromJson(winrt::JsonObject const& adaptiveJson)
+    winrt::RenderedAdaptiveCard AdaptiveCardRenderer::RenderAdaptiveCardFromJson(winrt::JsonObject const& adaptiveJson)
     {
         return RenderAdaptiveCardFromJsonString(JsonObjectToHString(adaptiveJson));
     }

--- a/source/uwp/Renderer/lib/AdaptiveCardRendererComponent.h
+++ b/source/uwp/Renderer/lib/AdaptiveCardRendererComponent.h
@@ -13,8 +13,8 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     {
     private:
         winrt::ResourceDictionary m_overrideDictionary;
-        Uwp::AdaptiveHostConfig m_hostConfig;
-        Uwp::AdaptiveFeatureRegistration m_featureRegistration;
+        winrt::AdaptiveHostConfig m_hostConfig;
+        winrt::AdaptiveFeatureRegistration m_featureRegistration;
         winrt::com_ptr<::AdaptiveCards::Rendering::Uwp::XamlBuilder> m_xamlBuilder;
         bool m_explicitDimensions = false;
         uint32_t m_desiredWidth = 0;
@@ -43,14 +43,14 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
             UpdateActionSentimentResourceDictionary();
         }
 
-        Uwp::AdaptiveHostConfig HostConfig() { return m_hostConfig; }
+        winrt::AdaptiveHostConfig HostConfig() { return m_hostConfig; }
 
         void FeatureRegistration(winrt::AdaptiveFeatureRegistration const& featureRegistration)
         {
             m_featureRegistration = featureRegistration;
         }
 
-        Uwp::AdaptiveFeatureRegistration FeatureRegistration();
+        winrt::AdaptiveFeatureRegistration FeatureRegistration();
 
         void SetFixedDimensions(uint32_t desiredWidth, uint32_t desiredHeight);
         void ResetFixedDimensions() { m_explicitDimensions = false; };
@@ -70,20 +70,17 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
             return GetHostConfig()->OverflowButtonAccessibilityText = text;
         }
 
-        Uwp::RenderedAdaptiveCard RenderAdaptiveCard(winrt::AdaptiveCard const& adaptiveCard);
-        Uwp::RenderedAdaptiveCard RenderAdaptiveCardFromJsonString(hstring const& adaptiveJson);
-        Uwp::RenderedAdaptiveCard RenderAdaptiveCardFromJson(winrt::JsonObject const& adaptiveJson);
+        winrt::RenderedAdaptiveCard RenderAdaptiveCard(winrt::AdaptiveCard const& adaptiveCard);
+        winrt::RenderedAdaptiveCard RenderAdaptiveCardFromJsonString(hstring const& adaptiveJson);
+        winrt::RenderedAdaptiveCard RenderAdaptiveCardFromJson(winrt::JsonObject const& adaptiveJson);
 
-        Uwp::AdaptiveElementRendererRegistration ElementRenderers() { return *m_elementRendererRegistration; }
-        Uwp::AdaptiveActionRendererRegistration ActionRenderers() { return *m_actionRendererRegistration; }
+        winrt::AdaptiveElementRendererRegistration ElementRenderers() { return *m_elementRendererRegistration; }
+        winrt::AdaptiveActionRendererRegistration ActionRenderers() { return *m_actionRendererRegistration; }
 
         winrt::ResourceDictionary GetMergedDictionary() { return m_mergedResourceDictionary; }
         bool GetFixedDimensions(_Out_ uint32_t* width, _Out_ uint32_t* height);
         winrt::com_ptr<::AdaptiveCards::Rendering::Uwp::XamlBuilder> GetXamlBuilder() { return m_xamlBuilder; }
-        winrt::ResourceDictionary GetActionSentimentResourceDictionary()
-        {
-            return m_actionSentimentResourceDictionary;
-        }
+        winrt::ResourceDictionary GetActionSentimentResourceDictionary() { return m_actionSentimentResourceDictionary; }
 
         auto ResourceResolvers() { return m_resourceResolvers; }
 
@@ -96,7 +93,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         winrt::ResourceDictionary m_defaultResourceDictionary;
         winrt::ResourceDictionary m_mergedResourceDictionary;
         winrt::ResourceDictionary m_actionSentimentResourceDictionary;
-        Uwp::AdaptiveCardResourceResolvers m_resourceResolvers;
+        winrt::AdaptiveCardResourceResolvers m_resourceResolvers;
         winrt::com_ptr<implementation::AdaptiveElementRendererRegistration> m_elementRendererRegistration;
         winrt::com_ptr<implementation::AdaptiveActionRendererRegistration> m_actionRendererRegistration;
     };

--- a/source/uwp/Renderer/lib/AdaptiveCardResourceResolvers.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveCardResourceResolvers.cpp
@@ -11,7 +11,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         m_resourceResolvers[scheme] = resolver;
     }
 
-    Uwp::IAdaptiveCardResourceResolver AdaptiveCardResourceResolvers::Get(hstring const& scheme)
+    winrt::IAdaptiveCardResourceResolver AdaptiveCardResourceResolvers::Get(hstring const& scheme)
     {
         auto found = m_resourceResolvers.find(scheme);
         if (found != m_resourceResolvers.end())

--- a/source/uwp/Renderer/lib/AdaptiveCardResourceResolvers.h
+++ b/source/uwp/Renderer/lib/AdaptiveCardResourceResolvers.h
@@ -11,9 +11,9 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         AdaptiveCardResourceResolvers() = default;
 
         void Set(hstring const& scheme, winrt::IAdaptiveCardResourceResolver const& resolver);
-        Uwp::IAdaptiveCardResourceResolver Get(hstring const& scheme);
+        winrt::IAdaptiveCardResourceResolver Get(hstring const& scheme);
 
-        std::map<hstring, Rendering::Uwp::IAdaptiveCardResourceResolver> m_resourceResolvers;
+        std::map<hstring, winrt::IAdaptiveCardResourceResolver> m_resourceResolvers;
     };
 }
 

--- a/source/uwp/Renderer/lib/AdaptiveElementRendererRegistration.h
+++ b/source/uwp/Renderer/lib/AdaptiveElementRendererRegistration.h
@@ -19,7 +19,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
             m_registration[type] = renderer;
         }
 
-        Uwp::IAdaptiveElementRenderer Get(hstring const& type)
+        winrt::IAdaptiveElementRenderer Get(hstring const& type)
         {
             auto it = m_registration.find(type);
             if (it != m_registration.end())

--- a/source/uwp/Renderer/lib/AdaptiveHostConfig.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveHostConfig.cpp
@@ -27,19 +27,19 @@
 
 namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
 {
-    Uwp::AdaptiveHostConfigParseResult AdaptiveHostConfig::FromJsonString(hstring const& hostConfigJson)
+    winrt::AdaptiveHostConfigParseResult AdaptiveHostConfig::FromJsonString(hstring const& hostConfigJson)
     {
         std::string adaptiveJsonString = HStringToUTF8(hostConfigJson);
         return AdaptiveHostConfig::_FromJsonString(adaptiveJsonString);
     }
 
-    Uwp::AdaptiveHostConfigParseResult AdaptiveHostConfig::FromJson(winrt::JsonObject const& hostConfigJson)
+    winrt::AdaptiveHostConfigParseResult AdaptiveHostConfig::FromJson(winrt::JsonObject const& hostConfigJson)
     {
         std::string adaptiveJsonString = JsonObjectToString(hostConfigJson);
         return AdaptiveHostConfig::_FromJsonString(adaptiveJsonString);
     }
 
-    Uwp::AdaptiveHostConfigParseResult AdaptiveHostConfig::_FromJsonString(std::string const& adaptiveJson)
+    winrt::AdaptiveHostConfigParseResult AdaptiveHostConfig::_FromJsonString(std::string const& adaptiveJson)
     {
         auto sharedHostConfig = ::AdaptiveCards::HostConfig::DeserializeFromString(adaptiveJson);
         auto parseResult = winrt::make<implementation::AdaptiveHostConfig>(sharedHostConfig);

--- a/source/uwp/Renderer/lib/AdaptiveHostConfig.h
+++ b/source/uwp/Renderer/lib/AdaptiveHostConfig.h
@@ -39,11 +39,11 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         // ITypePeek method
         void* PeekAt(REFIID riid) override { return PeekHelper(riid, this); }
 
-        static Uwp::AdaptiveHostConfigParseResult FromJsonString(hstring const& hostConfigJson);
-        static Uwp::AdaptiveHostConfigParseResult FromJson(winrt::JsonObject const& hostConfigJson);
+        static winrt::AdaptiveHostConfigParseResult FromJsonString(hstring const& hostConfigJson);
+        static winrt::AdaptiveHostConfigParseResult FromJson(winrt::JsonObject const& hostConfigJson);
 
     private:
-        static Uwp::AdaptiveHostConfigParseResult _FromJsonString(const std::string& jsonString);
+        static winrt::AdaptiveHostConfigParseResult _FromJsonString(const std::string& jsonString);
     };
 }
 namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation

--- a/source/uwp/Renderer/lib/AdaptiveInputs.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveInputs.cpp
@@ -7,7 +7,10 @@
 
 namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
 {
-    winrt::JsonObject AdaptiveInputs::AsJson() { return StringToJsonObject(GetInputItemsAsJsonString()); }
+    winrt::JsonObject AdaptiveInputs::AsJson()
+    {
+        return StringToJsonObject(GetInputItemsAsJsonString());
+    }
 
     void AdaptiveInputs::AddInputValue(winrt::IAdaptiveInputValue const& inputValue, winrt::AdaptiveRenderArgs const& renderArgs)
     {
@@ -40,7 +43,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         }
     }
 
-    void AdaptiveInputs::LinkSubmitActionToCard(winrt::IAdaptiveActionElement const& action, Uwp::AdaptiveRenderArgs const& renderArgs)
+    void AdaptiveInputs::LinkSubmitActionToCard(winrt::IAdaptiveActionElement const& action, winrt::AdaptiveRenderArgs const& renderArgs)
     {
         uint32_t actionId = GetInternalIdFromAction(action);
         uint32_t cardId = renderArgs.ParentCard().InternalId();
@@ -52,7 +55,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         m_parentCard[cardId] = parentCardId;
     }
 
-    Uwp::IAdaptiveInputValue AdaptiveInputs::GetInputValue(winrt::IAdaptiveInputElement const& inputElement)
+    winrt::IAdaptiveInputValue AdaptiveInputs::GetInputValue(winrt::IAdaptiveInputElement const& inputElement)
     {
         hstring elementId = inputElement.as<winrt::IAdaptiveCardElement>().Id();
         return m_inputValues[HStringToUTF8(elementId)];

--- a/source/uwp/Renderer/lib/AdaptiveInputs.h
+++ b/source/uwp/Renderer/lib/AdaptiveInputs.h
@@ -22,7 +22,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         void LinkSubmitActionToCard(winrt::IAdaptiveActionElement const& action, winrt::AdaptiveRenderArgs const& renderArgs);
         void LinkCardToParent(uint32_t cardId, uint32_t parentCardId);
 
-        Uwp::IAdaptiveInputValue GetInputValue(winrt::IAdaptiveInputElement const& inputElement);
+        winrt::IAdaptiveInputValue GetInputValue(winrt::IAdaptiveInputElement const& inputElement);
 
     private:
         std::string GetInputItemsAsJsonString();

--- a/source/uwp/Renderer/lib/AdaptiveRenderArgs.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveRenderArgs.cpp
@@ -10,7 +10,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     // This constructor is kept so all elements keep working as expected
     AdaptiveRenderArgs::AdaptiveRenderArgs(winrt::ContainerStyle const& containerStyle,
                                            winrt::IInspectable const& parentElement,
-                                           Uwp::AdaptiveRenderArgs const& renderArgs) :
+                                           winrt::AdaptiveRenderArgs const& renderArgs) :
         ContainerStyle{containerStyle},
         ParentElement{parentElement}
     {
@@ -24,7 +24,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     AdaptiveRenderArgs::AdaptiveRenderArgs(winrt::ContainerStyle const& containerStyle,
                                            winrt::IInspectable const& parentElement,
                                            winrt::AdaptiveCard const& parentCard,
-                                           Uwp::AdaptiveRenderArgs const& renderArgs) :
+                                           winrt::AdaptiveRenderArgs const& renderArgs) :
         ContainerStyle{containerStyle},
         ParentElement{parentElement}, ParentCard{parentCard}
     {

--- a/source/uwp/Renderer/lib/AdaptiveRenderArgs.h
+++ b/source/uwp/Renderer/lib/AdaptiveRenderArgs.h
@@ -12,12 +12,12 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
 
         AdaptiveRenderArgs(winrt::ContainerStyle const& containerStyle,
                            winrt::IInspectable const& parentElement,
-                           Uwp::AdaptiveRenderArgs const& renderArgs);
+                           winrt::AdaptiveRenderArgs const& renderArgs);
 
         AdaptiveRenderArgs(winrt::ContainerStyle const& containerStyle,
                            winrt::IInspectable const& parentElement,
                            winrt::AdaptiveCard const& parentCard,
-                           Uwp::AdaptiveRenderArgs const& renderArgs);
+                           winrt::AdaptiveRenderArgs const& renderArgs);
 
         property<winrt::ContainerStyle> ContainerStyle;
         property<winrt::IInspectable> ParentElement;

--- a/source/uwp/Renderer/lib/AdaptiveRenderContext.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveRenderContext.cpp
@@ -16,11 +16,11 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     {
     }
 
-    AdaptiveRenderContext::AdaptiveRenderContext(Rendering::Uwp::AdaptiveHostConfig const& hostConfig,
-                                                 Rendering::Uwp::AdaptiveFeatureRegistration const& featureRegistration,
-                                                 Rendering::Uwp::AdaptiveElementRendererRegistration const& elementRendererRegistration,
-                                                 Rendering::Uwp::AdaptiveActionRendererRegistration const& actionRendererRegistration,
-                                                 Rendering::Uwp::AdaptiveCardResourceResolvers const& resourceResolvers,
+    AdaptiveRenderContext::AdaptiveRenderContext(winrt::AdaptiveHostConfig const& hostConfig,
+                                                 winrt::AdaptiveFeatureRegistration const& featureRegistration,
+                                                 winrt::AdaptiveElementRendererRegistration const& elementRendererRegistration,
+                                                 winrt::AdaptiveActionRendererRegistration const& actionRendererRegistration,
+                                                 winrt::AdaptiveCardResourceResolvers const& resourceResolvers,
                                                  winrt::ResourceDictionary const& overrideStyles,
                                                  winrt::ResourceDictionary const& defaultActionSentimentStyles,
                                                  winrt::com_ptr<implementation::RenderedAdaptiveCard> const& renderResult) :
@@ -37,7 +37,10 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         }
     }
 
-    Uwp::AdaptiveInputs AdaptiveRenderContext::UserInputs() { return GetRenderResult()->UserInputs(); }
+    winrt::AdaptiveInputs AdaptiveRenderContext::UserInputs()
+    {
+        return GetRenderResult()->UserInputs();
+    }
 
     void AdaptiveRenderContext::AddError(winrt::ErrorStatusCode statusCode, hstring const& message)
     {
@@ -52,7 +55,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     void AdaptiveRenderContext::AddInlineShowCard(winrt::AdaptiveActionSet const& actionSet,
                                                   winrt::AdaptiveShowCardAction const& showCardAction,
                                                   winrt::UIElement const& showCardUIElement,
-                                                  Uwp::AdaptiveRenderArgs const& renderArgs)
+                                                  winrt::AdaptiveRenderArgs const& renderArgs)
     {
         GetRenderResult()->AddInlineShowCard(actionSet, showCardAction, showCardUIElement, renderArgs);
     }
@@ -60,7 +63,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     void AdaptiveRenderContext::AddInlineShowCard(winrt::AdaptiveCard const& adaptiveCard,
                                                   winrt::AdaptiveShowCardAction const& showCardAction,
                                                   winrt::UIElement const& showCardUIElement,
-                                                  Uwp::AdaptiveRenderArgs const& renderArgs)
+                                                  winrt::AdaptiveRenderArgs const& renderArgs)
     {
         GetRenderResult()->AddInlineShowCard(adaptiveCard, showCardAction, showCardUIElement, renderArgs);
     }
@@ -84,7 +87,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     }
 
     void AdaptiveRenderContext::LinkSubmitActionToCard(winrt::IAdaptiveActionElement const& submitAction,
-                                                       Uwp::AdaptiveRenderArgs const& renderArgs)
+                                                       winrt::AdaptiveRenderArgs const& renderArgs)
     {
         if (auto renderResult = GetRenderResult())
         {
@@ -100,7 +103,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         }
     }
 
-    Uwp::IAdaptiveInputValue AdaptiveRenderContext::GetInputValue(winrt::IAdaptiveInputElement const& inputElement)
+    winrt::IAdaptiveInputValue AdaptiveRenderContext::GetInputValue(winrt::IAdaptiveInputElement const& inputElement)
     {
         if (auto renderResult = GetRenderResult())
         {

--- a/source/uwp/Renderer/lib/AdaptiveRenderContext.h
+++ b/source/uwp/Renderer/lib/AdaptiveRenderContext.h
@@ -15,11 +15,11 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     {
         AdaptiveRenderContext();
 
-        AdaptiveRenderContext(Rendering::Uwp::AdaptiveHostConfig const& hostConfig,
-                              Rendering::Uwp::AdaptiveFeatureRegistration const& featureRegistration,
-                              Rendering::Uwp::AdaptiveElementRendererRegistration const& elementRendererRegistration,
-                              Rendering::Uwp::AdaptiveActionRendererRegistration const& actionRendererRegistration,
-                              Rendering::Uwp::AdaptiveCardResourceResolvers const& resourceResolvers,
+        AdaptiveRenderContext(winrt::AdaptiveHostConfig const& hostConfig,
+                              winrt::AdaptiveFeatureRegistration const& featureRegistration,
+                              winrt::AdaptiveElementRendererRegistration const& elementRendererRegistration,
+                              winrt::AdaptiveActionRendererRegistration const& actionRendererRegistration,
+                              winrt::AdaptiveCardResourceResolvers const& resourceResolvers,
                               winrt::ResourceDictionary const& overrideStyles,
                               winrt::ResourceDictionary const& defaultActionSentimentStyles,
                               winrt::com_ptr<implementation::RenderedAdaptiveCard> const& renderResult);
@@ -36,13 +36,13 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         property<winrt::AdaptiveCardResourceResolvers> ResourceResolvers;
         property<winrt::ResourceDictionary> OverrideStyles;
 
-        Uwp::AdaptiveInputs UserInputs();
+        winrt::AdaptiveInputs UserInputs();
 
         void AddInputValue(winrt::IAdaptiveInputValue const& inputValue, winrt::AdaptiveRenderArgs const& renderArgs);
-        void LinkSubmitActionToCard(winrt::IAdaptiveActionElement const& submitAction, Uwp::AdaptiveRenderArgs const& renderArgs);
+        void LinkSubmitActionToCard(winrt::IAdaptiveActionElement const& submitAction, winrt::AdaptiveRenderArgs const& renderArgs);
         void LinkCardToParent(winrt::AdaptiveCard const& card, winrt::AdaptiveRenderArgs const& args);
 
-        Uwp::IAdaptiveInputValue GetInputValue(winrt::IAdaptiveInputElement const& inputElement);
+        winrt::IAdaptiveInputValue GetInputValue(winrt::IAdaptiveInputElement const& inputElement);
 
         void AddError(winrt::ErrorStatusCode statusCode, hstring const& message);
         void AddWarning(winrt::WarningStatusCode statusCode, hstring const& message);
@@ -50,12 +50,12 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         void AddInlineShowCard(winrt::AdaptiveActionSet const& actionSet,
                                winrt::AdaptiveShowCardAction const& showCardAction,
                                winrt::UIElement const& showCardUIElement,
-                               Uwp::AdaptiveRenderArgs const& renderArgs);
+                               winrt::AdaptiveRenderArgs const& renderArgs);
 
         void AddInlineShowCard(winrt::AdaptiveCard const& adaptiveCard,
                                winrt::AdaptiveShowCardAction const& showCardAction,
                                winrt::UIElement const& showCardUIElement,
-                               Uwp::AdaptiveRenderArgs const& renderArgs);
+                               winrt::AdaptiveRenderArgs const& renderArgs);
 
         void AddOverflowButton(winrt::AdaptiveActionSet const& actionSet, winrt::UIElement const& actionUIElement);
 

--- a/source/uwp/Renderer/lib/AdaptiveShowCardActionConfig.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveShowCardActionConfig.cpp
@@ -9,7 +9,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
 {
     AdaptiveShowCardActionConfig::AdaptiveShowCardActionConfig(::AdaptiveCards::ShowCardActionConfig const& sharedShowCardActionConfig)
     {
-        ActionMode = static_cast<winrt::AdaptiveCards::Rendering::Uwp::ActionMode>(sharedShowCardActionConfig.actionMode);
+        ActionMode = static_cast<winrt::render_xaml::ActionMode>(sharedShowCardActionConfig.actionMode);
         Style = static_cast<winrt::ContainerStyle>(sharedShowCardActionConfig.style);
         InlineTopMargin = sharedShowCardActionConfig.inlineTopMargin;
     }

--- a/source/uwp/Renderer/lib/AdaptiveShowCardActionConfig.h
+++ b/source/uwp/Renderer/lib/AdaptiveShowCardActionConfig.h
@@ -10,7 +10,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     {
         AdaptiveShowCardActionConfig(::AdaptiveCards::ShowCardActionConfig const& showCardActionConfig = {});
 
-        property<winrt::AdaptiveCards::Rendering::Uwp::ActionMode> ActionMode;
+        property<winrt::render_xaml::ActionMode> ActionMode;
         property<winrt::ContainerStyle> Style;
         property<uint32_t> InlineTopMargin;
     };

--- a/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.cpp
@@ -11,8 +11,8 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     std::tuple<winrt::UIElement, winrt::Border> AdaptiveTextInputRenderer::HandleLayoutAndValidation(
         winrt::AdaptiveTextInput const& adaptiveTextInput,
         winrt::UIElement const& inputUIElement,
-        winrt::AdaptiveCards::Rendering::Uwp::AdaptiveRenderContext const& renderContext,
-        winrt::AdaptiveCards::Rendering::Uwp::AdaptiveRenderArgs const& renderArgs)
+        winrt::AdaptiveRenderContext const& renderContext,
+        winrt::AdaptiveRenderArgs const& renderArgs)
     {
         // The text box may need to go into a number of parent containers to handle validation and inline actions.
         // textBoxParentContainer represents the current parent container.

--- a/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.h
@@ -12,17 +12,17 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         AdaptiveTextInputRenderer() = default;
 
         winrt::UIElement Render(winrt::IAdaptiveCardElement const& cardElement,
-                                                   winrt::AdaptiveRenderContext const& renderContext,
-                                                   winrt::AdaptiveRenderArgs const& renderArgs);
+                                winrt::AdaptiveRenderContext const& renderContext,
+                                winrt::AdaptiveRenderArgs const& renderArgs);
 
     private:
         winrt::UIElement AdaptiveTextInputRenderer::RenderTextBox(winrt::AdaptiveTextInput const& adaptiveTextInput,
-                                                                                     winrt::AdaptiveRenderContext const& renderContext,
-                                                                                     winrt::AdaptiveRenderArgs const& renderArgs);
+                                                                  winrt::AdaptiveRenderContext const& renderContext,
+                                                                  winrt::AdaptiveRenderArgs const& renderArgs);
 
         winrt::UIElement AdaptiveTextInputRenderer::RenderPasswordBox(winrt::AdaptiveTextInput const& adaptiveTextInput,
-                                                                                         winrt::AdaptiveRenderContext const& renderContext,
-                                                                                         winrt::AdaptiveRenderArgs const& renderArgs);
+                                                                      winrt::AdaptiveRenderContext const& renderContext,
+                                                                      winrt::AdaptiveRenderArgs const& renderArgs);
 
         std::tuple<winrt::UIElement, winrt::Border> HandleLayoutAndValidation(winrt::AdaptiveTextInput const& adaptiveTextInput,
                                                                               winrt::UIElement const& textBox,

--- a/source/uwp/Renderer/lib/RenderedAdaptiveCard.cpp
+++ b/source/uwp/Renderer/lib/RenderedAdaptiveCard.cpp
@@ -61,8 +61,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         }
     }
 
-    void HandleToggleVisibilityClick(winrt::FrameworkElement const& cardFrameworkElement,
-                                     winrt::IAdaptiveActionElement const& action)
+    void HandleToggleVisibilityClick(winrt::FrameworkElement const& cardFrameworkElement, winrt::IAdaptiveActionElement const& action)
     {
         auto toggleAction = action.as<winrt::AdaptiveToggleVisibilityAction>();
         std::vector<winrt::Panel> parentPanels;
@@ -89,8 +88,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
                 else if (toggle == winrt::IsVisible::IsVisibleToggle)
                 {
                     bool currentVisibility = elementTagContent.ExpectedVisibility();
-                    visibilityToSet = currentVisibility ? winrt::Visibility::Collapsed :
-                                                          winrt::Visibility::Visible;
+                    visibilityToSet = currentVisibility ? winrt::Visibility::Collapsed : winrt::Visibility::Visible;
                 }
 
                 toggleElementAsUIElement.Visibility(visibilityToSet);
@@ -104,8 +102,9 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
                 if (auto cardElementAsColumn = cardElement.try_as<winrt::AdaptiveColumn>())
                 {
                     auto columnDefinition = elementTagContent.ColumnDefinition();
-                    ::AdaptiveCards::Rendering::Uwp::XamlHelpers::HandleColumnWidth(
-                        cardElementAsColumn, (visibilityToSet == winrt::Visibility::Visible), columnDefinition);
+                    ::AdaptiveCards::Rendering::Uwp::XamlHelpers::HandleColumnWidth(cardElementAsColumn,
+                                                                                    (visibilityToSet == winrt::Visibility::Visible),
+                                                                                    columnDefinition);
                 }
             }
         }
@@ -133,7 +132,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
             auto actionConfig = m_originatingHostConfig.Actions();
             auto showCardConfig = actionConfig.ShowCard();
             auto actionMode = showCardConfig.ActionMode();
-            bool handleInlineShowCard = (actionMode == Uwp::ActionMode::Inline);
+            bool handleInlineShowCard = (actionMode == winrt::render_xaml::ActionMode::Inline);
 
             if (handleInlineShowCard)
             {
@@ -166,7 +165,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
                 associatedInputs = actionElement.as<winrt::AdaptiveExecuteAction>().AssociatedInputs();
             }
 
-            Uwp::AdaptiveInputs gatheredInputs;
+            winrt::AdaptiveInputs gatheredInputs;
             bool inputsAreValid;
             if (associatedInputs == winrt::AssociatedInputs::None)
             {
@@ -210,9 +209,12 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         m_frameworkElement = value;
     }
 
-    void RenderedAdaptiveCard::SetOriginatingCard(winrt::AdaptiveCard const& value) { m_originatingCard = value; }
+    void RenderedAdaptiveCard::SetOriginatingCard(winrt::AdaptiveCard const& value)
+    {
+        m_originatingCard = value;
+    }
 
-    void RenderedAdaptiveCard::SetOriginatingHostConfig(Rendering::Uwp::AdaptiveHostConfig const& value)
+    void RenderedAdaptiveCard::SetOriginatingHostConfig(winrt::AdaptiveHostConfig const& value)
     {
         m_originatingHostConfig = value;
     }
@@ -220,7 +222,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     void RenderedAdaptiveCard::AddInlineShowCard(winrt::AdaptiveActionSet const& actionSet,
                                                  winrt::IAdaptiveShowCardAction const& showCardAction,
                                                  winrt::UIElement const& showCardUIElement,
-                                                 Rendering::Uwp::AdaptiveRenderArgs const& renderArgs)
+                                                 winrt::AdaptiveRenderArgs const& renderArgs)
     {
         AddInlineShowCardHelper(actionSet.InternalId(), showCardAction, showCardUIElement, renderArgs);
     }
@@ -228,7 +230,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     void RenderedAdaptiveCard::AddInlineShowCard(winrt::AdaptiveCard const& adaptiveCard,
                                                  winrt::IAdaptiveShowCardAction const& showCardAction,
                                                  winrt::UIElement const& showCardUIElement,
-                                                 Uwp::AdaptiveRenderArgs const& renderArgs)
+                                                 winrt::AdaptiveRenderArgs const& renderArgs)
     {
         AddInlineShowCardHelper(adaptiveCard.InternalId(), showCardAction, showCardUIElement, renderArgs);
     }
@@ -236,7 +238,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     void RenderedAdaptiveCard::AddInlineShowCardHelper(uint32_t actionSetId,
                                                        winrt::IAdaptiveShowCardAction const& showCardAction,
                                                        winrt::UIElement const& showCardUIElement,
-                                                       Uwp::AdaptiveRenderArgs const& renderArgs)
+                                                       winrt::AdaptiveRenderArgs const& renderArgs)
     {
         auto showCardInfo = std::make_shared<ShowCardInfo>();
         showCardInfo->actionSetId = actionSetId;
@@ -248,14 +250,12 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         LinkCardToParent(showCardAction.Card(), renderArgs);
     }
 
-    void RenderedAdaptiveCard::AddOverflowButton(winrt::AdaptiveActionSet const& actionSet,
-                                                 winrt::UIElement const& actionUIElement)
+    void RenderedAdaptiveCard::AddOverflowButton(winrt::AdaptiveActionSet const& actionSet, winrt::UIElement const& actionUIElement)
     {
         m_overflowButtons.emplace(std::make_pair(actionSet.InternalId(), actionUIElement));
     }
 
-    void RenderedAdaptiveCard::AddOverflowButton(winrt::AdaptiveCard const& actionCard,
-                                                 winrt::UIElement const& actionUIElement)
+    void RenderedAdaptiveCard::AddOverflowButton(winrt::AdaptiveCard const& actionCard, winrt::UIElement const& actionUIElement)
     {
         m_overflowButtons.emplace(std::make_pair(actionCard.InternalId(), actionUIElement));
     }
@@ -266,7 +266,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     }
 
     void RenderedAdaptiveCard::LinkActionToCard(winrt::IAdaptiveActionElement const& submitAction,
-                                                Uwp::AdaptiveRenderArgs const& renderArgs)
+                                                winrt::AdaptiveRenderArgs const& renderArgs)
     {
         return m_inputs->LinkSubmitActionToCard(submitAction, renderArgs);
     }
@@ -289,7 +289,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         m_inputs->LinkCardToParent(cardId, parentCardId);
     }
 
-    Rendering::Uwp::IAdaptiveInputValue RenderedAdaptiveCard::GetInputValue(winrt::IAdaptiveInputElement const& inputElement)
+    winrt::IAdaptiveInputValue RenderedAdaptiveCard::GetInputValue(winrt::IAdaptiveInputElement const& inputElement)
     {
         return m_inputs->GetInputValue(inputElement);
     }

--- a/source/uwp/Renderer/lib/RenderedAdaptiveCard.h
+++ b/source/uwp/Renderer/lib/RenderedAdaptiveCard.h
@@ -43,12 +43,12 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         void AddInlineShowCard(winrt::AdaptiveActionSet const& actionSet,
                                winrt::IAdaptiveShowCardAction const& showCardAction,
                                winrt::UIElement const& showCardUIElement,
-                               Rendering::Uwp::AdaptiveRenderArgs const& renderArgs);
+                               winrt::AdaptiveRenderArgs const& renderArgs);
 
         void AddInlineShowCard(winrt::AdaptiveCard const& adaptiveCard,
                                winrt::IAdaptiveShowCardAction const& showCardAction,
                                winrt::UIElement const& showCardUIElement,
-                               Uwp::AdaptiveRenderArgs const& renderArgs);
+                               winrt::AdaptiveRenderArgs const& renderArgs);
 
         void AddOverflowButton(winrt::AdaptiveActionSet const& actionSet, winrt::UIElement const& actionUIElement);
 
@@ -57,11 +57,11 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         void AddInputValue(winrt::IAdaptiveInputValue const& inputValue, winrt::AdaptiveRenderArgs const& renderArgs);
         void LinkActionToCard(winrt::IAdaptiveActionElement const& submitAction, winrt::AdaptiveRenderArgs const& renderArgs);
         void LinkCardToParent(winrt::AdaptiveCard const& card, winrt::AdaptiveRenderArgs const& renderArgs);
-        Uwp::IAdaptiveInputValue GetInputValue(winrt::IAdaptiveInputElement const& inputElement);
+        winrt::IAdaptiveInputValue GetInputValue(winrt::IAdaptiveInputElement const& inputElement);
 
         void SetFrameworkElement(winrt::FrameworkElement const& value);
         void SetOriginatingCard(winrt::AdaptiveCard const& value);
-        void SetOriginatingHostConfig(Rendering::Uwp::AdaptiveHostConfig const& value);
+        void SetOriginatingHostConfig(winrt::AdaptiveHostConfig const& value);
         void SendActionEvent(winrt::IAdaptiveActionElement const& eventArgs);
         void SendMediaClickedEvent(winrt::AdaptiveMedia const& eventArgs);
 
@@ -71,10 +71,10 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         void AddInlineShowCardHelper(uint32_t internalId,
                                      winrt::IAdaptiveShowCardAction const& showCardAction,
                                      winrt::UIElement const& showCardUIElement,
-                                     Uwp::AdaptiveRenderArgs const& renderArgs);
+                                     winrt::AdaptiveRenderArgs const& renderArgs);
 
         winrt::AdaptiveCard m_originatingCard;
-        Rendering::Uwp::AdaptiveHostConfig m_originatingHostConfig;
+        winrt::AdaptiveHostConfig m_originatingHostConfig;
         winrt::com_ptr<winrt::implementation::AdaptiveInputs> m_inputs;
         winrt::FrameworkElement m_frameworkElement;
 

--- a/source/uwp/Renderer/lib/Util.h
+++ b/source/uwp/Renderer/lib/Util.h
@@ -131,16 +131,13 @@ winrt::Windows::UI::Color GetColorFromAdaptiveColor(winrt::AdaptiveHostConfig co
                                                     bool isSubtle,
                                                     bool highlight);
 
-winrt::Windows::UI::Color GetBackgroundColorFromStyle(winrt::ContainerStyle const& style,
-   winrt::AdaptiveHostConfig const& hostConfig);
+winrt::Windows::UI::Color GetBackgroundColorFromStyle(winrt::ContainerStyle const& style, winrt::AdaptiveHostConfig const& hostConfig);
 
-winrt::Windows::UI::Color GetBorderColorFromStyle(winrt::ContainerStyle style,
-                                                  winrt::AdaptiveHostConfig const& hostConfig);
+winrt::Windows::UI::Color GetBorderColorFromStyle(winrt::ContainerStyle style, winrt::AdaptiveHostConfig const& hostConfig);
 
-winrt::TextHighlighter
-GetHighlighter(winrt::IAdaptiveTextElement const& adaptiveTextElement,
-               winrt::AdaptiveRenderContext const& renderContext,
-               winrt::AdaptiveRenderArgs const& renderArgs);
+winrt::TextHighlighter GetHighlighter(winrt::IAdaptiveTextElement const& adaptiveTextElement,
+                                      winrt::AdaptiveRenderContext const& renderContext,
+                                      winrt::AdaptiveRenderArgs const& renderArgs);
 
 winrt::hstring GetFontFamilyFromFontType(winrt::AdaptiveHostConfig const& hostConfig, winrt::FontType const& fontType);
 
@@ -175,7 +172,6 @@ struct ShowCardInfo
     winrt::UIElement cardUIElement{nullptr};
 };
 
-
 struct SeparatorParemeters
 {
     winrt::Windows::UI::Color color{0};
@@ -207,16 +203,13 @@ template<typename D, typename I> winrt::com_ptr<D> peek_innards(I&& o)
     return out;
 }
 
-winrt::Uri GetUrlFromString(winrt::AdaptiveHostConfig const& hostConfig,
-                                                 winrt::hstring const& urlString);
+winrt::Uri GetUrlFromString(winrt::AdaptiveHostConfig const& hostConfig, winrt::hstring const& urlString);
 
 winrt::Windows::UI::Color GenerateLHoverColor(winrt::Windows::UI::Color const& originalColor);
 
 winrt::DateTime GetDateTime(unsigned int year, unsigned int month, unsigned int day);
 
-winrt::IReference<winrt::DateTime> GetDateTimeReference(unsigned int year,
-                                                                                                  unsigned int month,
-                                                                                                  unsigned int day);
+winrt::IReference<winrt::DateTime> GetDateTimeReference(unsigned int year, unsigned int month, unsigned int day);
 
 winrt::IAdaptiveTextElement CopyTextElement(winrt::IAdaptiveTextElement const& textElement);
 

--- a/source/uwp/Renderer/lib/XamlHelpers.h
+++ b/source/uwp/Renderer/lib/XamlHelpers.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "WholeItemsPanel.h"
+
 namespace AdaptiveCards::Rendering::Uwp::XamlHelpers
 {
     void SetStyleFromResourceDictionary(winrt::AdaptiveRenderContext const& renderContext,


### PR DESCRIPTION
# Related Issue

N/A

# Description

Current references to the `::winrt::AdaptiveCards::Rendering::Uwp` namespace are inconsistent. Sometimes it is fully qualified, other times `Rendering::Uwp`, `Uwp`, or most often just `winrt` is used. This PR changes all references to use `winrt::`, except for with `ActionMode`, since there is a type of the same name in the ObjectModel. Here, we have an alias for the namespace, `render_xaml`, that we use in addition.

# How Verified

Manually tested UWP visualizer.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8094)