### PR TITLE
[AC Renderer] Add textBlock headingLevel to default config

### DIFF
--- a/source/nodejs/adaptivecards/src/host-config.ts
+++ b/source/nodejs/adaptivecards/src/host-config.ts
@@ -1204,5 +1204,8 @@ export const defaultHostConfig: HostConfig = new HostConfig({
     carousel: {
         maxCarouselPages: 10,
         minAutoplayDuration: 5000
+    },
+    textBlock: {
+        headingLevel: 2
     }
 });


### PR DESCRIPTION
# Related Issue

Fixes #8358

# Description

Add `TextBlock` `headingLevel` to the default config. Without it, `heading-level` is not included on the HTML element, and it is required.

# Sample Card

N/A

This can be tested by going to the `New Card` popup on the designer.

# How Verified

Verified manually on the `New Card` popup of the designer by running Accessibility Insights FastPass.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8514)