### PR TITLE
[Designer] Fix top margin on carousel arrows

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/containers/widget/widget-container-dark.css
+++ b/source/nodejs/adaptivecards-designer/src/containers/widget/widget-container-dark.css
@@ -1,3 +1,8 @@
+:root {
+    --widget-margin: 16px;
+    --left-right-arrow-height: 38px;
+}
+
 .widget-outer-container {
     border: 1px solid rgba(0, 0, 0, 0.1);
     background: #2c2c2c;
@@ -15,7 +20,7 @@
     z-index: 1;
     display: flex;
     justify-content: space-around;
-    margin: 16px;
+    margin: var(--widget-margin);
     border-radius: 8px 8px 0px 0px;
 }
 
@@ -62,15 +67,15 @@
 
 .ac-adaptiveCard {
     border: 0px;
-    padding: 48px 16px 16px 16px !important;
+    padding: 48px var(--widget-margin) var(--widget-margin) var(--widget-margin) !important;
     margin: 0px !important;
     border-radius: 8px;
 }
 
 .ac-card-elements-wrapper {
     height: 100%;
-    margin: 0px -16px 0px -16px !important;
-    padding: 0px 16px 0px 16px !important;
+    margin: 0px calc(0px - var(--widget-margin)) 0px calc(0px - var(--widget-margin)) !important;
+    padding: 0px var(--widget-margin) 0px var(--widget-margin) !important;
 }
 
 .no-overflow {
@@ -331,7 +336,7 @@ a.ac-anchor:hover {
 }
 
 .ac-carousel-container {
-    padding: 0px 16px 16px 16px !important;
+    padding: 0px var(--widget-margin) var(--widget-margin) var(--widget-margin) !important;
 }
 
 .ac-carousel-container-vertical {
@@ -339,7 +344,7 @@ a.ac-anchor:hover {
 }
 
 .ac-carousel-card-level-container {
-    margin: 0px -16px -16px -16px !important;
+    margin: 0px calc(0px - var(--widget-margin)) calc(0px - var(--widget-margin)) calc(0px - var(--widget-margin)) !important;
 }
 
 .ac-container.ac-adaptiveCard .swiper-button-prev.ac-carousel-left,
@@ -367,12 +372,11 @@ a.ac-anchor:hover {
 .swiper-button-prev.ac-carousel-left,
 .swiper-button-next.ac-carousel-right {
     border-radius:3px;
-    height:38px;
+    height: var(--left-right-arrow-height);
     width:16px;
     /* The arrows already have 'top: 50%' set
-    We need to subtract half of the bottom margin and half of the arrow height to center the arrows
-   (16/2) + (38/2) = 27 */
-    margin-top: -27px !important;
+    We need to subtract half of the bottom margin and half of the arrow height to center the arrows */
+    margin-top: calc(0px - ((var(--widget-margin) + var(--left-right-arrow-height)) / 2)) !important;
 }
 
 .swiper-button-prev.ac-carousel-up,

--- a/source/nodejs/adaptivecards-designer/src/containers/widget/widget-container-dark.css
+++ b/source/nodejs/adaptivecards-designer/src/containers/widget/widget-container-dark.css
@@ -369,6 +369,10 @@ a.ac-anchor:hover {
     border-radius:3px;
     height:38px;
     width:16px;
+    /* The arrows already have 'top: 50%' set
+    We need to subtract half of the bottom margin and half of the arrow height to center the arrows
+   (16/2) + (38/2) = 27 */
+    margin-top: -27px !important;
 }
 
 .swiper-button-prev.ac-carousel-up,

--- a/source/nodejs/adaptivecards-designer/src/containers/widget/widget-container-light.css
+++ b/source/nodejs/adaptivecards-designer/src/containers/widget/widget-container-light.css
@@ -370,6 +370,10 @@ a.ac-anchor:hover {
     border-radius:3px;
     height:38px;
     width:16px;
+    /* The arrows already have 'top: 50%' set
+    We need to subtract half of the bottom margin and half of the arrow height to center the arrows
+    (16/2) + (38/2) = 27 */
+    margin-top: -27px !important;
 }
 
 .swiper-button-prev.ac-carousel-up,

--- a/source/nodejs/adaptivecards-designer/src/containers/widget/widget-container-light.css
+++ b/source/nodejs/adaptivecards-designer/src/containers/widget/widget-container-light.css
@@ -1,14 +1,19 @@
+:root {
+    --widget-margin: 16px;
+    --left-right-arrow-height: 38px;
+}
+
 .ac-adaptiveCard {
     border: 0px;
-    padding: 48px 16px 16px 16px !important;
+    padding: 48px var(--widget-margin) var(--widget-margin) var(--widget-margin) !important;
     margin: 0px !important;
     border-radius: 8px;
 }
 
 .ac-card-elements-wrapper {
     height: 100%;
-    margin: 0px -16px 0px -16px !important;
-    padding: 0px 16px 0px 16px !important;
+    margin: 0px calc(0px - var(--widget-margin)) 0px calc(0px - var(--widget-margin)) !important;
+    padding: 0px var(--widget-margin) 0px var(--widget-margin) !important;
 }
 
 .no-overflow {
@@ -32,7 +37,7 @@
     z-index: 1;
     display: flex;
     justify-content: space-around;
-    margin: 16px;
+    margin: var(--widget-margin);
     border-radius: 8px 8px 0px 0px;
 }
 
@@ -332,7 +337,7 @@ a.ac-anchor:hover {
 }
 
 .ac-carousel-container {
-    padding: 0px 16px 16px 16px !important;
+    padding: 0px var(--widget-margin) var(--widget-margin) var(--widget-margin) !important;
 }
 
 .ac-carousel-container-vertical {
@@ -340,7 +345,7 @@ a.ac-anchor:hover {
 }
 
 .ac-carousel-card-level-container {
-    margin: 0px -16px -16px -16px !important;
+    margin: 0px calc(0px - var(--widget-margin)) calc(0px - var(--widget-margin)) calc(0px - var(--widget-margin)) !important;
 }
 
 .ac-container.ac-adaptiveCard .swiper-button-prev.ac-carousel-left,
@@ -368,12 +373,11 @@ a.ac-anchor:hover {
 .swiper-button-prev.ac-carousel-left,
 .swiper-button-next.ac-carousel-right {
     border-radius:3px;
-    height:38px;
+    height: var(--left-right-arrow-height);
     width:16px;
     /* The arrows already have 'top: 50%' set
-    We need to subtract half of the bottom margin and half of the arrow height to center the arrows
-    (16/2) + (38/2) = 27 */
-    margin-top: -27px !important;
+    We need to subtract half of the bottom margin and half of the arrow height to center the arrows */
+    margin-top: calc(0px - ((var(--widget-margin) + var(--left-right-arrow-height)) / 2)) !important;
 }
 
 .swiper-button-prev.ac-carousel-up,


### PR DESCRIPTION
# Related Issue

Tracked in ADO

# Description

I added a top margin of `-27px` to the left and right carousel arrows for widget board styling.

The arrows have `top: 50%` styling, which meant the top of the arrow was centered. We needed to shift the arrow up so that the _center_ of the arrow was centered.

27 was found by taking half of the arrow height and half of the bottom margin (needed bottom margin because there is no top margin).

# How Verified

Verified manually in the Adaptive Cards designer.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://api.github.com/repos/microsoft/AdaptiveCards/pulls/8285)