### PR TITLE
[Samples] Add placeholder text to inputs on InputsWithValidation.json

### DIFF
--- a/samples/Templates/Scenarios/InputsWithValidation.template.json
+++ b/samples/Templates/Scenarios/InputsWithValidation.template.json
@@ -18,32 +18,37 @@
 			"style": "text",
 			"id": "SimpleVal",
 			"isRequired": true,
-			"errorMessage": "Name is required"
+			"errorMessage": "Name is required",
+			"placeholder": "Enter your name"
 		},
 		{
 			"type": "Input.Text",
 			"label": "Homepage",
 			"style": "url",
-			"id": "UrlVal"
+			"id": "UrlVal",
+			"placeholder": "Enter your homepage url"
 		},
 		{
 			"type": "Input.Text",
 			"label": "Email",
 			"style": "email",
-			"id": "EmailVal"
+			"id": "EmailVal",
+			"placeholder": "Enter your email"
 		},
 		{
 			"type": "Input.Text",
 			"label": "Phone",
 			"style": "tel",
-			"id": "TelVal"
+			"id": "TelVal",
+			"placeholder": "Enter your phone number"
 		},
 		{
 			"type": "Input.Text",
 			"label": "Comments",
 			"style": "text",
 			"isMultiline": true,
-			"id": "MultiLineVal"
+			"id": "MultiLineVal",
+			"placeholder": "Enter any comments"
 		},
 		{
 			"type": "Input.Number",

--- a/samples/v1.5/Scenarios/InputsWithValidation.json
+++ b/samples/v1.5/Scenarios/InputsWithValidation.json
@@ -18,32 +18,37 @@
 			"style": "text",
 			"id": "SimpleVal",
 			"isRequired": true,
-			"errorMessage": "Name is required"
+			"errorMessage": "Name is required",
+			"placeholder": "Enter your name"
 		},
 		{
 			"type": "Input.Text",
 			"label": "Homepage",
 			"style": "url",
-			"id": "UrlVal"
+			"id": "UrlVal",
+			"placeholder": "Enter your homepage url"
 		},
 		{
 			"type": "Input.Text",
 			"label": "Email",
 			"style": "email",
-			"id": "EmailVal"
+			"id": "EmailVal",
+			"placeholder": "Enter your email"
 		},
 		{
 			"type": "Input.Text",
 			"label": "Phone",
 			"style": "tel",
-			"id": "TelVal"
+			"id": "TelVal",
+			"placeholder": "Enter your phone number"
 		},
 		{
 			"type": "Input.Text",
 			"label": "Comments",
 			"style": "text",
 			"isMultiline": true,
-			"id": "MultiLineVal"
+			"id": "MultiLineVal",
+			"placeholder": "Enter any comments"
 		},
 		{
 			"type": "TextBlock",
@@ -58,6 +63,7 @@
 			"type": "Input.Text",
 			"label": "Text input with an inline action with no icon",
 			"id": "textInlineActionId",
+			"placeholder": "Enter text",
 			"inlineAction": {
 				"type": "Action.OpenUrl",
 				"title": "Reply",


### PR DESCRIPTION
# Related Issue

Fixes #8187 

# Description

Add placeholder text to inputs.

# Sample Card

InputsWithValidation.json in Samples

# How Verified

Verified manually on the UWP visualizer.

<img width="242" alt="image" src="https://user-images.githubusercontent.com/98650930/233216916-8ed32fd8-3633-4acc-9834-622c6cd80dcb.png">

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8482)