### PR TITLE
Added check for strongThis before using

### DIFF
--- a/source/uwp/SharedRenderer/lib/AdaptiveImageRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveImageRenderer.cpp
@@ -427,7 +427,7 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
                     }
                 }
 
-                if (auto strongThis = weakThis.get(); isAutoSize)
+                if (auto strongThis = weakThis.get(); strongThis && isAutoSize)
                 {
                     strongThis->SetAutoSize(
                         properties.uiElement,


### PR DESCRIPTION
# Related Issue

#9197

# Description

This pull request includes a small but important fix in the `AdaptiveImageRenderer.cpp` file. The change ensures that the `strongThis` pointer is checked for validity before calling `SetAutoSize`, improving the safety of the code.

* [`source/uwp/SharedRenderer/lib/AdaptiveImageRenderer.cpp`](diffhunk://#diff-de9d0ba940c42728791a67c0d035838b4ab1fe530b4bc435dcaeab9efecef1b1L430-R430): Added a null check for `strongThis` in the condition to prevent potential dereferencing of a null pointer.

# How Verified

WIP
