### PR TITLE
Update viva connections css

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/containers/viva-connections/viva-connections-container-dark.css
+++ b/source/nodejs/adaptivecards-designer/src/containers/viva-connections/viva-connections-container-dark.css
@@ -314,6 +314,11 @@
   border-radius: 8px;
   box-shadow: 0 25px 57px 0 rgba(0, 0, 0, .22), 0 5px 14px 0 rgba(0, 0, 0, .18);
   min-height: 0;
-  min-width: 320px;
-  max-width: 375px;
+  width: 375px;
+}
+
+@media (max-width: 375px) {
+  .vivaConnectionsContainer {
+    width: 100%;
+  }
 }

--- a/source/nodejs/adaptivecards-designer/src/containers/viva-connections/viva-connections-container-light.css
+++ b/source/nodejs/adaptivecards-designer/src/containers/viva-connections/viva-connections-container-light.css
@@ -311,6 +311,11 @@
   border-radius: 8px;
   box-shadow: 0 25px 57px 0 rgba(0, 0, 0, .22), 0 5px 14px 0 rgba(0, 0, 0, .18);
   min-height: 0;
-  min-width: 320px;
-  max-width: 375px;
+  width: 375px;
+}
+
+@media (max-width: 375px) {
+  .vivaConnectionsContainer {
+    width: 100%;
+  }
 }


### PR DESCRIPTION
# Related Issue

Fixes #8369 
Fixes #8312

# Description

Updated the viva connections container to use 100% of available width if the screen size is below the desired width.

This ensures that the entire card is visible when the device resolution to 1280*1024 with 100% scale, and the Edge window has 400% zoom.

# Sample Card

Sample cards can be found in the linked issues

# How Verified

Verified manually on the Adaptive Cards Designer

<img width="504" alt="image" src="https://user-images.githubusercontent.com/98650930/233433766-42817372-9482-4946-908c-4c3115fad486.png">

<img width="523" alt="image" src="https://user-images.githubusercontent.com/98650930/233434147-cbd43885-2ed8-4057-a8f5-42406a03cf19.png">

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8486)