### PR TITLE
Remove innerHTML usage from dynamic typeahead

### DIFF
--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -4911,7 +4911,37 @@ export class FilteredChoiceSet {
         const choice = document.createElement("span");
         choice.className = this.hostConfig.makeCssClassName("ac-input", "ac-choiceSetInput-choice");
         choice.id = `ac-choiceSetInput-${this._choiceSetId}-choice-${id}`;
-        choice.innerHTML = value.replace(filter, `<b>${filter}</b>`);
+        
+        const startIndex = value.indexOf(filter);
+        if (startIndex === -1) {
+            // Filter wasn't found, add the value as is
+            const valueSpan = document.createElement("span");
+            valueSpan.innerText = value;
+            choice.appendChild(valueSpan);
+        } else {
+            if (startIndex > 0) {
+                // Add a span with the beginning unmatched text
+                const unmatchedBeg = value.substring(0, startIndex);
+                const unmatchedBegSpan = document.createElement("span");
+                unmatchedBegSpan.innerText = unmatchedBeg;
+                choice.appendChild(unmatchedBegSpan);
+            }
+
+            // Add the matched filter with bold styling
+            const filterSpan = document.createElement("span");
+            filterSpan.innerText = filter;
+            filterSpan.style.fontWeight = "bold";
+            choice.appendChild(filterSpan);
+
+            if (startIndex + filter.length < value.length) {
+                // Add a span with the ending unmatched text
+                const unmatchedEnd = value.substring(startIndex + filter.length);
+                const unmatchedEndSpan = document.createElement("span");
+                unmatchedEndSpan.innerText = unmatchedEnd;
+                choice.appendChild(unmatchedEndSpan);
+            }
+        }
+
         choice.tabIndex = -1;
 
         choice.onclick = () => {


### PR DESCRIPTION
# Related Issue

Fixes #8902 

# Description

Remove innerHTML usage from dynamic typeahead feature. Now we construct the bold text with individual spans + styling.

# Sample Card

```JSON
{
	"type": "AdaptiveCard",
	"version": "1.6",
	"body": [
		{
			"type": "Input.ChoiceSet",
			"id": "dynamicChoiceSet",
			"label": "Enter the name of your team",
			"placeholder": "AdaptiveCards",
			"isRequired": true,
			"errorMessage": "You must select a valid team",
			"choices": [
				{
					"title": "Office",
					"value": "1"
				},
				{
					"title": "Teams",
					"value": "2"
				},
				{
					"title": "Outlook",
					"value": "3"
				}
			],
			"choices.data": {
				"type": "Data.Query",
				"dataset": "teamScopeInOrg",
				"count": 15,
				"skip": 0
			}
		}
	]
}
```

# How Verified

Verified manually on the AC site. 

Example HTML:
![image](https://github.com/microsoft/AdaptiveCards/assets/98650930/d740ee50-4d1e-4169-a006-349c4fd3c325)

Behavior remains the same: https://github.com/microsoft/AdaptiveCards/assets/98650930/23c9ecff-5507-4146-a064-db98b3932e62


