### PR TITLE
Fix load wpf assembly fail in dotnet 6

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveCardRenderer.cs
+++ b/source/dotnet/Library/AdaptiveCards.Rendering.Wpf/AdaptiveCardRenderer.cs
@@ -92,10 +92,16 @@ namespace AdaptiveCards.Rendering.Wpf
                 // Wrap this to avoid Console applications to crash because of this : https://github.com/Microsoft/AdaptiveCards/issues/2121
                 try
                 {
+#if NET6_0_OR_GREATER
+                    const string assembly = "AdaptiveCards.Rendering.Wpf.Net6";
+#else
+                    const string assembly = "AdaptiveCards.Rendering.Wpf";
+#endif
+                    var source = new Uri($"/{assembly};component/Themes/generic.xaml",
+                        UriKind.RelativeOrAbsolute);
                     var resource = new ResourceDictionary
                     {
-                        Source = new Uri("/AdaptiveCards.Rendering.Wpf;component/Themes/generic.xaml",
-                       UriKind.RelativeOrAbsolute)
+                        Source = source
                     };
                     _resources.MergedDictionaries.Add(resource);
                 }


### PR DESCRIPTION


# Related Issue

Fixes #8949



# Description

Updating the assembly path when running with dotnet 6 framework.

# Sample Card

None.

# How Verified

How you verified the fix, including one or all of the following:

1. New unit tests that were added if any. If none were added please add a quick line explaining why not. Not need.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it
will aid in code reviews or corresponding fixes on other platforms for eg.***
