### PR TITLE
[UWP/WinUI3 Renderer]: Discard Background Image if URI is not valid

### DIFF
--- a/source/uwp/SharedRenderer/lib/MediaHelpers.cpp
+++ b/source/uwp/SharedRenderer/lib/MediaHelpers.cpp
@@ -192,36 +192,38 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering::MediaHelpers
                 if (const auto search = supportedCaptionTypes.find(captionSource.MimeType());
                     search != supportedCaptionTypes.end())
                 {
-                    const auto timedTextURL = GetUrlFromString(renderContext.HostConfig(), captionSource.Url());
-
-                    winrt::IAdaptiveCardResourceResolver resourceResolver{nullptr};
-                    if (const auto resourceResolvers = renderContext.ResourceResolvers())
+                    if (const auto timedTextURL = GetUrlFromString(renderContext.HostConfig(), captionSource.Url()))
                     {
-                        resourceResolver = resourceResolvers.Get(timedTextURL.SchemeName());
-                    }
 
-                    const auto timedTextSrcResolvedHelper =
-                        [label = captionSource.Label()](winrt::TimedTextSource const& /*sender*/,
-                                                        winrt::TimedTextSourceResolveResultEventArgs const& args)
-                    {
-                        if (!args.Error())
+                        winrt::IAdaptiveCardResourceResolver resourceResolver{ nullptr };
+                        if (const auto resourceResolvers = renderContext.ResourceResolvers())
                         {
-                            args.Tracks().GetAt(0).Label(label);
+                            resourceResolver = resourceResolvers.Get(timedTextURL.SchemeName());
                         }
-                    };
-                    if (!resourceResolver)
-                    {
-                        const auto timedTextSrc = winrt::TimedTextSource::CreateFromUri(timedTextURL);
-                        timedTextSrc.Resolved(timedTextSrcResolvedHelper);
-                        mediaSrc.ExternalTimedTextSources().Append(timedTextSrc);
-                    }
-                    else
-                    {
-                        auto args = winrt::make<winrt::implementation::AdaptiveCardGetResourceStreamArgs>(timedTextURL);
-                        const auto randomAccessStream = resourceResolver.GetResourceStreamAsync(args);
-                        auto timedTextSrc = winrt::TimedTextSource::CreateFromStream(randomAccessStream.get());
-                        timedTextSrc.Resolved(timedTextSrcResolvedHelper);
-                        mediaSrc.ExternalTimedTextSources().Append(timedTextSrc);
+
+                        const auto timedTextSrcResolvedHelper =
+                            [label = captionSource.Label()](winrt::TimedTextSource const& /*sender*/,
+                                winrt::TimedTextSourceResolveResultEventArgs const& args)
+                            {
+                                if (!args.Error())
+                                {
+                                    args.Tracks().GetAt(0).Label(label);
+                                }
+                            };
+                        if (!resourceResolver)
+                        {
+                            const auto timedTextSrc = winrt::TimedTextSource::CreateFromUri(timedTextURL);
+                            timedTextSrc.Resolved(timedTextSrcResolvedHelper);
+                            mediaSrc.ExternalTimedTextSources().Append(timedTextSrc);
+                        }
+                        else
+                        {
+                            auto args = winrt::make<winrt::implementation::AdaptiveCardGetResourceStreamArgs>(timedTextURL);
+                            const auto randomAccessStream = resourceResolver.GetResourceStreamAsync(args);
+                            auto timedTextSrc = winrt::TimedTextSource::CreateFromStream(randomAccessStream.get());
+                            timedTextSrc.Resolved(timedTextSrcResolvedHelper);
+                            mediaSrc.ExternalTimedTextSources().Append(timedTextSrc);
+                        }
                     }
                 }
             }

--- a/source/uwp/SharedRenderer/lib/MediaHelpers.cpp
+++ b/source/uwp/SharedRenderer/lib/MediaHelpers.cpp
@@ -225,6 +225,11 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering::MediaHelpers
                             mediaSrc.ExternalTimedTextSources().Append(timedTextSrc);
                         }
                     }
+                    else
+                    {
+                        renderContext.AddWarning(winrt::WarningStatusCode::AssetLoadFailed,
+                            L"Specified URI:" + captionSource.Url() + L" for Media Text Sources is not valid. Text sources loading has failed.");
+                    }
                 }
             }
         }

--- a/source/uwp/SharedRenderer/lib/Util.cpp
+++ b/source/uwp/SharedRenderer/lib/Util.cpp
@@ -536,27 +536,26 @@ bool IsBackgroundImageValid(winrt::AdaptiveBackgroundImage const& backgroundImag
     return false;
 }
 
-winrt::Uri UriTryCreate(winrt::hstring const &uri, winrt::hstring const& baseUri = L"")
+winrt::Uri UriTryCreate(winrt::hstring const &uriString, winrt::hstring const& baseUriString = L"")
 {
     auto factory = winrt::
         get_activation_factory<winrt::Windows::Foundation::Uri, winrt::Windows::Foundation::IUriRuntimeClassFactory>();
     auto abiFactory = static_cast<ABI::Windows::Foundation::IUriRuntimeClassFactory *>(winrt::get_abi(factory));
 
-    const winrt::hstring &localUri = uri;
-    winrt::Windows::Foundation::Uri returnValue{nullptr};
+    winrt::Windows::Foundation::Uri uri{nullptr};
     HRESULT hr = S_OK;
-    if (baseUri.empty())
+    if (baseUriString.empty())
     {
         hr = abiFactory->CreateUri(
-            static_cast<HSTRING>(winrt::get_abi(localUri)),
-            reinterpret_cast<ABI::Windows::Foundation::IUriRuntimeClass**>(winrt::put_abi(returnValue)));
+            static_cast<HSTRING>(winrt::get_abi(uriString)),
+            reinterpret_cast<ABI::Windows::Foundation::IUriRuntimeClass**>(winrt::put_abi(uri)));
     }
     else
     {
         hr = abiFactory->CreateWithRelativeUri(
-            static_cast<HSTRING>(winrt::get_abi(baseUri)),
-            static_cast<HSTRING>(winrt::get_abi(uri)),
-            reinterpret_cast<ABI::Windows::Foundation::IUriRuntimeClass**>(winrt::put_abi(returnValue)));
+            static_cast<HSTRING>(winrt::get_abi(baseUriString)),
+            static_cast<HSTRING>(winrt::get_abi(uriString)),
+            reinterpret_cast<ABI::Windows::Foundation::IUriRuntimeClass**>(winrt::put_abi(uri)));
     }
 
     if (FAILED(hr))
@@ -564,7 +563,7 @@ winrt::Uri UriTryCreate(winrt::hstring const &uri, winrt::hstring const& baseUri
         return winrt::Windows::Foundation::Uri { nullptr };
     }
 
-    return returnValue;
+    return uri;
 }
 
 winrt::Uri GetUrlFromString(winrt::AdaptiveHostConfig const& hostConfig, winrt::hstring const& urlString)

--- a/source/uwp/SharedRenderer/lib/Util.cpp
+++ b/source/uwp/SharedRenderer/lib/Util.cpp
@@ -29,6 +29,7 @@
 #include "AdaptiveSubmitActionRenderer.h"
 #include "AdaptiveToggleVisibilityActionRenderer.h"
 #include "AdaptiveExecuteActionRenderer.h"
+#include <windows.foundation.h>
 
 std::string WStringToString(std::wstring_view in)
 {
@@ -535,11 +536,42 @@ bool IsBackgroundImageValid(winrt::AdaptiveBackgroundImage const& backgroundImag
     return false;
 }
 
+winrt::Uri UriTryCreate(winrt::hstring const &uri, winrt::hstring const& baseUri = L"")
+{
+    auto factory = winrt::
+        get_activation_factory<winrt::Windows::Foundation::Uri, winrt::Windows::Foundation::IUriRuntimeClassFactory>();
+    auto abiFactory = static_cast<ABI::Windows::Foundation::IUriRuntimeClassFactory *>(winrt::get_abi(factory));
+
+    const winrt::hstring &localUri = uri;
+    winrt::Windows::Foundation::Uri returnValue{nullptr};
+    HRESULT hr = S_OK;
+    if (baseUri.empty())
+    {
+        hr = abiFactory->CreateUri(
+            static_cast<HSTRING>(winrt::get_abi(localUri)),
+            reinterpret_cast<ABI::Windows::Foundation::IUriRuntimeClass**>(winrt::put_abi(returnValue)));
+    }
+    else
+    {
+        hr = abiFactory->CreateWithRelativeUri(
+            static_cast<HSTRING>(winrt::get_abi(baseUri)),
+            static_cast<HSTRING>(winrt::get_abi(uri)),
+            reinterpret_cast<ABI::Windows::Foundation::IUriRuntimeClass**>(winrt::put_abi(returnValue)));
+    }
+
+    if (FAILED(hr))
+    {
+        return winrt::Windows::Foundation::Uri { nullptr };
+    }
+
+    return returnValue;
+}
+
 winrt::Uri GetUrlFromString(winrt::AdaptiveHostConfig const& hostConfig, winrt::hstring const& urlString)
 {
     winrt::Uri uri{nullptr};
 
-    if (const auto uriFromAbsoluteUri = winrt::Uri{urlString})
+    if (const auto uriFromAbsoluteUri = UriTryCreate(urlString))
     {
         return uriFromAbsoluteUri;
     }
@@ -547,7 +579,7 @@ winrt::Uri GetUrlFromString(winrt::AdaptiveHostConfig const& hostConfig, winrt::
     {
         winrt::hstring imageBaseUrl = hostConfig.ImageBaseUrl();
 
-        if (const auto uriFromRelativeUri = winrt::Uri{imageBaseUrl, urlString})
+        if (const auto uriFromRelativeUri = UriTryCreate(urlString, imageBaseUrl))
         {
             return uriFromRelativeUri;
         }

--- a/source/uwp/SharedRenderer/lib/XamlHelpers.cpp
+++ b/source/uwp/SharedRenderer/lib/XamlHelpers.cpp
@@ -358,36 +358,43 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering::XamlHelpers
                                winrt::AdaptiveRenderContext const& renderContext)
     {
         // Creates the background image for all fill modes
-        auto tileControl = winrt::make<winrt::implementation::TileControl>();
-        auto imageUrl = GetUrlFromString(renderContext.HostConfig(), adaptiveBackgroundImage.Url());
-        bool IsSvg = IsSvgImage(imageUrl);
-
-        // In order to reuse the image creation code paths, we simply create an adaptive card
-        // image element and then build that into xaml and apply to the root.
-        if (const auto backgroundImage = CreateBackgroundImage(renderContext, tileControl, IsSvg, imageUrl))
+        if (const auto imageUrl = GetUrlFromString(renderContext.HostConfig(), adaptiveBackgroundImage.Url()))
         {
-            // Set IsEnabled to false to avoid generating a tab stop for the background image tile control
-            tileControl.IsEnabled(false);
-            tileControl.BackgroundImage(adaptiveBackgroundImage);
-            if (!IsSvg)
+            auto tileControl = winrt::make<winrt::implementation::TileControl>();
+            bool IsSvg = IsSvgImage(imageUrl);
+
+            // In order to reuse the image creation code paths, we simply create an adaptive card
+            // image element and then build that into xaml and apply to the root.
+            if (const auto backgroundImage = CreateBackgroundImage(renderContext, tileControl, IsSvg, imageUrl))
             {
-                tileControl.LoadImageBrush(backgroundImage);
-            }
+                // Set IsEnabled to false to avoid generating a tab stop for the background image tile control
+                tileControl.IsEnabled(false);
+                tileControl.BackgroundImage(adaptiveBackgroundImage);
+                if (!IsSvg)
+                {
+                    tileControl.LoadImageBrush(backgroundImage);
+                }
 
-            XamlHelpers::AppendXamlElementToPanel(tileControl, rootPanel);
+                XamlHelpers::AppendXamlElementToPanel(tileControl, rootPanel);
 
-            // The overlay applied to the background image is determined by a resouce, so create
-            // the overlay if that resources exists
-            auto resourceDictionary = renderContext.OverrideStyles();
-            if (const auto backgroundOverlayBrush =
+                // The overlay applied to the background image is determined by a resouce, so create
+                // the overlay if that resources exists
+                auto resourceDictionary = renderContext.OverrideStyles();
+                if (const auto backgroundOverlayBrush =
                     XamlHelpers::TryGetResourceFromResourceDictionaries(resourceDictionary, c_BackgroundImageOverlayBrushKey)
-                        .try_as<winrt::Brush>())
-            {
-                winrt::Rectangle overlayRectangle;
-                overlayRectangle.Fill(backgroundOverlayBrush);
+                    .try_as<winrt::Brush>())
+                {
+                    winrt::Rectangle overlayRectangle;
+                    overlayRectangle.Fill(backgroundOverlayBrush);
 
-                XamlHelpers::AppendXamlElementToPanel(overlayRectangle, rootPanel);
+                    XamlHelpers::AppendXamlElementToPanel(overlayRectangle, rootPanel);
+                }
             }
+        }
+        else
+        {
+            renderContext.AddWarning(winrt::WarningStatusCode::AssetLoadFailed,
+               L"Specified URI:" + adaptiveBackgroundImage.Url() + L" for background image is not valid. Image loading has failed.");
         }
     }
 

--- a/source/uwp/UWPUnitTests/RenderTests.cs
+++ b/source/uwp/UWPUnitTests/RenderTests.cs
@@ -345,7 +345,6 @@ namespace UWPUnitTests
             Assert.AreEqual("Specified URI:${myBackgroundImage} for background image is not valid. Image loading has failed.", renderedCard.Warnings[0].Message);
         }
 
-
         public async Task<RenderedAdaptiveCard> RenderOnUIThread(AdaptiveCard card, AdaptiveHostConfig hostConfig = null, bool overflowMaxActions = false)
         {
             RenderedAdaptiveCard renderedCard = null;

--- a/source/uwp/UWPUnitTests/RenderTests.cs
+++ b/source/uwp/UWPUnitTests/RenderTests.cs
@@ -332,6 +332,19 @@ namespace UWPUnitTests
             Assert.AreEqual("Some actions were moved to an overflow menu due to exceeding the maximum number of actions allowed", renderedCard.Warnings[0].Message);
 
         }
+        [TestMethod]
+        public async Task FaultyBackgroundImageRenderTest()
+        {
+            AdaptiveCard card = new AdaptiveCard();
+            AdaptiveBackgroundImage backgroundImage = new AdaptiveBackgroundImage();
+            backgroundImage.Url = "${myBackgroundImage}";
+            card.BackgroundImage = backgroundImage;
+            var renderedCard = await RenderOnUIThread(card);
+            Assert.AreEqual(0, renderedCard.Errors.Count);
+            Assert.AreEqual(1, renderedCard.Warnings.Count);
+            Assert.AreEqual("Specified URI:${myBackgroundImage} for background image is not valid. Image loading has failed.", renderedCard.Warnings[0].Message);
+        }
+
 
         public async Task<RenderedAdaptiveCard> RenderOnUIThread(AdaptiveCard card, AdaptiveHostConfig hostConfig = null, bool overflowMaxActions = false)
         {


### PR DESCRIPTION
# Related Issue
For MSFT folks: https://microsoft.visualstudio.com/OS/_workitems/edit/52712745

# Description
Background Image with invalid URI would crash the entire app when we attempted to render it. This change addresses that and brings the behaviour on par with NodeJS renderer and drops the image in this case.  + added warning for text sources for mediasource for the similar problem.

# Sample Card
```
{
    "type": "AdaptiveCard",
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
    "version": "1.6",
    "backgroundImage" : "invalidURI",
    "body": []
}
```

# How Verified
Verified locally that the BackgroundImage is being discarded as well as added unit test for this scenario.

TODO: follow up on https://github.com/microsoft/AdaptiveCards/issues/8967
