### PR TITLE
[UWP Renderer] Fix table rendering

### DIFF
--- a/source/uwp/Renderer/lib/AdaptiveContainerRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveContainerRenderer.cpp
@@ -15,7 +15,8 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     {
         try
         {
-            auto adaptiveContainer = cardElement.as<winrt::AdaptiveContainer>();
+            auto adaptiveContainer = cardElement.as<winrt::IAdaptiveContainer>();
+            auto adaptiveContainerBase = cardElement.as<winrt::IAdaptiveContainerBase>();
             auto containerPanel = winrt::make<winrt::implementation::WholeItemsPanel>();
 
             // Get any RTL setting set on either the current context or on this container. Any value set on the
@@ -45,7 +46,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
                 containerPanel.VerticalAlignment(winrt::VerticalAlignment::Stretch);
             }
 
-            uint32_t containerMinHeight = adaptiveContainer.MinHeight();
+            uint32_t containerMinHeight = adaptiveContainerBase.MinHeight();
 
             if (containerMinHeight > 0)
             {
@@ -55,7 +56,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
             winrt::Border containerBorder{};
 
             auto containerStyle =
-                XamlHelpers::HandleStylingAndPadding(adaptiveContainer, containerBorder, renderContext, renderArgs);
+                XamlHelpers::HandleStylingAndPadding(adaptiveContainerBase, containerBorder, renderContext, renderArgs);
             auto newRenderArgs =
                 winrt::make<winrt::implementation::AdaptiveRenderArgs>(containerStyle, renderArgs.ParentElement(), renderArgs);
 
@@ -99,7 +100,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
 
             XamlHelpers::SetStyleFromResourceDictionary(renderContext, L"Adaptive.Container", containerPanel);
 
-            auto selectAction = adaptiveContainer.SelectAction();
+            auto selectAction = adaptiveContainerBase.SelectAction();
             auto hostConfig = renderContext.HostConfig();
 
             return render_xaml::ActionHelpers::HandleSelectAction(

--- a/source/uwp/Renderer/lib/AdaptiveTableRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveTableRenderer.cpp
@@ -170,7 +170,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
 
             // Set the row and column numbers on the cell
             winrt::Grid::SetColumn(cellFrameworkElement, columnNumber);
-            winrt::Grid::SetColumn(cellFrameworkElement, rowNumber);
+            winrt::Grid::SetRow(cellFrameworkElement, rowNumber);
 
             // Add the cell to the panel
             XamlHelpers::AppendXamlElementToPanel(cellFrameworkElement, xamlGrid);

--- a/source/uwp/Renderer/lib/XamlHelpers.cpp
+++ b/source/uwp/Renderer/lib/XamlHelpers.cpp
@@ -222,7 +222,7 @@ namespace AdaptiveCards::Rendering::Uwp::XamlHelpers
         auto pixelWidthRef = column.PixelWidth();
 
         uint32_t width = GetValueFromRef(widthRef, (uint32_t)0);
-        uint32_t pixelWidth = GetValueFromRef(widthRef, (uint32_t)0);
+        uint32_t pixelWidth = GetValueFromRef(pixelWidthRef, (uint32_t)0);
 
         bool isWidthUnset = (widthRef == nullptr) && (pixelWidthRef == nullptr);
 


### PR DESCRIPTION
# Related Issue

Fixes #8051

# Description

Table was not rendering because `TableCell` inherits from `IAdaptiveContainer` and `IAdaptiveContainerBase` and the container renderer casts the element to a `AdaptiveContainer`.

Updated to cast to both an `IAdaptiveContainer` and `IAdaptiveContainerBase`, then use the respective object when necessary.

# Sample Card

https://github.com/microsoft/AdaptiveCards/blob/main/samples/v1.5/Scenarios/FlightUpdateTable.json

# How Verified

Verified manually on the UWP Visualizer.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8131)