### PR TITLE
[WinUI 3] Add Visualizer for WinUI 3

### DIFF
--- a/source/uwp/SharedVisualizer/Converters/ErrorViewModelConverters.cs
+++ b/source/uwp/SharedVisualizer/Converters/ErrorViewModelConverters.cs
@@ -3,7 +3,12 @@
 using AdaptiveCardVisualizer.ViewModel;
 using System;
 
-#if !USE_WINUI3
+#if USE_WINUI3
+using Microsoft.UI;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Media;
+#else
 using Windows.UI;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Data;

--- a/source/uwp/SharedVisualizer/Converters/NotNullToVisibilityConverter.cs
+++ b/source/uwp/SharedVisualizer/Converters/NotNullToVisibilityConverter.cs
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 using System;
-#if !USE_WINUI3
+#if USE_WINUI3
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Data;
+#else
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Data;
 #endif

--- a/source/uwp/SharedVisualizer/CustomElements/CustomInput.cs
+++ b/source/uwp/SharedVisualizer/CustomElements/CustomInput.cs
@@ -6,8 +6,8 @@ using System.Linq;
 using Windows.Data.Json;
 
 #if USE_WINUI3
-using AdaptiveCards.Rendering.Winui3;
-using AdaptiveCards.ObjectModel.Winui3;
+using AdaptiveCards.Rendering.WinUI3;
+using AdaptiveCards.ObjectModel.WinUI3;
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;

--- a/source/uwp/SharedVisualizer/CustomElements/CustomInput.cs
+++ b/source/uwp/SharedVisualizer/CustomElements/CustomInput.cs
@@ -5,7 +5,14 @@ using System.Collections.Generic;
 using System.Linq;
 using Windows.Data.Json;
 
-#if !USE_WINUI3
+#if USE_WINUI3
+using AdaptiveCards.Rendering.Winui3;
+using AdaptiveCards.ObjectModel.Winui3;
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+#else
 using AdaptiveCards.Rendering.Uwp;
 using AdaptiveCards.ObjectModel.Uwp;
 using Windows.UI;

--- a/source/uwp/SharedVisualizer/ResourceResolvers/MySymbolResourceResolver.cs
+++ b/source/uwp/SharedVisualizer/ResourceResolvers/MySymbolResourceResolver.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#if !USE_WINUI3
+#if USE_WINUI3
+using AdaptiveCards.Rendering.Winui3;
+#else
 using AdaptiveCards.Rendering.Uwp;
 #endif
 using System;

--- a/source/uwp/SharedVisualizer/ResourceResolvers/MySymbolResourceResolver.cs
+++ b/source/uwp/SharedVisualizer/ResourceResolvers/MySymbolResourceResolver.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 #if USE_WINUI3
-using AdaptiveCards.Rendering.Winui3;
+using AdaptiveCards.Rendering.WinUI3;
 #else
 using AdaptiveCards.Rendering.Uwp;
 #endif

--- a/source/uwp/SharedVisualizer/ViewModel/DocumentViewModel.cs
+++ b/source/uwp/SharedVisualizer/ViewModel/DocumentViewModel.cs
@@ -10,7 +10,13 @@ using Windows.Data.Json;
 using Windows.Storage;
 using XamlCardVisualizer.CustomElements;
 
-#if !USE_WINUI3
+#if USE_WINUI3
+using AdaptiveCards.ObjectModel.Winui3;
+using AdaptiveCards.Rendering.Winui3;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+#else
 using AdaptiveCards.ObjectModel.Uwp;
 using AdaptiveCards.Rendering.Uwp;
 using Windows.UI.Xaml;

--- a/source/uwp/SharedVisualizer/ViewModel/DocumentViewModel.cs
+++ b/source/uwp/SharedVisualizer/ViewModel/DocumentViewModel.cs
@@ -11,8 +11,8 @@ using Windows.Storage;
 using XamlCardVisualizer.CustomElements;
 
 #if USE_WINUI3
-using AdaptiveCards.ObjectModel.Winui3;
-using AdaptiveCards.Rendering.Winui3;
+using AdaptiveCards.ObjectModel.WinUI3;
+using AdaptiveCards.Rendering.WinUI3;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;

--- a/source/uwp/SharedVisualizer/ViewModel/DocumentViewModel.cs
+++ b/source/uwp/SharedVisualizer/ViewModel/DocumentViewModel.cs
@@ -102,6 +102,9 @@ namespace AdaptiveCardVisualizer.ViewModel
                         _renderedAdaptiveCard.Action += async (sender, e) =>
                         {
                             var m_actionDialog = new ContentDialog();
+#if USE_WINUI3
+                            m_actionDialog.XamlRoot = this.MainPageViewModel._root;
+#endif
 
                             if (e.Action.ActionType == ActionType.ShowCard)
                             {
@@ -127,6 +130,9 @@ namespace AdaptiveCardVisualizer.ViewModel
                             _renderedAdaptiveCard.MediaClicked += async (sender, e) =>
                             {
                                 var onPlayDialog = new ContentDialog();
+#if USE_WINUI3
+                                onPlayDialog.XamlRoot = this.MainPageViewModel._root;
+#endif
                                 onPlayDialog.Content = "MediaClickedEvent:";
 
                                 foreach (var source in e.Media.Sources)

--- a/source/uwp/SharedVisualizer/ViewModel/DocumentViewModel.cs
+++ b/source/uwp/SharedVisualizer/ViewModel/DocumentViewModel.cs
@@ -103,7 +103,7 @@ namespace AdaptiveCardVisualizer.ViewModel
                         {
                             var m_actionDialog = new ContentDialog();
 #if USE_WINUI3
-                            m_actionDialog.XamlRoot = this.MainPageViewModel._root;
+                            m_actionDialog.XamlRoot = this.MainPageViewModel._xamlRoot;
 #endif
 
                             if (e.Action.ActionType == ActionType.ShowCard)
@@ -131,7 +131,7 @@ namespace AdaptiveCardVisualizer.ViewModel
                             {
                                 var onPlayDialog = new ContentDialog();
 #if USE_WINUI3
-                                onPlayDialog.XamlRoot = this.MainPageViewModel._root;
+                                onPlayDialog.XamlRoot = this.MainPageViewModel._xamlRoot;
 #endif
                                 onPlayDialog.Content = "MediaClickedEvent:";
 

--- a/source/uwp/SharedVisualizer/ViewModel/DocumentViewModel.cs
+++ b/source/uwp/SharedVisualizer/ViewModel/DocumentViewModel.cs
@@ -103,7 +103,7 @@ namespace AdaptiveCardVisualizer.ViewModel
                         {
                             var m_actionDialog = new ContentDialog();
 #if USE_WINUI3
-                            m_actionDialog.XamlRoot = this.MainPageViewModel._xamlRoot;
+                            m_actionDialog.XamlRoot = this.MainPageViewModel.XamlRoot;
 #endif
 
                             if (e.Action.ActionType == ActionType.ShowCard)
@@ -131,7 +131,7 @@ namespace AdaptiveCardVisualizer.ViewModel
                             {
                                 var onPlayDialog = new ContentDialog();
 #if USE_WINUI3
-                                onPlayDialog.XamlRoot = this.MainPageViewModel._xamlRoot;
+                                onPlayDialog.XamlRoot = this.MainPageViewModel.XamlRoot;
 #endif
                                 onPlayDialog.Content = "MediaClickedEvent:";
 

--- a/source/uwp/SharedVisualizer/ViewModel/GenericDocumentViewModel.cs
+++ b/source/uwp/SharedVisualizer/ViewModel/GenericDocumentViewModel.cs
@@ -126,6 +126,12 @@ namespace AdaptiveCardVisualizer.ViewModel
         private void CreateMessageDialog(string text)
         {
             var messageDialog = new MessageDialog(text);
+#if USE_WINUI3
+            // Get the current window's HWND by passing in the Window object
+            var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(App.Window);
+            // Associate the HWND with the file picker
+            WinRT.Interop.InitializeWithWindow.Initialize(messageDialog, hwnd);
+#endif
             // Set the index of the command to be used as cancel (when ESC is pressed)
             // As there's only one command, command 0 is selected
             messageDialog.CancelCommandIndex = 0;
@@ -135,6 +141,12 @@ namespace AdaptiveCardVisualizer.ViewModel
         private async Task SaveNewFileAsync()
         {
             var savePicker = new FileSavePicker();
+#if USE_WINUI3
+            // Get the current window's HWND by passing in the Window object
+            var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(App.Window);
+            // Associate the HWND with the file picker
+            WinRT.Interop.InitializeWithWindow.Initialize(savePicker, hwnd);
+#endif
             savePicker.SuggestedStartLocation = PickerLocationId.DocumentsLibrary;
             savePicker.FileTypeChoices.Add("Adaptive Card JSON", new List<string>() { ".json" });
             savePicker.SuggestedFileName = "NewAdaptiveCard.json";

--- a/source/uwp/SharedVisualizer/ViewModel/HostConfigEditorViewModel.cs
+++ b/source/uwp/SharedVisualizer/ViewModel/HostConfigEditorViewModel.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#if !USE_WINUI3
+#if USE_WINUI3
+using AdaptiveCards.Rendering.Winui3;
+#else
 using AdaptiveCards.Rendering.Uwp;
 #endif
 using System;

--- a/source/uwp/SharedVisualizer/ViewModel/HostConfigEditorViewModel.cs
+++ b/source/uwp/SharedVisualizer/ViewModel/HostConfigEditorViewModel.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 #if USE_WINUI3
-using AdaptiveCards.Rendering.Winui3;
+using AdaptiveCards.Rendering.WinUI3;
 #else
 using AdaptiveCards.Rendering.Uwp;
 #endif

--- a/source/uwp/SharedVisualizer/ViewModel/KeyboardPressTimeCounter.cs
+++ b/source/uwp/SharedVisualizer/ViewModel/KeyboardPressTimeCounter.cs
@@ -3,7 +3,12 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+
+#if USE_WINUI3
+using CommunityToolkit.WinUI;
+#else
 using Windows.UI.Core;
+#endif
 
 namespace AdaptiveCardVisualizer.ViewModel
 {
@@ -56,7 +61,12 @@ namespace AdaptiveCardVisualizer.ViewModel
 
         private async Task SendShowErrorsUpdateAsync()
         {
+#if USE_WINUI3
+            var queueController = Microsoft.UI.Dispatching.DispatcherQueueController.CreateOnDedicatedThread();
+            await queueController.DispatcherQueue.EnqueueAsync(() =>
+#else
             await Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+#endif
             {
                 GenericDocumentView.MakeErrorsLike();
             });

--- a/source/uwp/SharedVisualizer/ViewModel/KeyboardPressTimeCounter.cs
+++ b/source/uwp/SharedVisualizer/ViewModel/KeyboardPressTimeCounter.cs
@@ -62,8 +62,14 @@ namespace AdaptiveCardVisualizer.ViewModel
         private async Task SendShowErrorsUpdateAsync()
         {
 #if USE_WINUI3
-            var queueController = Microsoft.UI.Dispatching.DispatcherQueueController.CreateOnDedicatedThread();
-            await queueController.DispatcherQueue.EnqueueAsync(() =>
+            var dispatcher = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
+            if (dispatcher == null)
+            { 
+                var queueController = Microsoft.UI.Dispatching.DispatcherQueueController.CreateOnCurrentThread();
+                dispatcher = queueController.DispatcherQueue;
+            }
+            // Default priority is Normal
+            await dispatcher.EnqueueAsync(() =>
 #else
             await Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
 #endif

--- a/source/uwp/SharedVisualizer/ViewModel/MainPageViewModel.cs
+++ b/source/uwp/SharedVisualizer/ViewModel/MainPageViewModel.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#if !USE_WINUI3
+#if USE_WINUI3
+using AdaptiveCards.Rendering.Winui3;
+#else
 using AdaptiveCards.Rendering.Uwp;
 #endif
 using AdaptiveCardVisualizer.Helpers;

--- a/source/uwp/SharedVisualizer/ViewModel/MainPageViewModel.cs
+++ b/source/uwp/SharedVisualizer/ViewModel/MainPageViewModel.cs
@@ -97,6 +97,12 @@ namespace AdaptiveCardVisualizer.ViewModel
                 openPicker.ViewMode = PickerViewMode.List;
                 openPicker.FileTypeFilter.Add(".json");
 
+#if USE_WINUI3
+                // Get the current window's HWND by passing in the Window object
+                var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(App.Window);
+                // Associate the HWND with the file picker
+                WinRT.Interop.InitializeWithWindow.Initialize(openPicker, hwnd);
+#endif
                 StorageFile file = await openPicker.PickSingleFileAsync();
                 if (file != null)
                 {

--- a/source/uwp/SharedVisualizer/ViewModel/MainPageViewModel.cs
+++ b/source/uwp/SharedVisualizer/ViewModel/MainPageViewModel.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 #if USE_WINUI3
 using AdaptiveCards.Rendering.Winui3;
+using Microsoft.UI.Xaml;
 #else
 using AdaptiveCards.Rendering.Uwp;
 #endif
@@ -37,6 +38,10 @@ namespace AdaptiveCardVisualizer.ViewModel
         }
 
         public HostConfigEditorViewModel HostConfigEditor { get; private set; }
+
+#if USE_WINUI3
+        public XamlRoot _root;
+#endif
 
         public bool UseFixedDimensions
         {

--- a/source/uwp/SharedVisualizer/ViewModel/MainPageViewModel.cs
+++ b/source/uwp/SharedVisualizer/ViewModel/MainPageViewModel.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 #if USE_WINUI3
-using AdaptiveCards.Rendering.Winui3;
+using AdaptiveCards.Rendering.WinUI3;
 using Microsoft.UI.Xaml;
 #else
 using AdaptiveCards.Rendering.Uwp;

--- a/source/uwp/SharedVisualizer/ViewModel/MainPageViewModel.cs
+++ b/source/uwp/SharedVisualizer/ViewModel/MainPageViewModel.cs
@@ -40,7 +40,7 @@ namespace AdaptiveCardVisualizer.ViewModel
         public HostConfigEditorViewModel HostConfigEditor { get; private set; }
 
 #if USE_WINUI3
-        public XamlRoot _root;
+        public XamlRoot _xamlRoot;
 #endif
 
         public bool UseFixedDimensions

--- a/source/uwp/SharedVisualizer/ViewModel/MainPageViewModel.cs
+++ b/source/uwp/SharedVisualizer/ViewModel/MainPageViewModel.cs
@@ -40,7 +40,7 @@ namespace AdaptiveCardVisualizer.ViewModel
         public HostConfigEditorViewModel HostConfigEditor { get; private set; }
 
 #if USE_WINUI3
-        public XamlRoot _xamlRoot;
+        public XamlRoot XamlRoot { get; set; }
 #endif
 
         public bool UseFixedDimensions

--- a/source/uwp/SharedVisualizer/Views/DocumentView.xaml
+++ b/source/uwp/SharedVisualizer/Views/DocumentView.xaml
@@ -8,8 +8,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     d:DesignHeight="300"
-    d:DesignWidth="400"
-    xmlns:toolkitControls="using:Microsoft.Toolkit.Uwp.UI.Controls">
+    d:DesignWidth="400">
 
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <Grid.ColumnDefinitions>
@@ -20,18 +19,8 @@
         <!--Editor and errors-->
         <local:GenericDocumentView x:Name="GenericDocumentViewName"/>
 
-        <!--Vertical draggable column splitter-->
-        <toolkitControls:GridSplitter
-            AutomationProperties.Name="Content splitter"
-            Width="11"
-            Background="{ThemeResource SystemControlBackgroundAccentBrush}"
-            GripperCursor="Default"
-            HorizontalAlignment="Left"
-            Grid.Column="1"
-            ResizeDirection="Auto"
-            ResizeBehavior="BasedOnAlignment"
-            CursorBehavior="ChangeOnSplitterHover"
-            GripperForeground="White"/>
+        <!--Placeholder for vertical draggable column splitter-->
+        <Grid x:Name="GridSplitterPlaceholder" Grid.Column="1" />
 
         <!--Preview-->
         <Grid

--- a/source/uwp/SharedVisualizer/Views/DocumentView.xaml.cs
+++ b/source/uwp/SharedVisualizer/Views/DocumentView.xaml.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#if !USE_WINUI3
+#if USE_WINUI3
+using Microsoft.UI.Xaml.Controls;
+#else
 using Windows.UI.Xaml.Controls;
 #endif
 using AdaptiveCardVisualizer.ViewModel;

--- a/source/uwp/SharedVisualizer/Views/DocumentView.xaml.cs
+++ b/source/uwp/SharedVisualizer/Views/DocumentView.xaml.cs
@@ -1,9 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 #if USE_WINUI3
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using CommunityToolkit.WinUI.UI.Controls;
 #else
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+using Microsoft.Toolkit.Uwp.UI.Controls;
 #endif
 using AdaptiveCardVisualizer.ViewModel;
 
@@ -21,6 +31,24 @@ namespace AdaptiveCardVisualizer
         public DocumentView()
         {
             this.InitializeComponent();
+
+            // Create GridSplitter control in code behind instead of markup so we can use the 
+            // correct namespace for the version of XAML we're compiling.
+            var backgroundBrush = (SolidColorBrush)Resources["SystemControlBackgroundAccentBrush"];
+            var gridSplitter = new GridSplitter
+            {
+                Width = 11,
+                Background = backgroundBrush,
+                GripperCursor = GridSplitter.GripperCursorType.Default,
+                HorizontalAlignment = HorizontalAlignment.Left,
+                ResizeDirection = GridSplitter.GridResizeDirection.Auto,
+                ResizeBehavior = GridSplitter.GridResizeBehavior.BasedOnAlignment,
+                CursorBehavior = GridSplitter.SplitterCursorBehavior.ChangeOnSplitterHover,
+                GripperForeground = new SolidColorBrush(Colors.White)
+            };
+            AutomationProperties.SetName(gridSplitter, "Content splitter");
+
+            GridSplitterPlaceholder.Children.Add(gridSplitter);
         }
     }
 }

--- a/source/uwp/SharedVisualizer/Views/ErrorTabView.xaml.cs
+++ b/source/uwp/SharedVisualizer/Views/ErrorTabView.xaml.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#if !USE_WINUI3
+#if USE_WINUI3
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+#else
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 #endif

--- a/source/uwp/SharedVisualizer/Views/GenericDocumentView.xaml.cs
+++ b/source/uwp/SharedVisualizer/Views/GenericDocumentView.xaml.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#if !USE_WINUI3
+#if USE_WINUI3
+using Microsoft.UI.Xaml.Controls;
+#else
 using Windows.UI.Xaml.Controls;
 #endif
 

--- a/source/uwp/SharedVisualizer/Views/MainPage.xaml.cs
+++ b/source/uwp/SharedVisualizer/Views/MainPage.xaml.cs
@@ -44,6 +44,9 @@ namespace AdaptiveCardVisualizer
             DataContext = ViewModel;
 
             IsEnabled = true;
+#if USE_WINUI3
+            ViewModel._root = this.Content.XamlRoot;
+#endif
         }
 
         private void loadFileButton_Clicked(object sender, RoutedEventArgs args)

--- a/source/uwp/SharedVisualizer/Views/MainPage.xaml.cs
+++ b/source/uwp/SharedVisualizer/Views/MainPage.xaml.cs
@@ -45,7 +45,7 @@ namespace AdaptiveCardVisualizer
 
             IsEnabled = true;
 #if USE_WINUI3
-            ViewModel._root = this.Content.XamlRoot;
+            ViewModel._xamlRoot = this.Content.XamlRoot;
 #endif
         }
 

--- a/source/uwp/SharedVisualizer/Views/MainPage.xaml.cs
+++ b/source/uwp/SharedVisualizer/Views/MainPage.xaml.cs
@@ -45,7 +45,7 @@ namespace AdaptiveCardVisualizer
 
             IsEnabled = true;
 #if USE_WINUI3
-            ViewModel._xamlRoot = this.Content.XamlRoot;
+            ViewModel.XamlRoot = this.Content.XamlRoot;
 #endif
         }
 

--- a/source/uwp/SharedVisualizer/Views/MainPage.xaml.cs
+++ b/source/uwp/SharedVisualizer/Views/MainPage.xaml.cs
@@ -4,7 +4,12 @@ using AdaptiveCardVisualizer.ViewModel;
 using System.Linq;
 using Windows.System;
 
-#if !USE_WINUI3
+#if USE_WINUI3
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Input;
+#else
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;

--- a/source/uwp/SharedVisualizer/Views/TabView.xaml.cs
+++ b/source/uwp/SharedVisualizer/Views/TabView.xaml.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#if !USE_WINUI3
+#if USE_WINUI3
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+#else
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 #endif

--- a/source/uwp/winui3/AdaptiveCards.sln
+++ b/source/uwp/winui3/AdaptiveCards.sln
@@ -24,6 +24,14 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RendererCsProjection", "Ren
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SimpleVisualizer", "SimpleVisualizer\SimpleVisualizer.csproj", "{C3038503-11AC-4E7C-AAAE-4E5F887989C9}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AdaptiveCardVisualizer", "Visualizer\AdaptiveCardVisualizer.csproj", "{A0353998-CF26-43C8-85C3-9CC8011A3D91}"
+	ProjectSection(ProjectDependencies) = postProject
+		{90FC73CA-F54D-486F-A7F8-32CD3FF508BB} = {90FC73CA-F54D-486F-A7F8-32CD3FF508BB}
+		{BE5A624F-8376-43DE-B2FC-F758F78E9C99} = {BE5A624F-8376-43DE-B2FC-F758F78E9C99}
+	EndProjectSection
+EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "SharedVisualizer", "..\SharedVisualizer\SharedVisualizer.shproj", "{85425680-C8BF-43F3-84C4-773D0ADE45EF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -198,6 +206,36 @@ Global
 		{C3038503-11AC-4E7C-AAAE-4E5F887989C9}.Release|x86.ActiveCfg = Release|x86
 		{C3038503-11AC-4E7C-AAAE-4E5F887989C9}.Release|x86.Build.0 = Release|x86
 		{C3038503-11AC-4E7C-AAAE-4E5F887989C9}.Release|x86.Deploy.0 = Release|x86
+		{A0353998-CF26-43C8-85C3-9CC8011A3D91}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{A0353998-CF26-43C8-85C3-9CC8011A3D91}.Debug|Any CPU.Build.0 = Debug|x64
+		{A0353998-CF26-43C8-85C3-9CC8011A3D91}.Debug|Any CPU.Deploy.0 = Debug|x64
+		{A0353998-CF26-43C8-85C3-9CC8011A3D91}.Debug|ARM.ActiveCfg = Debug|x64
+		{A0353998-CF26-43C8-85C3-9CC8011A3D91}.Debug|ARM.Build.0 = Debug|x64
+		{A0353998-CF26-43C8-85C3-9CC8011A3D91}.Debug|ARM.Deploy.0 = Debug|x64
+		{A0353998-CF26-43C8-85C3-9CC8011A3D91}.Debug|arm64.ActiveCfg = Debug|ARM64
+		{A0353998-CF26-43C8-85C3-9CC8011A3D91}.Debug|arm64.Build.0 = Debug|ARM64
+		{A0353998-CF26-43C8-85C3-9CC8011A3D91}.Debug|arm64.Deploy.0 = Debug|ARM64
+		{A0353998-CF26-43C8-85C3-9CC8011A3D91}.Debug|x64.ActiveCfg = Debug|x64
+		{A0353998-CF26-43C8-85C3-9CC8011A3D91}.Debug|x64.Build.0 = Debug|x64
+		{A0353998-CF26-43C8-85C3-9CC8011A3D91}.Debug|x64.Deploy.0 = Debug|x64
+		{A0353998-CF26-43C8-85C3-9CC8011A3D91}.Debug|x86.ActiveCfg = Debug|x86
+		{A0353998-CF26-43C8-85C3-9CC8011A3D91}.Debug|x86.Build.0 = Debug|x86
+		{A0353998-CF26-43C8-85C3-9CC8011A3D91}.Debug|x86.Deploy.0 = Debug|x86
+		{A0353998-CF26-43C8-85C3-9CC8011A3D91}.Release|Any CPU.ActiveCfg = Release|x64
+		{A0353998-CF26-43C8-85C3-9CC8011A3D91}.Release|Any CPU.Build.0 = Release|x64
+		{A0353998-CF26-43C8-85C3-9CC8011A3D91}.Release|Any CPU.Deploy.0 = Release|x64
+		{A0353998-CF26-43C8-85C3-9CC8011A3D91}.Release|ARM.ActiveCfg = Release|x64
+		{A0353998-CF26-43C8-85C3-9CC8011A3D91}.Release|ARM.Build.0 = Release|x64
+		{A0353998-CF26-43C8-85C3-9CC8011A3D91}.Release|ARM.Deploy.0 = Release|x64
+		{A0353998-CF26-43C8-85C3-9CC8011A3D91}.Release|arm64.ActiveCfg = Release|ARM64
+		{A0353998-CF26-43C8-85C3-9CC8011A3D91}.Release|arm64.Build.0 = Release|ARM64
+		{A0353998-CF26-43C8-85C3-9CC8011A3D91}.Release|arm64.Deploy.0 = Release|ARM64
+		{A0353998-CF26-43C8-85C3-9CC8011A3D91}.Release|x64.ActiveCfg = Release|x64
+		{A0353998-CF26-43C8-85C3-9CC8011A3D91}.Release|x64.Build.0 = Release|x64
+		{A0353998-CF26-43C8-85C3-9CC8011A3D91}.Release|x64.Deploy.0 = Release|x64
+		{A0353998-CF26-43C8-85C3-9CC8011A3D91}.Release|x86.ActiveCfg = Release|x86
+		{A0353998-CF26-43C8-85C3-9CC8011A3D91}.Release|x86.Build.0 = Release|x86
+		{A0353998-CF26-43C8-85C3-9CC8011A3D91}.Release|x86.Deploy.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -207,7 +245,9 @@ Global
 	EndGlobalSection
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		..\SharedRenderer\SharedRenderer.vcxitems*{40c8962d-3e19-4142-a0b4-1614548aa3d1}*SharedItemsImports = 4
+		..\SharedVisualizer\SharedVisualizer.projitems*{85425680-c8bf-43f3-84c4-773d0ade45ef}*SharedItemsImports = 13
 		..\SharedObjectModel\SharedObjectModel.vcxitems*{8e2f84c6-5215-4c81-93fc-a35883762e10}*SharedItemsImports = 4
+		..\SharedVisualizer\SharedVisualizer.projitems*{a0353998-cf26-43c8-85c3-9cc8011a3d91}*SharedItemsImports = 5
 		..\SharedObjectModel\SharedObjectModel.vcxitems*{bb89bde2-fa11-4f6e-a27d-7025063b8b21}*SharedItemsImports = 9
 		..\SharedRenderer\SharedRenderer.vcxitems*{dcf1bda8-e94a-4d57-8ed6-5d30e29b69ed}*SharedItemsImports = 9
 	EndGlobalSection

--- a/source/uwp/winui3/Visualizer/AdaptiveCardVisualizer.csproj
+++ b/source/uwp/winui3/Visualizer/AdaptiveCardVisualizer.csproj
@@ -1,27 +1,33 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.22000.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
-    <RootNamespace>AdaptiveCardVisualizer</RootNamespace>
+    <RootNamespace>XamlCardVisualizer</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <PublishProfile>win10-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
+    <DefineConstants>USE_WINUI3</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Remove="Assets\**" />
-    <Content Remove="Assets\**" />
-    <EmbeddedResource Remove="Assets\**" />
-    <None Remove="Assets\**" />
-    <Page Remove="Assets\**" />
+    <Content Include="..\..\..\..\samples\v1.5\Scenarios\*.json">
+      <Link>Samples\%(Filename).json</Link>
+    </Content>
+    <Content Include="..\..\..\..\schemas\**\adaptive-card.json">
+      <Link>Schemas\%(RecursiveDir)adaptive-card.json</Link>
+    </Content>
+    <Content Include="..\..\..\..\schemas\host-config.json">
+      <Link>Schemas\renderer-options.json</Link>
+    </Content>
   </ItemGroup>
-
   <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.1" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.221109.1" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
+    <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.14" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 
@@ -33,6 +39,10 @@
   <ItemGroup Condition="'$(DisableMsixProjectCapabilityAddedByProject)'!='true' and '$(EnableMsixTooling)'=='true'">
     <ProjectCapability Include="Msix" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ObjectModelCsProjection\ObjectModelCsProjection.csproj" />
+    <ProjectReference Include="..\RendererCsProjection\RendererCsProjection.csproj" />
+  </ItemGroup>
 
   <!-- 
     Defining the "HasPackageAndPublishMenuAddedByProject" property here allows the Solution 
@@ -43,7 +53,4 @@
     <HasPackageAndPublishMenu>true</HasPackageAndPublishMenu>
   </PropertyGroup>
   <Import Project="..\..\SharedVisualizer\SharedVisualizer.projitems" Label="Shared" />
-  <ItemGroup>
-    <PRIResource Remove="Assets\**" />
-  </ItemGroup>
 </Project>

--- a/source/uwp/winui3/Visualizer/AdaptiveCardVisualizer.csproj
+++ b/source/uwp/winui3/Visualizer/AdaptiveCardVisualizer.csproj
@@ -1,0 +1,49 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <RootNamespace>AdaptiveCardVisualizer</RootNamespace>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <Platforms>x86;x64;ARM64</Platforms>
+    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <PublishProfile>win10-$(Platform).pubxml</PublishProfile>
+    <UseWinUI>true</UseWinUI>
+    <EnableMsixTooling>true</EnableMsixTooling>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Remove="Assets\**" />
+    <Content Remove="Assets\**" />
+    <EmbeddedResource Remove="Assets\**" />
+    <None Remove="Assets\**" />
+    <Page Remove="Assets\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.221109.1" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
+    <Manifest Include="$(ApplicationManifest)" />
+  </ItemGroup>
+
+  <!-- 
+    Defining the "Msix" ProjectCapability here allows the Single-project MSIX Packaging
+    Tools extension to be activated for this project even if the Windows App SDK Nuget
+    package has not yet been restored.
+  -->
+  <ItemGroup Condition="'$(DisableMsixProjectCapabilityAddedByProject)'!='true' and '$(EnableMsixTooling)'=='true'">
+    <ProjectCapability Include="Msix" />
+  </ItemGroup>
+
+  <!-- 
+    Defining the "HasPackageAndPublishMenuAddedByProject" property here allows the Solution 
+    Explorer "Package and Publish" context menu entry to be enabled for this project even if 
+    the Windows App SDK Nuget package has not yet been restored.
+  -->
+  <PropertyGroup Condition="'$(DisableHasPackageAndPublishMenuAddedByProject)'!='true' and '$(EnableMsixTooling)'=='true'">
+    <HasPackageAndPublishMenu>true</HasPackageAndPublishMenu>
+  </PropertyGroup>
+  <Import Project="..\..\SharedVisualizer\SharedVisualizer.projitems" Label="Shared" />
+  <ItemGroup>
+    <PRIResource Remove="Assets\**" />
+  </ItemGroup>
+</Project>

--- a/source/uwp/winui3/Visualizer/AdaptiveCardVisualizer.csproj
+++ b/source/uwp/winui3/Visualizer/AdaptiveCardVisualizer.csproj
@@ -24,6 +24,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="CommunityToolkit.WinUI" Version="7.1.2" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Layout" Version="7.1.2" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.1" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.221109.1" />

--- a/source/uwp/winui3/Visualizer/AdaptiveCardVisualizer.csproj
+++ b/source/uwp/winui3/Visualizer/AdaptiveCardVisualizer.csproj
@@ -24,6 +24,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Layout" Version="7.1.2" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.1" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.221109.1" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />

--- a/source/uwp/winui3/Visualizer/App.xaml
+++ b/source/uwp/winui3/Visualizer/App.xaml
@@ -1,0 +1,18 @@
+<!-- Copyright (c) Microsoft Corporation and Contributors. -->
+<!-- Licensed under the MIT License. -->
+
+<Application
+    x:Class="AdaptiveCardVisualizer.App"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:AdaptiveCardVisualizer">
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
+                <!-- Other merged dictionaries here -->
+            </ResourceDictionary.MergedDictionaries>
+            <!-- Other app resources here -->
+        </ResourceDictionary>
+    </Application.Resources>
+</Application>

--- a/source/uwp/winui3/Visualizer/App.xaml
+++ b/source/uwp/winui3/Visualizer/App.xaml
@@ -5,7 +5,9 @@
     x:Class="AdaptiveCardVisualizer.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:AdaptiveCardVisualizer">
+    xmlns:local="using:AdaptiveCardVisualizer"
+    RequestedTheme="Light"
+    xmlns:converters="using:AdaptiveCardVisualizer.Converters">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -13,6 +15,11 @@
                 <!-- Other merged dictionaries here -->
             </ResourceDictionary.MergedDictionaries>
             <!-- Other app resources here -->
+            <converters:NotNullToVisibilityConverter x:Key="NotNullToVisibilityConverter"/>
+            <Style x:Key="HorizontalListViewItemContainerStyle" TargetType="ListViewItem">
+                <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                <Setter Property="Padding" Value="0"/>
+            </Style>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/source/uwp/winui3/Visualizer/App.xaml.cs
+++ b/source/uwp/winui3/Visualizer/App.xaml.cs
@@ -46,8 +46,14 @@ namespace AdaptiveCardVisualizer
         {
             m_window = new MainWindow();
             m_window.Activate();
+#if USE_WINUI3
+            Window = m_window;
+#endif
         }
 
-        private Window m_window;
+        public Window m_window;
+#if USE_WINUI3
+        public static Window Window;
+#endif
     }
 }

--- a/source/uwp/winui3/Visualizer/App.xaml.cs
+++ b/source/uwp/winui3/Visualizer/App.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation and Contributors.
+// Copyright (c) Microsoft Corporation and Contributors.
 // Licensed under the MIT License.
 
 using Microsoft.UI.Xaml;

--- a/source/uwp/winui3/Visualizer/App.xaml.cs
+++ b/source/uwp/winui3/Visualizer/App.xaml.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Corporation and Contributors.
+// Licensed under the MIT License.
+
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+using Microsoft.UI.Xaml.Shapes;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.ApplicationModel;
+using Windows.ApplicationModel.Activation;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
+
+namespace AdaptiveCardVisualizer
+{
+    /// <summary>
+    /// Provides application-specific behavior to supplement the default Application class.
+    /// </summary>
+    public partial class App : Application
+    {
+        /// <summary>
+        /// Initializes the singleton application object.  This is the first line of authored code
+        /// executed, and as such is the logical equivalent of main() or WinMain().
+        /// </summary>
+        public App()
+        {
+            this.InitializeComponent();
+        }
+
+        /// <summary>
+        /// Invoked when the application is launched.
+        /// </summary>
+        /// <param name="args">Details about the launch request and process.</param>
+        protected override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
+        {
+            m_window = new MainWindow();
+            m_window.Activate();
+        }
+
+        private Window m_window;
+    }
+}

--- a/source/uwp/winui3/Visualizer/MainWindow.xaml
+++ b/source/uwp/winui3/Visualizer/MainWindow.xaml
@@ -1,0 +1,16 @@
+<!-- Copyright (c) Microsoft Corporation and Contributors. -->
+<!-- Licensed under the MIT License. -->
+
+<Window
+    x:Class="AdaptiveCardVisualizer.MainWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:AdaptiveCardVisualizer"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
+        <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>
+    </StackPanel>
+</Window>

--- a/source/uwp/winui3/Visualizer/MainWindow.xaml
+++ b/source/uwp/winui3/Visualizer/MainWindow.xaml
@@ -10,7 +10,5 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
-        <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>
-    </StackPanel>
+    <local:MainPage x:Name="mainPage"/>
 </Window>

--- a/source/uwp/winui3/Visualizer/MainWindow.xaml.cs
+++ b/source/uwp/winui3/Visualizer/MainWindow.xaml.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation and Contributors.
+// Licensed under the MIT License.
+
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
+
+namespace AdaptiveCardVisualizer
+{
+    /// <summary>
+    /// An empty window that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    public sealed partial class MainWindow : Window
+    {
+        public MainWindow()
+        {
+            this.InitializeComponent();
+        }
+
+        private void myButton_Click(object sender, RoutedEventArgs e)
+        {
+            myButton.Content = "Clicked";
+        }
+    }
+}

--- a/source/uwp/winui3/Visualizer/MainWindow.xaml.cs
+++ b/source/uwp/winui3/Visualizer/MainWindow.xaml.cs
@@ -3,18 +3,6 @@
 
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Data;
-using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Navigation;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -29,11 +17,6 @@ namespace AdaptiveCardVisualizer
         public MainWindow()
         {
             this.InitializeComponent();
-        }
-
-        private void myButton_Click(object sender, RoutedEventArgs e)
-        {
-            myButton.Content = "Clicked";
         }
     }
 }

--- a/source/uwp/winui3/Visualizer/Package.appxmanifest
+++ b/source/uwp/winui3/Visualizer/Package.appxmanifest
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  IgnorableNamespaces="uap rescap">
+
+  <Identity
+    Name="9f958379-af7e-435b-a19e-3b823ef087f0"
+    Publisher="CN=krschau"
+    Version="1.0.0.0" />
+
+  <Properties>
+    <DisplayName>AdaptiveCardVisualizer</DisplayName>
+    <PublisherDisplayName>krschau</PublisherDisplayName>
+    <Logo>Assets\StoreLogo.png</Logo>
+  </Properties>
+
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
+  </Dependencies>
+
+  <Resources>
+    <Resource Language="x-generate"/>
+  </Resources>
+
+  <Applications>
+    <Application Id="App"
+      Executable="$targetnametoken$.exe"
+      EntryPoint="$targetentrypoint$">
+      <uap:VisualElements
+        DisplayName="AdaptiveCardVisualizer"
+        Description="AdaptiveCardVisualizer"
+        BackgroundColor="transparent"
+        Square150x150Logo="Assets\Square150x150Logo.png"
+        Square44x44Logo="Assets\Square44x44Logo.png">
+        <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" />
+        <uap:SplashScreen Image="Assets\SplashScreen.png" />
+      </uap:VisualElements>
+    </Application>
+  </Applications>
+
+  <Capabilities>
+    <rescap:Capability Name="runFullTrust" />
+  </Capabilities>
+</Package>

--- a/source/uwp/winui3/Visualizer/Package.appxmanifest
+++ b/source/uwp/winui3/Visualizer/Package.appxmanifest
@@ -7,7 +7,7 @@
   IgnorableNamespaces="uap rescap">
 
   <Identity
-    Name="9f958379-af7e-435b-a19e-3b823ef087f0"
+    Name="AdaptiveCardVisualizer"
     Publisher="CN=Microsoft Corporation"
     Version="1.0.0.0" />
 

--- a/source/uwp/winui3/Visualizer/Package.appxmanifest
+++ b/source/uwp/winui3/Visualizer/Package.appxmanifest
@@ -8,12 +8,12 @@
 
   <Identity
     Name="9f958379-af7e-435b-a19e-3b823ef087f0"
-    Publisher="CN=krschau"
+    Publisher="CN=Microsoft Corporation"
     Version="1.0.0.0" />
 
   <Properties>
     <DisplayName>AdaptiveCardVisualizer</DisplayName>
-    <PublisherDisplayName>krschau</PublisherDisplayName>
+    <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
 

--- a/source/uwp/winui3/Visualizer/Properties/launchSettings.json
+++ b/source/uwp/winui3/Visualizer/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "AdaptiveCardVisualizer (Package)": {
+      "commandName": "MsixPackage"
+    },
+    "AdaptiveCardVisualizer (Unpackaged)": {
+      "commandName": "Project"
+    }
+  }
+}

--- a/source/uwp/winui3/Visualizer/app.manifest
+++ b/source/uwp/winui3/Visualizer/app.manifest
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="AdaptiveCardVisualizer.app"/>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!--The ID below informs the system that this application is compatible with OS features first introduced in Windows 8. 
+      For more info see https://docs.microsoft.com/windows/win32/sysinfo/targeting-your-application-at-windows-8-1 
+      
+      It is also necessary to support features in unpackaged applications, for example the custom titlebar implementation.-->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
+    </application>
+  </compatibility>
+  
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <!-- The combination of below two tags have the following effect:
+           1) Per-Monitor for >= Windows 10 Anniversary Update
+           2) System < Windows 10 Anniversary Update
+      -->
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/PM</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
+    </windowsSettings>
+  </application>
+</assembly>


### PR DESCRIPTION
# Related Issue

https://github.com/microsoft/AdaptiveCards/issues/5888

# Description

This change adds a WinUI 3 version of the Adaptive Card Visualizer, matching functionality of the UWP version. A few changes needed to be made to the shared code to work with both versions of Xaml:
- The `GridSplitter` control moves to code behind. In markup, we can't change which namespace it comes from (System Xaml or WinUI 3 version) based on which version we are compiling.
- In WinUI 3, we don't have the `CoreWindow.Dispatcher`, so instead use Community Toolkit's `Microsoft.UI.Dispatching.DispatcherQueueController.DispatcherQueue.EnqueueAsync()`
- In WinUI 3, `ContentDialog`s need their `XamlRoot` to be set. To have this info, we have to cache the XamlRoot when we create the MainPageViewModel.
- In WinUI 3, `MessageDialog`s need to be initialized with an HWND before they can be opened.

# How Verified

Checked each example card, plus creating and saving a new card.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8254)