### PR TITLE
[WinUI 3 Renderer] Change target platform to match WindowsAppSDK support

### DIFF
--- a/source/uwp/ObjectModelProjection/ObjectModelProjection.vcxproj
+++ b/source/uwp/ObjectModelProjection/ObjectModelProjection.vcxproj
@@ -196,7 +196,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.15063.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <ProjectName>ObjectModelProjection</ProjectName>

--- a/source/uwp/ObjectModelProjection/ObjectModelProjection.vcxproj
+++ b/source/uwp/ObjectModelProjection/ObjectModelProjection.vcxproj
@@ -196,7 +196,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.15063.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <ProjectName>ObjectModelProjection</ProjectName>

--- a/source/uwp/winui3/AdaptiveCardsObjectModel/AdaptiveCardsObjectModel.vcxproj
+++ b/source/uwp/winui3/AdaptiveCardsObjectModel/AdaptiveCardsObjectModel.vcxproj
@@ -14,7 +14,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.17763.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <TargetName>AdaptiveCards.ObjectModel.WinUI3</TargetName>
     <DesktopCompatible>true</DesktopCompatible>

--- a/source/uwp/winui3/AdaptiveCardsObjectModel/AdaptiveCardsObjectModel.vcxproj
+++ b/source/uwp/winui3/AdaptiveCardsObjectModel/AdaptiveCardsObjectModel.vcxproj
@@ -95,6 +95,7 @@
       <ModuleDefinitionFile>.\dll\AdaptiveCards.ObjectModel.WinUI3.def</ModuleDefinitionFile>
       <AdditionalDependencies>
         user32.lib;
+        OleAut32.lib;
         %(AdditionalDependencies);
       </AdditionalDependencies>
     </Link>

--- a/source/uwp/winui3/ObjectModelCsProjection/ObjectModelCsProjection.csproj
+++ b/source/uwp/winui3/ObjectModelCsProjection/ObjectModelCsProjection.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows10.0.22000.0</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.17763.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <!-- Set Platform to AnyCPU to allow consumption of the projection assembly from any architecture. -->
     <Platform>AnyCPU</Platform>

--- a/source/uwp/winui3/Renderer/AdaptiveCardRenderer.vcxproj
+++ b/source/uwp/winui3/Renderer/AdaptiveCardRenderer.vcxproj
@@ -5,7 +5,6 @@
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.210913.7\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210913.7\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
-    <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
     <MinimalCoreWin>true</MinimalCoreWin>
     <ProjectGuid>{40c8962d-3e19-4142-a0b4-1614548aa3d1}</ProjectGuid>
     <Keyword>AdaptiveCards</Keyword>
@@ -107,6 +106,8 @@
       <ModuleDefinitionFile>.\dll\AdaptiveCards.Rendering.WinUI3.def</ModuleDefinitionFile>
       <AdditionalDependencies>
         user32.lib;
+        Ole32.lib;
+        OleAut32.lib;
         %(AdditionalDependencies);
       </AdditionalDependencies>
       <AdditionalOptions>/profile %(AdditionalOptions)</AdditionalOptions>

--- a/source/uwp/winui3/Renderer/AdaptiveCardRenderer.vcxproj
+++ b/source/uwp/winui3/Renderer/AdaptiveCardRenderer.vcxproj
@@ -16,7 +16,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.17763.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <TargetName>AdaptiveCards.Rendering.WinUI3</TargetName>
     <DesktopCompatible>true</DesktopCompatible>

--- a/source/uwp/winui3/RendererCsProjection/RendererCsProjection.csproj
+++ b/source/uwp/winui3/RendererCsProjection/RendererCsProjection.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows10.0.22000.0</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.17763.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <!-- Set Platform to AnyCPU to allow consumption of the projection assembly from any architecture. -->
     <Platform>AnyCPU</Platform>

--- a/source/uwp/winui3/SimpleVisualizer/SimpleVisualizer.csproj
+++ b/source/uwp/winui3/SimpleVisualizer/SimpleVisualizer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.22000.0</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.17763.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>SimpleVisualizer</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>


### PR DESCRIPTION
# Related Issue

#5888

# Description

The Adaptive Cards WinUI 3 renderer should support all platforms that WinUI 3 / WindowsAppSDK can run on. This change supports that by explicitly targeting the lowest supported version. This requires linking a few additional libraries, as well as setting a specific target on the ObjectModelProjection projct.

# How Verified

Build pipelines

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://api.github.com/repos/microsoft/AdaptiveCards/pulls/8277)