### PR TITLE
[NodeJS] Fix site generation from Windows hosts

### DIFF
--- a/source/nodejs/adaptivecards-site/package.json
+++ b/source/nodejs/adaptivecards-site/package.json
@@ -10,7 +10,7 @@
 		"release": "npm run generate && npm run generate-sw",
 		"release-deps": "npx lerna run --scope @microsoft/adaptivecards-site --include-dependencies release --stream",
 		"start": "hexo server",
-		"pregenerate": "npx workbox-cli copyLibraries node_modules/",
+		"pregenerate": "hexo clean && npx workbox-cli copyLibraries node_modules/",
 		"generate": "hexo generate",
 		"generate-sw": "npx workbox-cli injectManifest workbox-config.json"
 	},
@@ -46,8 +46,8 @@
 		"highlightjs": "^9.16.2",
 		"jquery": "^3.6.1",
 		"js-yaml": "^4.1.0",
-		"marked": "^12",
 		"markdown-it": "^14.0.0",
+		"marked": "^12",
 		"md5": "^2.3.0",
 		"minimist": "^1.2.6",
 		"monaco-editor": "^0.34.0",

--- a/source/nodejs/package-lock.json
+++ b/source/nodejs/package-lock.json
@@ -4640,8 +4640,8 @@
 		},
 		"adaptivecards-site/node_modules/glob": {
 			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-			"integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+			"resolved": "https://microsoft.pkgs.visualstudio.com/AdaptiveCards/_packaging/npm-public/npm/registry/glob/-/glob-8.1.0.tgz",
+			"integrity": "sha1-04j2Vlk+9wjuPjRkD9+5mp/Rwz4=",
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",


### PR DESCRIPTION
Turns out that some of my changes to site generation didn't work properly on Windows builders (I authored using WSL). Mostly this was due to path munging interacting poorly with `glob` in `generators-adaptiveassets.js`.

[Here's](https://microsoft.visualstudio.com/AdaptiveCards/_build/results?buildId=97502826&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b&t=7cc137c2-61f2-5d65-b5f8-0e03d1af3170) a clean run showing that it works on Windows 👍🏼 