### PR TITLE
fix: add ShowCard nesting depth limit to prevent stack overflow

### DIFF
--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/ObjectModelTest.cpp
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/ObjectModelTest.cpp
@@ -739,5 +739,115 @@ namespace AdaptiveCardsSharedModelUnitTest
             const auto serializedCard = card->SerializeToJsonValue();
             Assert::IsTrue(serializedCard["body"][0]["isMultiline"].asBool());
         }
+
+        // Helper: Generate nested ShowCard JSON to the specified depth
+        static std::string MakeNestedShowCardJson(int depth)
+        {
+            std::string innermost = R"({"type":"AdaptiveCard","version":"1.5","body":[{"type":"TextBlock","text":"bottom"}]})";
+            std::string current = innermost;
+            for (int i = 0; i < depth; i++)
+            {
+                current = R"({"type":"AdaptiveCard","version":"1.5","body":[{"type":"TextBlock","text":"Level )" +
+                           std::to_string(depth - i) +
+                           R"("}],"actions":[{"type":"Action.ShowCard","title":"More","card":)" +
+                           current + R"(}]})";
+            }
+            return current;
+        }
+
+        // Helper: Walk the parsed ShowCard tree and count actual nesting depth
+        static int MeasureParsedDepth(std::shared_ptr<AdaptiveCard> card)
+        {
+            if (!card) return 0;
+            auto& actions = card->GetActions();
+            for (auto& action : actions)
+            {
+                if (action->GetElementType() == ActionType::ShowCard)
+                {
+                    auto showCard = std::static_pointer_cast<ShowCardAction>(action);
+                    auto inner = showCard->GetCard();
+                    if (inner && (!inner->GetBody().empty() || !inner->GetActions().empty()))
+                    {
+                        return 1 + MeasureParsedDepth(inner);
+                    }
+                }
+            }
+            return 0;
+        }
+
+        TEST_METHOD(ShowCardNesting_WithinLimit_ParsesFully)
+        {
+            // Depth 3 is well within the limit of 5
+            const auto json = MakeNestedShowCardJson(3);
+            const auto parseResult = AdaptiveCard::DeserializeFromString(json, "1.5");
+            const auto card = parseResult->GetAdaptiveCard();
+
+            Assert::AreEqual(3, MeasureParsedDepth(card));
+
+            // No warnings about depth
+            const auto warnings = parseResult->GetWarnings();
+            for (const auto& w : warnings)
+            {
+                Assert::AreNotEqual("Maximum ShowCard nesting depth exceeded"s, w->GetReason());
+            }
+        }
+
+        TEST_METHOD(ShowCardNesting_AtExactLimit_ParsesFully)
+        {
+            // Depth 5 is exactly the limit — should parse fully
+            const auto json = MakeNestedShowCardJson(5);
+            const auto parseResult = AdaptiveCard::DeserializeFromString(json, "1.5");
+            const auto card = parseResult->GetAdaptiveCard();
+
+            Assert::AreEqual(5, MeasureParsedDepth(card));
+
+            // No warnings about depth
+            const auto warnings = parseResult->GetWarnings();
+            for (const auto& w : warnings)
+            {
+                Assert::AreNotEqual("Maximum ShowCard nesting depth exceeded"s, w->GetReason());
+            }
+        }
+
+        TEST_METHOD(ShowCardNesting_ExceedsLimit_CappedWithWarning)
+        {
+            // Depth 10 exceeds the limit of 5 — should be capped
+            const auto json = MakeNestedShowCardJson(10);
+            const auto parseResult = AdaptiveCard::DeserializeFromString(json, "1.5");
+            const auto card = parseResult->GetAdaptiveCard();
+
+            // Should be capped at the max depth, not 10
+            const int parsedDepth = MeasureParsedDepth(card);
+            Assert::IsTrue(parsedDepth <= static_cast<int>(ParseContext::c_maxShowCardDepth));
+
+            // Should have emitted a warning
+            const auto warnings = parseResult->GetWarnings();
+            bool foundWarning = false;
+            for (const auto& w : warnings)
+            {
+                if (w->GetReason() == "Maximum ShowCard nesting depth exceeded")
+                {
+                    foundWarning = true;
+                    break;
+                }
+            }
+            Assert::IsTrue(foundWarning, L"Expected warning about ShowCard nesting depth");
+        }
+
+        TEST_METHOD(ShowCardNesting_DeepNesting_NoException)
+        {
+            // Depth 200 previously parsed successfully and could crash the renderer.
+            // Now it should be capped without throwing an exception.
+            const auto json = MakeNestedShowCardJson(200);
+            const auto parseResult = AdaptiveCard::DeserializeFromString(json, "1.5");
+            const auto card = parseResult->GetAdaptiveCard();
+
+            // Must not crash or throw — card should be valid
+            Assert::IsNotNull(card.get());
+
+            // Depth must be capped
+            const int parsedDepth = MeasureParsedDepth(card);
+            Assert::IsTrue(parsedDepth <= static_cast<int>(ParseContext::c_maxShowCardDepth));
+        }
     };
 }

--- a/source/shared/cpp/ObjectModel/ParseContext.cpp
+++ b/source/shared/cpp/ObjectModel/ParseContext.cpp
@@ -361,4 +361,22 @@ const std::string& ParseContext::GetLanguage() const
 {
     return m_language;
 }
+
+bool ParseContext::CanIncrementShowCardDepth() const
+{
+    return m_currentShowCardDepth < c_maxShowCardDepth;
+}
+
+void ParseContext::IncrementShowCardDepth()
+{
+    m_currentShowCardDepth++;
+}
+
+void ParseContext::DecrementShowCardDepth()
+{
+    if (m_currentShowCardDepth > 0)
+    {
+        m_currentShowCardDepth--;
+    }
+}
 } // namespace AdaptiveCards

--- a/source/shared/cpp/ObjectModel/ParseContext.h
+++ b/source/shared/cpp/ObjectModel/ParseContext.h
@@ -52,6 +52,12 @@ public:
     void RemoveProhibitedElementType(const std::vector<std::string>& list);
     void ShouldParse(const std::string& type);
 
+    // ShowCard nesting depth tracking — prevents stack overflow from deeply nested ShowCards
+    static constexpr unsigned int c_maxShowCardDepth = 5;
+    bool CanIncrementShowCardDepth() const;
+    void IncrementShowCardDepth();
+    void DecrementShowCardDepth();
+
 private:
     const AdaptiveCards::InternalId GetNearestFallbackId(const AdaptiveCards::InternalId& skipId) const;
     // This enum is just a helper to keep track of the position of contents within the std::tuple used in
@@ -83,6 +89,8 @@ private:
     std::vector<ContainerBleedDirection> m_parentalBleedDirection;
 
     std::unordered_set<std::string> m_prohibitedElementTypes;
+
+    unsigned int m_currentShowCardDepth{0};
 
     bool m_canFallbackToAncestor;
     std::string m_language;

--- a/source/shared/cpp/ObjectModel/ShowCardAction.cpp
+++ b/source/shared/cpp/ObjectModel/ShowCardAction.cpp
@@ -47,7 +47,17 @@ std::shared_ptr<BaseActionElement> ShowCardActionParser::Deserialize(ParseContex
 
     const std::string& propertyName = AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Card);
 
+    if (!context.CanIncrementShowCardDepth())
+    {
+        context.warnings.push_back(std::make_shared<AdaptiveCardParseWarning>(
+            WarningStatusCode::CustomWarning, "Maximum ShowCard nesting depth exceeded"));
+        showCardAction->SetCard(std::make_shared<AdaptiveCard>());
+        return showCardAction;
+    }
+
+    context.IncrementShowCardDepth();
     auto parseResult = AdaptiveCard::Deserialize(json.get(propertyName, Json::Value()), "", context);
+    context.DecrementShowCardDepth();
 
     auto showCardWarnings = parseResult->GetWarnings();
     auto warningsEnd = context.warnings.insert(context.warnings.end(), showCardWarnings.begin(), showCardWarnings.end());


### PR DESCRIPTION
**Summary**
Adds a maximum nesting depth limit (5 levels) for Action.ShowCard in the shared C++ object model parser. This prevents deeply nested ShowCard payloads from causing a stack overflow crash in downstream renderers.

**Problem**
`ShowCardActionParser`::Deserialize calls `AdaptiveCard`::Deserialize recursively with zero depth tracking. A malicious or malformed card payload with deeply nested Action.ShowCard actions creates an unbounded recursive parse tree. When this tree is then rendered by the XAML renderer (BuildXamlTreeFromAdaptiveCard → BuildActions → BuildInlineShowCard → BuildShowCard → recurse), the deep recursion overflows the stack, crashing the host process.

`Verified locally`: A card with 325 levels of ShowCard nesting parses successfully into a fully-recursive tree of 325 AdaptiveCard objects — the parser provides no resistance whatsoever. The only incidental barrier is jsoncpp's stackLimit (1000 JSON nesting levels), which is not an AdaptiveCards security control.

This is relevant to all renderers that use the shared C++ model (UWP, WinUI3, Android, iOS), since the unbounded tree is constructed at parse time before any renderer-specific code runs.

**Changes**
**4 files changed, 146 insertions:**

| File                                               | Change |
|----------------------------------------------------|--------|
| ParseContext.h                                     | Added `c_maxShowCardDepth` (5), depth counter, and `CanIncrementShowCardDepth()` / `IncrementShowCardDepth()` / `DecrementShowCardDepth()` methods |
| ParseContext.cpp                                   | Implemented the three depth tracking methods |
| ShowCardAction.cpp                                 | Guarded the recursive `AdaptiveCard::Deserialize` call in `ShowCardActionParser::Deserialize`  when depth exceeds the limit, sets an empty inner card and emits a `CustomWarning` |
| AdaptiveCardsSharedModelUnitTest/ObjectModelTest.cpp | Added 4 test methods: within-limit, at-exact-limit, exceeds-limit, and deep-nesting (200 levels) |



**How it works**

```
// Before parsing a ShowCard's inner card:
if (!context.CanIncrementShowCardDepth())    // depth >= 5?
{
    // Emit warning, set empty card, return early no recursion
    context.warnings.push_back(...);
    showCardAction->SetCard(std::make_shared<AdaptiveCard>());
    return showCardAction;
}

context.IncrementShowCardDepth();            // depth 0→1, 1→2, etc.
auto parseResult = AdaptiveCard::Deserialize(json.get(propertyName, ...), "", context);
context.DecrementShowCardDepth();            // restore on return
```

## Behavior

| Input depth | Before this fix | After this fix |
|---|---|---|
| 3 | Parses to depth 3 | Parses to depth 3 (unchanged) |
| 5 | Parses to depth 5 | Parses to depth 5 (unchanged) |
| 6 | Parses to depth 6 | Capped at depth 5 + warning |
| 10 | Parses to depth 10 | Capped at depth 5 + warning |
| 200 | Parses to depth 200 → renderer crash | Capped at depth 5 + warning, no crash |

No breaking changes. Real-world cards never nest ShowCards deeper than 2–3 levels. The limit of 5 is generous.

**Testing**
Verified with a standalone C++ test binary that builds against the ObjectModel library:

```
TEST 1: Depth 3 (within limit) parses fully         — PASS
TEST 2: Depth 5 (at limit) parses fully              — PASS
TEST 3: Depth 10 (exceeds limit) is capped           — PASS
TEST 4: Depth 200 (previously dangerous) is capped   — PASS
TEST 5: Depth 6 (one above limit) is capped          — PASS
TEST 6: Card without ShowCards is unaffected           — PASS
```
4 unit tests also added to `ObjectModelTest.cpp` in the existing CppUnitTest project.
