### PR TITLE
Add support for .NET 8 RIDs

### DIFF
--- a/source/uwp/winui3/NuGet/AdaptiveCards.ObjectModel.WinUI3.managed.props
+++ b/source/uwp/winui3/NuGet/AdaptiveCards.ObjectModel.WinUI3.managed.props
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <AdaptiveCardsObjectModelWinUI3WinMD>$(MSBuildThisFileDirectory)..\..\lib\uap10.0\AdaptiveCards.ObjectModel.WinUI3.winmd</AdaptiveCardsObjectModelWinUI3WinMD>
+        <AdaptiveCardsObjectModelWinUI3DllName>AdaptiveCards.ObjectModel.WinUI3.dll</AdaptiveCardsObjectModelWinUI3DllName>
+    </PropertyGroup>
+</Project>

--- a/source/uwp/winui3/NuGet/AdaptiveCards.ObjectModel.WinUI3.managed.targets
+++ b/source/uwp/winui3/NuGet/AdaptiveCards.ObjectModel.WinUI3.managed.targets
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <ItemGroup>
+        <WindowsMetadataReference Include="$(AdaptiveCardsObjectModelWinUI3WinMD)" Implementation="$(AdaptiveCardsObjectModelWinUI3DllName)" />
+    </ItemGroup>
+</Project>

--- a/source/uwp/winui3/NuGet/AdaptiveCards.ObjectModel.WinUI3.nuspec
+++ b/source/uwp/winui3/NuGet/AdaptiveCards.ObjectModel.WinUI3.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>AdaptiveCards.ObjectModel.WinUI3</id>
-        <version>3.0.0</version>
+        <version>1.0.2</version>
         <authors>Microsoft</authors>
         <summary>Adaptive Cards Object Model library for WinUI3</summary>
         <description>Used to work with the object model for Adaptive Cards</description>

--- a/source/uwp/winui3/NuGet/AdaptiveCards.ObjectModel.WinUI3.nuspec
+++ b/source/uwp/winui3/NuGet/AdaptiveCards.ObjectModel.WinUI3.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>AdaptiveCards.ObjectModel.WinUI3</id>
-        <version>0.4.0</version>
+        <version>3.0.0</version>
         <authors>Microsoft</authors>
         <summary>Adaptive Cards Object Model library for WinUI3</summary>
         <description>Used to work with the object model for Adaptive Cards</description>
@@ -16,17 +16,17 @@
     <files>
         <file src="..\x64\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.winmd" target="lib\uap10.0"/>
 
-        <file src="..\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.dll" target="runtimes\win10-x86\native"/>
-        <file src="..\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.lib" target="runtimes\win10-x86\native"/>
-        <file src="..\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.pdb" target="runtimes\win10-x86\native"/>
+        <file src="..\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.dll" target="runtimes\win-x86\native"/>
+        <file src="..\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.lib" target="runtimes\win-x86\native"/>
+        <file src="..\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.pdb" target="runtimes\win-x86\native"/>
 
-        <file src="..\x64\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.dll" target="runtimes\win10-x64\native"/>
-        <file src="..\x64\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.lib" target="runtimes\win10-x64\native"/>
-        <file src="..\x64\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.pdb" target="runtimes\win10-x64\native"/>
+        <file src="..\x64\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.dll" target="runtimes\win-x64\native"/>
+        <file src="..\x64\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.lib" target="runtimes\win-x64\native"/>
+        <file src="..\x64\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.pdb" target="runtimes\win-x64\native"/>
 
-        <file src="..\ARM64\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.dll" target="runtimes\win10-arm64\native"/>
-        <file src="..\ARM64\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.lib" target="runtimes\win10-arm64\native"/>
-        <file src="..\ARM64\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.pdb" target="runtimes\win10-arm64\native"/>
+        <file src="..\ARM64\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.dll" target="runtimes\win-arm64\native"/>
+        <file src="..\ARM64\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.lib" target="runtimes\win-arm64\native"/>
+        <file src="..\ARM64\$Configuration$\AdaptiveCardsObjectModel\AdaptiveCards.ObjectModel.WinUI3.pdb" target="runtimes\win-arm64\native"/>
 
         <file src="..\AnyCPU\ObjectModelCsProjection\$Configuration$\net6.0-windows10.0.17763.0\ObjectModelCsProjection.dll" target="lib\net6.0-windows10.0.17763.0\ObjectModelCsProjection.dll"/>
 

--- a/source/uwp/winui3/NuGet/AdaptiveCards.Rendering.WinUI3.managed.props
+++ b/source/uwp/winui3/NuGet/AdaptiveCards.Rendering.WinUI3.managed.props
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <AdaptiveCardsRenderingWinUI3WinMD>$(MSBuildThisFileDirectory)..\..\lib\uap10.0\AdaptiveCards.Rendering.WinUI3.winmd</AdaptiveCardsRenderingWinUI3WinMD>
+        <AdaptiveCardsRenderingWinUI3DllName>AdaptiveCards.Rendering.WinUI3.dll</AdaptiveCardsRenderingWinUI3DllName>
+    </PropertyGroup>
+</Project>

--- a/source/uwp/winui3/NuGet/AdaptiveCards.Rendering.WinUI3.managed.targets
+++ b/source/uwp/winui3/NuGet/AdaptiveCards.Rendering.WinUI3.managed.targets
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <ItemGroup>
+        <WindowsMetadataReference Include="$(AdaptiveCardsRenderingWinUI3WinMD)" Implementation="$(AdaptiveCardsRenderingWinUI3DllName)" />
+    </ItemGroup>
+</Project>

--- a/source/uwp/winui3/NuGet/AdaptiveCards.Rendering.WinUI3.nuspec
+++ b/source/uwp/winui3/NuGet/AdaptiveCards.Rendering.WinUI3.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>AdaptiveCards.Rendering.WinUI3</id>
-        <version>1.0.2</version>
+        <version>3.0.0</version>
         <authors>Microsoft</authors>
         <summary>Adaptive Cards library for WinUI3</summary>
         <description>Used to render Adaptive Cards into WinUI3 XAML</description>
@@ -19,21 +19,24 @@
     <files>
         <file src="..\x64\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.winmd" target="lib\uap10.0"/>
 
-        <file src="..\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.dll" target="runtimes\win10-x86\native"/>
-        <file src="..\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.lib" target="runtimes\win10-x86\native"/>
-        <file src="..\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.pdb" target="runtimes\win10-x86\native"/>
+        <file src="..\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.dll" target="runtimes\win-x86\native"/>
+        <file src="..\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.lib" target="runtimes\win-x86\native"/>
+        <file src="..\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.pdb" target="runtimes\win-x86\native"/>
 
-        <file src="..\x64\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.dll" target="runtimes\win10-x64\native"/>
-        <file src="..\x64\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.lib" target="runtimes\win10-x64\native"/>
-        <file src="..\x64\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.pdb" target="runtimes\win10-x64\native"/>
+        <file src="..\x64\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.dll" target="runtimes\win-x64\native"/>
+        <file src="..\x64\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.lib" target="runtimes\win-x64\native"/>
+        <file src="..\x64\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.pdb" target="runtimes\win-x64\native"/>
 
-        <file src="..\ARM64\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.dll" target="runtimes\win10-arm64\native"/>
-        <file src="..\ARM64\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.lib" target="runtimes\win10-arm64\native"/>
-        <file src="..\ARM64\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.pdb" target="runtimes\win10-arm64\native"/>
+        <file src="..\ARM64\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.dll" target="runtimes\win-arm64\native"/>
+        <file src="..\ARM64\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.lib" target="runtimes\win-arm64\native"/>
+        <file src="..\ARM64\$Configuration$\AdaptiveCardRenderer\AdaptiveCards.Rendering.WinUI3.pdb" target="runtimes\win-arm64\native"/>
 
         <file src="..\AnyCPU\RendererCsProjection\$Configuration$\net6.0-windows10.0.17763.0\RendererCsProjection.dll" target="lib\net6.0-windows10.0.17763.0\RendererCsProjection.dll" />
 
         <file src="EULA-Windows.txt" target="\"/>
         <file src="AdaptiveCards.Rendering.WinUI3.native.targets" target="build\native\AdaptiveCards.Rendering.WinUI3.targets"/>
+        
+        <file src="AdaptiveCards.Rendering.WinUI3.managed.targets" target="build\net6.0-windows10.0.17763.0\AdaptiveCards.Rendering.WinUI3.targets"/>
+        <file src="AdaptiveCards.Rendering.WinUI3.managed.props" target="build\net6.0-windows10.0.17763.0\AdaptiveCards.Rendering.WinUI3.props"/>
     </files>
 </package>

--- a/source/uwp/winui3/NuGet/AdaptiveCards.Rendering.WinUI3.nuspec
+++ b/source/uwp/winui3/NuGet/AdaptiveCards.Rendering.WinUI3.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>AdaptiveCards.Rendering.WinUI3</id>
-        <version>3.0.0</version>
+        <version>1.0.2</version>
         <authors>Microsoft</authors>
         <summary>Adaptive Cards library for WinUI3</summary>
         <description>Used to render Adaptive Cards into WinUI3 XAML</description>

--- a/source/uwp/winui3/ObjectModelCsProjection/ObjectModelCsProjection.csproj
+++ b/source/uwp/winui3/ObjectModelCsProjection/ObjectModelCsProjection.csproj
@@ -6,7 +6,6 @@
     <!-- Set Platform to AnyCPU to allow consumption of the projection assembly from any architecture. -->
     <Platform>AnyCPU</Platform>
     <RootNamespace>AdaptiveCards.ObjectModel.WinUI3</RootNamespace>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
   </PropertyGroup>

--- a/source/uwp/winui3/RendererCsProjection/RendererCsProjection.csproj
+++ b/source/uwp/winui3/RendererCsProjection/RendererCsProjection.csproj
@@ -6,7 +6,6 @@
     <!-- Set Platform to AnyCPU to allow consumption of the projection assembly from any architecture. -->
     <Platform>AnyCPU</Platform>
     <RootNamespace>AdaptiveCards.Rendering.WinUI3</RootNamespace>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
   </PropertyGroup>


### PR DESCRIPTION
# Related Issue

Closes #8868

# Description

Changes `win10` RIDs to `win` RIDs as .NET 8 dropped all version-specific RIDs.

# Sample Card

N/A

# How Verified

Tested by packaging a local NuGet package and installing in an app.