### PR TITLE
Add adaptivecards#markdownPassthroughPolicy and adaptivecards#restore…

### DIFF
--- a/source/nodejs/adaptivecards/package-lock.json
+++ b/source/nodejs/adaptivecards/package-lock.json
@@ -8,9 +8,6 @@
 			"name": "adaptivecards",
 			"version": "1.3.0-alpha1",
 			"license": "MIT",
-			"dependencies": {
-				"dompurify": "^3.1.6"
-			},
 			"devDependencies": {
 				"@types/jest": "^23.3.10",
 				"jest": "^24.5.0",
@@ -2395,11 +2392,6 @@
 			"dependencies": {
 				"webidl-conversions": "^4.0.2"
 			}
-		},
-		"node_modules/dompurify": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.6.tgz",
-			"integrity": "sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ=="
 		},
 		"node_modules/duplexify": {
 			"version": "3.6.1",

--- a/source/nodejs/adaptivecards/package-lock.json
+++ b/source/nodejs/adaptivecards/package-lock.json
@@ -8,6 +8,9 @@
 			"name": "adaptivecards",
 			"version": "1.3.0-alpha1",
 			"license": "MIT",
+			"dependencies": {
+				"@types/trusted-types": "^2.0.7"
+			},
 			"devDependencies": {
 				"@types/jest": "^23.3.10",
 				"jest": "^24.5.0",
@@ -554,6 +557,11 @@
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
 			"integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
 			"dev": true
+		},
+		"node_modules/@types/trusted-types": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
 		},
 		"node_modules/@types/yargs": {
 			"version": "12.0.10",
@@ -8873,9 +8881,9 @@
 			"dev": true
 		},
 		"node_modules/typescript": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
-			"integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==",
+			"version": "3.9.10",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+			"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",

--- a/source/nodejs/adaptivecards/package.json
+++ b/source/nodejs/adaptivecards/package.json
@@ -56,8 +56,5 @@
 			"jsx",
 			"json"
 		]
-	},
-	"dependencies": {
-		"dompurify": "^3.1.6"
 	}
 }

--- a/source/nodejs/adaptivecards/package.json
+++ b/source/nodejs/adaptivecards/package.json
@@ -56,5 +56,8 @@
 			"jsx",
 			"json"
 		]
+	},
+	"dependencies": {
+		"@types/trusted-types": "^2.0.7"
 	}
 }

--- a/source/nodejs/adaptivecards/src/card-elements.ts
+++ b/source/nodejs/adaptivecards/src/card-elements.ts
@@ -5,11 +5,10 @@ import * as Shared from "./shared";
 import * as Utils from "./utils";
 import * as HostConfig from "./host-config";
 import * as TextFormatters from "./text-formatters";
-import { sanitize } from "dompurify";
-import type { Config } from "dompurify";
 
-function sanitizeHTML(html: string, extendedConfig: Config = {}): string {
-	return sanitize(html, {...extendedConfig, USE_PROFILES: { html: true },  RETURN_TRUSTED_TYPE: true }) as unknown as string;
+function clearElement(element: HTMLElement) : void {
+    const trustedHtml = (typeof window === 'undefined') ? "" : (window.trustedTypes?.emptyHTML ?? "");
+    element.innerHTML = trustedHtml as string;
 }
 
 function invokeSetCollection(action: Action, collection: ActionCollection) {
@@ -1138,12 +1137,16 @@ export class TextBlock extends BaseTextBlock {
     private _treatAsPlainText: boolean = true;
 
     private restoreOriginalContent() {
-        var maxHeight = this.maxLines
-            ? (this._computedLineHeight * this.maxLines) + 'px'
-            : null;
+        if (this.renderedElement !== undefined) {
+            var maxHeight = this.maxLines
+                ? (this._computedLineHeight * this.maxLines) + 'px'
+                : null;
 
-        this.renderedElement.style.maxHeight = maxHeight;
-        this.renderedElement.innerHTML = sanitizeHTML(this._originalInnerHtml);
+            this.renderedElement.style.maxHeight = maxHeight;
+
+            const originalHtml = TextBlock._ttRoundtripPolicy?.createHTML(this._originalInnerHtml) ?? this._originalInnerHtml;
+            this.renderedElement.innerHTML = originalHtml as string;
+        }
     }
 
     private truncateIfSupported(maxHeight: number): boolean {
@@ -1167,6 +1170,22 @@ export class TextBlock extends BaseTextBlock {
 
         return false;
     }
+
+    // Markdown processing is handled outside of Adaptive Cards. It's up to the host to ensure that markdown is safely
+    // processed.
+    private static readonly _ttMarkdownPolicy = (typeof window === 'undefined') ? undefined : window.trustedTypes?.createPolicy(
+        "adaptivecards#markdownPassthroughPolicy",
+        { createHTML: (value) => value }
+    );
+
+    // When "advanced" truncation is enabled (see GlobalSettings.useAdvancedCardBottomTruncation and
+    // GlobalSettings.useAdvancedTextBlockTruncation), we store the original pre-truncation content in
+    // _originalInnerHtml so that we can restore/recalculate truncation later if space availability has changed (see
+    // TextBlock.restoreOriginalContent())
+    private static readonly _ttRoundtripPolicy = (typeof window === 'undefined') ? undefined : window.trustedTypes?.createPolicy(
+        "adaptivecards#restoreContentsPolicy",
+        { createHTML: (value) => value }
+    );
 
     protected setText(value: string) {
         super.setText(value);
@@ -1257,7 +1276,10 @@ export class TextBlock extends BaseTextBlock {
                 element.innerText = this._processedText;
             }
             else {
-                element.innerHTML = sanitizeHTML(this._processedText);
+                const processedHtml =
+                    TextBlock._ttMarkdownPolicy?.createHTML(this._processedText) ??
+                    this._processedText;
+                element.innerHTML = processedHtml as string;
             }
 
             if (element.firstElementChild instanceof HTMLElement) {
@@ -1939,27 +1961,29 @@ export class Image extends CardElement {
                 raiseImageLoadedEvent(this);
             }
             imageElement.onerror = (e: Event) => {
-                let card = this.getRootElement() as AdaptiveCard;
+                if (this.renderedElement) {
+                    let card = this.getRootElement() as AdaptiveCard;
 
-                this.renderedElement.innerHTML = sanitizeHTML("");
+                    clearElement(this.renderedElement);
 
-                if (card && card.designMode) {
-                    let errorElement = document.createElement("div");
-                    errorElement.style.display = "flex";
-                    errorElement.style.alignItems = "center";
-                    errorElement.style.justifyContent = "center";
-                    errorElement.style.backgroundColor = "#EEEEEE";
-                    errorElement.style.color = "black";
-                    errorElement.innerText = ":-(";
-                    errorElement.style.padding = "10px";
+                    if (card && card.designMode) {
+                        let errorElement = document.createElement("div");
+                        errorElement.style.display = "flex";
+                        errorElement.style.alignItems = "center";
+                        errorElement.style.justifyContent = "center";
+                        errorElement.style.backgroundColor = "#EEEEEE";
+                        errorElement.style.color = "black";
+                        errorElement.innerText = ":-(";
+                        errorElement.style.padding = "10px";
 
-                    this.applySize(errorElement);
+                        this.applySize(errorElement);
 
-                    this.renderedElement.appendChild(errorElement);
+                        this.renderedElement.appendChild(errorElement);
+                    }
                 }
 
                 raiseImageLoadedEvent(this);
-            }
+            };
             imageElement.style.maxHeight = "100%";
             imageElement.style.minWidth = "0";
             imageElement.classList.add(hostConfig.makeCssClassName("ac-image"));
@@ -2566,12 +2590,13 @@ export class Media extends CardElement {
                     e.preventDefault();
                     e.cancelBubble = true;
 
-                    let mediaPlayerElement = this.renderMediaPlayer();
+                    if (this.renderedElement) {
+                        let mediaPlayerElement = this.renderMediaPlayer();
+                        clearElement(this.renderedElement);
+                        this.renderedElement.appendChild(mediaPlayerElement);
 
-                    this.renderedElement.innerHTML = sanitizeHTML("");
-                    this.renderedElement.appendChild(mediaPlayerElement);
-
-                    mediaPlayerElement.play();
+                        mediaPlayerElement.play();
+                    }
                 }
                 else {
                     if (Media.onPlay) {
@@ -4534,7 +4559,7 @@ class ActionCollection {
     private _actionCard: HTMLElement = null;
 
     private refreshContainer() {
-        this._actionCardContainer.innerHTML = sanitizeHTML("");
+        clearElement(this._actionCardContainer);
 
         if (this._actionCard === null) {
             this._actionCardContainer.style.marginTop = "0px";


### PR DESCRIPTION
# Related Issue


**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

# Description

- The adaptivecards-v1 version we are using on outlook web at some point should be updated and use adaptivecards-v3 that already has the trusted types support, this is to unblock the enabling of the Trusted Types CSP on outlook.
- I copied exactly what Anna did on adaptivecards-v3 to have consistency on the fix.
- Using dompurify inside of this function could create more issues since the html can get tags or attributes needed on outlook.

# Sample Card

If appropriate, please include a link to a card in one of the samples directories that can be used to validate this change. This can be an existing card or a card added with this PR.

# How Verified

How you verified the fix, including one or all of the following:
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it
will aid in code reviews or corresponding fixes on other platforms for eg.***
