### PR TITLE
[NodeJS] Update hashing algorithm for webpack

### DIFF
--- a/source/nodejs/adaptivecards-aaf-testapp/webpack.config.js
+++ b/source/nodejs/adaptivecards-aaf-testapp/webpack.config.js
@@ -3,48 +3,48 @@ const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = (env, argv) => {
-	const mode = argv.mode || 'development';
-	const devMode = mode === "development";
+    const mode = argv.mode || 'development';
+    const devMode = mode === "development";
 
-	console.info('running webpack with mode:', mode);
+    console.info('running webpack with mode:', mode);
 
-	return {
-		mode: mode,
-		entry: {
-			"adaptivecards-aaf-testapp": "./src/app.ts",
-		},
-		output: {
-			path: path.resolve(__dirname, "dist"),
+    return {
+        mode: mode,
+        entry: {
+            "adaptivecards-aaf-testapp": "./src/app.ts",
+        },
+        output: {
+            path: path.resolve(__dirname, "dist"),
             hashFunction: "xxhash64",
-			filename: devMode ? "[name].js" : "[name].min.js",
-		},
-		resolve: {
-			extensions: [".ts", ".tsx", ".js"]
-		},
-		module: {
-			rules: [{
-					test: /\.ts$/,
-					loader: "ts-loader",
-					exclude: /(node_modules|__tests__)/
-				},
-				{
-					test: /\.css$/,
-					use: [
-						'style-loader',
-						MiniCssExtractPlugin.loader,
-						'css-loader'
-					]
-				}
-			]
-		},
-		plugins: [
+            filename: devMode ? "[name].js" : "[name].min.js",
+        },
+        resolve: {
+            extensions: [".ts", ".tsx", ".js"]
+        },
+        module: {
+            rules: [{
+                    test: /\.ts$/,
+                    loader: "ts-loader",
+                    exclude: /(node_modules|__tests__)/
+                },
+                {
+                    test: /\.css$/,
+                    use: [
+                        'style-loader',
+                        MiniCssExtractPlugin.loader,
+                        'css-loader'
+                    ]
+                }
+            ]
+        },
+        plugins: [
             new HtmlWebpackPlugin({
-				title: "AAF JavaScript Runtime test application",
-				template: "./index.html"
-			}),
+                title: "AAF JavaScript Runtime test application",
+                template: "./index.html"
+            }),
             new MiniCssExtractPlugin({
-				filename: '[name].css'
-			})
-		]
-	}
+                filename: '[name].css'
+            })
+        ]
+    }
 }

--- a/source/nodejs/adaptivecards-aaf-testapp/webpack.config.js
+++ b/source/nodejs/adaptivecards-aaf-testapp/webpack.config.js
@@ -15,6 +15,7 @@ module.exports = (env, argv) => {
 		},
 		output: {
 			path: path.resolve(__dirname, "dist"),
+            hashFunction: "xxhash64",
 			filename: devMode ? "[name].js" : "[name].min.js",
 		},
 		resolve: {

--- a/source/nodejs/adaptivecards-controls/webpack.config.js
+++ b/source/nodejs/adaptivecards-controls/webpack.config.js
@@ -3,64 +3,64 @@ const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 
 module.exports = (env, argv) => {
-	const mode = argv.mode || 'development';
-	const devMode = mode === "development";
+    const mode = argv.mode || 'development';
+    const devMode = mode === "development";
 
-	console.info('running webpack with mode:', mode);
+    console.info('running webpack with mode:', mode);
 
-	return {
-		mode: mode,
-		entry: {
-			"adaptivecards-controls": "./src/adaptivecards-controls.ts",
-		},
-		output: {
-			path: path.resolve(__dirname, "./dist"),
-			filename: devMode ? "[name].js" : "[name].min.js",
+    return {
+        mode: mode,
+        entry: {
+            "adaptivecards-controls": "./src/adaptivecards-controls.ts",
+        },
+        output: {
+            path: path.resolve(__dirname, "./dist"),
+            filename: devMode ? "[name].js" : "[name].min.js",
             hashFunction: "xxhash64",
-			libraryTarget: "umd",
-			library: "ACControls",
-			umdNamedDefine: true,
-			publicPath: "/dist/",
-			globalObject: "this"
-		},
-		devtool: devMode ? "inline-source-map" : "source-map",
-		resolve: {
-			extensions: [".ts", ".tsx", ".js"]
-		},
-		module: {
-			rules: [
-				{
-					test: /\.ts$/,
-					loader: "ts-loader",
-					exclude: /(node_modules|__tests__)/
-				},
-				{
-					test: /\.css$/,
-					use: [
-						'style-loader',
-						MiniCssExtractPlugin.loader,
-						'css-loader'
-					]
-				}
-			]
-		},
-		plugins: [
-			new MiniCssExtractPlugin({
-				filename: 'adaptivecards-controls.css',
-			}),
-			new CopyWebpackPlugin({
-				patterns: [{
-					from: 'src/adaptivecards-controls.css',
-					to: '../lib/[name][ext]'
-				},
-				{
-					from: 'src/adaptivecards-controls.css',
-					to: '../dist/[name][ext]'
-				}],
-				options: {
-				  concurrency: 8
-				}
-			})
-		]
-	};
+            libraryTarget: "umd",
+            library: "ACControls",
+            umdNamedDefine: true,
+            publicPath: "/dist/",
+            globalObject: "this"
+        },
+        devtool: devMode ? "inline-source-map" : "source-map",
+        resolve: {
+            extensions: [".ts", ".tsx", ".js"]
+        },
+        module: {
+            rules: [
+                {
+                    test: /\.ts$/,
+                    loader: "ts-loader",
+                    exclude: /(node_modules|__tests__)/
+                },
+                {
+                    test: /\.css$/,
+                    use: [
+                        'style-loader',
+                        MiniCssExtractPlugin.loader,
+                        'css-loader'
+                    ]
+                }
+            ]
+        },
+        plugins: [
+            new MiniCssExtractPlugin({
+                filename: 'adaptivecards-controls.css',
+            }),
+            new CopyWebpackPlugin({
+                patterns: [{
+                    from: 'src/adaptivecards-controls.css',
+                    to: '../lib/[name][ext]'
+                },
+                {
+                    from: 'src/adaptivecards-controls.css',
+                    to: '../dist/[name][ext]'
+                }],
+                options: {
+                  concurrency: 8
+                }
+            })
+        ]
+    };
 };

--- a/source/nodejs/adaptivecards-controls/webpack.config.js
+++ b/source/nodejs/adaptivecards-controls/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = (env, argv) => {
 		output: {
 			path: path.resolve(__dirname, "./dist"),
 			filename: devMode ? "[name].js" : "[name].min.js",
+            hashFunction: "xxhash64",
 			libraryTarget: "umd",
 			library: "ACControls",
 			umdNamedDefine: true,

--- a/source/nodejs/adaptivecards-designer-app/webpack.config.js
+++ b/source/nodejs/adaptivecards-designer-app/webpack.config.js
@@ -5,73 +5,73 @@ const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 module.exports = (env, argv) => {
-	const mode = argv.mode || 'development';
-	const devMode = mode === "development";
+    const mode = argv.mode || 'development';
+    const devMode = mode === "development";
 
-	console.info('running webpack with mode:', mode);
+    console.info('running webpack with mode:', mode);
 
-	return {
-		mode: mode,
-		entry: {
-			"adaptivecards-designer-app": "./src/app.ts",
-		},
-		output: {
-			path: path.resolve(__dirname, "dist"),
-			hashFunction: "xxhash64",
+    return {
+        mode: mode,
+        entry: {
+            "adaptivecards-designer-app": "./src/app.ts",
+        },
+        output: {
+            path: path.resolve(__dirname, "dist"),
+            hashFunction: "xxhash64",
             filename: devMode ? "[name].js" : "[name].min.js",
-		},
-		resolve: {
-			extensions: [".ts", ".tsx", ".js"]
-		},
-		module: {
-			rules: [
-				{
-					test: /\.ts$/,
-					loader: "ts-loader",
-					exclude: /(node_modules|__tests__)/
-				},
-				{
-					test: /\.ttf$/,
-					loader: "file-loader"
-				},
-				{
-					test: /\.css$/,
-					use: [
-						devMode ? 'style-loader' : MiniCssExtractPlugin.loader,
-						'css-loader'
-					]
-				},
-				{
-					test: /\.svg$/,
-					type: 'asset/resource'
-				}
-			]
-		},
-		plugins: [
-			new CopyWebpackPlugin({
-				patterns: [
-					{
-						from: 'node_modules/adaptivecards-designer/src/containers/**/*',
-						to: 'containers/[name][ext]'
-					},
-					{
-						// the designer expects to find its CSS here. an alternative for a consumer would
-						// be to make sure they load it themselves.
-						from: 'node_modules/adaptivecards-designer/dist/adaptivecards-designer.css',
-						to: 'adaptivecards-designer.css'
-					}
-				]
-			}),
-			new HtmlWebpackPlugin({
-				title: "Adaptive Cards Designer",
-				template: "./index.html"
-			}),
-			new MiniCssExtractPlugin({
-				filename: '[name].css'
-			}),
-			new MonacoWebpackPlugin({
-				languages: ['json']
-			})
-		]
-	}
+        },
+        resolve: {
+            extensions: [".ts", ".tsx", ".js"]
+        },
+        module: {
+            rules: [
+                {
+                    test: /\.ts$/,
+                    loader: "ts-loader",
+                    exclude: /(node_modules|__tests__)/
+                },
+                {
+                    test: /\.ttf$/,
+                    loader: "file-loader"
+                },
+                {
+                    test: /\.css$/,
+                    use: [
+                        devMode ? 'style-loader' : MiniCssExtractPlugin.loader,
+                        'css-loader'
+                    ]
+                },
+                {
+                    test: /\.svg$/,
+                    type: 'asset/resource'
+                }
+            ]
+        },
+        plugins: [
+            new CopyWebpackPlugin({
+                patterns: [
+                    {
+                        from: 'node_modules/adaptivecards-designer/src/containers/**/*',
+                        to: 'containers/[name][ext]'
+                    },
+                    {
+                        // the designer expects to find its CSS here. an alternative for a consumer would
+                        // be to make sure they load it themselves.
+                        from: 'node_modules/adaptivecards-designer/dist/adaptivecards-designer.css',
+                        to: 'adaptivecards-designer.css'
+                    }
+                ]
+            }),
+            new HtmlWebpackPlugin({
+                title: "Adaptive Cards Designer",
+                template: "./index.html"
+            }),
+            new MiniCssExtractPlugin({
+                filename: '[name].css'
+            }),
+            new MonacoWebpackPlugin({
+                languages: ['json']
+            })
+        ]
+    }
 }

--- a/source/nodejs/adaptivecards-designer-app/webpack.config.js
+++ b/source/nodejs/adaptivecards-designer-app/webpack.config.js
@@ -17,7 +17,8 @@ module.exports = (env, argv) => {
 		},
 		output: {
 			path: path.resolve(__dirname, "dist"),
-			filename: devMode ? "[name].js" : "[name].min.js",
+			hashFunction: "xxhash64",
+            filename: devMode ? "[name].js" : "[name].min.js",
 		},
 		resolve: {
 			extensions: [".ts", ".tsx", ".js"]

--- a/source/nodejs/adaptivecards-designer/webpack.config.js
+++ b/source/nodejs/adaptivecards-designer/webpack.config.js
@@ -6,137 +6,137 @@ const ConcatPlugin = require('webpack-concat-files-plugin');
 const Dotenv = require('dotenv-webpack');
 
 module.exports = (env, argv) => {
-	const mode = argv.mode || 'development';
-	const devMode = mode === "development";
+    const mode = argv.mode || 'development';
+    const devMode = mode === "development";
 
-	console.info('running webpack with mode:', mode);
+    console.info('running webpack with mode:', mode);
 
-	return {
-		mode: mode,
-		entry: {
-			"adaptivecards-designer": "./src/adaptivecards-designer.ts",
-			"adaptivecards-designer-standalone": "./src/adaptivecards-designer-standalone.ts"
-		},
-		output: {
-			path: path.resolve(__dirname, "./dist"),
-			filename: devMode ? "[name].js" : "[name].min.js",
+    return {
+        mode: mode,
+        entry: {
+            "adaptivecards-designer": "./src/adaptivecards-designer.ts",
+            "adaptivecards-designer-standalone": "./src/adaptivecards-designer-standalone.ts"
+        },
+        output: {
+            path: path.resolve(__dirname, "./dist"),
+            filename: devMode ? "[name].js" : "[name].min.js",
             hashFunction: "xxhash64",
-			libraryTarget: "umd",
-			library: "ACDesigner",
-			globalObject: "this"
-		},
-		devtool: devMode ? "inline-source-map" : "source-map",
-		devServer: {
-			static: './dist'
-		},
-		resolve: {
-			extensions: [".ts", ".tsx", ".js"]
-		},
-		module: {
-			rules: [
-				{
-					test: /\.ts$/,
-					loader: "ts-loader",
-					exclude: /(node_modules|__tests__)/
-				},
-				{
-					test: /\.css$/,
-					use: [
-						'style-loader',
-						MiniCssExtractPlugin.loader,
-						'css-loader'
-					]
-				},
-				{
-					test: /\.svg$/,
-					type: 'asset/inline'
-				}
-			]
-		},
-		plugins: [
-			new Dotenv(),
-			new HtmlWebpackPlugin({
-				title: "Adaptive Cards Designer (No Microsoft Hosts)",
-				template: "./noHosts.html",
-				filename: "noHosts.html",
-				chunks: ["adaptivecards-designer-standalone"]
-			}),
-			new HtmlWebpackPlugin({
-				title: "Adaptive Cards Designer",
-				template: "./index.html",
-				filename: "index.html",
-				chunks: ["adaptivecards-designer"]
-			}),
-			new HtmlWebpackPlugin({
-				title: "Adaptive Cards Designer (Preview Features)",
-				template: "./previewFeatures.html",
-				filename: "previewFeatures.html",
-				chunks: ["adaptivecards-designer"]
-			}),
-			new HtmlWebpackPlugin({
-				title: "Adaptive Cards Designer (No Microsoft Hosts)",
-				template: "./noHosts.html",
-				filename: "noHosts.html",
-				chunks: ["adaptivecards-designer-standalone"]
-			}),
-			new MiniCssExtractPlugin({
-				filename: '[name].css'
-			}),
-			new ConcatPlugin({
-				bundles: [
-					{
-						dest: 'dist/adaptivecards-designer.css',
-						src: [
-							'./node_modules/adaptivecards-controls/dist/adaptivecards-controls.css',
-							'./node_modules/adaptivecards/dist/adaptivecards-carousel.css',
-							'./src/adaptivecards-designer.css'
-						]
-					}
-				]
-			}),
-			new CopyWebpackPlugin({
-				patterns: [{
-					from: 'src/containers/default/adaptivecards-defaulthost.css',
-					to: '.'
-				},
-				{
-					from: 'src/containers/**/*.css',
-					to: 'containers/[name][ext]'
-				},
-				{
-					from: 'src/containers/**/*.png',
-					to: 'containers/[name][ext]'
-				},
-				{
-					from: 'src/containers/**/*.jpg',
-					to: 'containers/[name][ext]'
-				},
-				{
-					from: 'src/assets/*.*',
-					to: '../lib/assets/[name][ext]'
-				}],
-				options: {
-					concurrency: 8
-				}
-			})
-		],
-		externals: {
-			///^monaco-editor/ // <-- NOT WORKING for some reason
-			"adaptivecards": {
-				commonjs2: "adaptivecards",
-				commonjs: "adaptivecards",
-				root: "AdaptiveCards"
-			},
-			"adaptive-expressions": {
-				commonjs2: "adaptive-expressions",
-				commonjs: "adaptive-expressions",
-				root: "AEL"
-			},
-			"adaptivecards-templating": {
-				commonjs2: "adaptivecards-templating",
-				commonjs: "adaptivecards-templating",
-				root: "ACData"
-			}
-		}
-	}
+            libraryTarget: "umd",
+            library: "ACDesigner",
+            globalObject: "this"
+        },
+        devtool: devMode ? "inline-source-map" : "source-map",
+        devServer: {
+            static: './dist'
+        },
+        resolve: {
+            extensions: [".ts", ".tsx", ".js"]
+        },
+        module: {
+            rules: [
+                {
+                    test: /\.ts$/,
+                    loader: "ts-loader",
+                    exclude: /(node_modules|__tests__)/
+                },
+                {
+                    test: /\.css$/,
+                    use: [
+                        'style-loader',
+                        MiniCssExtractPlugin.loader,
+                        'css-loader'
+                    ]
+                },
+                {
+                    test: /\.svg$/,
+                    type: 'asset/inline'
+                }
+            ]
+        },
+        plugins: [
+            new Dotenv(),
+            new HtmlWebpackPlugin({
+                title: "Adaptive Cards Designer (No Microsoft Hosts)",
+                template: "./noHosts.html",
+                filename: "noHosts.html",
+                chunks: ["adaptivecards-designer-standalone"]
+            }),
+            new HtmlWebpackPlugin({
+                title: "Adaptive Cards Designer",
+                template: "./index.html",
+                filename: "index.html",
+                chunks: ["adaptivecards-designer"]
+            }),
+            new HtmlWebpackPlugin({
+                title: "Adaptive Cards Designer (Preview Features)",
+                template: "./previewFeatures.html",
+                filename: "previewFeatures.html",
+                chunks: ["adaptivecards-designer"]
+            }),
+            new HtmlWebpackPlugin({
+                title: "Adaptive Cards Designer (No Microsoft Hosts)",
+                template: "./noHosts.html",
+                filename: "noHosts.html",
+                chunks: ["adaptivecards-designer-standalone"]
+            }),
+            new MiniCssExtractPlugin({
+                filename: '[name].css'
+            }),
+            new ConcatPlugin({
+                bundles: [
+                    {
+                        dest: 'dist/adaptivecards-designer.css',
+                        src: [
+                            './node_modules/adaptivecards-controls/dist/adaptivecards-controls.css',
+                            './node_modules/adaptivecards/dist/adaptivecards-carousel.css',
+                            './src/adaptivecards-designer.css'
+                        ]
+                    }
+                ]
+            }),
+            new CopyWebpackPlugin({
+                patterns: [{
+                    from: 'src/containers/default/adaptivecards-defaulthost.css',
+                    to: '.'
+                },
+                {
+                    from: 'src/containers/**/*.css',
+                    to: 'containers/[name][ext]'
+                },
+                {
+                    from: 'src/containers/**/*.png',
+                    to: 'containers/[name][ext]'
+                },
+                {
+                    from: 'src/containers/**/*.jpg',
+                    to: 'containers/[name][ext]'
+                },
+                {
+                    from: 'src/assets/*.*',
+                    to: '../lib/assets/[name][ext]'
+                }],
+                options: {
+                    concurrency: 8
+                }
+            })
+        ],
+        externals: {
+            ///^monaco-editor/ // <-- NOT WORKING for some reason
+            "adaptivecards": {
+                commonjs2: "adaptivecards",
+                commonjs: "adaptivecards",
+                root: "AdaptiveCards"
+            },
+            "adaptive-expressions": {
+                commonjs2: "adaptive-expressions",
+                commonjs: "adaptive-expressions",
+                root: "AEL"
+            },
+            "adaptivecards-templating": {
+                commonjs2: "adaptivecards-templating",
+                commonjs: "adaptivecards-templating",
+                root: "ACData"
+            }
+        }
+    }
 }

--- a/source/nodejs/adaptivecards-designer/webpack.config.js
+++ b/source/nodejs/adaptivecards-designer/webpack.config.js
@@ -20,6 +20,7 @@ module.exports = (env, argv) => {
 		output: {
 			path: path.resolve(__dirname, "./dist"),
 			filename: devMode ? "[name].js" : "[name].min.js",
+            hashFunction: "xxhash64",
 			libraryTarget: "umd",
 			library: "ACDesigner",
 			globalObject: "this"

--- a/source/nodejs/adaptivecards-extras-designer/webpack.config.js
+++ b/source/nodejs/adaptivecards-extras-designer/webpack.config.js
@@ -1,59 +1,59 @@
 const path = require("path");
 
 module.exports = (env, argv) => {
-	const mode = argv.mode || 'development';
-	const devMode = mode === "development";
+    const mode = argv.mode || 'development';
+    const devMode = mode === "development";
 
-	console.info('running webpack with mode:', mode);
+    console.info('running webpack with mode:', mode);
 
-	return {
-		mode: mode,
-		entry: {
-			"adaptivecards-extras-designer": "./src/adaptivecards-extras-designer.ts"
-		},
-		output: {
-			path: path.resolve(__dirname, "./dist"),
-			filename: devMode ? "[name].js" : "[name].min.js",
-			library: "ACExtrasDesigner",
+    return {
+        mode: mode,
+        entry: {
+            "adaptivecards-extras-designer": "./src/adaptivecards-extras-designer.ts"
+        },
+        output: {
+            path: path.resolve(__dirname, "./dist"),
+            filename: devMode ? "[name].js" : "[name].min.js",
+            library: "ACExtrasDesigner",
             hashFunction: "xxhash64",
-			libraryTarget: "umd",
-			globalObject: "this",
-			// umdNamedDefine: true
-		},
-		devtool: devMode ? "inline-source-map" : "source-map",
-		devServer: {
-			static: {
-				directory: './dist'
-			}
-		},
-		resolve: {
-			extensions: [".ts", ".tsx", ".js"]
-		},
-		module: {
-			rules: [
-				{
-					test: /\.ts$/,
-					loader: "ts-loader",
-					exclude: /(node_modules|__tests__)/
-				}
-			]
-		},
-		externals: {
-			"adaptivecards": {
-				commonjs2: "adaptivecards",
-				commonjs: "adaptivecards",
-				root: "AdaptiveCards"
-			},
-			"adaptivecards-designer": {
-				commonjs2: "adaptivecards-designer",
-				commonjs: "adaptivecards-designer",
-				root: "ACDesigner"
-			},
-			"adaptivecards-extras": {
-				commonjs2: "adaptivecards-extras",
-				commonjs: "adaptivecards-extras",
-				root: "ACExtras"
-			}
-		}
-	}
+            libraryTarget: "umd",
+            globalObject: "this",
+            // umdNamedDefine: true
+        },
+        devtool: devMode ? "inline-source-map" : "source-map",
+        devServer: {
+            static: {
+                directory: './dist'
+            }
+        },
+        resolve: {
+            extensions: [".ts", ".tsx", ".js"]
+        },
+        module: {
+            rules: [
+                {
+                    test: /\.ts$/,
+                    loader: "ts-loader",
+                    exclude: /(node_modules|__tests__)/
+                }
+            ]
+        },
+        externals: {
+            "adaptivecards": {
+                commonjs2: "adaptivecards",
+                commonjs: "adaptivecards",
+                root: "AdaptiveCards"
+            },
+            "adaptivecards-designer": {
+                commonjs2: "adaptivecards-designer",
+                commonjs: "adaptivecards-designer",
+                root: "ACDesigner"
+            },
+            "adaptivecards-extras": {
+                commonjs2: "adaptivecards-extras",
+                commonjs: "adaptivecards-extras",
+                root: "ACExtras"
+            }
+        }
+    }
 }

--- a/source/nodejs/adaptivecards-extras-designer/webpack.config.js
+++ b/source/nodejs/adaptivecards-extras-designer/webpack.config.js
@@ -15,6 +15,7 @@ module.exports = (env, argv) => {
 			path: path.resolve(__dirname, "./dist"),
 			filename: devMode ? "[name].js" : "[name].min.js",
 			library: "ACExtrasDesigner",
+            hashFunction: "xxhash64",
 			libraryTarget: "umd",
 			globalObject: "this",
 			// umdNamedDefine: true

--- a/source/nodejs/adaptivecards-extras/webpack.config.js
+++ b/source/nodejs/adaptivecards-extras/webpack.config.js
@@ -14,7 +14,8 @@ module.exports = (env, argv) => {
 		output: {
 			path: path.resolve(__dirname, "./dist"),
 			filename: devMode ? "[name].js" : "[name].min.js",
-			library: "ACExtras",
+			hashFunction: "xxhash64",
+            library: "ACExtras",
 			libraryTarget: "umd",
 			globalObject: "this",
 			// umdNamedDefine: true

--- a/source/nodejs/adaptivecards-extras/webpack.config.js
+++ b/source/nodejs/adaptivecards-extras/webpack.config.js
@@ -1,49 +1,49 @@
 const path = require("path");
 
 module.exports = (env, argv) => {
-	const mode = argv.mode || 'development';
-	const devMode = mode === "development";
+    const mode = argv.mode || 'development';
+    const devMode = mode === "development";
 
-	console.info('running webpack with mode:', mode);
+    console.info('running webpack with mode:', mode);
 
-	return {
-		mode: mode,
-		entry: {
-			"adaptivecards-extras": "./src/adaptivecards-extras.ts"
-		},
-		output: {
-			path: path.resolve(__dirname, "./dist"),
-			filename: devMode ? "[name].js" : "[name].min.js",
-			hashFunction: "xxhash64",
+    return {
+        mode: mode,
+        entry: {
+            "adaptivecards-extras": "./src/adaptivecards-extras.ts"
+        },
+        output: {
+            path: path.resolve(__dirname, "./dist"),
+            filename: devMode ? "[name].js" : "[name].min.js",
+            hashFunction: "xxhash64",
             library: "ACExtras",
-			libraryTarget: "umd",
-			globalObject: "this",
-			// umdNamedDefine: true
-		},
-		devtool: devMode ? "inline-source-map" : "source-map",
-		devServer: {
-			static: {
-				directory: './dist'
-			}
-		},
-		resolve: {
-			extensions: [".ts", ".tsx", ".js"]
-		},
-		module: {
-			rules: [
-				{
-					test: /\.ts$/,
-					loader: "ts-loader",
-					exclude: /(node_modules|__tests__)/
-				}
-			]
-		},
-		externals: {
-			"adaptivecards": {
-				commonjs2: "adaptivecards",
-				commonjs: "adaptivecards",
-				root: "AdaptiveCards"
-			}
-		}
-	}
+            libraryTarget: "umd",
+            globalObject: "this",
+            // umdNamedDefine: true
+        },
+        devtool: devMode ? "inline-source-map" : "source-map",
+        devServer: {
+            static: {
+                directory: './dist'
+            }
+        },
+        resolve: {
+            extensions: [".ts", ".tsx", ".js"]
+        },
+        module: {
+            rules: [
+                {
+                    test: /\.ts$/,
+                    loader: "ts-loader",
+                    exclude: /(node_modules|__tests__)/
+                }
+            ]
+        },
+        externals: {
+            "adaptivecards": {
+                commonjs2: "adaptivecards",
+                commonjs: "adaptivecards",
+                root: "AdaptiveCards"
+            }
+        }
+    }
 }

--- a/source/nodejs/adaptivecards-react/webpack.config.js
+++ b/source/nodejs/adaptivecards-react/webpack.config.js
@@ -13,6 +13,7 @@ module.exports = (env, argv) => {
         output: {
             path: path.resolve(__dirname, './dist'),
             filename: devMode ? '[name].js' : '[name].min.js',
+            hashFunction: "xxhash64",
             libraryTarget: 'umd',
             library: 'AdaptiveCards',
             globalObject: 'this'

--- a/source/nodejs/adaptivecards-templating/webpack.config.js
+++ b/source/nodejs/adaptivecards-templating/webpack.config.js
@@ -1,47 +1,47 @@
 const path = require("path");
 
 module.exports = (env, argv) => {
-	const mode = argv.mode || 'development';
-	const devMode = mode === "development";
+    const mode = argv.mode || 'development';
+    const devMode = mode === "development";
 
-	console.info('running webpack with mode:', mode);
+    console.info('running webpack with mode:', mode);
 
-	return {
-		mode: mode,
-		entry: {
-			"adaptivecards-templating": "./src/adaptivecards-templating.ts"
-		},
-		output: {
-			path: path.resolve(__dirname, "./dist"),
-			filename: devMode ? "[name].js" : "[name].min.js",
+    return {
+        mode: mode,
+        entry: {
+            "adaptivecards-templating": "./src/adaptivecards-templating.ts"
+        },
+        output: {
+            path: path.resolve(__dirname, "./dist"),
+            filename: devMode ? "[name].js" : "[name].min.js",
             hashFunction: "xxhash64",
-			libraryTarget: "umd",
-			library: "ACData",
-			globalObject: "this"
-		},
-		devtool: devMode ? "inline-source-map" : "source-map",
-		devServer: {
-			static: {
-				directory: './dist'
-			}
-		},
-		externals: {
-			"adaptive-expressions": {
-				commonjs2: "adaptive-expressions",
-				commonjs: "adaptive-expressions",
-				root: "AEL"
-			}
-		},
-		resolve: {
-			extensions: [".ts", ".tsx", ".js"]
-		},
-		module: {
-			rules: [{
-					test: /\.ts$/,
-					loader: "ts-loader",
-					exclude: /(node_modules|__tests__)/
-				}
-			]
-		}
-	};
+            libraryTarget: "umd",
+            library: "ACData",
+            globalObject: "this"
+        },
+        devtool: devMode ? "inline-source-map" : "source-map",
+        devServer: {
+            static: {
+                directory: './dist'
+            }
+        },
+        externals: {
+            "adaptive-expressions": {
+                commonjs2: "adaptive-expressions",
+                commonjs: "adaptive-expressions",
+                root: "AEL"
+            }
+        },
+        resolve: {
+            extensions: [".ts", ".tsx", ".js"]
+        },
+        module: {
+            rules: [{
+                    test: /\.ts$/,
+                    loader: "ts-loader",
+                    exclude: /(node_modules|__tests__)/
+                }
+            ]
+        }
+    };
 }

--- a/source/nodejs/adaptivecards-templating/webpack.config.js
+++ b/source/nodejs/adaptivecards-templating/webpack.config.js
@@ -14,6 +14,7 @@ module.exports = (env, argv) => {
 		output: {
 			path: path.resolve(__dirname, "./dist"),
 			filename: devMode ? "[name].js" : "[name].min.js",
+            hashFunction: "xxhash64",
 			libraryTarget: "umd",
 			library: "ACData",
 			globalObject: "this"

--- a/source/nodejs/adaptivecards-ui-testapp/webpack.config.js
+++ b/source/nodejs/adaptivecards-ui-testapp/webpack.config.js
@@ -22,6 +22,7 @@ module.exports = (env, argv) => {
 		output: {
 			path: path.resolve(__dirname, "./dist"),
 			filename: devMode ? "[name].js" : "[name].min.js",
+            hashFunction: "xxhash64",
 			library: "ACUITestApp",
 			libraryTarget: "umd",
 			globalObject: "this",

--- a/source/nodejs/adaptivecards-ui-testapp/webpack.config.js
+++ b/source/nodejs/adaptivecards-ui-testapp/webpack.config.js
@@ -13,80 +13,80 @@ module.exports = (env, argv) => {
 
     console.info('running webpack with mode:', mode);
 
-	return {
-		mode: mode,
-		target: 'web',
-		entry: {
-			"adaptivecards-ui-testapp": "./src/adaptivecards-ui-testapp.ts"
-		},
-		output: {
-			path: path.resolve(__dirname, "./dist"),
-			filename: devMode ? "[name].js" : "[name].min.js",
+    return {
+        mode: mode,
+        target: 'web',
+        entry: {
+            "adaptivecards-ui-testapp": "./src/adaptivecards-ui-testapp.ts"
+        },
+        output: {
+            path: path.resolve(__dirname, "./dist"),
+            filename: devMode ? "[name].js" : "[name].min.js",
             hashFunction: "xxhash64",
-			library: "ACUITestApp",
-			libraryTarget: "umd",
-			globalObject: "this",
-			// umdNamedDefine: true
-		},
-		devtool: devMode ? "inline-source-map" : "source-map",
-		devServer: {
-			static: {
-				directory: path.resolve(__dirname, "./dist"),
-			},
-			liveReload: false,
-		},
-		resolve: {
-			extensions: [".ts", ".tsx", ".js"]
-		},
-		module: {
-			rules: [{
-				test: /\.ts$/,
-				loader: "ts-loader",
-				exclude: /(node_modules|__tests__)/
-			},
-			{
-				test: /\.css$/,
-				use: [
-					devMode ? 'style-loader' : MiniCssExtractPlugin.loader,
-					'css-loader'
-				]
-			}
-			]
-		},
-		plugins: [
-			new Dotenv(),
-			new HtmlWebpackPlugin({
-				title: "Adaptive Cards UI TestApp",
-				template: "./index.html",
-				filename: "index.html",
-				chunks: ["adaptivecards-ui-testapp"]
-			}),
-			new MiniCssExtractPlugin({
-				filename: '[name].css'
-			}),
-			new CopyWebpackPlugin({
-				patterns: [
-				{
-					from: '../../../samples/',
-					to: './samples/[path]/[name][ext]',
-					context: '.'
-				}],
-				options: {
-					concurrency: 8
-				}
-			})
-		],
-		externals: {
-			"adaptive-expressions": {
-				commonjs2: "adaptive-expressions",
-				commonjs: "adaptive-expressions",
-				root: "AEL"
-			},
-			"adaptivecards-templating": {
-				commonjs2: "adaptivecards-templating",
-				commonjs: "adaptivecards-templating",
-				root: "ACData"
-			}
-		}
-	}
+            library: "ACUITestApp",
+            libraryTarget: "umd",
+            globalObject: "this",
+            // umdNamedDefine: true
+        },
+        devtool: devMode ? "inline-source-map" : "source-map",
+        devServer: {
+            static: {
+                directory: path.resolve(__dirname, "./dist"),
+            },
+            liveReload: false,
+        },
+        resolve: {
+            extensions: [".ts", ".tsx", ".js"]
+        },
+        module: {
+            rules: [{
+                test: /\.ts$/,
+                loader: "ts-loader",
+                exclude: /(node_modules|__tests__)/
+            },
+            {
+                test: /\.css$/,
+                use: [
+                    devMode ? 'style-loader' : MiniCssExtractPlugin.loader,
+                    'css-loader'
+                ]
+            }
+            ]
+        },
+        plugins: [
+            new Dotenv(),
+            new HtmlWebpackPlugin({
+                title: "Adaptive Cards UI TestApp",
+                template: "./index.html",
+                filename: "index.html",
+                chunks: ["adaptivecards-ui-testapp"]
+            }),
+            new MiniCssExtractPlugin({
+                filename: '[name].css'
+            }),
+            new CopyWebpackPlugin({
+                patterns: [
+                {
+                    from: '../../../samples/',
+                    to: './samples/[path]/[name][ext]',
+                    context: '.'
+                }],
+                options: {
+                    concurrency: 8
+                }
+            })
+        ],
+        externals: {
+            "adaptive-expressions": {
+                commonjs2: "adaptive-expressions",
+                commonjs: "adaptive-expressions",
+                root: "AEL"
+            },
+            "adaptivecards-templating": {
+                commonjs2: "adaptivecards-templating",
+                commonjs: "adaptivecards-templating",
+                root: "ACData"
+            }
+        }
+    }
 }

--- a/source/nodejs/adaptivecards/webpack.config.js
+++ b/source/nodejs/adaptivecards/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = (env, argv) => {
 		output: {
 			path: path.resolve(__dirname, "./dist"),
 			filename: devMode ? "[name].js" : "[name].min.js",
+            hashFunction: "xxhash64",
 			libraryTarget: "umd",
 			library: "AdaptiveCards",
 			globalObject: "this"

--- a/source/nodejs/adaptivecards/webpack.config.js
+++ b/source/nodejs/adaptivecards/webpack.config.js
@@ -3,65 +3,65 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 module.exports = (env, argv) => {
-	const mode = argv.mode || 'development';
-	const devMode = mode === 'development';
+    const mode = argv.mode || 'development';
+    const devMode = mode === 'development';
 
-	console.info('running webpack with mode:', mode);
+    console.info('running webpack with mode:', mode);
 
-	return {
-		mode: mode,
-		entry: {
-			"adaptivecards": "./src/adaptivecards.ts"
-		},
-		output: {
-			path: path.resolve(__dirname, "./dist"),
-			filename: devMode ? "[name].js" : "[name].min.js",
+    return {
+        mode: mode,
+        entry: {
+            "adaptivecards": "./src/adaptivecards.ts"
+        },
+        output: {
+            path: path.resolve(__dirname, "./dist"),
+            filename: devMode ? "[name].js" : "[name].min.js",
             hashFunction: "xxhash64",
-			libraryTarget: "umd",
-			library: "AdaptiveCards",
-			globalObject: "this"
-		},
-		devtool: devMode ? "inline-source-map" : "source-map",
-		devServer: {
-			static: {
-				directory: './dist'
-			}
-		},
-		resolve: {
-			extensions: [".ts", ".tsx", ".js", ".scss"]
-		},
-		module: {
-			rules: [{
-				test: /\.ts$/,
-				loader: "ts-loader",
-				exclude: /(node_modules|__tests__)/
-			}]
-		},
-		plugins: [
-			new CopyWebpackPlugin(
-				{
-					patterns: [
-						{
-							from: 'src/scss/adaptivecards*',
-							to: '../dist/[name][ext]'
-						},
-						{
-							from: 'src/scss/adaptivecards*',
-							to: '../lib/[name][ext]'
-						},
-						{
-							from: 'lib/adaptivecards*.css*',
-							to: '../dist/[name][ext]'
-						}
-					]
-				}
-			),
-			new HtmlWebpackPlugin(
-				{
-					title: "Adaptive Cards Example",
-					template: "./example.html"
-				}
-			)
-		]
-	};
+            libraryTarget: "umd",
+            library: "AdaptiveCards",
+            globalObject: "this"
+        },
+        devtool: devMode ? "inline-source-map" : "source-map",
+        devServer: {
+            static: {
+                directory: './dist'
+            }
+        },
+        resolve: {
+            extensions: [".ts", ".tsx", ".js", ".scss"]
+        },
+        module: {
+            rules: [{
+                test: /\.ts$/,
+                loader: "ts-loader",
+                exclude: /(node_modules|__tests__)/
+            }]
+        },
+        plugins: [
+            new CopyWebpackPlugin(
+                {
+                    patterns: [
+                        {
+                            from: 'src/scss/adaptivecards*',
+                            to: '../dist/[name][ext]'
+                        },
+                        {
+                            from: 'src/scss/adaptivecards*',
+                            to: '../lib/[name][ext]'
+                        },
+                        {
+                            from: 'lib/adaptivecards*.css*',
+                            to: '../dist/[name][ext]'
+                        }
+                    ]
+                }
+            ),
+            new HtmlWebpackPlugin(
+                {
+                    title: "Adaptive Cards Example",
+                    template: "./example.html"
+                }
+            )
+        ]
+    };
 }

--- a/source/nodejs/spec-generator/webpack.config.js
+++ b/source/nodejs/spec-generator/webpack.config.js
@@ -1,35 +1,35 @@
 const path = require("path");
 
 module.exports = (env, argv) => {
-	const mode = argv.mode || 'development';
-	const devMode = mode === "development";
+    const mode = argv.mode || 'development';
+    const devMode = mode === "development";
 
-	console.info('running webpack with mode:', mode);
+    console.info('running webpack with mode:', mode);
 
-	return {
-		mode: mode,
-		target: "node",
-		entry: {
-			"spec-generator-script.0.5.0.0": "./src/spec-generator-script.ts",
-		},
-		output: {
-			path: path.resolve(__dirname, "dist"),
-			hashFunction: "xxhash64",
+    return {
+        mode: mode,
+        target: "node",
+        entry: {
+            "spec-generator-script.0.5.0.0": "./src/spec-generator-script.ts",
+        },
+        output: {
+            path: path.resolve(__dirname, "dist"),
+            hashFunction: "xxhash64",
             filename: devMode ? "[name].js" : "[name].min.js",
-		},
-		externals: {
-			fs: "commonjs fs"
-		},
-		resolve: {
-			extensions: [".ts", ".tsx", ".js"]
-		},
-		module: {
-			rules: [{
-					test: /\.ts$/,
-					loader: "ts-loader",
-					exclude: /(node_modules|__tests__)/
-				}
-			]
-		}
-	}
+        },
+        externals: {
+            fs: "commonjs fs"
+        },
+        resolve: {
+            extensions: [".ts", ".tsx", ".js"]
+        },
+        module: {
+            rules: [{
+                    test: /\.ts$/,
+                    loader: "ts-loader",
+                    exclude: /(node_modules|__tests__)/
+                }
+            ]
+        }
+    }
 }

--- a/source/nodejs/spec-generator/webpack.config.js
+++ b/source/nodejs/spec-generator/webpack.config.js
@@ -14,7 +14,8 @@ module.exports = (env, argv) => {
 		},
 		output: {
 			path: path.resolve(__dirname, "dist"),
-			filename: devMode ? "[name].js" : "[name].min.js",
+			hashFunction: "xxhash64",
+            filename: devMode ? "[name].js" : "[name].min.js",
 		},
 		externals: {
 			fs: "commonjs fs"


### PR DESCRIPTION
Building with NodeJS >16 yields errors complaining about deprecated hashing functions (`ERR_OSSL_EVP_UNSUPPORTED`). This is a known and intentional change in NodeJS to prevent using insecure hashing functions. It's a little overzealous in *this* case because the hashing function is just being used to break up chunks of code, but rather than having to opt everything into allowing insecure hashing functions, it's probably better to just make Webpack use a more recent function (i.e. [`xxhash64`](https://webpack.js.org/configuration/output/#outputhashfunction), the default in Webpack's next version).
