### PR TITLE
Fix AG_E_LAYOUT_CYCLE crash in widgets due to MinHeight exceeding Max Height

### DIFF
--- a/source/uwp/SharedRenderer/lib/AdaptiveCarouselRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveCarouselRenderer.cpp
@@ -95,13 +95,21 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
             }
 
             uint32_t carouselMinHeight = styledCollection.MinHeight();
+            auto fixedHeightInPixel = carousel.HeightInPixels();
 
+            // Ensure MinHeight doesn't exceed fixed height to prevent AG_E_LAYOUT_CYCLE
             if (carouselMinHeight > 0)
             {
-                gridContainer.MinHeight(carouselMinHeight);
+                if (fixedHeightInPixel && carouselMinHeight > fixedHeightInPixel)
+                {
+                    gridContainer.MinHeight(static_cast<double>(fixedHeightInPixel));
+                }
+                else
+                {
+                    gridContainer.MinHeight(carouselMinHeight);
+                }
             }
 
-            auto fixedHeightInPixel = carousel.HeightInPixels();
             if (fixedHeightInPixel)
             {
                 carouselUI.MaxHeight(static_cast<double>(fixedHeightInPixel));

--- a/source/uwp/SharedRenderer/lib/XamlBuilder.cpp
+++ b/source/uwp/SharedRenderer/lib/XamlBuilder.cpp
@@ -62,7 +62,16 @@ namespace AdaptiveCards::Rendering::Xaml_Rendering
 
             if (cardMinHeight > 0)
             {
-                rootAsFrameworkElement.MinHeight(cardMinHeight);
+                // If fixed dimensions are set, ensure MinHeight doesn't exceed MaxHeight to prevent AG_E_LAYOUT_CYCLE
+                if (xamlBuilder && xamlBuilder->m_fixedDimensions && cardMinHeight > xamlBuilder->m_fixedHeight)
+                {
+                    // Clamp MinHeight to not exceed the fixed height constraint
+                    rootAsFrameworkElement.MinHeight(xamlBuilder->m_fixedHeight);
+                }
+                else
+                {
+                    rootAsFrameworkElement.MinHeight(cardMinHeight);
+                }
             }
 
             auto selectAction = adaptiveCard.SelectAction();


### PR DESCRIPTION
When rendering adaptive cards in widgets with fixed dimensions, setting a MinHeight value greater than the MaxHeight constraint caused XAML to throw AG_E_LAYOUT_CYCLE (0x802B0014), resulting in widget crashes.

Changes:
- XamlBuilder.cpp: Clamp card MinHeight to not exceed fixed height when fixedDimensions are set, preventing impossible layout constraints
- AdaptiveCarouselRenderer.cpp: Apply same constraint validation for carousel elements with HeightInPixels property

The fix ensures MinHeight never exceeds MaxHeight by automatically clamping the value to the maximum allowed height, allowing cards to render successfully without layout cycle errors.