### PR TITLE
Refactor expense report sample to use showCard instead of toggleVisibility

### DIFF
--- a/samples/Templates/Scenarios/ExpenseReport.template.json
+++ b/samples/Templates/Scenarios/ExpenseReport.template.json
@@ -122,183 +122,83 @@
 			"style": "emphasis",
 			"items": [
 				{
-					"type": "ColumnSet",
-					"columns": [
-						{
-							"type": "Column",
-							"items": [
-								{
-									"type": "TextBlock",
-									"weight": "bolder",
-									"text": "DATE",
-									"wrap": true
-								}
-							],
-							"width": "auto"
-						},
-						{
-							"type": "Column",
-							"spacing": "large",
-							"items": [
-								{
-									"type": "TextBlock",
-									"weight": "bolder",
-									"text": "CATEGORY",
-									"wrap": true
-								}
-							],
-							"width": "stretch"
-						},
-						{
-							"type": "Column",
-							"items": [
-								{
-									"type": "TextBlock",
-									"weight": "bolder",
-									"text": "AMOUNT",
-									"wrap": true
-								}
-							],
-							"width": "auto"
-						}
-					]
+					"type": "TextBlock",
+					"weight": "bolder",
+					"text": "EXPENSE DETAILS",
+					"wrap": true
 				}
 			],
 			"bleed": true
 		},
 		{
+			"type": "ActionSet",
 			"$data": "${expenses}",
-			"type": "Container",
-			"items": [
+			"actions": [
 				{
-					"type": "ColumnSet",
-					"columns": [
-						{
-							"type": "Column",
-							"items": [
-								{
-									"type": "TextBlock",
-									"text": "${formatDateTime(created_time, 'MM-dd')}",
-									"wrap": true
-								}
-							],
-							"width": "auto"
-						},
-						{
-							"type": "Column",
-							"spacing": "medium",
-							"items": [
-								{
-									"type": "TextBlock",
-									"text": "${description}",
-									"wrap": true
-								}
-							],
-							"width": "stretch"
-						},
-						{
-							"type": "Column",
-							"items": [
-								{
-									"type": "TextBlock",
-									"text": "$${formatNumber(total, 2)}",
-									"wrap": true
-								}
-							],
-							"width": "auto"
-						},
-						{
-							"type": "Column",
-							"spacing": "small",
-							"selectAction": {
-								"type": "Action.ToggleVisibility",
-								"title": "expand",
-								"targetElements": [
-									"cardContent${$index}",
-									"chevronDown${$index}",
-									"chevronUp${$index}"
-								]
-							},
-							"verticalContentAlignment": "center",
-							"items": [
-								{
-									"type": "Image",
-									"id": "chevronDown${$index}",
-									"url": "https://adaptivecards.io/content/down.png",
-									"width": "20px",
-									"altText": "${description} $${total} collapsed"
-								},
-								{
-									"type": "Image",
-									"id": "chevronUp${$index}",
-									"url": "https://adaptivecards.io/content/up.png",
-									"width": "20px",
-									"altText": "${description} $${total} expanded",
-									"isVisible": false
-								}
-							],
-							"width": "auto"
-						}
-					]
-				},
-				{
-					"type": "Container",
-					"id": "cardContent${$index}",
-					"isVisible": false,
-					"items": [
-						{
-							"type": "Container",
-							"items": [
-								{
-									"$data": "${custom_fields}",
-									"type": "TextBlock",
-									"text": "* ${value}",
-									"isSubtle": true,
-									"wrap": true
-								},
-								{
-									"type": "Container",
-									"items": [
-										{
-											"type": "Input.Text",
-											"id": "comment${$index}",
-											"label": "Add your comment here"
-										}
-									]
-								}
-							]
-						},
-						{
-							"type": "Container",
-							"items": [
-								{
-									"type": "ColumnSet",
-									"columns": [
-										{
-											"type": "Column",
-											"items": [
-												{
-													"type": "ActionSet",
-													"actions": [
-														{
-															"type": "Action.Submit",
-															"title": "Send",
-															"data": {
-																"id": "_qkQW8dJlUeLVi7ZMEzYVw",
-																"action": "comment",
-																"lineItem": 1
+					"type": "Action.ShowCard",
+					"title": "${formatDateTime(created_time, 'MM-dd')}: ${description} - $${formatNumber(total, 2)}",
+					"card": {
+						"type": "AdaptiveCard",
+						"body": [
+							{
+								"type": "Container",
+								"items": [
+									{
+										"type": "Container",
+										"items": [
+											{
+												"$data": "${custom_fields}",
+												"type": "TextBlock",
+												"text": "* ${value}",
+												"isSubtle": true,
+												"wrap": true
+											},
+											{
+												"type": "Container",
+												"items": [
+													{
+														"type": "Input.Text",
+														"id": "comment${$index}",
+														"label": "Add your comment here"
+													}
+												]
+											}
+										]
+									},
+									{
+										"type": "Container",
+										"items": [
+											{
+												"type": "ColumnSet",
+												"columns": [
+													{
+														"type": "Column",
+														"items": [
+															{
+																"type": "ActionSet",
+																"actions": [
+																	{
+																		"type": "Action.Submit",
+																		"title": "Send",
+																		"data": {
+																			"id": "_qkQW8dJlUeLVi7ZMEzYVw",
+																			"action": "comment",
+																			"lineItem": 1
+																		}
+																	}
+																]
 															}
-														}
-													]
-												}
-											],
-											"width": "auto"
-										}
-									]
-								}
-							]
-						}
-					]
+														],
+														"width": "auto"
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
 				}
 			]
 		},
@@ -399,59 +299,33 @@
 			"bleed": true
 		},
 		{
-			"type": "ColumnSet",
-			"columns": [
+			"type": "ActionSet",
+			"actions": [
 				{
-					"type": "Column",
-					"selectAction": {
-						"type": "Action.ToggleVisibility",
-						"targetElements": ["cardContent4", "showHistory", "hideHistory"]
-					},
-					"verticalContentAlignment": "center",
-					"items": [
-						{
-							"type": "TextBlock",
-							"id": "showHistory",
-							"horizontalAlignment": "right",
-							"color": "accent",
-							"text": "Show history",
-							"wrap": true
-						},
-						{
-							"type": "TextBlock",
-							"id": "hideHistory",
-							"horizontalAlignment": "right",
-							"color": "accent",
-							"text": "Hide history",
-							"wrap": true,
-							"isVisible": false
-						}
-					],
-					"width": 1
-				}
-			]
-		},
-		{
-			"type": "Container",
-			"id": "cardContent4",
-			"isVisible": false,
-			"items": [
-				{
-					"type": "Container",
-					"items": [
-						{
-							"type": "TextBlock",
-							"text": "* Expense submitted by **${created_by_name}** on {{DATE(${formatDateTime(created_date, 'yyyy-MM-ddTHH:mm:ssZ')}, SHORT)}}",
-							"isSubtle": true,
-							"wrap": true
-						},
-						{
-							"type": "TextBlock",
-							"text": "* Expense ${expenses[0].status} by **${expenses[0].approver}** on {{DATE(${formatDateTime(approval_date, 'yyyy-MM-ddTHH:mm:ssZ')}, SHORT)}}",
-							"isSubtle": true,
-							"wrap": true
-						}
-					]
+					"type": "Action.ShowCard",
+					"title": "Show history",
+					"card": {
+						"type": "AdaptiveCard",
+						"body": [
+							{
+								"type": "Container",
+								"items": [
+									{
+										"type": "TextBlock",
+										"text": "* Expense submitted by **${created_by_name}** on {{DATE(${formatDateTime(created_date, 'yyyy-MM-ddTHH:mm:ssZ')}, SHORT)}}",
+										"isSubtle": true,
+										"wrap": true
+									},
+									{
+										"type": "TextBlock",
+										"text": "* Expense ${expenses[0].status} by **${expenses[0].approver}** on {{DATE(${formatDateTime(approval_date, 'yyyy-MM-ddTHH:mm:ssZ')}, SHORT)}}",
+										"isSubtle": true,
+										"wrap": true
+									}
+								]
+							}
+						]
+					}
 				}
 			]
 		},

--- a/samples/v1.5/Scenarios/ExpenseReport.json
+++ b/samples/v1.5/Scenarios/ExpenseReport.json
@@ -463,7 +463,7 @@
 								{
 									"type": "TextBlock",
 									"weight": "bolder",
-									"text": "$400.00",
+									"text": "$404.30",
 									"wrap": true
 								}
 							],

--- a/samples/v1.5/Scenarios/ExpenseReport.json
+++ b/samples/v1.5/Scenarios/ExpenseReport.json
@@ -122,416 +122,221 @@
 			"style": "emphasis",
 			"items": [
 				{
-					"type": "ColumnSet",
-					"columns": [
-						{
-							"type": "Column",
-							"items": [
-								{
-									"type": "TextBlock",
-									"weight": "bolder",
-									"text": "DATE",
-									"wrap": true
-								}
-							],
-							"width": "auto"
-						},
-						{
-							"type": "Column",
-							"spacing": "large",
-							"items": [
-								{
-									"type": "TextBlock",
-									"weight": "bolder",
-									"text": "CATEGORY",
-									"wrap": true
-								}
-							],
-							"width": "stretch"
-						},
-						{
-							"type": "Column",
-							"items": [
-								{
-									"type": "TextBlock",
-									"weight": "bolder",
-									"text": "AMOUNT",
-									"wrap": true
-								}
-							],
-							"width": "auto"
-						}
-					]
+					"type": "TextBlock",
+					"weight": "bolder",
+					"text": "EXPENSE DETAILS",
+					"wrap": true
 				}
 			],
 			"bleed": true
 		},
 		{
-			"type": "ColumnSet",
-			"columns": [
+			"type": "ActionSet",
+			"actions": [
 				{
-					"type": "Column",
-					"items": [
-						{
-							"type": "TextBlock",
-							"text": "06/19",
-							"wrap": true
-						}
-					],
-					"width": "auto"
-				},
-				{
-					"type": "Column",
-					"spacing": "medium",
-					"items": [
-						{
-							"type": "TextBlock",
-							"text": "Air Travel Expense",
-							"wrap": true
-						}
-					],
-					"width": "stretch"
-				},
-				{
-					"type": "Column",
-					"items": [
-						{
-							"type": "TextBlock",
-							"text": "$ 300",
-							"wrap": true
-						}
-					],
-					"width": "auto"
-				},
-				{
-					"type": "Column",
-					"spacing": "small",
-					"verticalContentAlignment": "center",
-					"items": [
-						{
-							"type": "Image",
-							"id": "chevronDown1",
-							"url": "https://adaptivecards.io/content/down.png",
-							"width": "20px",
-							"altText": "Air Travel Expense $300 collapsed"
-						},
-						{
-							"type": "Image",
-							"id": "chevronUp1",
-							"isVisible": false,
-							"url": "https://adaptivecards.io/content/up.png",
-							"width": "20px",
-							"altText": "Air Travel Expense $300 expanded"
-						}
-					],
-					"selectAction": {
-						"type": "Action.ToggleVisibility",
-						"targetElements": ["cardContent1", "chevronUp1", "chevronDown1"]
-					},
-					"width": "auto"
-				}
-			]
-		},
-		{
-			"type": "Container",
-			"id": "cardContent1",
-			"isVisible": false,
-			"items": [
-				{
-					"type": "Container",
-					"items": [
-						{
-							"type": "TextBlock",
-							"text": "* Leg 1 on Tue, Jun 19th, 2019 at 6:00 AM.",
-							"isSubtle": true,
-							"wrap": true
-						},
-						{
-							"type": "TextBlock",
-							"text": "* Leg 2 on Tue,Jun 19th, 2019 at 7:15 PM.",
-							"isSubtle": true,
-							"wrap": true
-						},
-						{
-							"type": "Container",
-							"items": [
-								{
-									"type": "Input.Text",
-									"id": "comment1",
-									"label": "Add your comment here"
-								}
-							]
-						}
-					]
-				},
-				{
-					"type": "Container",
-					"items": [
-						{
-							"type": "ColumnSet",
-							"columns": [
-								{
-									"type": "Column",
-									"items": [
-										{
-											"type": "ActionSet",
-											"actions": [
-												{
-													"type": "Action.Submit",
-													"title": "Send",
-													"data": {
-														"id": "_qkQW8dJlUeLVi7ZMEzYVw",
-														"action": "comment",
-														"lineItem": 1
+					"type": "Action.ShowCard",
+					"title": "06/19: Air Travel Expense - $300",
+					"card": {
+						"type": "AdaptiveCard",
+						"body": [
+							{
+								"type": "Container",
+								"items": [
+									{
+										"type": "Container",
+										"items": [
+											{
+												"type": "TextBlock",
+												"text": "* Leg 1 on Tue, Jun 19th, 2019 at 6:00 AM.",
+												"isSubtle": true,
+												"wrap": true
+											},
+											{
+												"type": "TextBlock",
+												"text": "* Leg 2 on Tue, Jun 19th, 2019 at 7:15 PM.",
+												"isSubtle": true,
+												"wrap": true
+											},
+											{
+												"type": "Container",
+												"items": [
+													{
+														"type": "Input.Text",
+														"id": "comment0",
+														"label": "Add your comment here"
 													}
-												}
-											]
-										}
-									],
-									"width": "auto"
-								}
-							]
-						}
-					]
-				}
-			]
-		},
-		{
-			"type": "ColumnSet",
-			"columns": [
-				{
-					"type": "Column",
-					"items": [
-						{
-							"type": "TextBlock",
-							"horizontalAlignment": "center",
-							"text": "06/19",
-							"wrap": true
-						}
-					],
-					"width": "auto"
-				},
-				{
-					"type": "Column",
-					"spacing": "medium",
-					"items": [
-						{
-							"type": "TextBlock",
-							"text": "Auto Mobile Expense",
-							"wrap": true
-						}
-					],
-					"width": "stretch"
-				},
-				{
-					"type": "Column",
-					"items": [
-						{
-							"type": "TextBlock",
-							"text": "$ 100",
-							"wrap": true
-						}
-					],
-					"width": "auto"
-				},
-				{
-					"type": "Column",
-					"spacing": "small",
-					"verticalContentAlignment": "center",
-					"items": [
-						{
-							"type": "Image",
-							"id": "chevronDown2",
-							"url": "https://adaptivecards.io/content/down.png",
-							"width": "20px",
-							"altText": "Auto Mobile Expense $100 collapsed"
-						},
-						{
-							"type": "Image",
-							"id": "chevronUp2",
-							"isVisible": false,
-							"url": "https://adaptivecards.io/content/up.png",
-							"width": "20px",
-							"altText": "Auto Mobile Expense $100 expanded"
-						}
-					],
-					"selectAction": {
-						"type": "Action.ToggleVisibility",
-						"targetElements": ["cardContent2", "chevronUp2", "chevronDown2"]
-					},
-					"width": "auto"
-				}
-			]
-		},
-		{
-			"type": "Container",
-			"id": "cardContent2",
-			"isVisible": false,
-			"items": [
-				{
-					"type": "Container",
-					"items": [
-						{
-							"type": "TextBlock",
-							"text": "* Contoso Car Rentrals, Tues 6/19 at 7:00 AM",
-							"isSubtle": true,
-							"wrap": true
-						},
-						{
-							"type": "Container",
-							"items": [
-								{
-									"type": "Input.Text",
-									"id": "comment2",
-									"label": "Add your comment here"
-								}
-							]
-						}
-					]
-				},
-				{
-					"type": "Container",
-					"items": [
-						{
-							"type": "ColumnSet",
-							"columns": [
-								{
-									"type": "Column",
-									"items": [
-										{
-											"type": "ActionSet",
-											"actions": [
-												{
-													"type": "Action.Submit",
-													"title": "Send",
-													"data": {
-														"id": "_qkQW8dJlUeLVi7ZMEzYVw",
-														"action": "comment",
-														"lineItem": 2
+												]
+											}
+										]
+									},
+									{
+										"type": "Container",
+										"items": [
+											{
+												"type": "ColumnSet",
+												"columns": [
+													{
+														"type": "Column",
+														"items": [
+															{
+																"type": "ActionSet",
+																"actions": [
+																	{
+																		"type": "Action.Submit",
+																		"title": "Send",
+																		"data": {
+																			"id": "_qkQW8dJlUeLVi7ZMEzYVw",
+																			"action": "comment",
+																			"lineItem": 1
+																		}
+																	}
+																]
+															}
+														],
+														"width": "auto"
 													}
-												}
-											]
-										}
-									],
-									"width": "auto"
-								}
-							]
-						}
-					]
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
 				}
 			]
 		},
 		{
-			"type": "ColumnSet",
-			"columns": [
+			"type": "ActionSet",
+			"actions": [
 				{
-					"type": "Column",
-					"items": [
-						{
-							"type": "TextBlock",
-							"horizontalAlignment": "center",
-							"text": "06/25",
-							"wrap": true
-						}
-					],
-					"width": "auto"
-				},
-				{
-					"type": "Column",
-					"spacing": "medium",
-					"items": [
-						{
-							"type": "TextBlock",
-							"text": "Excess Baggage Cost",
-							"wrap": true
-						}
-					],
-					"width": "stretch"
-				},
-				{
-					"type": "Column",
-					"items": [
-						{
-							"type": "TextBlock",
-							"text": "$ 4.30",
-							"wrap": true
-						}
-					],
-					"width": "auto"
-				},
-				{
-					"type": "Column",
-					"spacing": "small",
-					"verticalContentAlignment": "center",
-					"items": [
-						{
-							"type": "Image",
-							"id": "chevronDown3",
-							"url": "https://adaptivecards.io/content/down.png",
-							"width": "20px",
-							"altText": "Excess Baggage Cost $50.38 collapsed"
-						},
-						{
-							"type": "Image",
-							"id": "chevronUp3",
-							"isVisible": false,
-							"url": "https://adaptivecards.io/content/up.png",
-							"width": "20px",
-							"altText": "Excess Baggage Cost $50.38 expanded"
-						}
-					],
-					"selectAction": {
-						"type": "Action.ToggleVisibility",
-						"targetElements": ["cardContent3", "chevronUp3", "chevronDown3"]
-					},
-					"width": "auto"
-				}
-			]
-		},
-		{
-			"type": "Container",
-			"id": "cardContent3",
-			"isVisible": false,
-			"items": [
-				{
-					"type": "Container",
-					"items": [
-						{
-							"type": "Input.Text",
-							"id": "comment3",
-							"label": "Add your comment here"
-						}
-					]
-				},
-				{
-					"type": "Container",
-					"items": [
-						{
-							"type": "ColumnSet",
-							"columns": [
-								{
-									"type": "Column",
-									"items": [
-										{
-											"type": "ActionSet",
-											"actions": [
-												{
-													"type": "Action.Submit",
-													"title": "Send",
-													"data": {
-														"id": "_qkQW8dJlUeLVi7ZMEzYVw",
-														"action": "comment",
-														"lineItem": 3
+					"type": "Action.ShowCard",
+					"title": "06/19: Auto Mobile Expense - $100",
+					"card": {
+						"type": "AdaptiveCard",
+						"body": [
+							{
+								"type": "Container",
+								"items": [
+									{
+										"type": "Container",
+										"items": [
+											{
+												"type": "TextBlock",
+												"text": "*  Contoso Car Rentrals, Tues 6/19 at 7:00 AM",
+												"isSubtle": true,
+												"wrap": true
+											},
+											{
+												"type": "Container",
+												"items": [
+													{
+														"type": "Input.Text",
+														"id": "comment1",
+														"label": "Add your comment here"
 													}
-												}
-											]
-										}
-									],
-									"width": "auto"
-								}
-							]
-						}
-					]
+												]
+											}
+										]
+									},
+									{
+										"type": "Container",
+										"items": [
+											{
+												"type": "ColumnSet",
+												"columns": [
+													{
+														"type": "Column",
+														"items": [
+															{
+																"type": "ActionSet",
+																"actions": [
+																	{
+																		"type": "Action.Submit",
+																		"title": "Send",
+																		"data": {
+																			"id": "_qkQW8dJlUeLVi7ZMEzYVw",
+																			"action": "comment",
+																			"lineItem": 1
+																		}
+																	}
+																]
+															}
+														],
+														"width": "auto"
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			"type": "ActionSet",
+			"actions": [
+				{
+					"type": "Action.ShowCard",
+					"title": "06/21: Excess Baggage Cost - $4.30",
+					"card": {
+						"type": "AdaptiveCard",
+						"body": [
+							{
+								"type": "Container",
+								"items": [
+									{
+										"type": "Container",
+										"items": [
+											{
+												"type": "Container",
+												"items": [
+													{
+														"type": "Input.Text",
+														"id": "comment2",
+														"label": "Add your comment here"
+													}
+												]
+											}
+										]
+									},
+									{
+										"type": "Container",
+										"items": [
+											{
+												"type": "ColumnSet",
+												"columns": [
+													{
+														"type": "Column",
+														"items": [
+															{
+																"type": "ActionSet",
+																"actions": [
+																	{
+																		"type": "Action.Submit",
+																		"title": "Send",
+																		"data": {
+																			"id": "_qkQW8dJlUeLVi7ZMEzYVw",
+																			"action": "comment",
+																			"lineItem": 1
+																		}
+																	}
+																]
+															}
+														],
+														"width": "auto"
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
 				}
 			]
 		},
@@ -658,7 +463,7 @@
 								{
 									"type": "TextBlock",
 									"weight": "bolder",
-									"text": "$ 404.30",
+									"text": "$400.00",
 									"wrap": true
 								}
 							],
@@ -674,59 +479,33 @@
 			"bleed": true
 		},
 		{
-			"type": "ColumnSet",
-			"columns": [
+			"type": "ActionSet",
+			"actions": [
 				{
-					"type": "Column",
-					"selectAction": {
-						"type": "Action.ToggleVisibility",
-						"targetElements": ["cardContent4", "showHistory", "hideHistory"]
-					},
-					"verticalContentAlignment": "center",
-					"items": [
-						{
-							"type": "TextBlock",
-							"id": "showHistory",
-							"horizontalAlignment": "right",
-							"color": "accent",
-							"text": "Show history",
-							"wrap": true
-						},
-						{
-							"type": "TextBlock",
-							"id": "hideHistory",
-							"isVisible": false,
-							"horizontalAlignment": "right",
-							"color": "accent",
-							"text": "Hide history",
-							"wrap": true
-						}
-					],
-					"width": 1
-				}
-			]
-		},
-		{
-			"type": "Container",
-			"id": "cardContent4",
-			"isVisible": false,
-			"items": [
-				{
-					"type": "Container",
-					"items": [
-						{
-							"type": "TextBlock",
-							"text": "* Expense submitted by **Matt** on Wed, Apr 14th, 2019",
-							"isSubtle": true,
-							"wrap": true
-						},
-						{
-							"type": "TextBlock",
-							"text": "* Expense approved by **Thomas** on Thu, Apr 15th, 2019",
-							"isSubtle": true,
-							"wrap": true
-						}
-					]
+					"type": "Action.ShowCard",
+					"title": "Show history",
+					"card": {
+						"type": "AdaptiveCard",
+						"body": [
+							{
+								"type": "Container",
+								"items": [
+									{
+										"type": "TextBlock",
+										"text": "* Expense submitted by **Matt Hidinger** on {{DATE(2019-07-15T10:33:12+00:00, SHORT)}}",
+										"isSubtle": true,
+										"wrap": true
+									},
+									{
+										"type": "TextBlock",
+										"text": "* Expense approved by **Thomas** on {{DATE(2019-07-15T14:33:12+00:00, SHORT)}}",
+										"isSubtle": true,
+										"wrap": true
+									}
+								]
+							}
+						]
+					}
 				}
 			]
 		},
@@ -756,8 +535,8 @@
 										"type": "Input.Text",
 										"id": "RejectCommentID",
 										"label": "Please specify an appropriate reason for rejection",
-										"isRequired": true,
 										"isMultiline": true,
+										"isRequired": true,
 										"errorMessage": "A reason for rejection is necessary"
 									}
 								],
@@ -770,7 +549,8 @@
 											"action": "reject"
 										}
 									}
-								]
+								],
+								"$schema": "http://adaptivecards.io/schemas/adaptive-card.json"
 							}
 						}
 					]

--- a/source/nodejs/adaptivecards-designer/src/adaptivecards-designer.css
+++ b/source/nodejs/adaptivecards-designer/src/adaptivecards-designer.css
@@ -896,7 +896,7 @@
 }
 
 .acd-data-tree-item-additionalText {
-    color: #2D7BB7;
+    color: #5e5e5e;
     margin-left: 8px;
 }
 


### PR DESCRIPTION
# Related Issue

Fixes #8973
Fixes #8972

# Description

The ExpenseReport sample utilized ToggleVisibility which has a number of accessibility issues inherently. I refactored the sample to utilize ShowCard instead so that accessibility properties are set correctly.

New card:
![image](https://github.com/user-attachments/assets/6f3c7236-fb95-47f6-9dff-10a27482be76)

# Sample Card

Updated samples:
https://github.com/microsoft/AdaptiveCards/blob/a03d2f617cd272b05bfe6f971b19283a1902c629/samples/Templates/Scenarios/ExpenseReport.template.json
https://github.com/microsoft/AdaptiveCards/blob/a03d2f617cd272b05bfe6f971b19283a1902c629/samples/v1.5/Scenarios/ExpenseReport.json

# How Verified

Verified manually in the visualizer and updated confirmed that "Name" is set for the buttons via accessibility insights.
![image](https://github.com/user-attachments/assets/0acd5ffd-3d4d-4df1-baae-fb3b19b32842)
![image](https://github.com/user-attachments/assets/28eea68e-72c5-41e0-84e2-f263e16df22c)

