### PR TITLE
[Website] Make UHF popup a modal

### DIFF
--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/_partial/header.ejs
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/_partial/header.ejs
@@ -156,7 +156,9 @@
 															data-m='{"cN":"GlobalNav_More_nonnav","id":"nn1c1c9c2m1r1a1","sN":1,"aN":"c1c9c2m1r1a1"}'>
 															<span>All Microsoft</span>
 														</button>
-														<ul class="f-multi-column f-multi-column-6"
+														<ul role="dialog"
+															aria-modal="true"
+															class="f-multi-column f-multi-column-6"
 															aria-hidden="true"
 															data-m='{"cN":"More_cont","cT":"Container","id":"c2c1c9c2m1r1a1","sN":2,"aN":"c1c9c2m1r1a1"}'>
 															<li class="c-w0-contr">


### PR DESCRIPTION
# Related Issue

Fixes #7933 

# Description

When using voice access, numbers were shown for controls located under the popup.

By setting the popup window as a modal, Voice Access will recognize the popup as the foreground window and only show numbers for controls present within the popup.

**Note**: In order for this to work, focus must be on an element within the popup.

# How Verified

Verified manually on the AdaptiveCards site using Voice Access's "Show numbers" command.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8261)