### PR TITLE
Add `hljs-comment` color to fix contrast

### DIFF
--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/source/css/extracted.css
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/source/css/extracted.css
@@ -684,6 +684,10 @@ screen and (min-width:768px) {
 	color: #07704a;
 }
 
+.hljs-comment {
+    color: #006400;
+}
+
 .hljs-string {
 	color: #a31515;
 }


### PR DESCRIPTION
# Description

The default `hljs-comment` color doesn't quite meet accessibility requirements, so pick a better color that does meet requirements:

old:
![image](https://github.com/microsoft/AdaptiveCards/assets/16614499/f4cf93a8-dcc2-44ec-a896-eba383c04ade)

new:
![image](https://github.com/microsoft/AdaptiveCards/assets/16614499/96ca8dc0-463b-4247-a56e-f8a74b4454e4)


# How Verified

local build/test + accinsights