### PR TITLE
[UWP Renderer] Validate text inputs dynamically and make errors live regions

### DIFF
--- a/source/uwp/SharedRenderer/lib/AdaptiveTextInputRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveTextInputRenderer.cpp
@@ -113,7 +113,7 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 
         auto inputValue = winrt::make_self<winrt::TextInputValue>(adaptiveTextInput, textBox, validationBorder);
 
-        textBox.TextChanged([inputValue, textBox](winrt::IInspectable const& /*sender*/, winrt::TextChangedEventArgs const& /*args*/)
+        textBox.TextChanged([inputValue](winrt::IInspectable const& /*sender*/, winrt::TextChangedEventArgs const& /*args*/)
         {
             inputValue.as<IAdaptiveInputValue>().Validate();
         });

--- a/source/uwp/SharedRenderer/lib/AdaptiveTextInputRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveTextInputRenderer.cpp
@@ -112,6 +112,12 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
         auto [textInputControl, validationBorder] = HandleLayoutAndValidation(adaptiveTextInput, textBox, renderContext, renderArgs);
 
         auto inputValue = winrt::make_self<winrt::TextInputValue>(adaptiveTextInput, textBox, validationBorder);
+
+        textBox.TextChanged([inputValue, textBox](winrt::IInspectable const& /*sender*/, winrt::TextChangedEventArgs const& /*args*/)
+        {
+            inputValue.as<IAdaptiveInputValue>().Validate();
+        });
+
         renderContext.AddInputValue(*inputValue, renderArgs);
 
         XamlHelpers::SetStyleFromResourceDictionary(renderContext, L"Adaptive.Input.Text", textBox);

--- a/source/uwp/SharedRenderer/lib/InputValue.cpp
+++ b/source/uwp/SharedRenderer/lib/InputValue.cpp
@@ -49,8 +49,7 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering
             uiElementDescribers.Append(uiValidationErrorAsDependencyObject);
 
             // We also want to raise a LiveRegionChanged event so that the error text is announced by narrator when it appears
-            auto errorAutomationPeer = winrt::FrameworkElementAutomationPeer::FromElement(m_validationError);
-            if (errorAutomationPeer != nullptr)
+            if (const auto errorAutomationPeer = winrt::FrameworkElementAutomationPeer::FromElement(m_validationError))
             {
                 errorAutomationPeer.RaiseAutomationEvent(winrt::AutomationEvents::LiveRegionChanged);
             }

--- a/source/uwp/SharedRenderer/lib/InputValue.cpp
+++ b/source/uwp/SharedRenderer/lib/InputValue.cpp
@@ -37,6 +37,7 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering
     {
         auto uiElementDescribers = winrt::AutomationProperties::GetDescribedBy(m_uiInputElement);
 
+        winrt::AutomationProperties::SetLiveSetting(m_validationError, winrt::AutomationLiveSetting::Polite);
         auto uiValidationErrorAsDependencyObject = m_validationError.as<winrt::DependencyObject>();
 
         uint32_t index;
@@ -46,6 +47,13 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering
         if (!isInputValid && !found)
         {
             uiElementDescribers.Append(uiValidationErrorAsDependencyObject);
+
+            // We also want to raise a LiveRegionChanged event so that the error text is announced by narrator when it appears
+            auto errorAutomationPeer = winrt::FrameworkElementAutomationPeer::FromElement(m_validationError);
+            if (errorAutomationPeer != nullptr)
+            {
+                errorAutomationPeer.RaiseAutomationEvent(winrt::AutomationEvents::LiveRegionChanged);
+            }
         }
         else if (isInputValid && found)
         {

--- a/source/uwp/SharedRenderer/lib/InputValue.cpp
+++ b/source/uwp/SharedRenderer/lib/InputValue.cpp
@@ -37,7 +37,7 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering
     {
         auto uiElementDescribers = winrt::AutomationProperties::GetDescribedBy(m_uiInputElement);
 
-        winrt::AutomationProperties::SetLiveSetting(m_validationError, winrt::AutomationLiveSetting::Polite);
+        winrt::AutomationProperties::SetLiveSetting(m_validationError, winrt::AutomationLiveSetting::Assertive);
         auto uiValidationErrorAsDependencyObject = m_validationError.as<winrt::DependencyObject>();
 
         uint32_t index;


### PR DESCRIPTION
# Related Issue

Fixes #8191

# Description

We need to add dynamic input validation so that all necessary information is announced by Narrator.

In `AdaptiveTextInputRenderer`:
- Validate the text each time it changes

In `InputValue`:
- Make the errorMessage a live region. I used `Assertive` so that the error is announced as soon as possible
- Whenever the errorMessage appears, we raise a `LiveRegionChanged` event so that Narrator will announce it.

# Sample Card

https://github.com/microsoft/AdaptiveCards/blob/main/samples/v1.5/Scenarios/InputForm.json

# How Verified

Verified manually on the UWP Visualizer.

https://user-images.githubusercontent.com/98650930/234417261-20ddb46b-8dfd-4d65-bdd5-cf6754431d13.mp4


**Note:**  This should be excluded from the v1.6 release since it is only implemented on UWP.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8491)