### PR TITLE
[Website] Custom table generator to include aria-label

### DIFF
--- a/source/ios/tools/AdaptiveCards.podspec
+++ b/source/ios/tools/AdaptiveCards.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name             = 'AdaptiveCards'
 
-  spec.version          = '2.9.0'
+  spec.version          = '2.9.1'
 
   spec.license          = { :type => 'Adaptive Cards Binary EULA', :file => 'source/EULA-Non-Windows.txt' } 
 
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
 
   spec.summary          = 'Adaptive Cards are a new way for developers to exchange card content in a common and consistent way'
   
-  spec.source       = { :git => 'https://github.com/microsoft/AdaptiveCards.git', :tag => 'ios-v2.9.0' }
+  spec.source       = { :git => 'https://github.com/microsoft/AdaptiveCards.git', :tag => 'ios-v2.9.1' }
 
   spec.default_subspecs = 'AdaptiveCardsCore', 'AdaptiveCardsPrivate', 'ObjectModel', 'UIProviders'
 

--- a/source/nodejs/ac-typed-schema/src/markdown/generate-markdown.ts
+++ b/source/nodejs/ac-typed-schema/src/markdown/generate-markdown.ts
@@ -175,7 +175,7 @@ function createTable(formattedProperties: any[], title: string) {
 	// It is then removed from the header.
 	var firstValue = headerRow[0];
 	if (firstValue) {
-		headerRow[0] = `{${title}}` + firstValue;
+		headerRow[0] = `<!-- TableTitle: ${title} -->` + firstValue;
 	}
 
 	tableData.push(headerRow);

--- a/source/nodejs/ac-typed-schema/src/markdown/generate-markdown.ts
+++ b/source/nodejs/ac-typed-schema/src/markdown/generate-markdown.ts
@@ -170,7 +170,7 @@ function createTable(formattedProperties: any[], title: string) {
 	}
 
 	// Used for custom table rendering.
-	// We append the table title (wrapped in braces) to the first cell in the header,
+	// We append the table title to the first cell in the header,
 	// and the table renderer will use this value for aria-label.
 	// It is then removed from the header.
 	var firstValue = headerRow[0];

--- a/source/nodejs/ac-typed-schema/src/markdown/generate-markdown.ts
+++ b/source/nodejs/ac-typed-schema/src/markdown/generate-markdown.ts
@@ -139,13 +139,13 @@ export function createPropertiesSummary(classDefinition: SchemaClass, knownTypes
 
 		// Format as markdown table
 		if (mainFormattedProperties.length > 0) {
-			md += createTable(mainFormattedProperties);
+			md += createTable(mainFormattedProperties, classDefinition.type + " Properties");
 			md += '\n';
 		}
 
 		if (inheritedFormattedProperties.length > 0) {
 			md += "\n" + __("### Inherited properties") + "\n\n";
-			md += createTable(inheritedFormattedProperties);
+			md += createTable(inheritedFormattedProperties, classDefinition.type + " Inherited properties");
 			md += "\n";
 		}
 	}
@@ -153,7 +153,7 @@ export function createPropertiesSummary(classDefinition: SchemaClass, knownTypes
 	return md;
 }
 
-function createTable(formattedProperties: any[]) {
+function createTable(formattedProperties: any[], title: string) {
 	// Data needs to be formatted as follows for use with markdown library
 	/*
 		table([
@@ -164,6 +164,11 @@ function createTable(formattedProperties: any[]) {
 	*/
 	var tableData = [];
 	var headerRow = [];
+
+	// Used for custom table rendering
+	// The first header row cell will be used for the title, and then removed from the table
+	headerRow.push(title);
+
 	for (let propName in formattedProperties[0]) {
 		headerRow.push(__(propName));
 	}

--- a/source/nodejs/ac-typed-schema/src/markdown/generate-markdown.ts
+++ b/source/nodejs/ac-typed-schema/src/markdown/generate-markdown.ts
@@ -165,13 +165,19 @@ function createTable(formattedProperties: any[], title: string) {
 	var tableData = [];
 	var headerRow = [];
 
-	// Used for custom table rendering
-	// The first header row cell will be used for the title, and then removed from the table
-	headerRow.push(title);
-
 	for (let propName in formattedProperties[0]) {
 		headerRow.push(__(propName));
 	}
+
+	// Used for custom table rendering.
+	// We append the table title (wrapped in braces) to the first cell in the header,
+	// and the table renderer will use this value for aria-label.
+	// It is then removed from the header.
+	var firstValue = headerRow[0];
+	if (firstValue) {
+		headerRow[0] = `{${title}}` + firstValue;
+	}
+
 	tableData.push(headerRow);
 
 	formattedProperties.forEach((formattedProperty) => {

--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/scripts/filter-table.js
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/scripts/filter-table.js
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Used for custom rendering of the table element
+// We assume that the first header row cell contains the title of the table
+// We then remove the cell from the table html
+hexo.extend.filter.register('marked:renderer', function(renderer) {
+  renderer.table = function(header, body) {
+
+    // Example header string:
+    // <tr>
+    // <th>{Title here}</th>
+    // <th>Property</th>
+    // <th>Type</th>
+    // <th>Required</th>
+    // <th>Description</th>
+    // <th>Version</th>
+    // </tr>
+
+    // Index of the closing tag for the first cell
+    var closingIndex = header.indexOf("</th>");
+    // Parse for the title
+    var titleString = header.substring(9, closingIndex);
+    // Parse for the remaining header row cells
+    var remainingCells = header.substring(closingIndex + 5);
+  
+    if (body) body = `<tbody>${body}</tbody>`;
+
+    return '<table aria-label="' + titleString + '">\n'
+      + '<thead>\n'
+      + '<tr>\n'
+      + remainingCells
+      + '</thead>\n'
+      + body
+      + '</table>\n';
+  }
+})

--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/scripts/filter-table.js
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/scripts/filter-table.js
@@ -18,8 +18,8 @@ hexo.extend.filter.register('marked:renderer', function(renderer) {
 
     // Index for start of title
     var startingIndex = header.indexOf("<!-- TableTitle: ")
-    // Index for end of title (+4 for the 4 characters in the delimiter)
-    var closingIndex = header.indexOf(" -->") + 4;
+    // Index for end of title
+    var closingIndex = header.indexOf(" -->");
 
     var titleString = "";
     var updatedHeader = header;
@@ -27,12 +27,12 @@ hexo.extend.filter.register('marked:renderer', function(renderer) {
     // Only proceed if both indices are valid
     if (startingIndex !== -1 && closingIndex !== -1) {
         // Parse for the title. Should be: "<!-- TableTitle: Title -->"
-        titleString = header.substring(startingIndex, closingIndex);
+        titleString = header.substring(startingIndex, closingIndex + 4);
         // Remove delimiters
         titleString = titleString.replace("<!-- TableTitle: ", "");
         titleString = titleString.replace(" -->", "");
         // Remove the title from the header
-        updatedHeader = header.substring(0, startingIndex) + header.substring(closingIndex);
+        updatedHeader = header.substring(0, startingIndex) + header.substring(closingIndex + 4);
     }
   
     if (body) body = `<tbody>${body}</tbody>`;

--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/scripts/filter-table.js
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/scripts/filter-table.js
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 // Used for custom rendering of the table element
-// We assume that the first header row cell contains the title of the table, wrapped in braces
+// We check if the first header row cell contains the title of the table
 // We then remove the title from the first cell
 hexo.extend.filter.register('marked:renderer', function(renderer) {
   renderer.table = function(header, body) {

--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/scripts/filter-table.js
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/scripts/filter-table.js
@@ -2,34 +2,33 @@
 // Licensed under the MIT License.
 
 // Used for custom rendering of the table element
-// We assume that the first header row cell contains the title of the table
-// We then remove the cell from the table html
+// We assume that the first header row cell contains the title of the table, wrapped in braces
+// We then remove the title from the first cell
 hexo.extend.filter.register('marked:renderer', function(renderer) {
   renderer.table = function(header, body) {
 
     // Example header string:
     // <tr>
-    // <th>{Title here}</th>
-    // <th>Property</th>
+    // <th>{ActionSet Inherited properties}Property</th>
     // <th>Type</th>
     // <th>Required</th>
     // <th>Description</th>
     // <th>Version</th>
     // </tr>
 
-    // Index of the closing tag for the first cell
-    var closingIndex = header.indexOf("</th>");
+    // Index of the end of the title
+    var closingIndex = header.indexOf("}");
     // Parse for the title
-    var titleString = header.substring(9, closingIndex);
-    // Parse for the remaining header row cells
-    var remainingCells = header.substring(closingIndex + 5);
+    var titleString = header.substring(10, closingIndex);
+    // Remove the title from the header
+    var updatedHeader = header.substring(0, 9) + header.substring(closingIndex + 1);
   
     if (body) body = `<tbody>${body}</tbody>`;
 
+    // Use the title string for aria-label so that it is announced by screen readers
     return '<table aria-label="' + titleString + '">\n'
       + '<thead>\n'
-      + '<tr>\n'
-      + remainingCells
+      + updatedHeader
       + '</thead>\n'
       + body
       + '</table>\n';

--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/scripts/filter-table.js
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/scripts/filter-table.js
@@ -9,19 +9,31 @@ hexo.extend.filter.register('marked:renderer', function(renderer) {
 
     // Example header string:
     // <tr>
-    // <th>{ActionSet Inherited properties}Property</th>
+    // <th><!-- TableTitle: ActionSet Inherited properties -->Property</th>
     // <th>Type</th>
     // <th>Required</th>
     // <th>Description</th>
     // <th>Version</th>
     // </tr>
 
-    // Index of the end of the title
-    var closingIndex = header.indexOf("}");
-    // Parse for the title
-    var titleString = header.substring(10, closingIndex);
-    // Remove the title from the header
-    var updatedHeader = header.substring(0, 9) + header.substring(closingIndex + 1);
+    // Index for start of title
+    var startingIndex = header.indexOf("<!-- TableTitle: ")
+    // Index for end of title (+4 for the 4 characters in the delimiter)
+    var closingIndex = header.indexOf(" -->") + 4;
+
+    var titleString = "";
+    var updatedHeader = header;
+
+    // Only proceed if both indices are valid
+    if (startingIndex !== -1 && closingIndex !== -1) {
+        // Parse for the title. Should be: "<!-- TableTitle: Title -->"
+        titleString = header.substring(startingIndex, closingIndex);
+        // Remove delimiters
+        titleString = titleString.replace("<!-- TableTitle: ", "");
+        titleString = titleString.replace(" -->", "");
+        // Remove the title from the header
+        updatedHeader = header.substring(0, startingIndex) + header.substring(closingIndex);
+    }
   
     if (body) body = `<tbody>${body}</tbody>`;
 


### PR DESCRIPTION
# Related Issue

Fixes #8360

# Description

The markdown to html generator does not include narrator support for the table title. To fix this, we need to include a custom table renderer.

Since markdown does not contain a title element, I added the following steps to detect the table title.
- Within the first header cell, append the appropriate title wrapped in braces
- When we generate the html, parse for the title within the braces
- Remove the title from the header html before returning it

The table title is then used as the `aria-label` and is announced properly by Narrator

# Sample Card

N/A - see generated website

# How Verified

Verified manually on the AC site.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8622)