### PR TITLE
[NuGet] Repoint to internal nuget feeds

### DIFF
--- a/source/dotnet/NuGet.config
+++ b/source/dotnet/NuGet.config
@@ -3,7 +3,7 @@
   <packageSources>
     <!-- remove any machine-wide sources with <clear/> -->
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="AdaptiveCards-public" value="https://pkgs.dev.azure.com/microsoft/AdaptiveCards/_packaging/AdaptiveCards-public/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/source/uwp/winui3/NuGet.config
+++ b/source/uwp/winui3/NuGet.config
@@ -3,7 +3,7 @@
   <packageSources>
     <!-- remove any machine-wide sources with <clear/> -->
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="AdaptiveCards-public" value="https://pkgs.dev.azure.com/microsoft/AdaptiveCards/_packaging/AdaptiveCards-public/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />


### PR DESCRIPTION
There were a couple of nuget configs not pointing to our internal nuget feeds. This fixes that.