### PR TITLE
[Designer] Update data binding 

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/data.ts
+++ b/source/nodejs/adaptivecards-designer/src/data.ts
@@ -302,9 +302,17 @@ export class FieldDefinition {
         let forceIndexerSyntax: boolean = false;
 
         for (let i = path.length - 1; i >= 0; i--) {
-            let qualifiedName = path[i].qualifiedName(false)
+            let qualifiedName = path[i].qualifiedName(false);
 
-            if (shouldUseIndexerSyntax(qualifiedName) || forceIndexerSyntax) {
+            let modifiedName = qualifiedName;
+
+            // If we include `[0]` in the qualified name while determining if we should use indexer syntax,
+            // We could incorrectly wrap the name in []
+            if (this.dataType instanceof ArrayData && qualifiedName.endsWith("[0]")) {
+                modifiedName = qualifiedName.substring(0, qualifiedName.length - 3);
+            }
+
+            if (shouldUseIndexerSyntax(modifiedName) || forceIndexerSyntax) {
                 qualifiedName = "['" + qualifiedName + "']";
 
                 forceIndexerSyntax = true;

--- a/source/nodejs/adaptivecards-designer/src/data.ts
+++ b/source/nodejs/adaptivecards-designer/src/data.ts
@@ -308,7 +308,7 @@ export class FieldDefinition {
 
             // If we include `[0]` in the qualified name while determining if we should use indexer syntax,
             // We could incorrectly wrap the name in []
-            if (this.dataType instanceof ArrayData && qualifiedName.endsWith("[0]")) {
+            if (path[i].dataType instanceof ArrayData && qualifiedName.endsWith("[0]")) {
                 modifiedName = qualifiedName.substring(0, qualifiedName.length - 3);
             }
 


### PR DESCRIPTION
# Related Issue

Fixes #8013 

# Description

When generating the templating variable from the `Bind...` button in the designer, we have an edge case for data variables that contain special characters. In this scenario, we typically want to use index syntax and wrap the var in braces.

However, this does not work for arrays. For arrays, we index into the first element by appending `[0]` to the name. This forces the index syntax incorrectly because the name now includes special characters.

I updated the logic to remove `[0]` from the end of array type names before checking for special characters.

# Sample Card

```JSON
{
    "type": "AdaptiveCard",
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
    "version": "1.5",
    "body": [
        {
            "type": "TextBlock",
            "text": "${$root['employees[0]']['name']}",
            "wrap": true
        }
    ],
    "data": {
        "employees": [
            {
                "name": "Gabriela Leticia"
            },
            {
                "name": "Natalia Tercera"
            },
            {
                "name": "Waleska Cristobal"
            }
        ]
    }
}
```

# How Verified

Verified on the CI site.
