### PR TITLE
[NodeJS] Remove tab index from parent in compound inputs

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -4430,8 +4430,6 @@ export class ChoiceSetInput extends Input {
         element.className = this.hostConfig.makeCssClassName("ac-input", cssClassName);
         element.style.width = "100%";
 
-        element.tabIndex = this.isDesignMode() ? -1 : 0;
-
         this._toggleInputs = [];
         this._labels = [];
 


### PR DESCRIPTION
# Related Issue

Fixes #8733 

# Description

## Current behavior
When hitting the Submit button, focus is sent back to the first checkbox in a multi select ChoiceSet if it is a missing required input. On receiving focus, Narrator reads information for **all** of the checkboxes within the ChoiceSet. Video of the behavior can be seen in linked issue.

## Solution
Focusable elements are not meant to be nested. For compound ChoiceSets, we make the outer `div` focusable by setting a tabIndex. This is causing the unexpected behavior - When the `div` receives focus, information for all nested elements are read. This same issue is present when we _jump_ to focus on the first element within the div. When the outer `div` is not focusable, the behavior does not repro.

## New behavior
When focus is sent back to the first checkbox in a multi select ChoiceSet, only information for that checkbox is read by Narrator.

# Sample Card
Samples is from filed bug.

```JSON
{
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
    "type": "AdaptiveCard",
    "version": "1.6",
    "body": [
        {
            "type": "ColumnSet",
            "columns": [
                {
                    "type": "Column",
                    "width": 2,
                    "items": [
                        {
                            "type": "TextBlock",
                            "text": "Please enter the below details to create SAP user account request",
                            "weight": "Bolder",
                            "wrap": true
                        },
                        {
                            "type": "Input.ChoiceSet",
                            "id": "Roles",
                            "style": "expanded",
                            "isMultiSelect": true,
                            "isRequired": true,
                            "errorMessage": "Please select the role",
                            "label": "Role",
                            "wrap": true,
                            "choices": [
                                {
                                    "title": "Project Manager",
                                    "value": "Project Manager"
                                },
                                {
                                    "title": "Business Manager",
                                    "value": "Business Manager"
                                },
                                {
                                    "title": "Customer Account Manager",
                                    "value": "Customer Account Manager"
                                },
                                {
                                    "title": "Software Engineer",
                                    "value": "Software Engineer"
                                }
                            ],
                            "value": ""
                        },
                        {
                            "type": "Input.Text",
                            "id": "Justification",
                            "isMultiline": true,
                            "isRequired": true,
                            "errorMessage": "Please provide the business justification",
                            "label": "Business Justification",
                            "value": "",
                            "wrap": true
                        }
                    ]
                }
            ]
        }
    ],
    "actions": [
        {
            "type": "Action.Submit",
            "title": "Submit",
            "data": {
                "id": "SAPUserRequest_Submit"
            }
        }
    ]
}
```

# How Verified

Verified on the AC test site for this PR, and Accessibility Insights found no new issues.

New behavior:

https://github.com/microsoft/AdaptiveCards/assets/98650930/3d1d5381-6e63-429f-9fb0-42e3e36dc9cb



