### PR TITLE
[Android] Add content description to input labels

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/InputUtil.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/InputUtil.java
@@ -27,6 +27,8 @@ public class InputUtil
         CharSequence text = RendererUtil.handleSpecialText(label);
         paragraph.append(text);
 
+        CharSequence labelContentDescription = text;
+
         InputLabelConfig inputLabelConfig;
         if (isRequired)
         {
@@ -46,6 +48,13 @@ public class InputUtil
             if (requiredLabelSuffix == null || requiredLabelSuffix.isEmpty())
             {
                 requiredLabelSuffix = " *";
+
+                // TalkBack should read "required" instead of "asterisk"
+                labelContentDescription += " required";
+            }
+            else
+            {
+                labelContentDescription += requiredLabelSuffix;
             }
 
             paragraph.append(requiredLabelSuffix);
@@ -55,6 +64,7 @@ public class InputUtil
         TextView labelView = new TextView(context);
         labelView.setText(paragraph);
         labelView.setTextAlignment(View.TEXT_ALIGNMENT_VIEW_START);
+        labelView.setContentDescription(labelContentDescription);
 
         TextBlockRenderer.applyTextFormat(labelView, hostConfig, TextStyle.Default, FontType.Default, inputLabelConfig.getWeight(), renderArgs);
         TextBlockRenderer.applyTextSize(labelView, hostConfig, TextStyle.Default, FontType.Default, inputLabelConfig.getSize(), renderArgs);


### PR DESCRIPTION
# Related Issue

Fixes #7265

# Description

TalkBack announced `asterisk` instead of `required` when focusing on inputs.

Added `contentDescription` to input labels that includes `required` instead of `asterisk` for the default behavior.

# Sample Card

https://github.com/microsoft/AdaptiveCards/blob/main/samples/v1.5/Scenarios/InputForm.json

# How Verified

Verified manually on the Android visualizer.

https://user-images.githubusercontent.com/98650930/228036498-a4582fec-8208-4314-b446-937434b3e7fa.mp4

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8413)