### PR TITLE
[Samples] Move samples with label to v1.3

### DIFF
--- a/samples/v1.3/Elements/Action.Submit.json
+++ b/samples/v1.3/Elements/Action.Submit.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
 	"type": "AdaptiveCard",
-	"version": "1.0",
+	"version": "1.3",
 	"body": [
 		{
 			"type": "TextBlock",

--- a/samples/v1.3/Elements/Input.Number.json
+++ b/samples/v1.3/Elements/Input.Number.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
 	"type": "AdaptiveCard",
-	"version": "1.0",
+	"version": "1.3",
 	"body": [
 		{
 			"type": "Input.Number",


### PR DESCRIPTION
# Related Issue

Fixes #7914
Progress towards #7992

# Description

These samples include the `label` property for accessibility. They needed to be moved to v1.3 so that they are rendered at the correct version and the label appears.

# Sample Card

In PR

# How Verified

Verified manually on the Adaptive Cards site.

<img width="886" alt="image" src="https://user-images.githubusercontent.com/98650930/234942058-bf760627-28c5-4121-8fcd-da3b590e97b8.png">

<img width="875" alt="image" src="https://user-images.githubusercontent.com/98650930/234942141-264a14e7-4f40-4513-981f-b1123b0c2009.png">


 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8497)