### PR TITLE
Add host parameter to AdaptiveCards.Templating

### DIFF
--- a/source/dotnet/AdaptiveCards.sln
+++ b/source/dotnet/AdaptiveCards.sln
@@ -17,8 +17,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AdaptiveCards.Rendering.Wpf
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AdaptiveCards.Rendering.Wpf.Xceed", "Library\AdaptiveCards.Rendering.Wpf.Xceed\AdaptiveCards.Rendering.Wpf.Xceed.csproj", "{4741ABEC-33B0-424F-B5F1-464EC31AEEBD}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AdaptiveCards.Sample.Html", "Samples\AdaptiveCards.Sample.Html\AdaptiveCards.Sample.Html.csproj", "{C015DC5F-E523-4828-8E46-118A8242B51A}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AdaptiveCards.Test", "Test\AdaptiveCards.Test\AdaptiveCards.Test.csproj", "{4DB2C1D1-630A-4445-95F3-4E342ABD9342}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AdaptiveCards.Sample.ImageRender", "samples\AdaptiveCards.Sample.ImageRender\AdaptiveCards.Sample.ImageRender.csproj", "{BCFC1329-903B-4440-ABE1-160C22A3AE23}"
@@ -30,8 +28,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AdaptiveCards.Templating", "Library\AdaptiveCards.Templating\AdaptiveCards.Templating.csproj", "{F36E1451-6A16-4E83-B7B3-90024BF36B4C}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AdaptiveCards.Templating.Test", "Test\AdaptiveCards.Templating.Test\AdaptiveCards.Templating.Test.csproj", "{9E7E5953-A5B4-4867-9A06-046A754AFAC1}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A751CC8F-EF13-4EA1-B9FD-611135AD7C09}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCardTemplate.cs
+++ b/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCardTemplate.cs
@@ -96,21 +96,33 @@ namespace AdaptiveCards.Templating
                 return jsonTemplateString;
             }
 
-            string jsonData = "";
-
-            if (context != null && context.Root != null)
+            string rootJsonData = "";
+            if (context?.Root != null)
             {
-                if (context.Root is string)
+                if (context.Root is string root)
                 {
-                    jsonData = context.Root as string;
+                    rootJsonData = root;
                 }
                 else
                 {
-                    jsonData = JsonConvert.SerializeObject(context.Root);
+                    rootJsonData = JsonConvert.SerializeObject(context.Root);
                 }
             }
 
-            AdaptiveCardsTemplateVisitor eval = new AdaptiveCardsTemplateVisitor(nullSubstitutionOption, jsonData);
+            string hostJsonData = "";
+            if (context?.Host != null)
+            {
+                if (context.Host is string host)
+                {
+                    hostJsonData = host;
+                }
+                else
+                {
+                    hostJsonData = JsonConvert.SerializeObject(context.Host);
+                }
+            }
+
+            AdaptiveCardsTemplateVisitor eval = new AdaptiveCardsTemplateVisitor(nullSubstitutionOption, rootJsonData, hostJsonData);
             AdaptiveCardsTemplateResult result = eval.Visit(parseTree);
 
             templateExpansionWarnings = eval.getTemplateVisitorWarnings();

--- a/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCards.Templating.csproj
+++ b/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCards.Templating.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
 
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <VersionPrefix>1.0.0</VersionPrefix>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <Authors>Microsoft</Authors>

--- a/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCards.Templating.csproj
+++ b/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCards.Templating.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
 
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <VersionPrefix>1.0.0</VersionPrefix>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <Authors>Microsoft</Authors>

--- a/source/dotnet/Library/AdaptiveCards.Templating/EvaluationContext.cs
+++ b/source/dotnet/Library/AdaptiveCards.Templating/EvaluationContext.cs
@@ -17,6 +17,7 @@ namespace AdaptiveCards.Templating
         ///     ""person"": {
         ///         ""firstName"": ""Hello"",
         ///         ""lastName"": ""World""
+        ///     }
         /// }";
         ///
         /// var context = new EvaluationContext()
@@ -30,21 +31,55 @@ namespace AdaptiveCards.Templating
         { get; set; }
 
         /// <summary>
+        /// Provides Host Data Context 
+        /// </summary>
+        /// <remarks>
+        /// Typically this is supplied by the host application providing additional context for template binding. For example, the host might supply language or theming information that the template can use for layout.
+        /// </remarks>
+        /// <example>
+        /// <code>
+        /// 
+        /// string jsonData = @"{
+        ///     ""person"": {
+        ///         ""firstName"": ""Hello"",
+        ///         ""lastName"": ""World""
+        ///     }
+        /// }";
+        ///
+        /// string hostData = @"{
+        ///     ""applicationName"": ""Contoso AdaptiveCards Host",
+        ///     ""platform"": ""mobile""
+        /// }";
+        ///
+        /// var context = new EvaluationContext()
+        /// {
+        ///     Root = jsonData,
+        ///     Host = hostData
+        /// };
+        ///
+        /// </code>
+        /// </example>
+        public object Host
+        { get; set; }
+
+        /// <summary>
         /// default consturctor
         /// </summary>
         public EvaluationContext()
         {
             Root = null;
+            Host = null;
         }
 
         /// <summary>
-        /// constructor for <c>EvaluationContext</c> that takes one argument that will be used for root data context
+        /// constructor for <c>EvaluationContext</c> that takes one required argument used for root data context and one optional argument supplying host data
         /// </summary>
-        /// <param name="rootData"></param>
-        public EvaluationContext(object rootData)
+        /// <param name="rootData">Data to use while binding</param>
+        /// <param name="hostData">Data supplied by the host for use while binding</param>
+        public EvaluationContext(object rootData, object hostData = null)
         {
             Root = rootData;
+            Host = hostData;
         }
-
     }
 }

--- a/source/dotnet/Library/AdaptiveCards.Templating/docs/AdaptiveCardsTemplate.md
+++ b/source/dotnet/Library/AdaptiveCards.Templating/docs/AdaptiveCardsTemplate.md
@@ -45,7 +45,7 @@
   - [TryGetValue(path,value)](#M-AdaptiveCards-Templating-AdaptiveCardsTemplateSimpleObjectMemory-TryGetValue-System-String,System-Object@- 'AdaptiveCards.Templating.AdaptiveCardsTemplateSimpleObjectMemory.TryGetValue(System.String,System.Object@)')
   - [Version()](#M-AdaptiveCards-Templating-AdaptiveCardsTemplateSimpleObjectMemory-Version 'AdaptiveCards.Templating.AdaptiveCardsTemplateSimpleObjectMemory.Version')
 - [AdaptiveCardsTemplateVisitor](#T-AdaptiveCards-Templating-AdaptiveCardsTemplateVisitor 'AdaptiveCards.Templating.AdaptiveCardsTemplateVisitor')
-  - [#ctor(nullSubstitutionOption,data)](#M-AdaptiveCards-Templating-AdaptiveCardsTemplateVisitor-#ctor-System-Func{System-String,System-Object},System-String- 'AdaptiveCards.Templating.AdaptiveCardsTemplateVisitor.#ctor(System.Func{System.String,System.Object},System.String)')
+  - [#ctor(nullSubstitutionOption,data,hostData)](#M-AdaptiveCards-Templating-AdaptiveCardsTemplateVisitor-#ctor-System-Func{System-String,System-Object},System-String,System-String- 'AdaptiveCards.Templating.AdaptiveCardsTemplateVisitor.#ctor(System.Func{System.String,System.Object},System.String,System.String)')
   - [Expand(unboundString,data,isTemplatedString,options)](#M-AdaptiveCards-Templating-AdaptiveCardsTemplateVisitor-Expand-System-String,AdaptiveExpressions-Memory-IMemory,System-Boolean,AdaptiveExpressions-Options- 'AdaptiveCards.Templating.AdaptiveCardsTemplateVisitor.Expand(System.String,AdaptiveExpressions.Memory.IMemory,System.Boolean,AdaptiveExpressions.Options)')
   - [ExpandTemplatedString(node,isExpanded)](#M-AdaptiveCards-Templating-AdaptiveCardsTemplateVisitor-ExpandTemplatedString-Antlr4-Runtime-Tree-ITerminalNode,System-Boolean- 'AdaptiveCards.Templating.AdaptiveCardsTemplateVisitor.ExpandTemplatedString(Antlr4.Runtime.Tree.ITerminalNode,System.Boolean)')
   - [GetCurrentDataContext()](#M-AdaptiveCards-Templating-AdaptiveCardsTemplateVisitor-GetCurrentDataContext 'AdaptiveCards.Templating.AdaptiveCardsTemplateVisitor.GetCurrentDataContext')
@@ -72,13 +72,14 @@
   - [#ctor(message)](#M-AdaptiveCards-Templating-AdaptiveTemplateException-#ctor-System-String- 'AdaptiveCards.Templating.AdaptiveTemplateException.#ctor(System.String)')
   - [#ctor(message,innerException)](#M-AdaptiveCards-Templating-AdaptiveTemplateException-#ctor-System-String,System-Exception- 'AdaptiveCards.Templating.AdaptiveTemplateException.#ctor(System.String,System.Exception)')
 - [DataContext](#T-AdaptiveCards-Templating-AdaptiveCardsTemplateVisitor-DataContext 'AdaptiveCards.Templating.AdaptiveCardsTemplateVisitor.DataContext')
-  - [#ctor(jtoken,rootDataContext)](#M-AdaptiveCards-Templating-AdaptiveCardsTemplateVisitor-DataContext-#ctor-Newtonsoft-Json-Linq-JToken,Newtonsoft-Json-Linq-JToken- 'AdaptiveCards.Templating.AdaptiveCardsTemplateVisitor.DataContext.#ctor(Newtonsoft.Json.Linq.JToken,Newtonsoft.Json.Linq.JToken)')
-  - [#ctor(text,rootDataContext)](#M-AdaptiveCards-Templating-AdaptiveCardsTemplateVisitor-DataContext-#ctor-System-String,Newtonsoft-Json-Linq-JToken- 'AdaptiveCards.Templating.AdaptiveCardsTemplateVisitor.DataContext.#ctor(System.String,Newtonsoft.Json.Linq.JToken)')
+  - [#ctor(jtoken,rootDataContext,hostDataContext)](#M-AdaptiveCards-Templating-AdaptiveCardsTemplateVisitor-DataContext-#ctor-Newtonsoft-Json-Linq-JToken,Newtonsoft-Json-Linq-JToken,Newtonsoft-Json-Linq-JToken- 'AdaptiveCards.Templating.AdaptiveCardsTemplateVisitor.DataContext.#ctor(Newtonsoft.Json.Linq.JToken,Newtonsoft.Json.Linq.JToken,Newtonsoft.Json.Linq.JToken)')
+  - [#ctor(text,rootDataContext,hostDataContext)](#M-AdaptiveCards-Templating-AdaptiveCardsTemplateVisitor-DataContext-#ctor-System-String,Newtonsoft-Json-Linq-JToken,Newtonsoft-Json-Linq-JToken- 'AdaptiveCards.Templating.AdaptiveCardsTemplateVisitor.DataContext.#ctor(System.String,Newtonsoft.Json.Linq.JToken,Newtonsoft.Json.Linq.JToken)')
   - [GetDataContextAtIndex(index)](#M-AdaptiveCards-Templating-AdaptiveCardsTemplateVisitor-DataContext-GetDataContextAtIndex-System-Int32- 'AdaptiveCards.Templating.AdaptiveCardsTemplateVisitor.DataContext.GetDataContextAtIndex(System.Int32)')
-  - [Init(jtoken,rootDataContext)](#M-AdaptiveCards-Templating-AdaptiveCardsTemplateVisitor-DataContext-Init-Newtonsoft-Json-Linq-JToken,Newtonsoft-Json-Linq-JToken- 'AdaptiveCards.Templating.AdaptiveCardsTemplateVisitor.DataContext.Init(Newtonsoft.Json.Linq.JToken,Newtonsoft.Json.Linq.JToken)')
+  - [Init(jtoken,rootDataContext,hostDataContext)](#M-AdaptiveCards-Templating-AdaptiveCardsTemplateVisitor-DataContext-Init-Newtonsoft-Json-Linq-JToken,Newtonsoft-Json-Linq-JToken,Newtonsoft-Json-Linq-JToken- 'AdaptiveCards.Templating.AdaptiveCardsTemplateVisitor.DataContext.Init(Newtonsoft.Json.Linq.JToken,Newtonsoft.Json.Linq.JToken,Newtonsoft.Json.Linq.JToken)')
 - [EvaluationContext](#T-AdaptiveCards-Templating-EvaluationContext 'AdaptiveCards.Templating.EvaluationContext')
   - [#ctor()](#M-AdaptiveCards-Templating-EvaluationContext-#ctor 'AdaptiveCards.Templating.EvaluationContext.#ctor')
-  - [#ctor(rootData)](#M-AdaptiveCards-Templating-EvaluationContext-#ctor-System-Object- 'AdaptiveCards.Templating.EvaluationContext.#ctor(System.Object)')
+  - [#ctor(rootData,hostData)](#M-AdaptiveCards-Templating-EvaluationContext-#ctor-System-Object,System-Object- 'AdaptiveCards.Templating.EvaluationContext.#ctor(System.Object,System.Object)')
+  - [Host](#P-AdaptiveCards-Templating-EvaluationContext-Host 'AdaptiveCards.Templating.EvaluationContext.Host')
   - [Root](#P-AdaptiveCards-Templating-EvaluationContext-Root 'AdaptiveCards.Templating.EvaluationContext.Root')
 - [EvaluationResult](#T-AdaptiveCards-Templating-AdaptiveCardsTemplateResult-EvaluationResult 'AdaptiveCards.Templating.AdaptiveCardsTemplateResult.EvaluationResult')
   - [EvaluatedToFalse](#F-AdaptiveCards-Templating-AdaptiveCardsTemplateResult-EvaluationResult-EvaluatedToFalse 'AdaptiveCards.Templating.AdaptiveCardsTemplateResult.EvaluationResult.EvaluatedToFalse')
@@ -800,8 +801,8 @@ AdaptiveCards.Templating
 
 an intance of this class is used in visiting a parse tree that's been generated by antlr4 parser
 
-<a name='M-AdaptiveCards-Templating-AdaptiveCardsTemplateVisitor-#ctor-System-Func{System-String,System-Object},System-String-'></a>
-### #ctor(nullSubstitutionOption,data) `constructor`
+<a name='M-AdaptiveCards-Templating-AdaptiveCardsTemplateVisitor-#ctor-System-Func{System-String,System-Object},System-String,System-String-'></a>
+### #ctor(nullSubstitutionOption,data,hostData) `constructor`
 
 ##### Summary
 
@@ -812,7 +813,8 @@ a constructor for AdaptiveCardsTemplateVisitor
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | nullSubstitutionOption | [System.Func{System.String,System.Object}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Func 'System.Func{System.String,System.Object}') | it will called upon when AEL finds no suitable functions registered in given AEL expression during evaluation the expression |
-| data | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | json data in string which will be set as a root data context |
+| data | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | json data as string which will be set as a root data context |
+| hostData | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | json data as string which will be set as the host data context |
 
 <a name='M-AdaptiveCards-Templating-AdaptiveCardsTemplateVisitor-Expand-System-String,AdaptiveExpressions-Memory-IMemory,System-Boolean,AdaptiveExpressions-Options-'></a>
 ### Expand(unboundString,data,isTemplatedString,options) `method`
@@ -1007,7 +1009,7 @@ Visitor method for `obj` grammar rule `AdaptiveCardsTemplateParser.g4`
 
 ##### Summary
 
-antlr runtime wil call this method when parse tree's context is [TemplateDataContext](#T-AdaptiveCardsTemplateParser-TemplateDataContext 'AdaptiveCardsTemplateParser.TemplateDataContext')
+antlr runtime will call this method when parse tree's context is [TemplateDataContext](#T-AdaptiveCardsTemplateParser-TemplateDataContext 'AdaptiveCardsTemplateParser.TemplateDataContext')
 
 It is used in parsing a pair that has $data as key
 
@@ -1223,8 +1225,8 @@ AdaptiveCards.Templating.AdaptiveCardsTemplateVisitor
 
 maintains data context
 
-<a name='M-AdaptiveCards-Templating-AdaptiveCardsTemplateVisitor-DataContext-#ctor-Newtonsoft-Json-Linq-JToken,Newtonsoft-Json-Linq-JToken-'></a>
-### #ctor(jtoken,rootDataContext) `constructor`
+<a name='M-AdaptiveCards-Templating-AdaptiveCardsTemplateVisitor-DataContext-#ctor-Newtonsoft-Json-Linq-JToken,Newtonsoft-Json-Linq-JToken,Newtonsoft-Json-Linq-JToken-'></a>
+### #ctor(jtoken,rootDataContext,hostDataContext) `constructor`
 
 ##### Summary
 
@@ -1236,9 +1238,10 @@ constructs a data context of which current data is jtoken
 | ---- | ---- | ----------- |
 | jtoken | [Newtonsoft.Json.Linq.JToken](#T-Newtonsoft-Json-Linq-JToken 'Newtonsoft.Json.Linq.JToken') | new data to kept as data context |
 | rootDataContext | [Newtonsoft.Json.Linq.JToken](#T-Newtonsoft-Json-Linq-JToken 'Newtonsoft.Json.Linq.JToken') | root data context |
+| hostDataContext | [Newtonsoft.Json.Linq.JToken](#T-Newtonsoft-Json-Linq-JToken 'Newtonsoft.Json.Linq.JToken') | optional host data context |
 
-<a name='M-AdaptiveCards-Templating-AdaptiveCardsTemplateVisitor-DataContext-#ctor-System-String,Newtonsoft-Json-Linq-JToken-'></a>
-### #ctor(text,rootDataContext) `constructor`
+<a name='M-AdaptiveCards-Templating-AdaptiveCardsTemplateVisitor-DataContext-#ctor-System-String,Newtonsoft-Json-Linq-JToken,Newtonsoft-Json-Linq-JToken-'></a>
+### #ctor(text,rootDataContext,hostDataContext) `constructor`
 
 ##### Summary
 
@@ -1250,6 +1253,7 @@ overload contructor that takes `text` which is `string`
 | ---- | ---- | ----------- |
 | text | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | json in string |
 | rootDataContext | [Newtonsoft.Json.Linq.JToken](#T-Newtonsoft-Json-Linq-JToken 'Newtonsoft.Json.Linq.JToken') | a root data context |
+| hostDataContext | [Newtonsoft.Json.Linq.JToken](#T-Newtonsoft-Json-Linq-JToken 'Newtonsoft.Json.Linq.JToken') | optional host data context |
 
 ##### Exceptions
 
@@ -1274,8 +1278,8 @@ retrieve a [JObject](#T-Newtonsoft-Json-Linq-JObject 'Newtonsoft.Json.Linq.JObje
 | ---- | ---- | ----------- |
 | index | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 'System.Int32') |  |
 
-<a name='M-AdaptiveCards-Templating-AdaptiveCardsTemplateVisitor-DataContext-Init-Newtonsoft-Json-Linq-JToken,Newtonsoft-Json-Linq-JToken-'></a>
-### Init(jtoken,rootDataContext) `method`
+<a name='M-AdaptiveCards-Templating-AdaptiveCardsTemplateVisitor-DataContext-Init-Newtonsoft-Json-Linq-JToken,Newtonsoft-Json-Linq-JToken,Newtonsoft-Json-Linq-JToken-'></a>
+### Init(jtoken,rootDataContext,hostDataContext) `method`
 
 ##### Summary
 
@@ -1287,6 +1291,7 @@ Initializer method that takes jtoken and root data context to initialize a data 
 | ---- | ---- | ----------- |
 | jtoken | [Newtonsoft.Json.Linq.JToken](#T-Newtonsoft-Json-Linq-JToken 'Newtonsoft.Json.Linq.JToken') | current data context |
 | rootDataContext | [Newtonsoft.Json.Linq.JToken](#T-Newtonsoft-Json-Linq-JToken 'Newtonsoft.Json.Linq.JToken') | root data context |
+| hostDataContext | [Newtonsoft.Json.Linq.JToken](#T-Newtonsoft-Json-Linq-JToken 'Newtonsoft.Json.Linq.JToken') | optional host data context |
 
 <a name='T-AdaptiveCards-Templating-EvaluationContext'></a>
 ## EvaluationContext `type`
@@ -1310,18 +1315,52 @@ default consturctor
 
 This constructor has no parameters.
 
-<a name='M-AdaptiveCards-Templating-EvaluationContext-#ctor-System-Object-'></a>
-### #ctor(rootData) `constructor`
+<a name='M-AdaptiveCards-Templating-EvaluationContext-#ctor-System-Object,System-Object-'></a>
+### #ctor(rootData,hostData) `constructor`
 
 ##### Summary
 
-constructor for `EvaluationContext` that takes one argument that will be used for root data context
+constructor for `EvaluationContext` that takes one required argument used for root data context and one optional argument supplying host data
 
 ##### Parameters
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| rootData | [System.Object](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Object 'System.Object') |  |
+| rootData | [System.Object](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Object 'System.Object') | Data to use while binding |
+| hostData | [System.Object](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Object 'System.Object') | Data supplied by the host for use while binding |
+
+<a name='P-AdaptiveCards-Templating-EvaluationContext-Host'></a>
+### Host `property`
+
+##### Summary
+
+Provides Host Data Context
+
+##### Example
+
+```
+ 
+ string jsonData = @"{
+     ""person"": {
+         ""firstName"": ""Hello"",
+         ""lastName"": ""World""
+     }
+ }";
+ string hostData = @"{
+     ""applicationName"": ""Contoso AdaptiveCards Host",
+     ""platform"": ""mobile""
+ }";
+ var context = new EvaluationContext()
+ {
+     Root = jsonData,
+     Host = hostData
+ };
+ 
+```
+
+##### Remarks
+
+Typically this is supplied by the host application providing additional context for template binding. For example, the host might supply language or theming information that the template can use for layout.
 
 <a name='P-AdaptiveCards-Templating-EvaluationContext-Root'></a>
 ### Root `property`
@@ -1338,6 +1377,7 @@ Provides Root Data Context
      ""person"": {
          ""firstName"": ""Hello"",
          ""lastName"": ""World""
+     }
  }";
  var context = new EvaluationContext()
  {

--- a/source/dotnet/Library/AdaptiveCards/docs/AdaptiveCards.md
+++ b/source/dotnet/Library/AdaptiveCards/docs/AdaptiveCards.md
@@ -4784,7 +4784,7 @@ Collection of TableRows
 
 ##### Summary
 
-Specifies whether the first row of the table should be treated as a header row, and be announced as such by accessibility software.
+Specifies whether grid lines should be displayed.
 
 <a name='P-AdaptiveCards-AdaptiveTable-Type'></a>
 ### Type `property`

--- a/source/dotnet/Test/AdaptiveCards.Templating.Test/TestTransform.cs
+++ b/source/dotnet/Test/AdaptiveCards.Templating.Test/TestTransform.cs
@@ -13678,6 +13678,227 @@ namespace AdaptiveCards.Templating.Test
     }
 
     [TestClass]
+    public sealed class TestHostKeyword
+    {
+        [TestMethod]
+        public void TestRootInDataContext()
+        {
+            string jsonTemplate = @"{
+                ""type"": ""AdaptiveCard"",
+                ""body"": [
+                  {
+                    ""type"": ""Container"",
+                    ""items"": [
+                      {
+                        ""$data"": ""${$root.LineItems}"",
+                        ""type"": ""TextBlock"",
+                        ""id"": ""ReceiptRequired${$index}"",
+                        ""text"": ""${string(Milage)}""
+                      }
+                    ]
+                  },
+                  {
+                    ""type"": ""TextBlock"",
+                    ""text"": ""${$host.text}""
+                  }
+                ]
+            }";
+            string rootData = @"{
+              ""LineItems"": [
+                    {""Milage"" : 1},
+                    {""Milage"" : 10}
+                ]
+            }";
+
+            string hostData = @"{
+              ""text"": ""placeholder""
+            }";
+
+            AdaptiveCardTemplate transformer = new AdaptiveCardTemplate(jsonTemplate);
+            var context = new EvaluationContext
+            {
+                Root = rootData,
+                Host = hostData
+            };
+
+            string cardJson = transformer.Expand(context);
+
+            TestTemplate.AssertJsonEqual(@"{
+    ""type"": ""AdaptiveCard"",
+    ""body"": [
+              {
+                ""type"": ""Container"",
+                ""items"": [
+                {
+                    ""type"": ""TextBlock"",
+                    ""id"": ""ReceiptRequired0"",
+                    ""text"": ""1""
+                },
+                {
+                    ""type"": ""TextBlock"",
+                    ""id"": ""ReceiptRequired1"",
+                    ""text"": ""10""
+                }
+            ]
+        },
+            {
+              ""type"": ""TextBlock"",
+              ""text"": ""placeholder""
+            }
+    ]
+}", cardJson);
+        }
+
+        [TestMethod]
+        public void TestCanAccessByAEL()
+        {
+            string jsonTemplate = @"{
+                ""type"": ""AdaptiveCard"",
+                ""body"": [
+                  {
+                    ""type"": ""Container"",
+                    ""items"": [
+                      {
+                        ""type"": ""TextBlock"",
+                        ""text"": ""${$root.LineItems[0].Milage}""
+                      },
+                      {
+                        ""type"": ""TextBlock"",
+                        ""text"": ""${$root.LineItems[1].Milage}""
+                      }
+                    ]
+                  },
+                  {
+                    ""type"": ""Container"",
+                    ""items"": [
+                      {
+                        ""type"": ""TextBlock"",
+                        ""text"": ""${$host.Parameters[0].one}""
+                      },
+                      {
+                        ""type"": ""TextBlock"",
+                        ""text"": ""${$host.Parameters[1].two}""
+                      }
+                    ]
+                  }
+                ]
+            }";
+            string rootJsonData = @"{
+              ""LineItems"": [
+                    {""Milage"" : 1},
+                    {""Milage"" : 10}
+                ]
+            }";
+
+            string hostJsonData = @"{
+                ""Parameters"": [
+                    {""one"": 1},
+                    {""two"": 2}
+                ]
+            }";
+
+            AdaptiveCardTemplate transformer = new AdaptiveCardTemplate(jsonTemplate);
+            var context = new EvaluationContext
+            {
+                Root = rootJsonData,
+                Host = hostJsonData
+            };
+
+            string cardJson = transformer.Expand(context);
+
+            TestTemplate.AssertJsonEqual(@"{
+                ""type"": ""AdaptiveCard"",
+                ""body"": [
+                    {
+                        ""type"": ""Container"",
+                        ""items"": [
+                            {
+                                ""type"": ""TextBlock"",
+                                ""text"": 1
+                            },
+                            {
+                                ""type"": ""TextBlock"",
+                                ""text"": 10
+                            }
+                        ]
+                    },
+                    {
+                        ""type"": ""Container"",
+                        ""items"": [
+                            {
+                                ""type"": ""TextBlock"",
+                                ""text"": 1
+                            },
+                            {
+                                ""type"": ""TextBlock"",
+                                ""text"": 2
+                            }
+                        ]
+                    }
+                ]
+            }",
+            cardJson);
+        }
+
+        [TestMethod]
+        public void TestWorkWithRepeatingItems()
+        {
+            string jsonTemplate = @"{
+                    ""type"": ""AdaptiveCard"",
+                    ""body"": [
+                      {
+                        ""type"": ""Container"",
+                        ""items"": [
+                          {
+                            ""$data"": ""${$host.LineItems}"",
+                            ""type"": ""TextBlock"",
+                            ""text"": ""Class: ${$host.Class}, Mileage: ${Mileage}""
+                          }
+                        ]
+                      }
+                    ]
+                }";
+
+            string rootJsonData = "{}";
+            string hostJsonData = @"{
+                      ""Class"" : ""Ship"",
+                      ""LineItems"": [
+                            {""Mileage"" : 1},
+                            {""Mileage"" : 10}
+                        ]
+                    }";
+
+            AdaptiveCardTemplate transformer = new AdaptiveCardTemplate(jsonTemplate);
+            var context = new EvaluationContext
+            {
+                Root = rootJsonData,
+                Host = hostJsonData
+            };
+
+            string cardJson = transformer.Expand(context);
+
+            TestTemplate.AssertJsonEqual(@"{
+            ""type"": ""AdaptiveCard"",
+            ""body"": [
+                      {
+                        ""type"": ""Container"",
+                        ""items"": [
+                        {
+                            ""type"": ""TextBlock"",
+                            ""text"": ""Class: Ship, Mileage: 1""
+                        },
+                        {
+                            ""type"": ""TextBlock"",
+                            ""text"": ""Class: Ship, Mileage: 10""
+                        }
+                    ]
+                }
+            ]
+        }", cardJson);
+        }
+    }
+
+    [TestClass]
     public sealed class TestDataKeyword
     {
         [TestMethod]


### PR DESCRIPTION
Adds a `$host` parameter to the .NET Templating library (achieving parity with the `adaptivecards-templating` NPM package).

Basic idea: The app using the templating library can provide its own separate data blob to be used in the binding process. The structure of this data is not specified (similar to the root data blob that can already be supplied). This allows a host application to provide some environmental information for use by the template.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8328)