### PR TITLE
Remove a Vector

### DIFF
--- a/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCards.Templating.csproj
+++ b/source/dotnet/Library/AdaptiveCards.Templating/AdaptiveCards.Templating.csproj
@@ -13,7 +13,7 @@
     <PackageIconUrl>https://adaptivecards.io/content/icons_blue/blue-48.png</PackageIconUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/microsoft/AdaptiveCards/issues/2448</PackageProjectUrl>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <DefineConstants>$(DefineConstants);$(AdditionalConstants)</DefineConstants>
 
     <LangVersion>12</LangVersion>

--- a/source/uwp/SharedRenderer/lib/AdaptiveImageRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveImageRenderer.cpp
@@ -318,19 +318,10 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
                 dataWriter.WriteBytes(std::vector<byte>{data.begin(), data.end()});
             }
 
-            auto storeOp = dataWriter.StoreAsync();
-
-            if (const auto strongThis = weakThis.get())
-            {
-                strongThis->m_writeAsyncOperations.push_back(storeOp);
-
-                co_await storeOp;
-
-                auto stream = dataWriter.DetachStream().try_as<winrt::InMemoryRandomAccessStream>();
-                stream.Seek(0);
-
-                co_return stream;
-            }
+            dataWriter.StoreAsync().get();
+			auto stream = dataWriter.DetachStream().try_as<winrt::InMemoryRandomAccessStream>();
+			stream.Seek(0);
+			co_return stream;
         }
 
         // Otherwise, no resolver...

--- a/source/uwp/SharedRenderer/lib/AdaptiveImageRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveImageRenderer.cpp
@@ -318,7 +318,7 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
                 dataWriter.WriteBytes(std::vector<byte>{data.begin(), data.end()});
             }
 
-            dataWriter.StoreAsync().get();
+            co_await dataWriter.StoreAsync();
 			auto stream = dataWriter.DetachStream().try_as<winrt::InMemoryRandomAccessStream>();
 			stream.Seek(0);
 			co_return stream;

--- a/source/uwp/SharedRenderer/lib/XamlBuilder.h
+++ b/source/uwp/SharedRenderer/lib/XamlBuilder.h
@@ -68,7 +68,6 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
         std::set<IXamlBuilderListener*> m_listeners;
         std::vector<winrt::IAsyncOperationWithProgress<winrt::IInputStream, winrt::HttpProgress>> m_getStreamOperations;
         std::vector<winrt::IAsyncOperationWithProgress<uint64_t, uint64_t>> m_copyStreamOperations;
-        std::vector<winrt::IAsyncOperation<uint32_t>> m_writeAsyncOperations;
         uint32_t m_fixedWidth = 0;
         uint32_t m_fixedHeight = 0;
 


### PR DESCRIPTION
# Related Issue
We are seeing heap corruption originating from the ResolveStream routine. All incidents point to a vector push operation where we push storeOp into m_writeAsyncOperations.

# Description
This pull request focuses on simplifying asynchronous operations and cleaning up unused code in the `AdaptiveCards::Rendering::Xaml_Rendering` namespace. The most important changes include modifying how asynchronous operations are handled and removing unnecessary member variables.

Simplification of asynchronous operations:

* [`source/uwp/SharedRenderer/lib/AdaptiveImageRenderer.cpp`](diffhunk://#diff-de9d0ba940c42728791a67c0d035838b4ab1fe530b4bc435dcaeab9efecef1b1L321-L334): Simplified the asynchronous write operation by calling `dataWriter.StoreAsync().get()` directly and removing the associated coroutine logic.

Code cleanup:

* [`source/uwp/SharedRenderer/lib/XamlBuilder.h`](diffhunk://#diff-ed768131f3890505bdf7af94fae06f86a8748793e56db59edbcafa6247b53dd3L71): Removed the unused member variable `m_writeAsyncOperations` from the `XamlBuilder` class.

# How Verified
Ran unit tests and verified functionality using sample cards.