### PR TITLE
Site query params to configure designer host container

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/card-designer.ts
+++ b/source/nodejs/adaptivecards-designer/src/card-designer.ts
@@ -1761,6 +1761,11 @@ export class CardDesigner extends Designer.DesignContext {
         }
     }
 
+    public togglePreviewButton() {
+        this._togglePreviewButton.isToggled = true;
+        this.togglePreview();
+    }
+
     onCardPayloadChanged: (designer: CardDesigner) => void;
     onCardValidated: (designer: CardDesigner, validationLogEntries: Adaptive.IValidationEvent[]) => void;
     onActiveHostContainerChanged: (designer: CardDesigner) => void;

--- a/source/nodejs/adaptivecards-designer/src/card-designer.ts
+++ b/source/nodejs/adaptivecards-designer/src/card-designer.ts
@@ -1729,6 +1729,38 @@ export class CardDesigner extends Designer.DesignContext {
         this.setCardPayload(card, true);
     }
 
+    public configHostContainer(hostApp: number, theme: string, size: string, deviceEmulation: number){
+        if (hostApp && 0 <= hostApp && hostApp < this._hostContainers.length
+            && this._hostContainerChoicePicker.selectedIndex !== hostApp) {
+           this._hostContainerChoicePicker.selectedIndex = hostApp;
+        }
+
+        if (!!this.hostContainer.supportsMultipleThemes) {
+            if (!this.sampleHostData) {
+                this.sampleHostData = {};
+            }
+            if (theme && HostContainer.supportedContainerThemes.includes(theme)) {
+                this._containerThemeChoicePicker.selectedIndex = HostContainer.supportedContainerThemes.indexOf(theme);
+            }
+            this.updateHostDataThemeProperty();
+        }
+
+        if (!!this.hostContainer.supportsMultipleSizes) {
+            if (!this.sampleHostData) {
+                 this.sampleHostData = {};
+            }
+            if (size && WidgetContainer.supportedContainerSizes.includes(size)) {
+                this._containerSizeChoicePicker.selectedIndex = WidgetContainer.supportedContainerSizes.indexOf(size);
+            }
+            this.updateHostDataSizeProperty();
+        }
+
+        if (deviceEmulation && !!this._hostContainer.enableDeviceEmulation && 0 <= deviceEmulation && deviceEmulation < this._deviceEmulations.length &&
+             this._deviceEmulationChoicePicker.selectedIndex !== deviceEmulation) {
+            this._deviceEmulationChoicePicker.selectedIndex = deviceEmulation;
+        }
+    }
+
     onCardPayloadChanged: (designer: CardDesigner) => void;
     onCardValidated: (designer: CardDesigner, validationLogEntries: Adaptive.IValidationEvent[]) => void;
     onActiveHostContainerChanged: (designer: CardDesigner) => void;

--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/designer.ejs
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/designer.ejs
@@ -308,6 +308,8 @@
 				});
 			}
 			designer.sampleHostData = {};
+
+			designer.configHostContainer(parseInt(getParameterByName("hostApp")), getParameterByName("theme"), getParameterByName("size"), parseInt(getParameterByName("deviceEmulation")));
 		}
 
 		if (!ACDesigner.SettingsManager.isLocalStorageAvailable) {

--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/designer.ejs
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/designer.ejs
@@ -310,6 +310,10 @@
 			designer.sampleHostData = {};
 
 			designer.configHostContainer(parseInt(getParameterByName("hostApp")), getParameterByName("theme"), getParameterByName("size"), parseInt(getParameterByName("deviceEmulation")));
+
+			if (getParameterByName("preview") === "1") {
+				designer.togglePreviewButton();
+			}
 		}
 
 		if (!ACDesigner.SettingsManager.isLocalStorageAvailable) {


### PR DESCRIPTION
# Description

This PR allows to apply different configurations to the designer at the site. These are the query params:

- `hostApp`: Use a number to stablish the host app in the designer. Ex: https://adaptivecards.io/designer?hostApp=1 would set the host app to `Outlook Actionable Message`.
- `theme`:  By using a string with the name of the theme you can set the theme of the host container. The possible values depends on the available options for the host app. Ex: https://adaptivecards.io/designer?hostApp=2&theme=Dark would set the theme to `Dark` on the Microsoft Teams host app.
- `size`: By using a string with the name of the size you can set the size of the host container. The possible values depends on the available options for the host app. Ex: https://adaptivecards.io/designer?hostApp=8&size=Medium would set the size of the Widget host app to `Medium`.
- `deviceEmulation`: By using a number, the device emulation can be set. Ex:  Ex: https://adaptivecards.io/designer?hostApp=1&deviceEmulation=2 would set the emulation device to `Large mobile (414px)` at the Outlook Actionable Message host app.

I also added a query param that allows to activate the preview mode on the designer by adding `preview=1` to the url.

# How Verified

I tested it by running a local server
