### PR TITLE
Fix #8581 - WPF crash on clicking container with select action

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/Helpers/SelectActionHelper.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/Helpers/SelectActionHelper.cs
@@ -20,6 +20,11 @@ namespace AdaptiveCards.Rendering.Wpf
                     return uiElement;
                 }
 
+                if (selectAction is AdaptiveSubmitAction || selectAction is AdaptiveExecuteAction)
+                {
+                    context.SubmitActionCardId[selectAction] = context.RenderArgs.ContainerCardId;
+                }
+
                 context.IsRenderingSelectAction = true;
                 var uiButton = (Button) context.Render(selectAction);
                 context.IsRenderingSelectAction = false;


### PR DESCRIPTION
Fixes #8581

# Description

The RenderContext was crashing on validating inputs because Submit/Execute SelectActions were not registered in the SubmitActionCardId dictionary.

# Sample Card
Here's a card with the previously crashing SelectActions.

```
{
    "type": "AdaptiveCard",
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
    "version": "1.5",
    "body": [
        {
            "type": "Container",
            "style": "accent",
            "selectAction": {
                "type": "Action.Submit",
                "id": "option1",
                "title": "option1"
            },
            "items": [
                {
                    "type": "TextBlock",
                    "text": "Option 1",
                    "wrap": true
                }
            ]
        },
        {
            "type": "Container",
            "items": [
                {
                    "type": "TextBlock",
                    "text": "Option 2",
                    "wrap": true
                }
            ],
            "style": "good",
            "selectAction": {
                "type": "Action.Execute",
                "id": "option2"
            }
        },
        {
            "type": "ColumnSet",
            "columns": [
                {
                    "type": "Column",
                    "width": "stretch",
                    "items": [
                        {
                            "type": "TextBlock",
                            "text": "Column 1",
                            "wrap": true
                        }
                    ],
                    "selectAction": {
                        "type": "Action.Submit"
                    }
                },
                {
                    "type": "Column",
                    "width": "stretch",
                    "items": [
                        {
                            "type": "TextBlock",
                            "text": "Column 2",
                            "wrap": true
                        }
                    ],
                    "selectAction": {
                        "type": "Action.Execute"
                    }
                }
            ]
        },
        {
            "type": "ActionSet",
            "actions": [
                {
                    "type": "Action.Submit",
                    "title": "Cancel"
                }
            ]
        }
    ]
}
```

# How Verified

Verified that renderer no longer crashes when you click containers and columns with Visualizer.
