### PR TITLE
Updated template dependency

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCards.Templating.csproj
+++ b/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCards.Templating.csproj
@@ -52,7 +52,7 @@
 
   <ItemGroup>
     <PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.AdaptiveExpressions.Core" Version="4.22.7" />
+    <PackageReference Include="Microsoft.Bot.AdaptiveExpressions.Core" Version="4.22.9" />
     <PackageReference Include="PolySharp" Version="1.14.1" />
     <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>

--- a/source/dotnet/Test/AdaptiveCards.Templating.Test/AdaptiveCards.Templating.Test.csproj
+++ b/source/dotnet/Test/AdaptiveCards.Templating.Test/AdaptiveCards.Templating.Test.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
-    <PackageReference Include="Microsoft.Bot.AdaptiveExpressions.Core" Version="4.22.7" />
+    <PackageReference Include="Microsoft.Bot.AdaptiveExpressions.Core" Version="4.22.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />


### PR DESCRIPTION
# Related Issue
N/A
# Description
The current version of the `Microsoft.Bot.AdaptiveExpressions.Core` package is `4.22.7`.
It is causing a strong naming issue.
Updated `Microsoft.Bot.AdaptiveExpressions.Core` Library Version

# Sample Card
N/A
# How Verified
Verified using visualizer.