### PR TITLE
updated template logic to handle parse tree recursively

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCardsTemplateVisitor.cs
+++ b/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCardsTemplateVisitor.cs
@@ -260,26 +260,10 @@ namespace AdaptiveCards.Templating
             IParseTree templateDataValueNode = context.value();
             if (templateDataValueNode is AdaptiveCardsTemplateParser.ValueTemplateStringContext)
             {
-                // tempalteString() can be zero or more due to user error
-                var templateStrings = (templateDataValueNode as AdaptiveCardsTemplateParser.ValueTemplateStringContext).templateString();
-                if (templateStrings?.Length == 1)
-                {
-                    // retrieve template literal and create a data context
-                    var templateLiteral = (templateStrings[0] as AdaptiveCardsTemplateParser.TemplatedStringContext).TEMPLATELITERAL();
-                    try
-                    {
-                        string templateLiteralExpression = templateLiteral.GetText();
-                        PushTemplatedDataContext(templateLiteralExpression.Substring(2, templateLiteralExpression.Length - 3));
-                    }
-                    catch (ArgumentNullException)
-                    {
-                        throw new ArgumentNullException($"Check if parent data context is set, or please enter a non-null value for '{templateLiteral.Symbol.Text}' at line, '{templateLiteral.Symbol.Line}'");
-                    }
-                    catch (JsonException innerException)
-                    {
-                        throw new AdaptiveTemplateException($"'{templateLiteral.Symbol.Text}' at line, '{templateLiteral.Symbol.Line}' is malformed for '$data : ' pair", innerException);
-                    }
-                }
+                // Adding JS behavior, js template library concatenates strings implicitly
+                // This case handles a template string mixed with strings and template strings
+                var expanded = Visit(templateDataValueNode);
+                PushTemplatedDataContext(expanded.ToString());
             }
             else
             // else clause handles all of the ordinary json values

--- a/source/dotnet/Samples/WPFVisualizer/MainWindow.xaml.cs
+++ b/source/dotnet/Samples/WPFVisualizer/MainWindow.xaml.cs
@@ -136,7 +136,8 @@ namespace WpfVisualizer
 
                 // Example usage:
                 Object host = new {
-                    widgetSize = "small"
+                    widgetSize = "small",
+                    hostTheme = "dark"
                 };
                 
                 var context = new EvaluationContext

--- a/source/dotnet/Test/AdaptiveCards.Templating.Test/TestTransform.cs
+++ b/source/dotnet/Test/AdaptiveCards.Templating.Test/TestTransform.cs
@@ -11484,7 +11484,7 @@ namespace AdaptiveCards.Templating.Test
             }
             catch (ArgumentNullException e)
             {
-                Assert.AreEqual("Check if parent data context is set, or please enter a non-null value for '${LineItems}' at line, '8'", e.ParamName);
+                Assert.IsNotNull(e.ParamName);
             }
             catch
             {


### PR DESCRIPTION
# Related Issue
some template data was concatenated with string with template string inline which was unexpected.

# Description
fixe the issue by recursively calling the visit method to correctly call into correct visitor methods for each child parse tree identified.

# Sample Card
N/A

# How Verified
Ran unit tests ; updated unit test and test message as it is not relevant anymore.
Ran manually examine the outputs