### PR TITLE
Update CsWinRT for WinUI 3 renderer

### DIFF
--- a/source/uwp/winui3/ObjectModelCsProjection/ObjectModelCsProjection.csproj
+++ b/source/uwp/winui3/ObjectModelCsProjection/ObjectModelCsProjection.csproj
@@ -15,7 +15,7 @@
     <BaseOutputPath>$(SolutionDir)\$(Platform)\$(MSBuildProjectName)</BaseOutputPath>
   </PropertyGroup>
   <ItemGroup>
-      <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.1" />
+      <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.1" />
       <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.221109.1" />
       <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.1" />
   </ItemGroup>

--- a/source/uwp/winui3/ObjectModelCsProjection/ObjectModelCsProjection.csproj
+++ b/source/uwp/winui3/ObjectModelCsProjection/ObjectModelCsProjection.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0-windows10.0.17763.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
-    <WindowsSdkPackageVersion>10.0.18362.38</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.38</WindowsSdkPackageVersion>
     <!-- Set Platform to AnyCPU to allow consumption of the projection assembly from any architecture. -->
     <Platform>AnyCPU</Platform>
     <RootNamespace>AdaptiveCards.ObjectModel.WinUI3</RootNamespace>

--- a/source/uwp/winui3/ObjectModelCsProjection/ObjectModelCsProjection.csproj
+++ b/source/uwp/winui3/ObjectModelCsProjection/ObjectModelCsProjection.csproj
@@ -1,7 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0-windows10.0.17763.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <WindowsSdkPackageVersion>10.0.18362.38</WindowsSdkPackageVersion>
     <!-- Set Platform to AnyCPU to allow consumption of the projection assembly from any architecture. -->
     <Platform>AnyCPU</Platform>
     <RootNamespace>AdaptiveCards.ObjectModel.WinUI3</RootNamespace>

--- a/source/uwp/winui3/RendererCsProjection/RendererCsProjection.csproj
+++ b/source/uwp/winui3/RendererCsProjection/RendererCsProjection.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0-windows10.0.17763.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
-    <WindowsSdkPackageVersion>10.0.18362.38</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.38</WindowsSdkPackageVersion>
     <!-- Set Platform to AnyCPU to allow consumption of the projection assembly from any architecture. -->
     <Platform>AnyCPU</Platform>
     <RootNamespace>AdaptiveCards.Rendering.WinUI3</RootNamespace>

--- a/source/uwp/winui3/RendererCsProjection/RendererCsProjection.csproj
+++ b/source/uwp/winui3/RendererCsProjection/RendererCsProjection.csproj
@@ -15,7 +15,7 @@
     <BaseOutputPath>$(SolutionDir)\$(Platform)\$(MSBuildProjectName)</BaseOutputPath>
   </PropertyGroup>
   <ItemGroup>
-      <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.1" />
+      <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.1" />
       <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.221109.1" />
       <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.1" />
   </ItemGroup>

--- a/source/uwp/winui3/RendererCsProjection/RendererCsProjection.csproj
+++ b/source/uwp/winui3/RendererCsProjection/RendererCsProjection.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0-windows10.0.17763.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <WindowsSdkPackageVersion>10.0.18362.38</WindowsSdkPackageVersion>
     <!-- Set Platform to AnyCPU to allow consumption of the projection assembly from any architecture. -->
     <Platform>AnyCPU</Platform>
     <RootNamespace>AdaptiveCards.Rendering.WinUI3</RootNamespace>

--- a/source/uwp/winui3/SimpleVisualizer/SimpleVisualizer.csproj
+++ b/source/uwp/winui3/SimpleVisualizer/SimpleVisualizer.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.1" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.221109.1" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.1" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.14" />

--- a/source/uwp/winui3/SimpleVisualizer/SimpleVisualizer.csproj
+++ b/source/uwp/winui3/SimpleVisualizer/SimpleVisualizer.csproj
@@ -1,8 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0-windows10.0.17763.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <WindowsSdkPackageVersion>10.0.18362.38</WindowsSdkPackageVersion>
     <RootNamespace>SimpleVisualizer</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>

--- a/source/uwp/winui3/SimpleVisualizer/SimpleVisualizer.csproj
+++ b/source/uwp/winui3/SimpleVisualizer/SimpleVisualizer.csproj
@@ -3,7 +3,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0-windows10.0.17763.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
-    <WindowsSdkPackageVersion>10.0.18362.38</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.38</WindowsSdkPackageVersion>
     <RootNamespace>SimpleVisualizer</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>

--- a/source/uwp/winui3/Visualizer/AdaptiveCardVisualizer.csproj
+++ b/source/uwp/winui3/Visualizer/AdaptiveCardVisualizer.csproj
@@ -3,7 +3,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0-windows10.0.22000.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
-    <WindowsSdkPackageVersion>10.0.17763.38</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.22000.38</WindowsSdkPackageVersion>
     <RootNamespace>XamlCardVisualizer</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>

--- a/source/uwp/winui3/Visualizer/AdaptiveCardVisualizer.csproj
+++ b/source/uwp/winui3/Visualizer/AdaptiveCardVisualizer.csproj
@@ -26,7 +26,7 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.WinUI" Version="7.1.2" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Layout" Version="7.1.2" />
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.1" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.221109.1" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.14" />

--- a/source/uwp/winui3/Visualizer/AdaptiveCardVisualizer.csproj
+++ b/source/uwp/winui3/Visualizer/AdaptiveCardVisualizer.csproj
@@ -3,6 +3,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0-windows10.0.22000.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <WindowsSdkPackageVersion>10.0.18362.38</WindowsSdkPackageVersion>
     <RootNamespace>XamlCardVisualizer</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>

--- a/source/uwp/winui3/Visualizer/AdaptiveCardVisualizer.csproj
+++ b/source/uwp/winui3/Visualizer/AdaptiveCardVisualizer.csproj
@@ -3,7 +3,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0-windows10.0.22000.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
-    <WindowsSdkPackageVersion>10.0.18362.38</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.38</WindowsSdkPackageVersion>
     <RootNamespace>XamlCardVisualizer</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>

--- a/source/uwp/winui3/WinUI3ObjectModelTest/WinUI3ObjectModelTest.csproj
+++ b/source/uwp/winui3/WinUI3ObjectModelTest/WinUI3ObjectModelTest.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.1" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.221109.1" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.1" />
     <PackageReference Include="MSTest.TestAdapter">

--- a/source/uwp/winui3/WinUI3ObjectModelTest/WinUI3ObjectModelTest.csproj
+++ b/source/uwp/winui3/WinUI3ObjectModelTest/WinUI3ObjectModelTest.csproj
@@ -3,7 +3,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0-windows10.0.17763.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
-    <WindowsSdkPackageVersion>10.0.18362.38</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.17763.38</WindowsSdkPackageVersion>
     <RootNamespace>WinUI3ObjectModelTest</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;arm64</Platforms>

--- a/source/uwp/winui3/WinUI3ObjectModelTest/WinUI3ObjectModelTest.csproj
+++ b/source/uwp/winui3/WinUI3ObjectModelTest/WinUI3ObjectModelTest.csproj
@@ -3,6 +3,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0-windows10.0.17763.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <WindowsSdkPackageVersion>10.0.18362.38</WindowsSdkPackageVersion>
     <RootNamespace>WinUI3ObjectModelTest</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;arm64</Platforms>


### PR DESCRIPTION
# Related Issue

Closes #9001

# Description

Any WinUI 3 apps that use Adaptive Cards and would like to update to WindowsAppSDK 1.6 will need Adaptive Cards to support CsWinrt 2.1.0+. This change updates that version. It also adds the WindowsSdkPackageVersion property, as described in   https://github.com/microsoft/CsWinRT/releases/tag/2.1.1.240807.2

# Sample Card

N/A

# How Verified

How you verified the fix, including one or all of the following:
Manually verified with AdaptiveCardVisualizer
