### PR TITLE
[a11y] Update acd-peerButton height to 24px

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/adaptivecards-designer.css
+++ b/source/nodejs/adaptivecards-designer/src/adaptivecards-designer.css
@@ -774,7 +774,7 @@
     display: flex;
     align-items: center;
     pointer-events: all !important;
-    height: 20px;
+    height: 24px;
     border-radius: 0;
 }
 


### PR DESCRIPTION
# Related Issue

Fixes #8897

# Description

Update height of the acd peer button to height of 24px because of a11y requirements.

# Sample Card

N/A - designer issue

# How Verified

Will verify manually on PR site and add screenshots.

![image](https://github.com/microsoft/AdaptiveCards/assets/98650930/62cb5ca7-fb2a-45a5-940f-9efb0c40648c)

