### PR TITLE
[UWP Renderer] Resolve crash in filtered choice set

### DIFF
--- a/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.cpp
@@ -238,8 +238,8 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         autoSuggestBox.ItemsSource(choiceList);
 
         // When we get focus open the suggestion list. This ensures the choices are shown on first focus.
-        autoSuggestBox.GettingFocus(
-            [](IInspectable const& sender, winrt::GettingFocusEventArgs const& /* args */) -> void
+        autoSuggestBox.GotFocus(
+            [](IInspectable const& sender, winrt::RoutedEventArgs const& /* args */) -> void
             {
                 if (const auto autoSuggestBox = sender.try_as<winrt::AutoSuggestBox>())
                 {


### PR DESCRIPTION
# Related Issue

Fixes #8149 
# Description

Switch from `GettingFocus` event to `GotFocus` event.

# Sample Card

https://github.com/microsoft/AdaptiveCards/blob/main/samples/v1.5/Scenarios/RestaurantOrder.json

# How Verified
 
Verified manually in UWP visualizer.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8148)