### PR TITLE
Add banners in the web site to redirect users to the new https://adaptivecards.microsoft.com AC documentation hub

### DIFF
--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/archive.ejs
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/archive.ejs
@@ -87,6 +87,24 @@ layout: layout
 
 <div class="blog w3-content" >
 
+	<div class="w3-center" style="width: 100%; margin: 24px 0 50px 10px ; background-color: #fdf5fc; border-radius: 8px; border: 2px solid #af33a1; padding: 25px 50px">
+		<p class="w3-xlarge"><b>NEW</b></p>
+		<h1>Are you building Copilot, Teams or Outlook scenarios powered by Adaptive Cards?</h1>
+		<p class="w3-large">The <a class="w3-large" href="https://adaptivecards.microsoft.com">Adaptive Card Documentation Hub</a> is the new one-stop-shop for all your Adaptive Card needs! It has all the resources you're looking for, including complete documentation for many new features, such as
+			<a class="w3-large" href="https://adaptivecards.microsoft.com/?topic=responsive-layout">Responsive layout</a>,
+			<a class="w3-large" href="https://adaptivecards.microsoft.com/?topic=Icon">Icon</a>,
+			<a class="w3-large" href="https://adaptivecards.microsoft.com/?topic=Badge">Badge</a>,
+			<a class="w3-large" href="https://adaptivecards.microsoft.com/?topic=Carousel">Carousel</a>,
+			<a class="w3-large" href="https://adaptivecards.microsoft.com/?topic=Chart.Line">Charts</a>,
+			and much more!
+		</p>
+		<p class="w3-large">The <a href="https://adaptivecards.microsoft.com/designer">new Adaptive Card Designer</a> also has plenty of high quality samples built-in. Check them out!
+		</p>
+		<button role="link" onclick="window.location.href='https://adaptivecards.microsoft.com'"
+			class="w3-button w3-large w3-round-medium ac-blue" aria-label="Click to navigate to the Adaptive Card Documentation Hub">
+			Visit the hub
+		</button>
+	</div>
 
 	<% page.posts.each(function(post, i) { %>
 

--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/designer.ejs
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/designer.ejs
@@ -348,6 +348,7 @@
 
 <div style="display: flex; flex-direction: column; height: 100%; ">
 	<div style="text-align: center; font-size: 1.6em; background-color: #fdf5fc; border-radius: 8px; border: 2px solid #af33a1; padding: 10px">
+		<strong>Building Copilot, Teams or Outlook scenarios powered by Adaptive Cards?</strong><br />
 		Check out the <a class="w3-large" href="https://adaptivecards.microsoft.com/designer"><strong>NEW Adaptive Card Designer</strong></a> with plenty of new features and high quality samples!
 	</div>
 

--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/designer.ejs
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/designer.ejs
@@ -347,5 +347,9 @@
 </script>
 
 <div style="display: flex; flex-direction: column; height: 100%; ">
+	<div style="text-align: center; font-size: 1.6em; background-color: #fdf5fc; border-radius: 8px; border: 2px solid #af33a1; padding: 10px">
+		Check out the <a class="w3-large" href="https://adaptivecards.microsoft.com/designer"><strong>NEW Adaptive Card Designer</strong></a> with plenty of new features and high quality samples!
+	</div>
+
 	<div id="designerRootHost"></div>
 </div>

--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/explorer.ejs
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/explorer.ejs
@@ -42,6 +42,23 @@
 				</select>
 			</div>
 
+			<div class="w3-center" style="width: 100%; margin: 50px auto auto auto; background-color: #fdf5fc; border-radius: 8px; border: 2px solid #af33a1; padding: 25px 50px">
+				<p class="w3-xlarge"><b>NEW</b></p>
+				<h1>Are you building Copilot, Teams or Outlook scenarios powered by Adaptive Cards?</h1>
+				<p class="w3-large">The <a class="w3-large" href="https://adaptivecards.microsoft.com">Adaptive Card Documentation Hub</a> is the new one-stop-shop for all your Adaptive Card needs! It has all the resources you're looking for, including complete documentation for many new features, such as
+					<a class="w3-large" href="https://adaptivecards.microsoft.com/?topic=responsive-layout">Responsive layout</a>,
+					<a class="w3-large" href="https://adaptivecards.microsoft.com/?topic=Icon">Icon</a>,
+					<a class="w3-large" href="https://adaptivecards.microsoft.com/?topic=Badge">Badge</a>,
+					<a class="w3-large" href="https://adaptivecards.microsoft.com/?topic=Carousel">Carousel</a>,
+					<a class="w3-large" href="https://adaptivecards.microsoft.com/?topic=Chart.Line">Charts</a>,
+					and much more!
+				</p>
+				<button role="link" onclick="window.location.href='https://adaptivecards.microsoft.com'"
+					class="w3-button w3-large w3-round-medium ac-blue" aria-label="Click to navigate to the Adaptive Card Documentation Hub">
+					Visit the hub
+				</button>
+			</div>
+
 			<p><%- site.data.samples.en.accwarning %></p>
 
 			<h2 class='<%= page.previewClassName %>'><%= page.element.name %></h2>

--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/index.ejs
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/index.ejs
@@ -12,10 +12,26 @@
 		</div>
 	</div>
 
+	<div class="w3-center" style="max-width: 800px; margin: 50px auto auto auto; background-color: #fdf5fc; border-radius: 8px; border: 2px solid #af33a1; padding: 25px 50px">
+		<p class="w3-xlarge"><b>NEW</b></p>
+		<h1 class="w3-xxlarge">Are you building Copilot, Teams or Outlook scenarios powered by Adaptive Cards?</h1>
+		<p class="w3-large">The <a class="w3-large" href="https://adaptivecards.microsoft.com">Adaptive Card Documentation Hub</a> is the new one-stop-shop for all your Adaptive Card needs! It has all the resources you're looking for, including complete documentation for many new features, such as
+			<a class="w3-large" href="https://adaptivecards.microsoft.com/?topic=responsive-layout">Responsive layout</a>,
+			<a class="w3-large" href="https://adaptivecards.microsoft.com/?topic=Icon">Icon</a>,
+			<a class="w3-large" href="https://adaptivecards.microsoft.com/?topic=Badge">Badge</a>,
+			<a class="w3-large" href="https://adaptivecards.microsoft.com/?topic=Carousel">Carousel</a>,
+			<a class="w3-large" href="https://adaptivecards.microsoft.com/?topic=Chart.Line">Charts</a>,
+			and much more!
+		</p>
+		<button role="link" onclick="window.location.href='https://adaptivecards.microsoft.com'"
+			class="w3-button w3-large w3-round-medium ac-blue" aria-label="Click to navigate to the Adaptive Card Documentation Hub">
+			Visit the hub
+		</button>
+	</div>
 
 	<div class="w3-center" style="max-width: 600px; margin: auto">
 		<div class="w3-margin w3-padding-32">
-			<h1 class="w3-xxxlarge"><%- site.data.home.en.heading %></h1>
+			<h1 class="w3-xxlarge"><%- site.data.home.en.heading %></h1>
 			<div class="accent-paragraph"><%- site.data.home.en.heading_paragraph %></div>
 			<div class="w3-padding-16">
 				<button role="link" onclick="window.location.href='https://docs.microsoft.com/en-us/adaptive-cards/'"

--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/post.ejs
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/post.ejs
@@ -18,7 +18,6 @@
 </style>
 
 
-
 <div class="blog w3-content" style="max-width: 960px">
 
 	<div class="w3-row blog-post-wrapper">

--- a/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/sample.ejs
+++ b/source/nodejs/adaptivecards-site/themes/adaptivecards/layout/sample.ejs
@@ -22,6 +22,25 @@
 	<div class="w3-main" style="margin-left: 200px">
 
 		<div class="w3-row-padding">
+			<div class="w3-center" style="width: 100%; margin: 24px 0 50px 10px ; background-color: #fdf5fc; border-radius: 8px; border: 2px solid #af33a1; padding: 25px 50px">
+				<p class="w3-xlarge"><b>NEW</b></p>
+				<h1>Are you building Copilot, Teams or Outlook scenarios powered by Adaptive Cards?</h1>
+				<p class="w3-large">The <a class="w3-large" href="https://adaptivecards.microsoft.com">Adaptive Card Documentation Hub</a> is the new one-stop-shop for all your Adaptive Card needs! It has all the resources you're looking for, including complete documentation for many new features, such as
+					<a class="w3-large" href="https://adaptivecards.microsoft.com/?topic=responsive-layout">Responsive layout</a>,
+					<a class="w3-large" href="https://adaptivecards.microsoft.com/?topic=Icon">Icon</a>,
+					<a class="w3-large" href="https://adaptivecards.microsoft.com/?topic=Badge">Badge</a>,
+					<a class="w3-large" href="https://adaptivecards.microsoft.com/?topic=Carousel">Carousel</a>,
+					<a class="w3-large" href="https://adaptivecards.microsoft.com/?topic=Chart.Line">Charts</a>,
+					and much more!
+				</p>
+				<p class="w3-large">The <a href="https://adaptivecards.microsoft.com/designer">new Adaptive Card Designer</a> also has plenty of high quality samples built-in. Check them out!
+				</p>
+				<button role="link" onclick="window.location.href='https://adaptivecards.microsoft.com'"
+					class="w3-button w3-large w3-round-medium ac-blue" aria-label="Click to navigate to the Adaptive Card Documentation Hub">
+					Visit the hub
+				</button>
+			</div>
+
 			<div class="w3-col m6">
 				<h1><%= site.data.samples.en.title %></h1>
 				<p><%- site.data.samples.en.intro %></p>


### PR DESCRIPTION
This PR updates the AC web site to include banners prompting users to visit the new Adaptive Card Documentation Hub at https://adaptivecards.microsoft.com.

![image](https://github.com/user-attachments/assets/18d82155-db6b-4972-ba4c-5e3d488a4af5)
![image](https://github.com/user-attachments/assets/b1d5164a-ccbf-43bb-86b1-0adf51d90119)
![image](https://github.com/user-attachments/assets/d3e3db45-7ecf-4e5e-9da6-ac3c519fe34a)
![image](https://github.com/user-attachments/assets/1d33c6c1-978d-4a6b-9989-25756d6e0a94)

