### PR TITLE
Fix pipeline issues for WinUI3 Release

### DIFF
--- a/source/uwp/Build/CopySignFilesWinUI3.cmd
+++ b/source/uwp/Build/CopySignFilesWinUI3.cmd
@@ -34,7 +34,7 @@ call :checkedCopy %ACROOT%\Release\%ACPATH%%ACUWP%.winmd tosign\%ACPATH%%ACUWP%.
 call :checkedCopy %ACROOT%Release\%ACPATH%%ACUWP%.dll tosign\%ACPATH%Win32\%ACUWP%.dll
 call :checkedCopy %ACROOT%x64\Release\%ACPATH%%ACUWP%.dll tosign\%ACPATH%x64\%ACUWP%.dll
 call :checkedCopy %ACROOT%ARM64\Release\%ACPATH%%ACUWP%.dll tosign\%ACPATH%ARM64\%ACUWP%.dll
-call :checkedCopy %ACROOT%AnyCPU\RendererCsProjection\Release\net6.0-windows10.0.17763.0\RendererCsProjection.dll
+call :checkedCopy %ACROOT%AnyCPU\RendererCsProjection\Release\net6.0-windows10.0.17763.0\RendererCsProjection.dll tosign\%ACPATH%AnyCPU\RendererCsProjection.dll
 
 REM AdaptiveCards
 echo %ACPATHOM%
@@ -43,12 +43,13 @@ REM AdaptiveCards ObjectModel
 mkdir tosign\%ACPATHOM%\Win32
 mkdir tosign\%ACPATHOM%\x64
 mkdir tosign\%ACPATHOM%\ARM64
+mkdir tosign\%ACPATHOM%\AnyCPU
 
 call :checkedCopy %ACROOT%\Release\%ACPATHOM%%ACOM%.winmd tosign\%ACPATHOM%%ACOM%.winmd
 call :checkedCopy %ACROOT%Release\%ACPATHOM%%ACOM%.dll tosign\%ACPATHOM%Win32\%ACOM%.dll
 call :checkedCopy %ACROOT%x64\Release\%ACPATHOM%%ACOM%.dll tosign\%ACPATHOM%x64\%ACOM%.dll
 call :checkedCopy %ACROOT%ARM64\Release\%ACPATHOM%%ACOM%.dll tosign\%ACPATHOM%ARM64\%ACOM%.dll
-call :checkedCopy %ACROOT%AnyCPU\ObjectModelCsProjection\Release\net6.0-windows10.0.17763.0\ObjectModelCsProjection.dll
+call :checkedCopy %ACROOT%AnyCPU\ObjectModelCsProjection\Release\net6.0-windows10.0.17763.0\ObjectModelCsProjection.dll tosign\%ACPATHOM%AnyCPU\ObjectModelCsProjection.dll
 
 popd
 goto :end

--- a/source/uwp/Build/CopySignFilesWinUI3.cmd
+++ b/source/uwp/Build/CopySignFilesWinUI3.cmd
@@ -1,0 +1,90 @@
+REM @echo off
+REM This script copies the dll and winmd files to have different names to be signed and copies them back
+
+REM setting platform variables
+set AC=AdaptiveCards
+set ACUWP=AdaptiveCards.Rendering.WinUI3
+set ACOM=AdaptiveCards.ObjectModel.WinUI3
+
+REM setting path variables
+set ACROOT=source\uwp\winui3
+set ACPATH=AdaptiveCardRenderer\
+set ACPATHOM=AdaptiveCardsObjectModel\
+set BINPATH=Release\
+
+if "%2" == "" goto :usage
+if "%1" == "sign" goto :sign
+if "%1" == "afterSign" goto :afterSign
+
+goto :usage
+
+:sign
+pushd "%2"
+
+REM AdaptiveCards
+echo %ACPATH%
+REM AdaptiveCards UWP
+
+mkdir tosign\%ACPATH%\Win32
+mkdir tosign\%ACPATH%\x64
+mkdir tosign\%ACPATH%\ARM
+mkdir tosign\%ACPATH%\ARM64
+
+call :checkedCopy %ACROOT%\Release\%ACPATH%%ACUWP%.winmd tosign\%ACPATH%%ACUWP%.winmd
+call :checkedCopy %ACROOT%Release\%ACPATH%%ACUWP%.dll tosign\%ACPATH%Win32\%ACUWP%.dll
+call :checkedCopy %ACROOT%x64\Release\%ACPATH%%ACUWP%.dll tosign\%ACPATH%x64\%ACUWP%.dll
+call :checkedCopy %ACROOT%ARM\Release\%ACPATH%%ACUWP%.dll tosign\%ACPATH%ARM\%ACUWP%.dll
+call :checkedCopy %ACROOT%ARM64\Release\%ACPATH%%ACUWP%.dll tosign\%ACPATH%ARM64\%ACUWP%.dll
+
+REM AdaptiveCards
+echo %ACPATHOM%
+REM AdaptiveCards ObjectModel
+
+mkdir tosign\%ACPATHOM%\Win32
+mkdir tosign\%ACPATHOM%\x64
+mkdir tosign\%ACPATHOM%\ARM
+mkdir tosign\%ACPATHOM%\ARM64
+
+call :checkedCopy %ACROOT%\Release\%ACPATHOM%%ACOM%.winmd tosign\%ACPATHOM%%ACOM%.winmd
+call :checkedCopy %ACROOT%Release\%ACPATHOM%%ACOM%.dll tosign\%ACPATHOM%Win32\%ACOM%.dll
+call :checkedCopy %ACROOT%x64\Release\%ACPATHOM%%ACOM%.dll tosign\%ACPATHOM%x64\%ACOM%.dll
+call :checkedCopy %ACROOT%ARM\Release\%ACPATHOM%%ACOM%.dll tosign\%ACPATHOM%ARM\%ACOM%.dll
+call :checkedCopy %ACROOT%ARM64\Release\%ACPATHOM%%ACOM%.dll tosign\%ACPATHOM%ARM64\%ACOM%.dll
+
+popd
+goto :end
+
+:afterSign
+pushd "%2"
+
+REM AdaptiveCards
+call :checkedCopy signed\%ACPATH%%ACUWP%.winmd %ACROOT%Release\%ACPATH%%ACUWP%.winmd
+call :checkedCopy signed\%ACPATH%Win32\%ACUWP%.dll %ACROOT%Release\%ACPATH%%ACUWP%.dll
+call :checkedCopy signed\%ACPATH%x64\%ACUWP%.dll %ACROOT%x64\Release\%ACPATH%%ACUWP%.dll
+call :checkedCopy signed\%ACPATH%ARM\%ACUWP%.dll %ACROOT%ARM\Release\%ACPATH%%ACUWP%.dll
+call :checkedCopy signed\%ACPATH%ARM64\%ACUWP%.dll %ACROOT%ARM64\Release\%ACPATH%%ACUWP%.dll
+
+REM AdaptiveCardsObjectModel
+call :checkedCopy signed\%ACPATHOM%%ACOM%.winmd %ACROOT%Release\%ACPATHOM%%ACOM%.winmd
+call :checkedCopy signed\%ACPATHOM%Win32\%ACOM%.dll %ACROOT%Release\%ACPATHOM%%ACOM%.dll
+call :checkedCopy signed\%ACPATHOM%x64\%ACOM%.dll %ACROOT%x64\Release\%ACPATHOM%%ACOM%.dll
+call :checkedCopy signed\%ACPATHOM%ARM\%ACOM%.dll %ACROOT%ARM\Release\%ACPATHOM%%ACOM%.dll
+call :checkedCopy signed\%ACPATHOM%ARM64\%ACOM%.dll %ACROOT%ARM64\Release\%ACPATHOM%%ACOM%.dll
+
+popd
+goto :end
+
+:checkedCopy
+copy %1 %2
+if %errorlevel% NEQ 0 (
+    popd
+    echo "copy failed"
+    REM exit 1
+)
+REM exit /b
+
+:usage
+echo "Usage: CopySignFiles <sign | afterSign> <root of the repo>"
+echo "Will copy the binary release from <root>\Release to be sent to signed"
+
+:end

--- a/source/uwp/Build/CopySignFilesWinUI3.cmd
+++ b/source/uwp/Build/CopySignFilesWinUI3.cmd
@@ -7,7 +7,7 @@ set ACUWP=AdaptiveCards.Rendering.WinUI3
 set ACOM=AdaptiveCards.ObjectModel.WinUI3
 
 REM setting path variables
-set ACROOT=source\uwp\winui3
+set ACROOT=source\uwp\winui3\
 set ACPATH=AdaptiveCardRenderer\
 set ACPATHOM=AdaptiveCardsObjectModel\
 set BINPATH=Release\
@@ -27,13 +27,11 @@ REM AdaptiveCards UWP
 
 mkdir tosign\%ACPATH%\Win32
 mkdir tosign\%ACPATH%\x64
-mkdir tosign\%ACPATH%\ARM
 mkdir tosign\%ACPATH%\ARM64
 
 call :checkedCopy %ACROOT%\Release\%ACPATH%%ACUWP%.winmd tosign\%ACPATH%%ACUWP%.winmd
 call :checkedCopy %ACROOT%Release\%ACPATH%%ACUWP%.dll tosign\%ACPATH%Win32\%ACUWP%.dll
 call :checkedCopy %ACROOT%x64\Release\%ACPATH%%ACUWP%.dll tosign\%ACPATH%x64\%ACUWP%.dll
-call :checkedCopy %ACROOT%ARM\Release\%ACPATH%%ACUWP%.dll tosign\%ACPATH%ARM\%ACUWP%.dll
 call :checkedCopy %ACROOT%ARM64\Release\%ACPATH%%ACUWP%.dll tosign\%ACPATH%ARM64\%ACUWP%.dll
 
 REM AdaptiveCards
@@ -42,13 +40,11 @@ REM AdaptiveCards ObjectModel
 
 mkdir tosign\%ACPATHOM%\Win32
 mkdir tosign\%ACPATHOM%\x64
-mkdir tosign\%ACPATHOM%\ARM
 mkdir tosign\%ACPATHOM%\ARM64
 
 call :checkedCopy %ACROOT%\Release\%ACPATHOM%%ACOM%.winmd tosign\%ACPATHOM%%ACOM%.winmd
 call :checkedCopy %ACROOT%Release\%ACPATHOM%%ACOM%.dll tosign\%ACPATHOM%Win32\%ACOM%.dll
 call :checkedCopy %ACROOT%x64\Release\%ACPATHOM%%ACOM%.dll tosign\%ACPATHOM%x64\%ACOM%.dll
-call :checkedCopy %ACROOT%ARM\Release\%ACPATHOM%%ACOM%.dll tosign\%ACPATHOM%ARM\%ACOM%.dll
 call :checkedCopy %ACROOT%ARM64\Release\%ACPATHOM%%ACOM%.dll tosign\%ACPATHOM%ARM64\%ACOM%.dll
 
 popd
@@ -61,14 +57,12 @@ REM AdaptiveCards
 call :checkedCopy signed\%ACPATH%%ACUWP%.winmd %ACROOT%Release\%ACPATH%%ACUWP%.winmd
 call :checkedCopy signed\%ACPATH%Win32\%ACUWP%.dll %ACROOT%Release\%ACPATH%%ACUWP%.dll
 call :checkedCopy signed\%ACPATH%x64\%ACUWP%.dll %ACROOT%x64\Release\%ACPATH%%ACUWP%.dll
-call :checkedCopy signed\%ACPATH%ARM\%ACUWP%.dll %ACROOT%ARM\Release\%ACPATH%%ACUWP%.dll
 call :checkedCopy signed\%ACPATH%ARM64\%ACUWP%.dll %ACROOT%ARM64\Release\%ACPATH%%ACUWP%.dll
 
 REM AdaptiveCardsObjectModel
 call :checkedCopy signed\%ACPATHOM%%ACOM%.winmd %ACROOT%Release\%ACPATHOM%%ACOM%.winmd
 call :checkedCopy signed\%ACPATHOM%Win32\%ACOM%.dll %ACROOT%Release\%ACPATHOM%%ACOM%.dll
 call :checkedCopy signed\%ACPATHOM%x64\%ACOM%.dll %ACROOT%x64\Release\%ACPATHOM%%ACOM%.dll
-call :checkedCopy signed\%ACPATHOM%ARM\%ACOM%.dll %ACROOT%ARM\Release\%ACPATHOM%%ACOM%.dll
 call :checkedCopy signed\%ACPATHOM%ARM64\%ACOM%.dll %ACROOT%ARM64\Release\%ACPATHOM%%ACOM%.dll
 
 popd

--- a/source/uwp/Build/CopySignFilesWinUI3.cmd
+++ b/source/uwp/Build/CopySignFilesWinUI3.cmd
@@ -28,11 +28,13 @@ REM AdaptiveCards UWP
 mkdir tosign\%ACPATH%\Win32
 mkdir tosign\%ACPATH%\x64
 mkdir tosign\%ACPATH%\ARM64
+mkdir tosign\%ACPATH%\AnyCPU
 
 call :checkedCopy %ACROOT%\Release\%ACPATH%%ACUWP%.winmd tosign\%ACPATH%%ACUWP%.winmd
 call :checkedCopy %ACROOT%Release\%ACPATH%%ACUWP%.dll tosign\%ACPATH%Win32\%ACUWP%.dll
 call :checkedCopy %ACROOT%x64\Release\%ACPATH%%ACUWP%.dll tosign\%ACPATH%x64\%ACUWP%.dll
 call :checkedCopy %ACROOT%ARM64\Release\%ACPATH%%ACUWP%.dll tosign\%ACPATH%ARM64\%ACUWP%.dll
+call :checkedCopy %ACROOT%AnyCPU\RendererCsProjection\Release\net6.0-windows10.0.17763.0\RendererCsProjection.dll
 
 REM AdaptiveCards
 echo %ACPATHOM%
@@ -46,6 +48,7 @@ call :checkedCopy %ACROOT%\Release\%ACPATHOM%%ACOM%.winmd tosign\%ACPATHOM%%ACOM
 call :checkedCopy %ACROOT%Release\%ACPATHOM%%ACOM%.dll tosign\%ACPATHOM%Win32\%ACOM%.dll
 call :checkedCopy %ACROOT%x64\Release\%ACPATHOM%%ACOM%.dll tosign\%ACPATHOM%x64\%ACOM%.dll
 call :checkedCopy %ACROOT%ARM64\Release\%ACPATHOM%%ACOM%.dll tosign\%ACPATHOM%ARM64\%ACOM%.dll
+call :checkedCopy %ACROOT%AnyCPU\ObjectModelCsProjection\Release\net6.0-windows10.0.17763.0\ObjectModelCsProjection.dll
 
 popd
 goto :end

--- a/source/uwp/ObjectModelProjection/ObjectModelProjection.vcxproj
+++ b/source/uwp/ObjectModelProjection/ObjectModelProjection.vcxproj
@@ -205,13 +205,15 @@
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/source/uwp/winui3/NuGet/AdaptiveCards.ObjectModel.WinUI3.nuspec
+++ b/source/uwp/winui3/NuGet/AdaptiveCards.ObjectModel.WinUI3.nuspec
@@ -24,10 +24,6 @@
         <file src="..\x64\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.lib" target="runtimes\win10-x64\native"/>
         <file src="..\x64\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.pdb" target="runtimes\win10-x64\native"/>
 
-        <file src="..\ARM\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.dll" target="runtimes\win10-arm\native"/>
-        <file src="..\ARM\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.lib" target="runtimes\win10-arm\native"/>
-        <file src="..\ARM\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.pdb" target="runtimes\win10-arm\native"/>
-
         <file src="..\ARM64\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.dll" target="runtimes\win10-arm64\native"/>
         <file src="..\ARM64\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.lib" target="runtimes\win10-arm64\native"/>
         <file src="..\ARM64\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.pdb" target="runtimes\win10-arm64\native"/>

--- a/source/uwp/winui3/NuGet/AdaptiveCards.ObjectModel.WinUI3.nuspec
+++ b/source/uwp/winui3/NuGet/AdaptiveCards.ObjectModel.WinUI3.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>AdaptiveCards.ObjectModel.WinUI3</id>
-        <version>0.1.0</version>
+        <version>0.4.0</version>
         <authors>Microsoft</authors>
         <summary>Adaptive Cards Object Model library for WinUI3</summary>
         <description>Used to work with the object model for Adaptive Cards</description>

--- a/source/uwp/winui3/NuGet/AdaptiveCards.Rendering.WinUI3.nuspec
+++ b/source/uwp/winui3/NuGet/AdaptiveCards.Rendering.WinUI3.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>AdaptiveCards.Rendering.WinUI3</id>
-        <version>0.1.0</version>
+        <version>0.4.0</version>
         <authors>Microsoft</authors>
         <summary>Adaptive Cards library for WinUI3</summary>
         <description>Used to render Adaptive Cards into WinUI3 XAML</description>
@@ -13,7 +13,7 @@
         <license type="file">EULA-Windows.txt</license>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <dependencies>
-            <dependency id="AdaptiveCards.ObjectModel.WinUI3" version="0.1.0" />
+            <dependency id="AdaptiveCards.ObjectModel.WinUI3" version="0.4.0" />
         </dependencies>
     </metadata>
     <files>

--- a/source/uwp/winui3/NuGet/AdaptiveCards.Rendering.WinUI3.nuspec
+++ b/source/uwp/winui3/NuGet/AdaptiveCards.Rendering.WinUI3.nuspec
@@ -27,10 +27,6 @@
         <file src="..\x64\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.lib" target="runtimes\win10-x64\native"/>
         <file src="..\x64\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.pdb" target="runtimes\win10-x64\native"/>
 
-        <file src="..\ARM\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.dll" target="runtimes\win10-arm\native"/>
-        <file src="..\ARM\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.lib" target="runtimes\win10-arm\native"/>
-        <file src="..\ARM\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.pdb" target="runtimes\win10-arm\native"/>
-
         <file src="..\ARM64\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.dll" target="runtimes\win10-arm64\native"/>
         <file src="..\ARM64\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.lib" target="runtimes\win10-arm64\native"/>
         <file src="..\ARM64\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.pdb" target="runtimes\win10-arm64\native"/>


### PR DESCRIPTION
The following changes were made to enable the release of the packages:
* Removal of ARM file references from the Nuget configs
* Addition of cmd script to perform copy of files for signing (TODO: Update scripts to have a single script)
* Updated platform toolset to make it easier to build on VS2022
* Updated nuget package versions
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8459)