### PR TITLE
Switch WinUI3 + UWP AdaptiveCard projects to use HybridCRT

### DIFF
--- a/source/uwp/AdaptiveCardsObjectModel/AdaptiveCardsObjectModel.vcxproj
+++ b/source/uwp/AdaptiveCardsObjectModel/AdaptiveCardsObjectModel.vcxproj
@@ -53,8 +53,11 @@
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
     <CppWinRTFastAbi>true</CppWinRTFastAbi>
     <CppWinRTOptimized>true</CppWinRTOptimized>
+	<UseCrtSDKReferenceStaticWarning>false</UseCrtSDKReferenceStaticWarning>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <!-- Build with the Hybrid CRT (Universal CRT + Static VS CRT (for what little the Universal CRT doesn't cover) -->
+  <Import Project="$(MSBuildThisFileDirectory)..\HybridCRT.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>

--- a/source/uwp/HybridCRT.props
+++ b/source/uwp/HybridCRT.props
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup Condition="'$(HybridCrtConfiguration)'==''">
+    <HybridCrtConfiguration>$(Configuration)</HybridCrtConfiguration>
+  </PropertyGroup>
+
+  <ItemDefinitionGroup Condition="'$(HybridCrtConfiguration)'=='Debug'">
+    <ClCompile>
+      <!-- We use MultiThreadedDebug, rather than MultiThreadedDebugDLL, to avoid DLL dependencies on VCRUNTIME140d.dll and MSVCP140d.dll. -->
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <!-- Link statically against the runtime and STL, but link dynamically against the CRT by ignoring the static CRT
+           lib and instead linking against the Universal CRT DLL import library. This "hybrid" linking mechanism is
+           supported according to the CRT maintainer. Dynamic linking against the CRT makes the binaries a bit smaller
+           than they would otherwise be if the CRT, runtime, and STL were all statically linked in. -->
+      <IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries);libucrtd.lib</IgnoreSpecificDefaultLibraries>
+      <AdditionalOptions>%(AdditionalOptions) /defaultlib:ucrtd.lib</AdditionalOptions>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(HybridCrtConfiguration)'=='Release'">
+    <ClCompile>
+      <!-- We use MultiThreaded, rather than MultiThreadedDLL, to avoid DLL dependencies on VCRUNTIME140.dll and MSVCP140.dll. -->
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <!-- Link statically against the runtime and STL, but link dynamically against the CRT by ignoring the static CRT
+           lib and instead linking against the Universal CRT DLL import library. This "hybrid" linking mechanism is
+           supported according to the CRT maintainer. Dynamic linking against the CRT makes the binaries a bit smaller
+           than they would otherwise be if the CRT, runtime, and STL were all statically linked in. -->
+      <IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries);libucrt.lib</IgnoreSpecificDefaultLibraries>
+      <AdditionalOptions>%(AdditionalOptions) /defaultlib:ucrt.lib</AdditionalOptions>
+    </Link>
+  </ItemDefinitionGroup>
+
+</Project>

--- a/source/uwp/ObjectModelProjection/ObjectModelProjection.vcxproj
+++ b/source/uwp/ObjectModelProjection/ObjectModelProjection.vcxproj
@@ -204,8 +204,11 @@
     <WindowsTargetPlatformMinVersion>10.0.15063.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <ProjectName>ObjectModelProjection</ProjectName>
+	<UseCrtSDKReferenceStaticWarning>false</UseCrtSDKReferenceStaticWarning>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <!-- Build with the Hybrid CRT (Universal CRT + Static VS CRT (for what little the Universal CRT doesn't cover) -->
+  <Import Project="$(MSBuildThisFileDirectory)..\HybridCRT.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>

--- a/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj
+++ b/source/uwp/Renderer/AdaptiveCardRenderer.vcxproj
@@ -56,8 +56,11 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <PlatformToolset>v143</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+	<UseCrtSDKReferenceStaticWarning>false</UseCrtSDKReferenceStaticWarning>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <!-- Build with the Hybrid CRT (Universal CRT + Static VS CRT (for what little the Universal CRT doesn't cover) -->
+  <Import Project="$(MSBuildThisFileDirectory)..\HybridCRT.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>

--- a/source/uwp/winui3/AdaptiveCardsObjectModel/AdaptiveCardsObjectModel.vcxproj
+++ b/source/uwp/winui3/AdaptiveCardsObjectModel/AdaptiveCardsObjectModel.vcxproj
@@ -19,8 +19,11 @@
     <TargetName>AdaptiveCards.ObjectModel.WinUI3</TargetName>
     <DesktopCompatible>true</DesktopCompatible>
     <UseWinUI>true</UseWinUI>
+	<UseCrtSDKReferenceStaticWarning>false</UseCrtSDKReferenceStaticWarning>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <!-- Build with the Hybrid CRT (Universal CRT + Static VS CRT (for what little the Universal CRT doesn't cover) -->
+  <Import Project="$(MSBuildThisFileDirectory)..\..\HybridCRT.props" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>

--- a/source/uwp/winui3/Renderer/AdaptiveCardRenderer.vcxproj
+++ b/source/uwp/winui3/Renderer/AdaptiveCardRenderer.vcxproj
@@ -20,8 +20,11 @@
     <TargetName>AdaptiveCards.Rendering.WinUI3</TargetName>
     <DesktopCompatible>true</DesktopCompatible>
     <UseWinUI>true</UseWinUI>
+	<UseCrtSDKReferenceStaticWarning>false</UseCrtSDKReferenceStaticWarning>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <!-- Build with the Hybrid CRT (Universal CRT + Static VS CRT (for what little the Universal CRT doesn't cover) -->
+  <Import Project="$(MSBuildThisFileDirectory)..\..\HybridCRT.props" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>


### PR DESCRIPTION
Fixes #9056

# Description

This PR follows the guidance at aka.ms/hybridcrt to switch the UWP/WinUI3 AdaptiveCard projects to use HybridCRT. This is accomplished simply by copying over the [HybridCRT.props](https://github.com/microsoft/WindowsAppSDK/blob/main/HybridCRT.props) and importing them to the appropriate projects, and specifying 	`<UseCrtSDKReferenceStaticWarning>false</UseCrtSDKReferenceStaticWarning>`

# Sample Card

N/A

# How Verified

- [x] Built projects and used Depends.exe to validate that the DLLs produced no longer depended upon the Desktop CRT or UWP CRT DLLs
- [x] Tested UWP and WinUI3 rendering in AdaptiveCardVisualizer with various sample Widgets
  - [x] In both these cases, was able to confirm the DLLs being used in the Visualizer for rendering were using HybridCRT, as Depends.exe didn't show any dependency on the Desktop or UWP CRT
- [x] Replaced the current Client.CBS package DLLs for Widgets with these (AdaptiveCards.Rendering.Uwp.dll and AdaptiveCards.ObjectModel.Uwp.dll) and confirmed they were able to be loaded and used to render Widgets and resolved the current issue encountered with the current DLLs.
- [x] Replaced the DLLs for WidgetBoard with these (AdaptiveCards.Rendering.WinUI3.dll and AdaptiveCards.ObjectModel.WinUI3.dll) and confirmed they were able to be loaded and used to render Widgets
