### PR TITLE
Update how svg image file is being read

### DIFF
--- a/source/uwp/SharedRenderer/dll/CppWinRTIncludes.h
+++ b/source/uwp/SharedRenderer/dll/CppWinRTIncludes.h
@@ -77,6 +77,15 @@ namespace winrt
     {
         using namespace ::winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation;
     }
+    
+    // using namespace winrt::Windows::Data::Xml::Dom
+    using XmlDocument = ::winrt::Windows::Data::Xml::Dom::XmlDocument;
+    using IXmlNode = ::winrt::Windows::Data::Xml::Dom::IXmlNode;
+
+    // using namespace winrt::Windows::Web::Http
+    using HttpProgress = ::winrt::Windows::Web::Http::HttpProgress;
+    using HttpClient = ::winrt::Windows::Web::Http::HttpClient;
+    using HttpResponseMessage = ::winrt::Windows::Web::Http::HttpResponseMessage;
 
 #ifdef USE_WINUI3
     using MediaElement = xaml::Controls::MediaPlayerElement;
@@ -97,16 +106,8 @@ namespace winrt
     // using namespace winrt::Windows::Data::Json
     using JsonObject = ::winrt::Windows::Data::Json::JsonObject;
 
-    // using namespace winrt::Windows::Data::Xml::Dom
-    using XmlDocument = ::winrt::Windows::Data::Xml::Dom::XmlDocument;
-    using IXmlNode = ::winrt::Windows::Data::Xml::Dom::IXmlNode;
-
     // using namespace winrt::Windows::Globalization::DateTimeFormatting;
     using DateTimeFormatter = ::winrt::Windows::Globalization::DateTimeFormatting::DateTimeFormatter;
-
-    // using namespace winrt::Windows::Web::Http
-    using HttpProgress = ::winrt::Windows::Web::Http::HttpProgress;
-    using HttpClient = ::winrt::Windows::Web::Http::HttpClient;
 
     // using namespace winrt::Windows::Web::Http::HttpFilters
     using HttpBaseProtocolFilter = ::winrt::Windows::Web::Http::Filters::HttpBaseProtocolFilter;

--- a/source/uwp/SharedRenderer/dll/CppWinRTIncludes.h
+++ b/source/uwp/SharedRenderer/dll/CppWinRTIncludes.h
@@ -77,15 +77,6 @@ namespace winrt
     {
         using namespace ::winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation;
     }
-    
-    // using namespace winrt::Windows::Data::Xml::Dom
-    using XmlDocument = ::winrt::Windows::Data::Xml::Dom::XmlDocument;
-    using IXmlNode = ::winrt::Windows::Data::Xml::Dom::IXmlNode;
-
-    // using namespace winrt::Windows::Web::Http
-    using HttpProgress = ::winrt::Windows::Web::Http::HttpProgress;
-    using HttpClient = ::winrt::Windows::Web::Http::HttpClient;
-    using HttpResponseMessage = ::winrt::Windows::Web::Http::HttpResponseMessage;
 
 #ifdef USE_WINUI3
     using MediaElement = xaml::Controls::MediaPlayerElement;
@@ -106,8 +97,17 @@ namespace winrt
     // using namespace winrt::Windows::Data::Json
     using JsonObject = ::winrt::Windows::Data::Json::JsonObject;
 
+    // using namespace winrt::Windows::Data::Xml::Dom
+    using XmlDocument = ::winrt::Windows::Data::Xml::Dom::XmlDocument;
+    using IXmlNode = ::winrt::Windows::Data::Xml::Dom::IXmlNode;
+
     // using namespace winrt::Windows::Globalization::DateTimeFormatting;
     using DateTimeFormatter = ::winrt::Windows::Globalization::DateTimeFormatting::DateTimeFormatter;
+
+    // using namespace winrt::Windows::Web::Http
+    using HttpProgress = ::winrt::Windows::Web::Http::HttpProgress;
+    using HttpClient = ::winrt::Windows::Web::Http::HttpClient;
+    using HttpResponseMessage = ::winrt::Windows::Web::Http::HttpResponseMessage;
 
     // using namespace winrt::Windows::Web::Http::HttpFilters
     using HttpBaseProtocolFilter = ::winrt::Windows::Web::Http::Filters::HttpBaseProtocolFilter;


### PR DESCRIPTION
# Related Issue
#8892 

# Description
LoadFromUriAsync() gives a file not found error even if the file exists in WinUI3. Updated to read as string and parse into xml.
There is room for refactoring the SVG xml handling code. 

# Sample Card
1. Existing test: https://github.com/microsoft/AdaptiveCards/blob/main/samples/v1.5/Tests/Image.Svg.json

2. `{
  "type": "AdaptiveCard",
  "version": "1.6",
  "backgroundImage": {
    "url": "https://adaptivecards.io/content/Mostly%20Cloudy-Background.jpg"
  },
  "body": [
    {
      "type": "Image",
      "url": "https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/car.svg",
      "size": "large"
    }
  ],
  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json"
}`

# How Verified
Verified using the WinUI3 visualizer
1. https://github.com/microsoft/AdaptiveCards/blob/main/samples/v1.5/Tests/Image.Svg.json
![image](https://github.com/microsoft/AdaptiveCards/assets/91344388/8a8dc88b-0c00-4b01-8849-e99713a9b638)

2. 
![image](https://github.com/microsoft/AdaptiveCards/assets/91344388/5579f586-bf52-4adc-9324-7d5c6ba728d4)


