### PR TITLE
[JS Actions] Update action icon role to presentation

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -5551,6 +5551,7 @@ export abstract class Action extends CardObject {
                 iconElement.style.width = hostConfig.actions.iconSize + "px";
                 iconElement.style.height = hostConfig.actions.iconSize + "px";
                 iconElement.style.flex = "0 0 auto";
+                iconElement.setAttribute("role", "presentation");
 
                 if (hostConfig.actions.iconPlacement === Enums.ActionIconPlacement.AboveTitle) {
                     this.renderedElement.classList.add("iconAbove");


### PR DESCRIPTION
# Related Issue

Fixes #8700 

# Description

Add `role` `presentation` property to action image elements. With this change, altText is no longer required.

# Sample Card

Sample card found in the issue.

# How Verified

Verified manually with accessibility insights.
