### PR TITLE
Added suppression for CodeQL SM03781 SFI Item

### DIFF
--- a/source/uwp/Visualizer/AdaptiveCardVisualizer.csproj
+++ b/source/uwp/Visualizer/AdaptiveCardVisualizer.csproj
@@ -16,7 +16,7 @@
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-	<PackageCertificateKeyFile>AdaptiveCardVisualizer_TemporaryKey.pfx</PackageCertificateKeyFile>
+    <PackageCertificateKeyFile>AdaptiveCardVisualizer_TemporaryKey.pfx</PackageCertificateKeyFile>
     <NoWarn>;2008</NoWarn>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>


### PR DESCRIPTION
# Description
CodeQL [SM03781] InDomain is used to validate the URL domain, so this is safe. Adding suppression for CodeQL since known pattern not currently supported for SSRF query yet.