### PR TITLE
remove double quotes when returned from value

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCardsTemplateVisitor.cs
+++ b/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCardsTemplateVisitor.cs
@@ -190,7 +190,13 @@ namespace AdaptiveCards.Templating
                 throw new ArgumentNullException("Parent data context or selection path is null");
             }
 
-            var (value, error) = new ValueExpression("=" + Regex.Unescape(jpath)).TryGetValue(parentDataContext.AELMemory);
+            var unescaped = Regex.Unescape(jpath);
+            if (unescaped.StartsWith("\""))
+            {
+                unescaped = unescaped.Substring(1, unescaped.Length - 2);
+            }
+
+            var (value, error) = new ValueExpression("=" + unescaped).TryGetValue(parentDataContext.AELMemory);
             if (error == null)
             {
                 if (value is JsonNode jvalue)


### PR DESCRIPTION
# Related Issue
When template expression is expanded in the json value, it will double quotes wrapped.

This will fail in data binding phase as this needs to be deserialized.


# Description
Removes double quotes. We can also update parser, but this will fix this niche case.


# Sample Card
N/A

# How Verified

Ran unit tests and verified manually.