### PR TITLE
fixed filterred list where it closes onscreen keyboard after keyboard…

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetCompactStyleView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetCompactStyleView.mm
@@ -115,13 +115,13 @@ using namespace AdaptiveCards;
     } else if (_stateManager.isShowFilteredListControlSelected) {
         _button.selected = YES;
     }
+    
     if (_stateManager.shouldUpdateFilteredList) {
         if (_stateManager.isFilteredListVisible) {
             [self showListView];
         } else {
             [self hideListView];
         }
-        [_rootView.acrActionDelegate didChangeViewLayout:CGRectNull newFrame:self.frame];
     }
 }
 
@@ -153,6 +153,9 @@ using namespace AdaptiveCards;
             // announce layout change, and move the VO focus to the filtered list
             UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, self);
         }
+    } else {
+        [_stateManager expanded];
+        [self updateControls];
     }
 }
 
@@ -177,7 +180,6 @@ using namespace AdaptiveCards;
         }
     } else {
         [self resetFilteredList];
-        [_stateManager collapsed];
     }
 
     [self updateControls];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetCompactStyleView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetCompactStyleView.mm
@@ -115,7 +115,7 @@ using namespace AdaptiveCards;
     } else if (_stateManager.isShowFilteredListControlSelected) {
         _button.selected = YES;
     }
-    
+
     if (_stateManager.shouldUpdateFilteredList) {
         if (_stateManager.isFilteredListVisible) {
             [self showListView];


### PR DESCRIPTION
# Related Issue

Fixed #7601 

# Description
reloading table closes onscreen video.

fixed the issue by removing the call.

also improved ui experience by changing to always show menu options when the input is in focus.

# How Verified

Manually verified.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8434)