### PR TITLE
Update ASP.NET Core dependencies and add Kestrel in ImageRendererServer

### DIFF
--- a/source/dotnet/Samples/ImageRendererServer/ImageRendererServer.csproj
+++ b/source/dotnet/Samples/ImageRendererServer/ImageRendererServer.csproj
@@ -10,10 +10,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.3.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.3.9" />
     <PackageReference Include="Microsoft.AspNetCore.Server.IIS" Version="2.2.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="2.2.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="2.3.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.3.9" />
     <PackageReference Include="Microsoft.Internal.AntiSSRF" Version="2.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
   - Bump Microsoft.AspNetCore from 2.2.0 to 2.3.9
   - Bump Microsoft.AspNetCore.Mvc from 2.2.0 to 2.3.9
   - Bump Microsoft.AspNetCore.Server.IISIntegration from 2.2.1 to 2.3.9
   - Add Microsoft.AspNetCore.Server.Kestrel 2.3.9
