### PR TITLE
Feature/dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,12 @@
 version: 2
 updates:
   # ---- JavaScript / TypeScript (npm) ----
-  # /source/nodejs is a lerna + npm-workspaces monorepo; its single lockfile
-  # covers every workspace package (adaptivecards, -templating, -react, etc.).
+  # /source/nodejs is a lerna + npm-workspaces monorepo; its single top-level
+  # package.json + lockfile covers every workspace package (adaptivecards,
+  # -templating, -react, etc.). The repo-root and /schemas lockfiles are empty
+  # stubs with no package.json, so they are intentionally not listed.
   - package-ecosystem: "npm"
-    directories:
-      - "/"
-      - "/schemas"
-      - "/source/nodejs"
+    directory: "/source/nodejs"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 1

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,63 @@
+version: 2
+updates:
+  # ---- JavaScript / TypeScript (npm) ----
+  # /source/nodejs is a lerna + npm-workspaces monorepo; its single lockfile
+  # covers every workspace package (adaptivecards, -templating, -react, etc.).
+  - package-ecosystem: "npm"
+    directories:
+      - "/"
+      - "/schemas"
+      - "/source/nodejs"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 1
+    labels:
+      - "dependencies"
+      - "javascript"
+
+  # ---- .NET (NuGet) ----
+  # Target the concrete solution roots (each has its own .sln that references
+  # its projects) rather than broad "**" globs, which the Dependabot guidance
+  # warns can be slow / time out for NuGet.
+  - package-ecosystem: "nuget"
+    directories:
+      - "/source/dotnet"
+      - "/source/uwp"
+      - "/source/uwp/winui3"
+      - "/source/ios/tools/IOSFeed"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 1
+    labels:
+      - "dependencies"
+      - "dotnet"
+
+  # ---- Android (Gradle) ----
+  - package-ecosystem: "gradle"
+    directory: "/source/android"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 1
+    labels:
+      - "dependencies"
+      - "android"
+
+  # ---- Swift Package Manager (Package.swift at repo root) ----
+  - package-ecosystem: "swift"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 1
+    labels:
+      - "dependencies"
+      - "swift"
+
+  # ---- GitHub Actions workflows ----
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 1
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
# Add Dependabot version updates configuration

## What
Adds `.github/dependabot.yml` to enable Dependabot version-update PRs across the package ecosystems actually used in AdaptiveCards.

## Ecosystems covered
| Ecosystem | Directory / Directories |
| --- | --- |
| `npm` | `/source/nodejs` (lerna + npm-workspaces monorepo — its single top-level `package.json` + lockfile covers every workspace package) |
| `nuget` | `/source/dotnet`, `/source/uwp`, `/source/uwp/winui3`, `/source/ios/tools/IOSFeed` |
| `gradle` | `/source/android` (its `settings.gradle` includes the adaptivecards, mobile, mobilechatapp, and uitestapp subprojects) |
| `swift` | `/` (Package.swift) |
| `github-actions` | `/` (workflows) |

## Settings
- **Schedule:** weekly for every ecosystem
- **Open PR limit:** 1 per ecosystem (keeps noise low)
- Ecosystem-specific labels applied

## Scoping rationale
Directories were verified against the actual repo layout rather than using broad globs:
- **npm** is scoped to `/source/nodejs` only. The repo-root and `/schemas` `package-lock.json` files are empty stubs (`{"lockfileVersion": 1}`) with **no `package.json`** — Dependabot's npm updater would error on them, so they are intentionally excluded.
- **nuget** targets the concrete solution roots (each has its own `.sln` with real `PackageReference`/`packages.config` dependencies) instead of broad `**` globs, which the Dependabot guidance warns can be slow / time out for NuGet.
- `source/shared/cpp` C++ projects have **no NuGet dependencies**, so they are not listed.
- The `source/dotnet/.../package.json` is a **Unity (UPM)** manifest, not npm — Dependabot cannot process it, so it is excluded.

## Notes
- CocoaPods (iOS `Podfile`) is intentionally omitted — it is not a Dependabot-supported ecosystem.
- The `swift` entry is currently inert (`Package.swift` declares no external SPM dependencies) but is kept for forward-compatibility; it is a harmless no-op until an SPM dependency is added.
- This is a configuration file, not a pipeline; it enables version-update PRs. Dependabot alerts / security updates are managed separately in repo settings.

## Related
Part of the Component Governance onboarding effort for `github:microsoft/AdaptiveCards`.
