### PR TITLE
Update NDK to 23 for react native

### DIFF
--- a/source/android/adaptivecards/build.gradle
+++ b/source/android/adaptivecards/build.gradle
@@ -39,7 +39,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    ndkVersion '21.4.7075529'
+    ndkVersion '23.1.7779620'
 
     lintOptions {
         abortOnError false


### PR DESCRIPTION

# Description

Update NDK to 23 for react native. Teams app is crashing with latest reactnative package and will be updating NDK to 23 from 21. Need to update ndk here too

# How Verified

verified locally

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8569)