### PR TITLE
[UWP Renderer] Simplify header inclusions

### DIFF
--- a/source/uwp/Renderer/lib/ActionHelpers.cpp
+++ b/source/uwp/Renderer/lib/ActionHelpers.cpp
@@ -3,10 +3,11 @@
 #include "pch.h"
 
 #include "ActionHelpers.h"
+#include "AdaptiveHostConfig.h"
 #include "AdaptiveRenderArgs.h"
 #include "AdaptiveShowCardActionRenderer.h"
 #include "LinkButton.h"
-#include "AdaptiveHostConfig.h"
+#include "WholeItemsPanel.h"
 
 namespace AdaptiveCards::Rendering::Uwp::ActionHelpers
 {

--- a/source/uwp/Renderer/lib/AdaptiveActionInvoker.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveActionInvoker.cpp
@@ -4,7 +4,6 @@
 
 #include "AdaptiveActionInvoker.h"
 #include "AdaptiveActionInvoker.g.cpp"
-#include "Util.h"
 
 namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
 {

--- a/source/uwp/Renderer/lib/AdaptiveCardConfig.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveCardConfig.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 #include "pch.h"
-#include "Util.h"
+
 #include "AdaptiveCardConfig.h"
 #include "AdaptiveCardConfig.g.cpp"
 

--- a/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.cpp
@@ -4,6 +4,7 @@
 
 #include "AdaptiveChoiceSetInputRenderer.h"
 #include "AdaptiveChoiceSetInputRenderer.g.cpp"
+#include "InputValue.h"
 #include "ParseUtil.h"
 #include "WholeItemsPanel.h"
 

--- a/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.cpp
@@ -5,6 +5,7 @@
 #include "AdaptiveChoiceSetInputRenderer.h"
 #include "AdaptiveChoiceSetInputRenderer.g.cpp"
 #include "ParseUtil.h"
+#include "WholeItemsPanel.h"
 
 namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
 {

--- a/source/uwp/Renderer/lib/AdaptiveColorConfig.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveColorConfig.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 #include "pch.h"
-#include "Util.h"
+
 #include "AdaptiveColorConfig.h"
 #include "AdaptiveHighlightColorConfig.h"
 #include "AdaptiveColorConfig.g.cpp"

--- a/source/uwp/Renderer/lib/AdaptiveColumnRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveColumnRenderer.cpp
@@ -7,6 +7,7 @@
 
 #include "ActionHelpers.h"
 #include "AdaptiveRenderArgs.h"
+#include "WholeItemsPanel.h"
 
 namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
 {

--- a/source/uwp/Renderer/lib/AdaptiveColumnSetRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveColumnSetRenderer.cpp
@@ -7,6 +7,7 @@
 
 #include "ActionHelpers.h"
 #include "AdaptiveRenderArgs.h"
+#include "WholeItemsPanel.h"
 
 namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
 {

--- a/source/uwp/Renderer/lib/AdaptiveContainerRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveContainerRenderer.cpp
@@ -6,6 +6,7 @@
 #include "AdaptiveContainerRenderer.h"
 #include "AdaptiveContainerRenderer.g.cpp"
 #include "AdaptiveRenderArgs.h"
+#include "WholeItemsPanel.h"
 
 namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
 {

--- a/source/uwp/Renderer/lib/AdaptiveDateInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveDateInputRenderer.cpp
@@ -4,6 +4,7 @@
 
 #include "AdaptiveDateInputRenderer.h"
 #include "AdaptiveDateInputRenderer.g.cpp"
+#include "InputValue.h"
 
 namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
 {

--- a/source/uwp/Renderer/lib/AdaptiveFactSetRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveFactSetRenderer.cpp
@@ -5,6 +5,7 @@
 #include "AdaptiveFactSetRenderer.h"
 #include "AdaptiveFactSetRenderer.g.cpp"
 #include "TextHelpers.h"
+#include "WholeItemsPanel.h"
 
 namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
 {

--- a/source/uwp/Renderer/lib/AdaptiveImageRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImageRenderer.cpp
@@ -9,6 +9,7 @@
 #include "AdaptiveBase64Util.h"
 #include "AdaptiveCardGetResourceStreamArgs.h"
 #include <robuffer.h>
+#include "WholeItemsPanel.h"
 
 namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
 {

--- a/source/uwp/Renderer/lib/AdaptiveImageSetRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImageSetRenderer.cpp
@@ -5,6 +5,7 @@
 #include "AdaptiveImageSetRenderer.h"
 #include "AdaptiveImageSetRenderer.g.cpp"
 #include "AdaptiveRenderArgs.h"
+#include "WholeItemsPanel.h"
 
 namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
 {

--- a/source/uwp/Renderer/lib/AdaptiveInputs.h
+++ b/source/uwp/Renderer/lib/AdaptiveInputs.h
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 #pragma once
 
-#include "AdaptiveCards.Rendering.Uwp.h"
 #include "InputValue.h"
 #include "AdaptiveInputs.g.h"
 

--- a/source/uwp/Renderer/lib/AdaptiveMediaEventInvoker.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveMediaEventInvoker.cpp
@@ -4,7 +4,6 @@
 
 #include "AdaptiveMediaEventInvoker.h"
 #include "AdaptiveMediaEventInvoker.g.cpp"
-#include "Util.h"
 
 namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
 {

--- a/source/uwp/Renderer/lib/AdaptiveMediaRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveMediaRenderer.cpp
@@ -7,6 +7,7 @@
 
 #include "ActionHelpers.h"
 #include "MediaHelpers.h"
+#include "WholeItemsPanel.h"
 
 using namespace render_xaml::MediaHelpers;
 

--- a/source/uwp/Renderer/lib/AdaptiveNumberInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveNumberInputRenderer.cpp
@@ -5,6 +5,7 @@
 #include "AdaptiveNumberInputRenderer.h"
 #include "AdaptiveNumberInputRenderer.g.cpp"
 #include <limits>
+#include "InputValue.h"
 
 namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
 {

--- a/source/uwp/Renderer/lib/AdaptiveOpenUrlActionRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveOpenUrlActionRenderer.cpp
@@ -4,7 +4,6 @@
 
 #include "AdaptiveOpenUrlActionRenderer.h"
 #include "AdaptiveOpenUrlActionRenderer.g.cpp"
-#include "Util.h"
 #include "ActionHelpers.h"
 
 namespace winrt::AdaptiveCards::Rendering::Uwp::implementation

--- a/source/uwp/Renderer/lib/AdaptiveRenderContext.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveRenderContext.cpp
@@ -5,7 +5,6 @@
 #include "AdaptiveRenderContext.h"
 #include "AdaptiveRenderContext.g.cpp"
 #include "InputValue.h"
-#include "Util.h"
 
 namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
 {

--- a/source/uwp/Renderer/lib/AdaptiveRenderContext.h
+++ b/source/uwp/Renderer/lib/AdaptiveRenderContext.h
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 #pragma once
 
-#include "AdaptiveCards.Rendering.Uwp.h"
 #include "RenderedAdaptiveCard.h"
 #include "AdaptiveActionInvoker.h"
 #include "AdaptiveMediaEventInvoker.h"

--- a/source/uwp/Renderer/lib/AdaptiveTableRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTableRenderer.cpp
@@ -4,6 +4,7 @@
 
 #include "AdaptiveTableRenderer.h"
 #include "AdaptiveTableRenderer.g.cpp"
+#include "WholeItemsPanel.h"
 
 namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
 {

--- a/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTextInputRenderer.cpp
@@ -5,6 +5,7 @@
 #include "AdaptiveTextInputRenderer.h"
 #include "AdaptiveTextInputRenderer.g.cpp"
 #include "ActionHelpers.h"
+#include "InputValue.h"
 
 namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
 {

--- a/source/uwp/Renderer/lib/AdaptiveTimeInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTimeInputRenderer.cpp
@@ -4,6 +4,7 @@
 
 #include "AdaptiveTimeInputRenderer.h"
 #include "AdaptiveTimeInputRenderer.g.cpp"
+#include "InputValue.h"
 
 namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
 {

--- a/source/uwp/Renderer/lib/AdaptiveToggleInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveToggleInputRenderer.cpp
@@ -4,6 +4,7 @@
 
 #include "AdaptiveToggleInputRenderer.h"
 #include "AdaptiveToggleInputRenderer.g.cpp"
+#include "InputValue.h"
 
 namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
 {

--- a/source/uwp/Renderer/lib/DateTimeParser.cpp
+++ b/source/uwp/Renderer/lib/DateTimeParser.cpp
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 #include "pch.h"
+
 #include "DateTimeParser.h"
-#include "Util.h"
 #include <iomanip>
 #include <sstream>
 

--- a/source/uwp/Renderer/lib/InputValue.h
+++ b/source/uwp/Renderer/lib/InputValue.h
@@ -2,8 +2,6 @@
 // Licensed under the MIT License.
 #pragma once
 
-#include "winrt/AdaptiveCards.Rendering.Uwp.h"
-
 namespace winrt::AdaptiveCards::Rendering::Uwp
 {
     // Base class for input values. The InputValue is responsible for getting the current value and submit time, and also handles input validation.

--- a/source/uwp/Renderer/lib/MediaHelpers.cpp
+++ b/source/uwp/Renderer/lib/MediaHelpers.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 #include "pch.h"
 #include "AdaptiveCardGetResourceStreamArgs.h"
+#include "WholeItemsPanel.h"
 
 const double c_playIconSize = 30;
 const double c_playIconCornerRadius = 5;

--- a/source/uwp/Renderer/lib/RenderedAdaptiveCard.h
+++ b/source/uwp/Renderer/lib/RenderedAdaptiveCard.h
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 #pragma once
 
-#include "AdaptiveCards.Rendering.Uwp.h"
 #include "util.h"
 #include "InputValue.h"
 #include "AdaptiveInputs.h"

--- a/source/uwp/Renderer/lib/Util.h
+++ b/source/uwp/Renderer/lib/Util.h
@@ -3,20 +3,7 @@
 #pragma once
 #include <string>
 
-#include <BaseCardElement.h>
-#include <BaseActionElement.h>
-#include <ChoiceInput.h>
-#include <Column.h>
-#include <Fact.h>
-#include <Image.h>
 #include <Inline.h>
-#include <MediaSource.h>
-#include <ToggleVisibilityTarget.h>
-#include <windows.foundation.collections.h>
-#include <ParseContext.h>
-#include "AdaptiveCardParseWarning.h"
-#include "RemoteResourceInformation.h"
-#include "TableCell.h"
 #include "AdaptiveElementRendererRegistration.h"
 #include "AdaptiveActionRendererRegistration.h"
 

--- a/source/uwp/Renderer/lib/Util.h
+++ b/source/uwp/Renderer/lib/Util.h
@@ -4,7 +4,6 @@
 #include <string>
 
 #include "AdaptiveCards.Rendering.Uwp.h"
-#include "InputValue.h"
 #include <BaseCardElement.h>
 #include <BaseActionElement.h>
 #include <ChoiceInput.h>

--- a/source/uwp/Renderer/lib/Util.h
+++ b/source/uwp/Renderer/lib/Util.h
@@ -3,7 +3,6 @@
 #pragma once
 #include <string>
 
-#include "AdaptiveCards.Rendering.Uwp.h"
 #include <BaseCardElement.h>
 #include <BaseActionElement.h>
 #include <ChoiceInput.h>

--- a/source/uwp/Renderer/lib/XamlBuilder.h
+++ b/source/uwp/Renderer/lib/XamlBuilder.h
@@ -5,7 +5,6 @@
 #include "ImageLoadTracker.h"
 #include "IXamlBuilderListener.h"
 #include "IImageLoadTrackerListener.h"
-#include "RenderedAdaptiveCard.h"
 
 namespace AdaptiveCards::Rendering::Uwp
 {

--- a/source/uwp/Renderer/lib/XamlBuilder.h
+++ b/source/uwp/Renderer/lib/XamlBuilder.h
@@ -6,7 +6,6 @@
 #include "IXamlBuilderListener.h"
 #include "IImageLoadTrackerListener.h"
 #include "RenderedAdaptiveCard.h"
-#include "AdaptiveRenderContext.h"
 
 namespace AdaptiveCards::Rendering::Uwp
 {

--- a/source/uwp/Renderer/lib/XamlBuilder.h
+++ b/source/uwp/Renderer/lib/XamlBuilder.h
@@ -5,7 +5,6 @@
 #include "ImageLoadTracker.h"
 #include "IXamlBuilderListener.h"
 #include "IImageLoadTrackerListener.h"
-#include "InputValue.h"
 #include "RenderedAdaptiveCard.h"
 #include "AdaptiveRenderContext.h"
 

--- a/source/uwp/Renderer/lib/XamlHelpers.cpp
+++ b/source/uwp/Renderer/lib/XamlHelpers.cpp
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 #include "pch.h"
-#include "WholeItemsPanel.h"
+
 #include "ElementTagContent.h"
 #include "TileControl.h"
 #include "AdaptiveBase64Util.h"
+#include "WholeItemsPanel.h"
 
 namespace AdaptiveCards::Rendering::Uwp::XamlHelpers
 {

--- a/source/uwp/Renderer/lib/XamlHelpers.h
+++ b/source/uwp/Renderer/lib/XamlHelpers.h
@@ -2,8 +2,6 @@
 // Licensed under the MIT License.
 #pragma once
 
-#include "WholeItemsPanel.h"
-
 namespace AdaptiveCards::Rendering::Uwp::XamlHelpers
 {
     void SetStyleFromResourceDictionary(winrt::AdaptiveRenderContext const& renderContext,

--- a/source/uwp/Renderer/lib/pch.h
+++ b/source/uwp/Renderer/lib/pch.h
@@ -36,6 +36,7 @@
 #include "HostConfig.h"
 
 // Commonly-used AdaptiveCardRenderer headers
+#include "AdaptiveRenderContext.h"
 #include "Util.h"
 #include "XamlBuilder.h"
 #include "XamlHelpers.h"


### PR DESCRIPTION
# Related Issue

N/A

# Description

This change simplifies how various headers are included in the AdaptiveCardRenderer project.
- Util.h is included in pch.h. If a file already includes pch.h, it is unnecessary to include util.h as well
- Only include WholeItemsPanel.h where needed. It was previously included everywhere, due to being included in XamlHelpers.h, which is included in pch.h.
- Similarly, only include InputValue.h where needed.
- Include AdaptiveRenderContext.h directly in pch.h. It is required many places, and was previously included in pch.h via inclusion in XamlBuilder.h. Including in pch.h instead is clearer.
- Removed unnecessary headers from Util.h and XamlBuilder.h. This has a large effect since both are included in pch.h.
- Remove imports of `AdaptiveCards.Rendering.Uwp.h` as it is not needed.

# How Verified

Projects build and tests pass.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8128)