### PR TITLE
[WinUI3 Visualizer] Add if block for high contrast changed event

### DIFF
--- a/source/uwp/SharedVisualizer/ViewModel/HostConfigEditorViewModel.cs
+++ b/source/uwp/SharedVisualizer/ViewModel/HostConfigEditorViewModel.cs
@@ -8,7 +8,6 @@ using AdaptiveCards.Rendering.Uwp;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Windows.Storage;
 using Windows.UI.ViewManagement;

--- a/source/uwp/SharedVisualizer/ViewModel/HostConfigEditorViewModel.cs
+++ b/source/uwp/SharedVisualizer/ViewModel/HostConfigEditorViewModel.cs
@@ -8,6 +8,7 @@ using AdaptiveCards.Rendering.Uwp;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Windows.Storage;
 using Windows.UI.ViewManagement;
@@ -17,7 +18,10 @@ namespace AdaptiveCardVisualizer.ViewModel
     public class HostConfigEditorViewModel : GenericDocumentViewModel
     {
         private HostConfigEditorViewModel(MainPageViewModel mainPageViewModel) : base(mainPageViewModel) {
+#if !USE_WINUI3
+            // HighContrastChanged event does not work without a core window in WinUI3
             accessibilitySettings.HighContrastChanged += AccessibilitySettings_HighContrastChanged;
+#endif
         }
 
         public event EventHandler<AdaptiveHostConfig> HostConfigChanged;


### PR DESCRIPTION
# Related Issue

Fixes #8565

# Description

We cannot call AccessibilitySettings.HighContrastChanged with WinUI3 because it does not work without a core window.

Added an if block to resolve this error:
![image](https://github.com/microsoft/AdaptiveCards/assets/98650930/600b93be-32af-4eb7-b98e-9712cfac4bdc)

# Sample Card

N/A

# How Verified

Verified manually in the WinUI3 and System.XAML visualizers

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8564)