### PR TITLE
[Regression Fix]: Use FrameworkElement instead of empty statics for dependency property

### DIFF
--- a/source/uwp/SharedRenderer/lib/WholeItemsPanel.cpp
+++ b/source/uwp/SharedRenderer/lib/WholeItemsPanel.cpp
@@ -104,8 +104,7 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 
                                     // Text did not reach its minHeight property and we have to clear it otherwise
                                     // ellipses won't be displayed correctly...
-                                    winrt::IFrameworkElementStatics frameworkElementStatics;
-                                    child.ClearValue(frameworkElementStatics.MinHeightProperty());
+                                    child.ClearValue(winrt::FrameworkElement::MinHeightProperty());
                                 }
                                 else
                                 {


### PR DESCRIPTION
# Description
One of the partner teams discovered a bug that leads to a crash due to an invalid pointer read. This is regression that occurred during WRL -> Cpp/WinRT migration of the UWP codebase.

# How Verified
Verified locally and mentioned functionality in WholeItemsPanel works as expected now.
