### PR TITLE
[UWP Visualizer] Add override text for keyboard accelerator

### DIFF
--- a/source/uwp/Visualizer/AdaptiveCardVisualizer.csproj
+++ b/source/uwp/Visualizer/AdaptiveCardVisualizer.csproj
@@ -12,7 +12,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.17134.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/source/uwp/Visualizer/MainPage.xaml
+++ b/source/uwp/Visualizer/MainPage.xaml
@@ -73,7 +73,8 @@
                         ToolTipService.ToolTip="Open Settings (Ctrl+,)"
                         IsCompact="True"
                         Click="AppBarHostConfigEditor_Click"
-                        AccessKey=","/>
+                        AccessKey=","
+                        KeyboardAcceleratorTextOverride="Ctrl+,"/>
                 </StackPanel>
             </CommandBar.Content>
             <CommandBar.SecondaryCommands>


### PR DESCRIPTION
# Related Issue

Fixes #8111 

# Description

Upgraded the minimum platform version so that we can add `KeyboardAcceleratorTextOverride` property to the `AppBarButton`.

Without the override text, the visualizer crashes while using Narrator.

# How Verified

Verified manually on the UWP visualizer with Narrator enabled.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8112)