### PR TITLE
Set automation name for root AC element in UWP/WinUI3 renderer

### DIFF
--- a/source/uwp/SharedRenderer/lib/XamlBuilder.cpp
+++ b/source/uwp/SharedRenderer/lib/XamlBuilder.cpp
@@ -74,6 +74,9 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
 
             rootAsFrameworkElement = rootSelectActionElement.as<winrt::FrameworkElement>();
 
+            // Set automation name using speak property
+            winrt::Automation::AutomationProperties::SetName(rootAsFrameworkElement, adaptiveCard.Speak());
+
             // Enumerate the child items of the card and build xaml for them
             auto body = adaptiveCard.Body();
             auto bodyRenderArgs =


### PR DESCRIPTION
# Related Issue
#8874 

# Description
The speak property is not being hooked up for UWP and WinUI3 renderers.
Setting the automation name for the card root using the speak property in the template.

# How Verified
Verified the fix by using the CalendarReminder sample in the Visualizer which has a speak property.
Narrator reads the speak property in the UWP and WinUI3 Visualizers.
