### PR TITLE
[Samples A11y] Consolidate ColumnSets in FlightItinerary

### DIFF
--- a/samples/Templates/Scenarios/FlightItinerary.template.json
+++ b/samples/Templates/Scenarios/FlightItinerary.template.json
@@ -69,41 +69,7 @@
 							"text": "${Places[1].Name}",
 							"isSubtle": true,
 							"wrap": true
-						}
-					]
-				},
-				{
-					"type": "Column",
-					"width": 1,
-					"items": [
-						{
-							"type": "TextBlock",
-							"$when": "${Segments[0].DestinationStation == 11235}",
-							"text": "${Places[0].Name}",
-							"horizontalAlignment": "right",
-							"isSubtle": true,
-							"wrap": true
 						},
-						{
-							"type": "TextBlock",
-							"$when": "${Segments[0].DestinationStation == 13554}",
-							"text": "${Places[1].Name}",
-							"horizontalAlignment": "right",
-							"isSubtle": true,
-							"wrap": true
-						}
-					]
-				}
-			]
-		},
-		{
-			"type": "ColumnSet",
-			"spacing": "none",
-			"columns": [
-				{
-					"type": "Column",
-					"width": 1,
-					"items": [
 						{
 							"type": "TextBlock",
 							"size": "extraLarge",
@@ -127,11 +93,12 @@
 				{
 					"type": "Column",
 					"width": "auto",
+					"verticalContentAlignment": "center",
 					"items": [
 						{
 							"type": "Image",
 							"url": "https://adaptivecards.io/content/airplane.png",
-							"altText": "Airplane",
+							"altText": "Flight to",
 							"size": "small",
 							"spacing": "none"
 						}
@@ -141,6 +108,22 @@
 					"type": "Column",
 					"width": 1,
 					"items": [
+						{
+							"type": "TextBlock",
+							"$when": "${Segments[0].DestinationStation == 11235}",
+							"text": "${Places[0].Name}",
+							"horizontalAlignment": "right",
+							"isSubtle": true,
+							"wrap": true
+						},
+						{
+							"type": "TextBlock",
+							"$when": "${Segments[0].DestinationStation == 13554}",
+							"text": "${Places[1].Name}",
+							"horizontalAlignment": "right",
+							"isSubtle": true,
+							"wrap": true
+						},
 						{
 							"type": "TextBlock",
 							"size": "extraLarge",
@@ -200,41 +183,7 @@
 							"text": "${Places[1].Name}",
 							"isSubtle": true,
 							"wrap": true
-						}
-					]
-				},
-				{
-					"type": "Column",
-					"width": 1,
-					"items": [
-						{
-							"type": "TextBlock",
-							"$when": "${Segments[1].DestinationStation == 11235}",
-							"text": "${Places[0].Name}",
-							"horizontalAlignment": "right",
-							"isSubtle": true,
-							"wrap": true
 						},
-						{
-							"type": "TextBlock",
-							"$when": "${Segments[1].DestinationStation == 13554}",
-							"text": "${Places[1].Name}",
-							"horizontalAlignment": "right",
-							"isSubtle": true,
-							"wrap": true
-						}
-					]
-				}
-			]
-		},
-		{
-			"type": "ColumnSet",
-			"spacing": "none",
-			"columns": [
-				{
-					"type": "Column",
-					"width": 1,
-					"items": [
 						{
 							"type": "TextBlock",
 							"size": "extraLarge",
@@ -258,11 +207,12 @@
 				{
 					"type": "Column",
 					"width": "auto",
+					"verticalContentAlignment": "center",
 					"items": [
 						{
 							"type": "Image",
 							"url": "https://adaptivecards.io/content/airplane.png",
-							"altText": "Airplane",
+							"altText": "Flight to",
 							"size": "small",
 							"spacing": "none"
 						}
@@ -272,6 +222,22 @@
 					"type": "Column",
 					"width": 1,
 					"items": [
+						{
+							"type": "TextBlock",
+							"$when": "${Segments[1].DestinationStation == 11235}",
+							"text": "${Places[0].Name}",
+							"horizontalAlignment": "right",
+							"isSubtle": true,
+							"wrap": true
+						},
+						{
+							"type": "TextBlock",
+							"$when": "${Segments[1].DestinationStation == 13554}",
+							"text": "${Places[1].Name}",
+							"horizontalAlignment": "right",
+							"isSubtle": true,
+							"wrap": true
+						},
 						{
 							"type": "TextBlock",
 							"size": "extraLarge",

--- a/samples/v1.5/Scenarios/FlightItinerary.json
+++ b/samples/v1.5/Scenarios/FlightItinerary.json
@@ -62,32 +62,7 @@
 							"text": "San Francisco",
 							"isSubtle": true,
 							"wrap": true
-						}
-					]
-				},
-				{
-					"type": "Column",
-					"width": 1,
-					"items": [
-						{
-							"type": "TextBlock",
-							"horizontalAlignment": "right",
-							"text": "Amsterdam",
-							"isSubtle": true,
-							"wrap": true
-						}
-					]
-				}
-			]
-		},
-		{
-			"type": "ColumnSet",
-			"spacing": "none",
-			"columns": [
-				{
-					"type": "Column",
-					"width": 1,
-					"items": [
+						},
 						{
 							"type": "TextBlock",
 							"size": "extraLarge",
@@ -101,6 +76,7 @@
 				{
 					"type": "Column",
 					"width": "auto",
+					"verticalContentAlignment": "center",
 					"items": [
 						{
 							"type": "Image",
@@ -115,6 +91,13 @@
 					"type": "Column",
 					"width": 1,
 					"items": [
+						{
+							"type": "TextBlock",
+							"horizontalAlignment": "right",
+							"text": "Amsterdam",
+							"isSubtle": true,
+							"wrap": true
+						},
 						{
 							"type": "TextBlock",
 							"horizontalAlignment": "right",
@@ -155,32 +138,7 @@
 							"text": "Amsterdam",
 							"isSubtle": true,
 							"wrap": true
-						}
-					]
-				},
-				{
-					"type": "Column",
-					"width": 1,
-					"items": [
-						{
-							"type": "TextBlock",
-							"horizontalAlignment": "right",
-							"text": "San Francisco",
-							"isSubtle": true,
-							"wrap": true
-						}
-					]
-				}
-			]
-		},
-		{
-			"type": "ColumnSet",
-			"spacing": "none",
-			"columns": [
-				{
-					"type": "Column",
-					"width": 1,
-					"items": [
+						},
 						{
 							"type": "TextBlock",
 							"size": "extraLarge",
@@ -194,6 +152,7 @@
 				{
 					"type": "Column",
 					"width": "auto",
+					"verticalContentAlignment": "center",
 					"items": [
 						{
 							"type": "Image",
@@ -208,6 +167,13 @@
 					"type": "Column",
 					"width": 1,
 					"items": [
+						{
+							"type": "TextBlock",
+							"horizontalAlignment": "right",
+							"text": "San Francisco",
+							"isSubtle": true,
+							"wrap": true
+						},
 						{
 							"type": "TextBlock",
 							"horizontalAlignment": "right",


### PR DESCRIPTION
# Related Issue

Fixes #7839

# Description

Previously, we had the city name and the airport code in separate ColumnSets. This caused the focus order to be incorrect.

By consolidating these ColumnSets, we can get the correct focus order while using Narrator.

# Sample Card

FlightItinerary.json

# How Verified

Verified manually on the Adaptive Cards site.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8156)