### PR TITLE
Carousel layout cycle renderer bug

### DIFF
--- a/source/uwp/SharedRenderer/lib/AdaptiveCarouselRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveCarouselRenderer.cpp
@@ -123,16 +123,29 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
                 {
                     carouselUI.Items().Append(carouselPageUI);
                 }
+            }
 
-                // If no fixed height was specified, compute the max height from page content
-                // after the FlipView has been loaded (not during layout) to avoid layout cycles.
-                if (fixedHeightInPixel == 0)
-                {
-                    auto isUpdatingHeight = std::make_shared<bool>(false);
+            // If no fixed height was specified, compute the max height from page content
+            // after the FlipView has been loaded (not during layout) to avoid layout cycles.
+            if (fixedHeightInPixel == 0)
+            {
+                auto isUpdatingHeight = std::make_shared<bool>(false);
 
-                    // Use Loaded event to set initial height — fires once after the element
-                    // is in the visual tree and has been measured, but not during a layout pass.
-                    auto loadedToken = carouselUI.Loaded([carouselUI, isUpdatingHeight](auto&&, auto&&) {
+                // Use Loaded event to set initial height — fires once after the element
+                // is in the visual tree and has been measured, but not during a layout pass.
+                auto loadedToken = carouselUI.Loaded([carouselUI, isUpdatingHeight](auto&&, auto&&) {
+                    if (*isUpdatingHeight)
+                        return;
+                    *isUpdatingHeight = true;
+                    SetFlipViewMaxHeight(carouselUI);
+                    *isUpdatingHeight = false;
+                });
+
+                // Use SizeChanged to adjust if the FlipView width changes (e.g. window resize).
+                // SizeChanged fires after layout completes, so it won't cause a layout cycle
+                // as long as we guard against re-entrancy.
+                auto sizeChangedToken =
+                    carouselUI.SizeChanged([carouselUI, isUpdatingHeight](auto&&, winrt::SizeChangedEventArgs const&) {
                         if (*isUpdatingHeight)
                             return;
                         *isUpdatingHeight = true;
@@ -140,34 +153,20 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
                         *isUpdatingHeight = false;
                     });
 
-                    // Use SizeChanged to adjust if the FlipView width changes (e.g. window resize).
-                    // SizeChanged fires after layout completes, so it won't cause a layout cycle
-                    // as long as we guard against re-entrancy.
-                    auto sizeChangedToken =
-                        carouselUI.SizeChanged([carouselUI, isUpdatingHeight](auto&&, winrt::SizeChangedEventArgs const&) {
-                        if (*isUpdatingHeight)
-                            return;
-                        *isUpdatingHeight = true;
-                        SetFlipViewMaxHeight(carouselUI);
-                        *isUpdatingHeight = false;
-                    });
+                // Update height when the selected page changes, since pages may differ in size.
+                auto selectionChangedToken = carouselUI.SelectionChanged([carouselUI, isUpdatingHeight](auto&&, auto&&) {
+                    if (*isUpdatingHeight)
+                        return;
+                    *isUpdatingHeight = true;
+                    SetFlipViewMaxHeight(carouselUI);
+                    *isUpdatingHeight = false;
+                });
 
-                    // Update height when the selected page changes, since pages may differ in size.
-                    auto selectionChangedToken = carouselUI.SelectionChanged([carouselUI, isUpdatingHeight](auto&&, auto&&) {
-                        if (*isUpdatingHeight)
-                            return;
-                        *isUpdatingHeight = true;
-                        SetFlipViewMaxHeight(carouselUI);
-                        *isUpdatingHeight = false;
-                    });
-
-                    carouselUI.Unloaded([ carouselUI, loadedToken, sizeChangedToken, selectionChangedToken ](auto&&, auto&&) {
-                        carouselUI.Loaded(loadedToken);
-                        carouselUI.SizeChanged(sizeChangedToken);
-                        carouselUI.SelectionChanged(selectionChangedToken);
-                    });
-
-                }
+                carouselUI.Unloaded([carouselUI, loadedToken, sizeChangedToken, selectionChangedToken](auto&&, auto&&) {
+                    carouselUI.Loaded(loadedToken);
+                    carouselUI.SizeChanged(sizeChangedToken);
+                    carouselUI.SelectionChanged(selectionChangedToken);
+                });
             }
 
             if (carousel.InitialPage())

--- a/source/uwp/SharedRenderer/lib/AdaptiveCarouselRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveCarouselRenderer.cpp
@@ -11,240 +11,200 @@
 
 namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
-winrt::UIElement AdaptiveCarouselRenderer::Render(
-    winrt::AdaptiveCards::ObjectModel::Xaml_Rendering::IAdaptiveCardElement const& element,
-    winrt::AdaptiveCards::Rendering::Xaml_Rendering::AdaptiveRenderContext const& context,
-    winrt::AdaptiveCards::Rendering::Xaml_Rendering::AdaptiveRenderArgs const& renderArgs)
-{
-    auto carousel = element.as<winrt::IAdaptiveCarousel>();
-    auto styledCollection = element.as<winrt::IAdaptiveContainerBase>();
-
-    StackPanel stackPanel{};
-    FlipView carouselUI{};
-    bool loopEnabled{false};
-
-    if (carousel.AutoLoop())
+    winrt::UIElement AdaptiveCarouselRenderer::Render(
+        winrt::AdaptiveCards::ObjectModel::Xaml_Rendering::IAdaptiveCardElement const& element,
+        winrt::AdaptiveCards::Rendering::Xaml_Rendering::AdaptiveRenderContext const& context,
+        winrt::AdaptiveCards::Rendering::Xaml_Rendering::AdaptiveRenderArgs const& renderArgs)
     {
-        loopEnabled = carousel.AutoLoop().GetBoolean();
-    }
+        auto carousel = element.as<winrt::IAdaptiveCarousel>();
+        auto styledCollection = element.as<winrt::IAdaptiveContainerBase>();
 
-    PipsPager pipsPager{};
-    pipsPager.HorizontalAlignment(winrt::HorizontalAlignment::Center);
-    pipsPager.NumberOfPages(carousel.Pages().Size());
-    auto hostConfig = context.HostConfig();
+        StackPanel stackPanel{};
+        FlipView carouselUI{};
+        bool loopEnabled{false};
 
-    // FlipView has its own background color property, so we need to clear the background color
-    carouselUI.Background(winrt::SolidColorBrush{GetColorFromString("#00FFFFFF")});
-
-    // auto adaptiveCarouselContainer = element.as<winrt::IAdaptiveContainerBase>();
-    //  Get any RTL setting set on either the current context or on this container. Any value set on the
-    //  container should be set on the context to apply to all children
-    auto previousContextRtl = context.Rtl();
-    auto currentRtl = previousContextRtl;
-    auto containerRtl = carousel.Rtl();
-
-    bool updatedRtl = false;
-    if (containerRtl)
-    {
-        currentRtl = containerRtl;
-        context.Rtl(currentRtl);
-        updatedRtl = true;
-    }
-
-    if (currentRtl)
-    {
-        carouselUI.FlowDirection(currentRtl.GetBoolean() ? winrt::FlowDirection::RightToLeft : winrt::FlowDirection::LeftToRight);
-        pipsPager.FlowDirection(currentRtl.GetBoolean() ? winrt::FlowDirection::RightToLeft : winrt::FlowDirection::LeftToRight);
-    }
-
-    carouselUI.SelectionChanged([carouselUI, pipsPager, loopEnabled](auto&&, auto&&) {
-        auto val = carouselUI.SelectedIndex();
-        if (loopEnabled && static_cast<unsigned int>(val) == carouselUI.Items().Size())
+        if (carousel.AutoLoop())
         {
-            pipsPager.SelectedPageIndex(0);
-            carouselUI.SelectedIndex(0);
-        }
-        else
-        {
-            pipsPager.SelectedPageIndex(carouselUI.SelectedIndex());
-        }
-    });
-
-    pipsPager.SelectedIndexChanged([carouselUI](PipsPager pager, IPipsPagerSelectedIndexChangedEventArgs) {
-        carouselUI.SelectedIndex(pager.SelectedPageIndex());
-    });
-
-    stackPanel.Children().Append(carouselUI);
-    stackPanel.Children().Append(pipsPager);
-
-    winrt::AdaptiveFeatureRegistration featureRegistration = context.FeatureRegistration();
-    boolean ancestorHasFallback = renderArgs.AncestorHasFallback();
-
-    try
-    {
-        winrt::Border carouselBorder{};
-
-        auto gridContainer = winrt::make<winrt::implementation::WholeItemsPanel>();
-
-        // Assign vertical alignment to strech so column will stretch and respect vertical content alignment
-        auto containerHeightType = element.Height();
-        if (containerHeightType == winrt::HeightType::Auto)
-        {
-            gridContainer.VerticalAlignment(winrt::VerticalAlignment::Stretch);
+            loopEnabled = carousel.AutoLoop().GetBoolean();
         }
 
-        uint32_t carouselMinHeight = styledCollection.MinHeight();
+        PipsPager pipsPager{};
+        pipsPager.HorizontalAlignment(winrt::HorizontalAlignment::Center);
+        pipsPager.NumberOfPages(carousel.Pages().Size());
+        auto hostConfig = context.HostConfig();
 
-        if (carouselMinHeight > 0)
+        // FlipView has its own background color property, so we need to clear the background color
+        carouselUI.Background(winrt::SolidColorBrush{GetColorFromString("#00FFFFFF")});
+
+        //auto adaptiveCarouselContainer = element.as<winrt::IAdaptiveContainerBase>();
+        // Get any RTL setting set on either the current context or on this container. Any value set on the
+        // container should be set on the context to apply to all children
+        auto previousContextRtl = context.Rtl();
+        auto currentRtl = previousContextRtl;
+        auto containerRtl = carousel.Rtl();
+
+        bool updatedRtl = false;
+        if (containerRtl)
         {
-            gridContainer.MinHeight(carouselMinHeight);
+            currentRtl = containerRtl;
+            context.Rtl(currentRtl);
+            updatedRtl = true;
         }
 
-        auto fixedHeightInPixel = carousel.HeightInPixels();
-        if (fixedHeightInPixel)
+        if (currentRtl)
         {
-            carouselUI.MaxHeight(static_cast<double>(fixedHeightInPixel));
+            carouselUI.FlowDirection(currentRtl.GetBoolean() ? winrt::FlowDirection::RightToLeft : winrt::FlowDirection::LeftToRight);
+            pipsPager.FlowDirection(currentRtl.GetBoolean() ? winrt::FlowDirection::RightToLeft : winrt::FlowDirection::LeftToRight);
         }
 
-        auto containerStyle = XamlHelpers::HandleStylingAndPadding(styledCollection, carouselBorder, context, renderArgs);
-
-        auto newRenderArgs =
-            winrt::make<winrt::implementation::AdaptiveRenderArgs>(containerStyle, renderArgs.ParentElement(), renderArgs);
-
-        for (auto page : carousel.Pages())
-        {
-            auto [carouselPageUI, carouselPage] = ::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder::RenderAsUIElement(
-                page, context, newRenderArgs, featureRegistration, ancestorHasFallback);
-
-            if (carouselPageUI != nullptr)
+        carouselUI.SelectionChanged([carouselUI, pipsPager, loopEnabled](auto &&, auto &&) {
+            auto val = carouselUI.SelectedIndex();
+            if (loopEnabled &&
+                static_cast<unsigned int>(val) == carouselUI.Items().Size())
             {
-                carouselUI.Items().Append(carouselPageUI);
+                pipsPager.SelectedPageIndex(0);
+                carouselUI.SelectedIndex(0);
+            }
+            else
+            {
+                pipsPager.SelectedPageIndex(carouselUI.SelectedIndex());
+            }
+        });
+
+        pipsPager.SelectedIndexChanged([carouselUI](PipsPager pager, IPipsPagerSelectedIndexChangedEventArgs) {
+            carouselUI.SelectedIndex(pager.SelectedPageIndex());
+        });
+
+        stackPanel.Children().Append(carouselUI);
+        stackPanel.Children().Append(pipsPager);
+
+        winrt::AdaptiveFeatureRegistration featureRegistration = context.FeatureRegistration();
+        boolean ancestorHasFallback = renderArgs.AncestorHasFallback();
+
+        try
+        {
+            winrt::Border carouselBorder{};
+
+            auto gridContainer = winrt::make<winrt::implementation::WholeItemsPanel>();
+
+            // Assign vertical alignment to strech so column will stretch and respect vertical content alignment
+            auto containerHeightType = element.Height();
+            if (containerHeightType == winrt::HeightType::Auto)
+            {
+                gridContainer.VerticalAlignment(winrt::VerticalAlignment::Stretch);
+            }
+
+            uint32_t carouselMinHeight = styledCollection.MinHeight();
+
+            if (carouselMinHeight > 0)
+            {
+                gridContainer.MinHeight(carouselMinHeight);
+            }
+
+            auto fixedHeightInPixel = carousel.HeightInPixels();
+            if (fixedHeightInPixel)
+            {
+                carouselUI.MaxHeight(static_cast<double>(fixedHeightInPixel));
+            }
+
+            auto containerStyle =
+                XamlHelpers::HandleStylingAndPadding(styledCollection, carouselBorder, context, renderArgs);
+
+            auto newRenderArgs =
+                winrt::make<winrt::implementation::AdaptiveRenderArgs>(containerStyle, renderArgs.ParentElement(), renderArgs);
+
+            for (auto page : carousel.Pages())
+            {
+                auto [carouselPageUI, carouselPage] =
+                    ::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder::RenderAsUIElement(
+                    page, context, newRenderArgs, featureRegistration, ancestorHasFallback);
+
+                if (carouselPageUI != nullptr)
+                {
+                    carouselUI.Items().Append(carouselPageUI);
+
+                    if (fixedHeightInPixel == 0)
+                    {
+                        carouselPageUI.try_as<FrameworkElement>().LayoutUpdated(
+                            [carouselUI](auto&&, auto&&) { SetFlipViewMaxHeight(carouselUI); });
+                    }
+               }
+            }
+
+            if (carousel.InitialPage())
+            {
+                carouselUI.SelectedIndex(carousel.InitialPage().GetUInt32());
+            }
+
+            auto verticalContentAlignmentReference = carousel.VerticalContentAlignment();
+            winrt::VerticalContentAlignment verticalContentAlignment =
+                GetValueFromRef(verticalContentAlignmentReference, winrt::VerticalContentAlignment::Top);
+            XamlHelpers::SetVerticalContentAlignmentToChildren(gridContainer, verticalContentAlignment);
+
+            // Check if backgroundImage defined
+            auto backgroundImage = carousel.BackgroundImage();
+            if (IsBackgroundImageValid(backgroundImage))
+            {
+                winrt::Grid rootElement{};
+                XamlHelpers::ApplyBackgroundToRoot(rootElement, backgroundImage, context);
+
+                // Add rootElement to containerBorder
+                carouselBorder.Child(rootElement);
+
+                // Add containerPanel to rootElement
+                XamlHelpers::AppendXamlElementToPanel(gridContainer, rootElement, containerHeightType);
+            }
+            else
+            {
+                // instead, directly add containerPanel to containerBorder
+                carouselBorder.Child(gridContainer);
+            }
+
+            // If we changed the context's rtl setting, set it back after rendering the children
+            if (updatedRtl)
+            {
+                context.Rtl(previousContextRtl);
+            }
+
+            XamlHelpers::SetStyleFromResourceDictionary(context, L"Adaptive.Carousel", carouselUI);
+
+            auto adaptiveBaseElement = element.try_as<winrt::IAdaptiveCardElement>();
+            auto heightType = adaptiveBaseElement.Height();
+            XamlHelpers::AppendXamlElementToPanel(stackPanel, gridContainer, heightType);
+
+            auto selectAction = styledCollection.SelectAction();
+            return ::AdaptiveCards::Rendering::Xaml_Rendering::ActionHelpers::HandleSelectAction(
+                element, selectAction, context, renderArgs, carouselBorder, XamlHelpers::SupportsInteractivity(hostConfig), true);
+        }
+        catch (winrt::hresult_error const& ex)
+        {
+            // In case we need to perform fallback, propagate it up to the parent
+            if (ex.code() == E_PERFORM_FALLBACK)
+            {
+                throw ex;
+            }
+
+            XamlHelpers::ErrForRenderFailedForElement(context, element.ElementTypeString(), ex.message());
+        }
+        return nullptr;
+    }
+
+    void SetFlipViewMaxHeight(FlipView const& flipView)
+    {
+        auto selectIndex = flipView.SelectedIndex();
+        auto carouselPageUI = flipView.Items().GetAt(selectIndex).try_as<FrameworkElement>();
+
+        if (flipView.IsLoaded())
+        {
+            float width = static_cast<float>(flipView.ActualWidth());
+            const winrt::Size noVerticalLimit{width, std::numeric_limits<float>::infinity()};
+            carouselPageUI.Measure(noVerticalLimit);
+            auto maxHeight = carouselPageUI.DesiredSize().Height;
+            auto previousMaxHeight = flipView.MaxHeight();
+            if ((std::numeric_limits<float>::infinity() == previousMaxHeight) || previousMaxHeight < maxHeight)
+            {
+                flipView.MaxHeight(maxHeight);
             }
         }
-
-        // If no fixed height was specified, compute the max height from page content
-        // after the FlipView has been loaded (not during layout) to avoid layout cycles.
-        if (fixedHeightInPixel == 0)
-        {
-            auto isUpdatingHeight = std::make_shared<bool>(false);
-
-            // Use Loaded event to set initial height — fires once after the element
-            // is in the visual tree and has been measured, but not during a layout pass.
-            carouselUI.Loaded([carouselUI, isUpdatingHeight](auto&&, auto&&) {
-                if (*isUpdatingHeight)
-                    return;
-                *isUpdatingHeight = true;
-                SetFlipViewMaxHeight(carouselUI);
-                *isUpdatingHeight = false;
-            });
-
-            // Use SizeChanged to adjust if the FlipView width changes (e.g. window resize).
-            // SizeChanged fires after layout completes, so it won't cause a layout cycle
-            // as long as we guard against re-entrancy.
-            carouselUI.SizeChanged([carouselUI, isUpdatingHeight](auto&&, winrt::SizeChangedEventArgs const&) {
-                if (*isUpdatingHeight)
-                    return;
-                *isUpdatingHeight = true;
-                SetFlipViewMaxHeight(carouselUI);
-                *isUpdatingHeight = false;
-            });
-
-            // Update height when the selected page changes, since pages may differ in size.
-            carouselUI.SelectionChanged([carouselUI, isUpdatingHeight](auto&&, auto&&) {
-                if (*isUpdatingHeight)
-                    return;
-                *isUpdatingHeight = true;
-                SetFlipViewMaxHeight(carouselUI);
-                *isUpdatingHeight = false;
-            });
-        }
-
-        if (carousel.InitialPage())
-        {
-            carouselUI.SelectedIndex(carousel.InitialPage().GetUInt32());
-        }
-
-        auto verticalContentAlignmentReference = carousel.VerticalContentAlignment();
-        winrt::VerticalContentAlignment verticalContentAlignment =
-            GetValueFromRef(verticalContentAlignmentReference, winrt::VerticalContentAlignment::Top);
-        XamlHelpers::SetVerticalContentAlignmentToChildren(gridContainer, verticalContentAlignment);
-
-        // Check if backgroundImage defined
-        auto backgroundImage = carousel.BackgroundImage();
-        if (IsBackgroundImageValid(backgroundImage))
-        {
-            winrt::Grid rootElement{};
-            XamlHelpers::ApplyBackgroundToRoot(rootElement, backgroundImage, context);
-
-            // Add rootElement to containerBorder
-            carouselBorder.Child(rootElement);
-
-            // Add containerPanel to rootElement
-            XamlHelpers::AppendXamlElementToPanel(gridContainer, rootElement, containerHeightType);
-        }
-        else
-        {
-            // instead, directly add containerPanel to containerBorder
-            carouselBorder.Child(gridContainer);
-        }
-
-        // If we changed the context's rtl setting, set it back after rendering the children
-        if (updatedRtl)
-        {
-            context.Rtl(previousContextRtl);
-        }
-
-        XamlHelpers::SetStyleFromResourceDictionary(context, L"Adaptive.Carousel", carouselUI);
-
-        auto adaptiveBaseElement = element.try_as<winrt::IAdaptiveCardElement>();
-        auto heightType = adaptiveBaseElement.Height();
-        XamlHelpers::AppendXamlElementToPanel(stackPanel, gridContainer, heightType);
-
-        auto selectAction = styledCollection.SelectAction();
-        return ::AdaptiveCards::Rendering::Xaml_Rendering::ActionHelpers::HandleSelectAction(
-            element, selectAction, context, renderArgs, carouselBorder, XamlHelpers::SupportsInteractivity(hostConfig), true);
-    }
-    catch (winrt::hresult_error const& ex)
-    {
-        // In case we need to perform fallback, propagate it up to the parent
-        if (ex.code() == E_PERFORM_FALLBACK)
-        {
-            throw ex;
-        }
-
-        XamlHelpers::ErrForRenderFailedForElement(context, element.ElementTypeString(), ex.message());
-    }
-    return nullptr;
-}
-
-void SetFlipViewMaxHeight(FlipView const& flipView)
-{
-    auto selectIndex = flipView.SelectedIndex();
-
-    // FIX: Validate selectedIndex is within bounds
-    if (selectIndex < 0 || static_cast<uint32_t>(selectIndex) >= flipView.Items().Size())
-    {
-        return;
-    }
-
-    auto carouselPageUI = flipView.Items().GetAt(selectIndex).try_as<FrameworkElement>();
-
-    // FIX: Check if carouselPageUI is null before using it
-    if (carouselPageUI != nullptr && flipView.IsLoaded())
-    {
-        float width = static_cast<float>(flipView.ActualWidth());
-        if (width <= 0)
-        {
-            return;
-        }
-        const winrt::Size noVerticalLimit{width, std::numeric_limits<float>::infinity()};
-        carouselPageUI.Measure(noVerticalLimit);
-        auto maxHeight = carouselPageUI.DesiredSize().Height;
-        auto previousMaxHeight = flipView.MaxHeight();
-        if ((std::numeric_limits<float>::infinity() == previousMaxHeight) || previousMaxHeight < maxHeight)
-        {
-            flipView.MaxHeight(maxHeight);
-        }
     }
 }
-} // namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation

--- a/source/uwp/SharedRenderer/lib/AdaptiveCarouselRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveCarouselRenderer.cpp
@@ -11,200 +11,240 @@
 
 namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 {
-    winrt::UIElement AdaptiveCarouselRenderer::Render(
-        winrt::AdaptiveCards::ObjectModel::Xaml_Rendering::IAdaptiveCardElement const& element,
-        winrt::AdaptiveCards::Rendering::Xaml_Rendering::AdaptiveRenderContext const& context,
-        winrt::AdaptiveCards::Rendering::Xaml_Rendering::AdaptiveRenderArgs const& renderArgs)
+winrt::UIElement AdaptiveCarouselRenderer::Render(
+    winrt::AdaptiveCards::ObjectModel::Xaml_Rendering::IAdaptiveCardElement const& element,
+    winrt::AdaptiveCards::Rendering::Xaml_Rendering::AdaptiveRenderContext const& context,
+    winrt::AdaptiveCards::Rendering::Xaml_Rendering::AdaptiveRenderArgs const& renderArgs)
+{
+    auto carousel = element.as<winrt::IAdaptiveCarousel>();
+    auto styledCollection = element.as<winrt::IAdaptiveContainerBase>();
+
+    StackPanel stackPanel{};
+    FlipView carouselUI{};
+    bool loopEnabled{false};
+
+    if (carousel.AutoLoop())
     {
-        auto carousel = element.as<winrt::IAdaptiveCarousel>();
-        auto styledCollection = element.as<winrt::IAdaptiveContainerBase>();
-
-        StackPanel stackPanel{};
-        FlipView carouselUI{};
-        bool loopEnabled{false};
-
-        if (carousel.AutoLoop())
-        {
-            loopEnabled = carousel.AutoLoop().GetBoolean();
-        }
-
-        PipsPager pipsPager{};
-        pipsPager.HorizontalAlignment(winrt::HorizontalAlignment::Center);
-        pipsPager.NumberOfPages(carousel.Pages().Size());
-        auto hostConfig = context.HostConfig();
-
-        // FlipView has its own background color property, so we need to clear the background color
-        carouselUI.Background(winrt::SolidColorBrush{GetColorFromString("#00FFFFFF")});
-
-        //auto adaptiveCarouselContainer = element.as<winrt::IAdaptiveContainerBase>();
-        // Get any RTL setting set on either the current context or on this container. Any value set on the
-        // container should be set on the context to apply to all children
-        auto previousContextRtl = context.Rtl();
-        auto currentRtl = previousContextRtl;
-        auto containerRtl = carousel.Rtl();
-
-        bool updatedRtl = false;
-        if (containerRtl)
-        {
-            currentRtl = containerRtl;
-            context.Rtl(currentRtl);
-            updatedRtl = true;
-        }
-
-        if (currentRtl)
-        {
-            carouselUI.FlowDirection(currentRtl.GetBoolean() ? winrt::FlowDirection::RightToLeft : winrt::FlowDirection::LeftToRight);
-            pipsPager.FlowDirection(currentRtl.GetBoolean() ? winrt::FlowDirection::RightToLeft : winrt::FlowDirection::LeftToRight);
-        }
-
-        carouselUI.SelectionChanged([carouselUI, pipsPager, loopEnabled](auto &&, auto &&) {
-            auto val = carouselUI.SelectedIndex();
-            if (loopEnabled &&
-                static_cast<unsigned int>(val) == carouselUI.Items().Size())
-            {
-                pipsPager.SelectedPageIndex(0);
-                carouselUI.SelectedIndex(0);
-            }
-            else
-            {
-                pipsPager.SelectedPageIndex(carouselUI.SelectedIndex());
-            }
-        });
-
-        pipsPager.SelectedIndexChanged([carouselUI](PipsPager pager, IPipsPagerSelectedIndexChangedEventArgs) {
-            carouselUI.SelectedIndex(pager.SelectedPageIndex());
-        });
-
-        stackPanel.Children().Append(carouselUI);
-        stackPanel.Children().Append(pipsPager);
-
-        winrt::AdaptiveFeatureRegistration featureRegistration = context.FeatureRegistration();
-        boolean ancestorHasFallback = renderArgs.AncestorHasFallback();
-
-        try
-        {
-            winrt::Border carouselBorder{};
-
-            auto gridContainer = winrt::make<winrt::implementation::WholeItemsPanel>();
-
-            // Assign vertical alignment to strech so column will stretch and respect vertical content alignment
-            auto containerHeightType = element.Height();
-            if (containerHeightType == winrt::HeightType::Auto)
-            {
-                gridContainer.VerticalAlignment(winrt::VerticalAlignment::Stretch);
-            }
-
-            uint32_t carouselMinHeight = styledCollection.MinHeight();
-
-            if (carouselMinHeight > 0)
-            {
-                gridContainer.MinHeight(carouselMinHeight);
-            }
-
-            auto fixedHeightInPixel = carousel.HeightInPixels();
-            if (fixedHeightInPixel)
-            {
-                carouselUI.MaxHeight(static_cast<double>(fixedHeightInPixel));
-            }
-
-            auto containerStyle =
-                XamlHelpers::HandleStylingAndPadding(styledCollection, carouselBorder, context, renderArgs);
-
-            auto newRenderArgs =
-                winrt::make<winrt::implementation::AdaptiveRenderArgs>(containerStyle, renderArgs.ParentElement(), renderArgs);
-
-            for (auto page : carousel.Pages())
-            {
-                auto [carouselPageUI, carouselPage] =
-                    ::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder::RenderAsUIElement(
-                    page, context, newRenderArgs, featureRegistration, ancestorHasFallback);
-
-                if (carouselPageUI != nullptr)
-                {
-                    carouselUI.Items().Append(carouselPageUI);
-
-                    if (fixedHeightInPixel == 0)
-                    {
-                        carouselPageUI.try_as<FrameworkElement>().LayoutUpdated(
-                            [carouselUI](auto&&, auto&&) { SetFlipViewMaxHeight(carouselUI); });
-                    }
-               }
-            }
-
-            if (carousel.InitialPage())
-            {
-                carouselUI.SelectedIndex(carousel.InitialPage().GetUInt32());
-            }
-
-            auto verticalContentAlignmentReference = carousel.VerticalContentAlignment();
-            winrt::VerticalContentAlignment verticalContentAlignment =
-                GetValueFromRef(verticalContentAlignmentReference, winrt::VerticalContentAlignment::Top);
-            XamlHelpers::SetVerticalContentAlignmentToChildren(gridContainer, verticalContentAlignment);
-
-            // Check if backgroundImage defined
-            auto backgroundImage = carousel.BackgroundImage();
-            if (IsBackgroundImageValid(backgroundImage))
-            {
-                winrt::Grid rootElement{};
-                XamlHelpers::ApplyBackgroundToRoot(rootElement, backgroundImage, context);
-
-                // Add rootElement to containerBorder
-                carouselBorder.Child(rootElement);
-
-                // Add containerPanel to rootElement
-                XamlHelpers::AppendXamlElementToPanel(gridContainer, rootElement, containerHeightType);
-            }
-            else
-            {
-                // instead, directly add containerPanel to containerBorder
-                carouselBorder.Child(gridContainer);
-            }
-
-            // If we changed the context's rtl setting, set it back after rendering the children
-            if (updatedRtl)
-            {
-                context.Rtl(previousContextRtl);
-            }
-
-            XamlHelpers::SetStyleFromResourceDictionary(context, L"Adaptive.Carousel", carouselUI);
-
-            auto adaptiveBaseElement = element.try_as<winrt::IAdaptiveCardElement>();
-            auto heightType = adaptiveBaseElement.Height();
-            XamlHelpers::AppendXamlElementToPanel(stackPanel, gridContainer, heightType);
-
-            auto selectAction = styledCollection.SelectAction();
-            return ::AdaptiveCards::Rendering::Xaml_Rendering::ActionHelpers::HandleSelectAction(
-                element, selectAction, context, renderArgs, carouselBorder, XamlHelpers::SupportsInteractivity(hostConfig), true);
-        }
-        catch (winrt::hresult_error const& ex)
-        {
-            // In case we need to perform fallback, propagate it up to the parent
-            if (ex.code() == E_PERFORM_FALLBACK)
-            {
-                throw ex;
-            }
-
-            XamlHelpers::ErrForRenderFailedForElement(context, element.ElementTypeString(), ex.message());
-        }
-        return nullptr;
+        loopEnabled = carousel.AutoLoop().GetBoolean();
     }
 
-    void SetFlipViewMaxHeight(FlipView const& flipView)
-    {
-        auto selectIndex = flipView.SelectedIndex();
-        auto carouselPageUI = flipView.Items().GetAt(selectIndex).try_as<FrameworkElement>();
+    PipsPager pipsPager{};
+    pipsPager.HorizontalAlignment(winrt::HorizontalAlignment::Center);
+    pipsPager.NumberOfPages(carousel.Pages().Size());
+    auto hostConfig = context.HostConfig();
 
-        if (flipView.IsLoaded())
+    // FlipView has its own background color property, so we need to clear the background color
+    carouselUI.Background(winrt::SolidColorBrush{GetColorFromString("#00FFFFFF")});
+
+    // auto adaptiveCarouselContainer = element.as<winrt::IAdaptiveContainerBase>();
+    //  Get any RTL setting set on either the current context or on this container. Any value set on the
+    //  container should be set on the context to apply to all children
+    auto previousContextRtl = context.Rtl();
+    auto currentRtl = previousContextRtl;
+    auto containerRtl = carousel.Rtl();
+
+    bool updatedRtl = false;
+    if (containerRtl)
+    {
+        currentRtl = containerRtl;
+        context.Rtl(currentRtl);
+        updatedRtl = true;
+    }
+
+    if (currentRtl)
+    {
+        carouselUI.FlowDirection(currentRtl.GetBoolean() ? winrt::FlowDirection::RightToLeft : winrt::FlowDirection::LeftToRight);
+        pipsPager.FlowDirection(currentRtl.GetBoolean() ? winrt::FlowDirection::RightToLeft : winrt::FlowDirection::LeftToRight);
+    }
+
+    carouselUI.SelectionChanged([carouselUI, pipsPager, loopEnabled](auto&&, auto&&) {
+        auto val = carouselUI.SelectedIndex();
+        if (loopEnabled && static_cast<unsigned int>(val) == carouselUI.Items().Size())
         {
-            float width = static_cast<float>(flipView.ActualWidth());
-            const winrt::Size noVerticalLimit{width, std::numeric_limits<float>::infinity()};
-            carouselPageUI.Measure(noVerticalLimit);
-            auto maxHeight = carouselPageUI.DesiredSize().Height;
-            auto previousMaxHeight = flipView.MaxHeight();
-            if ((std::numeric_limits<float>::infinity() == previousMaxHeight) || previousMaxHeight < maxHeight)
+            pipsPager.SelectedPageIndex(0);
+            carouselUI.SelectedIndex(0);
+        }
+        else
+        {
+            pipsPager.SelectedPageIndex(carouselUI.SelectedIndex());
+        }
+    });
+
+    pipsPager.SelectedIndexChanged([carouselUI](PipsPager pager, IPipsPagerSelectedIndexChangedEventArgs) {
+        carouselUI.SelectedIndex(pager.SelectedPageIndex());
+    });
+
+    stackPanel.Children().Append(carouselUI);
+    stackPanel.Children().Append(pipsPager);
+
+    winrt::AdaptiveFeatureRegistration featureRegistration = context.FeatureRegistration();
+    boolean ancestorHasFallback = renderArgs.AncestorHasFallback();
+
+    try
+    {
+        winrt::Border carouselBorder{};
+
+        auto gridContainer = winrt::make<winrt::implementation::WholeItemsPanel>();
+
+        // Assign vertical alignment to strech so column will stretch and respect vertical content alignment
+        auto containerHeightType = element.Height();
+        if (containerHeightType == winrt::HeightType::Auto)
+        {
+            gridContainer.VerticalAlignment(winrt::VerticalAlignment::Stretch);
+        }
+
+        uint32_t carouselMinHeight = styledCollection.MinHeight();
+
+        if (carouselMinHeight > 0)
+        {
+            gridContainer.MinHeight(carouselMinHeight);
+        }
+
+        auto fixedHeightInPixel = carousel.HeightInPixels();
+        if (fixedHeightInPixel)
+        {
+            carouselUI.MaxHeight(static_cast<double>(fixedHeightInPixel));
+        }
+
+        auto containerStyle = XamlHelpers::HandleStylingAndPadding(styledCollection, carouselBorder, context, renderArgs);
+
+        auto newRenderArgs =
+            winrt::make<winrt::implementation::AdaptiveRenderArgs>(containerStyle, renderArgs.ParentElement(), renderArgs);
+
+        for (auto page : carousel.Pages())
+        {
+            auto [carouselPageUI, carouselPage] = ::AdaptiveCards::Rendering::Xaml_Rendering::XamlBuilder::RenderAsUIElement(
+                page, context, newRenderArgs, featureRegistration, ancestorHasFallback);
+
+            if (carouselPageUI != nullptr)
             {
-                flipView.MaxHeight(maxHeight);
+                carouselUI.Items().Append(carouselPageUI);
             }
+        }
+
+        // If no fixed height was specified, compute the max height from page content
+        // after the FlipView has been loaded (not during layout) to avoid layout cycles.
+        if (fixedHeightInPixel == 0)
+        {
+            auto isUpdatingHeight = std::make_shared<bool>(false);
+
+            // Use Loaded event to set initial height — fires once after the element
+            // is in the visual tree and has been measured, but not during a layout pass.
+            carouselUI.Loaded([carouselUI, isUpdatingHeight](auto&&, auto&&) {
+                if (*isUpdatingHeight)
+                    return;
+                *isUpdatingHeight = true;
+                SetFlipViewMaxHeight(carouselUI);
+                *isUpdatingHeight = false;
+            });
+
+            // Use SizeChanged to adjust if the FlipView width changes (e.g. window resize).
+            // SizeChanged fires after layout completes, so it won't cause a layout cycle
+            // as long as we guard against re-entrancy.
+            carouselUI.SizeChanged([carouselUI, isUpdatingHeight](auto&&, winrt::SizeChangedEventArgs const&) {
+                if (*isUpdatingHeight)
+                    return;
+                *isUpdatingHeight = true;
+                SetFlipViewMaxHeight(carouselUI);
+                *isUpdatingHeight = false;
+            });
+
+            // Update height when the selected page changes, since pages may differ in size.
+            carouselUI.SelectionChanged([carouselUI, isUpdatingHeight](auto&&, auto&&) {
+                if (*isUpdatingHeight)
+                    return;
+                *isUpdatingHeight = true;
+                SetFlipViewMaxHeight(carouselUI);
+                *isUpdatingHeight = false;
+            });
+        }
+
+        if (carousel.InitialPage())
+        {
+            carouselUI.SelectedIndex(carousel.InitialPage().GetUInt32());
+        }
+
+        auto verticalContentAlignmentReference = carousel.VerticalContentAlignment();
+        winrt::VerticalContentAlignment verticalContentAlignment =
+            GetValueFromRef(verticalContentAlignmentReference, winrt::VerticalContentAlignment::Top);
+        XamlHelpers::SetVerticalContentAlignmentToChildren(gridContainer, verticalContentAlignment);
+
+        // Check if backgroundImage defined
+        auto backgroundImage = carousel.BackgroundImage();
+        if (IsBackgroundImageValid(backgroundImage))
+        {
+            winrt::Grid rootElement{};
+            XamlHelpers::ApplyBackgroundToRoot(rootElement, backgroundImage, context);
+
+            // Add rootElement to containerBorder
+            carouselBorder.Child(rootElement);
+
+            // Add containerPanel to rootElement
+            XamlHelpers::AppendXamlElementToPanel(gridContainer, rootElement, containerHeightType);
+        }
+        else
+        {
+            // instead, directly add containerPanel to containerBorder
+            carouselBorder.Child(gridContainer);
+        }
+
+        // If we changed the context's rtl setting, set it back after rendering the children
+        if (updatedRtl)
+        {
+            context.Rtl(previousContextRtl);
+        }
+
+        XamlHelpers::SetStyleFromResourceDictionary(context, L"Adaptive.Carousel", carouselUI);
+
+        auto adaptiveBaseElement = element.try_as<winrt::IAdaptiveCardElement>();
+        auto heightType = adaptiveBaseElement.Height();
+        XamlHelpers::AppendXamlElementToPanel(stackPanel, gridContainer, heightType);
+
+        auto selectAction = styledCollection.SelectAction();
+        return ::AdaptiveCards::Rendering::Xaml_Rendering::ActionHelpers::HandleSelectAction(
+            element, selectAction, context, renderArgs, carouselBorder, XamlHelpers::SupportsInteractivity(hostConfig), true);
+    }
+    catch (winrt::hresult_error const& ex)
+    {
+        // In case we need to perform fallback, propagate it up to the parent
+        if (ex.code() == E_PERFORM_FALLBACK)
+        {
+            throw ex;
+        }
+
+        XamlHelpers::ErrForRenderFailedForElement(context, element.ElementTypeString(), ex.message());
+    }
+    return nullptr;
+}
+
+void SetFlipViewMaxHeight(FlipView const& flipView)
+{
+    auto selectIndex = flipView.SelectedIndex();
+
+    // FIX: Validate selectedIndex is within bounds
+    if (selectIndex < 0 || static_cast<uint32_t>(selectIndex) >= flipView.Items().Size())
+    {
+        return;
+    }
+
+    auto carouselPageUI = flipView.Items().GetAt(selectIndex).try_as<FrameworkElement>();
+
+    // FIX: Check if carouselPageUI is null before using it
+    if (carouselPageUI != nullptr && flipView.IsLoaded())
+    {
+        float width = static_cast<float>(flipView.ActualWidth());
+        if (width <= 0)
+        {
+            return;
+        }
+        const winrt::Size noVerticalLimit{width, std::numeric_limits<float>::infinity()};
+        carouselPageUI.Measure(noVerticalLimit);
+        auto maxHeight = carouselPageUI.DesiredSize().Height;
+        auto previousMaxHeight = flipView.MaxHeight();
+        if ((std::numeric_limits<float>::infinity() == previousMaxHeight) || previousMaxHeight < maxHeight)
+        {
+            flipView.MaxHeight(maxHeight);
         }
     }
 }
+} // namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation

--- a/source/uwp/SharedRenderer/lib/AdaptiveCarouselRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveCarouselRenderer.cpp
@@ -122,13 +122,44 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
                 if (carouselPageUI != nullptr)
                 {
                     carouselUI.Items().Append(carouselPageUI);
+                }
 
-                    if (fixedHeightInPixel == 0)
-                    {
-                        carouselPageUI.try_as<FrameworkElement>().LayoutUpdated(
-                            [carouselUI](auto&&, auto&&) { SetFlipViewMaxHeight(carouselUI); });
-                    }
-               }
+                // If no fixed height was specified, compute the max height from page content
+                // after the FlipView has been loaded (not during layout) to avoid layout cycles.
+                if (fixedHeightInPixel == 0)
+                {
+                    auto isUpdatingHeight = std::make_shared<bool>(false);
+
+                    // Use Loaded event to set initial height — fires once after the element
+                    // is in the visual tree and has been measured, but not during a layout pass.
+                    carouselUI.Loaded([carouselUI, isUpdatingHeight](auto&&, auto&&) {
+                        if (*isUpdatingHeight)
+                            return;
+                        *isUpdatingHeight = true;
+                        SetFlipViewMaxHeight(carouselUI);
+                        *isUpdatingHeight = false;
+                    });
+
+                    // Use SizeChanged to adjust if the FlipView width changes (e.g. window resize).
+                    // SizeChanged fires after layout completes, so it won't cause a layout cycle
+                    // as long as we guard against re-entrancy.
+                    carouselUI.SizeChanged([carouselUI, isUpdatingHeight](auto&&, winrt::SizeChangedEventArgs const&) {
+                        if (*isUpdatingHeight)
+                            return;
+                        *isUpdatingHeight = true;
+                        SetFlipViewMaxHeight(carouselUI);
+                        *isUpdatingHeight = false;
+                    });
+
+                    // Update height when the selected page changes, since pages may differ in size.
+                    carouselUI.SelectionChanged([carouselUI, isUpdatingHeight](auto&&, auto&&) {
+                        if (*isUpdatingHeight)
+                            return;
+                        *isUpdatingHeight = true;
+                        SetFlipViewMaxHeight(carouselUI);
+                        *isUpdatingHeight = false;
+                    });
+                }
             }
 
             if (carousel.InitialPage())
@@ -192,11 +223,22 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
     void SetFlipViewMaxHeight(FlipView const& flipView)
     {
         auto selectIndex = flipView.SelectedIndex();
+
+        // FIX: Validate selectedIndex is within bounds
+        if (selectIndex < 0 || static_cast<uint32_t>(selectIndex) >= flipView.Items().Size())
+        {
+            return;
+        }
+
         auto carouselPageUI = flipView.Items().GetAt(selectIndex).try_as<FrameworkElement>();
 
-        if (flipView.IsLoaded())
+        if (carouselPageUI != nullptr && flipView.IsLoaded())
         {
             float width = static_cast<float>(flipView.ActualWidth());
+            if (width <= 0)
+            {
+                return;
+            }
             const winrt::Size noVerticalLimit{width, std::numeric_limits<float>::infinity()};
             carouselPageUI.Measure(noVerticalLimit);
             auto maxHeight = carouselPageUI.DesiredSize().Height;

--- a/source/uwp/SharedRenderer/lib/AdaptiveCarouselRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveCarouselRenderer.cpp
@@ -132,7 +132,7 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 
                     // Use Loaded event to set initial height — fires once after the element
                     // is in the visual tree and has been measured, but not during a layout pass.
-                    carouselUI.Loaded([carouselUI, isUpdatingHeight](auto&&, auto&&) {
+                    auto loadedToken = carouselUI.Loaded([carouselUI, isUpdatingHeight](auto&&, auto&&) {
                         if (*isUpdatingHeight)
                             return;
                         *isUpdatingHeight = true;
@@ -143,7 +143,8 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
                     // Use SizeChanged to adjust if the FlipView width changes (e.g. window resize).
                     // SizeChanged fires after layout completes, so it won't cause a layout cycle
                     // as long as we guard against re-entrancy.
-                    carouselUI.SizeChanged([carouselUI, isUpdatingHeight](auto&&, winrt::SizeChangedEventArgs const&) {
+                    auto sizeChangedToken =
+                        carouselUI.SizeChanged([carouselUI, isUpdatingHeight](auto&&, winrt::SizeChangedEventArgs const&) {
                         if (*isUpdatingHeight)
                             return;
                         *isUpdatingHeight = true;
@@ -152,13 +153,20 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
                     });
 
                     // Update height when the selected page changes, since pages may differ in size.
-                    carouselUI.SelectionChanged([carouselUI, isUpdatingHeight](auto&&, auto&&) {
+                    auto selectionChangedToken = carouselUI.SelectionChanged([carouselUI, isUpdatingHeight](auto&&, auto&&) {
                         if (*isUpdatingHeight)
                             return;
                         *isUpdatingHeight = true;
                         SetFlipViewMaxHeight(carouselUI);
                         *isUpdatingHeight = false;
                     });
+
+                    carouselUI.Unloaded([ carouselUI, loadedToken, sizeChangedToken, selectionChangedToken ](auto&&, auto&&) {
+                        carouselUI.Loaded(loadedToken);
+                        carouselUI.SizeChanged(sizeChangedToken);
+                        carouselUI.SelectionChanged(selectionChangedToken);
+                    });
+
                 }
             }
 


### PR DESCRIPTION
# Description
**Root Cause**
The root cause of the "Layout cycle detected" error:

StackPanel (Vertical) → gives FlipView infinite height
  └─ FlipView (MaxH=inf) → sizes to content, asks pages for height
      └─ Page LayoutUpdated → calls SetFlipViewMaxHeight()
          └─ SetFlipViewMaxHeight() calls page.Measure() + sets flipView.MaxHeight()
              └─ This invalidates FlipView layout → triggers LayoutUpdated again → ∞ cycle



The problem is in AdaptiveCarouselRenderer.cpp. When HeightInPixels is 0, the LayoutUpdated handler calls Measure() on the page and sets MaxHeight on the FlipView during layout, which re-triggers layout — creating an infinite cycle.
Two issues compound this:
1.	LayoutUpdated fires during every layout pass — it's not a one-shot event
2.	The condition previousMaxHeight < maxHeight doesn't prevent oscillation because Measure() with infinity can return varying results


The carousel renderer was using LayoutUpdated handlers inside the per-page loop to dynamically compute the FlipView MaxHeight. Because LayoutUpdated fires during the layout pass, calling Measure() and setting MaxHeight inside it would re-invalidate layout, triggering an infinite cycle. This was the direct cause of the "Layout cycle detected" error.
Additionally, event handlers captured carouselUI by value (strong WinRT reference) and were never unregistered, leading to potential memory leaks when carousels were dynamically created and destroyed.
Changes
Replaced LayoutUpdated with safe, post-layout events:

- Loaded — fires once after the element is in the visual tree and has been measured. Used to compute the initial MaxHeight safely outside of a layout pass.

- SizeChanged — fires after layout completes (not during). Handles window resize or container width changes without causing layout invalidation.

- SelectionChanged for height update — different carousel pages may have different content heights, so MaxHeight is recalculated when the selected page changes.

- Added re-entrancy guard (isUpdatingHeight):

- A std::shared_ptr<bool> flag is captured by all three lambdas. This prevents SetFlipViewMaxHeight → MaxHeight change → SizeChanged → SetFlipViewMaxHeight feedback loops.

- Added width <= 0 guard in SetFlipViewMaxHeight:

If ActualWidth is 0 (element not yet laid out), Measure with zero width produces meaningless results. The early return avoids unnecessary work and incorrect height values.

- Added Unloaded handler for event cleanup:

An Unloaded handler revokes the Loaded, SizeChanged, and SelectionChanged event tokens when the FlipView is removed from the visual tree. This breaks the strong reference cycles created by the capturing lambdas and prevents memory leaks in scenarios with many carousel instances.


**JSON which is creating the issue -**
{
  "type": "AdaptiveCard",
  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
  "version": "1.6",
  "body": [
    {
      "type": "Carousel",
      "rtl": false,
      "pages": [
        {
          "type": "CarouselPage",
          "rtl": false,
          "items": [
            {
              "type": "Container",
              "items": [
                {
                  "type": "ColumnSet",
                  "spacing": "None",
                  "columns": [
                    {
                      "type": "Column",
                      "width": "100px",
                      "items": [
                        {
                          "type": "Image",
                          "url": "https://picsum.photos/seed/screen-01/200/200",
                          "altText": "Open screen recorder",
                          "horizontalAlignment": "Center",
                          "width": "76px",
                          "height": "64px"
                        }
                      ],
                      "horizontalAlignment": "Center",
                      "verticalContentAlignment": "Center",
                      "spacing": "None"
                    },
                    {
                      "type": "Column",
                      "width": "auto",
                      "items": [
                        {
                          "type": "TextBlock",
                          "text": "Record from screen",
                          "weight": "Bolder",
                          "spacing": "Small",
                          "wrap": true
                        },
                        {
                          "type": "TextBlock",
                          "text": "Capture your screen with audio in one tap.",
                          "wrap": true,
                          "spacing": "None",
                          "isSubtle": false,
                          "size": "Small",
                          "style": "default",
                          "fontType": "Default"
                        }
                      ],
                      "verticalContentAlignment": "Center",
                      "horizontalAlignment": "Left"
                    }
                  ],
                  "minHeight": "110px",
                  "horizontalAlignment": "Left",
                  "height": "stretch"
                }
              ],
              "backgroundImage": {
                "url": "https://images.unsplash.com/photo-1522199710521-72d69614c702?auto=format&fit=crop&w=1200&q=60",
                "horizontalAlignment": "Center",
                "verticalAlignment": "Center"
              },
              "minHeight": "110px",
              "selectAction": {
                "type": "Action.OpenUrl",
                "tooltip": "Open screen recorder",
                "url": "https://example.com/record/screen",
                "role": "Link"
              },
              "spacing": "None",
              "height": "stretch",
              "horizontalAlignment": "Center",
              "verticalContentAlignment": "Center"
            },
            {
              "type": "Container",
              "items": [
                {
                  "type": "ColumnSet",
                  "spacing": "None",
                  "columns": [
                    {
                      "type": "Column",
                      "width": "100px",
                      "items": [
                        {
                          "type": "Image",
                          "url": "https://picsum.photos/seed/camera-02/200/200",
                          "altText": "Open camera recorder",
                          "horizontalAlignment": "Center",
                          "width": "76px",
                          "height": "64px"
                        }
                      ],
                      "horizontalAlignment": "Center",
                      "verticalContentAlignment": "Center",
                      "spacing": "None"
                    },
                    {
                      "type": "Column",
                      "width": "auto",
                      "items": [
                        {
                          "type": "TextBlock",
                          "text": "Record from camera",
                          "weight": "Bolder",
                          "spacing": "Small",
                          "wrap": true
                        },
                        {
                          "type": "TextBlock",
                          "text": "Use your webcam to record a quick clip.",
                          "wrap": true,
                          "spacing": "None",
                          "isSubtle": false,
                          "size": "Small",
                          "style": "default",
                          "fontType": "Default"
                        }
                      ],
                      "verticalContentAlignment": "Center",
                      "horizontalAlignment": "Left"
                    }
                  ],
                  "minHeight": "110px",
                  "horizontalAlignment": "Left",
                  "height": "stretch"
                }
              ],
              "backgroundImage": {
                "url": "https://images.unsplash.com/photo-1526498460520-4c246339dccb?auto=format&fit=crop&w=1200&q=60",
                "horizontalAlignment": "Center",
                "verticalAlignment": "Center"
              },
              "minHeight": "110px",
              "selectAction": {
                "type": "Action.OpenUrl",
                "tooltip": "Open camera recorder",
                "role": "Link",
                "url": "https://example.com/record/camera"
              },
              "spacing": "Small",
              "horizontalAlignment": "Center",
              "verticalContentAlignment": "Center"
            }
          ]
        },
        {
          "type": "CarouselPage",
          "rtl": false,
          "items": [
            {
              "type": "Container",
              "items": [
                {
                  "type": "ColumnSet",
                  "spacing": "Medium",
                  "columns": [
                    {
                      "type": "Column",
                      "width": "100px",
                      "items": [
                        {
                          "type": "Image",
                          "url": "https://picsum.photos/seed/editor-03/200/200",
                          "altText": "Open editor mode",
                          "horizontalAlignment": "Center",
                          "width": "76px",
                          "height": "64px"
                        }
                      ],
                      "horizontalAlignment": "Left",
                      "verticalContentAlignment": "Center",
                      "height": "stretch"
                    },
                    {
                      "type": "Column",
                      "width": "auto",
                      "items": [
                        {
                          "type": "TextBlock",
                          "text": "Record from editor",
                          "wrap": true,
                          "weight": "Bolder",
                          "spacing": "Small"
                        },
                        {
                          "type": "TextBlock",
                          "text": "Create a recording while editing your document.",
                          "wrap": true,
                          "spacing": "None",
                          "isSubtle": false,
                          "style": "default",
                          "fontType": "Default",
                          "size": "Small",
                          "weight": "Default"
                        }
                      ],
                      "verticalContentAlignment": "Center",
                      "horizontalAlignment": "Left"
                    }
                  ],
                  "minHeight": "110px",
                  "horizontalAlignment": "Left",
                  "verticalContentAlignment": "Top",
                  "height": "stretch"
                }
              ],
              "backgroundImage": {
                "url": "https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1200&q=60"
              },
              "minHeight": "110px",
              "selectAction": {
                "type": "Action.OpenUrl",
                "tooltip": "Open editor mode",
                "url": "https://example.com/record/editor",
                "role": "Link"
              }
            },
            {
              "type": "Container",
              "height": "stretch",
              "minHeight": "110px"
            }
          ],
          "verticalContentAlignment": "Top"
        }
      ]
    }
  ]
}



# How Verified
Verified carousel renders without "Layout cycle detected" errors
