### PR TITLE
[Maintenance]: Migrate NugetRestore@1 to NugetCommand

### DIFF
--- a/.pipelines/uwp-ci.yml
+++ b/.pipelines/uwp-ci.yml
@@ -33,14 +33,14 @@ steps:
   inputs:
     versionSpec: 5.x
 
-- task: NuGetRestore@1
-  name: NuGetCommand2
+- task: NuGetCommand2
   displayName: NuGet restore
   inputs:
-    solution: $(solution)
-    selectOrConfig: config
+    command: 'restore'
+    feedsToUse: config
     nugetConfigPath: source/nuget.config
-    verbosity: '-'
+    restoreSolution: $(solution)
+    verbosityRestore: Detailed
 
 - task: VSBuild@1
   name: VSBuild3

--- a/.pipelines/uwp-ci.yml
+++ b/.pipelines/uwp-ci.yml
@@ -33,7 +33,7 @@ steps:
   inputs:
     versionSpec: 5.x
 
-- task: NuGetCommand2
+- task: NuGetCommand@2
   displayName: NuGet restore
   inputs:
     command: 'restore'

--- a/.pipelines/winui3-ci.yml
+++ b/.pipelines/winui3-ci.yml
@@ -34,7 +34,7 @@ steps:
 - task: NuGetAuthenticate@1
   name: NuGetAuthenticate2
 
-- task: NuGetCommand2
+- task: NuGetCommand@2
   displayName: NuGet restore
   inputs:
     command: 'restore'

--- a/.pipelines/winui3-ci.yml
+++ b/.pipelines/winui3-ci.yml
@@ -34,7 +34,7 @@ steps:
 - task: NuGetAuthenticate@1
   name: NuGetAuthenticate2
 
-- task: NuGetRestore@1
+- task: NuGetCommand2
   displayName: NuGet restore
   inputs:
     command: 'restore'

--- a/.pipelines/winui3-ci.yml
+++ b/.pipelines/winui3-ci.yml
@@ -35,13 +35,13 @@ steps:
   name: NuGetAuthenticate2
 
 - task: NuGetRestore@1
-  name: NuGetCommand3
   displayName: NuGet restore
   inputs:
-    solution: $(solution)
-    selectOrConfig: config
+    command: 'restore'
+    feedsToUse: config
     nugetConfigPath: source/uwp/winui3/nuget.config
-    verbosity: '-'
+    restoreSolution: $(solution)
+    verbosityRestore: Detailed
 
 - task: VSBuild@1
   name: VSBuild4


### PR DESCRIPTION
This change will fix failing pipelines due to:
##[error]Error: This task is deprecated. Please switch to using NuGetCommand@2's 'restore' option https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/nuget-command-v2
