### PR TITLE
[UWP] Remove weak_ref from method headers and pass by value

### DIFF
--- a/source/uwp/Renderer/lib/AdaptiveImageRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImageRenderer.cpp
@@ -534,16 +534,14 @@ namespace AdaptiveCards::Rendering::Uwp
             auto streamDataReader = winrt::DataReader(inputStream);
             auto loadDataReaderOperation = streamDataReader.LoadAsync((uint32_t)streamSize);
 
-            auto temp = winrt::weak_ref(imageSource.as<winrt::SvgImageSource>());
-
             loadDataReaderOperation.Completed(
                 [weakThis = this->get_weak(), streamDataReader, uiElementRef = winrt::make_weak(uiElement), isAutoSize, parentElementRef = winrt::make_weak(parentElement),
-                imageContainerRef = winrt::make_weak(imageContainer), isVisible, streamRef = winrt::make_weak(stream),
-                temp](
+                 imageContainerRef = winrt::make_weak(imageContainer), isVisible, streamRef = winrt::make_weak(stream),
+                 imageSourceRef = winrt::weak_ref(imageSource.as<winrt::SvgImageSource>())](
                     auto const& result, auto status) -> void
                 {
                     auto strongThis = weakThis.get();
-                    auto strongImageSource = temp.get();
+                    auto strongImageSource = imageSourceRef.get();
                     auto strongStream = streamRef.get();
                     auto strongUiElement = uiElementRef.get();
                     auto strongParentElement = parentElementRef.get();

--- a/source/uwp/Renderer/lib/AdaptiveImageRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImageRenderer.cpp
@@ -537,7 +537,7 @@ namespace AdaptiveCards::Rendering::Uwp
             loadDataReaderOperation.Completed(
                 [weakThis = this->get_weak(), streamDataReader, uiElementRef = winrt::make_weak(uiElement), isAutoSize, parentElementRef = winrt::make_weak(parentElement),
                  imageContainerRef = winrt::make_weak(imageContainer), isVisible, streamRef = winrt::make_weak(stream),
-                 imageSourceRef = winrt::weak_ref(imageSource.as<winrt::SvgImageSource>())](
+                 imageSourceRef = winrt::make_weak(imageSource.as<winrt::SvgImageSource>())](
                     auto const& result, auto status) -> void
                 {
                     auto strongThis = weakThis.get();

--- a/source/uwp/Renderer/lib/AdaptiveImageRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImageRenderer.cpp
@@ -393,14 +393,15 @@ namespace AdaptiveCards::Rendering::Uwp
 
             if (isImageSvg)
             {
+                auto temp = winrt::make_weak(image.as<winrt::SvgImageSource>());
                 // If we have an SVG, we need to try to parse for the image size before setting the image source
                 auto svgDocumentLoadOperation = winrt::XmlDocument::LoadFromUriAsync(imageUrl);
 
                 svgDocumentLoadOperation.Completed(
-                    [weakThis = this->get_weak(), imageSourceRef = winrt::make_weak(image.as<winrt::SvgImageSource>()), imageUrl](auto const& operation, auto status) -> void
+                    [weakThis = this->get_weak(), temp, imageUrl](auto const& operation, auto status) -> void
                     {
                         auto strongThis = weakThis.get();
-                        auto strongImageSource = imageSourceRef.get();
+                        auto strongImageSource = temp.get();
 
                         if (strongThis && strongImageSource)
                         {
@@ -532,14 +533,16 @@ namespace AdaptiveCards::Rendering::Uwp
             auto streamDataReader = winrt::DataReader(inputStream);
             auto loadDataReaderOperation = streamDataReader.LoadAsync((uint32_t)streamSize);
 
+            auto temp = winrt::weak_ref(imageSource.as<winrt::SvgImageSource>());
+
             loadDataReaderOperation.Completed(
                 [weakThis = this->get_weak(), streamDataReader, uiElementRef = winrt::make_weak(uiElement), isAutoSize, parentElementRef = winrt::make_weak(parentElement),
                 imageContainerRef = winrt::make_weak(imageContainer), isVisible, streamRef = winrt::make_weak(stream),
-                imageSourceRef = winrt::make_weak(imageSource.as<winrt::SvgImageSource>())](
+                temp](
                     auto const& result, auto status) -> void
                 {
                     auto strongThis = weakThis.get();
-                    auto strongImageSource = imageSourceRef.get();
+                    auto strongImageSource = temp.get();
                     auto strongStream = streamRef.get();
                     auto strongUiElement = uiElementRef.get();
                     auto strongParentElement = parentElementRef.get();
@@ -560,7 +563,7 @@ namespace AdaptiveCards::Rendering::Uwp
 
                         // Now that we've parsed the height, we can set the image source
                         strongThis->SetSvgImageSourceAsync(
-                            strongImageSource, strongStream, strongUiElement, isAutoSize, strongParentElement, strongImageContainer, isVisible);
+                            strongImageSource, strongStream, strongUiElement, isAutoSize, strongParentElement, strongImageContainer, isVisible).get();
                     }
                 });
         }
@@ -784,18 +787,18 @@ namespace AdaptiveCards::Rendering::Uwp
                                                                            double imageSize,
                                                                            bool dropIfUnset)
     {
-        auto test = imageSource;
+        //auto test = imageSource;
         //if (auto image = imageSourceRef.get())
         //{
             co_await winrt::resume_foreground(imageSource.Dispatcher());
-            auto currentSize = test.RasterizePixelHeight();
+            auto currentSize = imageSource.RasterizePixelHeight();
             bool sizeIsUnset = isinf(currentSize);
 
             bool dropHeight = sizeIsUnset && dropIfUnset;
 
             if (!dropHeight)
             {
-                test.RasterizePixelHeight(imageSize);
+                imageSource.RasterizePixelHeight(imageSize);
             }
         //}
     }
@@ -804,18 +807,18 @@ namespace AdaptiveCards::Rendering::Uwp
                                                                           double imageSize,
                                                                           bool dropIfUnset)
     {
-        auto test = imageSource;
+        //auto test = imageSource;
         //if (auto image = imageSourceRef.get())
         //{
             co_await winrt::resume_foreground(imageSource.Dispatcher());
-            auto currentSize = test.RasterizePixelWidth();
+            auto currentSize = imageSource.RasterizePixelWidth();
             bool sizeIsUnset = isinf(currentSize);
 
             bool dropWidth = sizeIsUnset && dropIfUnset;
 
             if (!dropWidth)
             {
-                test.RasterizePixelWidth(imageSize);
+                imageSource.RasterizePixelWidth(imageSize);
             }
         //}
     }

--- a/source/uwp/Renderer/lib/AdaptiveImageRenderer.cpp
+++ b/source/uwp/Renderer/lib/AdaptiveImageRenderer.cpp
@@ -587,11 +587,8 @@ namespace AdaptiveCards::Rendering::Uwp
     winrt::IAsyncAction render_xaml::XamlBuilder::SetSvgUriSource(winrt::SvgImageSource const imageSource,
                                                                   winrt::Uri const uri)
     {
-        if (imageSource && uri)
-        {
-            co_await winrt::resume_foreground(imageSource.Dispatcher());
-            imageSource.UriSource(uri);
-        }
+        co_await winrt::resume_foreground(imageSource.Dispatcher());
+        imageSource.UriSource(uri);
     }
 
     template<typename T, typename S>
@@ -603,25 +600,25 @@ namespace AdaptiveCards::Rendering::Uwp
                                                                          winrt::IInspectable const imageContainer,
                                                                          bool isVisible)
     {
-            co_await winrt::resume_foreground(imageSource.Dispatcher());
-            auto setSourceOperation = imageSource.SetSourceAsync(stream);
+        co_await winrt::resume_foreground(imageSource.Dispatcher());
+        auto setSourceOperation = imageSource.SetSourceAsync(stream);
 
-            setSourceOperation.Completed(
-                [weakThis = this->get_weak(), uiElement, isAutoSize, parentElement, imageContainer, isVisible](
-                    auto const& operation, auto status)
+        setSourceOperation.Completed(
+            [weakThis = this->get_weak(), uiElement, isAutoSize, parentElement, imageContainer, isVisible](
+                auto const& operation, auto status)
+            {
+                auto loadStatus = operation.GetResults();
+                if (status == winrt::AsyncStatus::Completed && loadStatus == winrt::SvgImageSourceLoadStatus::Success)
                 {
-                    auto loadStatus = operation.GetResults();
-                    if (status == winrt::AsyncStatus::Completed && loadStatus == winrt::SvgImageSourceLoadStatus::Success)
+                    if (auto strongThis = weakThis.get())
                     {
-                        if (auto strongThis = weakThis.get())
+                        if (isAutoSize)
                         {
-                            if (isAutoSize)
-                            {
-                                strongThis->SetAutoSize(uiElement, parentElement, imageContainer, isVisible, false /* imageFiresOpenEvent */);
-                            }
+                            strongThis->SetAutoSize(uiElement, parentElement, imageContainer, isVisible, false /* imageFiresOpenEvent */);
                         }
                     }
-                });
+                }
+            });
     }
 
     template<typename T>

--- a/source/uwp/Renderer/lib/XamlBuilder.h
+++ b/source/uwp/Renderer/lib/XamlBuilder.h
@@ -102,12 +102,12 @@ namespace AdaptiveCards::Rendering::Uwp
                                             winrt::weak_ref<winrt::Uri> const& uriRef);
 
         template<typename T, typename S>
-        winrt::IAsyncAction SetSvgImageSourceAsync(winrt::weak_ref<winrt::SvgImageSource> const& imageSourceRef,
-                                                   winrt::weak_ref<S> const& streamRef,
-                                                   winrt::weak_ref<T> const& uiElementRef,
+        winrt::IAsyncAction SetSvgImageSourceAsync(winrt::SvgImageSource const& imageSourceRef,
+                                                   S const& streamRef,
+                                                   T const& uiElementRef,
                                                    bool isAutoSize,
-                                                   winrt::weak_ref<winrt::IInspectable> const& parentElementRef,
-                                                   winrt::weak_ref<winrt::IInspectable> const& imageContainerRef,
+                                                   winrt::IInspectable const& parentElementRef,
+                                                   winrt::IInspectable const& imageContainerRef,
                                                    bool isVisible);
 
         boolean IsSvgImage(std::string url);
@@ -116,12 +116,12 @@ namespace AdaptiveCards::Rendering::Uwp
         void FireImagesLoadingHadError();
 
         void ParseXmlForHeightAndWidth(winrt::XmlDocument const& xmlDoc,
-                                       winrt::weak_ref<winrt::SvgImageSource> const& imageSourceRef);
+                                       winrt::SvgImageSource const& imageSourceRef);
         
-        winrt::IAsyncAction SetRasterizedPixelHeight(winrt::weak_ref<winrt::SvgImageSource> const& imageSourceRef,
+        winrt::IAsyncAction SetRasterizedPixelHeight(winrt::SvgImageSource const& imageSourceRef,
                                                      double imageSize,
                                                      bool dropIfUnset = false);
-        winrt::IAsyncAction SetRasterizedPixelWidth(winrt::weak_ref<winrt::SvgImageSource> const& imageSourceRef,
+        winrt::IAsyncAction SetRasterizedPixelWidth(winrt::SvgImageSource const& imageSourceRef,
                                                     double imageSize,
                                                     bool dropIfUnset = false);
 

--- a/source/uwp/Renderer/lib/XamlBuilder.h
+++ b/source/uwp/Renderer/lib/XamlBuilder.h
@@ -98,16 +98,16 @@ namespace AdaptiveCards::Rendering::Uwp
                                               winrt::ImageSource const& imageSource,
                                               winrt::Stretch stretch);
 
-        winrt::IAsyncAction SetSvgUriSource(winrt::weak_ref<winrt::SvgImageSource> const& imageSourceRef,
-                                            winrt::weak_ref<winrt::Uri> const& uriRef);
+        winrt::IAsyncAction SetSvgUriSource(winrt::SvgImageSource const imageSourceRef,
+                                            winrt::Uri const uriRef);
 
         template<typename T, typename S>
-        winrt::IAsyncAction SetSvgImageSourceAsync(winrt::SvgImageSource const& imageSourceRef,
-                                                   S const& streamRef,
-                                                   T const& uiElementRef,
+        winrt::IAsyncAction SetSvgImageSourceAsync(winrt::SvgImageSource const imageSourceRef,
+                                                   S const streamRef,
+                                                   T const uiElementRef,
                                                    bool isAutoSize,
-                                                   winrt::IInspectable const& parentElementRef,
-                                                   winrt::IInspectable const& imageContainerRef,
+                                                   winrt::IInspectable const parentElementRef,
+                                                   winrt::IInspectable const imageContainerRef,
                                                    bool isVisible);
 
         boolean IsSvgImage(std::string url);
@@ -118,10 +118,10 @@ namespace AdaptiveCards::Rendering::Uwp
         void ParseXmlForHeightAndWidth(winrt::XmlDocument const& xmlDoc,
                                        winrt::SvgImageSource const& imageSourceRef);
         
-        winrt::IAsyncAction SetRasterizedPixelHeight(winrt::SvgImageSource const& imageSourceRef,
+        winrt::IAsyncAction SetRasterizedPixelHeight(winrt::SvgImageSource const imageSourceRef,
                                                      double imageSize,
                                                      bool dropIfUnset = false);
-        winrt::IAsyncAction SetRasterizedPixelWidth(winrt::SvgImageSource const& imageSourceRef,
+        winrt::IAsyncAction SetRasterizedPixelWidth(winrt::SvgImageSource const imageSourceRef,
                                                     double imageSize,
                                                     bool dropIfUnset = false);
 


### PR DESCRIPTION
# Related Issue

N/A

# Description

Pass variables by const value instead of reference when the method will call `resume_foreground`. 

# How Verified

Verified manually

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8295)