### PR TITLE
Fix CG pipeline: update retired windows-2019 image to windows-2022

### DIFF
--- a/.pipelines/dotnet-ci.yml
+++ b/.pipelines/dotnet-ci.yml
@@ -21,8 +21,7 @@ variables:
   buildPlatform: any cpu
 
 pool:
-  name: Azure Pipelines
-  vmImage: windows-2019
+  vmImage: windows-2022
 
 steps:
 - task: UseDotNet@2


### PR DESCRIPTION
# Related Issue

No existing GitHub issue — addresses an internal Component Governance compliance action item. 
# Description

The `AdaptiveCards-.NET-Daily` pipeline (`.pipelines/dotnet-ci.yml`) failed at agent allocation:

> `No image label found to route agent pool Azure Pipelines. Image: windows-2019`

The hosted `windows-2019` image is **retired**, so the job never started — the `ComponentGovernanceComponentDetection@0` task never ran, leaving the repo **non-compliant for Component Governance**.

Fix: update the hosted image to a supported one.

```diff
 pool:
-  name: Azure Pipelines
-  vmImage: windows-2019
+  vmImage: windows-2022
```

CI-config-only change; no product/runtime impact. (`vmImage` alone targets the hosted "Azure Pipelines" pool, so the explicit `name` line is redundant and was removed.)

# Sample Card

Not applicable — pipeline configuration change only.



