### PR TITLE
[Designer] Add alerts for narrator

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/adaptivecards-designer.css
+++ b/source/nodejs/adaptivecards-designer/src/adaptivecards-designer.css
@@ -1718,3 +1718,16 @@ a.default-ac-anchor:visited:active {
         visibility: hidden;
     }
 }
+
+.screen-reader-only {
+    border: 0;
+    clip: rect(0,0,0,0);
+    clip-path: inset(50%);
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+}

--- a/source/nodejs/adaptivecards-designer/src/card-designer.ts
+++ b/source/nodejs/adaptivecards-designer/src/card-designer.ts
@@ -1525,7 +1525,11 @@ export class CardDesigner extends Designer.DesignContext {
                     text: (trigger) => JSON.stringify(this.getBoundCard(), null, 4)
                 })
                 .on("error", () => this._copyJSONButton.renderedElement.focus())
-                .on("success", () => this._copyJSONButton.renderedElement.focus());
+                .on("success", () => {
+                    this._copyJSONButton.renderedElement.focus()
+
+                    this.toolbar.addAlert("Card payload copied");
+                });
         }
 
         // Tool palette panel

--- a/source/nodejs/adaptivecards-designer/src/toolbar.ts
+++ b/source/nodejs/adaptivecards-designer/src/toolbar.ts
@@ -399,8 +399,6 @@ export class Toolbar {
 
         this._alertPanel = document.createElement("div");
         this._alertPanel.className = "screen-reader-only";
-        this._alertPanel.setAttribute("aria-live", "polite");
-
         this._attachedTo.appendChild(this._alertPanel);
     }
 
@@ -449,6 +447,7 @@ export class Toolbar {
     addAlert(alertText: string) {
         var alert = document.createElement('div');
         alert.innerHTML = alertText;
+        alert.setAttribute("aria-live", "polite");
         this._alertPanel.appendChild(alert);
     }
 }

--- a/source/nodejs/adaptivecards-designer/src/toolbar.ts
+++ b/source/nodejs/adaptivecards-designer/src/toolbar.ts
@@ -334,6 +334,7 @@ export class ToolbarChoicePicker extends ToolbarElement {
 export class Toolbar {
     private _elements: Array<ToolbarElement> = [];
     private _attachedTo: HTMLElement;
+    private _alertPanel: HTMLDivElement;
 
     private createSeparatorElement(): HTMLElement {
         let separatorElement = document.createElement("div");
@@ -395,6 +396,12 @@ export class Toolbar {
 
         this._attachedTo.appendChild(leftContainer);
         this._attachedTo.appendChild(rightContainer);
+
+        this._alertPanel = document.createElement("div");
+        this._alertPanel.className = "screen-reader-only";
+        this._alertPanel.setAttribute("aria-live", "polite");
+
+        this._attachedTo.appendChild(this._alertPanel);
     }
 
     addElement(element: ToolbarElement) {
@@ -437,5 +444,11 @@ export class Toolbar {
         // Insert as first element if no element was found with the
         // specified id
         this._elements.splice(0, 0, element);
+    }
+
+    addAlert(alertText: string) {
+        var alert = document.createElement('div');
+        alert.innerHTML = alertText;
+        this._alertPanel.appendChild(alert);
     }
 }


### PR DESCRIPTION
# Related Issue

Fixes #8361 

# Description

Narrator needs to announce when a card payload is copied. The following changes were made:
- Add a css class `screen-reader-only` that hides the elements visually, but are still picked up by the screen reader. CSS adopted from: https://www.a11yproject.com/posts/how-to-hide-content/
- Add a `div` to the main toolbar to hold narrator alerts. Ensure that alerts are announced via `aria-live`
- When a card payload is successfully copied, add an alert to the pane

# Sample Card

N/A - test with the generated site

# How Verified

Verified manually on the adaptive cards site. Verified with Narrator on Edge and Chrome. Did not work on firefox.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8617)