### PR TITLE
Create hard dependency on non-Vulnerable Newtonsoft.Json for projects leveraging Newtonsoft.Json.Schema

### DIFF
--- a/source/uwp/winui3/SimpleVisualizer/SimpleVisualizer.csproj
+++ b/source/uwp/winui3/SimpleVisualizer/SimpleVisualizer.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.1" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.221109.1" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.14" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>

--- a/source/uwp/winui3/Visualizer/AdaptiveCardVisualizer.csproj
+++ b/source/uwp/winui3/Visualizer/AdaptiveCardVisualizer.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.1" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.221109.1" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.14" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>


### PR DESCRIPTION
Fixes #9102 

# Description

2 Projects contained transitive dependencies on vulnerable versions of Newtonsoft.Json caused by Newtonsoft.Json.Schema v[3.0.14](https://www.nuget.org/packages/Newtonsoft.Json.Schema/3.0.14#dependencies-body-tab). This change makes a hard dependency on the non-vulnerable version 13.03, like the rest of the project.

# How Verified

1. Confirmed project built.