### PR TITLE
[Designer] Add link option for toolbar buttons

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/toolbar.ts
+++ b/source/nodejs/adaptivecards-designer/src/toolbar.ts
@@ -59,6 +59,7 @@ export class ToolbarButton extends ToolbarElement {
     private _isEnabled: boolean = true;
     private _allowToggle: boolean = false;
     private _isToggled: boolean = false;
+    private _isLink: boolean = false;
 
     protected clicked() {
         if (this.isEnabled && this.onClick) {
@@ -105,6 +106,10 @@ export class ToolbarButton extends ToolbarElement {
         }
 
         this.renderedElement.title = this.toolTip ? this.toolTip : "";
+        
+        if (this._isLink) {
+            this.renderedElement.setAttribute("role", "link");
+        }
     }
 
     protected internalRender(): HTMLElement {
@@ -128,12 +133,14 @@ export class ToolbarButton extends ToolbarElement {
         id: string,
         caption: string,
         iconClass: string,
-        onClick: (sender: ToolbarButton) => void = null) {
+        onClick: (sender: ToolbarButton) => void = null,
+        isLink: boolean = false) {
         super(id);
 
         this.caption = caption;
         this.iconClass = iconClass;
         this.onClick = onClick;
+        this._isLink = isLink;
     }
 
     get allowToggle(): boolean {

--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/designer.ejs
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/designer.ejs
@@ -99,7 +99,8 @@
 				"acd-icon-storyboard",
 				function () {
 					window.open("https://docs.microsoft.com/en-us/adaptive-cards/resources/partners")
-				}
+				},
+				true
 			);
 			hostDocsButton.separator = true;
 			hostDocsButton.toolTip = "Learn more about the Host Apps";
@@ -112,7 +113,8 @@
 				function () {
 					appInsights.trackEvent({ name: "ViewedTemplatingDocs" }, { Origin: "Designer" });
 					window.open("https://docs.microsoft.com/en-us/adaptive-cards/templating/");
-				}
+				},
+				true
 			);
 			templateDocsButton.separator = false;
 			templateDocsButton.toolTip = "Learn more about Adaptive Cards templating";
@@ -129,7 +131,8 @@
 						+ encodeURIComponent("[Designer] Feedback title here")
 						+ "&labels=" + encodeURIComponent("Bug,Triage-Needed,Area-Designer")
 						+ "&template=" + encodeURIComponent("designer-bug-report.md"))
-				}
+				},
+				true
 			);
 
 			feedbackButton.separator = true;


### PR DESCRIPTION
# Related Issue

Fixes #8167 

# Description

Added an optional parameter to the designer's `ToolbarButton`. If `isLink` is set to `true`, we will assign `role="link"` to the toolbarButton. `isLink` defaults to `false`.

This change ensures that Narrator announces buttons properly when they navigate to a new page.

# How Verified

Verified manually on the Adaptive Cards website.
