### PR TITLE
Fix min height for touch target

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/Util.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/Util.java
@@ -4,12 +4,14 @@ package io.adaptivecards.renderer;
 
 import android.content.Context;
 import android.graphics.Bitmap;
+import android.graphics.Rect;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
 import android.util.DisplayMetrics;
 import android.util.Pair;
 import android.util.TypedValue;
+import android.view.TouchDelegate;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -45,6 +47,26 @@ public final class Util {
         DisplayMetrics metrics = context.getResources().getDisplayMetrics();
         int returnVal = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, dp, metrics);
         return returnVal;
+    }
+
+    public static void expandClickArea(@NonNull View viewToIncreaseClickArea, int adjustedMinSize) {
+        // Get the hit rectangle for the button.
+        Rect delegateArea = new Rect();
+        viewToIncreaseClickArea.getHitRect(delegateArea);
+
+        // Extend the touch area to include the above and below the button to the edges of the card
+        int widthOffset = (int) ((adjustedMinSize - delegateArea.width()) / 2f);
+        int heightOffset = (int) ((adjustedMinSize - delegateArea.height()) / 2f);
+        delegateArea.left -= widthOffset;
+        delegateArea.right += widthOffset;
+        delegateArea.top -= heightOffset;
+        delegateArea.bottom += heightOffset;
+
+        // Sets the TouchDelegate on the parent view and touches within the new extended bounds are routed to button.
+        TouchDelegate touchDelegate = new TouchDelegate(delegateArea, viewToIncreaseClickArea);
+        if (viewToIncreaseClickArea.getParent() instanceof View) {
+            ((View) viewToIncreaseClickArea.getParent()).setTouchDelegate(touchDelegate);
+        }
     }
 
     public static byte[] getBytes(CharVector charVector)

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/action/ActionElementRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/action/ActionElementRenderer.java
@@ -4,7 +4,6 @@ package io.adaptivecards.renderer.action;
 
 import android.content.Context;
 import android.content.res.Resources;
-import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.text.TextUtils;
 import android.util.TypedValue;

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/action/ActionElementRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/action/ActionElementRenderer.java
@@ -4,6 +4,7 @@ package io.adaptivecards.renderer.action;
 
 import android.content.Context;
 import android.content.res.Resources;
+import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.text.TextUtils;
 import android.util.TypedValue;
@@ -142,6 +143,8 @@ public class ActionElementRenderer extends BaseActionElementRenderer
         }
 
         button.setLayoutParams(layoutParams);
+        int minHeight = context.getResources().getDimensionPixelSize(R.dimen.action_min_height);
+        button.post(() -> Util.expandClickArea(button, minHeight));
 
         String iconUrl = baseActionElement.GetIconUrl();
         if (!iconUrl.isEmpty())

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/ChoiceSetInputRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/ChoiceSetInputRenderer.java
@@ -151,6 +151,7 @@ public class ChoiceSetInputRenderer extends BaseCardElementRenderer
         {
             ChoiceInput choiceInput = choiceInputVector.get(i);
             final CheckBox checkBox = new CheckBox(context);
+            checkBox.setMinimumHeight(context.getResources().getDimensionPixelSize(R.dimen.check_box_min_height));
             checkBox.setText(choiceInput.GetTitle());
 
             if (!choiceSetInput.GetWrap())
@@ -208,6 +209,9 @@ public class ChoiceSetInputRenderer extends BaseCardElementRenderer
         {
             ChoiceInput choiceInput = choiceInputVector.get(i);
             RadioButton radioButton = new RadioButton(context);
+            ViewGroup.LayoutParams params = new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+            radioButton.setLayoutParams(params);
+            radioButton.setMinimumHeight(context.getResources().getDimensionPixelSize(R.dimen.radio_button_min_height));
             radioButton.setId(i);
 
             if(!choiceSetInput.GetWrap())

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/customcontrols/ValidatedCheckBox.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/customcontrols/ValidatedCheckBox.java
@@ -27,6 +27,7 @@ public class ValidatedCheckBox extends AppCompatCheckBox implements IValidatedIn
     {
         super(context);
         setLayoutParams(new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT));
+        setMinimumHeight(context.getResources().getDimensionPixelSize(R.dimen.check_box_min_height));
         setBackground(ContextCompat.getDrawable(context, R.drawable.adaptive_choiceset_expanded_background));
 
         m_isInvalid = false;

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/customcontrols/ValidatedSpinner.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/customcontrols/ValidatedSpinner.java
@@ -29,6 +29,7 @@ public class ValidatedSpinner extends Spinner implements IValidatedInputView
     {
         super(context);
         setLayoutParams(new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT));
+        setMinimumHeight(context.getResources().getDimensionPixelSize(R.dimen.spinner_min_height));
         m_isInvalid = false;
         verifyIfUsingCustomInputs(context);
     }

--- a/source/android/adaptivecards/src/main/res/values/dimens.xml
+++ b/source/android/adaptivecards/src/main/res/values/dimens.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="radio_button_min_height">48dp</dimen>
+    <dimen name="check_box_min_height">48dp</dimen>
+    <dimen name="text_view_min_height">48dp</dimen>
+    <dimen name="spinner_min_height">48dp</dimen>
+</resources>
+

--- a/source/android/adaptivecards/src/main/res/values/dimens.xml
+++ b/source/android/adaptivecards/src/main/res/values/dimens.xml
@@ -2,6 +2,7 @@
 <resources>
     <dimen name="radio_button_min_height">48dp</dimen>
     <dimen name="check_box_min_height">48dp</dimen>
+    <dimen name="action_min_height">48dp</dimen>
     <dimen name="spinner_min_height">48dp</dimen>
 </resources>
 

--- a/source/android/adaptivecards/src/main/res/values/dimens.xml
+++ b/source/android/adaptivecards/src/main/res/values/dimens.xml
@@ -2,7 +2,6 @@
 <resources>
     <dimen name="radio_button_min_height">48dp</dimen>
     <dimen name="check_box_min_height">48dp</dimen>
-    <dimen name="text_view_min_height">48dp</dimen>
     <dimen name="spinner_min_height">48dp</dimen>
 </resources>
 


### PR DESCRIPTION
# Related Issue

Issue: https://domoreexp.visualstudio.com/MSTeams/_workitems/edit/3026129

# Description

The touch target for **radio buttons**, **checkboxes** and **spinner** needs to be increased to 48dp as specified by the Android accessibility guidelines: https://support.google.com/accessibility/android/answer/7101858

Also the touch target's width needs to span out across the adaptive card

# Sample Card

Before:
<img src="https://github.com/microsoft/AdaptiveCards/assets/23054357/a7252029-4c0e-4693-bf64-61659ba328dc" width=180 height=380>

After: 
<img src="https://github.com/microsoft/AdaptiveCards/assets/23054357/54532672-d68f-493b-9aa5-9fc1bbde81cc" width=180 height=380>


# How Verified

Verified Locally

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/AdaptiveCards/pull/8638)