### PR TITLE
Update Bot Framework Web Chat to target version 1.6

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/containers/webchat/webchat-container.ts
+++ b/source/nodejs/adaptivecards-designer/src/containers/webchat/webchat-container.ts
@@ -20,6 +20,6 @@ export class WebChatContainer extends SingleThemeHostContainer {
     }
 
     get targetVersion(): Adaptive.Version {
-        return Adaptive.Versions.v1_3;
+        return Adaptive.Versions.v1_6;
     }
 }


### PR DESCRIPTION
# Description

[Bot Framework Web Chat v4.16.1](https://github.com/microsoft/BotFramework-WebChat?tab=readme-ov-file#4161-notable-changes) introduced support for Adaptive Cards 1.6. However, the Adaptive Cards Designer's Web Chat container hasn't been updated and shows an incorrect warning message when targeting over 1.3:

![image](https://github.com/user-attachments/assets/d68119d6-cb85-4d6a-a82e-624ccda64630)


This PR updates the Adaptive Card Designer's Web Chat container to target 1.6 instead of 1.3, so the warning message doesn't appear:

![image](https://github.com/user-attachments/assets/dbb93586-5de7-49c0-870a-8d37640327ec)

# How Verified

How you verified the fix, including one or all of the following:
1. New unit tests that were added if any. If none were added please add a quick line explaining why not:
    **There are no unit tests that cover webchat's target version. I tested my changes manually and included screenshots above.**
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any: **included above**
