### PR TITLE
Render SVG images in WinUI 3

### DIFF
--- a/source/uwp/AdaptiveCardsObjectModel/AdaptiveCardsObjectModel.vcxproj
+++ b/source/uwp/AdaptiveCardsObjectModel/AdaptiveCardsObjectModel.vcxproj
@@ -145,8 +145,8 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.210913.7\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210913.7\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.211019.2\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.211019.2\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -154,5 +154,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210913.7\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.210913.7\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210913.7\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.210913.7\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.211019.2\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.211019.2\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
   </Target>
 </Project>

--- a/source/uwp/AdaptiveCardsObjectModel/packages.config
+++ b/source/uwp/AdaptiveCardsObjectModel/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210913.7" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.210803.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.211019.2" targetFramework="native" />
 </packages>

--- a/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj
+++ b/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj
@@ -191,6 +191,7 @@
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.210913.7\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210913.7\build\native\Microsoft.Windows.CppWinRT.targets')" />
     <Import Project="..\packages\XamlStraddle.0.0.6\build\XamlStraddle.targets" Condition="Exists('..\packages\XamlStraddle.0.0.6\build\XamlStraddle.targets')" />
+    <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.211019.2\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.211019.2\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -199,5 +200,6 @@
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210913.7\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.210913.7\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210913.7\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.210913.7\build\native\Microsoft.Windows.CppWinRT.targets'))" />
     <Error Condition="!Exists('..\packages\XamlStraddle.0.0.6\build\XamlStraddle.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\XamlStraddle.0.0.6\build\XamlStraddle.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.211019.2\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.211019.2\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
   </Target>
 </Project>

--- a/source/uwp/Renderer/packages.config
+++ b/source/uwp/Renderer/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210913.7" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.211019.2" targetFramework="native" />
   <package id="XamlStraddle" version="0.0.6" targetFramework="native" />
 </packages>

--- a/source/uwp/SharedRenderer/dll/CppWinRTIncludes.h
+++ b/source/uwp/SharedRenderer/dll/CppWinRTIncludes.h
@@ -39,9 +39,10 @@
 #include <UI.Xaml.Media.Imaging.h>
 #include <UI.Xaml.Shapes.h>
 
+#include <wil/cppwinrt_helpers.h>
+
 #ifdef USE_WINUI3
 #include <winrt/AdaptiveCards.ObjectModel.WinUI3.h>
-#include <wil/cppwinrt_helpers.h>
 #else
 #include <winrt/AdaptiveCards.ObjectModel.Uwp.h>
 #endif

--- a/source/uwp/SharedRenderer/dll/CppWinRTIncludes.h
+++ b/source/uwp/SharedRenderer/dll/CppWinRTIncludes.h
@@ -41,6 +41,7 @@
 
 #ifdef USE_WINUI3
 #include <winrt/AdaptiveCards.ObjectModel.WinUI3.h>
+#include <wil/cppwinrt_helpers.h>
 #else
 #include <winrt/AdaptiveCards.ObjectModel.Uwp.h>
 #endif

--- a/source/uwp/SharedRenderer/lib/AdaptiveImageRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveImageRenderer.cpp
@@ -35,6 +35,15 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 
 namespace AdaptiveCards::Rendering::Xaml_Rendering
 {
+    auto inline GetDispatcher(winrt::SvgImageSource const &imageSource)
+    {
+#ifdef USE_WINUI3
+        return imageSource.DispatcherQueue();
+#else
+        return imageSource.Dispatcher();
+#endif
+    }
+
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     //
     // IMPORTANT! Methods below here are actually XamlBuilder methods. They're defined here because they're only used
@@ -599,11 +608,7 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
     winrt::fire_and_forget XamlBuilder::SetSvgUriSource(winrt::SvgImageSource const imageSource,
                                                         winrt::Uri const uri)
     {
-#ifdef USE_WINUI3
-        co_await wil::resume_foreground(imageSource.DispatcherQueue());
-#else
-        co_await winrt::resume_foreground(imageSource.Dispatcher());
-#endif
+        co_await wil::resume_foreground(GetDispatcher(imageSource));
         imageSource.UriSource(uri);
     }
 
@@ -614,11 +619,7 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
     {
         auto weakThis = this->get_weak();
 
-#ifdef USE_WINUI3
-        co_await wil::resume_foreground(imageSource.DispatcherQueue());
-#else
-        co_await winrt::resume_foreground(imageSource.Dispatcher());
-#endif
+        co_await wil::resume_foreground(GetDispatcher(imageSource));
         auto setSourceOperation = imageSource.SetSourceAsync(stream);
 
         setSourceOperation.Completed(
@@ -809,11 +810,7 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
                                                                       double const imageSize,
                                                                       bool const dropIfUnset)
     {
-#ifdef USE_WINUI3
-        co_await wil::resume_foreground(imageSource.DispatcherQueue());
-#else
-        co_await winrt::resume_foreground(imageSource.Dispatcher());
-#endif
+        co_await wil::resume_foreground(GetDispatcher(imageSource));
         auto currentSize = imageSource.RasterizePixelHeight();
         bool sizeIsUnset = isinf(currentSize);
 
@@ -832,11 +829,7 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
                                                                      double const imageSize,
                                                                      bool const dropIfUnset)
     {
-#ifdef USE_WINUI3
-        co_await wil::resume_foreground(imageSource.DispatcherQueue());
-#else
-        co_await winrt::resume_foreground(imageSource.Dispatcher());
-#endif
+        co_await wil::resume_foreground(GetDispatcher(imageSource));
         auto currentSize = imageSource.RasterizePixelWidth();
         bool sizeIsUnset = isinf(currentSize);
 

--- a/source/uwp/SharedRenderer/lib/AdaptiveImageRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveImageRenderer.cpp
@@ -11,6 +11,10 @@
 #include <robuffer.h>
 #include "WholeItemsPanel.h"
 
+#ifdef USE_WINUI3
+#include <wil/cppwinrt_helpers.h>
+#endif
+
 namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveImageRenderer::AdaptiveImageRenderer(winrt::com_ptr<::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder> xamlBuilder) :
@@ -599,7 +603,11 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
     winrt::fire_and_forget XamlBuilder::SetSvgUriSource(winrt::SvgImageSource const imageSource,
                                                         winrt::Uri const uri)
     {
+#ifdef USE_WINUI3
+        co_await wil::resume_foreground(imageSource.DispatcherQueue());
+#else
         co_await winrt::resume_foreground(imageSource.Dispatcher());
+#endif
         imageSource.UriSource(uri);
     }
 
@@ -610,7 +618,11 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
     {
         auto weakThis = this->get_weak();
 
+#ifdef USE_WINUI3
+        co_await wil::resume_foreground(imageSource.DispatcherQueue());
+#else
         co_await winrt::resume_foreground(imageSource.Dispatcher());
+#endif
         auto setSourceOperation = imageSource.SetSourceAsync(stream);
 
         setSourceOperation.Completed(
@@ -798,10 +810,14 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
     }
 
     winrt::fire_and_forget XamlBuilder::SetRasterizedPixelHeightAsync(winrt::SvgImageSource const imageSource,
-                                                                           double const imageSize,
-                                                                           bool const dropIfUnset)
+                                                                      double const imageSize,
+                                                                      bool const dropIfUnset)
     {
+#ifdef USE_WINUI3
+        co_await wil::resume_foreground(imageSource.DispatcherQueue());
+#else
         co_await winrt::resume_foreground(imageSource.Dispatcher());
+#endif
         auto currentSize = imageSource.RasterizePixelHeight();
         bool sizeIsUnset = isinf(currentSize);
 
@@ -817,10 +833,14 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
     }
 
     winrt::fire_and_forget XamlBuilder::SetRasterizedPixelWidthAsync(winrt::SvgImageSource const imageSource,
-                                                                          double const imageSize,
-                                                                          bool const dropIfUnset)
+                                                                     double const imageSize,
+                                                                     bool const dropIfUnset)
     {
+#ifdef USE_WINUI3
+        co_await wil::resume_foreground(imageSource.DispatcherQueue());
+#else
         co_await winrt::resume_foreground(imageSource.Dispatcher());
+#endif
         auto currentSize = imageSource.RasterizePixelWidth();
         bool sizeIsUnset = isinf(currentSize);
 

--- a/source/uwp/SharedRenderer/lib/AdaptiveImageRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveImageRenderer.cpp
@@ -11,10 +11,6 @@
 #include <robuffer.h>
 #include "WholeItemsPanel.h"
 
-#ifdef USE_WINUI3
-#include <wil/cppwinrt_helpers.h>
-#endif
-
 namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
     AdaptiveImageRenderer::AdaptiveImageRenderer(winrt::com_ptr<::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder> xamlBuilder) :

--- a/source/uwp/SharedVisualizer/ViewModel/DocumentViewModel.cs
+++ b/source/uwp/SharedVisualizer/ViewModel/DocumentViewModel.cs
@@ -17,14 +17,12 @@ using AdaptiveCards.Rendering.WinUI3;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
-using Windows.UI;
 #else
 using AdaptiveCards.ObjectModel.Uwp;
 using AdaptiveCards.Rendering.Uwp;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
-using Windows.UI;
 #endif
 
 namespace AdaptiveCardVisualizer.ViewModel
@@ -310,7 +308,7 @@ namespace AdaptiveCardVisualizer.ViewModel
                 {
                     Grid grid = (Grid)RenderedCard;
 
-                    (RenderedCard as Grid).BorderBrush = new SolidColorBrush((Color)grid.Resources["SystemColorWindowTextColor"]);
+                    (RenderedCard as Grid).BorderBrush = new SolidColorBrush((Windows.UI.Color)grid.Resources["SystemColorWindowTextColor"]);
                     (RenderedCard as Grid).BorderThickness = new Thickness(2);
                 }
             }


### PR DESCRIPTION
# Related Issue

Fixes #8558

# Description

Rendering an SVG in WinUI 3 is currently broken, since an access violation exception is thrown. WinUI 3 needs to use `SvgImageSource.DispatcherQueue()`, rather than UWP's `SvgImageSource.Dispatcher()`, which in WinUI 3 will always return `null`.
https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/migrate-to-windows-app-sdk/guides/threading#migrate-winrtresume_foreground-cwinrt

Also fixes an issue where the list of cards in AdaptiveCardsVisualizer wouldn't load.

# Sample Card

If appropriate, please include a link to a card in one of the samples directories that can be used to validate this change. This can be an existing card or a card added with this PR.

# How Verified

Verified with AdaptiveCards/samples/v1.5/Tests/Image.Svg.json card as well as other cards containing svgs in base64.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8559)