### PR TITLE
[Website][Accessibility] Refactor treeitems in schema explorer and add captions to overview video

### DIFF
--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/explorer.ejs
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/explorer.ejs
@@ -1,21 +1,20 @@
+<!-- This is the schema explorer index page -->
+
 <div id="content-wrapper" class="w3-row explorer" style="max-width:1564px">
 
 	<nav id="sidebar-todo" class="toc-todo sidebar w3-cell w3-hide-small w3-hide-medium w3-bar-block"
 		style="width: 200px">
 		<div class="sidebar__inner">
-			<ul class="toc-tree" role="tree">
-				<% page.schema.forEach(function(root) { %>
-				<li role="treeitem" aria-expanded="true"><span><i class="fa fa-angle-down"></i> <%= root.title %></span>
-					<ul role="group">
-						<% root.children.forEach(function(child) { %>
-						<li class='<%= page.childPath === child.htmlPath ? "selectedHolder" : "" %>' role="treeitem">
-							<a href="<%- url_for(child.htmlPath) %>" aria-label="<%= child.accessibleName %>"><%= child.name %></a>
-						</li>
-						<% }) %>
-					</ul>
-				</li>
+			<% page.schema.forEach(function(root) { %>
+			<ul role="listbox" aria-label="<%= root.title %>" class="samples-sidebar-list">
+				<span><%= root.title %></span>
+				<% root.children.forEach(function(child) { %>
+					<a role="option"
+						aria-setsize='<%= root.children.length.toString() %>'
+						href="<%- url_for(child.htmlPath) %>" aria-label="<%= child.accessibleName %>"><%= child.name %></a>
 				<% }) %>
 			</ul>
+			<% }) %>
 		</div>
 	</nav>
 

--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/index.ejs
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/index.ejs
@@ -2,9 +2,10 @@
 
 	<div id="videoModal" class="w3-modal w3-card-4">
 		<div class="w3-modal-content w3-animate-zoom">
-			<video id="overviewVideo" tabIndex="0" controls="" width="100" style="width: 100%" poster="<%- url_for('content/poster-video.png') %>">
+			<video id="overviewVideo" tabIndex="0" controls="" width="100" style="width: 100%" poster="<%- url_for('content/poster-video.png') %>" crossorigin>
 				<source src="https://adaptivecardsblob.blob.core.windows.net/assets/AdaptiveCardsOverviewVideo.mp4"
 					type="video/mp4" />
+				<track src="https://raw.githubusercontent.com/microsoft/AdaptiveCards/5ac07e8adb8d7dcd7480973321e57d279d1f7d2c/assets/ProductVideoSubtitles.vtt" kind="captions" label="English (vtt)">
 			</video>
 			<span id="closeVideo" tabIndex="0" aria-label="Close video" class="w3-button w3-xlarge w3-transparent w3-display-topright"
 				title="Close video">×</span>


### PR DESCRIPTION
# Related Issue

Fixes #9029
Fixes #9031

# Description

This pull request resolves two accessibility issues.

1. Add captions to the overview video on the main page of our website
2. Refactor the schema explorer index page to use `listbox` instead of `tree` roles for navigation. The previous implementation noted the full list as a tree and individual items as treeitems. This required that we implement additional keyboard functionality and that each section is collapsible. By refactoring to use `listbox`, we can simplify the keyboard navigation, and the list does not need to be collapsible.

# Sample Card

N/A

# How Verified
Verified manually on the test site.

## Captions
![image](https://github.com/user-attachments/assets/4aa9e4ee-0660-42b8-991d-d9bbe791c3b7)

## Updated schema explorer navigation
![image](https://github.com/user-attachments/assets/bef5eeec-ae40-43fc-8641-d539214327d0)


