### PR TITLE
Add SerializationContext to React wrapper interface.

### DIFF
--- a/source/nodejs/adaptivecards-react/README.md
+++ b/source/nodejs/adaptivecards-react/README.md
@@ -65,3 +65,24 @@ import {ProvidesHostConfigContext, AdaptiveCardUsingHostConfigContext } from "ad
         </...>    
       </ProvidesHostConfigContext>
 ```
+
+- extend AdativeCard with [custom elements](https://learn.microsoft.com/en-us/adaptive-cards/sdk/rendering-cards/javascript/extensibility):
+
+```tsx
+import { CardElement, CardObjectRegistry, GlobalRegistry, SerializationContext } from "adaptivecards";
+
+// populate element registry
+const elementRegistry = new CardObjectRegistry<CardElement>();
+GlobalRegistry.populateWithDefaultElements(elementRegistry);
+elementRegistry.register(CustomElement.JsonTypeName, CustomElement);
+
+// customize serialization context
+const serializationContext = new SerializationContext();
+serializationContext.setElementRegistry(elementRegistry);
+
+// ...
+
+// pass context to the adaptive card host
+    <AdaptiveCard payload={card} hostConfig={hostConfig} serializationContext={serializationContext} />
+
+```

--- a/source/nodejs/adaptivecards-react/src/adaptive-card.tsx
+++ b/source/nodejs/adaptivecards-react/src/adaptive-card.tsx
@@ -21,6 +21,7 @@ export interface Props {
     onError?: Function;
     style?: object;
     hostConfig?: object;
+    serializationContext?: AdaptiveCards.SerializationContext;
 }
 
 const propTypes = {
@@ -40,6 +41,8 @@ const propTypes = {
     style: PropTypes.object,
     /** HostConfig. [More Info](https://docs.microsoft.com/en-us/adaptive-cards/rendering-cards/host-config) */
     hostConfig: PropTypes.object,
+    /** Custom serialization context for elements customization. [More Info](https://learn.microsoft.com/en-us/adaptive-cards/sdk/rendering-cards/javascript/extensibility) */
+    serializationContext: PropTypes.object
 };
 
 const defaultOpenUrlHandler = (action: AdaptiveCards.OpenUrlAction) => {
@@ -66,6 +69,7 @@ export const AdaptiveCard = ({
     onError,
     style,
     hostConfig,
+    serializationContext
 }: Props) => {
     const [error, setError] = useState<Error>();
     const targetRef = useRef<HTMLDivElement>(null);
@@ -122,7 +126,7 @@ export const AdaptiveCard = ({
         const card = cardRef.current;
 
         try {
-            card.parse(payload);
+            card.parse(payload, serializationContext);
             const result = card.render() as HTMLElement;
             const trustedHtml = (typeof window === 'undefined') ? "" : (window.trustedTypes?.emptyHTML ?? "");
             targetRef.current.innerHTML = trustedHtml as string;


### PR DESCRIPTION
# Related Issue

Addresses #9014

# Description

This PR adds a property to AdaptiveCard React wrapper that allows passing a custom SerializationContext down to JS SDK's AdaptiveCard allowing to extend it with custom elements.

README was updated accordingly with sample code.

There is no new logic added here, per se, just exposing the existing one from lower level.