### PR TITLE
[Website] Fix links and buttons in high contrast

### DIFF
--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/source/css/style.css
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/source/css/style.css
@@ -345,9 +345,17 @@ s {
 }
 
 @media (forced-colors: active) {
-    .toc-todo .selectedHolder {
-        background-color: highlight;
+    .w3-button.w3-round-xxlarge.ac-blue {
+        border: 1px solid buttonBorder
+    }
+
+    .toc-todo .selectedHolder,
+    .toc-todo .selectedHolder > a,
+    .toc-todo .selectedHolder > a:hover,
+    .toc-todo a.selectedHolder:hover
+    {
         color: highlightText;
+        background-color: highlight;
         forced-color-adjust: none;
     }
 }


### PR DESCRIPTION
# Related Issue

Fixes #7866 

# Description

This PR contains two changes to meet high contrast requirements.

1. The `Get Started` button on the home page looks like a link since the blue background color is no longer present.

<img width="606" alt="image" src="https://user-images.githubusercontent.com/98650930/211084452-b1b49969-53f5-4cd4-a0f7-46df634e097d.png">

I added a border so that it is clearly a button.

<img width="551" alt="image" src="https://user-images.githubusercontent.com/98650930/211085110-9fe29123-6ff4-4db6-b5cf-ce8049a62daf.png">

2. Selected elements in the Schema Explorer navigation pane did not adopt the correct text color.

<img width="220" alt="image" src="https://user-images.githubusercontent.com/98650930/211084749-330024e4-995c-4ac6-847b-2aa69572a1a2.png">

With changes:
<img width="209" alt="image" src="https://user-images.githubusercontent.com/98650930/211085070-b2fd89d2-1699-4348-a338-2914df8b987c.png">

# How Verified

Verified manually on the Adaptive Cards site. See above images.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8212)