### PR TITLE
[XAML] Fix for exception thrown in `WholeItemsPanel`

### DIFF
--- a/source/uwp/SharedRenderer/lib/WholeItemsPanel.cpp
+++ b/source/uwp/SharedRenderer/lib/WholeItemsPanel.cpp
@@ -354,7 +354,7 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
         for (auto child : panel.Children())
         {
             // Subgroups (columns) are implemented with WholeItemsPanel
-            if (auto childAsWholeItemPanel = child.as<winrt::WholeItemsPanel>())
+            if (auto childAsWholeItemPanel = child.try_as<winrt::WholeItemsPanel>())
             {
                 if (childAsWholeItemPanel.IsTruncated())
                 {


### PR DESCRIPTION
Looks like a simple mistake in the conversion to cppwinrt (`as` vs. `try_as`). The converted version would throw instead of quietly skipping the check...

**original**
https://github.com/microsoft/AdaptiveCards/blob/d6084118fe516aa1793370bda7378b7a7ccd1616/source/uwp/Renderer/lib/WholeItemsPanel.cpp#L469-L478

**converted**
https://github.com/microsoft/AdaptiveCards/blob/1dcef8c69715bd56cc4384ab2b1a80906e696922/source/uwp/Renderer/lib/WholeItemsPanel.cpp#L357-L363