### PR TITLE
Switch from textblock to label in Input.Time sample

### DIFF
--- a/samples/v1.0/Elements/Input.Time.json
+++ b/samples/v1.0/Elements/Input.Time.json
@@ -4,11 +4,8 @@
 	"version": "1.0",
 	"body": [
 		{
-			"type": "TextBlock",
-			"text": "What time do you want to meet?"
-		},
-		{
 			"type": "Input.Time",
+			"label": "What time do you want to meet?",
 			"id": "time",
 			"min": "09:00",
 			"max": "17:00",


### PR DESCRIPTION
# Description

For a11y we need to use the `label` property. This one just got missed.

# How Verified

designer