### PR TITLE
Fixed Overflow action button not announcing view chagnes

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -6644,11 +6644,13 @@ class OverflowAction extends Action {
             }
 
             contextMenu.onClose = () => {
+                this.renderedElement?.focus();
                 this.renderedElement?.setAttribute("aria-expanded", "false");
             }
 
             this.renderedElement.setAttribute("aria-expanded", "true");
             contextMenu.popup(this.renderedElement);
+            contextMenu.selectedIndex = 0;
         }
     }
     

--- a/source/nodejs/adaptivecards/src/controls/menu-item.ts
+++ b/source/nodejs/adaptivecards/src/controls/menu-item.ts
@@ -63,8 +63,8 @@ export class MenuItem {
             };
             this._element.onkeydown = (e) => {
                 if (e.key === Constants.keys.enter) {
-                    e.cancelBubble = true;
-
+                    e.stopPropagation();
+                    e.preventDefault();
                     this.click();
                 }
             };

--- a/source/nodejs/adaptivecards/src/controls/popup-menu.ts
+++ b/source/nodejs/adaptivecards/src/controls/popup-menu.ts
@@ -21,6 +21,11 @@ export class PopupMenu extends PopupControl {
 
             element.appendChild(renderedItem);
 
+            if (i == 0)
+            {
+                renderedItem.setAttribute("aria-expanded", "true");
+            }
+
             if (i === this.selectedIndex) {
                 renderedItem.focus();
             }
@@ -63,6 +68,7 @@ export class PopupMenu extends PopupControl {
                 }
 
                 this.selectedIndex = selectedItemIndex;
+                this.removeAriaExpanded(selectedItemIndex);
 
                 e.cancelBubble = true;
 
@@ -76,6 +82,7 @@ export class PopupMenu extends PopupControl {
                     if (selectedItemIndex >= this._renderedItems.length) {
                         selectedItemIndex = 0;
                     }
+                    this.removeAriaExpanded(selectedItemIndex);
                 }
 
                 this.selectedIndex = selectedItemIndex;
@@ -101,4 +108,14 @@ export class PopupMenu extends PopupControl {
             this._selectedIndex = index;
         }
     }
+
+    // remove aria-expanded attribute from menu item
+    private removeAriaExpanded(index: number) {
+        if (this._renderedItems[index].getAttribute("aria-expanded") === "true") {
+            this._renderedItems[index].removeAttribute("aria-expanded");
+        }
+    }
+
+
+
 }


### PR DESCRIPTION
# Related Issue
Fixed #8654.

# Description
As focus is moved to a menu overlay from a button, buttons aria-expanded state is not announced by voice over. moved the aria-expanded to menu item itself, where the focus is set. When menu item closes, have the focus to be back on the button with aria-expanded set to false. however, with keyboard navigation, when 'return' key is used to close the menu item, it will trigger click event on the button when the focus is back to the button. In order to stop such behavior, preventDefault() was used.

# Sample Card
N/A

# How Verified

Manually verified.