### PR TITLE
Remove ARM config from WinUI3 nuspec

### DIFF
--- a/source/uwp/winui3/NuGet/AdaptiveCards.ObjectModel.WinUI3.nuspec
+++ b/source/uwp/winui3/NuGet/AdaptiveCards.ObjectModel.WinUI3.nuspec
@@ -24,10 +24,6 @@
         <file src="..\x64\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.lib" target="runtimes\win10-x64\native"/>
         <file src="..\x64\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.pdb" target="runtimes\win10-x64\native"/>
 
-        <file src="..\ARM\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.dll" target="runtimes\win10-arm\native"/>
-        <file src="..\ARM\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.lib" target="runtimes\win10-arm\native"/>
-        <file src="..\ARM\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.pdb" target="runtimes\win10-arm\native"/>
-
         <file src="..\ARM64\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.dll" target="runtimes\win10-arm64\native"/>
         <file src="..\ARM64\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.lib" target="runtimes\win10-arm64\native"/>
         <file src="..\ARM64\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.pdb" target="runtimes\win10-arm64\native"/>

--- a/source/uwp/winui3/NuGet/AdaptiveCards.Rendering.WinUI3.nuspec
+++ b/source/uwp/winui3/NuGet/AdaptiveCards.Rendering.WinUI3.nuspec
@@ -27,10 +27,6 @@
         <file src="..\x64\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.lib" target="runtimes\win10-x64\native"/>
         <file src="..\x64\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.pdb" target="runtimes\win10-x64\native"/>
 
-        <file src="..\ARM\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.dll" target="runtimes\win10-arm\native"/>
-        <file src="..\ARM\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.lib" target="runtimes\win10-arm\native"/>
-        <file src="..\ARM\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.pdb" target="runtimes\win10-arm\native"/>
-
         <file src="..\ARM64\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.dll" target="runtimes\win10-arm64\native"/>
         <file src="..\ARM64\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.lib" target="runtimes\win10-arm64\native"/>
         <file src="..\ARM64\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.pdb" target="runtimes\win10-arm64\native"/>


### PR DESCRIPTION
# Related Issue

# Description

WinUI 3 does not support arm32, so don't try to pack bits for it.

# Sample Card

# How Verified


 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8458)