### PR TITLE
Fixing Accessibilty color contrast ratio issue on hyper link

### DIFF
--- a/source/nodejs/adaptivecards-designer/src/containers/teams/teams-container-dark.css
+++ b/source/nodejs/adaptivecards-designer/src/containers/teams/teams-container-dark.css
@@ -90,19 +90,19 @@ a.ac-anchor {
 }
 
 a.ac-anchor:link {
-    color: #6264A7;
+    color: #8686ff;
 }
 
 a.ac-anchor:visited {
-    color: #6264A7;
+    color: #8686ff;
 }
 
 a.ac-anchor:link:active {
-    color: #6264A7;
+    color: #8686ff;
 }
 
 a.ac-anchor:visited:active {
-    color: #6264A7;
+    color: #8686ff;
 }
 
 .ac-container.ac-selectable, .ac-columnSet.ac-selectable {


### PR DESCRIPTION
# Related Issue
https://github.com/microsoft/AdaptiveCards/issues/9070

# Description
In dark mode, the color contrast ratio of 'Learn more', w.r.t background color is 2.23:1, which is less than 4.5:1
So fix the issue by changing the hyper link color

# How Verified
Ran the website locally and verified the contrast ratio using accessibility tool
![image](https://github.com/user-attachments/assets/2f372016-a701-4076-a152-d62ea566f6f8)
