### PR TITLE
Update color contrast on designer

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/adaptivecards-designer.css
+++ b/source/nodejs/adaptivecards-designer/src/adaptivecards-designer.css
@@ -896,7 +896,7 @@
 }
 
 .acd-data-tree-item-additionalText {
-    color: #2D7BB7;
+    color: #5e5e5e;
     margin-left: 8px;
 }
 


### PR DESCRIPTION
# Related Issue

Fixes #9013

# Description
Update color contrast on `acd-data-tree-item-additionalText` to meet requirements.
![image](https://github.com/user-attachments/assets/9d0791fd-b8c3-41ba-8f5e-09f4e41a75d8)

# Sample Card

N/A

# How Verified

Verified manually on the website.
