### PR TITLE
Added validation to split SPM and CocoaPods header includes.

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOActionOverflow.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOActionOverflow.h
@@ -5,7 +5,13 @@
 //  Copyright © 2021 Microsoft. All rights reserved.
 //
 
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACOBaseActionElement.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACOBaseActionElement.h>
+#endif
 #import <Foundation/Foundation.h>
 
 @interface ACOActionOverflow : ACOBaseActionElement

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOAdaptiveCard.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOAdaptiveCard.h
@@ -5,11 +5,21 @@
 //  Copyright © 2017 Microsoft. All rights reserved.
 //
 
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACOAdaptiveCardParseResult.h"
 #import "ACOAuthentication.h"
 #import "ACORefresh.h"
 #import "ACORemoteResourceInformation.h"
 #import "ACRIBaseInputHandler.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACOAdaptiveCardParseResult.h>
+#import <AdaptiveCards/ACORemoteResourceInformation.h>
+#import <AdaptiveCards/ACRIBaseInputHandler.h>
+#import <AdaptiveCards/ACORefresh.h>
+#import <AdaptiveCards/ACOAuthentication.h>
+#endif
 #import <Foundation/Foundation.h>
 
 @interface ACOAdaptiveCard : NSObject

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOAdaptiveCard.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOAdaptiveCard.h
@@ -15,10 +15,10 @@
 #else
 /// Cocoapods Imports
 #import <AdaptiveCards/ACOAdaptiveCardParseResult.h>
+#import <AdaptiveCards/ACOAuthentication.h>
+#import <AdaptiveCards/ACORefresh.h>
 #import <AdaptiveCards/ACORemoteResourceInformation.h>
 #import <AdaptiveCards/ACRIBaseInputHandler.h>
-#import <AdaptiveCards/ACORefresh.h>
-#import <AdaptiveCards/ACOAuthentication.h>
 #endif
 #import <Foundation/Foundation.h>
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRAggregateTarget.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRAggregateTarget.h
@@ -5,8 +5,15 @@
 //  Copyright © 2018 Microsoft. All rights reserved.
 //
 
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACOInputResults.h"
 #import "ACRBaseTarget.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACOInputResults.h>
+#import <AdaptiveCards/ACRBaseTarget.h>
+#endif
 #import "ACRIContentHoldingView.h"
 #import "ACRView.h"
 #import <UIKit/UIKit.h>

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSourceCompactStyle.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSourceCompactStyle.mm
@@ -11,8 +11,8 @@
 #import "ACRChoiceSetViewDataSource.h"
 #else
 /// Cocoapods Imports
-#import <AdaptiveCards/ACRChoiceSetViewDataSourceCompactStyle.h>
 #import <AdaptiveCards/ACRChoiceSetViewDataSource.h>
+#import <AdaptiveCards/ACRChoiceSetViewDataSourceCompactStyle.h>
 #endif
 #import "ACOBundle.h"
 #import "ACRActionDelegate.h"

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSourceCompactStyle.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSourceCompactStyle.mm
@@ -5,10 +5,17 @@
 //  Copyright © 2018 Microsoft. All rights reserved.
 //
 
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACRChoiceSetViewDataSourceCompactStyle.h"
+#import "ACRChoiceSetViewDataSource.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACRChoiceSetViewDataSourceCompactStyle.h>
+#import <AdaptiveCards/ACRChoiceSetViewDataSource.h>
+#endif
 #import "ACOBundle.h"
 #import "ACRActionDelegate.h"
-#import "ACRChoiceSetViewDataSource.h"
 #import "ACRView.h"
 #import <Foundation/Foundation.h>
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRColumnSetRenderer.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRColumnSetRenderer.h
@@ -5,7 +5,13 @@
 //  Copyright © 2017 Microsoft. All rights reserved.
 //
 
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACRBaseCardElementRenderer.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACRBaseCardElementRenderer.h>
+#endif
 
 @interface ACRColumnSetRenderer : ACRBaseCardElementRenderer
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRImageProperties.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRImageProperties.h
@@ -5,9 +5,17 @@
 //  Copyright © 2021 Microsoft. All rights reserved.
 //
 
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACOBaseCardElement.h"
 #import "ACOHostConfig.h"
 #import "ACREnums.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACOBaseCardElement.h>
+#import <AdaptiveCards/ACOHostConfig.h>
+#import <AdaptiveCards/ACREnums.h>
+#endif
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputChoiceSetRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputChoiceSetRenderer.mm
@@ -12,11 +12,11 @@
 /// Cocoapods Imports
 #import <AdaptiveCards/ACRChoiceSetViewDataSource.h>
 #endif
-#import "ACRInputChoiceSetRenderer.h"
 #import "ACOBaseCardElementPrivate.h"
 #import "ACOHostConfigPrivate.h"
 #import "ACRChoiceSetCompactStyleView.h"
 #import "ACRChoiceSetFilteredStyleView.h"
+#import "ACRInputChoiceSetRenderer.h"
 #import "ACRInputLabelViewPrivate.h"
 #import "ACRInputTableView.h"
 #import "ACRTypeaheadSearchParameters.h"

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputChoiceSetRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputChoiceSetRenderer.mm
@@ -5,12 +5,18 @@
 //  Copyright © 2018 Microsoft. All rights reserved.
 //
 
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
+#import "ACRChoiceSetViewDataSource.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACRChoiceSetViewDataSource.h>
+#endif
 #import "ACRInputChoiceSetRenderer.h"
 #import "ACOBaseCardElementPrivate.h"
 #import "ACOHostConfigPrivate.h"
 #import "ACRChoiceSetCompactStyleView.h"
 #import "ACRChoiceSetFilteredStyleView.h"
-#import "ACRChoiceSetViewDataSource.h"
 #import "ACRInputLabelViewPrivate.h"
 #import "ACRInputTableView.h"
 #import "ACRTypeaheadSearchParameters.h"

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.h
@@ -5,8 +5,15 @@
 //  Copyright © 2020 Microsoft. All rights reserved.
 //
 
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACOEnums.h"
 #import "ACRIBaseInputHandler.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACRIBaseInputHandler.h>
+#import <AdaptiveCards/ACOEnums.h>
+#endif
 #import <UIKit/UIKit.h>
 
 @interface ACRInputLabelView : UIView <ACRIBaseInputHandler>

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.h
@@ -11,8 +11,8 @@
 #import "ACRIBaseInputHandler.h"
 #else
 /// Cocoapods Imports
-#import <AdaptiveCards/ACRIBaseInputHandler.h>
 #import <AdaptiveCards/ACOEnums.h>
+#import <AdaptiveCards/ACRIBaseInputHandler.h>
 #endif
 #import <UIKit/UIKit.h>
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRegistration.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRegistration.h
@@ -7,9 +7,16 @@
 //
 @class ACRBaseCardElementRenderer;
 
-#import "ACOBaseCardElement.h"
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACRBaseActionElementRenderer.h"
 #import "ACRTargetBuilder.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACRBaseActionElementRenderer.h>
+#import <AdaptiveCards/ACRTargetBuilder.h>
+#endif
+#import "ACOBaseCardElement.h"
 
 @interface ACRRegistration : NSObject
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRenderResult.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRenderResult.h
@@ -8,7 +8,13 @@
 @class ACRView;
 @class ACRRenderer;
 
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACRViewController.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACRViewController.h>
+#endif
 #import <Foundation/Foundation.h>
 
 @interface ACRRenderResult : NSObject

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRenderer.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRenderer.h
@@ -5,9 +5,15 @@
 //  Copyright © 2017 Microsoft. All rights reserved.
 //
 
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
+#import "ACRRenderResult.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACRRenderResult.h>
+#endif
 #import "ACOAdaptiveCard.h"
 #import "ACOHostConfig.h"
-#import "ACRRenderResult.h"
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTableCellRenderer.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTableCellRenderer.h
@@ -5,7 +5,13 @@
 //  Copyright © 2021 Microsoft. All rights reserved.
 //
 
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACRContainerRenderer.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACRContainerRenderer.h>
+#endif
 
 @interface ACRTableCellRenderer : ACRContainerRenderer
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTableRow.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTableRow.h
@@ -5,8 +5,15 @@
 //  Copyright © 2021 Microsoft. All rights reserved.
 //
 
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACRContentStackView.h"
 #import "ACREnums.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACRContentStackView.h>
+#import <AdaptiveCards/ACREnums.h>
+#endif
 
 #import <UIKit/UIKit.h>
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTapGestureRecognizerFactory.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTapGestureRecognizerFactory.h
@@ -4,8 +4,15 @@
 //
 //  Copyright © 2018 Microsoft. All rights reserved.
 //
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACRBaseTarget.h"
 #import "ACRIContentHoldingView.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACRBaseTarget.h>
+#import <AdaptiveCards/ACRIContentHoldingView.h>
+#endif
 #import "ACRTapGestureRecognizerEventHandler.h"
 #import "ACRView.h"
 #import <Foundation/Foundation.h>

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRViewController.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRViewController.h
@@ -5,10 +5,17 @@
 //  Copyright © 2017 Microsoft. All rights reserved.
 //
 
-#import "ACOAdaptiveCard.h"
-#import "ACOHostConfig.h"
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACOWarning.h"
 #import "ACRActionDelegate.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACOWarning.h>
+#import <AdaptiveCards/ACRActionDelegate.h>
+#endif
+#import "ACOAdaptiveCard.h"
+#import "ACOHostConfig.h"
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/AdaptiveCards.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/AdaptiveCards.h
@@ -12,6 +12,8 @@ FOUNDATION_EXPORT double AdaptiveCardsFrameworkVersionNumber;
 
 //! Project version string for AFramework.
 FOUNDATION_EXPORT const unsigned char AdaptiveCarsFrameworkVersionString[];
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACOActionOverflow.h"
 #import "ACOAdaptiveCard.h"
 #import "ACOAdaptiveCardParseResult.h"
@@ -76,3 +78,70 @@ FOUNDATION_EXPORT const unsigned char AdaptiveCarsFrameworkVersionString[];
 #import "ACRTextView.h"
 #import "ACRToggleInputView.h"
 #import "ACRView.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACROverflowTarget.h>
+#import <AdaptiveCards/ACRAggregateTarget.h>
+#import <AdaptiveCards/ACOActionOverflow.h>
+#import <AdaptiveCards/ACOAdaptiveCard.h>
+#import <AdaptiveCards/ACOAdaptiveCardParseResult.h>
+#import <AdaptiveCards/ACOBaseCardElement.h>
+#import <AdaptiveCards/ACOEnums.h>
+#import <AdaptiveCards/ACOHostConfig.h>
+#import <AdaptiveCards/ACOHostConfigParseResult.h>
+#import <AdaptiveCards/ACOIResourceResolver.h>
+#import <AdaptiveCards/ACOInputResults.h>
+#import <AdaptiveCards/ACOMediaEvent.h>
+#import <AdaptiveCards/ACORemoteResourceInformation.h>
+#import <AdaptiveCards/ACORenderContext.h>
+#import <AdaptiveCards/ACOResourceResolvers.h>
+#import <AdaptiveCards/ACRActionDelegate.h>
+#import <AdaptiveCards/ACRActionOpenURLRenderer.h>
+#import <AdaptiveCards/ACRActionSetRenderer.h>
+#import <AdaptiveCards/ACRActionShowCardRenderer.h>
+#import <AdaptiveCards/ACRActionSubmitRenderer.h>
+#import <AdaptiveCards/ACRBaseActionElementRenderer.h>
+#import <AdaptiveCards/ACRBaseCardElementRenderer.h>
+#import <AdaptiveCards/ACRBaseTarget.h>
+#import <AdaptiveCards/ACRButton.h>
+#import <AdaptiveCards/ACRChoiceSetCompactStyleView.h>
+#import <AdaptiveCards/ACRColumnRenderer.h>
+#import <AdaptiveCards/ACRColumnSetRenderer.h>
+#import <AdaptiveCards/ACRContainerRenderer.h>
+#import <AdaptiveCards/ACRContentHoldingUIView.h>
+#import <AdaptiveCards/ACRErrors.h>
+#import <AdaptiveCards/ACRFactSetRenderer.h>
+#import <AdaptiveCards/ACRIBaseActionElementRenderer.h>
+#import <AdaptiveCards/ACRIBaseCardElementRenderer.h>
+#import <AdaptiveCards/ACRIBaseInputHandler.h>
+#import <AdaptiveCards/ACRIMedia.h>
+#import <AdaptiveCards/ACRImageProperties.h>
+#import <AdaptiveCards/ACRImageRenderer.h>
+#import <AdaptiveCards/ACRImageSetRenderer.h>
+#import <AdaptiveCards/ACRInputChoiceSetRenderer.h>
+#import <AdaptiveCards/ACRInputDateRenderer.h>
+#import <AdaptiveCards/ACRInputLabelView.h>
+#import <AdaptiveCards/ACRInputNumberRenderer.h>
+#import <AdaptiveCards/ACRInputRenderer.h>
+#import <AdaptiveCards/ACRInputTimeRenderer.h>
+#import <AdaptiveCards/ACRInputToggleRenderer.h>
+#import <AdaptiveCards/ACRMediaRenderer.h>
+#import <AdaptiveCards/ACRMediaTarget.h>
+#import <AdaptiveCards/ACRParseWarning.h>
+#import <AdaptiveCards/ACRRegistration.h>
+#import <AdaptiveCards/ACRRenderResult.h>
+#import <AdaptiveCards/ACRRenderer.h>
+#import <AdaptiveCards/ACRRichTextBlockRenderer.h>
+#import <AdaptiveCards/ACRTableCellRenderer.h>
+#import <AdaptiveCards/ACRTableRenderer.h>
+#import <AdaptiveCards/ACRTableRow.h>
+#import <AdaptiveCards/ACRTableView.h>
+#import <AdaptiveCards/ACRTapGestureRecognizerEventHandler.h>
+#import <AdaptiveCards/ACRTapGestureRecognizerFactory.h>
+#import <AdaptiveCards/ACRTextBlockRenderer.h>
+#import <AdaptiveCards/ACRTextInputHandler.h>
+#import <AdaptiveCards/ACRTextView.h>
+#import <AdaptiveCards/ACRToggleInputView.h>
+#import <AdaptiveCards/ACRView.h>
+
+#endif

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/AdaptiveCards.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/AdaptiveCards.h
@@ -80,8 +80,6 @@ FOUNDATION_EXPORT const unsigned char AdaptiveCarsFrameworkVersionString[];
 #import "ACRView.h"
 #else
 /// Cocoapods Imports
-#import <AdaptiveCards/ACROverflowTarget.h>
-#import <AdaptiveCards/ACRAggregateTarget.h>
 #import <AdaptiveCards/ACOActionOverflow.h>
 #import <AdaptiveCards/ACOAdaptiveCard.h>
 #import <AdaptiveCards/ACOAdaptiveCardParseResult.h>
@@ -100,6 +98,7 @@ FOUNDATION_EXPORT const unsigned char AdaptiveCarsFrameworkVersionString[];
 #import <AdaptiveCards/ACRActionSetRenderer.h>
 #import <AdaptiveCards/ACRActionShowCardRenderer.h>
 #import <AdaptiveCards/ACRActionSubmitRenderer.h>
+#import <AdaptiveCards/ACRAggregateTarget.h>
 #import <AdaptiveCards/ACRBaseActionElementRenderer.h>
 #import <AdaptiveCards/ACRBaseCardElementRenderer.h>
 #import <AdaptiveCards/ACRBaseTarget.h>
@@ -127,6 +126,7 @@ FOUNDATION_EXPORT const unsigned char AdaptiveCarsFrameworkVersionString[];
 #import <AdaptiveCards/ACRInputToggleRenderer.h>
 #import <AdaptiveCards/ACRMediaRenderer.h>
 #import <AdaptiveCards/ACRMediaTarget.h>
+#import <AdaptiveCards/ACROverflowTarget.h>
 #import <AdaptiveCards/ACRParseWarning.h>
 #import <AdaptiveCards/ACRRegistration.h>
 #import <AdaptiveCards/ACRRenderResult.h>

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACOActionOverflowPrivate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACOActionOverflowPrivate.h
@@ -5,8 +5,15 @@
 //  Copyright © 2021 Microsoft. All rights reserved.
 //
 
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACOBaseActionElement.h"
 #import "BaseActionElement.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACOBaseActionElement.h>
+#import <AdaptiveCards/BaseActionElement.h>
+#endif
 #import <Foundation/Foundation.h>
 
 using namespace AdaptiveCards;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACOAdaptiveCardPrivate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACOAdaptiveCardPrivate.h
@@ -5,8 +5,15 @@
 //  Copyright © 2018 Microsoft. All rights reserved.
 //
 
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACOAdaptiveCard.h"
 #import "SharedAdaptiveCard.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACOAdaptiveCard.h>
+#import <AdaptiveCards/SharedAdaptiveCard.h>
+#endif
 using namespace AdaptiveCards;
 
 @interface ACOAdaptiveCard ()

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACOAuthCardButtonPrivate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACOAuthCardButtonPrivate.h
@@ -5,8 +5,15 @@
 //  Copyright © 2021 Microsoft. All rights reserved.
 //
 
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACOAuthCardButton.h"
 #import "AuthCardButton.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACOAuthCardButton.h>
+#import <AdaptiveCards/AuthCardButton.h>
+#endif
 
 using namespace AdaptiveCards;
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACOAuthenticationPrivate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACOAuthenticationPrivate.h
@@ -5,8 +5,15 @@
 //  Copyright © 2021 Microsoft. All rights reserved.
 //
 
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACOAuthentication.h"
 #import "Authentication.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACOAuthentication.h>
+#import <AdaptiveCards/Authentication.h>
+#endif
 
 using namespace AdaptiveCards;
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACOBaseActionElementPrivate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACOBaseActionElementPrivate.h
@@ -4,8 +4,15 @@
 //
 //  Copyright © 2017 Microsoft. All rights reserved.
 //
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACOBaseActionElement.h"
 #import "BaseActionElement.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACOBaseActionElement.h>
+#import <AdaptiveCards/BaseActionElement.h>
+#endif
 
 using namespace AdaptiveCards;
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACOBaseCardElementPrivate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACOBaseCardElementPrivate.h
@@ -4,8 +4,15 @@
 //
 //  Copyright © 2018 Microsoft. All rights reserved.
 //
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACOBaseCardElement.h"
 #import "BaseCardElement.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACOBaseCardElement.h>
+#import <AdaptiveCards/BaseCardElement.h>
+#endif
 
 using namespace AdaptiveCards;
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACOHostConfigPrivate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACOHostConfigPrivate.h
@@ -4,6 +4,8 @@
 //
 //  Copyright © 2017 Microsoft. All rights reserved.
 //
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACOBaseActionElement.h"
 #import "ACOBaseCardElement.h"
 #import "ACOHostConfig.h"
@@ -11,6 +13,16 @@
 #import "ACREnums.h"
 #import "HostConfig.h"
 #import "TextBlock.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACOBaseActionElement.h>
+#import <AdaptiveCards/ACOBaseCardElement.h>
+#import <AdaptiveCards/ACOHostConfig.h>
+#import <AdaptiveCards/ACORenderContext.h>
+#import <AdaptiveCards/ACREnums.h>
+#import <AdaptiveCards/HostConfig.h>
+#import <AdaptiveCards/TextBlock.h>
+#endif
 #import <UIKit/UIKit.h>
 
 using namespace AdaptiveCards;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACOParseContextPrivate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACOParseContextPrivate.h
@@ -4,8 +4,15 @@
 //
 //  Copyright © 2019 Microsoft. All rights reserved.
 //
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACOParseContext.h"
 #import "ParseContext.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACOParseContext.h>
+#import <AdaptiveCards/ParseContext.h>
+#endif
 
 using namespace AdaptiveCards;
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACORefreshPrivate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACORefreshPrivate.h
@@ -5,8 +5,15 @@
 //  Copyright © 2021 Microsoft. All rights reserved.
 //
 
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACORefresh.h"
 #import "Refresh.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACORefresh.h>
+#import <AdaptiveCards/Refresh.h>
+#endif
 
 using namespace AdaptiveCards;
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACORemoteResourceInformationPrivate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACORemoteResourceInformationPrivate.h
@@ -4,8 +4,15 @@
 //
 //  Copyright © 2018 Microsoft. All rights reserved.
 //
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACORemoteResourceInformation.h"
 #import "RemoteResourceInformation.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACORemoteResourceInformation.h>
+#import <AdaptiveCards/RemoteResourceInformation.h>
+#endif
 
 @interface ACORemoteResourceInformation ()
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACOTokenExchangeResourcePrivate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACOTokenExchangeResourcePrivate.h
@@ -5,8 +5,15 @@
 //  Copyright © 2021 Microsoft. All rights reserved.
 //
 
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACOTokenExchangeResource.h"
 #import "TokenExchangeResource.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACOTokenExchangeResource.h>
+#import <AdaptiveCards/TokenExchangeResource.h>
+#endif
 
 using namespace AdaptiveCards;
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRChoiceSetViewDataSource.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRChoiceSetViewDataSource.h
@@ -5,11 +5,21 @@
 //  Copyright © 2018 Microsoft. All rights reserved.
 //
 
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACOBaseCardElement.h"
 #import "ACRIBaseInputHandler.h"
 #import "ChoiceInput.h"
 #import "ChoiceSetInput.h"
 #import "HostConfig.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACOBaseCardElement.h>
+#import <AdaptiveCards/ACRIBaseInputHandler.h>
+#import <AdaptiveCards/ChoiceInput.h>
+#import <AdaptiveCards/ChoiceSetInput.h>
+#import <AdaptiveCards/HostConfig.h>
+#endif
 #import <UIKit/UIKit.h>
 
 extern NSString *checkedCheckboxReuseID;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRChoiceSetViewDataSourceCompactStyle.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRChoiceSetViewDataSourceCompactStyle.h
@@ -5,11 +5,21 @@
 //  Copyright © 2018 Microsoft. All rights reserved.
 //
 
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACRIBaseInputHandler.h"
 #import "ACRView.h"
 #import "ChoiceInput.h"
 #import "ChoiceSetInput.h"
 #import "HostConfig.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACRIBaseInputHandler.h>
+#import <AdaptiveCards/ACRView.h>
+#import <AdaptiveCards/ChoiceInput.h>
+#import <AdaptiveCards/ChoiceSetInput.h>
+#import <AdaptiveCards/HostConfig.h>
+#endif
 #import <UIKit/UIKit.h>
 
 @interface ACRChoiceSetViewDataSourceCompactStyle : NSObject <UITableViewDataSource, UITableViewDelegate, UIPickerViewDataSource, UIPickerViewDelegate, ACRIBaseInputHandler>

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRDateTextField.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRDateTextField.h
@@ -5,10 +5,19 @@
 //  Copyright © 2017 Microsoft. All rights reserved.
 //
 
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACRIBaseInputHandler.h"
 #import "ACRTextField.h"
 #import "BaseInputElement.h"
 #import "SharedAdaptiveCard.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACRIBaseInputHandler.h>
+#import <AdaptiveCards/ACRTextField.h>
+#import <AdaptiveCards/BaseInputElement.h>
+#import <AdaptiveCards/SharedAdaptiveCard.h>
+#endif
 #import <UIKit/UIKit.h>
 
 @interface ACRDateTextField : ACRTextField <ACRIBaseInputHandler>

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRImageSetUICollectionView.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRImageSetUICollectionView.h
@@ -5,10 +5,19 @@
 //
 //  Copyright © 2017 Microsoft. All rights reserved.
 //
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACRView.h"
 #import "HostConfig.h"
 #import "ImageSet.h"
 #import "SharedAdaptiveCard.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACRView.h>
+#import <AdaptiveCards/HostConfig.h>
+#import <AdaptiveCards/ImageSet.h>
+#import <AdaptiveCards/SharedAdaptiveCard.h>
+#endif
 #import <UIKit/UIKit.h>
 
 @interface ACRImageSetUICollectionView : UICollectionView <UICollectionViewDataSource, UICollectionViewDelegateFlowLayout>

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRInputLabelViewPrivate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRInputLabelViewPrivate.h
@@ -6,10 +6,19 @@
 //
 //
 
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACRInputLabelView.h"
 #import "ACRView.h"
 #import "BaseInputElement.h"
 #import "SharedAdaptiveCard.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACRInputLabelView.h>
+#import <AdaptiveCards/BaseInputElement.h>
+#import <AdaptiveCards/SharedAdaptiveCard.h>
+#import <AdaptiveCards/ACRView.h>
+#endif
 
 using namespace AdaptiveCards;
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRInputLabelViewPrivate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRInputLabelViewPrivate.h
@@ -15,9 +15,9 @@
 #else
 /// Cocoapods Imports
 #import <AdaptiveCards/ACRInputLabelView.h>
+#import <AdaptiveCards/ACRView.h>
 #import <AdaptiveCards/BaseInputElement.h>
 #import <AdaptiveCards/SharedAdaptiveCard.h>
-#import <AdaptiveCards/ACRView.h>
 #endif
 
 using namespace AdaptiveCards;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRParseWarningPrivate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRParseWarningPrivate.h
@@ -5,8 +5,15 @@
 //  Copyright © 2018 Microsoft. All rights reserved.
 //
 
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACRParseWarning.h"
 #import "AdaptiveCardParseWarning.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACRParseWarning.h>
+#import <AdaptiveCards/AdaptiveCardParseWarning.h>
+#endif
 #import <Foundation/Foundation.h>
 
 @interface ACRParseWarning ()

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRRegistrationPrivate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRRegistrationPrivate.h
@@ -1,5 +1,12 @@
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACRRegistration.h"
 #import "FeatureRegistration.h"
+#else
+/// Cocoapods Imports
+#include <AdaptiveCards/ACRRegistration.h>
+#include <AdaptiveCards/FeatureRegistration.h>
+#endif
 
 using namespace AdaptiveCards;
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRRendererPrivate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRRendererPrivate.h
@@ -6,12 +6,23 @@
 //
 //
 
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACRBaseCardElementRenderer.h"
 #import "ACRIContentHoldingView.h"
 #import "ACRRenderer.h"
 #import "BackgroundImage.h"
 #import "HostConfig.h"
 #import "SharedAdaptiveCard.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACRBaseCardElementRenderer.h>
+#import <AdaptiveCards/ACRIContentHoldingView.h>
+#import <AdaptiveCards/ACRRenderer.h>
+#import <AdaptiveCards/BackgroundImage.h>
+#import <AdaptiveCards/HostConfig.h>
+#import <AdaptiveCards/SharedAdaptiveCard.h>
+#endif
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRSeparator.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRSeparator.h
@@ -4,10 +4,19 @@
 //
 //  Copyright © 2017 Microsoft. All rights reserved.
 //
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACRContentStackView.h"
 #import "ACRIContentHoldingView.h"
 #import "HostConfig.h"
 #import "SharedAdaptiveCard.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACRContentStackView.h>
+#import <AdaptiveCards/ACRIContentHoldingView.h>
+#import <AdaptiveCards/HostConfig.h>
+#import <AdaptiveCards/SharedAdaptiveCard.h>
+#endif
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRShowCardTarget.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRShowCardTarget.h
@@ -5,11 +5,21 @@
 //  Copyright © 2017 Microsoft. All rights reserved.
 //
 
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACRBaseTarget.h"
 #import "ACRIContentHoldingView.h"
 #import "ACRView.h"
 #import "SharedAdaptiveCard.h"
 #import "ShowCardAction.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACRBaseTarget.h>
+#import <AdaptiveCards/ACRIContentHoldingView.h>
+#import <AdaptiveCards/ACRView.h>
+#import <AdaptiveCards/SharedAdaptiveCard.h>
+#import <AdaptiveCards/ShowCardAction.h>
+#endif
 #import <UIKit/UIKit.h>
 
 @interface ACRShowCardTarget : ACRBaseTarget

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRTableCellView.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRTableCellView.h
@@ -5,8 +5,15 @@
 //  Copyright © 2021 Microsoft. All rights reserved.
 //
 
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACRContentStackView.h"
 #import "ACRView.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACRContentStackView.h>
+#import <AdaptiveCards/ACRView.h>
+#endif
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRTargetBuilderDirector.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRTargetBuilderDirector.h
@@ -5,9 +5,17 @@
 //  Copyright © 2019 Microsoft. All rights reserved.
 //
 
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACOBaseActionElementPrivate.h"
 #import "ACRTargetBuilder.h"
 #import "ACRView.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACOBaseActionElementPrivate.h>
+#import <AdaptiveCards/ACRView.h>
+#import <AdaptiveCards/ACRTargetBuilder.h>
+#endif
 #import <Foundation/Foundation.h>
 
 // protocol all TargetBuild should implement

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRTargetBuilderDirector.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRTargetBuilderDirector.h
@@ -13,8 +13,8 @@
 #else
 /// Cocoapods Imports
 #import <AdaptiveCards/ACOBaseActionElementPrivate.h>
-#import <AdaptiveCards/ACRView.h>
 #import <AdaptiveCards/ACRTargetBuilder.h>
+#import <AdaptiveCards/ACRView.h>
 #endif
 #import <Foundation/Foundation.h>
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRToggleInputDataSource.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRToggleInputDataSource.h
@@ -5,12 +5,23 @@
 //  Copyright © 2018 Microsoft. All rights reserved.
 //
 
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACOBaseCardElement.h"
 #import "ACRColumnSetView.h"
 #import "ACRIBaseCardElementRenderer.h"
 #import "ACRIBaseInputHandler.h"
 #import "HostConfig.h"
 #import "ToggleInput.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACOBaseCardElement.h>
+#import <AdaptiveCards/ACRColumnSetView.h>
+#import <AdaptiveCards/ACRIBaseCardElementRenderer.h>
+#import <AdaptiveCards/ACRIBaseInputHandler.h>
+#import <AdaptiveCards/HostConfig.h>
+#import <AdaptiveCards/ToggleInput.h>
+#endif
 
 @interface ACRToggleInputDataSource : NSObject <ACRIBaseInputHandler>
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRToggleVisibilityTarget.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRToggleVisibilityTarget.h
@@ -5,10 +5,19 @@
 //  Copyright © 2018 Microsoft. All rights reserved.
 //
 
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACRBaseTarget.h"
 #import "ACRIContentHoldingView.h"
 #import "ACRView.h"
 #import "ToggleVisibilityAction.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACRBaseTarget.h>
+#import <AdaptiveCards/ACRIContentHoldingView.h>
+#import <AdaptiveCards/ACRView.h>
+#import <AdaptiveCards/ToggleVisibilityAction.h>
+#endif
 
 #import <UIKit/UIKit.h>
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRTypeaheadSearchViewControllerPrivate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRTypeaheadSearchViewControllerPrivate.h
@@ -5,8 +5,9 @@
 //  Copyright © 2023 Microsoft. All rights reserved.
 //
 
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACOTypeaheadDebouncer.h"
-#import "ACOTypeaheadDynamicChoicesService.h"
 #import "ACOTypeaheadSearchHandler.h"
 #import "ACRChoiceSetCompactStyleView.h"
 #import "ACRChoiceSetFilteredStyleView.h"
@@ -14,6 +15,18 @@
 #import "ACRView.h"
 #import "BaseCardElement.h"
 #import "HostConfig.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACOTypeaheadDebouncer.h>
+#import <AdaptiveCards/ACOTypeaheadSearchHandler.h>
+#import <AdaptiveCards/ACRChoiceSetCompactStyleView.h>
+#import <AdaptiveCards/ACRChoiceSetFilteredStyleView.h>
+#import <AdaptiveCards/ACRTypeaheadSearchParameters.h>
+#import <AdaptiveCards/ACRView.h>
+#import <AdaptiveCards/BaseCardElement.h>
+#import <AdaptiveCards/HostConfig.h>
+#endif
+#import "ACOTypeaheadDynamicChoicesService.h"
 #import <UIKit/UIKit.h>
 
 @interface ACRTypeaheadSearchViewController : UIViewController <UISearchBarDelegate, UITableViewDelegate, UITableViewDataSource, ACRTypeaheadSearchProtocol>

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRViewPrivate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRViewPrivate.h
@@ -20,16 +20,16 @@
 #import "StyledCollectionElement.h"
 #else
 /// Cocoapods Imports
-#import <AdaptiveCards/ACRErrors.h>
 #import <AdaptiveCards/ACOInputResults.h>
+#import <AdaptiveCards/ACRErrors.h>
+#import <AdaptiveCards/ACRRegistration.h>
 #import <AdaptiveCards/ACRTargetBuilderDirector.h>
 #import <AdaptiveCards/ACRView.h>
 #import <AdaptiveCards/ActionParserRegistration.h>
 #import <AdaptiveCards/BackgroundImage.h>
-#import <AdaptiveCards/StyledCollectionElement.h>
 #import <AdaptiveCards/Image.h>
 #import <AdaptiveCards/SharedAdaptiveCard.h>
-#import <AdaptiveCards/ACRRegistration.h>
+#import <AdaptiveCards/StyledCollectionElement.h>
 #endif
 
 using namespace AdaptiveCards;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRViewPrivate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRViewPrivate.h
@@ -6,6 +6,8 @@
 //
 //
 
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACOInputResults.h"
 #import "ACRErrors.h"
 #import "ACRRegistration.h"
@@ -16,6 +18,19 @@
 #import "Image.h"
 #import "SharedAdaptiveCard.h"
 #import "StyledCollectionElement.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACRErrors.h>
+#import <AdaptiveCards/ACOInputResults.h>
+#import <AdaptiveCards/ACRTargetBuilderDirector.h>
+#import <AdaptiveCards/ACRView.h>
+#import <AdaptiveCards/ActionParserRegistration.h>
+#import <AdaptiveCards/BackgroundImage.h>
+#import <AdaptiveCards/StyledCollectionElement.h>
+#import <AdaptiveCards/Image.h>
+#import <AdaptiveCards/SharedAdaptiveCard.h>
+#import <AdaptiveCards/ACRRegistration.h>
+#endif
 
 using namespace AdaptiveCards;
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/UtiliOS.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/UtiliOS.h
@@ -4,6 +4,8 @@
 //  Copyfight © 2021 Microsoft. All rights reserved.
 //
 
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACORenderContext.h"
 #import "ACOVisibilityManager.h"
 #import "ACRErrors.h"
@@ -16,6 +18,22 @@
 #import "TextBlock.h"
 #import "TextRun.h"
 #import "UnknownAction.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACORenderContext.h>
+#import <AdaptiveCards/ACOVisibilityManager.h>
+#import <AdaptiveCards/ACRErrors.h>
+#import <AdaptiveCards/ACRIBaseCardElementRenderer.h>
+#import <AdaptiveCards/ACRSeparator.h>
+#import <AdaptiveCards/ACRViewPrivate.h>
+#import <AdaptiveCards/BaseCardElement.h>
+#import <AdaptiveCards/RichTextElementProperties.h>
+#import <AdaptiveCards/StyledCollectionElement.h>
+#import <AdaptiveCards/TextBlock.h>
+#import <AdaptiveCards/TextRun.h>
+#import <AdaptiveCards/UnknownAction.h>
+
+#endif
 #import <UIKit/UIKit.h>
 
 using namespace AdaptiveCards;


### PR DESCRIPTION
# Related Issue

When 2.9.0 pod is integrated, missing header files issues appears. The root cause of this was a side effect of header changes for SwiftPackageManager support.

# Fix

To mitigate this issue, the headers include for SPM and CocoaPods were handled separately using preprocessor if-else.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8604)