### PR TITLE
[CI] Don't use explicit service connection for nuget restore

### DIFF
--- a/.pipelines/uwp-ci.yml
+++ b/.pipelines/uwp-ci.yml
@@ -35,8 +35,6 @@ steps:
 
 - task: NuGetAuthenticate@1
   displayName: Authenticate to NuGet
-  inputs:
-    nuGetServiceConnections: acNugetConnection
 
 - task: NuGetCommand@2
   displayName: NuGet restore
@@ -45,7 +43,6 @@ steps:
     feedsToUse: config
     nugetConfigPath: source/nuget.config
     restoreSolution: $(solution)
-    externalFeedCredentials: 'acNugetConnection'
     verbosityRestore: Detailed
 
 - task: VSBuild@1


### PR DESCRIPTION
The `acNugetConnection` service connection being used in the `uwp-ci` job relies on a PAT to authenticate against our artifact feed. With PATs come expiry/rotation etc. - pain in the butt. But it turns out that by default if you don't specify a service connection, nuget will authenticate as the build agent, which _already_ has permissions to the feed, so we can just remove the connection altogether.