### PR TITLE
Update colors for contrast requirements

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/containers/outlook/outlook-container.css
+++ b/source/nodejs/adaptivecards-designer/src/containers/outlook/outlook-container.css
@@ -81,7 +81,7 @@ a.ac-anchor:visited:active {
     user-select: none;
     height: 31px;
     background-color: white;
-    color: #0079db;
+    color: #0B78D0;
     border: 1px solid #6290FF;
 }
 

--- a/source/nodejs/adaptivecards/src/scss/adaptivecards-default.scss
+++ b/source/nodejs/adaptivecards/src/scss/adaptivecards-default.scss
@@ -13,7 +13,7 @@ $destructive-bg-color: #E50000;
 $destructive-hl-bg-color: #BF0000;
 @include base-push-button(
     $background-color: $main-fg-color,
-    $color: #0079db,
+    $color: #0B78D0,
     $border: $border-style #B2E0FF,
     $hover-background-color: $button-hl-bg-color,
     $hover-color: $main-fg-color,


### PR DESCRIPTION
# Related Issue

Fixes #8574

# Description

Updated the default button color for contrast requirements.

# Sample Card

Schema explorer samples on website.

# How Verified

Verified manually
<img width="758" alt="image" src="https://github.com/microsoft/AdaptiveCards/assets/98650930/0ec1ed14-23a0-45e9-8fc1-52d9d2dda2c2">


 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8576)