### PR TITLE
Remove unnecessary `aria-required` property from container element

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -3557,7 +3557,6 @@ export abstract class Input extends CardElement implements IInput {
             this._renderedInputControlElement.style.minWidth = "0px";
 
             if (this.isNullable && this.isRequired) {
-                this._renderedInputControlElement.setAttribute("aria-required", "true");
                 this._renderedInputControlElement.classList.add(
                     hostConfig.makeCssClassName("ac-input-required")
                 );


### PR DESCRIPTION
# Description

The `aria-required` attribute is only valid on elements (or elements with a role matching an element) that have a `required` HTML property. To specify `aria-required` on other elements violates WCAG rules.

# How Verified

Local build/test and Accessibility Insights verification