### PR TITLE
[UWP Renderer] Do not wrap textblock in ComboBoxItem for compact choiceset

### DIFF
--- a/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveChoiceSetInputRenderer.cpp
@@ -103,17 +103,14 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         for (auto adaptiveChoiceInput : choices)
         {
             auto title = adaptiveChoiceInput.Title();
-
-            winrt::ComboBoxItem comboBoxItem{};
-
-            XamlHelpers::SetContent(comboBoxItem, title, wrap);
+            auto content = XamlHelpers::CreateTextBlockWithContent(title, wrap);
 
             if (values.size() == 1 && IsChoiceSelected(values, adaptiveChoiceInput))
             {
                 // If multiple values are specified, no option is selected
                 selectedIndex = currentIndex;
             }
-            items.Append(comboBoxItem);
+            items.Append(content);
             currentIndex++;
         }
 

--- a/source/uwp/Renderer/lib/XamlHelpers.cpp
+++ b/source/uwp/Renderer/lib/XamlHelpers.cpp
@@ -230,6 +230,18 @@ namespace AdaptiveCards::Rendering::Uwp::XamlHelpers
         columnDefinition.Width(CalculateColumnWidth(true, false, false, isWidthUnset, pixelWidth, width));
     }
 
+    winrt::TextBlock CreateTextBlockWithContent(winrt::hstring const& contentString, bool wrap)
+    {
+        winrt::TextBlock content{};
+        content.Text(contentString);
+        if (wrap)
+        {
+            content.TextWrapping(winrt::TextWrapping::WrapWholeWords);
+        }
+
+        return content;
+    }
+
     winrt::Image CreateBackgroundImage(winrt::AdaptiveRenderContext const& renderContext, winrt::hstring const& url)
     {
         try

--- a/source/uwp/Renderer/lib/XamlHelpers.h
+++ b/source/uwp/Renderer/lib/XamlHelpers.h
@@ -61,6 +61,8 @@ namespace AdaptiveCards::Rendering::Uwp::XamlHelpers
         return GetValueFromRef(toggleButton.IsChecked(), false);
     }
 
+    winrt::TextBlock CreateTextBlockWithContent(winrt::hstring const& contentString, bool wrap);
+
     template<typename T> void SetContent(T const& item, winrt::hstring const& contentString)
     {
         SetContent(item, contentString, false /* wrap */);
@@ -70,13 +72,7 @@ namespace AdaptiveCards::Rendering::Uwp::XamlHelpers
     {
         if (const auto contentControl = item.try_as<winrt::ContentControl>())
         {
-            winrt::TextBlock content{};
-            content.Text(contentString);
-
-            if (wrap)
-            {
-                content.TextWrapping(winrt::TextWrapping::WrapWholeWords);
-            }
+            auto content = CreateTextBlockWithContent(contentString, wrap);
             contentControl.Content(content);
         }
     }


### PR DESCRIPTION
# Related Issue

Fixes #7828

# Description

Per [the documentation](https://learn.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.combobox?view=winrt-22621), "Items added to the ComboBox are wrapped in [ComboBoxItem](https://learn.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.comboboxitem?view=winrt-22621) containers.". 

Since we were already wrapping the provided TextBlocks in ComboBoxItems before adding them to the ComboBox control, the items were wrapped _twice_, and Narrator did not handle this behavior correctly.

Adding TextBlocks to the ComboBox directly fixes this issue, and Narrator will announce "Snooze for 5 minutes ComboBox" as expected.

# Sample Card

https://github.com/microsoft/AdaptiveCards/blob/main/samples/v1.5/Scenarios/CalendarReminder.json

# How Verified

Verified manually on the UWP Visualizer.
