### PR TITLE
refactor: only use PolySharp as private asset

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCards.Templating.csproj
+++ b/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCards.Templating.csproj
@@ -53,7 +53,7 @@
   <ItemGroup>
     <PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
     <PackageReference Include="Microsoft.Bot.AdaptiveExpressions.Core" Version="4.22.9" />
-    <PackageReference Include="PolySharp" Version="1.14.1" />
+    <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="all" />
     <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 


### PR DESCRIPTION
# PolySharp adds transitive build behavior

## Description

PolySharp is used in `AdaptiveCards.Templating` and adds transitive build behavior which introduces a security risk for package consumers. Furthermore PolySharp is not required for the usage of AdaptiveCards.

## Solution
Add `PrivatAssets = all` to PolySharp package reference.