### PR TITLE
added forceLoad option for image

### DIFF
--- a/samples/v1.6/Elements/Image.ForceLoad.json
+++ b/samples/v1.6/Elements/Image.ForceLoad.json
@@ -1,0 +1,21 @@
+{
+	"type": "AdaptiveCard",
+	"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+	"version": "1.6",
+	"body": [
+		{
+			"type": "Image",
+			"height": "32px",
+			"width": "32px",
+			"url": "https://live-tile-images.scdn.co/dw-dark-previewl.gif",
+			"horizontalAlignment": "Center"
+		}, {
+			"type": "Image",
+			"height": "32px",
+			"width": "32px",
+			"url": "https://live-tile-images.scdn.co/dw-dark-previewl.gif",
+			"forceLoad": true,
+			"horizontalAlignment": "Center"
+		}
+	]
+}

--- a/samples/v1.6/Elements/Image.ForceLoad.json
+++ b/samples/v1.6/Elements/Image.ForceLoad.json
@@ -7,13 +7,13 @@
 			"type": "Image",
 			"height": "32px",
 			"width": "32px",
-			"url": "https://live-tile-images.scdn.co/dw-dark-previewl.gif",
+			"url": "https://media.giphy.com/media/83eQIMgNvkiY/giphy.gif",
 			"horizontalAlignment": "Center"
 		}, {
 			"type": "Image",
 			"height": "32px",
 			"width": "32px",
-			"url": "https://live-tile-images.scdn.co/dw-dark-previewl.gif",
+			"url": "https://media.giphy.com/media/83eQIMgNvkiY/giphy.gif",
 			"forceLoad": true,
 			"horizontalAlignment": "Center"
 		}

--- a/samples/v1.6/Elements/Image.ForceLoad.json
+++ b/samples/v1.6/Elements/Image.ForceLoad.json
@@ -1,21 +1,20 @@
 {
-	"type": "AdaptiveCard",
-	"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
-	"version": "1.6",
-	"body": [
-		{
-			"type": "Image",
-			"height": "32px",
-			"width": "32px",
-			"url": "https://media.giphy.com/media/83eQIMgNvkiY/giphy.gif",
-			"horizontalAlignment": "Center"
-		}, {
-			"type": "Image",
-			"height": "32px",
-			"width": "32px",
-			"url": "https://media.giphy.com/media/83eQIMgNvkiY/giphy.gif",
-			"forceLoad": true,
-			"horizontalAlignment": "Center"
-		}
-	]
+    "type": "AdaptiveCard",
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.6",
+    "body": [
+        {
+            "type": "Image",
+            "size": "Medium",
+            "url": "https://media.giphy.com/media/83eQIMgNvkiY/giphy.gif",
+            "horizontalAlignment": "Center"
+        },
+        {
+            "type": "Image",
+            "size": "Medium",
+            "url": "https://media.giphy.com/media/83eQIMgNvkiY/giphy.gif",
+            "forceLoad": true,
+            "horizontalAlignment": "Center"
+        }
+    ]
 }

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -1948,6 +1948,7 @@ export class Image extends CardElement {
     static readonly selectActionProperty = new ActionProperty(Versions.v1_1, "selectAction", [
         "Action.ShowCard"
     ]);
+    static readonly shouldForceLoadProperty = new BoolProperty(Versions.v1_6, "forceLoad", false);
 
     protected populateSchema(schema: SerializableObjectSchema) {
         super.populateSchema(schema);
@@ -1980,6 +1981,9 @@ export class Image extends CardElement {
 
     @property(Image.selectActionProperty)
     selectAction?: Action;
+
+    @property(Image.shouldForceLoadProperty)
+    forceLoad: boolean;
 
     //#endregion
 
@@ -2140,6 +2144,8 @@ export class Image extends CardElement {
                 imageElement.style.backgroundColor = backgroundColor;
             }
 
+            this.configureImageForForceLoading();
+
             imageElement.src = <string>this.preProcessPropertyValue(Image.urlProperty);
 
             const altTextProperty = this.preProcessPropertyValue(Image.altTextProperty);
@@ -2187,6 +2193,24 @@ export class Image extends CardElement {
 
     getResourceInformation(): IResourceInformation[] {
         return this.url ? [{ url: this.url, mimeType: "image" }] : [];
+    }
+
+    // configures Image element to fetch a new image data from url source instead of relying on cache
+    private configureImageForForceLoading(): void {
+        if (this.forceLoad) {
+            // currently rudimentary refreshing scheme is used
+            // by attaching unique query string to url, we bypass the cache usage
+            this.url = this.appendUniqueQueryStringToURL(this.url);
+        }
+    }
+
+    private appendUniqueQueryStringToURL(url: string | undefined) : string | undefined
+    {
+        // we can do better by appending unique key such as uuid instead of epoch
+        // however the current usage is for front-end ui and networking,  
+        // since ui is running in single main thread, this is sufficient mechanism
+        // without needing to depend on external library for our small use cases.
+        return (url && url.length) ? url + '?' + Date.now() : url;
     }
 }
 

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -2146,7 +2146,7 @@ export class Image extends CardElement {
 
             this.configureImageForForceLoading();
 
-            imageElement.src = <string>this.preProcessPropertyValue(Image.urlProperty);
+            imageElement.src = <string>this.preProcessPropertyValue( {prop = Image.urlProperty, propertyValue = nil});
 
             const altTextProperty = this.preProcessPropertyValue(Image.altTextProperty);
             if (altTextProperty) {


### PR DESCRIPTION
# Related Issue
https://microsoft.visualstudio.com/OS/_workitems/edit/42514115

# Description
Unlike static image, animation has state. Due to caching, animation state cannot be reset. Added a forceLoad option that directs browser to fetch from the source instead of relying on its cache. 

# Sample Card
Included in PR.

# How Verified
The first Image element doesn't have forceLoad property, and its animation doesn't get refreshed vs 2n image element that does.
https://user-images.githubusercontent.com/4112696/214984279-c58f8d7b-08fe-4735-80f7-f782eeadab37.mp4



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8260)