### PR TITLE
Rename Action.Execute related interfaces

### DIFF
--- a/source/nodejs/adaptivecards-aaf-testapp/src/app.ts
+++ b/source/nodejs/adaptivecards-aaf-testapp/src/app.ts
@@ -24,19 +24,19 @@ window.onload = function() {
     applet.channelAdapter = new TestChannelAdapter("https://acv2testbot.azurewebsites.net/aaftestbot/invoke");
 
     applet.setCard(Shared.sampleCard);
-    // applet.onActivityRequestFailed = (sender, response) => { return 2000; }
-    applet.onActivityRequestSucceeded = (sender: Adaptive.AdaptiveApplet, response: Adaptive.SuccessResponse, parsedContent: string | Adaptive.AdaptiveCard) => {
+    // applet.onExecuteRequestFailed = (sender, response) => { return 2000; }
+    applet.onExecuteRequestSucceeded = (sender: Adaptive.AdaptiveApplet, response: Adaptive.SuccessResponse, parsedContent: string | Adaptive.AdaptiveCard) => {
         if (parsedContent !== undefined && typeof parsedContent === "string") {
             alert(parsedContent);
         }
     }
-    applet.onSSOTokenNeeded = (sender: Adaptive.AdaptiveApplet, request: Adaptive.IActivityRequest, tokenExchangeResource: Adaptive.TokenExchangeResource) => {
+    applet.onSSOTokenNeeded = (sender: Adaptive.AdaptiveApplet, request: Adaptive.IExecuteRequest, tokenExchangeResource: Adaptive.TokenExchangeResource) => {
         request.authToken = "valid_sso_token";
         request.retryAsync();
 
         return true;
     }
-    applet.onShowSigninPrompt = (sender: Adaptive.AdaptiveApplet, request: Adaptive.IActivityRequest, signinButton: Adaptive.AuthCardButton) => {
+    applet.onShowSigninPrompt = (sender: Adaptive.AdaptiveApplet, request: Adaptive.IExecuteRequest, signinButton: Adaptive.AuthCardButton) => {
         alert("Simulating auth prompt...");
 
         request.authCode = request.attemptNumber > 1 ? "valid_auth_code" : "invalid_auth_code";

--- a/source/nodejs/adaptivecards-aaf-testapp/src/test-channel-adapter.ts
+++ b/source/nodejs/adaptivecards-aaf-testapp/src/test-channel-adapter.ts
@@ -7,7 +7,7 @@ export class TestChannelAdapter extends Adaptive.ChannelAdapter {
         super();
     }
 
-    async sendRequestAsync(request: Adaptive.IActivityRequest): Promise<Adaptive.ActivityResponse> {
+    async sendRequestAsync(request: Adaptive.IExecuteRequest): Promise<Adaptive.ActivityResponse> {
         if (request.action.verb === "localException") {
             throw new Error("Local exception");
         }

--- a/source/nodejs/adaptivecards/docs/README.md
+++ b/source/nodejs/adaptivecards/docs/README.md
@@ -145,6 +145,7 @@
 
 * [ActivityRequest](interfaces/activityrequest.md)
 * [ActivityResponse](interfaces/activityresponse.md)
+* [ExecuteRequest](interfaces/executerequest.md)
 * [IAction](interfaces/iaction.md)
 * [IAdaptiveCard](interfaces/iadaptivecard.md)
 * [IBackgroundImage](interfaces/ibackgroundimage.md)

--- a/source/nodejs/adaptivecards/docs/classes/adaptiveapplet.md
+++ b/source/nodejs/adaptivecards/docs/classes/adaptiveapplet.md
@@ -15,12 +15,12 @@
 ### Properties
 
 * [channelAdapter](adaptiveapplet.md#channeladapter)
-* [onActivityRequestFailed](adaptiveapplet.md#optional-onactivityrequestfailed)
-* [onActivityRequestSucceeded](adaptiveapplet.md#optional-onactivityrequestsucceeded)
+* [onExecuteRequestFailed](adaptiveapplet.md#optional-onexecuterequestfailed)
+* [onExecuteRequestSucceeded](adaptiveapplet.md#optional-onexecuterequestsucceeded)
 * [onCardChanged](adaptiveapplet.md#optional-oncardchanged)
 * [onCardChanging](adaptiveapplet.md#optional-oncardchanging)
 * [onCreateProgressOverlay](adaptiveapplet.md#optional-oncreateprogressoverlay)
-* [onPrepareActivityRequest](adaptiveapplet.md#optional-onprepareactivityrequest)
+* [onPrepareExecuteRequest](adaptiveapplet.md#optional-onprepareexecuterequest)
 * [onRenderRefreshButton](adaptiveapplet.md#optional-onrenderrefreshbutton)
 * [renderedElement](adaptiveapplet.md#renderedelement)
 * [userId](adaptiveapplet.md#optional-userid)
@@ -51,15 +51,15 @@
 
 ___
 
-### `Optional` onActivityRequestFailed
+### `Optional` onExecuteRequestFailed
 
-• **onActivityRequestFailed**? : *undefined | function*
+• **onExecuteRequestFailed**? : *undefined | function*
 
 ___
 
-### `Optional` onActivityRequestSucceeded
+### `Optional` onExecuteRequestSucceeded
 
-• **onActivityRequestSucceeded**? : *undefined | function*
+• **onExecuteRequestSucceeded**? : *undefined | function*
 
 ___
 
@@ -81,9 +81,9 @@ ___
 
 ___
 
-### `Optional` onPrepareActivityRequest
+### `Optional` onPrepareExecuteRequest
 
-• **onPrepareActivityRequest**? : *undefined | function*
+• **onPrepareExecuteRequest**? : *undefined | function*
 
 ___
 

--- a/source/nodejs/adaptivecards/docs/interfaces/activityrequest.md
+++ b/source/nodejs/adaptivecards/docs/interfaces/activityrequest.md
@@ -10,24 +10,10 @@
 
 ### Properties
 
-* [activity](activityrequest.md#activity)
-* [attemptNumber](activityrequest.md#attemptnumber)
-* [consecutiveRefreshes](activityrequest.md#consecutiverefreshes)
+* [retryAsync](activityrequest.md#retryAsync)
 
 ## Properties
 
-###  activity
+###  retryAsync
 
-• **activity**: *[InvokeActivity](invokeactivity.md)*
-
-___
-
-###  attemptNumber
-
-• **attemptNumber**: *number*
-
-___
-
-###  consecutiveRefreshes
-
-• **consecutiveRefreshes**: *number*
+• **retryAsync**(): *void*

--- a/source/nodejs/adaptivecards/docs/interfaces/executerequest.md
+++ b/source/nodejs/adaptivecards/docs/interfaces/executerequest.md
@@ -1,0 +1,33 @@
+[Adaptive Cards Javascript SDK](../README.md) › [ExecuteRequest](executerequest.md)
+
+# Interface: ExecuteRequest
+
+## Hierarchy
+
+* **ExecuteRequest**
+
+## Index
+
+### Properties
+
+* [activity](executerequest.md#activity)
+* [attemptNumber](executerequest.md#attemptnumber)
+* [consecutiveRefreshes](executerequest.md#consecutiverefreshes)
+
+## Properties
+
+###  activity
+
+• **activity**: *[InvokeActivity](invokeactivity.md)*
+
+___
+
+###  attemptNumber
+
+• **attemptNumber**: *number*
+
+___
+
+###  consecutiveRefreshes
+
+• **consecutiveRefreshes**: *number*

--- a/source/nodejs/adaptivecards/src/activity-request.ts
+++ b/source/nodejs/adaptivecards/src/activity-request.ts
@@ -7,21 +7,23 @@ import {
     TokenExchangeResource
 } from "./card-elements";
 
-export enum ActivityRequestTrigger {
+export enum ExecuteRequestTrigger {
     Automatic = "automatic",
     Manual = "manual"
 }
 
 export interface IActivityRequest {
+    retryAsync(): void;
+}
+
+export interface IExecuteRequest extends IActivityRequest {
     readonly action: ExecuteAction;
-    readonly trigger: ActivityRequestTrigger;
+    readonly trigger: ExecuteRequestTrigger;
     readonly attemptNumber: number;
     readonly consecutiveRefreshes: number;
 
     authCode?: string;
     authToken?: string;
-
-    retryAsync(): void;
 }
 
 export class ActivityRequestError {
@@ -48,7 +50,7 @@ export class LoginRequestResponse extends ActivityResponse {
     private _auth: Authentication;
     readonly signinButton?: AuthCardButton;
 
-    constructor(readonly request: IActivityRequest, auth: Authentication) {
+    constructor(readonly request: IExecuteRequest, auth: Authentication) {
         super(request);
         this._auth = auth;
 


### PR DESCRIPTION
# Related Issue
https://github.com/microsoft/AdaptiveCards/issues/3924

# Description
We aim to utilize **ChannelAdapter** abstraction to handle request/response for Dynamic Typeahead in Input.Choiceset. Currently, it is only used for Action.Execute and the interfaces tied up with it, although general in name, are specific to Action.Execute. This PR introduces the changes which make it more generic to be used for other types of requests.

# Breaking Changes
1. [activity-request.ts](https://github.com/microsoft/AdaptiveCards/blob/main/source/nodejs/adaptivecards/src/activity-request.ts): Renamed interface IActivityRequest to IExecuteRequest
3. [adaptive-applet.ts](https://github.com/microsoft/AdaptiveCards/blob/main/source/nodejs/adaptivecards/src/adaptive-applet.ts): Renamed instance methods of class AdaptiveApplet: 
- onPrepareActivityRequest to onPrepareExecuteRequest
- onActivityRequestSucceeded to onExecuteRequestSucceeded
- onActivityRequestFailed to onExecuteRequestFailed

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8108)