### PR TITLE
[NodeJS|UITests]: Fix ActivityUpdate Test after accessbility fix to the card

### DIFF
--- a/source/nodejs/tests/ui-tests/src/ui-tests.test.ts
+++ b/source/nodejs/tests/ui-tests/src/ui-tests.test.ts
@@ -36,7 +36,7 @@ describe("Mock function", function() {
         let dueDateInput = await ACInputDate.getInputWithId("dueDate");
         await dueDateInput.setDate(1993, 2, 4);
 
-        await ACAction.clickOnActionWithTitle("OK");
+        await ACAction.clickOnActionWithTitle("Send");
         
         Assert.strictEqual(await utils.getInputFor("dueDate"), "1993-02-04");
 


### PR DESCRIPTION
NodeJS daily tests are failing because after https://github.com/microsoft/AdaptiveCards/pull/8092 was checked in - the test for the updated card didn't reflect the changes.