### PR TITLE
Separate CocoaPods imports for MediaEventPrivate header.

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACOMediaEventPrivate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACOMediaEventPrivate.h
@@ -5,10 +5,19 @@
 //  Copyright © 2018 Microsoft. All rights reserved.
 //
 
+#ifdef SWIFT_PACKAGE
+/// Swift Package Imports
 #import "ACOMediaEvent.h"
 #import "Media.h"
 #import "MediaSource.h"
 #import "SharedAdaptiveCard.h"
+#else
+/// Cocoapods Imports
+#import <AdaptiveCards/ACOMediaEvent.h>
+#import <AdaptiveCards/Media.h>
+#import <AdaptiveCards/MediaSource.h>
+#import <AdaptiveCards/SharedAdaptiveCard.h>
+#endif
 #import <Foundation/Foundation.h>
 
 using namespace AdaptiveCards;


### PR DESCRIPTION
# Related Issue

This prevent the missing header issue for MediaEventPrivate
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8608)