### PR TITLE
Fix Carousel layout crashes from missing null/bounds checks in AdaptiveCarouselRenderer

### DIFF
--- a/source/uwp/SharedRenderer/lib/AdaptiveCarouselRenderer.cpp
+++ b/source/uwp/SharedRenderer/lib/AdaptiveCarouselRenderer.cpp
@@ -59,6 +59,10 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 
         carouselUI.SelectionChanged([carouselUI, pipsPager, loopEnabled](auto &&, auto &&) {
             auto val = carouselUI.SelectedIndex();
+            if (val < 0)
+            {
+                return;
+            }
             if (loopEnabled &&
                 static_cast<unsigned int>(val) == carouselUI.Items().Size())
             {
@@ -67,7 +71,7 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
             }
             else
             {
-                pipsPager.SelectedPageIndex(carouselUI.SelectedIndex());
+                pipsPager.SelectedPageIndex(val);
             }
         });
 
@@ -125,15 +129,22 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
 
                     if (fixedHeightInPixel == 0)
                     {
-                        carouselPageUI.try_as<FrameworkElement>().LayoutUpdated(
-                            [carouselUI](auto&&, auto&&) { SetFlipViewMaxHeight(carouselUI); });
+                        if (auto fe = carouselPageUI.try_as<FrameworkElement>())
+                        {
+                            fe.LayoutUpdated(
+                                [carouselUI](auto&&, auto&&) { SetFlipViewMaxHeight(carouselUI); });
+                        }
                     }
                }
             }
 
             if (carousel.InitialPage())
             {
-                carouselUI.SelectedIndex(carousel.InitialPage().GetUInt32());
+                auto initialPageIndex = carousel.InitialPage().GetUInt32();
+                if (initialPageIndex < carouselUI.Items().Size())
+                {
+                    carouselUI.SelectedIndex(initialPageIndex);
+                }
             }
 
             auto verticalContentAlignmentReference = carousel.VerticalContentAlignment();
@@ -192,7 +203,16 @@ namespace winrt::AdaptiveCards::Rendering::Xaml_Rendering::implementation
     void SetFlipViewMaxHeight(FlipView const& flipView)
     {
         auto selectIndex = flipView.SelectedIndex();
+        if (selectIndex < 0 || static_cast<uint32_t>(selectIndex) >= flipView.Items().Size())
+        {
+            return;
+        }
+
         auto carouselPageUI = flipView.Items().GetAt(selectIndex).try_as<FrameworkElement>();
+        if (!carouselPageUI)
+        {
+            return;
+        }
 
         if (flipView.IsLoaded())
         {


### PR DESCRIPTION
## Summary

Fixes multiple crash paths in `AdaptiveCarouselRenderer` that cause `STOWED_EXCEPTION` (`0x88000fa8`) during XAML layout pass when rendering Carousel elements.

**Affected apps:** WidgetBoard (77.6%), lockapp (3.9%)  
**Affected SDK:** `AdaptiveCards.Rendering.Uwp 3.2.x`, `AdaptiveCards.Rendering.WinUI3 2.2.3-beta`

## Root Cause

`AdaptiveCarouselRenderer.cpp` has several unguarded code paths that throw during XAML layout/rendering:

### Bug 1 — SelectionChanged handler crashes with SelectedIndex = -1
When `carouselUI.Items().Append()` is called during rendering, the FlipView fires `SelectionChanged` before any item is selected (`SelectedIndex() == -1`). The handler calls `pipsPager.SelectedPageIndex(-1)` which throws `InvalidOperationException` because PipsPager does not accept negative indices.

### Bug 2 — `SetFlipViewMaxHeight` calls `GetAt()` without bounds check
`flipView.SelectedIndex()` can return -1 (no selection). `GetAt(-1)` throws `E_BOUNDS`. This function is called from a `LayoutUpdated` event handler — outside the `try-catch` in `Render()` — so the exception propagates unhandled and becomes a stowed exception that crashes the host process.

### Bug 3 — `SetFlipViewMaxHeight` calls `.Measure()` on unchecked `try_as` result
`try_as<FrameworkElement>()` can return `nullptr`. The code calls `.Measure()` on the result without a null check → null pointer dereference.

### Bug 4 — `try_as<FrameworkElement>()` chained directly into `.LayoutUpdated()`
In the render loop, `carouselPageUI.try_as<FrameworkElement>().LayoutUpdated(...)` chains the method call without checking if `try_as` returned null.

### Bug 5 — `InitialPage` index used without bounds validation
`carousel.InitialPage().GetUInt32()` is passed directly to `SelectedIndex()` without checking it's within `Items().Size()`.

## Fix

- **SelectionChanged handler:** Early return when `SelectedIndex() < 0`
- **SetFlipViewMaxHeight:** Validate `selectIndex >= 0 && < Items().Size()` before `GetAt()`. Null-check `try_as` result before `.Measure()`.
- **Render loop:** Store `try_as` result and guard `.LayoutUpdated()` call with null check.
- **InitialPage:** Validate index against `carouselUI.Items().Size()` before setting.

## Repro

1. Build and run `source/uwp/winui3/SimpleVisualizer/SimpleVisualizer.sln`
2. Click "Show Adaptive Card" —> loads `ClipchampCarousel.json`
3. **Before fix:** `System.InvalidOperationException: 'Operation is not valid due to the current state of the object.'` during `RenderAdaptiveCard()`
4. **After fix:** Carousel renders and displays without crash

## Files Changed

- `source/uwp/SharedRenderer/lib/AdaptiveCarouselRenderer.cpp` —> All 5 fixes
- `source/uwp/winui3/SimpleVisualizer/ClipchampCarousel.json` —> Test template (Clipchamp-style Carousel with empty Container)
- `source/uwp/winui3/SimpleVisualizer/MainWindow.xaml.cs` —> Use `AppContext.BaseDirectory` instead of `Package.Current.InstalledLocation.Path`

<img width="1033" height="511" alt="image" src="https://github.com/user-attachments/assets/c2527555-b514-463a-b47e-7e9ea01d18b4" />

