### PR TITLE
[Designer] Update data binding accessible text

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/strings.ts
+++ b/source/nodejs/adaptivecards-designer/src/strings.ts
@@ -19,7 +19,7 @@ export class Strings {
             commands: {
                 bindData: {
                     displayText: () => "...",
-                    accessibleText: (propertyLabel: string) => "Data Binding"
+                    accessibleText: (propertyLabel: string) => `Options for ${propertyLabel} Data Binding`
                 }
             }
         },


### PR DESCRIPTION
# Related Issue

Fixes #9034 

# Description
Updated the accessible text to include more information for data binding buttons.

Narrator will now announce "Button Options for <property> Data Binding"

# Sample Card
N/A

# How Verified
Validated on a local build of our site:
![image](https://github.com/user-attachments/assets/b3da49c5-97ad-4f2d-bf6d-3081c34ebfdb)

