### PR TITLE
fix: add element count limit per collection to prevent resource exhau…

### DIFF
--- a/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/ObjectModelTest.cpp
+++ b/source/shared/cpp/AdaptiveCardsSharedModel/AdaptiveCardsSharedModelUnitTest/ObjectModelTest.cpp
@@ -739,5 +739,90 @@ namespace AdaptiveCardsSharedModelUnitTest
             const auto serializedCard = card->SerializeToJsonValue();
             Assert::IsTrue(serializedCard["body"][0]["isMultiline"].asBool());
         }
+
+        // Helper: build a card JSON with N TextBlocks in the body
+        static std::string MakeCardWithNElements(unsigned int count)
+        {
+            std::string json = R"({"type":"AdaptiveCard","version":"1.5","body":[)";
+            for (unsigned int i = 0; i < count; i++)
+            {
+                if (i > 0) json += ",";
+                json += R"({"type":"TextBlock","text":"Item )" + std::to_string(i) + R"("})";
+            }
+            json += "]}";
+            return json;
+        }
+
+        // Helper: build a card JSON with N OpenUrl actions
+        static std::string MakeCardWithNActions(unsigned int count)
+        {
+            std::string json = R"({"type":"AdaptiveCard","version":"1.5","body":[{"type":"TextBlock","text":"hi"}],"actions":[)";
+            for (unsigned int i = 0; i < count; i++)
+            {
+                if (i > 0) json += ",";
+                json += R"({"type":"Action.OpenUrl","title":"L)" + std::to_string(i) + R"(","url":"https://x.com"})";
+            }
+            json += "]}";
+            return json;
+        }
+
+        TEST_METHOD(ElementCollection_WithinLimit_ParsesFully)
+        {
+            const auto json = MakeCardWithNElements(10);
+            const auto result = AdaptiveCard::DeserializeFromString(json, "1.5");
+            Assert::AreEqual(10ui64, result->GetAdaptiveCard()->GetBody().size());
+        }
+
+        TEST_METHOD(ElementCollection_AtLimit_ParsesFully)
+        {
+            const unsigned int limit = ParseContext::c_maxElementsPerCollection;
+            const auto json = MakeCardWithNElements(limit);
+            const auto result = AdaptiveCard::DeserializeFromString(json, "1.5");
+            Assert::AreEqual(static_cast<size_t>(limit), result->GetAdaptiveCard()->GetBody().size());
+        }
+
+        TEST_METHOD(ElementCollection_ExceedsLimit_CappedWithWarning)
+        {
+            const unsigned int limit = ParseContext::c_maxElementsPerCollection;
+            const auto json = MakeCardWithNElements(limit + 50);
+            const auto result = AdaptiveCard::DeserializeFromString(json, "1.5");
+
+            // Body should be capped at the limit
+            Assert::AreEqual(static_cast<size_t>(limit), result->GetAdaptiveCard()->GetBody().size());
+
+            // Should have a warning about it
+            bool foundWarning = false;
+            for (const auto& w : result->GetWarnings())
+            {
+                if (w->GetReason().find("Maximum number of elements") != std::string::npos)
+                {
+                    foundWarning = true;
+                    break;
+                }
+            }
+            Assert::IsTrue(foundWarning, L"Expected warning about element collection limit");
+        }
+
+        TEST_METHOD(ActionCollection_ExceedsLimit_CappedWithWarning)
+        {
+            const unsigned int limit = ParseContext::c_maxElementsPerCollection;
+            const auto json = MakeCardWithNActions(limit + 50);
+            const auto result = AdaptiveCard::DeserializeFromString(json, "1.5");
+
+            // Actions should be capped
+            Assert::IsTrue(result->GetAdaptiveCard()->GetActions().size() <= static_cast<size_t>(limit));
+
+            // Should have a warning
+            bool foundWarning = false;
+            for (const auto& w : result->GetWarnings())
+            {
+                if (w->GetReason().find("Maximum number of actions") != std::string::npos)
+                {
+                    foundWarning = true;
+                    break;
+                }
+            }
+            Assert::IsTrue(foundWarning, L"Expected warning about action collection limit");
+        }
     };
 }

--- a/source/shared/cpp/ObjectModel/ParseContext.h
+++ b/source/shared/cpp/ObjectModel/ParseContext.h
@@ -52,6 +52,9 @@ public:
     void RemoveProhibitedElementType(const std::vector<std::string>& list);
     void ShouldParse(const std::string& type);
 
+    // Max items allowed in a single collection (body, actions, columns, etc.)
+    static constexpr unsigned int c_maxElementsPerCollection = 200;
+
 private:
     const AdaptiveCards::InternalId GetNearestFallbackId(const AdaptiveCards::InternalId& skipId) const;
     // This enum is just a helper to keep track of the position of contents within the std::tuple used in

--- a/source/shared/cpp/ObjectModel/ParseUtil.cpp
+++ b/source/shared/cpp/ObjectModel/ParseUtil.cpp
@@ -455,10 +455,20 @@ std::vector<std::shared_ptr<BaseActionElement>> ParseUtil::GetActionCollection(
         return elements;
     }
 
-    elements.reserve(elementArray.size());
+    const size_t maxElements = static_cast<size_t>(ParseContext::c_maxElementsPerCollection);
+    elements.reserve(std::min(static_cast<size_t>(elementArray.size()), maxElements));
 
     for (const auto& curJsonValue : elementArray)
     {
+        // Cap the number of actions to prevent resource exhaustion
+        if (elements.size() >= maxElements)
+        {
+            context.warnings.emplace_back(
+                std::make_shared<AdaptiveCardParseWarning>(WarningStatusCode::CustomWarning,
+                    "Maximum number of actions in a collection exceeded; remaining items were dropped"));
+            break;
+        }
+
         auto action = ParseUtil::GetActionFromJsonValue(context, curJsonValue);
         if (action != nullptr)
         {

--- a/source/shared/cpp/ObjectModel/ParseUtil.h
+++ b/source/shared/cpp/ObjectModel/ParseUtil.h
@@ -215,11 +215,21 @@ std::vector<std::shared_ptr<T>> ParseUtil::GetElementCollectionOfSingleType(
         return elements;
     }
 
-    elements.reserve(elementArray.size());
+    const size_t maxElements = static_cast<size_t>(ParseContext::c_maxElementsPerCollection);
+    elements.reserve(std::min(static_cast<size_t>(elementArray.size()), maxElements));
 
     // Deserialize every element in the array
     for (const Json::Value& curJsonValue : elementArray)
     {
+        // Cap the number of elements to prevent resource exhaustion
+        if (elements.size() >= maxElements)
+        {
+            context.warnings.emplace_back(
+                std::make_shared<AdaptiveCardParseWarning>(WarningStatusCode::CustomWarning,
+                    "Maximum number of elements in a collection exceeded; remaining items were dropped"));
+            break;
+        }
+
         // Parse the element
         auto el = deserializer(context, curJsonValue);
         if (el != nullptr)
@@ -280,13 +290,22 @@ std::vector<std::shared_ptr<T>> ParseUtil::GetElementCollection(
     }
 
     const size_t elemSize = elementArray.size();
-    elements.reserve(elemSize);
+    const size_t maxElements = static_cast<size_t>(ParseContext::c_maxElementsPerCollection);
+    elements.reserve(std::min(elemSize, maxElements));
 
     const ContainerBleedDirection previousBleedState = context.GetBleedDirection();
 
     size_t currentIndex = 0;
     for (auto& curJsonValue : elementArray)
     {
+        // Cap the number of elements to prevent resource exhaustion
+        if (elements.size() >= maxElements)
+        {
+            context.warnings.emplace_back(
+                std::make_shared<AdaptiveCardParseWarning>(WarningStatusCode::CustomWarning,
+                    "Maximum number of elements in a collection exceeded; remaining items were dropped"));
+            break;
+        }
         ContainerBleedDirection currentBleedState = previousBleedState;
 
         if (currentIndex != 0)


### PR DESCRIPTION
**Summary**
Adds a maximum element count limit (200) per collection in the shared C++ object model parser. Collections exceeding the limit are truncated with a parse warning.

**Problem**
`GetElementCollection`, `GetElementCollectionOfSingleType`, and `GetActionCollection `in ParseUtil.h/ParseUtil.cpp loop over every item in a JSON array with no upper bound. Additionally, `elements.reserve(elementArray.size())` allocates memory for the full array size upfront.
A card with 100,000 TextBlocks in the body creates 100,000 parsed C++ objects. When rendered, each becomes a XAML control — exhausting memory and freezing the UI thread.


**Verified locally**: A standalone C++ binary linked against the ObjectModel library confirmed:
```
+--------------------------+-------------+-----------------------------------+----------------------------------+
| Collection               | Input count | Before fix                        | After fix                        |
+--------------------------+-------------+-----------------------------------+----------------------------------+
| Body (TextBlock)         | 100,000     | 100,000 parsed (853ms)            | 200 parsed (3ms)                 |
| Actions (OpenUrl)        | 100,000     | 100,000 parsed (952ms)            | 200 parsed (4ms)                 |
| Body (TextBlock)         | 10          | 10 parsed                         | 10 parsed (unchanged)            |
| Body (TextBlock)         | 200         | 200 parsed                        | 200 parsed (at limit, unchanged) |
+--------------------------+-------------+-----------------------------------+----------------------------------+
```

This affects all renderers using the shared C++ model (UWP, WinUI3, Android, iOS). The parser currently provides no API for hosts to set a collection size limit —> even hosts that want to cap elements have no way to do so.

**Changes**
4 files changed, 120 insertions, 3 deletions:

```
+-----------------------------------------------------------+----------------------------------------------------------------------------------------------+
| File                                                      | Change                                                                                       |
+-----------------------------------------------------------+----------------------------------------------------------------------------------------------+
| ParseContext.h                                            | Added c_maxElementsPerCollection = 200 as a static constexpr                                 |
| ParseUtil.h                                               | Added limit check + warning in GetElementCollection and GetElementCollectionOfSingleType;    |
|                                                           | capped reserve()                                                                             |
| ParseUtil.cpp                                             | Added limit check + warning in GetActionCollection; capped reserve()                         |
| AdaptiveCardsSharedModelUnitTest/ObjectModelTest.cpp      | Added 4 test methods: within-limit, at-limit, body-exceeds-limit, actions-exceed-limit      |
+-----------------------------------------------------------+----------------------------------------------------------------------------------------------+
```

**How it works**
All three collection parsing functions now check before each item:

```
const size_t maxElements = static_cast<size_t>(ParseContext::c_maxElementsPerCollection);
elements.reserve(std::min(elemSize, maxElements));  // cap upfront allocation too

for (auto& curJsonValue : elementArray)
{
    if (elements.size() >= maxElements)
    {
        context.warnings.emplace_back(std::make_shared<AdaptiveCardParseWarning>(
            WarningStatusCode::CustomWarning,
            "Maximum number of elements in a collection exceeded; remaining items were dropped"));
        break;
    }
    // ... parse item
}
```

**Scope**
Covers all 19 call sites through the 3 guarded functions:

- Card body, actions, Container items, Column items, ColumnSet columns
- Carousel pages, ChoiceSet choices, FactSet facts, ImageSet images
- Table rows, TableRow cells, RichTextBlock inlines
- Media sources, caption sources, auth buttons, toggle visibility targets
- ActionSet actions

**Behavior**
```
┌────────────────────────────────────┬───────────────────────────────────────────┐
│ Scenario                           │ Result                                    │
├────────────────────────────────────┼───────────────────────────────────────────┤
│ Card with 10 body elements         │ Parses all 10 (unchanged)                 │
│ Card with 200 body elements        │ Parses all 200 (at limit, unchanged)      │
│ Card with 250 body elements        │ Parses 200 + emits warning                │
│ Card with 100,000 body elements    │ Parses 200 + emits warning                │
│ Card with 250 actions              │ Parses 200 + emits warning                │
└────────────────────────────────────┴───────────────────────────────────────────┘
```
No breaking changes. Real-world Adaptive Cards rarely have more than 20-30 elements in a single collection. The limit of 200 is very generous.

**Testing**

4 unit tests added to ObjectModelTest.cpp:

- ElementCollection_WithinLimit_ParsesFully — 10 elements, all parsed
- ElementCollection_AtLimit_ParsesFully — 200 elements, all parsed
- ElementCollection_ExceedsLimit_CappedWithWarning — 250 elements, capped at 200 + warning
- ActionCollection_ExceedsLimit_CappedWithWarning — 250 actions, capped at 200 + warning
- Standalone repro binary verified body and action capping across 10 to 100,000 items.

**Context**
`This is a defense-in-depth hardening for scenarios where AdaptiveCards renders untrusted content (e.g., Windows Widgets accepting 3rd-party card payloads). The parser was originally designed for trusted-source cards, but the threat model has expanded. There is currently no existing API or config for hosts to limit collection sizes.`