### PR TITLE
Add a style override to the root container named "Adaptive.RootContainer"

### DIFF
--- a/source/uwp/SharedRenderer/lib/XamlBuilder.cpp
+++ b/source/uwp/SharedRenderer/lib/XamlBuilder.cpp
@@ -105,15 +105,6 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
 
             bool isInShowCard = renderArgs.IsInShowCard();
 
-            if (isInShowCard)
-            {
-                XamlHelpers::SetStyleFromResourceDictionary(renderContext, L"Adaptive.ShowCard.Card", rootAsFrameworkElement);
-            }
-            else
-            {
-                XamlHelpers::SetStyleFromResourceDictionary(renderContext, L"Adaptive.Card", rootAsFrameworkElement);
-            }
-
             xamlTreeRoot = rootAsFrameworkElement;
 
             if (!isInShowCard && xamlBuilder)
@@ -214,7 +205,15 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
             winrt::WholeItemsPanel bodyElementHost = *bodyElementHostImpl;
 
             // Override the root styles
-            XamlHelpers::SetStyleFromResourceDictionary(renderContext, L"Adaptive.RootContainer", bodyElementHost);
+            if (renderArgs.IsInShowCard())
+            {
+                XamlHelpers::SetStyleFromResourceDictionary(renderContext, L"Adaptive.ShowCard.Card", bodyElementHost);
+            }
+            else
+            {
+                XamlHelpers::SetStyleFromResourceDictionary(renderContext, L"Adaptive.Card", bodyElementHost);
+            }
+
             // If a style was not applied, add margins from the host config
             if (!bodyElementHost.Style())
             {

--- a/source/uwp/SharedRenderer/lib/XamlBuilder.cpp
+++ b/source/uwp/SharedRenderer/lib/XamlBuilder.cpp
@@ -213,7 +213,13 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
             bodyElementHostImpl->SetAdaptiveHeight(true);
             winrt::WholeItemsPanel bodyElementHost = *bodyElementHostImpl;
 
-            XamlHelpers::ApplyMarginToXamlElement(hostConfig, bodyElementHost);
+            // Override the root styles
+            XamlHelpers::SetStyleFromResourceDictionary(renderContext, L"Adaptive.RootContainer", bodyElementHost);
+            // If a style was not applied, add margins from the host config
+            if (!bodyElementHost.Style())
+            {
+                XamlHelpers::ApplyMarginToXamlElement(hostConfig, bodyElementHost);
+            }
 
             winrt::HeightType adaptiveCardHeightType = adaptiveCard.Height();
 


### PR DESCRIPTION
Add a style override to the root container named "Adaptive.RootContainer" so that custom margins can be applied

# Description
This style enables a host to set the margins of the container to be other than uniform.  This enables the background of the panel to bleed up into the frame for a card that may be contained in UI that provides a title bar.

# How Verified
Manually verified in a host that sets an OverrideStyles that contains a style with this name in its dictionary.