### PR TITLE
[Designer] Add headingLevel to viva connections host config

### DIFF
--- a/samples/HostConfig/viva-connections-dark.json
+++ b/samples/HostConfig/viva-connections-dark.json
@@ -50,6 +50,9 @@
 			}
 		}
 	},
+	"textBlock": {
+		"headingLevel": 2
+	},
 	"containerStyles": {
 		"default": {
 			"backgroundColor": "#1b1a19",

--- a/samples/HostConfig/viva-connections-light.json
+++ b/samples/HostConfig/viva-connections-light.json
@@ -50,6 +50,9 @@
 			}
 		}
 	},
+	"textBlock": {
+		"headingLevel": 2
+	},
 	"containerStyles": {
 		"default": {
 			"backgroundColor": "#FFFFFF",


### PR DESCRIPTION
# Related Issue

Fixes #8714

# Description

The viva connections hosts were missing `aria-level` for textBlocks with the heading `role`. This is fixed by adding `headingLevel` to the host config.

# Sample Card

Sample card in ticket.

# How Verified

Verified manually with accessibility insights.
