### PR TITLE
[Accessibility|Visualizer]: Add shortcuts for interface buttons

### DIFF
--- a/source/uwp/Visualizer/MainPage.xaml
+++ b/source/uwp/Visualizer/MainPage.xaml
@@ -11,7 +11,7 @@
     <Page.Resources>
         <Style x:Key="CommandButton" TargetType="Button">
             <Setter Property="Margin" Value="5,0,0,0"/>
-        </Style>  
+        </Style>
     </Page.Resources>
 
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
@@ -27,27 +27,53 @@
                     <AppBarButton
                         Icon="Add"
                         Label="New card"
+                        ToolTipService.ToolTip="New Card (Ctrl+N)" 
                         x:Name="AppBarNew"
                         Click="AppBarNew_Click"
-                        IsCompact="True"/>
+                        IsCompact="True"
+                        AccessKey="N">
+                        <AppBarButton.KeyboardAccelerators>
+                            <KeyboardAccelerator
+                                Modifiers="Control"
+                                Key="N"/>
+                        </AppBarButton.KeyboardAccelerators>
+                    </AppBarButton>
                     <AppBarButton
                         x:Name="AppBarOpen"
                         Icon="OpenFile"
                         Label="Open file"
+                        ToolTipService.ToolTip="Open File (Ctrl+O)" 
                         Click="AppBarOpen_Click"
-                        IsCompact="True"/>
+                        IsCompact="True"
+                        AccessKey="O">
+                        <AppBarButton.KeyboardAccelerators>
+                            <KeyboardAccelerator
+                                Modifiers="Control"
+                                Key="O"/>
+                        </AppBarButton.KeyboardAccelerators>
+                    </AppBarButton>
                     <AppBarButton
                         x:Name="AppBarSave"
                         Icon="Save"
                         Label="Save file"
+                        ToolTipService.ToolTip="Save File (Ctrl+S)"
                         Click="AppBarSave_Click"
-                        IsCompact="True"/>
+                        IsCompact="True"
+                        AccessKey="S">
+                        <AppBarButton.KeyboardAccelerators>
+                            <KeyboardAccelerator
+                                Modifiers="Control"
+                                Key="S"/>
+                        </AppBarButton.KeyboardAccelerators>
+                    </AppBarButton>
                     <AppBarButton
                         x:Name="AppBarHostConfigEditor"
                         Icon="Setting"
                         Label="Host config"
+                        ToolTipService.ToolTip="Open Settings (Ctrl+,)"
                         IsCompact="True"
-                        Click="AppBarHostConfigEditor_Click"/>
+                        Click="AppBarHostConfigEditor_Click"
+                        AccessKey=","/>
                 </StackPanel>
             </CommandBar.Content>
             <CommandBar.SecondaryCommands>
@@ -62,7 +88,7 @@
                 <ColumnDefinition Width="200"/>
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
-            
+
             <!--Tabs-->
             <ListView
                 x:Name="ListViewTabs"
@@ -87,13 +113,13 @@
                 Visibility="{Binding CurrentDocument, Converter={StaticResource NotNullToVisibilityConverter}}"/>
 
         </Grid>
-        
+
         <!--Host config editor-->
         <Grid
             Grid.Row="1"
             x:Name="HostConfigEditorView"
             Visibility="Collapsed">
-            
+
             <Rectangle
                 Fill="Black"
                 Opacity="0.3"
@@ -120,5 +146,5 @@
         </Grid>
 
     </Grid>
-    
+
 </Page>

--- a/source/uwp/Visualizer/MainPage.xaml.cs
+++ b/source/uwp/Visualizer/MainPage.xaml.cs
@@ -19,6 +19,7 @@ using Windows.UI.Xaml.Navigation;
 
 using AdaptiveCards.Rendering.Uwp;
 using AdaptiveCardVisualizer.ViewModel;
+using Windows.System;
 
 // The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=402352&clcid=0x409
 
@@ -40,6 +41,8 @@ namespace AdaptiveCardVisualizer
 
         private async void Load()
         {
+            SetKeyboardAcceleratorForSettingsButton();
+
             IsEnabled = false;
 
             ViewModel = await MainPageViewModel.LoadAsync();
@@ -125,6 +128,21 @@ namespace AdaptiveCardVisualizer
         private void HostConfigTransparentBackdrop_Tapped(object sender, TappedRoutedEventArgs e)
         {
             SetIsInHostConfigEditor(false);
+        }
+
+        /*
+         * We need to set KeyboardAccelerator for Settings button in code behind
+         * because virtual key for "comma" doesn't exist in the Windows.System.VirtualKey enum
+         * and we're not able to assign this shortcut in the markup.
+        */
+        private void SetKeyboardAcceleratorForSettingsButton()
+        {
+            KeyboardAccelerator accelerator = new KeyboardAccelerator
+            {
+                Key = (Windows.System.VirtualKey)188, // 188 is VK_OEM_COMMA which doesn't exist in enum
+                Modifiers = VirtualKeyModifiers.Control
+            };
+            AppBarHostConfigEditor.KeyboardAccelerators.Add(accelerator);
         }
     }
 }


### PR DESCRIPTION
# Related Issue

Closes #8043

# Description

This PR will add shortcuts for the main interface buttons in UWP Visualizer and `AccessKeys` (alt + Accesskey) to use their functionality.

# Screenshots

After ALT was pressed:
![image](https://user-images.githubusercontent.com/21356912/205734617-a9720caf-5736-4cf8-abd2-a8e42f0612bd.png)

Tooltips:
![image](https://user-images.githubusercontent.com/21356912/205734676-bba22a5e-d674-4f62-9fd9-c84ff9341987.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8100)