### PR TITLE
[UWP Renderer] Clean up imports and usings in Renderer and Visualizer

### DIFF
--- a/source/uwp/AdaptiveCardsObjectModel/lib/AdaptiveActionParserRegistration.cpp
+++ b/source/uwp/AdaptiveCardsObjectModel/lib/AdaptiveActionParserRegistration.cpp
@@ -9,7 +9,6 @@
 #include "AdaptiveOpenUrlActionParser.h"
 #include "AdaptiveToggleVisibilityActionParser.h"
 #include "AdaptiveExecuteActionParser.h"
-#include "windows.ui.xaml.h"
 #include "AdaptiveActionParserRegistration.g.cpp"
 
 namespace winrt::AdaptiveCards::ObjectModel::Uwp::implementation

--- a/source/uwp/Renderer/dll/CppWinRTIncludes.h
+++ b/source/uwp/Renderer/dll/CppWinRTIncludes.h
@@ -4,30 +4,32 @@
 #pragma once
 
 #include <winrt/base.h>
+#include <winrt/Windows.Data.Json.h>
+#include <winrt/Windows.Data.Xml.Dom.h>
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Globalization.DateTimeFormatting.h>
+#include <winrt/Windows.Media.Core.h>
+#include <winrt/Windows.Media.Playback.h>
 #include <winrt/Windows.Storage.Streams.h>
 #include <winrt/Windows.System.h>
+#include <winrt/Windows.UI.Core.h>
+#include <winrt/Windows.UI.Text.h>
 #include <winrt/Windows.Web.Http.h>
 #include <winrt/Windows.Web.Http.Filters.h>
-#include <winrt/Windows.UI.Core.h>
+
 #include <winrt/Windows.UI.Xaml.Automation.h>
 #include <winrt/Windows.UI.Xaml.Automation.Peers.h>
 #include <winrt/Windows.UI.Xaml.Controls.h>
 #include <winrt/Windows.UI.Xaml.Controls.Primitives.h>
+#include <winrt/Windows.UI.Xaml.Documents.h>
 #include <winrt/Windows.UI.Xaml.Input.h>
 #include <winrt/Windows.UI.Xaml.Markup.h>
 #include <winrt/Windows.UI.Xaml.Media.h>
-#include <winrt/Windows.UI.Xaml.Shapes.h>
-#include <winrt/Windows.UI.Xaml.Documents.h>
 #include <winrt/Windows.UI.Xaml.Media.Imaging.h>
-#include <winrt/Windows.Data.Json.h>
-#include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.Foundation.Collections.h>
-#include <winrt/Windows.Media.Core.h>
-#include <winrt/Windows.Media.Playback.h>
-#include <winrt/Windows.Data.Xml.Dom.h>
+#include <winrt/Windows.UI.Xaml.Shapes.h>
+
 #include <winrt/AdaptiveCards.ObjectModel.Uwp.h>
-#include <winrt/Windows.UI.Text.h>
 
 namespace winrt
 {
@@ -39,16 +41,18 @@ namespace winrt
     using namespace ::winrt::Windows::Storage::Streams;
     using namespace ::winrt::Windows::System;
     using namespace ::winrt::Windows::UI;
-    using namespace ::winrt::Windows::UI::Xaml;
-    using namespace ::winrt::Windows::UI::Xaml::Controls;
-    using namespace ::winrt::Windows::UI::Xaml::Controls::Primitives;
-    using namespace ::winrt::Windows::UI::Xaml::Automation;
-    using namespace ::winrt::Windows::UI::Xaml::Automation::Peers;
-    using namespace ::winrt::Windows::UI::Xaml::Documents;
-    using namespace ::winrt::Windows::UI::Xaml::Input;
-    using namespace ::winrt::Windows::UI::Xaml::Markup;
-    using namespace ::winrt::Windows::UI::Xaml::Media::Imaging;
-    using namespace ::winrt::Windows::UI::Xaml::Shapes;
+
+    namespace xaml = ::winrt::Windows::UI::Xaml;
+    using namespace xaml;
+    using namespace xaml::Controls;
+    using namespace xaml::Controls::Primitives;
+    using namespace xaml::Automation;
+    using namespace xaml::Automation::Peers;
+    using namespace xaml::Documents;
+    using namespace xaml::Input;
+    using namespace xaml::Media::Imaging;
+    using namespace xaml::Shapes;
+
     using namespace ::winrt::AdaptiveCards::ObjectModel::Uwp;
 
     // In order to avoid "namespace not defined" errors we have to define the namespace here too.
@@ -65,15 +69,17 @@ namespace winrt
         using namespace ::winrt::AdaptiveCards::Rendering::Uwp::implementation;
     }
 
-    using Brush = winrt::Windows::UI::Xaml::Media::Brush;
-    using FontFamily = winrt::Windows::UI::Xaml::Media::FontFamily;
-    using ImageBrush = ::winrt::Windows::UI::Xaml::Media::ImageBrush;
-    using ImageSource = ::winrt::Windows::UI::Xaml::Media::ImageSource;
-    using RectangleGeometry = winrt::Windows::UI::Xaml::Media::RectangleGeometry;
-    using SolidColorBrush = ::winrt::Windows::UI::Xaml::Media::SolidColorBrush;
-    using Stretch = ::winrt::Windows::UI::Xaml::Media::Stretch;
-    using AlignmentX = ::winrt::Windows::UI::Xaml::Media::AlignmentX;
-    using AlignmentY = ::winrt::Windows::UI::Xaml::Media::AlignmentY;
+    using XamlReader = xaml::Markup::XamlReader;
+
+    using AlignmentX = xaml::Media::AlignmentX;
+    using AlignmentY = xaml::Media::AlignmentY;
+    using Brush = xaml::Media::Brush;
+    using FontFamily = xaml::Media::FontFamily;
+    using ImageBrush = xaml::Media::ImageBrush;
+    using ImageSource = xaml::Media::ImageSource;
+    using RectangleGeometry = xaml::Media::RectangleGeometry;
+    using SolidColorBrush = xaml::Media::SolidColorBrush;
+    using Stretch = xaml::Media::Stretch;
 
     // using namespace winrt::Windows::Data::Json
     using JsonObject = ::winrt::Windows::Data::Json::JsonObject;

--- a/source/uwp/Renderer/lib/AdaptiveContainerRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveContainerRenderer.h
@@ -11,9 +11,9 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     {
         AdaptiveContainerRenderer() = default;
 
-        Windows::UI::Xaml::UIElement Render(winrt::IAdaptiveCardElement const& element,
-                                            winrt::AdaptiveRenderContext const& context,
-                                            winrt::AdaptiveRenderArgs const& renderArgs);
+        winrt::UIElement Render(winrt::IAdaptiveCardElement const& element,
+                                winrt::AdaptiveRenderContext const& context,
+                                winrt::AdaptiveRenderArgs const& renderArgs);
     };
 }
 namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation

--- a/source/uwp/Renderer/lib/AdaptiveExecuteActionRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveExecuteActionRenderer.h
@@ -10,9 +10,9 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     {
         AdaptiveExecuteActionRenderer() = default;
 
-        Windows::UI::Xaml::UIElement Render(winrt::IAdaptiveActionElement const& action,
-                                            winrt::AdaptiveRenderContext const& renderContext,
-                                            winrt::AdaptiveRenderArgs const& renderArgs);
+        winrt::UIElement Render(winrt::IAdaptiveActionElement const& action,
+                                winrt::AdaptiveRenderContext const& renderContext,
+                                winrt::AdaptiveRenderArgs const& renderArgs);
     };
 }
 namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation

--- a/source/uwp/Renderer/lib/AdaptiveFactSetRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveFactSetRenderer.h
@@ -10,9 +10,9 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     {
         AdaptiveFactSetRenderer() = default;
 
-        Windows::UI::Xaml::UIElement Render(winrt::IAdaptiveCardElement const& cardElement,
-                                            winrt::AdaptiveRenderContext const& renderContext,
-                                            winrt::AdaptiveRenderArgs const& renderArgs);
+        winrt::UIElement Render(winrt::IAdaptiveCardElement const& cardElement,
+                                winrt::AdaptiveRenderContext const& renderContext,
+                                winrt::AdaptiveRenderArgs const& renderArgs);
     };
 }
 namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation

--- a/source/uwp/Renderer/lib/AdaptiveNumberInputRenderer.h
+++ b/source/uwp/Renderer/lib/AdaptiveNumberInputRenderer.h
@@ -9,9 +9,9 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     struct AdaptiveNumberInputRenderer : AdaptiveNumberInputRendererT<AdaptiveNumberInputRenderer>
     {
     public:
-        Windows::UI::Xaml::UIElement Render(winrt::IAdaptiveCardElement const& cardElement,
-                                            winrt::AdaptiveRenderContext const& renderContext,
-                                            winrt::AdaptiveRenderArgs const& renderArgs);
+        winrt::UIElement Render(winrt::IAdaptiveCardElement const& cardElement,
+                                winrt::AdaptiveRenderContext const& renderContext,
+                                winrt::AdaptiveRenderArgs const& renderArgs);
     };
 
 }

--- a/source/uwp/Visualizer/App.xaml.cs
+++ b/source/uwp/Visualizer/App.xaml.cs
@@ -1,20 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Data;
-using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
 namespace AdaptiveCardVisualizer

--- a/source/uwp/Visualizer/Converters/ErrorViewModelConverters.cs
+++ b/source/uwp/Visualizer/Converters/ErrorViewModelConverters.cs
@@ -1,10 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Windows.UI;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Data;

--- a/source/uwp/Visualizer/Converters/NotNullToVisibilityConverter.cs
+++ b/source/uwp/Visualizer/Converters/NotNullToVisibilityConverter.cs
@@ -1,10 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Data;
 

--- a/source/uwp/Visualizer/GenericDocumentView.xaml.cs
+++ b/source/uwp/Visualizer/GenericDocumentView.xaml.cs
@@ -1,19 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
-using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Data;
-using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Navigation;
 
 // The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
 

--- a/source/uwp/Visualizer/Helpers/BindableBase.cs
+++ b/source/uwp/Visualizer/Helpers/BindableBase.cs
@@ -1,12 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace AdaptiveCardVisualizer.Helpers
 {

--- a/source/uwp/Visualizer/Helpers/IListExtensions.cs
+++ b/source/uwp/Visualizer/Helpers/IListExtensions.cs
@@ -3,8 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace AdaptiveCardVisualizer.Helpers
 {

--- a/source/uwp/Visualizer/Helpers/PayloadValidator.cs
+++ b/source/uwp/Visualizer/Helpers/PayloadValidator.cs
@@ -3,13 +3,10 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Schema;
-using Newtonsoft.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Windows.Storage;
 using AdaptiveCardVisualizer.ViewModel;

--- a/source/uwp/Visualizer/MainPage.xaml.cs
+++ b/source/uwp/Visualizer/MainPage.xaml.cs
@@ -1,23 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
-using Windows.Storage;
-using Windows.Storage.Pickers;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Navigation;
-
-using AdaptiveCards.Rendering.Uwp;
 using AdaptiveCardVisualizer.ViewModel;
 using Windows.System;
 

--- a/source/uwp/Visualizer/Properties/AssemblyInfo.cs
+++ b/source/uwp/Visualizer/Properties/AssemblyInfo.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/source/uwp/Visualizer/ResourceResolvers/MySymbolResourceResolver.cs
+++ b/source/uwp/Visualizer/ResourceResolvers/MySymbolResourceResolver.cs
@@ -2,9 +2,6 @@
 // Licensed under the MIT License.
 using AdaptiveCards.Rendering.Uwp;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Windows.Foundation;
 using Windows.Storage;

--- a/source/uwp/Visualizer/Settings.cs
+++ b/source/uwp/Visualizer/Settings.cs
@@ -1,10 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Windows.Storage;
 
 namespace AdaptiveCardVisualizer

--- a/source/uwp/Visualizer/TabView.xaml.cs
+++ b/source/uwp/Visualizer/TabView.xaml.cs
@@ -1,19 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Data;
-using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Navigation;
 using AdaptiveCardVisualizer.ViewModel;
 
 // The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236

--- a/source/uwp/Visualizer/ViewModel/DocumentViewModel.cs
+++ b/source/uwp/Visualizer/ViewModel/DocumentViewModel.cs
@@ -184,7 +184,7 @@ namespace AdaptiveCardVisualizer.ViewModel
 
                 if (RenderedCard is FrameworkElement)
                 {
-                    (RenderedCard as FrameworkElement).VerticalAlignment = Windows.UI.Xaml.VerticalAlignment.Top;
+                    (RenderedCard as FrameworkElement).VerticalAlignment = VerticalAlignment.Top;
                 }
                 errors = newErrors;
                 TimeCounter.ResetCounter();

--- a/source/uwp/Visualizer/ViewModel/ErrorViewModel.cs
+++ b/source/uwp/Visualizer/ViewModel/ErrorViewModel.cs
@@ -1,10 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace AdaptiveCardVisualizer.ViewModel
 {

--- a/source/uwp/Visualizer/ViewModel/GenericDocumentViewModel.cs
+++ b/source/uwp/Visualizer/ViewModel/GenericDocumentViewModel.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Windows.Storage;
 using Windows.UI.Popups;
 using Windows.Storage.Pickers;
-using Windows.UI.Xaml;
 using Windows.Storage.Provider;
 
 namespace AdaptiveCardVisualizer.ViewModel

--- a/source/uwp/Visualizer/ViewModel/HostConfigEditorViewModel.cs
+++ b/source/uwp/Visualizer/ViewModel/HostConfigEditorViewModel.cs
@@ -4,11 +4,8 @@ using AdaptiveCards.Rendering.Uwp;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Windows.Storage;
-using AdaptiveCardVisualizer.Helpers;
 
 namespace AdaptiveCardVisualizer.ViewModel
 {

--- a/source/uwp/Visualizer/ViewModel/KeyboardPressTimeCounter.cs
+++ b/source/uwp/Visualizer/ViewModel/KeyboardPressTimeCounter.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Windows.UI.Core;

--- a/source/uwp/Visualizer/ViewModel/MainPageViewModel.cs
+++ b/source/uwp/Visualizer/ViewModel/MainPageViewModel.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT License.
 using AdaptiveCards.Rendering.Uwp;
 using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Windows.ApplicationModel;
 using Windows.Storage;


### PR DESCRIPTION
# Description

This change removes unnecessary explicit references to the `Windows::UI::Xaml` namespace. It removes unused `include`s from the AdaptiveCardsObjectModel project and `using`s from the Visualizer project. Additionally, it alphabetizes the `include`s in the Renderer's `CppWinRTIncludes.h`.

# How Verified

Built and ran tests.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8158)