### PR TITLE
[Designer] Fix treeview control accessibility

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/adaptivecards-designer.css
+++ b/source/nodejs/adaptivecards-designer/src/adaptivecards-designer.css
@@ -78,6 +78,7 @@
     overflow-y: auto;
     overflow-x: hidden;
     padding-top: 6px;
+    padding-bottom: 6px;
     background-color: white;
 }
 
@@ -444,6 +445,7 @@
 
 .acd-icon-chevronDown::before {
     content: "\E70D";
+    line-height: 16px;
 }
 
 .acd-icon-chevronUp::before {
@@ -452,6 +454,7 @@
 
 .acd-icon-chevronRight::before {
     content: "\E76C";
+    line-height: 16px;
 }
 
 .acd-icon-chevronLeft::before {
@@ -848,6 +851,14 @@
 
 .acd-tree-item {
     cursor: pointer;
+}
+
+.acd-treeView li:focus-visible {
+    outline: none;
+}
+
+.acd-treeView li:focus-visible > .acd-tree-item {
+    outline: 1px solid #2D7BB7;
 }
 
 .acd-tree-item.selected {

--- a/source/nodejs/adaptivecards-designer/src/card-designer.ts
+++ b/source/nodejs/adaptivecards-designer/src/card-designer.ts
@@ -108,6 +108,18 @@ export class CardDesigner extends Designer.DesignContext {
             }
             else {
                 let treeView = new TreeView(this.designerSurface.rootPeer.treeItem);
+                treeView.onItemInvoked = () => {
+                    const propertySheetHosts = document.getElementsByClassName("acd-propertySheet-host");
+                    if (propertySheetHosts.length === 1) {
+                        const propertySheetHost = <HTMLElement>propertySheetHosts[0];
+
+                        // get focusable children
+                        const focusableElements = propertySheetHost.querySelectorAll('a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex="0"]');
+                        if (focusableElements.length > 0) {
+                            (<HTMLElement>focusableElements[0]).focus();
+                        }
+                    }
+                };
 
                 this._treeViewToolbox.content.appendChild(treeView.render());
             }

--- a/source/nodejs/adaptivecards-designer/src/field-picker.ts
+++ b/source/nodejs/adaptivecards-designer/src/field-picker.ts
@@ -17,12 +17,9 @@ export class FieldPicker extends Controls.PopupControl {
 
         this._treeView = new TreeView(treeItem);
 
-        this._treeView.onSelectedItemChanged = (sender) => {
-            this._selectedField = (this._treeView.selectedItem as DataTreeItem).field;
-
-            if (this._selectedField) {
-                this.closePopup(false);
-            }
+        this._treeView.onItemInvoked = (sender) => {
+            this._selectedField = (sender as DataTreeItem).field;
+            this.closePopup(false);
         };
 
         element.appendChild(this._treeView.render());


### PR DESCRIPTION
# Description

This was a bit of a ride. Prior to this change, the Designer's treeview control is represented in the DOM by a structure something like this: 

```html
<ul role="tree">
  <li role="treeitem">
    <div role="treeitem">some stuff</div>
  </li>
  <li role="treeitem">
    <div role="treeitem">
      <div class="expandcollapsebutton">...</div>
      <div>some more stuff</div>
    </div>
    <ul role="group">
      <li role="treeitem"><div role="treeitem">oh look! a child item!</li>
    </ul>
  </li>
</ul>
```

Unfortunately, it's not valid to have `role="treeitem"` on an element unless its parent's `role` is either `group` or `tree`. It turns out that, while eliding the `role` on the `li > div` causes a11y tooling to stop complaining, it also totally breaks keyboard navigation -- the user can't actually select an element in the tree because they can't put keyboard focus on the right element.

So I did what anyone would do and basically rewrote keyboard navigation for the treeview control. 

The old model was tab-based. Each node in the tree and each expand/collapse chevron had `tabIndex="0"`. With focus on a node in the tree, `<Tab>` effectively means "if this node has children, focus the expand/collapse chevron", otherwise focus the next nearest sibling. `<SPC>` or `<RET>` means "expand/collapse children" or "select this node" depending on what's currently in focus. Aside from not matching [a11y best practices for Treeviews](https://www.w3.org/WAI/ARIA/apg/patterns/treeview/), this approach has a number of downsides from a usability perspective:
- if the user has keyboard focus on the last of 20 `Column`s, the user must press `<S-TAB>` 20 times to put focus on the parent `ColumnSet`
- if the user has selected an element in the middle of the tree, they have to `<TAB>` or `<S-TAB>` a bunch of times to get out of the tree
- the expand/collapse chevron is always in the tabbing order even if the user never utilizes this functionality

The new model follows the aforementioned best practices:
- You can navigate using arrow keys in the way you'd expect (`<LEFT>`, `<RIGHT>`, `<UP>`, and `<DOWN>`)
- We use the [roving `tabIndex`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Keyboard-navigable_JavaScript_widgets#managing_focus_inside_groups) approach to track which tree item is selected.
  - This means that you can tab into the tree with focus landing on the last selected item, and you can change your selection and tab back out again without losing your place.
- Selection tracks focus, so you don't have to manually select which item is displaying properties.
- Pressing `<RET>` (`<ENTER>`) puts keyboard focus on the first focusable element in the selected item's properties page.

# How Verified

Local build, devtools, Accessibility Insights, Narrator
