### PR TITLE
[WinUI 3 Renderer] Prepare SharedRenderer code for WinUI 3 Renderer

### DIFF
--- a/source/uwp/SharedRenderer/dll/CppWinRTIncludes.h
+++ b/source/uwp/SharedRenderer/dll/CppWinRTIncludes.h
@@ -3,6 +3,12 @@
 
 #pragma once
 
+#ifndef USE_WINUI3
+#define Xaml_OM Uwp
+#else
+#define Xaml_OM Winui3
+#endif
+
 #include <winrt/base.h>
 #include <winrt/Windows.Data.Json.h>
 #include <winrt/Windows.Data.Xml.Dom.h>
@@ -53,7 +59,7 @@ namespace winrt
     using namespace xaml::Media::Imaging;
     using namespace xaml::Shapes;
 
-    using namespace ::winrt::AdaptiveCards::ObjectModel::Uwp;
+    using namespace ::winrt::AdaptiveCards::ObjectModel::Xaml_OM;
 
     // In order to avoid "namespace not defined" errors we have to define the namespace here too.
     namespace AdaptiveCards::Rendering::Uwp{}
@@ -104,4 +110,4 @@ namespace winrt
 
     // using namespace winrt::Windows::UI::Text
     using TextDecorations = ::winrt::Windows::UI::Text::TextDecorations;
-}
+} // namespace winrt

--- a/source/uwp/SharedRenderer/dll/CppWinRTIncludes.h
+++ b/source/uwp/SharedRenderer/dll/CppWinRTIncludes.h
@@ -3,12 +3,12 @@
 
 #pragma once
 
-#ifndef USE_WINUI3
-#define Xaml_OM Uwp
-#define Xaml_Rendering Uwp
-#else
+#ifdef USE_WINUI3
 #define Xaml_OM Winui3
 #define Xaml_Rendering Winui3
+#else
+#define Xaml_OM Uwp
+#define Xaml_Rendering Uwp
 #endif
 
 #include <winrt/base.h>

--- a/source/uwp/SharedRenderer/dll/CppWinRTIncludes.h
+++ b/source/uwp/SharedRenderer/dll/CppWinRTIncludes.h
@@ -67,10 +67,6 @@ namespace winrt
     namespace AdaptiveCards::Rendering::Xaml_Rendering{}
     using namespace ::winrt::AdaptiveCards::Rendering::Xaml_Rendering;
 
-    // winrt_render_xaml namespace alias used to differentiate in cases where a type exists in both
-    // the renderer and the object model (ie. ActionMode)
-    namespace winrt_render_xaml = ::winrt::AdaptiveCards::Rendering::Uwp;
-
     namespace AdaptiveCards::Rendering::Xaml_Rendering::implementation{}
     namespace implementation
     {

--- a/source/uwp/SharedRenderer/dll/CppWinRTIncludes.h
+++ b/source/uwp/SharedRenderer/dll/CppWinRTIncludes.h
@@ -5,8 +5,10 @@
 
 #ifndef USE_WINUI3
 #define Xaml_OM Uwp
+#define Xaml_Rendering Uwp
 #else
 #define Xaml_OM Winui3
+#define Xaml_Rendering Winui3
 #endif
 
 #include <winrt/base.h>
@@ -62,17 +64,17 @@ namespace winrt
     using namespace ::winrt::AdaptiveCards::ObjectModel::Xaml_OM;
 
     // In order to avoid "namespace not defined" errors we have to define the namespace here too.
-    namespace AdaptiveCards::Rendering::Uwp{}
-    using namespace ::winrt::AdaptiveCards::Rendering::Uwp;
+    namespace AdaptiveCards::Rendering::Xaml_Rendering{}
+    using namespace ::winrt::AdaptiveCards::Rendering::Xaml_Rendering;
 
     // winrt_render_xaml namespace alias used to differentiate in cases where a type exists in both
     // the renderer and the object model (ie. ActionMode)
     namespace winrt_render_xaml = ::winrt::AdaptiveCards::Rendering::Uwp;
 
-    namespace AdaptiveCards::Rendering::Uwp::implementation{}
+    namespace AdaptiveCards::Rendering::Xaml_Rendering::implementation{}
     namespace implementation
     {
-        using namespace ::winrt::AdaptiveCards::Rendering::Uwp::implementation;
+        using namespace ::winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation;
     }
 
     using XamlReader = xaml::Markup::XamlReader;

--- a/source/uwp/SharedRenderer/lib/ActionHelpers.cpp
+++ b/source/uwp/SharedRenderer/lib/ActionHelpers.cpp
@@ -868,7 +868,7 @@ namespace AdaptiveCards::Rendering::Uwp::ActionHelpers
                 renderArgs.AllowAboveTitleIconPlacement(false);
             }
 
-            if (currentButtonIndex < maxActions && mode == winrt::AdaptiveCards::ObjectModel::Uwp::ActionMode::Primary)
+            if (currentButtonIndex < maxActions && mode == winrt::AdaptiveCards::ObjectModel::Xaml_OM::ActionMode::Primary)
             {
                 // If we have fewer than the maximum number of actions and this action's mode is primary, make a button
                 actionControl = CreateActionButtonInActionSet(adaptiveCard,
@@ -884,7 +884,7 @@ namespace AdaptiveCards::Rendering::Uwp::ActionHelpers
                 currentButtonIndex++;
             }
             else if (currentButtonIndex >= maxActions &&
-                     (mode == winrt::AdaptiveCards::ObjectModel::Uwp::ActionMode::Primary) && !overflowMaxActions)
+                     (mode == winrt::AdaptiveCards::ObjectModel::Xaml_OM::ActionMode::Primary) && !overflowMaxActions)
             {
                 // If we have more primary actions than the max actions and we're not allowed to overflow them just set a warning and continue
                 renderContext.AddWarning(winrt::WarningStatusCode::MaxActionsExceeded,
@@ -904,7 +904,7 @@ namespace AdaptiveCards::Rendering::Uwp::ActionHelpers
                 AddOverflowFlyoutItem(action, overflowButton, adaptiveCard, adaptiveActionSet, showCardsStackPanel, renderContext, renderArgs);
 
                 // If this was supposed to be a primary action but it got overflowed due to max actions, add a warning
-                if (mode == winrt::AdaptiveCards::ObjectModel::Uwp::ActionMode::Primary)
+                if (mode == winrt::AdaptiveCards::ObjectModel::Xaml_OM::ActionMode::Primary)
                 {
                     renderContext.AddWarning(winrt::WarningStatusCode::MaxActionsExceeded,
                                              {L"Some actions were moved to an overflow menu due to exceeding the maximum number of actions allowed"});

--- a/source/uwp/SharedRenderer/lib/ActionHelpers.cpp
+++ b/source/uwp/SharedRenderer/lib/ActionHelpers.cpp
@@ -690,7 +690,7 @@ namespace AdaptiveCards::Rendering::Uwp::ActionHelpers
         auto showCardActionConfig = actionsConfig.ShowCard();
         auto showCardActionMode = showCardActionConfig.ActionMode();
         // ActionMode enum exists both in Rendering in ObjectModel namespaces. When the time permits, fix it.
-        if (showCardActionMode == winrt::winrt_render_xaml::ActionMode::Inline)
+        if (showCardActionMode == winrt::AdaptiveCards::Rendering::Xaml_Rendering::ActionMode::Inline)
         {
             // Get the card to be shown
             auto actionAsShowCardAction = action.as<winrt::AdaptiveShowCardAction>();

--- a/source/uwp/SharedRenderer/lib/ActionHelpers.cpp
+++ b/source/uwp/SharedRenderer/lib/ActionHelpers.cpp
@@ -9,7 +9,7 @@
 #include "LinkButton.h"
 #include "WholeItemsPanel.h"
 
-namespace AdaptiveCards::Rendering::Uwp::ActionHelpers
+namespace AdaptiveCards::Rendering::Xaml_Rendering::ActionHelpers
 {
     winrt::Thickness GetButtonMargin(winrt::AdaptiveActionsConfig const& actionsConfig)
     {

--- a/source/uwp/SharedRenderer/lib/ActionHelpers.h
+++ b/source/uwp/SharedRenderer/lib/ActionHelpers.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 
-namespace AdaptiveCards::Rendering::Uwp::ActionHelpers
+namespace AdaptiveCards::Rendering::Xaml_Rendering::ActionHelpers
 {
     winrt::UIElement BuildAction(winrt::IAdaptiveActionElement const& adaptiveActionElement,
                                                     winrt::AdaptiveRenderContext const& renderContext,

--- a/source/uwp/SharedRenderer/lib/AdaptiveActionEventArgs.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveActionEventArgs.cpp
@@ -5,6 +5,6 @@
 #include "AdaptiveActionEventArgs.h"
 #include "AdaptiveActionEventArgs.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
 }

--- a/source/uwp/SharedRenderer/lib/AdaptiveActionEventArgs.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveActionEventArgs.h
@@ -3,7 +3,7 @@
 #pragma once
 #include "AdaptiveActionEventArgs.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveActionEventArgs : AdaptiveActionEventArgsT<AdaptiveActionEventArgs>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveActionInvoker.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveActionInvoker.cpp
@@ -5,7 +5,7 @@
 #include "AdaptiveActionInvoker.h"
 #include "AdaptiveActionInvoker.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     void AdaptiveActionInvoker::SendActionEvent(winrt::IAdaptiveActionElement const& actionElement)
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveActionInvoker.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveActionInvoker.h
@@ -5,7 +5,7 @@
 #include "RenderedAdaptiveCard.h"
 #include "AdaptiveActionInvoker.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveActionInvoker : AdaptiveActionInvokerT<AdaptiveActionInvoker>
     {
@@ -18,7 +18,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         winrt::weak_ref<winrt::RenderedAdaptiveCard> m_weakRenderResult;
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveActionInvoker : AdaptiveActionInvokerT<AdaptiveActionInvoker, implementation::AdaptiveActionInvoker>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveActionRendererRegistration.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveActionRendererRegistration.cpp
@@ -4,7 +4,7 @@
 #include "AdaptiveActionRendererRegistration.h"
 #include "AdaptiveActionRendererRegistration.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     void AdaptiveActionRendererRegistration::Set(winrt::hstring const& type, winrt::IAdaptiveActionRenderer const& renderer)
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveActionRendererRegistration.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveActionRendererRegistration.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveActionRendererRegistration.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveActionRendererRegistration : AdaptiveActionRendererRegistrationT<AdaptiveActionRendererRegistration>
     {
@@ -20,7 +20,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         RegistrationMap m_registration;
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveActionRendererRegistration
         : AdaptiveActionRendererRegistrationT<AdaptiveActionRendererRegistration, implementation::AdaptiveActionRendererRegistration>

--- a/source/uwp/SharedRenderer/lib/AdaptiveActionSetRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveActionSetRenderer.cpp
@@ -30,7 +30,7 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
                 auto adaptiveActionSet = cardElement.as<winrt::AdaptiveActionSet>();
                 auto actions = adaptiveActionSet.Actions();
 
-                return render_xaml::ActionHelpers::BuildActionSetHelper(nullptr, adaptiveActionSet, actions, renderContext, renderArgs);
+                return ::AdaptiveCards::Rendering::Xaml_Rendering::ActionHelpers::BuildActionSetHelper(nullptr, adaptiveActionSet, actions, renderContext, renderArgs);
             }
         }
         catch (winrt::hresult_error const& ex)

--- a/source/uwp/SharedRenderer/lib/AdaptiveActionSetRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveActionSetRenderer.cpp
@@ -8,7 +8,7 @@
 #include "ActionHelpers.h"
 #include "AdaptiveRenderArgs.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     winrt::UIElement AdaptiveActionSetRenderer::Render(winrt::IAdaptiveCardElement const& cardElement,
                                                        winrt::AdaptiveRenderContext const& renderContext,

--- a/source/uwp/SharedRenderer/lib/AdaptiveActionSetRenderer.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveActionSetRenderer.h
@@ -5,7 +5,7 @@
 #include "ActionSet.h"
 #include "AdaptiveActionSetRenderer.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveActionSetRenderer : AdaptiveActionSetRendererT<AdaptiveActionSetRenderer>
     {
@@ -16,7 +16,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
                                 winrt::AdaptiveRenderArgs const& renderArgs);
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveActionSetRenderer : AdaptiveActionSetRendererT<AdaptiveActionSetRenderer, implementation::AdaptiveActionSetRenderer>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveActionsConfig.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveActionsConfig.cpp
@@ -5,7 +5,7 @@
 #include "AdaptiveShowCardActionConfig.h"
 #include "AdaptiveActionsConfig.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveActionsConfig::AdaptiveActionsConfig(::AdaptiveCards::ActionsConfig const& actionsConfig) :
         ShowCard{winrt::make<winrt::implementation::AdaptiveShowCardActionConfig>(actionsConfig.showCard)}

--- a/source/uwp/SharedRenderer/lib/AdaptiveActionsConfig.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveActionsConfig.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveActionsConfig.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveActionsConfig : AdaptiveActionsConfigT<AdaptiveActionsConfig>
     {
@@ -20,7 +20,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         property<uint32_t> IconSize;
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveActionsConfig : AdaptiveActionsConfigT<AdaptiveActionsConfig, implementation::AdaptiveActionsConfig>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveCardConfig.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveCardConfig.cpp
@@ -5,7 +5,7 @@
 #include "AdaptiveCardConfig.h"
 #include "AdaptiveCardConfig.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveCardConfig::AdaptiveCardConfig(::AdaptiveCards::AdaptiveCardConfig const& adaptiveCardConfig)
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveCardConfig.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveCardConfig.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveCardConfig.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveCardConfig : AdaptiveCardConfigT<AdaptiveCardConfig>
     {
@@ -13,7 +13,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         property<bool> AllowCustomStyle;
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveCardConfig : AdaptiveCardConfigT<AdaptiveCardConfig, implementation::AdaptiveCardConfig>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveCardGetResourceStreamArgs.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveCardGetResourceStreamArgs.cpp
@@ -4,6 +4,6 @@
 #include "AdaptiveCardGetResourceStreamArgs.h"
 #include "AdaptiveCardGetResourceStreamArgs.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
 }

--- a/source/uwp/SharedRenderer/lib/AdaptiveCardGetResourceStreamArgs.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveCardGetResourceStreamArgs.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveCardGetResourceStreamArgs.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveCardGetResourceStreamArgs : AdaptiveCardGetResourceStreamArgsT<AdaptiveCardGetResourceStreamArgs>
     {
@@ -13,7 +13,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         property<winrt::Uri> Url;
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveCardGetResourceStreamArgs
         : AdaptiveCardGetResourceStreamArgsT<AdaptiveCardGetResourceStreamArgs, implementation::AdaptiveCardGetResourceStreamArgs>

--- a/source/uwp/SharedRenderer/lib/AdaptiveCardRendererComponent.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveCardRendererComponent.cpp
@@ -44,10 +44,10 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
         m_featureRegistration(winrt::make<implementation::AdaptiveFeatureRegistration>()),
         m_hostConfig(winrt::make<implementation::AdaptiveHostConfig>()),
         m_resourceResolvers(winrt::make<implementation::AdaptiveCardResourceResolvers>()),
-        m_xamlBuilder(winrt::make_self<render_xaml::XamlBuilder>())
+        m_xamlBuilder(winrt::make_self<::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder>())
     {
-        render_xaml::RegisterDefaultElementRenderers(m_elementRendererRegistration.get(), m_xamlBuilder);
-        render_xaml::RegisterDefaultActionRenderers(m_actionRendererRegistration.get());
+        ::AdaptiveCards::Rendering::Xaml_Rendering::RegisterDefaultElementRenderers(m_elementRendererRegistration.get(), m_xamlBuilder);
+        ::AdaptiveCards::Rendering::Xaml_Rendering::RegisterDefaultActionRenderers(m_actionRendererRegistration.get());
         InitializeDefaultResourceDictionary();
         UpdateActionSentimentResourceDictionary();
     }
@@ -105,7 +105,7 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
             {
                 renderContext->LinkCardToParent(adaptiveCard, nullptr);
                 auto xamlTreeRoot =
-                    render_xaml::XamlBuilder::BuildXamlTreeFromAdaptiveCard(adaptiveCard, *renderContext, m_xamlBuilder.get());
+                    ::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder::BuildXamlTreeFromAdaptiveCard(adaptiveCard, *renderContext, m_xamlBuilder.get());
                 renderedCard->SetFrameworkElement(xamlTreeRoot);
             }
             catch (...)

--- a/source/uwp/SharedRenderer/lib/AdaptiveCardRendererComponent.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveCardRendererComponent.cpp
@@ -36,7 +36,7 @@
 #include "InputValue.h"
 #include "RenderedAdaptiveCard.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveCardRenderer::AdaptiveCardRenderer() :
         m_elementRendererRegistration(winrt::make_self<implementation::AdaptiveElementRendererRegistration>()),

--- a/source/uwp/SharedRenderer/lib/AdaptiveCardRendererComponent.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveCardRendererComponent.h
@@ -15,7 +15,7 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
         winrt::ResourceDictionary m_overrideDictionary;
         winrt::AdaptiveHostConfig m_hostConfig;
         winrt::AdaptiveFeatureRegistration m_featureRegistration;
-        winrt::com_ptr<render_xaml::XamlBuilder> m_xamlBuilder;
+        winrt::com_ptr<::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder> m_xamlBuilder;
         bool m_explicitDimensions = false;
         uint32_t m_desiredWidth = 0;
         uint32_t m_desiredHeight = 0;
@@ -79,7 +79,7 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 
         winrt::ResourceDictionary GetMergedDictionary() { return m_mergedResourceDictionary; }
         bool GetFixedDimensions(_Out_ uint32_t* width, _Out_ uint32_t* height);
-        winrt::com_ptr<render_xaml::XamlBuilder> GetXamlBuilder() { return m_xamlBuilder; }
+        winrt::com_ptr<::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder> GetXamlBuilder() { return m_xamlBuilder; }
         winrt::ResourceDictionary GetActionSentimentResourceDictionary() { return m_actionSentimentResourceDictionary; }
 
         auto ResourceResolvers() { return m_resourceResolvers; }

--- a/source/uwp/SharedRenderer/lib/AdaptiveCardRendererComponent.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveCardRendererComponent.h
@@ -6,7 +6,7 @@
 #include "AdaptiveCardRenderer.g.h"
 #include "AdaptiveHostConfig.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     // This class is effectively a singleton, and stays around between subsequent renders.
     struct AdaptiveCardRenderer : AdaptiveCardRendererT<AdaptiveCardRenderer>
@@ -98,7 +98,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         winrt::com_ptr<implementation::AdaptiveActionRendererRegistration> m_actionRendererRegistration;
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveCardRenderer : AdaptiveCardRendererT<AdaptiveCardRenderer, implementation::AdaptiveCardRenderer>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveCardResourceResolvers.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveCardResourceResolvers.cpp
@@ -4,7 +4,7 @@
 #include "AdaptiveCardResourceResolvers.h"
 #include "AdaptiveCardResourceResolvers.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     void AdaptiveCardResourceResolvers::Set(hstring const& scheme, winrt::IAdaptiveCardResourceResolver const& resolver)
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveCardResourceResolvers.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveCardResourceResolvers.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveCardResourceResolvers.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveCardResourceResolvers : AdaptiveCardResourceResolversT<AdaptiveCardResourceResolvers>
     {
@@ -17,7 +17,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     };
 }
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveCardResourceResolvers
         : AdaptiveCardResourceResolversT<AdaptiveCardResourceResolvers, implementation::AdaptiveCardResourceResolvers>

--- a/source/uwp/SharedRenderer/lib/AdaptiveChoiceSetInputRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveChoiceSetInputRenderer.cpp
@@ -8,7 +8,7 @@
 #include "ParseUtil.h"
 #include "WholeItemsPanel.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     winrt::UIElement AdaptiveChoiceSetInputRenderer::Render(winrt::IAdaptiveCardElement const& cardElement,
                                                             winrt::AdaptiveRenderContext const& renderContext,

--- a/source/uwp/SharedRenderer/lib/AdaptiveChoiceSetInputRenderer.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveChoiceSetInputRenderer.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveChoiceSetInputRenderer.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveChoiceSetInputRenderer : AdaptiveChoiceSetInputRendererT<AdaptiveChoiceSetInputRenderer>
     {
@@ -35,7 +35,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     };
 }
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveChoiceSetInputRenderer
         : AdaptiveChoiceSetInputRendererT<AdaptiveChoiceSetInputRenderer, implementation::AdaptiveChoiceSetInputRenderer>

--- a/source/uwp/SharedRenderer/lib/AdaptiveColorConfig.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveColorConfig.cpp
@@ -6,7 +6,7 @@
 #include "AdaptiveHighlightColorConfig.h"
 #include "AdaptiveColorConfig.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveColorConfig::AdaptiveColorConfig(::AdaptiveCards::ColorConfig colorConfig)
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveColorConfig.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveColorConfig.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveColorConfig.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveColorConfig : AdaptiveColorConfigT<AdaptiveColorConfig>
     {
@@ -17,7 +17,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     };
 }
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveColorConfig : AdaptiveColorConfigT<AdaptiveColorConfig, implementation::AdaptiveColorConfig>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveColorsConfig.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveColorsConfig.cpp
@@ -5,7 +5,7 @@
 #include "AdaptiveColorConfig.h"
 #include "AdaptiveColorsConfig.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveColorsConfig::AdaptiveColorsConfig(::AdaptiveCards::ColorsConfig colorsConfig)
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveColorsConfig.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveColorsConfig.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveColorsConfig.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveColorsConfig : AdaptiveColorsConfigT<AdaptiveColorsConfig>
     {
@@ -20,7 +20,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     };
 }
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveColorsConfig : AdaptiveColorsConfigT<AdaptiveColorsConfig, implementation::AdaptiveColorsConfig>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveColumnRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveColumnRenderer.cpp
@@ -9,7 +9,7 @@
 #include "AdaptiveRenderArgs.h"
 #include "WholeItemsPanel.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     winrt::UIElement AdaptiveColumnRenderer::Render(winrt::IAdaptiveCardElement const& cardElement,
                                                     winrt::AdaptiveRenderContext const& renderContext,

--- a/source/uwp/SharedRenderer/lib/AdaptiveColumnRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveColumnRenderer.cpp
@@ -52,7 +52,7 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 
             auto childItems = adaptiveColumn.Items();
 
-            render_xaml::XamlBuilder::BuildPanelChildren(childItems, columnPanel, renderContext, newRenderArgs, [](auto&&) {});
+            ::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder::BuildPanelChildren(childItems, columnPanel, renderContext, newRenderArgs, [](auto&&) {});
 
             // If we changed the context's rtl setting, set it back after rendering the children
             if (updatedRtl)
@@ -105,7 +105,7 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 
             auto hostConfig = renderContext.HostConfig();
 
-            auto columnControl = render_xaml::ActionHelpers::HandleSelectAction(
+            auto columnControl = ::AdaptiveCards::Rendering::Xaml_Rendering::ActionHelpers::HandleSelectAction(
                 cardElement, selectAction, renderContext, columnAsUIElement, XamlHelpers::SupportsInteractivity(hostConfig), false);
 
             return columnControl;

--- a/source/uwp/SharedRenderer/lib/AdaptiveColumnRenderer.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveColumnRenderer.h
@@ -5,7 +5,7 @@
 #include "Column.h"
 #include "AdaptiveColumnRenderer.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveColumnRenderer : AdaptiveColumnRendererT<AdaptiveColumnRenderer>
     {
@@ -17,7 +17,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
 
 }
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveColumnRenderer : AdaptiveColumnRendererT<AdaptiveColumnRenderer, implementation::AdaptiveColumnRenderer>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveColumnSetRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveColumnSetRenderer.cpp
@@ -9,7 +9,7 @@
 #include "AdaptiveRenderArgs.h"
 #include "WholeItemsPanel.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     winrt::UIElement AdaptiveColumnSetRenderer::Render(winrt::IAdaptiveCardElement const& cardElement,
                                                        winrt::AdaptiveRenderContext const& renderContext,

--- a/source/uwp/SharedRenderer/lib/AdaptiveColumnSetRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveColumnSetRenderer.cpp
@@ -142,7 +142,7 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 
             XamlHelpers::AppendXamlElementToPanel(xamlGrid, gridContainer, columnSetHeightType);
 
-            return render_xaml::ActionHelpers::HandleSelectAction(
+            return ::AdaptiveCards::Rendering::Xaml_Rendering::ActionHelpers::HandleSelectAction(
                 cardElement, selectAction, renderContext, columnSetBorder, XamlHelpers::SupportsInteractivity(hostConfig), true);
         }
         catch (winrt::hresult_error const& ex)

--- a/source/uwp/SharedRenderer/lib/AdaptiveColumnSetRenderer.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveColumnSetRenderer.h
@@ -5,7 +5,7 @@
 #include "ColumnSet.h"
 #include "AdaptiveColumnSetRenderer.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveColumnSetRenderer : AdaptiveColumnSetRendererT<AdaptiveColumnSetRenderer>
     {
@@ -18,7 +18,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     };
 }
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveColumnSetRenderer : AdaptiveColumnSetRendererT<AdaptiveColumnSetRenderer, implementation::AdaptiveColumnSetRenderer>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveContainerRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveContainerRenderer.cpp
@@ -8,7 +8,7 @@
 #include "AdaptiveRenderArgs.h"
 #include "WholeItemsPanel.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     winrt::UIElement AdaptiveContainerRenderer::Render(winrt::IAdaptiveCardElement const& cardElement,
                                                        winrt::AdaptiveRenderContext const& renderContext,

--- a/source/uwp/SharedRenderer/lib/AdaptiveContainerRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveContainerRenderer.cpp
@@ -64,7 +64,7 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
             auto parentElement = renderArgs.ParentElement();
 
             auto childItems = adaptiveContainer.Items();
-            render_xaml::XamlBuilder::BuildPanelChildren(
+            ::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder::BuildPanelChildren(
                 childItems, containerPanel.as<winrt::Panel>(), renderContext, newRenderArgs, [](winrt::UIElement) {});
 
             // If we changed the context's rtl setting, set it back after rendering the children
@@ -104,7 +104,7 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
             auto selectAction = adaptiveContainerBase.SelectAction();
             auto hostConfig = renderContext.HostConfig();
 
-            return render_xaml::ActionHelpers::HandleSelectAction(
+            return ::AdaptiveCards::Rendering::Xaml_Rendering::ActionHelpers::HandleSelectAction(
                 cardElement, selectAction, renderContext, containerBorder, XamlHelpers::SupportsInteractivity(hostConfig), true);
         }
         catch (winrt::hresult_error const& ex)

--- a/source/uwp/SharedRenderer/lib/AdaptiveContainerRenderer.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveContainerRenderer.h
@@ -5,7 +5,7 @@
 #include "AdaptiveContainerRenderer.g.h"
 #include "Container.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveContainerRenderer : AdaptiveContainerRendererT<AdaptiveContainerRenderer>
     {
@@ -16,7 +16,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
                                 winrt::AdaptiveRenderArgs const& renderArgs);
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveContainerRenderer : AdaptiveContainerRendererT<AdaptiveContainerRenderer, implementation::AdaptiveContainerRenderer>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveContainerStyleDefinition.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveContainerStyleDefinition.cpp
@@ -5,7 +5,7 @@
 #include "AdaptiveContainerStyleDefinition.g.cpp"
 #include "AdaptiveColorsConfig.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveContainerStyleDefinition::AdaptiveContainerStyleDefinition(::AdaptiveCards::ContainerStyleDefinition styleDefinition) :
         ForegroundColors{winrt::make<implementation::AdaptiveColorsConfig>(styleDefinition.foregroundColors)},

--- a/source/uwp/SharedRenderer/lib/AdaptiveContainerStyleDefinition.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveContainerStyleDefinition.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveContainerStyleDefinition.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveContainerStyleDefinition : AdaptiveContainerStyleDefinitionT<AdaptiveContainerStyleDefinition>
     {
@@ -17,7 +17,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     };
 }
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveContainerStyleDefinition
         : AdaptiveContainerStyleDefinitionT<AdaptiveContainerStyleDefinition, implementation::AdaptiveContainerStyleDefinition>

--- a/source/uwp/SharedRenderer/lib/AdaptiveContainerStylesDefinition.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveContainerStylesDefinition.cpp
@@ -5,7 +5,7 @@
 #include "AdaptiveContainerStylesDefinition.h"
 #include "AdaptiveContainerStylesDefinition.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveContainerStylesDefinition::AdaptiveContainerStylesDefinition(::AdaptiveCards::ContainerStylesDefinition const& stylesDefinition) :
         Default{winrt::make<implementation::AdaptiveContainerStyleDefinition>(stylesDefinition.defaultPalette)},

--- a/source/uwp/SharedRenderer/lib/AdaptiveContainerStylesDefinition.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveContainerStylesDefinition.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveContainerStylesDefinition.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveContainerStylesDefinition : AdaptiveContainerStylesDefinitionT<AdaptiveContainerStylesDefinition>
     {
@@ -18,7 +18,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         property<winrt::AdaptiveContainerStyleDefinition> Accent;
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveContainerStylesDefinition
         : AdaptiveContainerStylesDefinitionT<AdaptiveContainerStylesDefinition, implementation::AdaptiveContainerStylesDefinition>

--- a/source/uwp/SharedRenderer/lib/AdaptiveDateInputRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveDateInputRenderer.cpp
@@ -6,7 +6,7 @@
 #include "AdaptiveDateInputRenderer.g.cpp"
 #include "InputValue.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     winrt::UIElement AdaptiveDateInputRenderer::Render(winrt::IAdaptiveCardElement const& cardElement,
                                                        winrt::AdaptiveRenderContext const& renderContext,

--- a/source/uwp/SharedRenderer/lib/AdaptiveDateInputRenderer.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveDateInputRenderer.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveDateInputRenderer.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveDateInputRenderer : AdaptiveDateInputRendererT<AdaptiveDateInputRenderer>
     {
@@ -15,7 +15,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
                                                    winrt::AdaptiveRenderArgs const& renderArgs);
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveDateInputRenderer : AdaptiveDateInputRendererT<AdaptiveDateInputRenderer, implementation::AdaptiveDateInputRenderer>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveElementRendererRegistration.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveElementRendererRegistration.cpp
@@ -4,6 +4,6 @@
 #include "AdaptiveElementRendererRegistration.h"
 #include "AdaptiveElementRendererRegistration.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
 }

--- a/source/uwp/SharedRenderer/lib/AdaptiveElementRendererRegistration.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveElementRendererRegistration.h
@@ -5,7 +5,7 @@
 #include "Util.h"
 #include "AdaptiveElementREndererRegistration.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveElementRendererRegistration : AdaptiveElementRendererRegistrationT<AdaptiveElementRendererRegistration>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveErrorMessageConfig.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveErrorMessageConfig.cpp
@@ -5,7 +5,7 @@
 #include "AdaptiveErrorMessageConfig.h"
 #include "AdaptiveErrorMessageConfig.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveErrorMessageConfig::AdaptiveErrorMessageConfig(::AdaptiveCards::ErrorMessageConfig errorMessageConfig)
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveErrorMessageConfig.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveErrorMessageConfig.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveErrorMessageConfig.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveErrorMessageConfig : AdaptiveErrorMessageConfigT<AdaptiveErrorMessageConfig>
     {
@@ -15,7 +15,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         property<winrt::TextWeight> Weight;
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveErrorMessageConfig : AdaptiveErrorMessageConfigT<AdaptiveErrorMessageConfig, implementation::AdaptiveErrorMessageConfig>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveExecuteActionRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveExecuteActionRenderer.cpp
@@ -6,7 +6,7 @@
 #include "AdaptiveExecuteActionRenderer.g.cpp"
 #include "ActionHelpers.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     winrt::UIElement AdaptiveExecuteActionRenderer::Render(winrt::IAdaptiveActionElement const& action,
                                                            winrt::AdaptiveRenderContext const& renderContext,

--- a/source/uwp/SharedRenderer/lib/AdaptiveExecuteActionRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveExecuteActionRenderer.cpp
@@ -15,7 +15,7 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
         try
         {
             renderContext.LinkSubmitActionToCard(action, renderArgs);
-            return render_xaml::ActionHelpers::BuildAction(action, renderContext, renderArgs, false);
+            return ::AdaptiveCards::Rendering::Xaml_Rendering::ActionHelpers::BuildAction(action, renderContext, renderArgs, false);
         }
         catch (winrt::hresult_error const& ex)
         {

--- a/source/uwp/SharedRenderer/lib/AdaptiveExecuteActionRenderer.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveExecuteActionRenderer.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveExecuteActionRenderer.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveExecuteActionRenderer : AdaptiveExecuteActionRendererT<AdaptiveExecuteActionRenderer>
     {
@@ -15,7 +15,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
                                 winrt::AdaptiveRenderArgs const& renderArgs);
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveExecuteActionRenderer
         : AdaptiveExecuteActionRendererT<AdaptiveExecuteActionRenderer, implementation::AdaptiveExecuteActionRenderer>

--- a/source/uwp/SharedRenderer/lib/AdaptiveFactSetConfig.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveFactSetConfig.cpp
@@ -6,7 +6,7 @@
 #include "AdaptiveFactSetConfig.g.cpp"
 #include "AdaptiveFactSetTextConfig.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveFactSetConfig::AdaptiveFactSetConfig(::AdaptiveCards::FactSetConfig const& factSetConfig) :
         Title{winrt::make<implementation::AdaptiveFactSetTextConfig>(factSetConfig.title)},

--- a/source/uwp/SharedRenderer/lib/AdaptiveFactSetConfig.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveFactSetConfig.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveFactSetConfig.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveFactSetConfig : AdaptiveFactSetConfigT<AdaptiveFactSetConfig>
     {
@@ -15,7 +15,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         property<uint32_t> Spacing;
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveFactSetConfig : AdaptiveFactSetConfigT<AdaptiveFactSetConfig, implementation::AdaptiveFactSetConfig>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveFactSetRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveFactSetRenderer.cpp
@@ -7,7 +7,7 @@
 #include "TextHelpers.h"
 #include "WholeItemsPanel.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     winrt::UIElement AdaptiveFactSetRenderer::Render(winrt::IAdaptiveCardElement const& cardElement,
                                                      winrt::AdaptiveRenderContext const& renderContext,

--- a/source/uwp/SharedRenderer/lib/AdaptiveFactSetRenderer.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveFactSetRenderer.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveFactSetRenderer.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveFactSetRenderer : AdaptiveFactSetRendererT<AdaptiveFactSetRenderer>
     {
@@ -15,7 +15,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
                                 winrt::AdaptiveRenderArgs const& renderArgs);
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveFactSetRenderer : AdaptiveFactSetRendererT<AdaptiveFactSetRenderer, implementation::AdaptiveFactSetRenderer>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveFactSetTextConfig.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveFactSetTextConfig.cpp
@@ -5,7 +5,7 @@
 #include "AdaptiveFactSetTextConfig.h"
 #include "AdaptiveFactSetTextConfig.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveFactSetTextConfig::AdaptiveFactSetTextConfig(::AdaptiveCards::FactSetTextConfig const& textConfig) :
         AdaptiveTextStyleConfigBase(textConfig)

--- a/source/uwp/SharedRenderer/lib/AdaptiveFactSetTextConfig.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveFactSetTextConfig.h
@@ -5,7 +5,7 @@
 #include "AdaptiveTextStyleConfig.h"
 #include "AdaptiveFactSetTextConfig.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveFactSetTextConfig : AdaptiveFactSetTextConfigT<AdaptiveFactSetTextConfig>, AdaptiveTextStyleConfigBase
     {
@@ -15,7 +15,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         property<uint32_t> MaxWidth;
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveFactSetTextConfig : AdaptiveFactSetTextConfigT<AdaptiveFactSetTextConfig, implementation::AdaptiveFactSetTextConfig>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveFeatureRegistration.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveFeatureRegistration.cpp
@@ -4,7 +4,7 @@
 #include "AdaptiveFeatureRegistration.h"
 #include "AdaptiveFeatureRegistration.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveFeatureRegistration::AdaptiveFeatureRegistration(std::shared_ptr<::AdaptiveCards::FeatureRegistration> sharedParserRegistration) :
         m_sharedFeatureRegistration(sharedParserRegistration)

--- a/source/uwp/SharedRenderer/lib/AdaptiveFeatureRegistration.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveFeatureRegistration.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveFeatureRegistration.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct DECLSPEC_UUID("34988ccd-4c0d-4043-b53d-3c1d2868860b") AdaptiveFeatureRegistration
         : AdaptiveFeatureRegistrationT<AdaptiveFeatureRegistration, ITypePeek>
@@ -28,7 +28,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         std::shared_ptr<::AdaptiveCards::FeatureRegistration> m_sharedFeatureRegistration;
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveFeatureRegistration
         : AdaptiveFeatureRegistrationT<AdaptiveFeatureRegistration, implementation::AdaptiveFeatureRegistration>

--- a/source/uwp/SharedRenderer/lib/AdaptiveFontSizesConfig.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveFontSizesConfig.cpp
@@ -5,7 +5,7 @@
 #include "AdaptiveFontSizesConfig.h"
 #include "AdaptiveFontSizesConfig.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveFontSizesConfig::AdaptiveFontSizesConfig(::AdaptiveCards::FontSizesConfig const& fontSizesConfig)
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveFontSizesConfig.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveFontSizesConfig.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveFontSizesConfig.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveFontSizesConfig : AdaptiveFontSizesConfigT<AdaptiveFontSizesConfig>
     {
@@ -17,7 +17,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         property<uint32_t> ExtraLarge;
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveFontSizesConfig : AdaptiveFontSizesConfigT<AdaptiveFontSizesConfig, implementation::AdaptiveFontSizesConfig>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveFontTypeDefinition.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveFontTypeDefinition.cpp
@@ -7,7 +7,7 @@
 #include "AdaptiveFontWeightsConfig.h"
 #include "AdaptiveFontSizesConfig.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveFontTypeDefinition::AdaptiveFontTypeDefinition(::AdaptiveCards::FontTypeDefinition const& typeDefinition) :
         FontFamily{UTF8ToHString(typeDefinition.fontFamily)}, FontWeights{winrt::make<implementation::AdaptiveFontWeightsConfig>(

--- a/source/uwp/SharedRenderer/lib/AdaptiveFontTypeDefinition.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveFontTypeDefinition.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveFontTypeDefinition.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveFontTypeDefinition : AdaptiveFontTypeDefinitionT<AdaptiveFontTypeDefinition>
     {
@@ -15,7 +15,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         property<winrt::AdaptiveFontSizesConfig> FontSizes;
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveFontTypeDefinition : AdaptiveFontTypeDefinitionT<AdaptiveFontTypeDefinition, implementation::AdaptiveFontTypeDefinition>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveFontTypesDefinition.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveFontTypesDefinition.cpp
@@ -6,7 +6,7 @@
 #include "AdaptiveFontTypesDefinition.h"
 #include "AdaptiveFontTypesDefinition.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveFontTypesDefinition::AdaptiveFontTypesDefinition(::AdaptiveCards::FontTypesDefinition const& typesDefinition) :
         Default{winrt::make<implementation::AdaptiveFontTypeDefinition>(typesDefinition.defaultFontType)},

--- a/source/uwp/SharedRenderer/lib/AdaptiveFontTypesDefinition.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveFontTypesDefinition.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveFontTypesDefinition.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveFontTypesDefinition : AdaptiveFontTypesDefinitionT<AdaptiveFontTypesDefinition>
     {
@@ -15,7 +15,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     };
 }
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveFontTypesDefinition
         : AdaptiveFontTypesDefinitionT<AdaptiveFontTypesDefinition, implementation::AdaptiveFontTypesDefinition>

--- a/source/uwp/SharedRenderer/lib/AdaptiveFontWeightsConfig.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveFontWeightsConfig.cpp
@@ -5,7 +5,7 @@
 #include "AdaptiveFontWeightsConfig.h"
 #include "AdaptiveFontWeightsConfig.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveFontWeightsConfig::AdaptiveFontWeightsConfig(::AdaptiveCards::FontWeightsConfig const& fontWeightsConfig)
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveFontWeightsConfig.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveFontWeightsConfig.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveFontWeightsConfig.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveFontWeightsConfig : AdaptiveFontWeightsConfigT<AdaptiveFontWeightsConfig>
     {
@@ -15,7 +15,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         property<uint16_t> Bolder;
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveFontWeightsConfig : AdaptiveFontWeightsConfigT<AdaptiveFontWeightsConfig, implementation::AdaptiveFontWeightsConfig>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveHighlightColorConfig.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveHighlightColorConfig.cpp
@@ -5,7 +5,7 @@
 #include "AdaptiveHighlightColorConfig.h"
 #include "AdaptiveHighlightColorConfig.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveHighlightColorConfig::AdaptiveHighlightColorConfig(::AdaptiveCards::HighlightColorConfig const& colorConfig)
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveHighlightColorConfig.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveHighlightColorConfig.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveHighlightColorConfig.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveHighlightColorConfig : AdaptiveHighlightColorConfigT<AdaptiveHighlightColorConfig>
     {
@@ -15,7 +15,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     };
 }
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveHighlightColorConfig
         : AdaptiveHighlightColorConfigT<AdaptiveHighlightColorConfig, implementation::AdaptiveHighlightColorConfig>

--- a/source/uwp/SharedRenderer/lib/AdaptiveHostConfig.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveHostConfig.cpp
@@ -25,7 +25,7 @@
 #include "AdaptiveTextStylesConfig.h"
 #include "AdaptiveHostConfig.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     winrt::AdaptiveHostConfigParseResult AdaptiveHostConfig::FromJsonString(hstring const& hostConfigJson)
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveHostConfig.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveHostConfig.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveHostConfig.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct DECLSPEC_UUID("6A0EFDB7-AC1B-4C76-981E-2188297095AD") AdaptiveHostConfig
         : AdaptiveHostConfigT<AdaptiveHostConfig, ITypePeek>
@@ -46,7 +46,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         static winrt::AdaptiveHostConfigParseResult _FromJsonString(const std::string& jsonString);
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveHostConfig : AdaptiveHostConfigT<AdaptiveHostConfig, implementation::AdaptiveHostConfig>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveHostConfigParseResult.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveHostConfigParseResult.cpp
@@ -5,7 +5,7 @@
 #include "AdaptiveHostConfigParseResult.h"
 #include "AdaptiveHostConfigParseResult.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveHostConfigParseResult::AdaptiveHostConfigParseResult(winrt::AdaptiveHostConfig const& value) :
         Errors{winrt::single_threaded_vector<winrt::AdaptiveError>()}, HostConfig{value}

--- a/source/uwp/SharedRenderer/lib/AdaptiveHostConfigParseResult.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveHostConfigParseResult.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveHostConfigParseResult.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveHostConfigParseResult : AdaptiveHostConfigParseResultT<AdaptiveHostConfigParseResult>
     {
@@ -14,7 +14,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         property<winrt::IVector<winrt::AdaptiveError>> Errors;
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveHostConfigParseResult
         : AdaptiveHostConfigParseResultT<AdaptiveHostConfigParseResult, implementation::AdaptiveHostConfigParseResult>

--- a/source/uwp/SharedRenderer/lib/AdaptiveImageConfig.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveImageConfig.cpp
@@ -5,7 +5,7 @@
 #include "AdaptiveImageConfig.h"
 #include "AdaptiveImageConfig.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveImageConfig::AdaptiveImageConfig(::AdaptiveCards::ImageConfig const& sharedImageConfig)
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveImageConfig.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveImageConfig.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveImageConfig.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveImageConfig : AdaptiveImageConfigT<AdaptiveImageConfig>
     {
@@ -13,7 +13,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         property<winrt::ImageSize> ImageSize;
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveImageConfig : AdaptiveImageConfigT<AdaptiveImageConfig, implementation::AdaptiveImageConfig>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveImageRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveImageRenderer.cpp
@@ -13,7 +13,7 @@
 
 namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
-    AdaptiveImageRenderer::AdaptiveImageRenderer(winrt::com_ptr<render_xaml::XamlBuilder> xamlBuilder) :
+    AdaptiveImageRenderer::AdaptiveImageRenderer(winrt::com_ptr<::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder> xamlBuilder) :
         m_xamlBuilder(xamlBuilder)
     {
     }
@@ -44,7 +44,7 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
     //
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    winrt::UIElement render_xaml::XamlBuilder::BuildImage(winrt::IAdaptiveCardElement const& adaptiveCardElement,
+    winrt::UIElement ::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder::BuildImage(winrt::IAdaptiveCardElement const& adaptiveCardElement,
                                                           winrt::AdaptiveRenderContext const& renderContext,
                                                           winrt::AdaptiveRenderArgs const& renderArgs)
     {
@@ -270,7 +270,7 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
     }
 
     template<typename T>
-    void render_xaml::XamlBuilder::SetImageOnUIElement(winrt::Uri const& imageUrl,
+    void ::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder::SetImageOnUIElement(winrt::Uri const& imageUrl,
                                                        T const& uiElement,
                                                        winrt::AdaptiveCardResourceResolvers const& resolvers,
                                                        bool isAutoSize,
@@ -483,7 +483,7 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
         }
     }
 
-    winrt::ImageSource render_xaml::XamlBuilder::CreateImageSource(bool isImageSvg)
+    winrt::ImageSource ::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder::CreateImageSource(bool isImageSvg)
     {
         if (isImageSvg)
         {
@@ -499,7 +499,7 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
 
     // Issue #8127
     template<typename T>
-    void render_xaml::XamlBuilder::PopulateImageFromUrlAsync(winrt::Uri const& imageUrl, T const& imageControl, bool const& isImageSvg)
+    void ::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder::PopulateImageFromUrlAsync(winrt::Uri const& imageUrl, T const& imageControl, bool const& isImageSvg)
     {
         winrt::HttpBaseProtocolFilter httpBaseProtocolFilter{};
         httpBaseProtocolFilter.AllowUI(false);
@@ -542,13 +542,13 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
     }
 
     template<typename T>
-    void render_xaml::XamlBuilder::SetImageSource(T const& destination, winrt::ImageSource const& imageSource, winrt::Stretch /*stretch*/)
+    void ::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder::SetImageSource(T const& destination, winrt::ImageSource const& imageSource, winrt::Stretch /*stretch*/)
     {
         destination.Source(imageSource);
     };
 
     template<>
-    void render_xaml::XamlBuilder::SetImageSource<winrt::Ellipse>(winrt::Ellipse const& destination,
+    void ::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder::SetImageSource<winrt::Ellipse>(winrt::Ellipse const& destination,
                                                                   winrt::ImageSource const& imageSource,
                                                                   winrt::Stretch stretch)
     {
@@ -560,7 +560,7 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
     };
 
     template<>
-    void render_xaml::XamlBuilder::SetAutoSize<winrt::Ellipse>(winrt::Ellipse const& ellipse,
+    void ::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder::SetAutoSize<winrt::Ellipse>(winrt::Ellipse const& ellipse,
                                                                winrt::IInspectable const& parentElement,
                                                                winrt::IInspectable const& imageContainer,
                                                                bool isVisible,
@@ -615,7 +615,7 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
     }
 
     template<typename T>
-    void render_xaml::XamlBuilder::SetAutoSize(T const& destination,
+    void ::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder::SetAutoSize(T const& destination,
                                                winrt::IInspectable const& parentElement,
                                                winrt::IInspectable const&, /* imageContainer */
                                                bool isVisible,
@@ -660,7 +660,7 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
         }
     }
 
-    boolean render_xaml::XamlBuilder::IsSvgImage(std::string url)
+    boolean ::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder::IsSvgImage(std::string url)
     {
         // Question: is this check sufficient?
         auto foundSvg = url.find("svg");

--- a/source/uwp/SharedRenderer/lib/AdaptiveImageRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveImageRenderer.cpp
@@ -11,7 +11,7 @@
 #include <robuffer.h>
 #include "WholeItemsPanel.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveImageRenderer::AdaptiveImageRenderer(winrt::com_ptr<render_xaml::XamlBuilder> xamlBuilder) :
         m_xamlBuilder(xamlBuilder)
@@ -34,7 +34,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     }
 }
 
-namespace AdaptiveCards::Rendering::Uwp
+namespace AdaptiveCards::Rendering::Xaml_Rendering
 {
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     //

--- a/source/uwp/SharedRenderer/lib/AdaptiveImageRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveImageRenderer.cpp
@@ -18,9 +18,8 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
     {
     }
 
-    winrt::UIElement AdaptiveImageRenderer::Render(winrt::IAdaptiveCardElement const& cardElement,
-                                                   winrt::AdaptiveRenderContext const& renderContext,
-                                                   winrt::AdaptiveRenderArgs const& renderArgs)
+    winrt::UIElement AdaptiveImageRenderer::Render(
+        winrt::IAdaptiveCardElement const& cardElement, winrt::AdaptiveRenderContext const& renderContext, winrt::AdaptiveRenderArgs const& renderArgs)
     {
         try
         {
@@ -44,9 +43,10 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
     //
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    winrt::UIElement ::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder::BuildImage(winrt::IAdaptiveCardElement const& adaptiveCardElement,
-                                                          winrt::AdaptiveRenderContext const& renderContext,
-                                                          winrt::AdaptiveRenderArgs const& renderArgs)
+    winrt::UIElement XamlBuilder::BuildImage(
+        winrt::IAdaptiveCardElement const& adaptiveCardElement,
+        winrt::AdaptiveRenderContext const& renderContext,
+        winrt::AdaptiveRenderArgs const& renderArgs)
     {
         auto adaptiveImage = adaptiveCardElement.as<winrt::AdaptiveImage>();
 
@@ -101,7 +101,8 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
             auto ellipseAsShape = ellipse.as<winrt::Shape>();
             auto backgrondEllipseAsShape = backgroundEllipse.as<winrt::Shape>();
 
-            SetImageOnUIElement(imageUrl, ellipse, resourceResolvers, (size == winrt::ImageSize::Auto), parentElement, ellipseAsShape, isVisible, isImageSvg, imageStretch);
+            SetImageOnUIElement(
+                imageUrl, ellipse, resourceResolvers, (size == winrt::ImageSize::Auto), parentElement, ellipseAsShape, isVisible, isImageSvg, imageStretch);
 
             if (size == winrt::ImageSize::None || size == winrt::ImageSize::Stretch || size == winrt::ImageSize::Auto || hasExplicitMeasurements)
             {
@@ -161,7 +162,8 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
 
             auto parentElement = renderArgs.ParentElement();
 
-            SetImageOnUIElement(imageUrl, xamlImage, resourceResolvers, (size == winrt::ImageSize::Auto), parentElement, frameworkElement, isVisible, isImageSvg);
+            SetImageOnUIElement(
+                imageUrl, xamlImage, resourceResolvers, (size == winrt::ImageSize::Auto), parentElement, frameworkElement, isVisible, isImageSvg);
         }
 
         auto sizeOptions = hostConfig.ImageSizes();
@@ -269,16 +271,17 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
             adaptiveCardElement, selectAction, renderContext, frameworkElement, XamlHelpers::SupportsInteractivity(hostConfig), true);
     }
 
-    template<typename T>
-    void ::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder::SetImageOnUIElement(winrt::Uri const& imageUrl,
-                                                       T const& uiElement,
-                                                       winrt::AdaptiveCardResourceResolvers const& resolvers,
-                                                       bool isAutoSize,
-                                                       winrt::IInspectable const& parentElement,
-                                                       winrt::IInspectable const& imageContainer,
-                                                       bool isVisible,
-                                                       bool isImageSvg,
-                                                       winrt::Stretch stretch)
+    template <typename T>
+    void XamlBuilder::SetImageOnUIElement(
+        winrt::Uri const& imageUrl,
+        T const& uiElement,
+        winrt::AdaptiveCardResourceResolvers const& resolvers,
+        bool isAutoSize,
+        winrt::IInspectable const& parentElement,
+        winrt::IInspectable const& imageContainer,
+        bool isVisible,
+        bool isImageSvg,
+        winrt::Stretch stretch)
     {
         bool mustHideElement = true;
 
@@ -483,7 +486,7 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
         }
     }
 
-    winrt::ImageSource ::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder::CreateImageSource(bool isImageSvg)
+    winrt::ImageSource XamlBuilder::CreateImageSource(bool isImageSvg)
     {
         if (isImageSvg)
         {
@@ -498,8 +501,8 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
     }
 
     // Issue #8127
-    template<typename T>
-    void ::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder::PopulateImageFromUrlAsync(winrt::Uri const& imageUrl, T const& imageControl, bool const& isImageSvg)
+    template <typename T>
+    void XamlBuilder::PopulateImageFromUrlAsync(winrt::Uri const& imageUrl, T const& imageControl, bool const& isImageSvg)
     {
         winrt::HttpBaseProtocolFilter httpBaseProtocolFilter{};
         httpBaseProtocolFilter.AllowUI(false);
@@ -541,16 +544,14 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
         m_getStreamOperations.push_back(getStreamOperation);
     }
 
-    template<typename T>
-    void ::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder::SetImageSource(T const& destination, winrt::ImageSource const& imageSource, winrt::Stretch /*stretch*/)
+    template <typename T>
+    void XamlBuilder::SetImageSource(T const& destination, winrt::ImageSource const& imageSource, winrt::Stretch /*stretch*/)
     {
         destination.Source(imageSource);
     };
 
-    template<>
-    void ::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder::SetImageSource<winrt::Ellipse>(winrt::Ellipse const& destination,
-                                                                  winrt::ImageSource const& imageSource,
-                                                                  winrt::Stretch stretch)
+    template <>
+    void XamlBuilder::SetImageSource<winrt::Ellipse>(winrt::Ellipse const& destination, winrt::ImageSource const& imageSource, winrt::Stretch stretch)
     {
         winrt::ImageBrush imageBrush{};
         imageBrush.ImageSource(imageSource);
@@ -559,12 +560,13 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
         destination.Fill(imageBrush);
     };
 
-    template<>
-    void ::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder::SetAutoSize<winrt::Ellipse>(winrt::Ellipse const& ellipse,
-                                                               winrt::IInspectable const& parentElement,
-                                                               winrt::IInspectable const& imageContainer,
-                                                               bool isVisible,
-                                                               bool imageFiresOpenEvent)
+    template <>
+    void XamlBuilder::SetAutoSize<winrt::Ellipse>(
+        winrt::Ellipse const& ellipse,
+        winrt::IInspectable const& parentElement,
+        winrt::IInspectable const& imageContainer,
+        bool isVisible,
+        bool imageFiresOpenEvent)
     {
         // Check if the image source fits in the parent container, if so, set the framework element's size to match the original image.
         if (parentElement && m_enableXamlImageHandling)
@@ -614,12 +616,13 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
         }
     }
 
-    template<typename T>
-    void ::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder::SetAutoSize(T const& destination,
-                                               winrt::IInspectable const& parentElement,
-                                               winrt::IInspectable const&, /* imageContainer */
-                                               bool isVisible,
-                                               bool imageFiresOpenEvent)
+    template <typename T>
+    void XamlBuilder::SetAutoSize(
+        T const& destination,
+        winrt::IInspectable const& parentElement,
+        winrt::IInspectable const&, /* imageContainer */
+        bool isVisible,
+        bool imageFiresOpenEvent)
     {
         if (parentElement && m_enableXamlImageHandling)
         {
@@ -640,9 +643,9 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
                 auto weakImage = winrt::make_weak(xamlImage);
 
                 xamlImage.ImageOpened(
-                    [weakImage, weakParent, imageSource, isVisible](winrt::IInspectable const& /*sender*/,
-                                                                                  winrt::RoutedEventArgs const&
-                                                                                  /*args*/) -> void
+                    [weakImage, weakParent, imageSource, isVisible](
+                        winrt::IInspectable const& /*sender*/, winrt::RoutedEventArgs const&
+                        /*args*/) -> void
                     {
                         if (const auto lambdaImageAsFrameworkElement = weakImage.get())
                         {
@@ -660,7 +663,7 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
         }
     }
 
-    boolean ::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder::IsSvgImage(std::string url)
+    boolean XamlBuilder::IsSvgImage(std::string url)
     {
         // Question: is this check sufficient?
         auto foundSvg = url.find("svg");

--- a/source/uwp/SharedRenderer/lib/AdaptiveImageRenderer.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveImageRenderer.h
@@ -11,14 +11,14 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
     {
     public:
         AdaptiveImageRenderer(){};
-        AdaptiveImageRenderer(winrt::com_ptr<render_xaml::XamlBuilder> xamlBuilder);
+        AdaptiveImageRenderer(winrt::com_ptr<::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder> xamlBuilder);
 
         winrt::UIElement Render(winrt::IAdaptiveCardElement const& cardElement,
                                 winrt::AdaptiveRenderContext const& renderContext,
                                 winrt::AdaptiveRenderArgs const& renderArgs);
 
     private:
-        winrt::com_ptr<render_xaml::XamlBuilder> m_xamlBuilder;
+        winrt::com_ptr<::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder> m_xamlBuilder;
     };
 }
 

--- a/source/uwp/SharedRenderer/lib/AdaptiveImageRenderer.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveImageRenderer.h
@@ -5,7 +5,7 @@
 #include "AdaptiveImageRenderer.g.h"
 #include "Image.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveImageRenderer : AdaptiveImageRendererT<AdaptiveImageRenderer>
     {
@@ -22,7 +22,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     };
 }
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveImageRenderer : AdaptiveImageRendererT<AdaptiveImageRenderer, implementation::AdaptiveImageRenderer>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveImageSetConfig.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveImageSetConfig.cpp
@@ -5,7 +5,7 @@
 #include "AdaptiveImageSetConfig.h"
 #include "AdaptiveImageSetConfig.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveImageSetConfig::AdaptiveImageSetConfig(::AdaptiveCards::ImageSetConfig const& sharedImageSetConfig)
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveImageSetConfig.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveImageSetConfig.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveImageSetConfig.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveImageSetConfig : AdaptiveImageSetConfigT<AdaptiveImageSetConfig>
     {
@@ -14,7 +14,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         property<uint32_t> MaxImageHeight;
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveImageSetConfig : AdaptiveImageSetConfigT<AdaptiveImageSetConfig, implementation::AdaptiveImageSetConfig>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveImageSetRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveImageSetRenderer.cpp
@@ -7,7 +7,7 @@
 #include "AdaptiveRenderArgs.h"
 #include "WholeItemsPanel.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     winrt::UIElement AdaptiveImageSetRenderer::Render(winrt::IAdaptiveCardElement const& cardElement,
                                                       winrt::AdaptiveRenderContext const& renderContext,

--- a/source/uwp/SharedRenderer/lib/AdaptiveImageSetRenderer.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveImageSetRenderer.h
@@ -5,7 +5,7 @@
 #include "AdaptiveImageSetRenderer.g.h"
 #include "ImageSet.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveImageSetRenderer : AdaptiveImageSetRendererT<AdaptiveImageSetRenderer>
     {
@@ -16,7 +16,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     };
 }
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveImageSetRenderer : AdaptiveImageSetRendererT<AdaptiveImageSetRenderer, implementation::AdaptiveImageSetRenderer>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveImageSizesConfig.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveImageSizesConfig.cpp
@@ -5,7 +5,7 @@
 #include "AdaptiveImageSizesConfig.h"
 #include "AdaptiveImageSizesConfig.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveImageSizesConfig::AdaptiveImageSizesConfig(::AdaptiveCards::ImageSizesConfig const& imageSizesConfig)
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveImageSizesConfig.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveImageSizesConfig.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveImageSizesConfig.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveImageSizesConfig : AdaptiveImageSizesConfigT<AdaptiveImageSizesConfig>
     {
@@ -16,7 +16,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     };
 }
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveImageSizesConfig : AdaptiveImageSizesConfigT<AdaptiveImageSizesConfig, implementation::AdaptiveImageSizesConfig>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveInputLabelConfig.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveInputLabelConfig.cpp
@@ -5,7 +5,7 @@
 #include "AdaptiveInputLabelConfig.h"
 #include "AdaptiveInputLabelConfig.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveInputLabelConfig::AdaptiveInputLabelConfig(::AdaptiveCards::InputLabelConfig const& inputLabelConfig)
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveInputLabelConfig.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveInputLabelConfig.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveInputLabelConfig.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveInputLabelConfig : AdaptiveInputLabelConfigT<AdaptiveInputLabelConfig>
     {
@@ -18,7 +18,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     };
 }
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveInputLabelConfig : AdaptiveInputLabelConfigT<AdaptiveInputLabelConfig, implementation::AdaptiveInputLabelConfig>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveInputs.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveInputs.cpp
@@ -5,7 +5,7 @@
 #include "AdaptiveInputs.g.cpp"
 #include "AdaptiveRenderArgs.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     winrt::JsonObject AdaptiveInputs::AsJson()
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveInputs.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveInputs.h
@@ -5,7 +5,7 @@
 #include "InputValue.h"
 #include "AdaptiveInputs.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveInputs : AdaptiveInputsT<AdaptiveInputs>
     {
@@ -51,7 +51,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     };
 }
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveInputs : AdaptiveInputsT<AdaptiveInputs, implementation::AdaptiveInputs>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveInputsConfig.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveInputsConfig.cpp
@@ -5,7 +5,7 @@
 #include "AdaptiveInputsConfig.h"
 #include "AdaptiveInputsConfig.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveInputsConfig::AdaptiveInputsConfig(::AdaptiveCards::InputsConfig const& inputsConfig) :
         ErrorMessage{winrt::make<implementation::AdaptiveErrorMessageConfig>(inputsConfig.errorMessage)},

--- a/source/uwp/SharedRenderer/lib/AdaptiveInputsConfig.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveInputsConfig.h
@@ -6,7 +6,7 @@
 #include "AdaptiveErrorMessageConfig.h"
 #include "AdaptiveInputsConfig.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveInputsConfig : AdaptiveInputsConfigT<AdaptiveInputsConfig>
     {
@@ -17,7 +17,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     };
 }
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveInputsConfig : AdaptiveInputsConfigT<AdaptiveInputsConfig, implementation::AdaptiveInputsConfig>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveLabelConfig.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveLabelConfig.cpp
@@ -5,7 +5,7 @@
 #include "AdaptiveLabelConfig.h"
 #include "AdaptiveLabelConfig.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveLabelConfig::AdaptiveLabelConfig(::AdaptiveCards::LabelConfig const& labelConfig) :
         InputSpacing{static_cast<winrt::Spacing>(labelConfig.inputSpacing)},

--- a/source/uwp/SharedRenderer/lib/AdaptiveLabelConfig.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveLabelConfig.h
@@ -5,7 +5,7 @@
 #include "AdaptiveInputLabelConfig.h"
 #include "AdaptiveLabelConfig.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveLabelConfig : AdaptiveLabelConfigT<AdaptiveLabelConfig>
     {
@@ -16,7 +16,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         property<winrt::AdaptiveInputLabelConfig> OptionalInputs;
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveLabelConfig : AdaptiveLabelConfigT<AdaptiveLabelConfig, implementation::AdaptiveLabelConfig>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveMediaConfig.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveMediaConfig.cpp
@@ -5,7 +5,7 @@
 #include "AdaptiveMediaConfig.h"
 #include "AdaptiveMediaConfig.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveMediaConfig::AdaptiveMediaConfig(::AdaptiveCards::MediaConfig const& mediaConfig)
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveMediaConfig.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveMediaConfig.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveMediaConfig.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveMediaConfig : AdaptiveMediaConfigT<AdaptiveMediaConfig>
     {
@@ -16,7 +16,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     };
 }
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveMediaConfig : AdaptiveMediaConfigT<AdaptiveMediaConfig, implementation::AdaptiveMediaConfig>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveMediaEventArgs.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveMediaEventArgs.cpp
@@ -3,6 +3,6 @@
 #include "pch.h"
 #include "AdaptiveMediaEventArgs.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
 }

--- a/source/uwp/SharedRenderer/lib/AdaptiveMediaEventArgs.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveMediaEventArgs.h
@@ -3,7 +3,7 @@
 #pragma once
 #include "AdaptiveMediaEventArgs.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveMediaEventArgs : AdaptiveMediaEventArgsT<AdaptiveMediaEventArgs>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveMediaEventInvoker.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveMediaEventInvoker.cpp
@@ -5,7 +5,7 @@
 #include "AdaptiveMediaEventInvoker.h"
 #include "AdaptiveMediaEventInvoker.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     void AdaptiveMediaEventInvoker::SendMediaClickedEvent(winrt::AdaptiveMedia const& mediaElement)
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveMediaEventInvoker.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveMediaEventInvoker.h
@@ -5,7 +5,7 @@
 #include "RenderedAdaptiveCard.h"
 #include "AdaptiveMediaEventInvoker.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveMediaEventInvoker : AdaptiveMediaEventInvokerT<AdaptiveMediaEventInvoker>
     {
@@ -19,7 +19,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     };
 }
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveMediaEventInvoker : AdaptiveMediaEventInvokerT<AdaptiveMediaEventInvoker, implementation::AdaptiveMediaEventInvoker>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveMediaRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveMediaRenderer.cpp
@@ -9,7 +9,7 @@
 #include "MediaHelpers.h"
 #include "WholeItemsPanel.h"
 
-using namespace render_xaml::MediaHelpers;
+using namespace ::AdaptiveCards::Rendering::Xaml_Rendering::MediaHelpers;
 
 namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
@@ -39,7 +39,7 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 
             winrt::hstring altText = adaptiveMedia.AltText();
 
-            auto touchTargetUIElement = render_xaml::ActionHelpers::WrapInTouchTarget(
+            auto touchTargetUIElement = ::AdaptiveCards::Rendering::Xaml_Rendering::ActionHelpers::WrapInTouchTarget(
                 cardElement, posterContainer, nullptr, renderContext, true, L"Adaptive.SelectAction", altText, false);
 
             // Create a panel to hold the poster and the media element

--- a/source/uwp/SharedRenderer/lib/AdaptiveMediaRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveMediaRenderer.cpp
@@ -11,7 +11,7 @@
 
 using namespace render_xaml::MediaHelpers;
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     winrt::UIElement AdaptiveMediaRenderer::Render(winrt::IAdaptiveCardElement const& cardElement,
                                                    winrt::AdaptiveRenderContext const& renderContext,

--- a/source/uwp/SharedRenderer/lib/AdaptiveMediaRenderer.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveMediaRenderer.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveMediaRenderer.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveMediaRenderer : AdaptiveMediaRendererT<AdaptiveMediaRenderer>
     {
@@ -17,7 +17,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     };
 }
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveMediaRenderer : AdaptiveMediaRendererT<AdaptiveMediaRenderer, implementation::AdaptiveMediaRenderer>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveNumberInputRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveNumberInputRenderer.cpp
@@ -7,7 +7,7 @@
 #include <limits>
 #include "InputValue.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     winrt::UIElement AdaptiveNumberInputRenderer::Render(winrt::IAdaptiveCardElement const& cardElement,
                                                          winrt::AdaptiveRenderContext const& renderContext,

--- a/source/uwp/SharedRenderer/lib/AdaptiveNumberInputRenderer.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveNumberInputRenderer.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveNumberInputRenderer.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveNumberInputRenderer : AdaptiveNumberInputRendererT<AdaptiveNumberInputRenderer>
     {
@@ -16,7 +16,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
 
 }
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveNumberInputRenderer
         : AdaptiveNumberInputRendererT<AdaptiveNumberInputRenderer, implementation::AdaptiveNumberInputRenderer>

--- a/source/uwp/SharedRenderer/lib/AdaptiveOpenUrlActionRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveOpenUrlActionRenderer.cpp
@@ -14,7 +14,7 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
     {
         try
         {
-            return render_xaml::ActionHelpers::BuildAction(action, renderContext, renderArgs, false);
+            return ::AdaptiveCards::Rendering::Xaml_Rendering::ActionHelpers::BuildAction(action, renderContext, renderArgs, false);
         }
         catch (winrt::hresult_error const& ex)
         {

--- a/source/uwp/SharedRenderer/lib/AdaptiveOpenUrlActionRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveOpenUrlActionRenderer.cpp
@@ -6,7 +6,7 @@
 #include "AdaptiveOpenUrlActionRenderer.g.cpp"
 #include "ActionHelpers.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     winrt::UIElement AdaptiveOpenUrlActionRenderer::Render(winrt::IAdaptiveActionElement const& action,
                                                            winrt::AdaptiveRenderContext const& renderContext,

--- a/source/uwp/SharedRenderer/lib/AdaptiveOpenUrlActionRenderer.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveOpenUrlActionRenderer.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveOpenUrlActionRenderer.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveOpenUrlActionRenderer : AdaptiveOpenUrlActionRendererT<AdaptiveOpenUrlActionRenderer>
     {
@@ -15,7 +15,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
                                                    winrt::AdaptiveRenderArgs const& renderArgs);
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveOpenUrlActionRenderer
         : AdaptiveOpenUrlActionRendererT<AdaptiveOpenUrlActionRenderer, implementation::AdaptiveOpenUrlActionRenderer>

--- a/source/uwp/SharedRenderer/lib/AdaptiveRenderArgs.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveRenderArgs.cpp
@@ -5,7 +5,7 @@
 #include "AdaptiveRenderArgs.h"
 #include "AdaptiveRenderArgs.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     // This constructor is kept so all elements keep working as expected
     AdaptiveRenderArgs::AdaptiveRenderArgs(winrt::ContainerStyle const& containerStyle,

--- a/source/uwp/SharedRenderer/lib/AdaptiveRenderArgs.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveRenderArgs.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveRenderArgs.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveRenderArgs : AdaptiveRenderArgsT<AdaptiveRenderArgs>
     {
@@ -28,7 +28,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         property<bool> AddContainerPadding{false};
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveRenderArgs : AdaptiveRenderArgsT<AdaptiveRenderArgs, implementation::AdaptiveRenderArgs>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveRenderContext.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveRenderContext.cpp
@@ -6,7 +6,7 @@
 #include "AdaptiveRenderContext.g.cpp"
 #include "InputValue.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveRenderContext::AdaptiveRenderContext() :
         HostConfig{nullptr}, FeatureRegistration{nullptr}, ElementRenderers{nullptr}, ActionRenderers{nullptr},

--- a/source/uwp/SharedRenderer/lib/AdaptiveRenderContext.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveRenderContext.h
@@ -7,7 +7,7 @@
 #include "AdaptiveMediaEventInvoker.h"
 #include "AdaptiveRenderContext.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct DECLSPEC_UUID("F29649FF-C718-4F94-8F39-2415C86BE77E") AdaptiveRenderContext
         : AdaptiveRenderContextT<AdaptiveRenderContext, ITypePeek>
@@ -71,7 +71,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     };
 }
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveRenderContext : AdaptiveRenderContextT<AdaptiveRenderContext, implementation::AdaptiveRenderContext>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveRichTextBlockRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveRichTextBlockRenderer.cpp
@@ -7,7 +7,7 @@
 #include "AdaptiveRenderContext.h"
 #include "TextHelpers.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     winrt::UIElement AdaptiveRichTextBlockRenderer::Render(winrt::IAdaptiveCardElement const& cardElement,
                                                            winrt::AdaptiveRenderContext const& renderContext,

--- a/source/uwp/SharedRenderer/lib/AdaptiveRichTextBlockRenderer.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveRichTextBlockRenderer.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveRichTextBlockRenderer.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveRichTextBlockRenderer : AdaptiveRichTextBlockRendererT<AdaptiveRichTextBlockRenderer>
     {
@@ -15,7 +15,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
                                                    winrt::AdaptiveRenderArgs const& renderArgs);
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveRichTextBlockRenderer
         : AdaptiveRichTextBlockRendererT<AdaptiveRichTextBlockRenderer, implementation::AdaptiveRichTextBlockRenderer>

--- a/source/uwp/SharedRenderer/lib/AdaptiveSeparatorConfig.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveSeparatorConfig.cpp
@@ -5,7 +5,7 @@
 #include "AdaptiveSeparatorConfig.h"
 #include "AdaptiveSeparatorConfig.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveSeparatorConfig::AdaptiveSeparatorConfig(::AdaptiveCards::SeparatorConfig const& sharedSeparatorConfig)
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveSeparatorConfig.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveSeparatorConfig.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveSeparatorConfig.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveSeparatorConfig : AdaptiveSeparatorConfigT<AdaptiveSeparatorConfig>
     {
@@ -15,7 +15,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     };
 }
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveSeparatorConfig : AdaptiveSeparatorConfigT<AdaptiveSeparatorConfig, AdaptiveSeparatorConfig>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveShowCardActionConfig.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveShowCardActionConfig.cpp
@@ -5,7 +5,7 @@
 #include "AdaptiveShowCardActionConfig.h"
 #include "AdaptiveShowCardActionConfig.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveShowCardActionConfig::AdaptiveShowCardActionConfig(::AdaptiveCards::ShowCardActionConfig const& sharedShowCardActionConfig)
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveShowCardActionConfig.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveShowCardActionConfig.cpp
@@ -9,7 +9,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
 {
     AdaptiveShowCardActionConfig::AdaptiveShowCardActionConfig(::AdaptiveCards::ShowCardActionConfig const& sharedShowCardActionConfig)
     {
-        ActionMode = static_cast<winrt_render_xaml::ActionMode>(sharedShowCardActionConfig.actionMode);
+        ActionMode = static_cast<winrt::AdaptiveCards::Rendering::Xaml_Rendering::ActionMode>(sharedShowCardActionConfig.actionMode);
         Style = static_cast<winrt::ContainerStyle>(sharedShowCardActionConfig.style);
         InlineTopMargin = sharedShowCardActionConfig.inlineTopMargin;
     }

--- a/source/uwp/SharedRenderer/lib/AdaptiveShowCardActionConfig.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveShowCardActionConfig.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveShowCardActionConfig.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveShowCardActionConfig : AdaptiveShowCardActionConfigT<AdaptiveShowCardActionConfig>
     {
@@ -15,7 +15,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         property<uint32_t> InlineTopMargin;
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveShowCardActionConfig
         : AdaptiveShowCardActionConfigT<AdaptiveShowCardActionConfig, implementation::AdaptiveShowCardActionConfig>

--- a/source/uwp/SharedRenderer/lib/AdaptiveShowCardActionConfig.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveShowCardActionConfig.h
@@ -10,7 +10,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     {
         AdaptiveShowCardActionConfig(::AdaptiveCards::ShowCardActionConfig const& showCardActionConfig = {});
 
-        property<winrt_render_xaml::ActionMode> ActionMode;
+        property<winrt::AdaptiveCards::Rendering::Xaml_Rendering::ActionMode> ActionMode;
         property<winrt::ContainerStyle> Style;
         property<uint32_t> InlineTopMargin;
     };

--- a/source/uwp/SharedRenderer/lib/AdaptiveShowCardActionRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveShowCardActionRenderer.cpp
@@ -6,7 +6,7 @@
 #include "AdaptiveShowCardActionRenderer.g.cpp"
 #include "ActionHelpers.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     winrt::UIElement AdaptiveShowCardActionRenderer::Render(winrt::IAdaptiveActionElement const& action,
                                                             winrt::AdaptiveRenderContext const& renderContext,

--- a/source/uwp/SharedRenderer/lib/AdaptiveShowCardActionRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveShowCardActionRenderer.cpp
@@ -14,7 +14,7 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
     {
         try
         {
-            return render_xaml::ActionHelpers::BuildAction(action, renderContext, renderArgs, false);
+            return ::AdaptiveCards::Rendering::Xaml_Rendering::ActionHelpers::BuildAction(action, renderContext, renderArgs, false);
         }
         catch (winrt::hresult_error const& ex)
         {
@@ -39,7 +39,7 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
             renderContext.LinkCardToParent(showCard, renderArgs);
 
             auto localUiShowCard =
-                render_xaml::XamlBuilder::BuildXamlTreeFromAdaptiveCard(showCard, renderContext, nullptr, showCardConfigStyle);
+                ::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder::BuildXamlTreeFromAdaptiveCard(showCard, renderContext, nullptr, showCardConfigStyle);
             renderArgs.IsInShowCard(wasInShowCard);
 
             // Set the padding

--- a/source/uwp/SharedRenderer/lib/AdaptiveShowCardActionRenderer.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveShowCardActionRenderer.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveShowCardActionRenderer.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveShowCardActionRenderer : AdaptiveShowCardActionRendererT<AdaptiveShowCardActionRenderer>
     {
@@ -20,7 +20,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     };
 }
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveShowCardActionRenderer
         : AdaptiveShowCardActionRendererT<AdaptiveShowCardActionRenderer, implementation::AdaptiveShowCardActionRenderer>

--- a/source/uwp/SharedRenderer/lib/AdaptiveSpacingConfig.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveSpacingConfig.cpp
@@ -5,7 +5,7 @@
 #include "AdaptiveSpacingConfig.h"
 #include "AdaptiveSpacingConfig.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveSpacingConfig::AdaptiveSpacingConfig(::AdaptiveCards::SpacingConfig const& spacingConfig)
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveSpacingConfig.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveSpacingConfig.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveSpacingConfig.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveSpacingConfig : AdaptiveSpacingConfigT<AdaptiveSpacingConfig>
     {
@@ -18,7 +18,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         property<uint32_t> Padding;
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveSpacingConfig : AdaptiveSpacingConfigT<AdaptiveSpacingConfig, implementation::AdaptiveSpacingConfig>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveSubmitActionRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveSubmitActionRenderer.cpp
@@ -6,7 +6,7 @@
 #include "AdaptiveSubmitActionRenderer.g.cpp"
 #include "ActionHelpers.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     winrt::UIElement AdaptiveSubmitActionRenderer::Render(winrt::IAdaptiveActionElement const& action,
                                                           winrt::AdaptiveRenderContext const& renderContext,

--- a/source/uwp/SharedRenderer/lib/AdaptiveSubmitActionRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveSubmitActionRenderer.cpp
@@ -15,7 +15,7 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
         try
         {
             renderContext.LinkSubmitActionToCard(action, renderArgs);
-            return render_xaml::ActionHelpers::BuildAction(action, renderContext, renderArgs, false);
+            return ::AdaptiveCards::Rendering::Xaml_Rendering::ActionHelpers::BuildAction(action, renderContext, renderArgs, false);
         }
         catch (winrt::hresult_error const& ex)
         {

--- a/source/uwp/SharedRenderer/lib/AdaptiveSubmitActionRenderer.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveSubmitActionRenderer.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveSubmitActionRenderer.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveSubmitActionRenderer : AdaptiveSubmitActionRendererT<AdaptiveSubmitActionRenderer>
     {
@@ -16,7 +16,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     };
 }
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveSubmitActionRenderer
         : AdaptiveSubmitActionRendererT<AdaptiveSubmitActionRenderer, implementation::AdaptiveSubmitActionRenderer>

--- a/source/uwp/SharedRenderer/lib/AdaptiveTableConfig.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveTableConfig.cpp
@@ -5,7 +5,7 @@
 #include "AdaptiveTableConfig.h"
 #include "AdaptiveTableConfig.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveTableConfig::AdaptiveTableConfig(::AdaptiveCards::TableConfig const& tableConfig)
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveTableConfig.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveTableConfig.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveTableConfig.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveTableConfig : AdaptiveTableConfigT<AdaptiveTableConfig>
     {
@@ -13,7 +13,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         property<uint32_t> CellSpacing;
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveTableConfig : AdaptiveTableConfigT<AdaptiveTableConfig, implementation::AdaptiveTableConfig>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveTableRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveTableRenderer.cpp
@@ -6,7 +6,7 @@
 #include "AdaptiveTableRenderer.g.cpp"
 #include "WholeItemsPanel.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     winrt::FrameworkElement AdaptiveTableRenderer::RenderCell(winrt::AdaptiveTableCell const& cell,
                                                               winrt::AdaptiveRenderContext const& renderContext,

--- a/source/uwp/SharedRenderer/lib/AdaptiveTableRenderer.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveTableRenderer.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveTableRenderer.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveTableRenderer : AdaptiveTableRendererT<AdaptiveTableRenderer>
     {
@@ -38,7 +38,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     };
 }
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveTableRenderer : AdaptiveTableRendererT<AdaptiveTableRenderer, implementation::AdaptiveTableRenderer>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveTextBlockConfig.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveTextBlockConfig.cpp
@@ -5,7 +5,7 @@
 #include "AdaptiveTextBlockConfig.h"
 #include "AdaptiveTextBlockConfig.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveTextBlockConfig::AdaptiveTextBlockConfig(::AdaptiveCards::TextBlockConfig const& textBlockConfig)
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveTextBlockConfig.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveTextBlockConfig.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveTextBlockConfig.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveTextBlockConfig : AdaptiveTextBlockConfigT<AdaptiveTextBlockConfig>
     {
@@ -13,7 +13,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         property<uint32_t> HeadingLevel;
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveTextBlockConfig : AdaptiveTextBlockConfigT<AdaptiveTextBlockConfig, implementation::AdaptiveTextBlockConfig>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveTextBlockRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveTextBlockRenderer.cpp
@@ -7,7 +7,7 @@
 #include "AdaptiveRenderContext.h"
 #include "TextHelpers.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     winrt::UIElement AdaptiveTextBlockRenderer::Render(winrt::IAdaptiveCardElement const& cardElement,
                                                        winrt::AdaptiveRenderContext const& renderContext,

--- a/source/uwp/SharedRenderer/lib/AdaptiveTextBlockRenderer.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveTextBlockRenderer.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveTextBlockRenderer.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveTextBlockRenderer : AdaptiveTextBlockRendererT<AdaptiveTextBlockRenderer>
     {
@@ -19,7 +19,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         winrt::AutomationHeadingLevel GetHeadingLevelFromContext(winrt::AdaptiveRenderContext const& renderContext);
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveTextBlockRenderer : AdaptiveTextBlockRendererT<AdaptiveTextBlockRenderer, implementation::AdaptiveTextBlockRenderer>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveTextInputRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveTextInputRenderer.cpp
@@ -7,7 +7,7 @@
 #include "ActionHelpers.h"
 #include "InputValue.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     std::tuple<winrt::UIElement, winrt::Border>
     AdaptiveTextInputRenderer::HandleLayoutAndValidation(winrt::AdaptiveTextInput const& adaptiveTextInput,

--- a/source/uwp/SharedRenderer/lib/AdaptiveTextInputRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveTextInputRenderer.cpp
@@ -41,7 +41,7 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
             bool isMultiline = adaptiveTextInput.IsMultiline();
             winrt::TextInputStyle style = adaptiveTextInput.TextInputStyle();
             isMultiline &= style != winrt::TextInputStyle::Password;
-            textBoxParentContainer = render_xaml::ActionHelpers::HandleInlineAction(
+            textBoxParentContainer = ::AdaptiveCards::Rendering::Xaml_Rendering::ActionHelpers::HandleInlineAction(
                 renderContext, renderArgs, inputUIElement, textBoxParentContainer, isMultiline, inlineAction);
         }
 

--- a/source/uwp/SharedRenderer/lib/AdaptiveTextInputRenderer.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveTextInputRenderer.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveTextInputRenderer.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveTextInputRenderer : AdaptiveTextInputRendererT<AdaptiveTextInputRenderer>
     {
@@ -30,7 +30,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
                                                                               winrt::AdaptiveRenderArgs const& renderArgs);
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveTextInputRenderer : AdaptiveTextInputRendererT<AdaptiveTextInputRenderer, implementation::AdaptiveTextInputRenderer>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveTextStyleConfig.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveTextStyleConfig.cpp
@@ -5,6 +5,6 @@
 #include "AdaptiveTextStyleConfig.h"
 #include "AdaptiveTextStyleConfig.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
 }

--- a/source/uwp/SharedRenderer/lib/AdaptiveTextStyleConfig.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveTextStyleConfig.h
@@ -5,7 +5,7 @@
 #include "AdaptiveTextStyleConfigBase.h"
 #include "AdaptiveTextStyleConfig.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveTextStyleConfig : AdaptiveTextStyleConfigT<AdaptiveTextStyleConfig>, AdaptiveTextStyleConfigBase
     {
@@ -16,7 +16,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     };
 }
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveTextStyleConfig : AdaptiveTextStyleConfigT<AdaptiveTextStyleConfig, implementation::AdaptiveTextStyleConfig>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveTextStyleConfigBase.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveTextStyleConfigBase.cpp
@@ -4,7 +4,7 @@
 
 #include "AdaptiveTextStyleConfigBase.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveTextStyleConfigBase::AdaptiveTextStyleConfigBase(::AdaptiveCards::TextStyleConfig const& textStyleConfig)
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveTextStyleConfigBase.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveTextStyleConfigBase.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveTextStyleConfigBase
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveTextStylesConfig.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveTextStylesConfig.cpp
@@ -6,7 +6,7 @@
 #include "AdaptiveTextStylesConfig.h"
 #include "AdaptiveTextStylesConfig.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveTextStylesConfig::AdaptiveTextStylesConfig(::AdaptiveCards::TextStylesConfig const& textStylesConfig) :
         Heading{winrt::make<implementation::AdaptiveTextStyleConfig>(textStylesConfig.heading)},

--- a/source/uwp/SharedRenderer/lib/AdaptiveTextStylesConfig.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveTextStylesConfig.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveTextStylesConfig.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveTextStylesConfig : AdaptiveTextStylesConfigT<AdaptiveTextStylesConfig>
     {
@@ -14,7 +14,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
         property<winrt::AdaptiveTextStyleConfig> ColumnHeader;
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveTextStylesConfig : AdaptiveTextStylesConfigT<AdaptiveTextStylesConfig, implementation::AdaptiveTextStylesConfig>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveTimeInputRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveTimeInputRenderer.cpp
@@ -6,7 +6,7 @@
 #include "AdaptiveTimeInputRenderer.g.cpp"
 #include "InputValue.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     winrt::UIElement AdaptiveTimeInputRenderer::Render(winrt::IAdaptiveCardElement const& cardElement,
                                                        winrt::AdaptiveRenderContext const& renderContext,

--- a/source/uwp/SharedRenderer/lib/AdaptiveTimeInputRenderer.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveTimeInputRenderer.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveTimeInputRenderer.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveTimeInputRenderer : AdaptiveTimeInputRendererT<AdaptiveTimeInputRenderer>
     {
@@ -16,7 +16,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     };
 }
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveTimeInputRenderer : AdaptiveTimeInputRendererT<AdaptiveTimeInputRenderer, implementation::AdaptiveTimeInputRenderer>
     {

--- a/source/uwp/SharedRenderer/lib/AdaptiveToggleInputRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveToggleInputRenderer.cpp
@@ -6,7 +6,7 @@
 #include "AdaptiveToggleInputRenderer.g.cpp"
 #include "InputValue.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     winrt::UIElement AdaptiveToggleInputRenderer::Render(winrt::IAdaptiveCardElement const& cardElement,
                                                          winrt::AdaptiveRenderContext const& renderContext,

--- a/source/uwp/SharedRenderer/lib/AdaptiveToggleInputRenderer.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveToggleInputRenderer.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveToggleInputRenderer.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveToggleInputRenderer : AdaptiveToggleInputRendererT<AdaptiveToggleInputRenderer>
     {
@@ -15,7 +15,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
                                                    winrt::AdaptiveRenderArgs const& renderArgs);
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveToggleInputRenderer
         : AdaptiveToggleInputRendererT<AdaptiveToggleInputRenderer, implementation::AdaptiveToggleInputRenderer>

--- a/source/uwp/SharedRenderer/lib/AdaptiveToggleVisibilityActionRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveToggleVisibilityActionRenderer.cpp
@@ -6,7 +6,7 @@
 #include "AdaptiveToggleVisibilityActionRenderer.g.cpp"
 #include "ActionHelpers.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     winrt::UIElement AdaptiveToggleVisibilityActionRenderer::Render(winrt::IAdaptiveActionElement const& action,
                                                                     winrt::AdaptiveRenderContext const& renderContext,

--- a/source/uwp/SharedRenderer/lib/AdaptiveToggleVisibilityActionRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveToggleVisibilityActionRenderer.cpp
@@ -14,7 +14,7 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
     {
         try
         {
-            return render_xaml::ActionHelpers::BuildAction(action, renderContext, renderArgs, false);
+            return ::AdaptiveCards::Rendering::Xaml_Rendering::ActionHelpers::BuildAction(action, renderContext, renderArgs, false);
         }
         catch (winrt::hresult_error const& ex)
         {

--- a/source/uwp/SharedRenderer/lib/AdaptiveToggleVisibilityActionRenderer.h
+++ b/source/uwp/SharedRenderer/lib/AdaptiveToggleVisibilityActionRenderer.h
@@ -4,7 +4,7 @@
 
 #include "AdaptiveToggleVisibilityActionRenderer.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct AdaptiveToggleVisibilityActionRenderer : AdaptiveToggleVisibilityActionRendererT<AdaptiveToggleVisibilityActionRenderer>
     {
@@ -15,7 +15,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
                                                    winrt::AdaptiveRenderArgs const& renderArgs);
     };
 }
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct AdaptiveToggleVisibilityActionRenderer
         : AdaptiveToggleVisibilityActionRendererT<AdaptiveToggleVisibilityActionRenderer, implementation::AdaptiveToggleVisibilityActionRenderer>

--- a/source/uwp/SharedRenderer/lib/DateTimeParser.cpp
+++ b/source/uwp/SharedRenderer/lib/DateTimeParser.cpp
@@ -6,7 +6,7 @@
 #include <iomanip>
 #include <sstream>
 
-namespace AdaptiveCards::Rendering::Uwp
+namespace AdaptiveCards::Rendering::Xaml_Rendering
 {
     DateTimeParser::DateTimeParser(const std::string& language) { m_languageString = language; }
 

--- a/source/uwp/SharedRenderer/lib/DateTimeParser.h
+++ b/source/uwp/SharedRenderer/lib/DateTimeParser.h
@@ -5,7 +5,7 @@
 
 #include <string>
 
-namespace AdaptiveCards::Rendering::Uwp
+namespace AdaptiveCards::Rendering::Xaml_Rendering
 {
     class DateTimeParser
     {

--- a/source/uwp/SharedRenderer/lib/ElementTagContent.cpp
+++ b/source/uwp/SharedRenderer/lib/ElementTagContent.cpp
@@ -6,7 +6,7 @@
 #include "ElementTagContent.h"
 #include "ElementTagContent.g.cpp"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     ElementTagContent::ElementTagContent(winrt::IAdaptiveCardElement const& cardElement,
                                          winrt::Panel const& parentPanel,

--- a/source/uwp/SharedRenderer/lib/ElementTagContent.h
+++ b/source/uwp/SharedRenderer/lib/ElementTagContent.h
@@ -5,7 +5,7 @@
 
 #include "ElementTagContent.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct DECLSPEC_UUID("0331D653-957C-4385-A327-D326750C10B6") ElementTagContent
         : public ElementTagContentT<ElementTagContent, ITypePeek>
@@ -37,7 +37,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     };
 }
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct ElementTagContent : ElementTagContentT<ElementTagContent, implementation::ElementTagContent>
     {

--- a/source/uwp/SharedRenderer/lib/IImageLoadTrackerListener.h
+++ b/source/uwp/SharedRenderer/lib/IImageLoadTrackerListener.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 
-namespace AdaptiveCards::Rendering::Uwp
+namespace AdaptiveCards::Rendering::Xaml_Rendering
 {
     struct DECLSPEC_UUID("D940E878-F2E0-4AF7-A844-4D090C7379E3") IImageLoadTrackerListener : ::IUnknown
     {

--- a/source/uwp/SharedRenderer/lib/IXamlBuilderListener.h
+++ b/source/uwp/SharedRenderer/lib/IXamlBuilderListener.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 
-namespace AdaptiveCards::Rendering::Uwp
+namespace AdaptiveCards::Rendering::Xaml_Rendering
 {
     MIDL_INTERFACE("BF58F7BB-A330-4C75-AF7F-6E5FD8C0C070")
     IXamlBuilderListener : public ::IUnknown

--- a/source/uwp/SharedRenderer/lib/ImageLoadTracker.cpp
+++ b/source/uwp/SharedRenderer/lib/ImageLoadTracker.cpp
@@ -96,7 +96,7 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
         m_svgEventRevokers.clear();
     }
 
-    void ImageLoadTracker::AddListener(render_xaml::IImageLoadTrackerListener* listener)
+    void ImageLoadTracker::AddListener(::AdaptiveCards::Rendering::Xaml_Rendering::IImageLoadTrackerListener* listener)
     {
         if (m_listeners.find(listener) == m_listeners.end())
         {
@@ -104,7 +104,7 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
         }
     }
 
-    void ImageLoadTracker::RemoveListener(render_xaml::IImageLoadTrackerListener* listener)
+    void ImageLoadTracker::RemoveListener(::AdaptiveCards::Rendering::Xaml_Rendering::IImageLoadTrackerListener* listener)
     {
         if (m_listeners.find(listener) != m_listeners.end())
         {

--- a/source/uwp/SharedRenderer/lib/ImageLoadTracker.cpp
+++ b/source/uwp/SharedRenderer/lib/ImageLoadTracker.cpp
@@ -3,7 +3,7 @@
 #include "pch.h"
 #include "ImageLoadTracker.h"
 
-namespace AdaptiveCards::Rendering::Uwp
+namespace AdaptiveCards::Rendering::Xaml_Rendering
 {
     ImageLoadTracker::~ImageLoadTracker()
     {

--- a/source/uwp/SharedRenderer/lib/ImageLoadTracker.h
+++ b/source/uwp/SharedRenderer/lib/ImageLoadTracker.h
@@ -4,7 +4,7 @@
 
 #include "IImageLoadTrackerListener.h"
 
-namespace AdaptiveCards::Rendering::Uwp
+namespace AdaptiveCards::Rendering::Xaml_Rendering
 {
     // Q: Can we have TrackedImageDetails and TrackedSvgImageDetails extend a base class?
     // If we do this, we could just store one map of the image details

--- a/source/uwp/SharedRenderer/lib/InputValue.cpp
+++ b/source/uwp/SharedRenderer/lib/InputValue.cpp
@@ -4,7 +4,7 @@
 #include "InputValue.h"
 #include "json/json.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering
 {
     InputValue::InputValue(winrt::IAdaptiveInputElement const& adaptiveInputElement,
                            winrt::UIElement const& uiInputElement,

--- a/source/uwp/SharedRenderer/lib/InputValue.h
+++ b/source/uwp/SharedRenderer/lib/InputValue.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 
-namespace winrt::AdaptiveCards::Rendering::Uwp
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering
 {
     // Base class for input values. The InputValue is responsible for getting the current value and submit time, and also handles input validation.
     struct DECLSPEC_UUID("BB1D1269-2243-4F34-B4EC-5216296EBBA0") InputValue : public winrt::implements<InputValue, IAdaptiveInputValue>

--- a/source/uwp/SharedRenderer/lib/LinkButton.cpp
+++ b/source/uwp/SharedRenderer/lib/LinkButton.cpp
@@ -3,7 +3,7 @@
 #include "pch.h"
 #include "LinkButton.h"
 
-namespace AdaptiveCards::Rendering::Uwp
+namespace AdaptiveCards::Rendering::Xaml_Rendering
 {
     winrt::AutomationPeer LinkButton::OnCreateAutomationPeer()
     {

--- a/source/uwp/SharedRenderer/lib/LinkButton.h
+++ b/source/uwp/SharedRenderer/lib/LinkButton.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 
-namespace AdaptiveCards::Rendering::Uwp
+namespace AdaptiveCards::Rendering::Xaml_Rendering
 {
     // LinkButton is a templated button that exists strictly to behave as a button but appear as a link for
     // accessibility purposes.

--- a/source/uwp/SharedRenderer/lib/MediaHelpers.cpp
+++ b/source/uwp/SharedRenderer/lib/MediaHelpers.cpp
@@ -10,7 +10,7 @@ const double c_playIconOpacity = .5;
 const winrt::hstring supportedMimeTypes[] = {L"video/mp4", L"audio/mp4", L"audio/aac", L"audio/mpeg"};
 const std::unordered_set<winrt::hstring> supportedCaptionTypes = {L"vtt", L"srt"};
 
-namespace AdaptiveCards::Rendering::Uwp::MediaHelpers
+namespace AdaptiveCards::Rendering::Xaml_Rendering::MediaHelpers
 {
     winrt::Image GetMediaPosterAsImage(winrt::AdaptiveRenderContext const& renderContext,
                                        winrt::AdaptiveRenderArgs const& renderArgs,

--- a/source/uwp/SharedRenderer/lib/MediaHelpers.h
+++ b/source/uwp/SharedRenderer/lib/MediaHelpers.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 
-namespace AdaptiveCards::Rendering::Uwp::MediaHelpers
+namespace AdaptiveCards::Rendering::Xaml_Rendering::MediaHelpers
 {
     winrt::Image GetMediaPosterAsImage(winrt::AdaptiveRenderContext const& renderContext,
                                        winrt::AdaptiveRenderArgs const& renderArgs,

--- a/source/uwp/SharedRenderer/lib/RenderedAdaptiveCard.cpp
+++ b/source/uwp/SharedRenderer/lib/RenderedAdaptiveCard.cpp
@@ -12,7 +12,7 @@
 
 using namespace concurrency;
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     RenderedAdaptiveCard::RenderedAdaptiveCard() :
         RenderedAdaptiveCard(winrt::single_threaded_vector<winrt::AdaptiveError>(),

--- a/source/uwp/SharedRenderer/lib/RenderedAdaptiveCard.cpp
+++ b/source/uwp/SharedRenderer/lib/RenderedAdaptiveCard.cpp
@@ -130,7 +130,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
             auto actionConfig = m_originatingHostConfig.Actions();
             auto showCardConfig = actionConfig.ShowCard();
             auto actionMode = showCardConfig.ActionMode();
-            bool handleInlineShowCard = (actionMode == winrt_render_xaml::ActionMode::Inline);
+            bool handleInlineShowCard = (actionMode == winrt::AdaptiveCards::Rendering::Xaml_Rendering::ActionMode::Inline);
 
             if (handleInlineShowCard)
             {

--- a/source/uwp/SharedRenderer/lib/RenderedAdaptiveCard.h
+++ b/source/uwp/SharedRenderer/lib/RenderedAdaptiveCard.h
@@ -16,7 +16,7 @@ template<typename TSrc, typename TPayload> struct auto_event
     auto operator()(TSrc const& src, TPayload const& p) { return m_event(src, p); }
 };
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct DECLSPEC_UUID("F25E0D36-0B5B-4398-AFC8-F84105EC46A2") RenderedAdaptiveCard
         : RenderedAdaptiveCardT<RenderedAdaptiveCard, ITypePeek>
@@ -86,7 +86,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     };
 }
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct RenderedAdaptiveCard : RenderedAdaptiveCardT<RenderedAdaptiveCard, implementation::RenderedAdaptiveCard>
     {

--- a/source/uwp/SharedRenderer/lib/TextHelpers.cpp
+++ b/source/uwp/SharedRenderer/lib/TextHelpers.cpp
@@ -6,7 +6,7 @@
 #include "TextHelpers.h"
 #include <safeint.h>
 
-using namespace AdaptiveCards::Rendering::Uwp;
+using namespace AdaptiveCards::Rendering::Xaml_Rendering;
 using namespace AdaptiveCards;
 using namespace msl::utilities;
 using namespace std::string_literals;

--- a/source/uwp/SharedRenderer/lib/TileControl.cpp
+++ b/source/uwp/SharedRenderer/lib/TileControl.cpp
@@ -6,7 +6,7 @@
 #include "TileControl.g.cpp"
 #include <cmath>
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     TileControl::TileControl()
     {

--- a/source/uwp/SharedRenderer/lib/TileControl.h
+++ b/source/uwp/SharedRenderer/lib/TileControl.h
@@ -5,7 +5,7 @@
 #include "pch.h"
 #include "TileControl.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct DECLSPEC_UUID("0F485063-EF2A-400E-A946-73E00EDFAC83") TileControl : public TileControlT<TileControl, ITypePeek>
     {
@@ -51,7 +51,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     };
 }
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct TileControl : TileControlT<TileControl, implementation::TileControl>
     {

--- a/source/uwp/SharedRenderer/lib/Util.cpp
+++ b/source/uwp/SharedRenderer/lib/Util.cpp
@@ -589,7 +589,7 @@ winrt::IAdaptiveTextElement CopyTextElement(winrt::IAdaptiveTextElement const& t
     return nullptr;
 }
 
-namespace AdaptiveCards::Rendering::Uwp
+namespace AdaptiveCards::Rendering::Xaml_Rendering
 {
     void RegisterDefaultElementRenderers(winrt::implementation::AdaptiveElementRendererRegistration* registration,
                                          winrt::com_ptr<XamlBuilder> xamlBuilder)

--- a/source/uwp/SharedRenderer/lib/Util.h
+++ b/source/uwp/SharedRenderer/lib/Util.h
@@ -212,7 +212,7 @@ template<typename T> inline T GetValueFromRef(winrt::IReference<T> const& ref, T
     return defaultValue;
 }
 
-namespace AdaptiveCards::Rendering::Uwp
+namespace AdaptiveCards::Rendering::Xaml_Rendering
 {
     struct XamlBuilder;
 

--- a/source/uwp/SharedRenderer/lib/WholeItemsPanel.cpp
+++ b/source/uwp/SharedRenderer/lib/WholeItemsPanel.cpp
@@ -11,7 +11,7 @@
 
 static const float OutsidePanelY = -1000.0f;
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     uint32_t WholeItemsPanel::s_bleedMargin = 0;
 

--- a/source/uwp/SharedRenderer/lib/WholeItemsPanel.h
+++ b/source/uwp/SharedRenderer/lib/WholeItemsPanel.h
@@ -4,7 +4,7 @@
 
 #include "WholeItemsPanel.g.h"
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     struct DECLSPEC_UUID("32934D77-6248-4915-BD2A-8F52EF6C8322") WholeItemsPanel : public WholeItemsPanelT<WholeItemsPanel, ITypePeek>
     {
@@ -75,7 +75,7 @@ namespace winrt::AdaptiveCards::Rendering::Uwp::implementation
     };
 }
 
-namespace winrt::AdaptiveCards::Rendering::Uwp::factory_implementation
+namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::factory_implementation
 {
     struct WholeItemsPanel : WholeItemsPanelT<WholeItemsPanel, implementation::WholeItemsPanel>
     {

--- a/source/uwp/SharedRenderer/lib/XamlBuilder.cpp
+++ b/source/uwp/SharedRenderer/lib/XamlBuilder.cpp
@@ -7,7 +7,7 @@
 #include "ActionHelpers.h"
 #include "WholeItemsPanel.h"
 
-namespace AdaptiveCards::Rendering::Uwp
+namespace AdaptiveCards::Rendering::Xaml_Rendering
 {
     XamlBuilder::XamlBuilder()
     {

--- a/source/uwp/SharedRenderer/lib/XamlBuilder.h
+++ b/source/uwp/SharedRenderer/lib/XamlBuilder.h
@@ -6,7 +6,7 @@
 #include "IXamlBuilderListener.h"
 #include "IImageLoadTrackerListener.h"
 
-namespace AdaptiveCards::Rendering::Uwp
+namespace AdaptiveCards::Rendering::Xaml_Rendering
 {
     struct XamlBuilder : winrt::implements<XamlBuilder, winrt::IInspectable, IImageLoadTrackerListener>
     {

--- a/source/uwp/SharedRenderer/lib/XamlHelpers.cpp
+++ b/source/uwp/SharedRenderer/lib/XamlHelpers.cpp
@@ -7,7 +7,7 @@
 #include "AdaptiveBase64Util.h"
 #include "WholeItemsPanel.h"
 
-namespace AdaptiveCards::Rendering::Uwp::XamlHelpers
+namespace AdaptiveCards::Rendering::Xaml_Rendering::XamlHelpers
 {
     constexpr PCWSTR c_BackgroundImageOverlayBrushKey = L"AdaptiveCard.BackgroundOverlayBrush";
 

--- a/source/uwp/SharedRenderer/lib/XamlHelpers.h
+++ b/source/uwp/SharedRenderer/lib/XamlHelpers.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 
-namespace AdaptiveCards::Rendering::Uwp::XamlHelpers
+namespace AdaptiveCards::Rendering::Xaml_Rendering::XamlHelpers
 {
     void SetStyleFromResourceDictionary(winrt::AdaptiveRenderContext const& renderContext,
                                         winrt::hstring const& resourceName,

--- a/source/uwp/SharedRenderer/lib/pch.h
+++ b/source/uwp/SharedRenderer/lib/pch.h
@@ -41,7 +41,7 @@
 #include "XamlBuilder.h"
 #include "XamlHelpers.h"
 
-namespace render_xaml = ::AdaptiveCards::Rendering::Uwp;
+namespace render_xaml = ::AdaptiveCards::Rendering::Xaml_Rendering;
 
 namespace XamlHelpers = render_xaml::XamlHelpers;
 

--- a/source/uwp/SharedRenderer/lib/pch.h
+++ b/source/uwp/SharedRenderer/lib/pch.h
@@ -41,9 +41,7 @@
 #include "XamlBuilder.h"
 #include "XamlHelpers.h"
 
-namespace render_xaml = ::AdaptiveCards::Rendering::Xaml_Rendering;
-
-namespace XamlHelpers = render_xaml::XamlHelpers;
+namespace XamlHelpers = ::AdaptiveCards::Rendering::Xaml_Rendering::XamlHelpers;
 
 #ifndef MAKE_HRESULT
 #define MAKE_HRESULT(sev, fac, code) \


### PR DESCRIPTION
# Related Issue

https://github.com/microsoft/AdaptiveCards/issues/5888

# Description

This change removes explicit references to UWP in the SharedRenderer code, replacing them with a variable that can be changed depending on if the code is compiling for UWP or WinUI 3. For references to the Object Model, we use the Xaml_OM alias that has already been introduced. For the Renderer, we use Xaml_Rendering. This also means we can remove the render_xaml and winrt_render_xaml aliases, which were never ideal. Instances of these go back to fully qualified namespaces (ie. `::AdaptiveCards::Rendering::Xaml_Rendering`).

# How Verified

Build/pipelines.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8226)