### PR TITLE
[Nodejs|UITests]: Add wait time for image load in failing test

### DIFF
--- a/source/nodejs/tests/ui-tests/src/ui-tests.test.ts
+++ b/source/nodejs/tests/ui-tests/src/ui-tests.test.ts
@@ -8,8 +8,12 @@ import { WaitUtils } from "./wait-utils";
 describe("Mock function", function() {
     let utils: TestUtils;
 
+    // This is a constant value for the wait time until the image is loaded.
+    // Only use this if you see some test flakiness. Values is given in ms.
+    const timeoutForImageLoad: number = 1000;
+
     // This is a constant value for the wait time between pressing an action and retrieving
-    // the input value. Only use this if you see some test flakiness. Value is given in ms
+    // the input value. Only use this if you see some test flakiness. Value is given in ms.
     const delayForCarouselTimer: number = 6000;
     const timeOutValueForCarousel: number = 30000;
     const timeOutValueForSuddenJumpTest: number = 20000;
@@ -198,6 +202,8 @@ describe("Mock function", function() {
         await utils.goToTestCase("v1.0/Image.SelectAction");
 
         let image = await ACImage.getImage("cool link");
+
+        await TestUtils.getInstance().driver.wait(image.elementIsVisible(), timeoutForImageLoad);
         await image.click();
         
         Assert.strictEqual(await utils.getUrlInRetrievedInputs(), "https://www.youtube.com/watch?v=dQw4w9WgXcQ");


### PR DESCRIPTION
In the recent test runs `Image: Test select action can be clicked` was behaving inconsistently. The image that the test is trying to click was not loaded in time and the test failed. I believe it may be caused by network/image hosting server response time.

I've added a minimum wait to make sure image is loaded and test is consistent.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8110)