### PR TITLE
fix: fix MicrosoftFluentUI/Tooltip_ios version

### DIFF
--- a/source/ios/tools/AdaptiveCards.podspec
+++ b/source/ios/tools/AdaptiveCards.podspec
@@ -39,7 +39,7 @@ Pod::Spec.new do |spec|
   end
 
   spec.subspec 'UIProviders' do | sspec |
-    sspec.dependency 'MicrosoftFluentUI/Tooltip_ios', '~> 0.3.6'
+    sspec.dependency 'MicrosoftFluentUI/Tooltip_ios', '~> 0.3'
     sspec.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'ADAPTIVECARDS_USE_FLUENT_TOOLTIPS=1' }
   end
 


### PR DESCRIPTION
# Related Issue

N/A


# Description

I have an iOS app and it depends on `AdaptiveCards` and `MicrosoftFluentUI`. Here is my Podfile

<img width="688" alt="image" src="https://github.com/user-attachments/assets/fe24e057-3462-431e-9ae6-1bc96ce4df71" />

When I do `pod install`, it returns this

<img width="1450" alt="image" src="https://github.com/user-attachments/assets/179edb06-8791-442a-b571-623d69d27422" />

Basically, for all projects depends on both AdaptiveCards and MicrosoftFluentUI are unable to complete pod install