### PR TITLE
Fix site schema explorer render version

### DIFF
--- a/samples/v1.1/Elements/Column.SelectAction.json
+++ b/samples/v1.1/Elements/Column.SelectAction.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
 	"type": "AdaptiveCard",
-	"version": "1.1",
+	"version": "1.5",
 	"body": [
 		{
 			"type": "TextBlock",

--- a/samples/v1.1/Elements/ColumnSet.SelectAction.json
+++ b/samples/v1.1/Elements/ColumnSet.SelectAction.json
@@ -1,6 +1,6 @@
 {
 	"type": "AdaptiveCard",
-	"version": "1.1",
+	"version": "1.5",
 	"body": [
 		{
 			"type": "TextBlock",

--- a/samples/v1.1/Elements/Container.SelectAction.json
+++ b/samples/v1.1/Elements/Container.SelectAction.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
 	"type": "AdaptiveCard",
-	"version": "1.1",
+	"version": "1.5",
 	"body": [
 		{
 			"type": "Container",

--- a/samples/v1.2/Tests/RichTextBlock.TextRun.SelectActions.json
+++ b/samples/v1.2/Tests/RichTextBlock.TextRun.SelectActions.json
@@ -1,6 +1,6 @@
 {
 	"type": "AdaptiveCard",
-	"version": "1.2",
+	"version": "1.5",
 	"body": [
 		{
 			"type": "TextBlock",

--- a/samples/v1.3/Elements/Input.Text.InlineAction.json
+++ b/samples/v1.3/Elements/Input.Text.InlineAction.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
 	"type": "AdaptiveCard",
-	"version": "1.3",
+	"version": "1.5",
 	"body": [
 		{
 			"type": "Input.Text",

--- a/samples/v1.5/Tests/Image.SelectAction.IsEnabled.json
+++ b/samples/v1.5/Tests/Image.SelectAction.IsEnabled.json
@@ -1,7 +1,7 @@
 {
 	"type": "AdaptiveCard",
 	"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
-	"version": "1.3",
+	"version": "1.5",
 	"body": [
 		{
 			"type": "Image",


### PR DESCRIPTION
# Description

This was a pretty interesting issue to track down... the [`Input.Text`](https://adaptivecards.io/explorer/Input.Text.html) `inlineAction` example's inline submit button didn't have its tooltip applied properly. However, the sample example worked just fine in the designer.

Turns out the examples are rendering with the version specified in the sample itself. I updated all of the samples referencing `tooltip` to be at least version `1.5`.

Future reference for anyone wanting to answer a question like "what is the version of all samples with the word 'tooltip' in them", here's something useful in WSL (you'll need to have `ripgrep` and `jq` available):

```sh
# from the samples/ directory
rg --files-with-matches tooltip | xargs -I _ sh -c "echo -n '_: ' && cat _ | jq .version"
```

sample output for above:

![image](https://github.com/microsoft/AdaptiveCards/assets/16614499/b7caf93d-9421-4d06-9bcf-504670904921)

# How Verified

Local build/devtools