### PR TITLE
Add role property to samples

### DIFF
--- a/samples/Templates/Scenarios/ActivityUpdate.template.json
+++ b/samples/Templates/Scenarios/ActivityUpdate.template.json
@@ -93,7 +93,8 @@
 		{
 			"type": "Action.OpenUrl",
 			"title": "View",
-			"url": "${viewUrl}"
+			"url": "${viewUrl}",
+			"role": "button"
 		}
 	],
 	"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",

--- a/samples/v1.5/Scenarios/InputsWithValidation.json
+++ b/samples/v1.5/Scenarios/InputsWithValidation.json
@@ -62,7 +62,8 @@
 				"type": "Action.OpenUrl",
 				"title": "Reply",
 				"tooltip": "Reply to this message",
-				"url": "https://adaptivecards.io"
+				"url": "https://adaptivecards.io",
+				"role": "button"
 			}
 		},
 		{


### PR DESCRIPTION
# Related Issue

Fixes #8188 

# Description

Add `"role": "button"` to `OpenUrl` actions that do not launch new windows. Since the url is not opened in the visualizer, we should not announce it as `link`.

# Sample Card

https://github.com/microsoft/AdaptiveCards/blob/ade6c26c13be7e814a9a9eed46b69c46bdc1bda3/samples/Templates/Scenarios/ActivityUpdate.template.json
https://github.com/microsoft/AdaptiveCards/blob/ade6c26c13be7e814a9a9eed46b69c46bdc1bda3/samples/v1.5/Scenarios/InputsWithValidation.json

# How Verified

Verified manually on the UWP visualizer and tested with Narrator.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8483)