### PR TITLE
Fixed imageSet select action issue

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRImageSetUICollectionView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRImageSetUICollectionView.mm
@@ -21,6 +21,7 @@ using namespace AdaptiveCards;
     std::shared_ptr<ImageSet> _imgSet;
     ImageSize _imageSize;
     ACRView *_rootView;
+    __weak UIView<ACRIContentHoldingView> *_viewGroup;
     CGSize _size;
 }
 
@@ -49,6 +50,7 @@ using namespace AdaptiveCards;
         ((UICollectionViewFlowLayout *)self.collectionViewLayout).itemSize = itemSize;
         self.scrollEnabled = NO;
         self.translatesAutoresizingMaskIntoConstraints = NO;
+        _viewGroup = (UIView<ACRIContentHoldingView> *)view;
     }
     return self;
 }
@@ -75,7 +77,7 @@ using namespace AdaptiveCards;
 
     ACRBaseCardElementRenderer *imageRenderer = [[ACRRegistration getInstance] getRenderer:[NSNumber numberWithInteger:ACRImage]];
 
-    UIView *content = [imageRenderer render:nil rootView:_rootView inputs:nil baseCardElement:_acoElem hostConfig:_acoConfig];
+    UIView *content = [imageRenderer render:_viewGroup rootView:_rootView inputs:nil baseCardElement:_acoElem hostConfig:_acoConfig];
 
     UICollectionViewCell *cell = [collectionView dequeueReusableCellWithReuseIdentifier:identifier forIndexPath:indexPath];
 


### PR DESCRIPTION
# Related Issue

Fixed #8044 

# Description
Added a ViewGroup view to hold target for actions.

# Sample Card
```json
{
	"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
	"type": "AdaptiveCard",
	"version": "1.0",
	"body": [
		{
			"type": "ImageSet",
			"images": [
				{
					"type": "Image",
					"url": "https://adaptivecards.io/content/cats/1.png",
                    "selectAction": {
                        "type": "Action.OpenUrl",
                        "title": "cool link",
                        "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
                    }
				},
				{
					"type": "Image",
					"url": "https://adaptivecards.io/content/cats/1.png",
                    "selectAction": {
                        "type": "Action.OpenUrl",
                        "title": "cool link",
                        "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
                    }
				}
			]
		}
	]
}
```

# How Verified

Manually verified.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8200)