### PR TITLE
[Samples] Remove decorative image from FlightDetails sample

### DIFF
--- a/samples/Templates/Scenarios/FlightDetails.template.json
+++ b/samples/Templates/Scenarios/FlightDetails.template.json
@@ -86,20 +86,7 @@
 													"wrap": true
 												}
 											],
-											"width": "auto"
-										},
-										{
-											"type": "Column",
-											"verticalContentAlignment": "center",
-											"items": [
-												{
-													"type": "Image",
-													"url": "https://messagecardplayground.azurewebsites.net/assets/graydot2x2.png",
-													"width": "10000px",
-													"height": "2px"
-												}
-											],
-											"width": "stretch"
+											"width": "1"
 										},
 										{
 											"type": "Column",
@@ -126,7 +113,7 @@
 													"wrap": true
 												}
 											],
-											"width": "auto"
+											"width": "1"
 										}
 									]
 								},

--- a/samples/v1.5/Scenarios/FlightDetails.json
+++ b/samples/v1.5/Scenarios/FlightDetails.json
@@ -86,24 +86,10 @@
 													"wrap": true
 												}
 											],
-											"width": "auto"
+											"width": "1"
 										},
 										{
 											"type": "Column",
-											"verticalContentAlignment": "center",
-											"items": [
-												{
-													"type": "Image",
-													"url": "https://messagecardplayground.azurewebsites.net/assets/graydot2x2.png",
-													"width": "10000px",
-													"height": "2px"
-												}
-											],
-											"width": "stretch"
-										},
-										{
-											"type": "Column",
-											"spacing": "small",
 											"verticalContentAlignment": "center",
 											"items": [
 												{
@@ -127,7 +113,7 @@
 													"wrap": true
 												}
 											],
-											"width": "auto"
+											"width": "1"
 										}
 									]
 								},


### PR DESCRIPTION
# Related Issue

Fixes #7829 

# Description

We have a decorative image within the FlightDetails sample that either needed `atlText` or no presentation. Since there is no suitable atlText and we do not have presentation modes enabled in our platform, I removed the decorative image.

# Sample Card

FlightDetails.json from our samples

# How Verified

Verified manually on the UWP Visualizer.

<img width="250" alt="image" src="https://user-images.githubusercontent.com/98650930/233216371-c7e9fb32-151f-4dcf-b37b-7aa6c1a117fd.png">

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8481)