### PR TITLE
updated when

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCardsTemplateVisitor.cs
+++ b/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCardsTemplateVisitor.cs
@@ -498,6 +498,10 @@ namespace AdaptiveCards.Templating
                             else
                             {
                                 whenEvaluationResult = returnedResult.WhenEvaluationResult;
+                                if(whenEvaluationResult == AdaptiveCardsTemplateResult.EvaluationResult.EvaluatedToFalse)
+                                {
+                                    break;
+                                }
                             }
                         }
                         else


### PR DESCRIPTION
# Related Issue
n/a

# Description
Added pruning at $When evaluation.
There is no reason to continue evaluating the obj when the expression is evaluated to false.
Made changes to short-circuit when false.

# Sample Card
n/a

# How Verified

1. Ran unit test
2. Tested manually.