### PR TITLE
[JS Renderer] Add loop property to carousel

### DIFF
--- a/samples/v1.6/Elements/Carousel.Loop.json
+++ b/samples/v1.6/Elements/Carousel.Loop.json
@@ -1,0 +1,51 @@
+{
+	"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+	"type": "AdaptiveCard",
+	"version": "1.6",
+	"body": [
+		{
+			"type": "Carousel",
+			"loop": false,
+			"pages": [
+				{
+					"type": "CarouselPage",
+					"id": "firstPage",
+					"items": [
+						{
+							"type": "Image",
+							"url": "https://picsum.photos/id/100/300/300",
+							"altText": "beach"
+						}
+					]
+				},
+				{
+					"type": "CarouselPage",
+					"id": "secondPage",
+					"items": [
+						{
+							"type": "Image",
+							"url": "https://picsum.photos/id/110/300/300",
+							"altText": "sunset"
+						}
+					]
+				},
+				{
+					"type": "CarouselPage",
+					"id": "thirdPage",
+					"items": [
+						{
+							"type": "Image",
+							"url": "https://picsum.photos/id/120/300/300",
+							"altText": "sunset"
+						}
+					]
+				}
+			]
+		},
+		{
+			"type": "TextBlock",
+			"text": "You can disable carousel looping by setting the value of *loop* property",
+			"wrap": true
+		}
+	]
+}

--- a/source/nodejs/adaptivecards/src/carousel.ts
+++ b/source/nodejs/adaptivecards/src/carousel.ts
@@ -11,7 +11,7 @@ import {
 } from "./card-elements";
 import * as Enums from "./enums";
 import {
-	BoolProperty,
+    BoolProperty,
     NumProperty,
     property,
     PropertyBag,
@@ -156,9 +156,9 @@ export class Carousel extends Container {
         }
     }
 
-	static readonly loopProperty = new BoolProperty(Versions.v1_6, "loop", true);
-	@property(Carousel.loopProperty)
-	carouselLoop: boolean = true;
+    static readonly loopProperty = new BoolProperty(Versions.v1_6, "loop", true);
+    @property(Carousel.loopProperty)
+    carouselLoop: boolean = true;
     
     private isValidParsedPageIndex(index: number) : boolean {
         return this._pages ? this.isValidPageIndex(index, this._pages.length) : false;

--- a/source/nodejs/adaptivecards/src/carousel.ts
+++ b/source/nodejs/adaptivecards/src/carousel.ts
@@ -11,6 +11,7 @@ import {
 } from "./card-elements";
 import * as Enums from "./enums";
 import {
+	BoolProperty,
     NumProperty,
     property,
     PropertyBag,
@@ -154,6 +155,10 @@ export class Carousel extends Container {
             this.setValue(Carousel.initialPageProperty, 0); 
         }
     }
+
+	static readonly loopProperty = new BoolProperty(Versions.v1_6, "loop", true);
+	@property(Carousel.loopProperty)
+	carouselLoop: boolean = true;
     
     private isValidParsedPageIndex(index: number) : boolean {
         return this._pages ? this.isValidPageIndex(index, this._pages.length) : false;
@@ -456,7 +461,7 @@ export class Carousel extends Container {
     ): void {
 
         const swiperOptions: SwiperOptions = {
-            loop: !this.isDesignMode(),
+            loop: !this.isDesignMode() && this.carouselLoop,
             modules: [Navigation, Pagination, Scrollbar, A11y, History, Keyboard],
             pagination: {
                 el: paginationElement,


### PR DESCRIPTION
# Related Issue

Issue in external repository

# Description

Adds an additional schema property to `Carousel` element. `loop` will allow the card author to disable swiper looping (going from the last slide to the first slide).

`loop`
- boolean value
- defaults to `true` 

# Sample Card

Sample card included in the PR.

# How Verified

Verified manually on the Adaptive Cards Designer
![carouselLoop](https://user-images.githubusercontent.com/98650930/214960742-d491c7dc-d5c1-4ddb-8344-4c939bc5a01e.gif)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8259)