### PR TITLE
Avoid outdated results in Dynamic Typeahead Input.Choiceset

### DIFF
--- a/source/nodejs/adaptivecards/src/adaptive-applet.ts
+++ b/source/nodejs/adaptivecards/src/adaptive-applet.ts
@@ -753,6 +753,7 @@ export class AdaptiveApplet {
         if (!this.channelAdapter) {
             throw new Error("internalSendDataQueryRequestAsync: channel adapter not set");
         }
+        const filter = (request.action as DataQuery).filter;
         if (this._choiceSet) {
             this._choiceSet.showLoadingIndicator();
             let response: ActivityResponse | undefined = undefined;
@@ -760,7 +761,7 @@ export class AdaptiveApplet {
                 response = await this.channelAdapter.sendRequestAsync(request);
             } catch (error) {
                 logEvent(Enums.LogLevel.Error, "Activity request failed: " + error);
-                this._choiceSet.showErrorIndicator("Unable to load");
+                this._choiceSet.showErrorIndicator(filter, "Unable to load");
             }
             this._choiceSet.removeLoadingIndicator();
             if (response) {
@@ -771,16 +772,16 @@ export class AdaptiveApplet {
                         try {
                             parsedResponse = JSON.parse(rawResponse);
                         } catch (error) {
-                            this._choiceSet.showErrorIndicator("Unable to load");
+                            this._choiceSet.showErrorIndicator(filter, "Unable to load");
                             throw new Error(
                                 "internalSendDataQueryRequestAsync: Cannot parse response object: " +
                                     rawResponse
                             );
                         }
                         if (typeof parsedResponse === "object") {
-                            this._choiceSet.renderChoices(parsedResponse);
+                            this._choiceSet.renderChoices(filter, parsedResponse);
                         } else {
-                            this._choiceSet.showErrorIndicator("Error loading results.");
+                            this._choiceSet.showErrorIndicator(filter, "Error loading results.");
                             throw new Error(
                                 "internalSendDataQueryRequestAsync: Data.Query result is of unsupported type (" +
                                     typeof rawResponse +
@@ -788,18 +789,18 @@ export class AdaptiveApplet {
                             );
                         }
                     } else {
-                        this._choiceSet.showErrorIndicator("No results found.");
+                        this._choiceSet.showErrorIndicator(filter, "No results found.");
                     }
                     this.activityRequestSucceeded(response, rawResponse);
                 } else if (response instanceof ErrorResponse) {
-                    this._choiceSet.showErrorIndicator("Error loading results.");
+                    this._choiceSet.showErrorIndicator(filter, "Error loading results.");
                     logEvent(
                         Enums.LogLevel.Error,
                         `Activity request failed: ${response.error.message}.`
                     );
                     this.activityRequestFailed(response);
                 } else {
-                    this._choiceSet.showErrorIndicator("Unable to load");
+                    this._choiceSet.showErrorIndicator(filter, "Unable to load");
                     throw new Error("Unhandled response type: " + JSON.stringify(response));
                 }
             }

--- a/source/nodejs/adaptivecards/src/adaptive-applet.ts
+++ b/source/nodejs/adaptivecards/src/adaptive-applet.ts
@@ -760,10 +760,9 @@ export class AdaptiveApplet {
             try {
                 response = await this.channelAdapter.sendRequestAsync(request);
             } catch (error) {
-                logEvent(Enums.LogLevel.Error, "Activity request failed: " + error);
                 this._choiceSet.showErrorIndicator(filter, "Unable to load");
+                logEvent(Enums.LogLevel.Error, "Activity request failed: " + error);
             }
-            this._choiceSet.removeLoadingIndicator();
             if (response) {
                 if (response instanceof SuccessResponse) {
                     const rawResponse = response.rawContent;
@@ -780,8 +779,9 @@ export class AdaptiveApplet {
                         }
                         if (typeof parsedResponse === "object") {
                             this._choiceSet.renderChoices(filter, parsedResponse);
+                            this.activityRequestSucceeded(response, rawResponse);
                         } else {
-                            this._choiceSet.showErrorIndicator(filter, "Error loading results.");
+                            this._choiceSet.showErrorIndicator(filter, "Error loading results");
                             throw new Error(
                                 "internalSendDataQueryRequestAsync: Data.Query result is of unsupported type (" +
                                     typeof rawResponse +
@@ -789,11 +789,16 @@ export class AdaptiveApplet {
                             );
                         }
                     } else {
-                        this._choiceSet.showErrorIndicator(filter, "No results found.");
+                        this._choiceSet.showErrorIndicator(filter, "Unable to load");
+                        throw new Error(
+                            "internalSendDataQueryRequestAsync: Data.Query result is undefined"
+                        );
                     }
-                    this.activityRequestSucceeded(response, rawResponse);
                 } else if (response instanceof ErrorResponse) {
-                    this._choiceSet.showErrorIndicator(filter, "Error loading results.");
+                    this._choiceSet.showErrorIndicator(
+                        filter,
+                        response.error.message || "Error loading results"
+                    );
                     logEvent(
                         Enums.LogLevel.Error,
                         `Activity request failed: ${response.error.message}.`
@@ -803,6 +808,8 @@ export class AdaptiveApplet {
                     this._choiceSet.showErrorIndicator(filter, "Unable to load");
                     throw new Error("Unhandled response type: " + JSON.stringify(response));
                 }
+            } else {
+                this._choiceSet.removeLoadingIndicator();
             }
         }
     }

--- a/source/nodejs/adaptivecards/src/adaptive-applet.ts
+++ b/source/nodejs/adaptivecards/src/adaptive-applet.ts
@@ -778,11 +778,7 @@ export class AdaptiveApplet {
                             );
                         }
                         if (typeof parsedResponse === "object") {
-                            if (parsedResponse.length === 0) {
-                                this._choiceSet.showErrorIndicator("No results found.");
-                            } else {
-                                this._choiceSet.renderChoices(parsedResponse);
-                            }
+                            this._choiceSet.renderChoices(parsedResponse);
                         } else {
                             this._choiceSet.showErrorIndicator("Error loading results.");
                             throw new Error(

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -4348,6 +4348,10 @@ export class ChoiceSetInput extends Input {
         return this._filteredChoiceSet?.textInput?.value;
     }
 
+    getDropdownElement() {
+        return this._filteredChoiceSet?.dropdown;
+    }
+
     renderChoices(filter: string, fetchedChoices: FetchedChoice[]) {
         this._filteredChoiceSet?.processResponse(filter, fetchedChoices);
     }
@@ -4819,6 +4823,7 @@ export class FilteredChoiceSet {
     private _choices: Choice[];
     private _dynamicChoices: FetchedChoice[];
     private _visibleChoiceCount: number;
+    private _highlightedChoiceId: number;
     private _textInput?: HTMLInputElement;
     private _dropdown?: HTMLDivElement;
     private _loadingIndicator?: HTMLDivElement;
@@ -4831,6 +4836,7 @@ export class FilteredChoiceSet {
         this._choices = choices;
         this._dynamicChoices = [];
         this._visibleChoiceCount = 0;
+        this._highlightedChoiceId = -1;
         this._hostConfig = hostConfig;
     }
 
@@ -4850,7 +4856,16 @@ export class FilteredChoiceSet {
 
         this._textInput.onkeydown = (event) => {
             if (event.key === "ArrowDown") {
-                this.focusChoice(0);
+                event.preventDefault();
+                this.highlightChoice(this._highlightedChoiceId + 1);
+            } else if (event.key === "ArrowUp") {
+                event.preventDefault();
+                this.highlightChoice(this._highlightedChoiceId - 1);
+            } else if (event.key === "Enter") {
+                const choice = document.getElementById(
+                    `ac-choiceSetInput-${this._choiceSetId}-choice-${this._highlightedChoiceId}`
+                );
+                choice?.click();
             }
         };
 
@@ -4862,18 +4877,6 @@ export class FilteredChoiceSet {
 
         choiceSetContainer.append(this._textInput, this._dropdown);
 
-        document.onclick = (event) => {
-            if (this._dropdown) {
-                let child = this._dropdown.firstChild;
-                while (child && event.target !== child) {
-                    child = child.nextSibling;
-                }
-                // Dropdown closes if user clicks outside the choiceset.
-                if (child || !(event.target === this._textInput)) {
-                    this._dropdown.classList.remove("open");
-                }
-            }
-        };
         this._renderedElement = choiceSetContainer;
     }
 
@@ -4884,72 +4887,62 @@ export class FilteredChoiceSet {
         choice.innerHTML = value.replace(filter, `<b>${filter}</b>`);
         choice.tabIndex = -1;
 
-        choice.addEventListener("focusin", () => {
-            choice.classList.add("focused");
-        });
-
-        choice.addEventListener("focusout", () => {
-            choice.classList.remove("focused");
-        });
-
         choice.onclick = () => {
+            choice.classList.remove("focused");
+            this._highlightedChoiceId = -1;
             if (this._textInput) {
                 this._textInput.value = choice.innerText;
+                this._textInput.focus();
             }
             if (this._dropdown) {
                 this._dropdown.classList.remove("open");
             }
         };
-
-        choice.onkeydown = (event) => {
-            if (event.key === "ArrowDown") {
-                this.focusChoice(id + 1);
-            } else if (event.key === "ArrowUp") {
-                this.focusChoice(id - 1);
-            } else if (event.key === "Enter") {
-                choice.click();
-            }
-        };
-
-        choice.onmouseover = () => {
-            this.focusChoice(id);
+        choice.onmouseenter = () => {
+            this.highlightChoice(id);
         };
 
         return choice;
     }
 
-    private focusChoice(id: number) {
-        const choice = document.getElementById(
-            `ac-choiceSetInput-${this._choiceSetId}-choice-${id}`
-        );
-        if (choice) {
-            choice.focus();
-        } else if (this._textInput) {
-            this._textInput.focus();
-            const textLength = this._textInput.value.length;
-            this._textInput.setSelectionRange(textLength, textLength);
+    private highlightChoice(id: number) {
+        if (this._visibleChoiceCount > 0) {
+            const currentHighlightedChoice = document.getElementById(
+                `ac-choiceSetInput-${this._choiceSetId}-choice-${this._highlightedChoiceId}`
+            );
+            const nextHighlightedChoice = document.getElementById(
+                `ac-choiceSetInput-${this._choiceSetId}-choice-${id}`
+            );
+            if (nextHighlightedChoice) {
+                currentHighlightedChoice?.classList.remove("focused");
+                nextHighlightedChoice.classList.add("focused");
+                nextHighlightedChoice.scrollIntoView();
+                this._highlightedChoiceId = id;
+            } else if (currentHighlightedChoice && this._highlightedChoiceId !== 0) {
+                this.highlightChoice(0);
+            } else {
+                this.highlightChoice(this._visibleChoiceCount - 1);
+            }
         }
     }
 
     private filterChoices() {
-        const filter = this._textInput?.value.toLowerCase();
-        if (filter) {
-            const choices = [...this._choices, ...this._dynamicChoices];
-            for (const choice of choices) {
-                if (choice.title) {
-                    const matchIndex = choice.title.toLowerCase().indexOf(filter);
-                    if (matchIndex !== -1) {
-                        const matchedText = choice.title.substring(
-                            matchIndex,
-                            matchIndex + filter.length
-                        );
-                        const choiceContainer = this.createChoice(
-                            choice.title,
-                            matchedText,
-                            this._visibleChoiceCount++
-                        );
-                        this._dropdown?.appendChild(choiceContainer);
-                    }
+        const filter = this._textInput?.value.toLowerCase().trim() || "";
+        const choices = [...this._choices, ...this._dynamicChoices];
+        for (const choice of choices) {
+            if (choice.title) {
+                const matchIndex = choice.title.toLowerCase().indexOf(filter);
+                if (matchIndex !== -1) {
+                    const matchedText = choice.title.substring(
+                        matchIndex,
+                        matchIndex + filter.length
+                    );
+                    const choiceContainer = this.createChoice(
+                        choice.title,
+                        matchedText,
+                        this._visibleChoiceCount++
+                    );
+                    this._dropdown?.appendChild(choiceContainer);
                 }
             }
         }
@@ -4988,6 +4981,7 @@ export class FilteredChoiceSet {
         if (this._dropdown) {
             Utils.clearElementChildren(this._dropdown);
             this._visibleChoiceCount = 0;
+            this._highlightedChoiceId = -1;
         }
     }
 
@@ -5009,7 +5003,7 @@ export class FilteredChoiceSet {
             this._dynamicChoices = fetchedChoices;
             this.filterChoices();
             if (this._visibleChoiceCount === 0) {
-                this.showErrorIndicator(filter, "No results found.");
+                this.showErrorIndicator(filter, "No results found");
             }
         }
     }
@@ -5064,6 +5058,10 @@ export class FilteredChoiceSet {
 
     get textInput() {
         return this._textInput;
+    }
+
+    get dropdown() {
+        return this._dropdown;
     }
 }
 
@@ -9395,6 +9393,18 @@ export class AdaptiveCard extends ContainerWithActions {
 
             this.updateLayout();
         }
+
+        const inputElements = this.getAllInputs();
+        document.onclick = (event) => {
+            inputElements.forEach((input) => {
+                if (
+                    input instanceof ChoiceSetInput &&
+                    !input.renderedElement?.contains(event.target as Node)
+                ) {
+                    input.getDropdownElement()?.classList.remove("open");
+                }
+            });
+        };
 
         return renderedCard;
     }

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -4899,13 +4899,13 @@ export class FilteredChoiceSet {
             }
         };
         choice.onmouseenter = () => {
-            this.highlightChoice(id);
+            this.highlightChoice(id, false);
         };
 
         return choice;
     }
 
-    private highlightChoice(id: number) {
+    private highlightChoice(id: number, scrollIntoView: boolean = true) {
         if (this._visibleChoiceCount > 0) {
             const currentHighlightedChoice = document.getElementById(
                 `ac-choiceSetInput-${this._choiceSetId}-choice-${this._highlightedChoiceId}`
@@ -4916,7 +4916,9 @@ export class FilteredChoiceSet {
             if (nextHighlightedChoice) {
                 currentHighlightedChoice?.classList.remove("focused");
                 nextHighlightedChoice.classList.add("focused");
-                nextHighlightedChoice.scrollIntoView();
+                if (scrollIntoView) {
+                    nextHighlightedChoice.scrollIntoView();
+                }
                 this._highlightedChoiceId = id;
             } else if (currentHighlightedChoice && this._highlightedChoiceId !== 0) {
                 this.highlightChoice(0);

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -4931,10 +4931,10 @@ export class FilteredChoiceSet {
         }
     }
 
-    private filterChoices(isDynamic?: boolean) {
+    private filterChoices() {
         const filter = this._textInput?.value.toLowerCase();
         if (filter) {
-            const choices = isDynamic ? this._dynamicChoices : this._choices;
+            const choices = [...this._choices, ...this._dynamicChoices];
             for (const choice of choices) {
                 if (choice.title) {
                     const matchIndex = choice.title.toLowerCase().indexOf(filter);
@@ -5004,8 +5004,9 @@ export class FilteredChoiceSet {
     }
 
     processResponse(fetchedChoices: FetchedChoice[]) {
+        this.resetDropdown();
         this._dynamicChoices = fetchedChoices;
-        this.filterChoices(true);
+        this.filterChoices();
         if (this._visibleChoiceCount === 0) {
             this.showErrorIndicator("No results found.");
         }
@@ -5024,7 +5025,7 @@ export class FilteredChoiceSet {
     }
 
     showErrorIndicator(error: string) {
-        this.removeLoadingIndicator();
+        this.processStaticChoices();
         const errorIndicator = this.getStatusIndicator(error);
         this._dropdown?.appendChild(errorIndicator);
     }

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -4348,8 +4348,8 @@ export class ChoiceSetInput extends Input {
         return this._filteredChoiceSet?.textInput?.value;
     }
 
-    renderChoices(fetchedChoices: FetchedChoice[]) {
-        this._filteredChoiceSet?.processResponse(fetchedChoices);
+    renderChoices(filter: string, fetchedChoices: FetchedChoice[]) {
+        this._filteredChoiceSet?.processResponse(filter, fetchedChoices);
     }
 
     showLoadingIndicator() {
@@ -4360,8 +4360,8 @@ export class ChoiceSetInput extends Input {
         this._filteredChoiceSet?.removeLoadingIndicator();
     }
 
-    showErrorIndicator(error: string) {
-        this._filteredChoiceSet?.showErrorIndicator(error);
+    showErrorIndicator(filter: string, error: string) {
+        this._filteredChoiceSet?.showErrorIndicator(filter, error);
     }
 
     private createPlaceholderOptionWhenValueDoesNotExist(): HTMLElement | undefined {
@@ -5003,12 +5003,14 @@ export class FilteredChoiceSet {
         this.showDropdown();
     }
 
-    processResponse(fetchedChoices: FetchedChoice[]) {
-        this.resetDropdown();
-        this._dynamicChoices = fetchedChoices;
-        this.filterChoices();
-        if (this._visibleChoiceCount === 0) {
-            this.showErrorIndicator("No results found.");
+    processResponse(filter: string, fetchedChoices: FetchedChoice[]) {
+        if (filter === this._textInput?.value) {
+            this.resetDropdown();
+            this._dynamicChoices = fetchedChoices;
+            this.filterChoices();
+            if (this._visibleChoiceCount === 0) {
+                this.showErrorIndicator(filter, "No results found.");
+            }
         }
     }
 
@@ -5024,10 +5026,12 @@ export class FilteredChoiceSet {
         }
     }
 
-    showErrorIndicator(error: string) {
-        this.processStaticChoices();
-        const errorIndicator = this.getStatusIndicator(error);
-        this._dropdown?.appendChild(errorIndicator);
+    showErrorIndicator(filter: string, error: string) {
+        if (filter === this._textInput?.value) {
+            this.processStaticChoices();
+            const errorIndicator = this.getStatusIndicator(error);
+            this._dropdown?.appendChild(errorIndicator);
+        }
     }
 
     get dynamicChoices() {

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -4836,17 +4836,17 @@ export class FilteredChoiceSet {
 
     render() {
         const choiceSetContainer = document.createElement("div");
-        choiceSetContainer.style.position = "relative";
-        choiceSetContainer.style.width = "100%";
+        choiceSetContainer.className = this.hostConfig.makeCssClassName(
+            "ac-input",
+            "ac-choiceSetInput-filtered-container"
+        );
 
         this._textInput = document.createElement("input");
         this._textInput.className = this.hostConfig.makeCssClassName(
             "ac-input",
-            "ac-multichoiceInput",
-            "ac-choiceSetInput-filtered"
+            "ac-choiceSetInput-filtered-textbox"
         );
         this._textInput.type = "text";
-        this._textInput.style.width = "100%";
 
         this._textInput.onkeydown = (event) => {
             if (event.key === "ArrowDown") {
@@ -4855,10 +4855,8 @@ export class FilteredChoiceSet {
         };
 
         this._dropdown = document.createElement("div");
-        this._dropdown.style.display = "none";
         this._dropdown.className = this.hostConfig.makeCssClassName(
             "ac-input",
-            "ac-multichoiceInput",
             "ac-choiceSetInput-filtered-dropdown"
         );
 
@@ -4872,7 +4870,7 @@ export class FilteredChoiceSet {
                 }
                 // Dropdown closes if user clicks outside the choiceset.
                 if (child || !(event.target === this._textInput)) {
-                    this._dropdown.style.display = "none";
+                    this._dropdown.classList.remove("open");
                 }
             }
         };
@@ -4899,7 +4897,7 @@ export class FilteredChoiceSet {
                 this._textInput.value = choice.innerText;
             }
             if (this._dropdown) {
-                this._dropdown.style.display = "none";
+                this._dropdown.classList.remove("open");
             }
         };
 
@@ -4994,8 +4992,8 @@ export class FilteredChoiceSet {
     }
 
     private showDropdown() {
-        if (this._dropdown?.hasChildNodes) {
-            this._dropdown.style.display = "block";
+        if (this._dropdown?.hasChildNodes()) {
+            this._dropdown.classList.add("open");
         }
     }
 

--- a/source/nodejs/adaptivecards/src/scss/adaptivecards-base.scss
+++ b/source/nodejs/adaptivecards/src/scss/adaptivecards-base.scss
@@ -283,19 +283,6 @@ $font-family: 'Segoe UI', sans-serif;
             padding: $padding;
             background-color: $background-color;
 
-            &.ac-choiceSetInput-filtered-dropdown {
-                background-color: white;
-                border-top: 0px;
-                display: none;
-                max-height: 200px;
-                overflow-y: scroll;
-                padding-top: 0px;
-                padding-bottom: 0px;
-                position: absolute;
-                width: 100%;
-                z-index: 1;
-            }
-
             &:hover {
                 border: $hover-border;
                 background-color: $hover-background-color;
@@ -318,26 +305,52 @@ $font-family: 'Segoe UI', sans-serif;
             }
         }
 
-        &.ac-choiceSetInput-choice {
-            padding: $padding;
-            padding-left: 0px;
-            padding-right: 0px;
+        &.ac-choiceSetInput-filtered-container {
             display: flex;
+            position: relative;
+            width: 100%;
+        }
+
+        &.ac-choiceSetInput-filtered-textbox {
+            border: $border;
+            padding: $padding;
+            background-color: $background-color;
+            width: 100%;
+        }
+
+        &.ac-choiceSetInput-filtered-dropdown {
+            background-color: white;
+            border: $border;
+            border-top: 0px;
+            box-sizing: border-box;
+            display: none;
+            max-height: 200px;
+            overflow-y: scroll;
+            position: absolute;
+            top: calc(100%);
+            width: 100%;
+
+            &.open {
+                display: flex;
+                flex-direction: column;
+            }
+        }
+
+        &.ac-choiceSetInput-choice {
+            box-sizing: border-box;
+            padding: $padding;
             width: 100%;
 
             &.focused {
                 background-color: #DEECF9;
-                box-shadow: #DEECF9 8px 0px 0px, #DEECF9 -8px 0px 0px;
                 outline: none;
             }
         }
 
         &.ac-choiceSetInput-statusIndicator {
-            background-color: white;
+            box-sizing: border-box;
             color: #A19F9D;
             padding: $padding;
-            padding-left: 0px;
-            padding-right: 0px;
             width: 100%;
 
             &.ac-choiceSetInput-errorIndicator {
@@ -345,7 +358,7 @@ $font-family: 'Segoe UI', sans-serif;
                 text-align: center;
             }
         }
-        
+
         &.ac-inputStyle-revealOnHover-onrender {
             border: $transparent-border;
             background-color: $transparent-background;

--- a/source/nodejs/adaptivecards/src/scss/adaptivecards-base.scss
+++ b/source/nodejs/adaptivecards/src/scss/adaptivecards-base.scss
@@ -323,12 +323,14 @@ $font-family: 'Segoe UI', sans-serif;
             border: $border;
             border-top: 0px;
             box-sizing: border-box;
+            cursor: pointer;
             display: none;
             max-height: 200px;
             overflow-y: scroll;
             position: absolute;
             top: calc(100%);
             width: 100%;
+            z-index: 1;
 
             &.open {
                 display: flex;
@@ -350,6 +352,7 @@ $font-family: 'Segoe UI', sans-serif;
         &.ac-choiceSetInput-statusIndicator {
             box-sizing: border-box;
             color: #A19F9D;
+            cursor: default;
             padding: $padding;
             width: 100%;
 


### PR DESCRIPTION
### Description
When the user changes the text in the input field rapidly, a possibility exists that a new request might be sent when the previous request is still in progress. This is expected and the latest response must be shown in the choiceset.  We discovered a bug in a corner case that proved otherwise as the outdated results were not being cleared when the latest response came. In the current implementation, we cleared the old response only when a text change got detected which caused the bug because if the response from the old request had not come, there would be nothing to clear at that moment.

### Fix
We can identify the latest request by comparing the filter sent in the request object to the text present in the input field. 
When a request is completed, we either process the freshly received choices or display an error message. 
In the former case, we reset the dropdown to clear everything and filter the choices (static + dynamic) with the latest filter. 
The latter case implies that the fetching of dynamic choices failed, so we reset the dropdown, process the static choices once more and display the error message. 
Both these cases only proceed if the filter in the request object matches with the text present in the input field.
This allows no outdated results to stay in the dropdown list.

### UX improvements
1. Input field is not losing focus and is writable even when choices are being browsed via mouse or keys.
2. On selection of a choice, the input field is focused and writable.

### Code Changes
1. Passing the filter used in the request in the processResponse/showErrorIndicator methods to compare it with the text in the input field to identify the latest request.
4. Updated filterChoices method so that it always filters with both static and dynamic choices.
5. Removed unnecessary case in internalSendDataQueryRequestAsync which is already handled.
6. Updated processResponse method to proceed only if the filter in the request matches with the text in the input field. If yes,  reset dropdown before filtering all the choices with the latest filter.
7. Updated showErrorIndicator to proceed only if the filter in the request matches with the text in the input field. If yes, reset dropdown and filter the static choices before showing the error message for the failed fetch of dynamic choices.
8. Added event handler at the right place to ensure the dropdown gets closed whenever click is detected not inside the choiceset.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8528)