### PR TITLE
[UWP/WinUI3 Renderer]: Add Input collection and validation for inline actions

### DIFF
--- a/source/uwp/SharedRenderer/lib/ActionHelpers.cpp
+++ b/source/uwp/SharedRenderer/lib/ActionHelpers.cpp
@@ -461,6 +461,7 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering::ActionHelpers
                                                       actionUIElement,
                                                       inlineAction,
                                                       renderContext,
+                                                      renderArgs,
                                                       false,
                                                       L"Adaptive.Input.Text.InlineAction",
                                                       L"",
@@ -493,6 +494,7 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering::ActionHelpers
                                        winrt::UIElement const& elementToWrap,
                                        winrt::IAdaptiveActionElement const& action,
                                        winrt::AdaptiveRenderContext const& renderContext,
+                                       winrt::AdaptiveRenderArgs const& renderArgs,
                                        bool fullWidth,
                                        const std::wstring& style,
                                        winrt::hstring const& altText,
@@ -587,7 +589,7 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering::ActionHelpers
         // can we do explicit check? or need to call check_pointer()?
         if (action)
         {
-            WireButtonClickToAction(button, action, renderContext);
+            WireButtonClickToAction(button, action, renderContext, renderArgs);
         }
 
         return button;
@@ -595,8 +597,10 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering::ActionHelpers
 
     void WireButtonClickToAction(winrt::Button const& button,
                                  winrt::IAdaptiveActionElement const& action,
-                                 winrt::AdaptiveRenderContext const& renderContext)
+                                 winrt::AdaptiveRenderContext const& renderContext,
+                                 winrt::AdaptiveRenderArgs const& renderArgs)
     {
+        renderContext.LinkSubmitActionToCard(action, renderArgs);
         auto actionInvoker = renderContext.ActionInvoker();
 
         auto token = button.Click([action, actionInvoker](winrt::IInspectable const&, winrt::RoutedEventArgs const&)
@@ -606,13 +610,14 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering::ActionHelpers
     winrt::UIElement HandleSelectAction(winrt::IAdaptiveCardElement const& adaptiveCardElement,
                                         winrt::IAdaptiveActionElement const& selectAction,
                                         winrt::AdaptiveRenderContext const& renderContext,
+                                        winrt::AdaptiveRenderArgs const& renderArgs,
                                         winrt::UIElement const& uiElement,
                                         bool supportsInteractivity,
                                         bool fullWidthTouchTarget)
     {
         if (selectAction && supportsInteractivity)
         {
-            return WrapInTouchTarget(adaptiveCardElement, uiElement, selectAction, renderContext, fullWidthTouchTarget, L"Adaptive.SelectAction", L"", true);
+            return WrapInTouchTarget(adaptiveCardElement, uiElement, selectAction, renderContext, renderArgs, fullWidthTouchTarget, L"Adaptive.SelectAction", L"", true);
         }
         else
         {

--- a/source/uwp/SharedRenderer/lib/ActionHelpers.h
+++ b/source/uwp/SharedRenderer/lib/ActionHelpers.h
@@ -50,12 +50,14 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering::ActionHelpers
 
     void WireButtonClickToAction(winrt::Button const& button,
                                  winrt::IAdaptiveActionElement const& action,
-                                 winrt::AdaptiveRenderContext const& renderContext);
+                                 winrt::AdaptiveRenderContext const& renderContext,
+                                 winrt::AdaptiveRenderArgs const& renderArgs);
 
     winrt::UIElement WrapInTouchTarget(winrt::IAdaptiveCardElement const& adaptiveCardElement,
                                                           winrt::UIElement const& elementToWrap,
                                                           winrt::IAdaptiveActionElement const& action,
                                                           winrt::AdaptiveRenderContext const& renderContext,
+                                                          winrt::AdaptiveRenderArgs const& renderArgs,
                                                           bool fullWidth,
                                                           const std::wstring& style,
                                                           winrt::hstring const& altText,
@@ -64,6 +66,7 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering::ActionHelpers
     winrt::UIElement HandleSelectAction(winrt::IAdaptiveCardElement const& adaptiveCardElement,
                                                            winrt::IAdaptiveActionElement const& selectAction,
                                                            winrt::AdaptiveRenderContext const& renderContext,
+                                                           winrt::AdaptiveRenderArgs const& renderArgs,
                                                            winrt::UIElement const& uiElement,
                                                            bool supportsInteractivity,
                                                            bool fullWidthTouchTarget);

--- a/source/uwp/SharedRenderer/lib/AdaptiveCarouselRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveCarouselRenderer.cpp
@@ -174,7 +174,7 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 
             auto selectAction = styledCollection.SelectAction();
             return ::AdaptiveCards::Rendering::Xaml_Rendering::ActionHelpers::HandleSelectAction(
-                element, selectAction, context, carouselBorder, XamlHelpers::SupportsInteractivity(hostConfig), true);
+                element, selectAction, context, renderArgs, carouselBorder, XamlHelpers::SupportsInteractivity(hostConfig), true);
         }
         catch (winrt::hresult_error const& ex)
         {

--- a/source/uwp/SharedRenderer/lib/AdaptiveColumnRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveColumnRenderer.cpp
@@ -106,7 +106,7 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
             auto hostConfig = renderContext.HostConfig();
 
             auto columnControl = ::AdaptiveCards::Rendering::Xaml_Rendering::ActionHelpers::HandleSelectAction(
-                cardElement, selectAction, renderContext, columnAsUIElement, XamlHelpers::SupportsInteractivity(hostConfig), false);
+                cardElement, selectAction, renderContext, renderArgs, columnAsUIElement, XamlHelpers::SupportsInteractivity(hostConfig), false);
 
             return columnControl;
         }

--- a/source/uwp/SharedRenderer/lib/AdaptiveColumnSetRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveColumnSetRenderer.cpp
@@ -156,7 +156,7 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
             XamlHelpers::AppendXamlElementToPanel(xamlGrid, gridContainer, columnSetHeightType);
 
             return ::AdaptiveCards::Rendering::Xaml_Rendering::ActionHelpers::HandleSelectAction(
-                cardElement, selectAction, renderContext, columnSetBorder, XamlHelpers::SupportsInteractivity(hostConfig), true);
+                cardElement, selectAction, renderContext, renderArgs, columnSetBorder, XamlHelpers::SupportsInteractivity(hostConfig), true);
         }
         catch (winrt::hresult_error const& ex)
         {

--- a/source/uwp/SharedRenderer/lib/AdaptiveContainerRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveContainerRenderer.cpp
@@ -105,7 +105,7 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
             auto hostConfig = renderContext.HostConfig();
 
             return ::AdaptiveCards::Rendering::Xaml_Rendering::ActionHelpers::HandleSelectAction(
-                cardElement, selectAction, renderContext, containerBorder, XamlHelpers::SupportsInteractivity(hostConfig), true);
+                cardElement, selectAction, renderContext, renderArgs, containerBorder, XamlHelpers::SupportsInteractivity(hostConfig), true);
         }
         catch (winrt::hresult_error const& ex)
         {

--- a/source/uwp/SharedRenderer/lib/AdaptiveImageRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveImageRenderer.cpp
@@ -277,7 +277,7 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
         winrt::AutomationProperties::SetName(frameworkElement, altText);
 
         return ActionHelpers::HandleSelectAction(
-            adaptiveCardElement, selectAction, renderContext, frameworkElement, XamlHelpers::SupportsInteractivity(hostConfig), true);
+            adaptiveCardElement, selectAction, renderContext, renderArgs, frameworkElement, XamlHelpers::SupportsInteractivity(hostConfig), true);
     }
 
     winrt::IAsyncOperation<winrt::IRandomAccessStream> XamlBuilder::ResolveToStreamAsync(winrt::Uri const imageUrl,

--- a/source/uwp/SharedRenderer/lib/AdaptiveMediaRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveMediaRenderer.cpp
@@ -40,7 +40,7 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
             winrt::hstring altText = adaptiveMedia.AltText();
 
             auto touchTargetUIElement = ::AdaptiveCards::Rendering::Xaml_Rendering::ActionHelpers::WrapInTouchTarget(
-                cardElement, posterContainer, nullptr, renderContext, true, L"Adaptive.SelectAction", altText, false);
+                cardElement, posterContainer, nullptr, renderContext, renderArgs, true, L"Adaptive.SelectAction", altText, false);
 
             // Create a panel to hold the poster and the media element
             winrt::StackPanel mediaStackPanel{};

--- a/source/uwp/SharedRenderer/lib/XamlBuilder.cpp
+++ b/source/uwp/SharedRenderer/lib/XamlBuilder.cpp
@@ -70,7 +70,7 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
             // Create a new UIElement pointer to house the root element decorated with select action
 
             auto rootSelectActionElement =
-                ActionHelpers::HandleSelectAction(nullptr, selectAction, renderContext, rootElement, ifSupportsInteractivity, true);
+                ActionHelpers::HandleSelectAction(nullptr, selectAction, renderContext, renderArgs, rootElement, ifSupportsInteractivity, true);
 
             rootAsFrameworkElement = rootSelectActionElement.as<winrt::FrameworkElement>();
 


### PR DESCRIPTION
# Related Issue
[task.ms/56300488](https://task.ms/56300488)

# Description
Inline Actions in UWP/WinUI3 renderers are not rendered using their respective renderer classes (like `AdaptiveExecuteActionRenderer` for example). They're rendered separately from usual `Action` codepath and they're missing link to the hosting card.

# Sample Card
```
{
    "type": "AdaptiveCard",
    "body": [
        {
            "type": "TextBlock",
            "text": "You have clicked the button 0 times"
        },
        {
        "type": "Input.Date",
        "id": "CountdownDate",
        "height": "stretch",
        "isRequired": true,
        "errorMessage": "Fill it out"
        },
        {
            "type": "Input.Text",
            "placeholder": "yoyo",
            "id": "CountdownName",
            "height": "stretch",
            "isRequired": true,
            "errorMessage": "Fill input text too"
        },
        {
            "type": "Image",
            "url": "https://adaptivecards.io/content/person_w1.png",
            "selectAction": {
                "type": "Action.Execute",
                "verb": "AddCountdown",
                "tooltip": "tooltip",
                "associatedInputs": "auto"
            }
        }
    ],
    "actions": [
        {
            "type": "Action.Execute",
            "title": "Increment",
            "verb": "inc"
        }
    ],
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
    "version": "1.5"
}
```

# How Verified
Verified locally with multiple scenarios:
1) Inline action and associated inputs are on the same level in AdaptiveCard.
2) Inline action is nested deeper down than input in AdaptiveCard.
3) Adaptive input is nested deeper down than inline action in AdaptiveCard.

In all these cases on Action Execution the input is properly validated and is included in action payload.
