### PR TITLE
Add PAT usage for uwp-ci pipeline

### DIFF
--- a/.pipelines/uwp-ci.yml
+++ b/.pipelines/uwp-ci.yml
@@ -33,6 +33,10 @@ steps:
   inputs:
     versionSpec: 5.x
 
+- task: NuGetAuthenticate@1
+    inputs:
+      nuGetServiceConnections: acNugetConnection
+
 - task: NuGetCommand@2
   displayName: NuGet restore
   inputs:

--- a/.pipelines/uwp-ci.yml
+++ b/.pipelines/uwp-ci.yml
@@ -40,6 +40,7 @@ steps:
     feedsToUse: config
     nugetConfigPath: source/nuget.config
     restoreSolution: $(solution)
+    externalFeedCredentials: 'acNugetConnection'
     verbosityRestore: Detailed
 
 - task: VSBuild@1

--- a/.pipelines/uwp-ci.yml
+++ b/.pipelines/uwp-ci.yml
@@ -34,8 +34,9 @@ steps:
     versionSpec: 5.x
 
 - task: NuGetAuthenticate@1
-    inputs:
-      nuGetServiceConnections: acNugetConnection
+  displayName: Authenticate to NuGet
+  inputs:
+    nuGetServiceConnections: acNugetConnection
 
 - task: NuGetCommand@2
   displayName: NuGet restore


### PR DESCRIPTION
# Description

Contributors trying to create a pull request are getting hit with build failures when trying to run the uwp-ci pipeline as the access to the feed is limited to users inside a specific organization, trying to do a turn around for the build process.

# How Verified

Build