### PR TITLE
[NodeJS] Add `ImageSet` class to enable styling

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -2521,6 +2521,7 @@ export class ImageSet extends CardElementContainer {
             element = document.createElement("div");
             element.style.display = "flex";
             element.style.flexWrap = "wrap";
+            element.classList.add(this.hostConfig.makeCssClassName("ac-imageSet"));
 
             for (const image of this._images) {
                 switch (this.imageSize) {


### PR DESCRIPTION
Simple addition of class to `ImageSet` element. As-is, this doesn't change anything, but it _does_ allow host applications to apply special styling to `ImageSet`s without a bunch of effort.