### PR TITLE
[DRAFT] Refactor toolbox to improve accessibility

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/tool-box.ts
+++ b/source/nodejs/adaptivecards-designer/src/tool-box.ts
@@ -112,9 +112,6 @@ export class Toolbox {
             
             this._isExpanded = false;
             this.toggled(saveState);
-
-            // Now that we've updated the visual state, move focus
-            this._collapsedStateButtonElement.focus();
         }
     }
 
@@ -124,9 +121,6 @@ export class Toolbox {
 
             this._isExpanded = true;
             this.toggled();
-            
-            // Now that we've updated the visual state, move focus
-            this._expandedStateButtonElement.focus();
         }
     }
 
@@ -218,11 +212,19 @@ export class Toolbox {
         this._expandedStateButtonElement.onkeydown = (e) => {
             if (e.key === Constants.keys.enter || e.key === Constants.keys.space) {
                 this.collapse();
+
+                // Now that we've updated the visual state, move focus 
+                this._collapsedStateButtonElement.focus();
+                
                 e.preventDefault();
             }
 
             if (e.key === Constants.keys.escape) {
                 this.collapse();
+
+                // Now that we've updated the visual state, move focus 
+                this._collapsedStateButtonElement.focus();
+                
                 e.preventDefault();
             }
         }
@@ -265,12 +267,20 @@ export class Toolbox {
         this._collapsedStateButtonElement.onkeydown = (e) => {
             if (e.key === Constants.keys.enter || e.key === Constants.keys.space) {
                 this.expand();
+
+                // Now that we've updated the visual state, move focus
+                this._expandedStateButtonElement.focus();
+                
                 e.preventDefault();
             }
         }
 
         this._collapsedStateButtonElement.onclick = (e) => {
             this.expand();
+
+            // Now that we've updated the visual state, move focus
+            this._expandedStateButtonElement.focus();
+
             e.preventDefault();
             return true;
         }


### PR DESCRIPTION
# Related Issue

Fixes #7919 

# Description

Refactor designer's `toolbox` so that the expand/collapse button is not moved between divs.

To keep the same behavior, there are two buttons (expand **and** collapse), and we hide the collapsed button header when the toolbox is expanded.

# How Verified

Verified manually on the Adaptive Cards site.

Narrator focus now follows the button
![expandCollapse](https://user-images.githubusercontent.com/98650930/216467433-d15cb0ab-402d-4b93-b656-ffea6328c494.gif)

# Outstanding issues

- The expand/collapse state is only announced the first time we move to the button when toggling. However, the other button attributes are announced correctly when toggling the button.
- The collapsed button is not moved to correctly for the toolboxes along the bottom of the page.
![expandCollapse2](https://user-images.githubusercontent.com/98650930/216467902-6ecebe16-3804-4298-b7a5-38264b2067bd.gif)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://api.github.com/repos/microsoft/AdaptiveCards/pulls/8276)