### PR TITLE
[Website a11y] Update role for samples list on website

### DIFF
--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/sample.ejs
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/sample.ejs
@@ -3,11 +3,11 @@
 	<nav id="sidebar-todo" class="toc-todo sidebar w3-cell w3-hide-small w3-hide-medium w3-bar-block"
 		style="width: 200px" aria-label="Sample cards">
 		<div class="sidebar__inner">
-			<ul class="samples-sidebar-list">
+			<ul role="listbox" aria-label="Sample cards" class="samples-sidebar-list">
 				<% page.samples.forEach(function(sample, i) {
                     const isSelected = (page.samplePath === sample.htmlPath);
                 %>
-					<a role="listitem"
+					<a role="option"
                        <%= isSelected ? "class=selectedHolder" : "" %>
                        aria-current='<%= isSelected.toString() %>'
                        aria-posinset='<%= (i+1).toString() %>'


### PR DESCRIPTION
# Related Issue

Fixes #8350 

# Description

HTML link elements cannot have `listitem` as `role`. I switched the role to `option` so that we can remove the error and the other aria properties are still valid.

This change required the parent element's role to be `listbox` and include `aria-label`

# Sample Card

N/A

# How Verified

Verified manually on the samples page of our website by running the Accessibility Insights FastPass, and with Narrator.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8512)