### PR TITLE
[Designer] Update card container width for 400% zoom

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/containers/webchat/webchat-container.css
+++ b/source/nodejs/adaptivecards-designer/src/containers/webchat/webchat-container.css
@@ -252,6 +252,12 @@ a.ac-anchor:visited:active {
     border-radius: 4px;
 }
 
+@media (max-width: 416px) {
+    .webChatOuterContainer {
+        width: 100%;
+    }
+}
+
 /* Popup menu */
 
 .ac-ctrl-overlay {


### PR DESCRIPTION
# Related Issue

Fixes #8185 

# Description

Update the webchat container so that the width adjusts when the screen size is below `416px`. 

`416` was chosen because this the fixed size of the webchat container.

# Sample Card

Sample card can be found in the issue.

# How Verified

Verified manually on the Adaptive Cards website.

## After
<img width="1248" alt="after2" src="https://user-images.githubusercontent.com/98650930/230682103-9c7f6f29-e84d-44a6-b948-d68a865179a2.png">

<img width="1248" alt="after1" src="https://user-images.githubusercontent.com/98650930/230682080-763a7314-c7f5-4f9e-aac9-f5595e2ae402.png">

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8454)