### PR TITLE
[UWP Renderer] Allow nested fallbacks

### DIFF
--- a/source/uwp/Renderer/lib/XamlBuilder.cpp
+++ b/source/uwp/Renderer/lib/XamlBuilder.cpp
@@ -302,7 +302,18 @@ namespace AdaptiveCards::Rendering::Uwp
                     throw ex;
                 }
 
-                std::tie(newControl, renderedElement) = XamlHelpers::RenderFallback(element, renderContext, renderArgs);
+                try
+                {
+                    std::tie(newControl, renderedElement) = XamlHelpers::RenderFallback(element, renderContext, renderArgs);
+                }
+                catch (winrt::hresult_error const& ex)
+                {
+                    // if we get an E_PERFORM_FALLBACK error again, we should only throw it if `ancestorHasFallBack`
+                    if (ex.code() != E_PERFORM_FALLBACK || (ex.code() == E_PERFORM_FALLBACK && ancestorHasFallback))
+                    {
+                        throw ex;
+                    }
+                }
             }
 
             // If we got a control, add a separator if needed and the control to the parent panel

--- a/source/uwp/Renderer/lib/XamlHelpers.cpp
+++ b/source/uwp/Renderer/lib/XamlHelpers.cpp
@@ -321,15 +321,28 @@ namespace AdaptiveCards::Rendering::Uwp::XamlHelpers
 
             if (fallbackElementRenderer)
             {
-                fallbackControl = fallbackElementRenderer.Render(fallbackElement, renderContext, renderArgs);
-
-                renderedElement = fallbackElement;
+                try
+                {
+                    fallbackControl = fallbackElementRenderer.Render(fallbackElement, renderContext, renderArgs);
+                    renderedElement = fallbackElement;
+                }
+                catch (winrt::hresult_error const& ex)
+                {
+                    if (ex.code() == E_PERFORM_FALLBACK)
+                    {
+                        std::tie(fallbackControl, renderedElement) = RenderFallback(fallbackElement, renderContext, renderArgs);
+                    }
+                    else
+                    {
+                        throw(ex);
+                    }
+                }
             }
-
-            if (!fallbackControl)
+            else
             {
                 std::tie(fallbackControl, renderedElement) = RenderFallback(fallbackElement, renderContext, renderArgs);
             }
+
             fallbackHandled = true;
             break;
         }


### PR DESCRIPTION
# Related Issue

[TODO]

Nested fallbacks are not working correctly

# Description

1. Added a try/catch block so that we can make the recursive call to `RenderFallback` if we catch `E_PERFORM_FALLBACK`
2. Call `RenderFallback` if no `fallbackRenderer` is found
3. If the last fallback element within nested fallback does not render, `ancestorHasFallback` will be true. This caused us to throw `E_PERFORM_CALLBACK` which is caught by the initial element. If this element did not have a fallback, it will be dropped.

   Ex: Container (does not have fallback) -> ChildElement -> Fallback1 -> Fallback2 -> Fallback3
         ChildElement, Fallback1, and Fallback2 all failed. When Fallback3 fails, it will try to get the fallback mechanism of it's ancestor (Fallback2) by throwing `E_PERFORM_FALLBACK`. However, this error will land on the Container since all of the other elements failed. Without a fallback mechanism, the Container will be dropped.

    To fix this issue, I added a try/catch block for when we call `RenderFallback` on a child element. In the catch, we can verify that the parent element actually has a fallback mechanism before throwing the error.

# Sample Card

https://github.com/microsoft/AdaptiveCards/blob/main/samples/v1.2/Tests/ContainerDoubleFallback.json
https://github.com/microsoft/AdaptiveCards/blob/main/samples/v1.2/Tests/DeepFallback.json

# How Verified

Verified manually on the AdaptiveCards Visualizer.

## Before

![image](https://user-images.githubusercontent.com/98650930/212834995-141305e9-2c3a-42aa-a541-acb7b985d401.png)

![image](https://user-images.githubusercontent.com/98650930/212835096-67e84621-8365-48d6-b59b-c36a4115e287.png)

## After

![image](https://user-images.githubusercontent.com/98650930/212835417-75b168e0-3650-4d0e-9a2e-dcbb488567dc.png)

![image](https://user-images.githubusercontent.com/98650930/212835504-9d4f5496-7a57-438a-8c32-500b96bee7ce.png)
